### PR TITLE
feat: Add tests for changing stages in InheritInSubtypesTest

### DIFF
--- a/tests/FeatureCheck.Test/AggregateTests/Subtypes/InheritInSubtypesTest.cs
+++ b/tests/FeatureCheck.Test/AggregateTests/Subtypes/InheritInSubtypesTest.cs
@@ -1,0 +1,42 @@
+using FeatureCheck.Domain.Aggregates.SubTypes.InheritInSubtypesTypes;
+using FeatureCheck.Domain.Aggregates.SubTypes.InheritInSubtypesTypes.Commands;
+using FeatureCheck.Domain.Shared;
+using Sekiban.Testing.SingleProjections;
+using Xunit;
+namespace FeatureCheck.Test.AggregateTests.Subtypes;
+
+public class InheritInSubtypesTest : AggregateTest<IInheritInSubtypesType, FeatureCheckDependency>
+{
+    [Fact]
+    public void InheritInSubtypesChangeStageSpec()
+    {
+        Subtype<FirstStage>()
+            .GivenCommand(new CreateInheritInSubtypesType(1))
+            .WhenCommand(new ChangeToSecond(GetAggregateId(), 2));
+        ThenPayloadTypeShouldBe<SecondStage>();
+    }
+
+    [Fact]
+    public void InheritInSubtypesChangeBackStageSpec()
+    {
+        Subtype<FirstStage>()
+            .GivenCommand(new CreateInheritInSubtypesType(1))
+            .GivenCommand(new ChangeToSecond(GetAggregateId(), 2));
+        ThenPayloadTypeShouldBe<SecondStage>()
+            .WhenCommand(new MoveBackToFirst(GetAggregateId()));
+        ThenPayloadTypeShouldBe<FirstStage>();
+    }
+
+    [Fact]
+    public void InheritInSubtypesChangeBackStageSpec2()
+    {
+        Subtype<FirstStage>()
+            .GivenCommand(new CreateInheritInSubtypesType(1))
+            .GivenCommand(new ChangeToSecond(GetAggregateId(), 2));
+        ThenPayloadTypeShouldBe<SecondStage>()
+            .GivenCommand(new MoveBackToFirst(GetAggregateId()));
+        ThenPayloadTypeShouldBe<FirstStage>()
+            .WhenCommand(new ChangeToSecond(GetAggregateId(), 3));
+        ThenPayloadTypeShouldBe<SecondStage>();
+    }
+}


### PR DESCRIPTION
This commit adds tests for changing stages in the InheritInSubtypesTest class. The tests cover scenarios such as changing to the second stage, changing back to the first stage, and changing back to the second stage again. These tests ensure that the stage changes are correctly handled by the code.

The commit message follows the established convention of using a prefix to indicate the type of change (`feat` for a new feature) and provides a clear summary of the changes made.

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Add Test

## Related Tickets & Documents


- Related Issue #337
- Closes #337

## QA Instructions, Screenshots, Recordings

## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

