### PR TITLE
Enhance OrleansTagStatePersistent with serialization and update dependencies

### DIFF
--- a/internalUsages/DcbOrleans.ApiService/DcbOrleans.ApiService.csproj
+++ b/internalUsages/DcbOrleans.ApiService/DcbOrleans.ApiService.csproj
@@ -16,7 +16,9 @@
         <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.8"/>
         <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.8"/>
         <PackageReference Include="Microsoft.Orleans.Clustering.AzureStorage" Version="9.2.1"/>
+        <PackageReference Include="Microsoft.Orleans.Clustering.Cosmos" Version="9.2.1" />
         <PackageReference Include="Microsoft.Orleans.Persistence.AzureStorage" Version="9.2.1"/>
+        <PackageReference Include="Microsoft.Orleans.Persistence.Cosmos" Version="9.2.1" />
         <PackageReference Include="Microsoft.Orleans.Persistence.Memory" Version="9.2.1"/>
         <PackageReference Include="Microsoft.Orleans.Server" Version="9.2.1"/>
         <PackageReference Include="Microsoft.Orleans.Streaming" Version="9.2.1"/>

--- a/internalUsages/OrleansSekiban.ApiService/OrleansSekiban.ApiService.csproj
+++ b/internalUsages/OrleansSekiban.ApiService/OrleansSekiban.ApiService.csproj
@@ -31,9 +31,9 @@
         <PackageReference Include="OrleansDashboard" Version="8.2.0"/>
         <PackageReference Include="Scalar.AspNetCore" Version="2.7.2" />
         <PackageReference Include="Microsoft.Orleans.Streaming.AzureStorage" Version="9.2.1"/>
-        <PackageReference Include="Sekiban.Pure.CosmosDb" Version="1.0.2-preview07"/>
-        <PackageReference Include="Sekiban.Pure.Orleans" Version="1.0.2-preview07"/>
-        <PackageReference Include="Sekiban.Pure.Postgres" Version="1.0.2-preview07"/>
+        <PackageReference Include="Sekiban.Pure.CosmosDb" Version="1.0.2-preview08"/>
+        <PackageReference Include="Sekiban.Pure.Orleans" Version="1.0.2-preview08"/>
+        <PackageReference Include="Sekiban.Pure.Postgres" Version="1.0.2-preview08"/>
     </ItemGroup>
 
 </Project>

--- a/internalUsages/OrleansSekiban.Unit/OrleansSekiban.Unit.csproj
+++ b/internalUsages/OrleansSekiban.Unit/OrleansSekiban.Unit.csproj
@@ -13,8 +13,8 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1"/>
-        <PackageReference Include="Sekiban.Pure.Orleans.xUnit" Version="1.0.2-preview07"/>
-        <PackageReference Include="Sekiban.Pure.xUnit" Version="1.0.2-preview07"/>
+        <PackageReference Include="Sekiban.Pure.Orleans.xUnit" Version="1.0.2-preview08"/>
+        <PackageReference Include="Sekiban.Pure.xUnit" Version="1.0.2-preview08"/>
         <PackageReference Include="xunit" Version="2.9.3"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4">
             <PrivateAssets>all</PrivateAssets>

--- a/src/Sekiban.Dcb.BlobStorage.AzureStorage/Sekiban.Dcb.BlobStorage.AzureStorage.csproj
+++ b/src/Sekiban.Dcb.BlobStorage.AzureStorage/Sekiban.Dcb.BlobStorage.AzureStorage.csproj
@@ -8,14 +8,14 @@
         <AssemblyName>Sekiban.Dcb.BlobStorage.AzureStorage</AssemblyName>
         <RootNamespace>Sekiban.Dcb.BlobStorage.AzureStorage</RootNamespace>
         <PackageId>Sekiban.Dcb.BlobStorage.AzureStorage</PackageId>
-        <Version>1.0.2-preview07</Version>
+        <Version>1.0.2-preview08</Version>
         <Authors>J-Tech Group</Authors>
         <Company>J-Tech-Japan</Company>
         <Copyright>Copyright (c) J-Tech-Japan 2025</Copyright>
         <PackageDescription>Sekiban - Dynamic Consistency Boundary Azure Blob Storage Integration</PackageDescription>
         <RepositoryUrl>https://github.com/J-Tech-Japan/Sekiban</RepositoryUrl>
         <PackageProjectUrl>https://github.com/J-Tech-Japan/Sekiban</PackageProjectUrl>
-        <PackageVersion>1.0.2-preview07</PackageVersion>
+        <PackageVersion>1.0.2-preview08</PackageVersion>
         <Description>Azure Blob Storage snapshot offloading for Sekiban DCB MultiProjection. Provides efficient binary snapshot storage for large projection states.</Description>
         <PackageTags>event-sourcing;cqrs;ddd;dcb;sekiban;azure;blob-storage;snapshots</PackageTags>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>

--- a/src/Sekiban.Dcb.CosmosDb/Sekiban.Dcb.CosmosDb.csproj
+++ b/src/Sekiban.Dcb.CosmosDb/Sekiban.Dcb.CosmosDb.csproj
@@ -8,14 +8,14 @@
         <AssemblyName>Sekiban.Dcb.CosmosDb</AssemblyName>
         <RootNamespace>Sekiban.Dcb.CosmosDb</RootNamespace>
         <PackageId>Sekiban.Dcb.CosmosDb</PackageId>
-        <Version>1.0.2-preview07</Version>
+        <Version>1.0.2-preview08</Version>
         <Authors>J-Tech Group</Authors>
         <Company>J-Tech-Japan</Company>
         <Copyright>Copyright (c) J-Tech-Japan 2025</Copyright>
         <PackageDescription>Sekiban - Dynamic Consistency Boundary CosmosDB Integration</PackageDescription>
         <RepositoryUrl>https://github.com/J-Tech-Japan/Sekiban</RepositoryUrl>
         <PackageProjectUrl>https://github.com/J-Tech-Japan/Sekiban</PackageProjectUrl>
-        <PackageVersion>1.0.2-preview07</PackageVersion>
+        <PackageVersion>1.0.2-preview08</PackageVersion>
         <Description>CosmosDB event store and persistence layer for Sekiban DCB</Description>
         <PackageTags>event-sourcing;cqrs;ddd;dcb;sekiban;cosmosdb;azure</PackageTags>
         <AnalysisLevel>latest-All</AnalysisLevel>

--- a/src/Sekiban.Dcb.Orleans/Grains/MultiProjectionGrain.cs
+++ b/src/Sekiban.Dcb.Orleans/Grains/MultiProjectionGrain.cs
@@ -365,12 +365,12 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
                 {
                     var unsafeSt = unsafeStateInfo.GetValue();
                     var safeSt = safeStateInfo.GetValue();
-                    Console.WriteLine($"[{this.GetPrimaryKeyString()}] Snapshot state - Safe: {safeSt.Version} events @ {safeSt.LastSortableUniqueId?.Substring(0, 20) ?? "empty"}, Unsafe: {unsafeSt.Version} events @ {unsafeSt.LastSortableUniqueId?.Substring(0, 20) ?? "empty"}");
+                    Console.WriteLine($"[{this.GetPrimaryKeyString()}] Snapshot state - Safe: {safeSt.Version} events @ {(safeSt.LastSortableUniqueId?.Length >= 20 ? safeSt.LastSortableUniqueId.Substring(0, 20) : safeSt.LastSortableUniqueId) ?? "empty"}, Unsafe: {unsafeSt.Version} events @ {(unsafeSt.LastSortableUniqueId?.Length >= 20 ? unsafeSt.LastSortableUniqueId.Substring(0, 20) : unsafeSt.LastSortableUniqueId) ?? "empty"}");
                 }
             }
             catch { }
             var storageProviderName = "OrleansStorage"; // 現在利用しているプロバイダ名想定
-            Console.WriteLine($"[{this.GetPrimaryKeyString()}] Writing snapshot: {data.Size:N0} bytes, {_eventsProcessed:N0} events, checkpoint: {data.SafeLastSortableUniqueId?.Substring(0, 20) ?? "empty"}...");
+            Console.WriteLine($"[{this.GetPrimaryKeyString()}] Writing snapshot: {data.Size:N0} bytes, {_eventsProcessed:N0} events, checkpoint: {(data.SafeLastSortableUniqueId?.Length >= 20 ? data.SafeLastSortableUniqueId.Substring(0, 20) : data.SafeLastSortableUniqueId) ?? "empty"}...");
 
             // Update grain state
             _state.State.ProjectorName = this.GetPrimaryKeyString();

--- a/src/Sekiban.Dcb.Orleans/Grains/OrleansTagStatePersistent.cs
+++ b/src/Sekiban.Dcb.Orleans/Grains/OrleansTagStatePersistent.cs
@@ -6,7 +6,7 @@ namespace Sekiban.Dcb.Orleans.Grains;
 ///     Orleans-specific implementation of ITagStatePersistent using grain state
 ///     Converts between TagState and SerializableTagState for storage
 /// </summary>
-internal class OrleansTagStatePersistent : ITagStatePersistent
+public class OrleansTagStatePersistent : ITagStatePersistent
 {
     private readonly IPersistentState<TagStateCacheState> _cache;
     private readonly ITagStatePayloadTypes _payloadTypes;

--- a/src/Sekiban.Dcb.Orleans/Grains/OrleansTagStatePersistent.cs
+++ b/src/Sekiban.Dcb.Orleans/Grains/OrleansTagStatePersistent.cs
@@ -1,27 +1,76 @@
 using Sekiban.Dcb.Tags;
+using Sekiban.Dcb.Domains;
 namespace Sekiban.Dcb.Orleans.Grains;
 
 /// <summary>
 ///     Orleans-specific implementation of ITagStatePersistent using grain state
+///     Converts between TagState and SerializableTagState for storage
 /// </summary>
 internal class OrleansTagStatePersistent : ITagStatePersistent
 {
     private readonly IPersistentState<TagStateCacheState> _cache;
+    private readonly ITagStatePayloadTypes _payloadTypes;
 
-    public OrleansTagStatePersistent(IPersistentState<TagStateCacheState> cache) => _cache = cache;
+    public OrleansTagStatePersistent(
+        IPersistentState<TagStateCacheState> cache,
+        ITagStatePayloadTypes payloadTypes)
+    {
+        _cache = cache;
+        _payloadTypes = payloadTypes;
+    }
 
     public Task<TagState?> LoadStateAsync()
     {
         if (_cache.State?.CachedState != null)
         {
-            return Task.FromResult<TagState?>(_cache.State.CachedState);
+            var serializable = _cache.State.CachedState;
+            
+            // Deserialize payload from SerializableTagState
+            var deserializeResult = _payloadTypes.DeserializePayload(
+                serializable.TagPayloadName,
+                serializable.Payload);
+            
+            if (!deserializeResult.IsSuccess)
+            {
+                throw new InvalidOperationException(
+                    $"Failed to deserialize payload: {deserializeResult.GetException().Message}");
+            }
+            
+            var tagState = new TagState(
+                deserializeResult.GetValue(),
+                serializable.Version,
+                serializable.LastSortedUniqueId,
+                serializable.TagGroup,
+                serializable.TagContent,
+                serializable.TagProjector,
+                serializable.ProjectorVersion);
+            
+            return Task.FromResult<TagState?>(tagState);
         }
         return Task.FromResult<TagState?>(null);
     }
 
     public async Task SaveStateAsync(TagState state)
     {
-        _cache.State = new TagStateCacheState { CachedState = state };
+        // Convert TagState to SerializableTagState
+        var serializeResult = _payloadTypes.SerializePayload(state.Payload);
+        if (!serializeResult.IsSuccess)
+        {
+            throw new InvalidOperationException(
+                $"Failed to serialize payload: {serializeResult.GetException().Message}");
+        }
+        
+        var serializable = new SerializableTagState(
+            serializeResult.GetValue(),
+            state.Version,
+            state.LastSortedUniqueId,
+            state.TagGroup,
+            state.TagContent,
+            state.TagProjector,
+            state.Payload.GetType().Name,
+            state.ProjectorVersion);
+        
+        _cache.State = new TagStateCacheState { CachedState = serializable };
         await _cache.WriteStateAsync();
     }
 

--- a/src/Sekiban.Dcb.Orleans/Grains/TagStateCacheState.cs
+++ b/src/Sekiban.Dcb.Orleans/Grains/TagStateCacheState.cs
@@ -3,10 +3,11 @@ namespace Sekiban.Dcb.Orleans.Grains;
 
 /// <summary>
 ///     State object for caching tag state in Orleans grain storage
+///     Uses SerializableTagState to avoid interface serialization issues
 /// </summary>
 [GenerateSerializer]
 public class TagStateCacheState
 {
     [Id(0)]
-    public TagState? CachedState { get; set; }
+    public SerializableTagState? CachedState { get; set; }
 }

--- a/src/Sekiban.Dcb.Orleans/Grains/TagStateGrain.cs
+++ b/src/Sekiban.Dcb.Orleans/Grains/TagStateGrain.cs
@@ -102,7 +102,7 @@ public class TagStateGrain : Grain, ITagStateGrain
         var tagStateId = this.GetPrimaryKeyString();
 
         // Create the actor instance with Orleans-specific cache persistence
-        var tagStatePersistent = new OrleansTagStatePersistent(_cache);
+        var tagStatePersistent = new OrleansTagStatePersistent(_cache, _domainTypes.TagStatePayloadTypes);
         _actor = new GeneralTagStateActor(
             tagStateId,
             _eventStore,

--- a/src/Sekiban.Dcb.Orleans/Sekiban.Dcb.Orleans.csproj
+++ b/src/Sekiban.Dcb.Orleans/Sekiban.Dcb.Orleans.csproj
@@ -8,14 +8,14 @@
         <AssemblyName>Sekiban.Dcb.Orleans</AssemblyName>
         <RootNamespace>Sekiban.Dcb.Orleans</RootNamespace>
         <PackageId>Sekiban.Dcb.Orleans</PackageId>
-        <Version>1.0.2-preview07</Version>
+        <Version>1.0.2-preview08</Version>
         <Authors>J-Tech Group</Authors>
         <Company>J-Tech-Japan</Company>
         <Copyright>Copyright (c) J-Tech-Japan 2025</Copyright>
         <PackageDescription>Sekiban - Dynamic Consistency Boundary Orleans Integration</PackageDescription>
         <RepositoryUrl>https://github.com/J-Tech-Japan/Sekiban</RepositoryUrl>
         <PackageProjectUrl>https://github.com/J-Tech-Japan/Sekiban</PackageProjectUrl>
-        <PackageVersion>1.0.2-preview07</PackageVersion>
+        <PackageVersion>1.0.2-preview08</PackageVersion>
         <Description>Orleans integration for Sekiban DCB with Multi-Projection Grains and Event Streaming</Description>
         <PackageTags>event-sourcing;cqrs;ddd;dcb;sekiban;orleans;actor-model</PackageTags>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/src/Sekiban.Dcb.Postgres/Sekiban.Dcb.Postgres.csproj
+++ b/src/Sekiban.Dcb.Postgres/Sekiban.Dcb.Postgres.csproj
@@ -8,14 +8,14 @@
         <AssemblyName>Sekiban.Dcb.Postgres</AssemblyName>
         <RootNamespace>Sekiban.Dcb.Postgres</RootNamespace>
         <PackageId>Sekiban.Dcb.Postgres</PackageId>
-        <Version>1.0.2-preview07</Version>
+        <Version>1.0.2-preview08</Version>
         <Authors>J-Tech Group</Authors>
         <Company>J-Tech-Japan</Company>
         <Copyright>Copyright (c) J-Tech-Japan 2025</Copyright>
         <PackageDescription>Sekiban - Dynamic Consistency Boundary PostgreSQL Integration</PackageDescription>
         <RepositoryUrl>https://github.com/J-Tech-Japan/Sekiban</RepositoryUrl>
         <PackageProjectUrl>https://github.com/J-Tech-Japan/Sekiban</PackageProjectUrl>
-        <PackageVersion>1.0.2-preview07</PackageVersion>
+        <PackageVersion>1.0.2-preview08</PackageVersion>
         <Description>PostgreSQL event store and persistence layer for Sekiban DCB</Description>
         <PackageTags>event-sourcing;cqrs;ddd;dcb;sekiban;postgresql;postgres</PackageTags>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>

--- a/src/Sekiban.Dcb/Domains/ITagStatePayloadTypes.cs
+++ b/src/Sekiban.Dcb/Domains/ITagStatePayloadTypes.cs
@@ -22,4 +22,11 @@ public interface ITagStatePayloadTypes
     /// <param name="jsonBytes">The JSON bytes to deserialize</param>
     /// <returns>ResultBox containing the deserialized payload or error</returns>
     ResultBox<ITagStatePayload> DeserializePayload(string payloadName, byte[] jsonBytes);
+
+    /// <summary>
+    ///     Serializes a tag state payload to JSON bytes
+    /// </summary>
+    /// <param name="payload">The payload to serialize</param>
+    /// <returns>ResultBox containing the serialized JSON bytes or error</returns>
+    ResultBox<byte[]> SerializePayload(ITagStatePayload payload);
 }

--- a/src/Sekiban.Dcb/Domains/SimpleTagStatePayloadTypes.cs
+++ b/src/Sekiban.Dcb/Domains/SimpleTagStatePayloadTypes.cs
@@ -62,6 +62,28 @@ public class SimpleTagStatePayloadTypes : ITagStatePayloadTypes
         }
     }
 
+    public ResultBox<byte[]> SerializePayload(ITagStatePayload payload)
+    {
+        try
+        {
+            // Special handling for empty payload
+            if (payload is EmptyTagStatePayload)
+            {
+                return ResultBox.FromValue(Array.Empty<byte>());
+            }
+
+            // Serialize the payload to JSON
+            var json = JsonSerializer.Serialize(payload, payload.GetType(), _jsonSerializerOptions);
+            var jsonBytes = Encoding.UTF8.GetBytes(json);
+
+            return ResultBox.FromValue(jsonBytes);
+        }
+        catch (Exception ex)
+        {
+            return ResultBox.Error<byte[]>(ex);
+        }
+    }
+
     public void RegisterPayloadType<T>(string? name = null) where T : ITagStatePayload
     {
         var payloadName = name ?? typeof(T).Name;

--- a/src/Sekiban.Dcb/Sekiban.Dcb.csproj
+++ b/src/Sekiban.Dcb/Sekiban.Dcb.csproj
@@ -8,14 +8,14 @@
         <AssemblyName>Sekiban.Dcb</AssemblyName>
         <RootNamespace>Sekiban.Dcb</RootNamespace>
         <PackageId>Sekiban.Dcb</PackageId>
-        <Version>1.0.2-preview07</Version>
+        <Version>1.0.2-preview08</Version>
         <Authors>J-Tech Group</Authors>
         <Company>J-Tech-Japan</Company>
         <Copyright>Copyright (c) J-Tech-Japan 2025</Copyright>
         <PackageDescription>Sekiban - Dynamic Consistency Boundary Event Sourcing Framework</PackageDescription>
         <RepositoryUrl>https://github.com/J-Tech-Japan/Sekiban</RepositoryUrl>
         <PackageProjectUrl>https://github.com/J-Tech-Japan/Sekiban</PackageProjectUrl>
-        <PackageVersion>1.0.2-preview07</PackageVersion>
+        <PackageVersion>1.0.2-preview08</PackageVersion>
         <Description>Dynamic Consistency Boundary implementation for Event Sourcing with Multi-Projection support</Description>
         <PackageTags>event-sourcing;cqrs;ddd;dcb;sekiban</PackageTags>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>

--- a/src/Sekiban.Pure.AspNetCore/Sekiban.Pure.AspNetCore.csproj
+++ b/src/Sekiban.Pure.AspNetCore/Sekiban.Pure.AspNetCore.csproj
@@ -5,12 +5,12 @@
         <Nullable>enable</Nullable>
         <LangVersion>preview</LangVersion>
         <PackageId>Sekiban.Pure.AspNetCore</PackageId>
-        <Version>1.0.2-preview07</Version>
+        <Version>1.0.2-preview08</Version>
         <Authors>J-Tech Group</Authors>
         <Company>J-Tech-Japan</Company>
         <PackageDescription>Sekiban - Pure Event Sourcing Framework AspNetCore Integration</PackageDescription>
         <RepositoryUrl>https://github.com/J-Tech-Japan/Sekiban</RepositoryUrl>
-        <PackageVersion>1.0.2-preview07</PackageVersion>
+        <PackageVersion>1.0.2-preview08</PackageVersion>
         <Description>Multi Blob saving and reading issue resolved</Description>
         <AssemblyName>Sekiban.Pure.AspNetCore</AssemblyName>
         <RootNamespace>Sekiban.Pure.AspNetCore</RootNamespace>
@@ -28,7 +28,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Sekiban.Pure" Version="1.0.2-preview07"/>
+        <PackageReference Include="Sekiban.Pure" Version="1.0.2-preview08"/>
         <ProjectReference Include="..\Sekiban.Pure\Sekiban.Pure.csproj"/>
         <PackageReference Include="Microsoft.Sbom.Targets" Version="4.1.2">
             <PrivateAssets>all</PrivateAssets>

--- a/src/Sekiban.Pure.CosmosDb/Sekiban.Pure.CosmosDb.csproj
+++ b/src/Sekiban.Pure.CosmosDb/Sekiban.Pure.CosmosDb.csproj
@@ -5,12 +5,12 @@
         <Nullable>enable</Nullable>
         <LangVersion>preview</LangVersion>
         <PackageId>Sekiban.Pure.CosmosDb</PackageId>
-        <Version>1.0.2-preview07</Version>
+        <Version>1.0.2-preview08</Version>
         <Authors>J-Tech Group</Authors>
         <Company>J-Tech-Japan</Company>
         <PackageDescription>Sekiban - Pure Event Sourcing Framework CosmosDB Integration</PackageDescription>
         <RepositoryUrl>https://github.com/J-Tech-Japan/Sekiban</RepositoryUrl>
-        <PackageVersion>1.0.2-preview07</PackageVersion>
+        <PackageVersion>1.0.2-preview08</PackageVersion>
         <Description>Multi Blob saving and reading issue resolved</Description>
         <AssemblyName>Sekiban.Pure.CosmosDb</AssemblyName>
         <RootNamespace>Sekiban.Pure.CosmosDb</RootNamespace>
@@ -37,7 +37,7 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <None Include="..\README.md" Pack="true" PackagePath="\"/>
-        <PackageReference Include="Sekiban.Pure.AspNetCore" Version="1.0.2-preview07"/>
+        <PackageReference Include="Sekiban.Pure.AspNetCore" Version="1.0.2-preview08"/>
     </ItemGroup>
 
 </Project>

--- a/src/Sekiban.Pure.Dapr/Sekiban.Pure.Dapr.csproj
+++ b/src/Sekiban.Pure.Dapr/Sekiban.Pure.Dapr.csproj
@@ -6,14 +6,14 @@
         <Nullable>enable</Nullable>
         <LangVersion>preview</LangVersion>
         <PackageId>Sekiban.Pure.Dapr</PackageId>
-        <Version>1.0.2-preview07</Version>
+        <Version>1.0.2-preview08</Version>
         <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
         <Title>Sekiban.Pure.Dapr</Title>
         <Description>Event Sourcing and CQRS Framework with Dapr integration</Description>
         <PackageDescription>Sekiban - Pure Event Sourcing Framework Dapr Integration</PackageDescription>
         <PackageProjectUrl>https://github.com/J-Tech-Japan/Sekiban</PackageProjectUrl>
         <PackageReadmeFile>README.md</PackageReadmeFile>
-        <PackageVersion>1.0.2-preview07</PackageVersion>
+        <PackageVersion>1.0.2-preview08</PackageVersion>
         <AssemblyName>Sekiban.Pure.Dapr</AssemblyName>
         <RootNamespace>Sekiban.Pure.Dapr</RootNamespace>
         <IncludeSymbols>true</IncludeSymbols>

--- a/src/Sekiban.Pure.NUnit/Sekiban.Pure.NUnit.csproj
+++ b/src/Sekiban.Pure.NUnit/Sekiban.Pure.NUnit.csproj
@@ -5,12 +5,12 @@
         <Nullable>enable</Nullable>
         <LangVersion>preview</LangVersion>
         <PackageId>Sekiban.Pure.NUnit</PackageId>
-        <Version>1.0.2-preview07</Version>
+        <Version>1.0.2-preview08</Version>
         <Authors>J-Tech Group</Authors>
         <Company>J-Tech-Japan</Company>
         <PackageDescription>Sekiban - Pure Event Sourcing Framework NUnit Integration</PackageDescription>
         <RepositoryUrl>https://github.com/J-Tech-Japan/Sekiban</RepositoryUrl>
-        <PackageVersion>1.0.2-preview07</PackageVersion>
+        <PackageVersion>1.0.2-preview08</PackageVersion>
         <Description>Multi Blob saving and reading issue resolved</Description>
         <AssemblyName>Sekiban.Pure.NUnit</AssemblyName>
         <RootNamespace>Sekiban.Pure.NUnit</RootNamespace>
@@ -35,7 +35,7 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <None Include="..\README.md" Pack="true" PackagePath="\"/>
-        <PackageReference Include="Sekiban.Pure.AspNetCore" Version="1.0.2-preview07"/>
+        <PackageReference Include="Sekiban.Pure.AspNetCore" Version="1.0.2-preview08"/>
     </ItemGroup>
 
 </Project>

--- a/src/Sekiban.Pure.Orleans.NUnit/Sekiban.Pure.Orleans.NUnit.csproj
+++ b/src/Sekiban.Pure.Orleans.NUnit/Sekiban.Pure.Orleans.NUnit.csproj
@@ -7,12 +7,12 @@
         <Nullable>enable</Nullable>
         <LangVersion>preview</LangVersion>
         <PackageId>Sekiban.Pure.Orleans.NUnit</PackageId>
-        <Version>1.0.2-preview07</Version>
+        <Version>1.0.2-preview08</Version>
         <Authors>J-Tech Group</Authors>
         <Company>J-Tech-Japan</Company>
         <PackageDescription>Sekiban - Pure Event Sourcing Framework Orleans NUnit Integration</PackageDescription>
         <RepositoryUrl>https://github.com/J-Tech-Japan/Sekiban</RepositoryUrl>
-        <PackageVersion>1.0.2-preview07</PackageVersion>
+        <PackageVersion>1.0.2-preview08</PackageVersion>
         <Description>Multi Blob saving and reading issue resolved</Description>
         <AssemblyName>Sekiban.Pure.Orleans.NUnit</AssemblyName>
         <RootNamespace>Sekiban.Pure.Orleans.NUnit</RootNamespace>
@@ -39,7 +39,7 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <None Include="..\README.md" Pack="true" PackagePath="\"/>
-        <PackageReference Include="Sekiban.Pure.Orleans" Version="1.0.2-preview07"/>
+        <PackageReference Include="Sekiban.Pure.Orleans" Version="1.0.2-preview08"/>
     </ItemGroup>
 
 </Project>

--- a/src/Sekiban.Pure.Orleans.xUnit/Sekiban.Pure.Orleans.xUnit.csproj
+++ b/src/Sekiban.Pure.Orleans.xUnit/Sekiban.Pure.Orleans.xUnit.csproj
@@ -7,12 +7,12 @@
         <Nullable>enable</Nullable>
         <LangVersion>preview</LangVersion>
         <PackageId>Sekiban.Pure.Orleans.xUnit</PackageId>
-        <Version>1.0.2-preview07</Version>
+        <Version>1.0.2-preview08</Version>
         <Authors>J-Tech Group</Authors>
         <Company>J-Tech-Japan</Company>
         <PackageDescription>Sekiban - Pure Event Sourcing Framework Orleans xUnit Integration</PackageDescription>
         <RepositoryUrl>https://github.com/J-Tech-Japan/Sekiban</RepositoryUrl>
-        <PackageVersion>1.0.2-preview07</PackageVersion>
+        <PackageVersion>1.0.2-preview08</PackageVersion>
         <Description>Multi Blob saving and reading issue resolved</Description>
         <AssemblyName>Sekiban.Pure.Orleans.xUnit</AssemblyName>
         <RootNamespace>Sekiban.Pure.Orleans.xUnit</RootNamespace>
@@ -31,7 +31,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.Orleans.TestingHost" Version="9.2.1"/>
-        <PackageReference Include="Sekiban.Pure.Orleans" Version="1.0.2-preview07"/>
+        <PackageReference Include="Sekiban.Pure.Orleans" Version="1.0.2-preview08"/>
         <PackageReference Include="xunit" Version="2.9.3"/>
         <PackageReference Include="Microsoft.Sbom.Targets" Version="4.1.2">
             <PrivateAssets>all</PrivateAssets>

--- a/src/Sekiban.Pure.Orleans/Sekiban.Pure.Orleans.csproj
+++ b/src/Sekiban.Pure.Orleans/Sekiban.Pure.Orleans.csproj
@@ -5,12 +5,12 @@
         <Nullable>enable</Nullable>
         <LangVersion>preview</LangVersion>
         <PackageId>Sekiban.Pure.Orleans</PackageId>
-        <Version>1.0.2-preview07</Version>
+        <Version>1.0.2-preview08</Version>
         <Authors>J-Tech Group</Authors>
         <Company>J-Tech-Japan</Company>
         <PackageDescription>Sekiban - Pure Event Sourcing Framework Orleans Integration</PackageDescription>
         <RepositoryUrl>https://github.com/J-Tech-Japan/Sekiban</RepositoryUrl>
-        <PackageVersion>1.0.2-preview07</PackageVersion>
+        <PackageVersion>1.0.2-preview08</PackageVersion>
         <Description>Multi Blob saving and reading issue resolved</Description>
         <AssemblyName>Sekiban.Pure.Orleans</AssemblyName>
         <RootNamespace>Sekiban.Pure.Orleans</RootNamespace>
@@ -31,7 +31,7 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <None Include="..\README.md" Pack="true" PackagePath="\"/>
-        <PackageReference Include="Sekiban.Pure.AspNetCore" Version="1.0.2-preview07"/>
+        <PackageReference Include="Sekiban.Pure.AspNetCore" Version="1.0.2-preview08"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Sekiban.Pure.Postgres/Sekiban.Pure.Postgres.csproj
+++ b/src/Sekiban.Pure.Postgres/Sekiban.Pure.Postgres.csproj
@@ -5,12 +5,12 @@
         <Nullable>enable</Nullable>
         <LangVersion>preview</LangVersion>
         <PackageId>Sekiban.Pure.Postgres</PackageId>
-        <Version>1.0.2-preview07</Version>
+        <Version>1.0.2-preview08</Version>
         <Authors>J-Tech Group</Authors>
         <Company>J-Tech-Japan</Company>
         <PackageDescription>Sekiban - Pure Event Sourcing Framework PostgreSQL Integration</PackageDescription>
         <RepositoryUrl>https://github.com/J-Tech-Japan/Sekiban</RepositoryUrl>
-        <PackageVersion>1.0.2-preview07</PackageVersion>
+        <PackageVersion>1.0.2-preview08</PackageVersion>
         <Description>Multi Blob saving and reading issue resolved</Description>
         <AssemblyName>Sekiban.Pure.Postgres</AssemblyName>
         <RootNamespace>Sekiban.Pure.Postgres</RootNamespace>
@@ -33,7 +33,7 @@
         <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.8"/>
         <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.8"/>
         <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4"/>
-        <PackageReference Include="Sekiban.Pure.AspNetCore" Version="1.0.2-preview07"/>
+        <PackageReference Include="Sekiban.Pure.AspNetCore" Version="1.0.2-preview08"/>
         <PackageReference Include="System.Configuration.ConfigurationManager" Version="9.0.8"/>
         <PackageReference Include="Microsoft.Sbom.Targets" Version="4.1.2">
             <PrivateAssets>all</PrivateAssets>

--- a/src/Sekiban.Pure.ReadModel/Sekiban.Pure.ReadModel.csproj
+++ b/src/Sekiban.Pure.ReadModel/Sekiban.Pure.ReadModel.csproj
@@ -6,12 +6,12 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <PackageId>Sekiban.Pure.ReadModel</PackageId>
-        <Version>1.0.2-preview07</Version>
+        <Version>1.0.2-preview08</Version>
         <Authors>J-Tech Group</Authors>
         <Company>J-Tech-Japan</Company>
         <PackageDescription>Sekiban - Pure Event Sourcing Framework Orleans Integration</PackageDescription>
         <RepositoryUrl>https://github.com/J-Tech-Japan/Sekiban</RepositoryUrl>
-        <PackageVersion>1.0.2-preview07</PackageVersion>
+        <PackageVersion>1.0.2-preview08</PackageVersion>
         <Description>Multi Blob saving and reading issue resolved</Description>
         <AssemblyName>Sekiban.Pure.ReadModel</AssemblyName>
         <RootNamespace>Sekiban.Pure.ReadModel</RootNamespace>
@@ -25,7 +25,7 @@
 
     <ItemGroup>
         <ProjectReference Include="..\Sekiban.Pure\Sekiban.Pure.csproj"/>
-        <PackageReference Include="Sekiban.Pure" Version="1.0.2-preview07"/>
+        <PackageReference Include="Sekiban.Pure" Version="1.0.2-preview08"/>
         <None Include="..\README.md" Pack="true" PackagePath="\"/>
         <PackageReference Include="Microsoft.Sbom.Targets" Version="4.1.2">
             <PrivateAssets>all</PrivateAssets>

--- a/src/Sekiban.Pure.SourceGenerator/Sekiban.Pure.SourceGenerator.csproj
+++ b/src/Sekiban.Pure.SourceGenerator/Sekiban.Pure.SourceGenerator.csproj
@@ -4,12 +4,12 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <PackageId>Sekiban.Pure.SourceGenerator</PackageId>
-        <Version>1.0.2-preview07</Version>
+        <Version>1.0.2-preview08</Version>
         <Authors>J-Tech Group</Authors>
         <Company>J-Tech-Japan</Company>
         <PackageDescription>Sekiban - Pure Event Sourcing Framework Source Generator</PackageDescription>
         <RepositoryUrl>https://github.com/J-Tech-Japan/Sekiban</RepositoryUrl>
-        <PackageVersion>1.0.2-preview07</PackageVersion>
+        <PackageVersion>1.0.2-preview08</PackageVersion>
         <Description>Multi Blob saving and reading issue resolved</Description>
         <AssemblyName>Sekiban.Pure.SourceGenerator</AssemblyName>
         <RootNamespace>Sekiban.Pure.SourceGenerator</RootNamespace>

--- a/src/Sekiban.Pure.xUnit/Sekiban.Pure.xUnit.csproj
+++ b/src/Sekiban.Pure.xUnit/Sekiban.Pure.xUnit.csproj
@@ -5,12 +5,12 @@
         <Nullable>enable</Nullable>
         <LangVersion>preview</LangVersion>
         <PackageId>Sekiban.Pure.xUnit</PackageId>
-        <Version>1.0.2-preview07</Version>
+        <Version>1.0.2-preview08</Version>
         <Authors>J-Tech Group</Authors>
         <Company>J-Tech-Japan</Company>
         <PackageDescription>Sekiban - Pure Event Sourcing Framework xUnit Integration</PackageDescription>
         <RepositoryUrl>https://github.com/J-Tech-Japan/Sekiban</RepositoryUrl>
-        <PackageVersion>1.0.2-preview07</PackageVersion>
+        <PackageVersion>1.0.2-preview08</PackageVersion>
         <Description>Multi Blob saving and reading issue resolved</Description>
         <AssemblyName>Sekiban.Pure.xUnit</AssemblyName>
         <RootNamespace>Sekiban.Pure.xUnit</RootNamespace>
@@ -34,7 +34,7 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <None Include="..\README.md" Pack="true" PackagePath="\"/>
-        <PackageReference Include="Sekiban.Pure.AspNetCore" Version="1.0.2-preview07"/>
+        <PackageReference Include="Sekiban.Pure.AspNetCore" Version="1.0.2-preview08"/>
     </ItemGroup>
 
 </Project>

--- a/src/Sekiban.Pure/Sekiban.Pure.csproj
+++ b/src/Sekiban.Pure/Sekiban.Pure.csproj
@@ -5,12 +5,12 @@
         <Nullable>enable</Nullable>
         <LangVersion>preview</LangVersion>
         <PackageId>Sekiban.Pure</PackageId>
-        <Version>1.0.2-preview07</Version>
+        <Version>1.0.2-preview08</Version>
         <Authors>J-Tech Group</Authors>
         <Company>J-Tech-Japan</Company>
         <PackageDescription>Sekiban - Pure Event Sourcing Framework</PackageDescription>
         <RepositoryUrl>https://github.com/J-Tech-Japan/Sekiban</RepositoryUrl>
-        <PackageVersion>1.0.2-preview07</PackageVersion>
+        <PackageVersion>1.0.2-preview08</PackageVersion>
         <Description>Multi Blob saving and reading issue resolved</Description>
         <AssemblyName>Sekiban.Pure</AssemblyName>
         <RootNamespace>Sekiban.Pure</RootNamespace>

--- a/tests/Sekiban.Dcb.BlobStorage.AzureStorage.Unit/AzuriteTestFixture.cs
+++ b/tests/Sekiban.Dcb.BlobStorage.AzureStorage.Unit/AzuriteTestFixture.cs
@@ -20,9 +20,9 @@ public class AzuriteTestFixture : IAsyncLifetime
         // Generate unique container name to avoid conflicts
         var containerName = $"azurite-test-{Guid.NewGuid():N}";
         
-        // Start new Azurite container with random ports to avoid conflicts
+        // Start new Azurite container with random ports to avoid conflicts and skip API version check
         var result = await RunCommandAsync("docker", 
-            $"run -d --name {containerName} -P mcr.microsoft.com/azure-storage/azurite");
+            $"run -d --name {containerName} -P mcr.microsoft.com/azure-storage/azurite azurite --skipApiVersionCheck");
         
         _containerId = result.Trim();
         Console.WriteLine($"Started Azurite container: {_containerId}");

--- a/tests/Sekiban.Dcb.Orleans.Tests/MinimalOrleansTests.cs
+++ b/tests/Sekiban.Dcb.Orleans.Tests/MinimalOrleansTests.cs
@@ -183,6 +183,16 @@ public class MinimalOrleansTests : IAsyncLifetime
                     services.AddSingleton<IEventStore, InMemoryEventStore>();
                     services.AddSingleton<IEventSubscriptionResolver>(
                         new DefaultOrleansEventSubscriptionResolver("EventStreamProvider", "AllEvents", Guid.Empty));
+                    // Add mock IBlobStorageSnapshotAccessor for tests
+                    services.AddSingleton<Sekiban.Dcb.Snapshots.IBlobStorageSnapshotAccessor, MockBlobStorageSnapshotAccessor>();
+                    // Add event statistics for MultiProjectionGrain
+                    services.AddTransient<Sekiban.Dcb.MultiProjections.IMultiProjectionEventStatistics, Sekiban.Dcb.MultiProjections.NoOpMultiProjectionEventStatistics>();
+                    // Add actor options for MultiProjectionGrain
+                    services.AddTransient<Sekiban.Dcb.Actors.GeneralMultiProjectionActorOptions>(_ => new Sekiban.Dcb.Actors.GeneralMultiProjectionActorOptions
+                    {
+                        SafeWindowMs = 20000,
+                        SnapshotOffloadThresholdBytes = 2 * 1024 * 1024
+                    });
                 })
                 .AddMemoryGrainStorageAsDefault()
                 .AddMemoryGrainStorage("OrleansStorage")

--- a/tests/Sekiban.Dcb.Orleans.Tests/MockBlobStorageSnapshotAccessor.cs
+++ b/tests/Sekiban.Dcb.Orleans.Tests/MockBlobStorageSnapshotAccessor.cs
@@ -1,0 +1,26 @@
+using Sekiban.Dcb.Snapshots;
+
+namespace Sekiban.Dcb.Orleans.Tests;
+
+/// <summary>
+/// Mock implementation of IBlobStorageSnapshotAccessor for testing
+/// </summary>
+public class MockBlobStorageSnapshotAccessor : IBlobStorageSnapshotAccessor
+{
+    private readonly Dictionary<string, byte[]> _storage = new();
+
+    public string ProviderName => "MockStorage";
+
+    public Task<string> WriteAsync(byte[] data, string projectorName, CancellationToken cancellationToken = default)
+    {
+        var key = $"{projectorName}-{Guid.NewGuid():N}";
+        _storage[key] = data;
+        return Task.FromResult(key);
+    }
+
+    public Task<byte[]> ReadAsync(string key, CancellationToken cancellationToken = default)
+    {
+        _storage.TryGetValue(key, out var data);
+        return Task.FromResult(data ?? Array.Empty<byte>());
+    }
+}

--- a/tests/Sekiban.Dcb.Orleans.Tests/OrleansTagStatePersistentTests.cs
+++ b/tests/Sekiban.Dcb.Orleans.Tests/OrleansTagStatePersistentTests.cs
@@ -1,4 +1,3 @@
-using Orleans.TestingHost;
 using Sekiban.Dcb.Domains;
 using Sekiban.Dcb.Orleans.Grains;
 using Sekiban.Dcb.Tags;
@@ -7,22 +6,21 @@ using Xunit;
 
 namespace Sekiban.Dcb.Orleans.Tests;
 
-public class OrleansTagStatePersistentTests : IClassFixture<TestClusterFixture>
+public class OrleansTagStatePersistentTests
 {
-    private readonly TestCluster _cluster;
     private readonly ITagStatePayloadTypes _payloadTypes;
 
-    public OrleansTagStatePersistentTests(TestClusterFixture fixture)
+    public OrleansTagStatePersistentTests()
     {
-        _cluster = fixture.Cluster;
-        _payloadTypes = new SimpleTagStatePayloadTypes(new JsonSerializerOptions
+        var simpleTypes = new SimpleTagStatePayloadTypes(new JsonSerializerOptions
         {
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
             WriteIndented = true
         });
         
         // Register test payload types
-        _payloadTypes.RegisterPayloadType<TestStatePayload>();
+        simpleTypes.RegisterPayloadType<TestStatePayload>();
+        _payloadTypes = simpleTypes;
     }
 
     [Fact]

--- a/tests/Sekiban.Dcb.Orleans.Tests/OrleansTagStatePersistentTests.cs
+++ b/tests/Sekiban.Dcb.Orleans.Tests/OrleansTagStatePersistentTests.cs
@@ -1,0 +1,180 @@
+using Orleans.TestingHost;
+using Sekiban.Dcb.Domains;
+using Sekiban.Dcb.Orleans.Grains;
+using Sekiban.Dcb.Tags;
+using System.Text.Json;
+using Xunit;
+
+namespace Sekiban.Dcb.Orleans.Tests;
+
+public class OrleansTagStatePersistentTests : IClassFixture<TestClusterFixture>
+{
+    private readonly TestCluster _cluster;
+    private readonly ITagStatePayloadTypes _payloadTypes;
+
+    public OrleansTagStatePersistentTests(TestClusterFixture fixture)
+    {
+        _cluster = fixture.Cluster;
+        _payloadTypes = new SimpleTagStatePayloadTypes(new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            WriteIndented = true
+        });
+        
+        // Register test payload types
+        _payloadTypes.RegisterPayloadType<TestStatePayload>();
+    }
+
+    [Fact]
+    public async Task SaveAndLoadState_WithSerializableTagState_ShouldSucceed()
+    {
+        // Arrange
+        var testPayload = new TestStatePayload
+        {
+            Id = Guid.NewGuid(),
+            Name = "Test State",
+            Value = 100
+        };
+
+        var originalState = new TagState(
+            testPayload,
+            1,
+            "unique-id-123",
+            "TestGroup",
+            "TestContent",
+            "TestProjector",
+            "1.0.0");
+
+        // Create in-memory cache state for testing
+        var cacheState = new TagStateCacheState();
+        var persistentState = new TestPersistentState<TagStateCacheState>(cacheState);
+        
+        var persistent = new OrleansTagStatePersistent(persistentState, _payloadTypes);
+
+        // Act - Save
+        await persistent.SaveStateAsync(originalState);
+
+        // Assert - Saved as SerializableTagState
+        Assert.NotNull(persistentState.State.CachedState);
+        var serializable = persistentState.State.CachedState;
+        Assert.Equal(originalState.Version, serializable.Version);
+        Assert.Equal(originalState.TagGroup, serializable.TagGroup);
+        Assert.Equal(nameof(TestStatePayload), serializable.TagPayloadName);
+        Assert.NotEmpty(serializable.Payload);
+
+        // Act - Load
+        var loadedState = await persistent.LoadStateAsync();
+
+        // Assert - Loaded correctly
+        Assert.NotNull(loadedState);
+        Assert.Equal(originalState.Version, loadedState.Version);
+        Assert.Equal(originalState.TagGroup, loadedState.TagGroup);
+        Assert.Equal(originalState.TagContent, loadedState.TagContent);
+        
+        var loadedPayload = loadedState.Payload as TestStatePayload;
+        Assert.NotNull(loadedPayload);
+        Assert.Equal(testPayload.Id, loadedPayload.Id);
+        Assert.Equal(testPayload.Name, loadedPayload.Name);
+        Assert.Equal(testPayload.Value, loadedPayload.Value);
+    }
+
+    [Fact]
+    public async Task LoadState_WithEmptyCache_ShouldReturnNull()
+    {
+        // Arrange
+        var cacheState = new TagStateCacheState();
+        var persistentState = new TestPersistentState<TagStateCacheState>(cacheState);
+        var persistent = new OrleansTagStatePersistent(persistentState, _payloadTypes);
+
+        // Act
+        var result = await persistent.LoadStateAsync();
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task ClearState_ShouldRemoveCachedState()
+    {
+        // Arrange
+        var testPayload = new TestStatePayload { Id = Guid.NewGuid(), Name = "Test" };
+        var state = new TagState(testPayload, 1, "id", "group", "content", "projector", "1.0");
+        
+        var cacheState = new TagStateCacheState();
+        var persistentState = new TestPersistentState<TagStateCacheState>(cacheState);
+        var persistent = new OrleansTagStatePersistent(persistentState, _payloadTypes);
+
+        await persistent.SaveStateAsync(state);
+        Assert.NotNull(persistentState.State.CachedState);
+
+        // Act
+        await persistent.ClearStateAsync();
+
+        // Assert
+        Assert.Null(persistentState.State.CachedState);
+    }
+
+    [Fact]
+    public async Task SaveAndLoad_WithEmptyTagStatePayload_ShouldSucceed()
+    {
+        // Arrange
+        var emptyPayload = new EmptyTagStatePayload();
+        var state = new TagState(
+            emptyPayload,
+            0,
+            string.Empty,
+            "EmptyGroup",
+            "EmptyContent",
+            "EmptyProjector",
+            "1.0.0");
+
+        var cacheState = new TagStateCacheState();
+        var persistentState = new TestPersistentState<TagStateCacheState>(cacheState);
+        var persistent = new OrleansTagStatePersistent(persistentState, _payloadTypes);
+
+        // Act
+        await persistent.SaveStateAsync(state);
+        var loaded = await persistent.LoadStateAsync();
+
+        // Assert
+        Assert.NotNull(loaded);
+        Assert.IsType<EmptyTagStatePayload>(loaded.Payload);
+        Assert.Equal(state.Version, loaded.Version);
+        Assert.Equal(state.TagGroup, loaded.TagGroup);
+    }
+
+    // Test helper class
+    private class TestPersistentState<T> : IPersistentState<T> where T : new()
+    {
+        public TestPersistentState(T state)
+        {
+            State = state;
+        }
+
+        public T State { get; set; }
+        public string Etag => "test-etag";
+        public bool RecordExists => State != null;
+
+        public Task ClearStateAsync()
+        {
+            State = new T();
+            return Task.CompletedTask;
+        }
+
+        public Task ReadStateAsync() => Task.CompletedTask;
+
+        public Task WriteStateAsync()
+        {
+            // Simulate write
+            return Task.CompletedTask;
+        }
+    }
+
+    // Test payload type
+    public record TestStatePayload : ITagStatePayload
+    {
+        public Guid Id { get; init; }
+        public string Name { get; init; } = string.Empty;
+        public int Value { get; init; }
+    }
+}

--- a/tests/Sekiban.Dcb.Orleans.Tests/SimpleOrleansCommandQueryTests.cs
+++ b/tests/Sekiban.Dcb.Orleans.Tests/SimpleOrleansCommandQueryTests.cs
@@ -506,6 +506,16 @@ public class SimpleOrleansCommandQueryTests : IAsyncLifetime
                     services.AddSingleton<IEventSubscriptionResolver>(
                         new DefaultOrleansEventSubscriptionResolver("EventStreamProvider", "AllEvents", Guid.Empty));
                     services.AddSingleton<IActorObjectAccessor, OrleansActorObjectAccessor>();
+                    // Add mock IBlobStorageSnapshotAccessor for tests
+                    services.AddSingleton<Sekiban.Dcb.Snapshots.IBlobStorageSnapshotAccessor, MockBlobStorageSnapshotAccessor>();
+                    // Add event statistics for MultiProjectionGrain
+                    services.AddTransient<Sekiban.Dcb.MultiProjections.IMultiProjectionEventStatistics, Sekiban.Dcb.MultiProjections.NoOpMultiProjectionEventStatistics>();
+                    // Add actor options for MultiProjectionGrain
+                    services.AddTransient<Sekiban.Dcb.Actors.GeneralMultiProjectionActorOptions>(_ => new Sekiban.Dcb.Actors.GeneralMultiProjectionActorOptions
+                    {
+                        SafeWindowMs = 20000,
+                        SnapshotOffloadThresholdBytes = 2 * 1024 * 1024
+                    });
                 })
                 .AddMemoryGrainStorageAsDefault()
                 .AddMemoryGrainStorage("OrleansStorage")

--- a/tests/Sekiban.Dcb.Orleans.Tests/Support/CounterProjector.cs
+++ b/tests/Sekiban.Dcb.Orleans.Tests/Support/CounterProjector.cs
@@ -9,7 +9,7 @@ using Sekiban.Dcb.Tags;
 namespace Sekiban.Dcb.Orleans.Tests;
 
 [GenerateSerializer]
-public record CounterProjector([property: Id(0)] int Count) : IMultiProjector<CounterProjector>
+public record CounterProjector([property: Id(0)] int Count) : IMultiProjectorWithCustomSerialization<CounterProjector>
 {
     public CounterProjector() : this(0) {}
     public static string MultiProjectorVersion => "1.0";

--- a/tests/Sekiban.Dcb.Tests/TagStateSerializationTests.cs
+++ b/tests/Sekiban.Dcb.Tests/TagStateSerializationTests.cs
@@ -1,0 +1,164 @@
+using ResultBoxes;
+using Sekiban.Dcb.Domains;
+using Sekiban.Dcb.Tags;
+using System.Text.Json;
+using Xunit;
+
+namespace Sekiban.Dcb.Tests;
+
+public class TagStateSerializationTests
+{
+    private readonly ITagStatePayloadTypes _payloadTypes;
+
+    public TagStateSerializationTests()
+    {
+        var simpleTypes = new SimpleTagStatePayloadTypes(new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            WriteIndented = true
+        });
+        
+        // Register test payload types
+        simpleTypes.RegisterPayloadType<TestPayload>();
+        simpleTypes.RegisterPayloadType<ComplexTestPayload>();
+        
+        _payloadTypes = simpleTypes;
+    }
+
+    [Fact]
+    public void SerializePayload_WithSimplePayload_ShouldSucceed()
+    {
+        // Arrange
+        var payload = new TestPayload { Value = "test", Number = 42 };
+
+        // Act
+        var result = _payloadTypes.SerializePayload(payload);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        var bytes = result.GetValue();
+        Assert.NotEmpty(bytes);
+    }
+
+    [Fact]
+    public void DeserializePayload_WithSimplePayload_ShouldRecreateOriginal()
+    {
+        // Arrange
+        var original = new TestPayload { Value = "test", Number = 42 };
+        var serializeResult = _payloadTypes.SerializePayload(original);
+        Assert.True(serializeResult.IsSuccess);
+        var bytes = serializeResult.GetValue();
+
+        // Act
+        var deserializeResult = _payloadTypes.DeserializePayload(nameof(TestPayload), bytes);
+
+        // Assert
+        Assert.True(deserializeResult.IsSuccess);
+        var deserialized = deserializeResult.GetValue() as TestPayload;
+        Assert.NotNull(deserialized);
+        Assert.Equal(original.Value, deserialized.Value);
+        Assert.Equal(original.Number, deserialized.Number);
+    }
+
+    [Fact]
+    public void SerializePayload_WithEmptyPayload_ShouldReturnEmptyBytes()
+    {
+        // Arrange
+        var payload = new EmptyTagStatePayload();
+
+        // Act
+        var result = _payloadTypes.SerializePayload(payload);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        var bytes = result.GetValue();
+        Assert.Empty(bytes);
+    }
+
+    [Fact]
+    public void DeserializePayload_WithEmptyPayload_ShouldSucceed()
+    {
+        // Arrange & Act
+        var result = _payloadTypes.DeserializePayload(nameof(EmptyTagStatePayload), Array.Empty<byte>());
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        var payload = result.GetValue();
+        Assert.IsType<EmptyTagStatePayload>(payload);
+    }
+
+    [Fact]
+    public void SerializePayload_WithComplexPayload_ShouldSucceed()
+    {
+        // Arrange
+        var payload = new ComplexTestPayload
+        {
+            Id = Guid.NewGuid(),
+            Items = new List<string> { "item1", "item2", "item3" },
+            Metadata = new Dictionary<string, object>
+            {
+                ["key1"] = "value1",
+                ["key2"] = 123
+            },
+            CreatedAt = DateTimeOffset.UtcNow
+        };
+
+        // Act
+        var serializeResult = _payloadTypes.SerializePayload(payload);
+        Assert.True(serializeResult.IsSuccess);
+        var bytes = serializeResult.GetValue();
+
+        var deserializeResult = _payloadTypes.DeserializePayload(nameof(ComplexTestPayload), bytes);
+
+        // Assert
+        Assert.True(deserializeResult.IsSuccess);
+        var deserialized = deserializeResult.GetValue() as ComplexTestPayload;
+        Assert.NotNull(deserialized);
+        Assert.Equal(payload.Id, deserialized.Id);
+        Assert.Equal(payload.Items, deserialized.Items);
+        Assert.Equal(payload.CreatedAt, deserialized.CreatedAt);
+    }
+
+    [Fact]
+    public void DeserializePayload_WithUnregisteredType_ShouldReturnError()
+    {
+        // Arrange
+        var bytes = System.Text.Encoding.UTF8.GetBytes("{}");
+
+        // Act
+        var result = _payloadTypes.DeserializePayload("UnregisteredType", bytes);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        var error = result.GetException();
+        Assert.Contains("not registered", error.Message);
+    }
+
+    [Fact]
+    public void DeserializePayload_WithInvalidJson_ShouldReturnError()
+    {
+        // Arrange
+        var bytes = System.Text.Encoding.UTF8.GetBytes("invalid json");
+
+        // Act
+        var result = _payloadTypes.DeserializePayload(nameof(TestPayload), bytes);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+    }
+
+    // Test payload types
+    public record TestPayload : ITagStatePayload
+    {
+        public string Value { get; init; } = string.Empty;
+        public int Number { get; init; }
+    }
+
+    public record ComplexTestPayload : ITagStatePayload
+    {
+        public Guid Id { get; init; }
+        public List<string> Items { get; init; } = new();
+        public Dictionary<string, object> Metadata { get; init; } = new();
+        public DateTimeOffset CreatedAt { get; init; }
+    }
+}


### PR DESCRIPTION
Implement serialization and deserialization for tag state payloads in OrleansTagStatePersistent, improve logging in MultiProjectionGrain, and update Sekiban packages to version 1.0.2-preview08. Add comprehensive tests and mock implementations for better testing capabilities.