### PR TITLE
Update package versions to 1.0.2-preview09 and add new tag group interfaces

### DIFF
--- a/internalUsages/Dcb.Domain/Student/StudentTag.cs
+++ b/internalUsages/Dcb.Domain/Student/StudentTag.cs
@@ -16,3 +16,22 @@ public record StudentTag(Guid StudentId) : IGuidTagGroup<StudentTag>
     /// </summary>
     public Guid GetId() => StudentId;
 }
+
+public record YearlyStudentsTag(int Year) : IIntTagGroup<YearlyStudentsTag>
+{
+
+    public bool IsConsistencyTag() => true;
+    public string GetTagContent() => Year.ToString();
+    public static string TagGroupName => "YearlyStudents";
+    public int GetId() => Year;
+    static YearlyStudentsTag ITagGroup<YearlyStudentsTag>.FromContent(string content) => new(int.Parse(content));
+}
+
+public record StudentCodeTag(string StudentCode) : IStringTagGroup<StudentCodeTag>
+{
+    public bool IsConsistencyTag() => false;
+    public string GetTagContent() => StudentCode;
+    public static string TagGroupName => "StudentCode";
+    public string GetId() => StudentCode;
+    static StudentCodeTag ITagGroup<StudentCodeTag>.FromContent(string content) => new(content);
+}

--- a/internalUsages/OrleansSekiban.ApiService/OrleansSekiban.ApiService.csproj
+++ b/internalUsages/OrleansSekiban.ApiService/OrleansSekiban.ApiService.csproj
@@ -31,9 +31,9 @@
         <PackageReference Include="OrleansDashboard" Version="8.2.0"/>
         <PackageReference Include="Scalar.AspNetCore" Version="2.7.2" />
         <PackageReference Include="Microsoft.Orleans.Streaming.AzureStorage" Version="9.2.1"/>
-        <PackageReference Include="Sekiban.Pure.CosmosDb" Version="1.0.2-preview08"/>
-        <PackageReference Include="Sekiban.Pure.Orleans" Version="1.0.2-preview08"/>
-        <PackageReference Include="Sekiban.Pure.Postgres" Version="1.0.2-preview08"/>
+        <PackageReference Include="Sekiban.Pure.CosmosDb" Version="1.0.2-preview09"/>
+        <PackageReference Include="Sekiban.Pure.Orleans" Version="1.0.2-preview09"/>
+        <PackageReference Include="Sekiban.Pure.Postgres" Version="1.0.2-preview09"/>
     </ItemGroup>
 
 </Project>

--- a/internalUsages/OrleansSekiban.Unit/OrleansSekiban.Unit.csproj
+++ b/internalUsages/OrleansSekiban.Unit/OrleansSekiban.Unit.csproj
@@ -13,8 +13,8 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1"/>
-        <PackageReference Include="Sekiban.Pure.Orleans.xUnit" Version="1.0.2-preview08"/>
-        <PackageReference Include="Sekiban.Pure.xUnit" Version="1.0.2-preview08"/>
+        <PackageReference Include="Sekiban.Pure.Orleans.xUnit" Version="1.0.2-preview09"/>
+        <PackageReference Include="Sekiban.Pure.xUnit" Version="1.0.2-preview09"/>
         <PackageReference Include="xunit" Version="2.9.3"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4">
             <PrivateAssets>all</PrivateAssets>

--- a/src/Sekiban.Dcb.BlobStorage.AzureStorage/Sekiban.Dcb.BlobStorage.AzureStorage.csproj
+++ b/src/Sekiban.Dcb.BlobStorage.AzureStorage/Sekiban.Dcb.BlobStorage.AzureStorage.csproj
@@ -8,14 +8,14 @@
         <AssemblyName>Sekiban.Dcb.BlobStorage.AzureStorage</AssemblyName>
         <RootNamespace>Sekiban.Dcb.BlobStorage.AzureStorage</RootNamespace>
         <PackageId>Sekiban.Dcb.BlobStorage.AzureStorage</PackageId>
-        <Version>1.0.2-preview08</Version>
+        <Version>1.0.2-preview09</Version>
         <Authors>J-Tech Group</Authors>
         <Company>J-Tech-Japan</Company>
         <Copyright>Copyright (c) J-Tech-Japan 2025</Copyright>
         <PackageDescription>Sekiban - Dynamic Consistency Boundary Azure Blob Storage Integration</PackageDescription>
         <RepositoryUrl>https://github.com/J-Tech-Japan/Sekiban</RepositoryUrl>
         <PackageProjectUrl>https://github.com/J-Tech-Japan/Sekiban</PackageProjectUrl>
-        <PackageVersion>1.0.2-preview08</PackageVersion>
+        <PackageVersion>1.0.2-preview09</PackageVersion>
         <Description>Azure Blob Storage snapshot offloading for Sekiban DCB MultiProjection. Provides efficient binary snapshot storage for large projection states.</Description>
         <PackageTags>event-sourcing;cqrs;ddd;dcb;sekiban;azure;blob-storage;snapshots</PackageTags>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>

--- a/src/Sekiban.Dcb.CosmosDb/Sekiban.Dcb.CosmosDb.csproj
+++ b/src/Sekiban.Dcb.CosmosDb/Sekiban.Dcb.CosmosDb.csproj
@@ -8,14 +8,14 @@
         <AssemblyName>Sekiban.Dcb.CosmosDb</AssemblyName>
         <RootNamespace>Sekiban.Dcb.CosmosDb</RootNamespace>
         <PackageId>Sekiban.Dcb.CosmosDb</PackageId>
-        <Version>1.0.2-preview08</Version>
+        <Version>1.0.2-preview09</Version>
         <Authors>J-Tech Group</Authors>
         <Company>J-Tech-Japan</Company>
         <Copyright>Copyright (c) J-Tech-Japan 2025</Copyright>
         <PackageDescription>Sekiban - Dynamic Consistency Boundary CosmosDB Integration</PackageDescription>
         <RepositoryUrl>https://github.com/J-Tech-Japan/Sekiban</RepositoryUrl>
         <PackageProjectUrl>https://github.com/J-Tech-Japan/Sekiban</PackageProjectUrl>
-        <PackageVersion>1.0.2-preview08</PackageVersion>
+        <PackageVersion>1.0.2-preview09</PackageVersion>
         <Description>CosmosDB event store and persistence layer for Sekiban DCB</Description>
         <PackageTags>event-sourcing;cqrs;ddd;dcb;sekiban;cosmosdb;azure</PackageTags>
         <AnalysisLevel>latest-All</AnalysisLevel>

--- a/src/Sekiban.Dcb.Orleans/Sekiban.Dcb.Orleans.csproj
+++ b/src/Sekiban.Dcb.Orleans/Sekiban.Dcb.Orleans.csproj
@@ -8,14 +8,14 @@
         <AssemblyName>Sekiban.Dcb.Orleans</AssemblyName>
         <RootNamespace>Sekiban.Dcb.Orleans</RootNamespace>
         <PackageId>Sekiban.Dcb.Orleans</PackageId>
-        <Version>1.0.2-preview08</Version>
+        <Version>1.0.2-preview09</Version>
         <Authors>J-Tech Group</Authors>
         <Company>J-Tech-Japan</Company>
         <Copyright>Copyright (c) J-Tech-Japan 2025</Copyright>
         <PackageDescription>Sekiban - Dynamic Consistency Boundary Orleans Integration</PackageDescription>
         <RepositoryUrl>https://github.com/J-Tech-Japan/Sekiban</RepositoryUrl>
         <PackageProjectUrl>https://github.com/J-Tech-Japan/Sekiban</PackageProjectUrl>
-        <PackageVersion>1.0.2-preview08</PackageVersion>
+        <PackageVersion>1.0.2-preview09</PackageVersion>
         <Description>Orleans integration for Sekiban DCB with Multi-Projection Grains and Event Streaming</Description>
         <PackageTags>event-sourcing;cqrs;ddd;dcb;sekiban;orleans;actor-model</PackageTags>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/src/Sekiban.Dcb.Postgres/Sekiban.Dcb.Postgres.csproj
+++ b/src/Sekiban.Dcb.Postgres/Sekiban.Dcb.Postgres.csproj
@@ -8,14 +8,14 @@
         <AssemblyName>Sekiban.Dcb.Postgres</AssemblyName>
         <RootNamespace>Sekiban.Dcb.Postgres</RootNamespace>
         <PackageId>Sekiban.Dcb.Postgres</PackageId>
-        <Version>1.0.2-preview08</Version>
+        <Version>1.0.2-preview09</Version>
         <Authors>J-Tech Group</Authors>
         <Company>J-Tech-Japan</Company>
         <Copyright>Copyright (c) J-Tech-Japan 2025</Copyright>
         <PackageDescription>Sekiban - Dynamic Consistency Boundary PostgreSQL Integration</PackageDescription>
         <RepositoryUrl>https://github.com/J-Tech-Japan/Sekiban</RepositoryUrl>
         <PackageProjectUrl>https://github.com/J-Tech-Japan/Sekiban</PackageProjectUrl>
-        <PackageVersion>1.0.2-preview08</PackageVersion>
+        <PackageVersion>1.0.2-preview09</PackageVersion>
         <Description>PostgreSQL event store and persistence layer for Sekiban DCB</Description>
         <PackageTags>event-sourcing;cqrs;ddd;dcb;sekiban;postgresql;postgres</PackageTags>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>

--- a/src/Sekiban.Dcb/Sekiban.Dcb.csproj
+++ b/src/Sekiban.Dcb/Sekiban.Dcb.csproj
@@ -8,14 +8,14 @@
         <AssemblyName>Sekiban.Dcb</AssemblyName>
         <RootNamespace>Sekiban.Dcb</RootNamespace>
         <PackageId>Sekiban.Dcb</PackageId>
-        <Version>1.0.2-preview08</Version>
+        <Version>1.0.2-preview09</Version>
         <Authors>J-Tech Group</Authors>
         <Company>J-Tech-Japan</Company>
         <Copyright>Copyright (c) J-Tech-Japan 2025</Copyright>
         <PackageDescription>Sekiban - Dynamic Consistency Boundary Event Sourcing Framework</PackageDescription>
         <RepositoryUrl>https://github.com/J-Tech-Japan/Sekiban</RepositoryUrl>
         <PackageProjectUrl>https://github.com/J-Tech-Japan/Sekiban</PackageProjectUrl>
-        <PackageVersion>1.0.2-preview08</PackageVersion>
+        <PackageVersion>1.0.2-preview09</PackageVersion>
         <Description>Dynamic Consistency Boundary implementation for Event Sourcing with Multi-Projection support</Description>
         <PackageTags>event-sourcing;cqrs;ddd;dcb;sekiban</PackageTags>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>

--- a/src/Sekiban.Dcb/Tags/IGuidTagGroup.cs
+++ b/src/Sekiban.Dcb/Tags/IGuidTagGroup.cs
@@ -15,5 +15,16 @@ public interface IGuidTagGroup<TTagGroup> : ITagGroup<TTagGroup> where TTagGroup
     /// </summary>
     /// <returns>The GUID identifier</returns>
     Guid GetId();
-    static abstract new TTagGroup FromContent(string content);
+}
+
+public interface IStringTagGroup<TTagGroup> : ITagGroup<TTagGroup> where TTagGroup : IStringTagGroup<TTagGroup>
+{
+
+    // Re-declare static abstract members to avoid CS8920
+    static abstract new string TagGroupName { get; }
+    /// <summary>
+    ///     Get the string identifier for this tag
+    /// </summary>
+    /// <returns>The string identifier</returns>
+    string GetId();
 }

--- a/src/Sekiban.Dcb/Tags/IIntTagGroup.cs
+++ b/src/Sekiban.Dcb/Tags/IIntTagGroup.cs
@@ -1,0 +1,13 @@
+namespace Sekiban.Dcb.Tags;
+
+public interface IIntTagGroup<TTagGroup> : ITagGroup<TTagGroup> where TTagGroup : IIntTagGroup<TTagGroup>
+{
+
+    // Re-declare static abstract members to avoid CS8920
+    static abstract new string TagGroupName { get; }
+    /// <summary>
+    ///     Get the GUID identifier for this tag
+    /// </summary>
+    /// <returns>The GUID identifier</returns>
+    int GetId();
+}

--- a/src/Sekiban.Pure.AspNetCore/Sekiban.Pure.AspNetCore.csproj
+++ b/src/Sekiban.Pure.AspNetCore/Sekiban.Pure.AspNetCore.csproj
@@ -5,12 +5,12 @@
         <Nullable>enable</Nullable>
         <LangVersion>preview</LangVersion>
         <PackageId>Sekiban.Pure.AspNetCore</PackageId>
-        <Version>1.0.2-preview08</Version>
+        <Version>1.0.2-preview09</Version>
         <Authors>J-Tech Group</Authors>
         <Company>J-Tech-Japan</Company>
         <PackageDescription>Sekiban - Pure Event Sourcing Framework AspNetCore Integration</PackageDescription>
         <RepositoryUrl>https://github.com/J-Tech-Japan/Sekiban</RepositoryUrl>
-        <PackageVersion>1.0.2-preview08</PackageVersion>
+        <PackageVersion>1.0.2-preview09</PackageVersion>
         <Description>Multi Blob saving and reading issue resolved</Description>
         <AssemblyName>Sekiban.Pure.AspNetCore</AssemblyName>
         <RootNamespace>Sekiban.Pure.AspNetCore</RootNamespace>
@@ -28,7 +28,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Sekiban.Pure" Version="1.0.2-preview08"/>
+        <PackageReference Include="Sekiban.Pure" Version="1.0.2-preview09"/>
         <ProjectReference Include="..\Sekiban.Pure\Sekiban.Pure.csproj"/>
         <PackageReference Include="Microsoft.Sbom.Targets" Version="4.1.2">
             <PrivateAssets>all</PrivateAssets>

--- a/src/Sekiban.Pure.CosmosDb/Sekiban.Pure.CosmosDb.csproj
+++ b/src/Sekiban.Pure.CosmosDb/Sekiban.Pure.CosmosDb.csproj
@@ -5,12 +5,12 @@
         <Nullable>enable</Nullable>
         <LangVersion>preview</LangVersion>
         <PackageId>Sekiban.Pure.CosmosDb</PackageId>
-        <Version>1.0.2-preview08</Version>
+        <Version>1.0.2-preview09</Version>
         <Authors>J-Tech Group</Authors>
         <Company>J-Tech-Japan</Company>
         <PackageDescription>Sekiban - Pure Event Sourcing Framework CosmosDB Integration</PackageDescription>
         <RepositoryUrl>https://github.com/J-Tech-Japan/Sekiban</RepositoryUrl>
-        <PackageVersion>1.0.2-preview08</PackageVersion>
+        <PackageVersion>1.0.2-preview09</PackageVersion>
         <Description>Multi Blob saving and reading issue resolved</Description>
         <AssemblyName>Sekiban.Pure.CosmosDb</AssemblyName>
         <RootNamespace>Sekiban.Pure.CosmosDb</RootNamespace>
@@ -37,7 +37,7 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <None Include="..\README.md" Pack="true" PackagePath="\"/>
-        <PackageReference Include="Sekiban.Pure.AspNetCore" Version="1.0.2-preview08"/>
+        <PackageReference Include="Sekiban.Pure.AspNetCore" Version="1.0.2-preview09"/>
     </ItemGroup>
 
 </Project>

--- a/src/Sekiban.Pure.Dapr/Sekiban.Pure.Dapr.csproj
+++ b/src/Sekiban.Pure.Dapr/Sekiban.Pure.Dapr.csproj
@@ -6,14 +6,14 @@
         <Nullable>enable</Nullable>
         <LangVersion>preview</LangVersion>
         <PackageId>Sekiban.Pure.Dapr</PackageId>
-        <Version>1.0.2-preview08</Version>
+        <Version>1.0.2-preview09</Version>
         <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
         <Title>Sekiban.Pure.Dapr</Title>
         <Description>Event Sourcing and CQRS Framework with Dapr integration</Description>
         <PackageDescription>Sekiban - Pure Event Sourcing Framework Dapr Integration</PackageDescription>
         <PackageProjectUrl>https://github.com/J-Tech-Japan/Sekiban</PackageProjectUrl>
         <PackageReadmeFile>README.md</PackageReadmeFile>
-        <PackageVersion>1.0.2-preview08</PackageVersion>
+        <PackageVersion>1.0.2-preview09</PackageVersion>
         <AssemblyName>Sekiban.Pure.Dapr</AssemblyName>
         <RootNamespace>Sekiban.Pure.Dapr</RootNamespace>
         <IncludeSymbols>true</IncludeSymbols>

--- a/src/Sekiban.Pure.NUnit/Sekiban.Pure.NUnit.csproj
+++ b/src/Sekiban.Pure.NUnit/Sekiban.Pure.NUnit.csproj
@@ -5,12 +5,12 @@
         <Nullable>enable</Nullable>
         <LangVersion>preview</LangVersion>
         <PackageId>Sekiban.Pure.NUnit</PackageId>
-        <Version>1.0.2-preview08</Version>
+        <Version>1.0.2-preview09</Version>
         <Authors>J-Tech Group</Authors>
         <Company>J-Tech-Japan</Company>
         <PackageDescription>Sekiban - Pure Event Sourcing Framework NUnit Integration</PackageDescription>
         <RepositoryUrl>https://github.com/J-Tech-Japan/Sekiban</RepositoryUrl>
-        <PackageVersion>1.0.2-preview08</PackageVersion>
+        <PackageVersion>1.0.2-preview09</PackageVersion>
         <Description>Multi Blob saving and reading issue resolved</Description>
         <AssemblyName>Sekiban.Pure.NUnit</AssemblyName>
         <RootNamespace>Sekiban.Pure.NUnit</RootNamespace>
@@ -35,7 +35,7 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <None Include="..\README.md" Pack="true" PackagePath="\"/>
-        <PackageReference Include="Sekiban.Pure.AspNetCore" Version="1.0.2-preview08"/>
+        <PackageReference Include="Sekiban.Pure.AspNetCore" Version="1.0.2-preview09"/>
     </ItemGroup>
 
 </Project>

--- a/src/Sekiban.Pure.Orleans.NUnit/Sekiban.Pure.Orleans.NUnit.csproj
+++ b/src/Sekiban.Pure.Orleans.NUnit/Sekiban.Pure.Orleans.NUnit.csproj
@@ -7,12 +7,12 @@
         <Nullable>enable</Nullable>
         <LangVersion>preview</LangVersion>
         <PackageId>Sekiban.Pure.Orleans.NUnit</PackageId>
-        <Version>1.0.2-preview08</Version>
+        <Version>1.0.2-preview09</Version>
         <Authors>J-Tech Group</Authors>
         <Company>J-Tech-Japan</Company>
         <PackageDescription>Sekiban - Pure Event Sourcing Framework Orleans NUnit Integration</PackageDescription>
         <RepositoryUrl>https://github.com/J-Tech-Japan/Sekiban</RepositoryUrl>
-        <PackageVersion>1.0.2-preview08</PackageVersion>
+        <PackageVersion>1.0.2-preview09</PackageVersion>
         <Description>Multi Blob saving and reading issue resolved</Description>
         <AssemblyName>Sekiban.Pure.Orleans.NUnit</AssemblyName>
         <RootNamespace>Sekiban.Pure.Orleans.NUnit</RootNamespace>
@@ -39,7 +39,7 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <None Include="..\README.md" Pack="true" PackagePath="\"/>
-        <PackageReference Include="Sekiban.Pure.Orleans" Version="1.0.2-preview08"/>
+        <PackageReference Include="Sekiban.Pure.Orleans" Version="1.0.2-preview09"/>
     </ItemGroup>
 
 </Project>

--- a/src/Sekiban.Pure.Orleans.xUnit/Sekiban.Pure.Orleans.xUnit.csproj
+++ b/src/Sekiban.Pure.Orleans.xUnit/Sekiban.Pure.Orleans.xUnit.csproj
@@ -7,12 +7,12 @@
         <Nullable>enable</Nullable>
         <LangVersion>preview</LangVersion>
         <PackageId>Sekiban.Pure.Orleans.xUnit</PackageId>
-        <Version>1.0.2-preview08</Version>
+        <Version>1.0.2-preview09</Version>
         <Authors>J-Tech Group</Authors>
         <Company>J-Tech-Japan</Company>
         <PackageDescription>Sekiban - Pure Event Sourcing Framework Orleans xUnit Integration</PackageDescription>
         <RepositoryUrl>https://github.com/J-Tech-Japan/Sekiban</RepositoryUrl>
-        <PackageVersion>1.0.2-preview08</PackageVersion>
+        <PackageVersion>1.0.2-preview09</PackageVersion>
         <Description>Multi Blob saving and reading issue resolved</Description>
         <AssemblyName>Sekiban.Pure.Orleans.xUnit</AssemblyName>
         <RootNamespace>Sekiban.Pure.Orleans.xUnit</RootNamespace>
@@ -31,7 +31,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.Orleans.TestingHost" Version="9.2.1"/>
-        <PackageReference Include="Sekiban.Pure.Orleans" Version="1.0.2-preview08"/>
+        <PackageReference Include="Sekiban.Pure.Orleans" Version="1.0.2-preview09"/>
         <PackageReference Include="xunit" Version="2.9.3"/>
         <PackageReference Include="Microsoft.Sbom.Targets" Version="4.1.2">
             <PrivateAssets>all</PrivateAssets>

--- a/src/Sekiban.Pure.Orleans/Sekiban.Pure.Orleans.csproj
+++ b/src/Sekiban.Pure.Orleans/Sekiban.Pure.Orleans.csproj
@@ -5,12 +5,12 @@
         <Nullable>enable</Nullable>
         <LangVersion>preview</LangVersion>
         <PackageId>Sekiban.Pure.Orleans</PackageId>
-        <Version>1.0.2-preview08</Version>
+        <Version>1.0.2-preview09</Version>
         <Authors>J-Tech Group</Authors>
         <Company>J-Tech-Japan</Company>
         <PackageDescription>Sekiban - Pure Event Sourcing Framework Orleans Integration</PackageDescription>
         <RepositoryUrl>https://github.com/J-Tech-Japan/Sekiban</RepositoryUrl>
-        <PackageVersion>1.0.2-preview08</PackageVersion>
+        <PackageVersion>1.0.2-preview09</PackageVersion>
         <Description>Multi Blob saving and reading issue resolved</Description>
         <AssemblyName>Sekiban.Pure.Orleans</AssemblyName>
         <RootNamespace>Sekiban.Pure.Orleans</RootNamespace>
@@ -31,7 +31,7 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <None Include="..\README.md" Pack="true" PackagePath="\"/>
-        <PackageReference Include="Sekiban.Pure.AspNetCore" Version="1.0.2-preview08"/>
+        <PackageReference Include="Sekiban.Pure.AspNetCore" Version="1.0.2-preview09"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Sekiban.Pure.Postgres/Sekiban.Pure.Postgres.csproj
+++ b/src/Sekiban.Pure.Postgres/Sekiban.Pure.Postgres.csproj
@@ -5,12 +5,12 @@
         <Nullable>enable</Nullable>
         <LangVersion>preview</LangVersion>
         <PackageId>Sekiban.Pure.Postgres</PackageId>
-        <Version>1.0.2-preview08</Version>
+        <Version>1.0.2-preview09</Version>
         <Authors>J-Tech Group</Authors>
         <Company>J-Tech-Japan</Company>
         <PackageDescription>Sekiban - Pure Event Sourcing Framework PostgreSQL Integration</PackageDescription>
         <RepositoryUrl>https://github.com/J-Tech-Japan/Sekiban</RepositoryUrl>
-        <PackageVersion>1.0.2-preview08</PackageVersion>
+        <PackageVersion>1.0.2-preview09</PackageVersion>
         <Description>Multi Blob saving and reading issue resolved</Description>
         <AssemblyName>Sekiban.Pure.Postgres</AssemblyName>
         <RootNamespace>Sekiban.Pure.Postgres</RootNamespace>
@@ -33,7 +33,7 @@
         <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.8"/>
         <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.8"/>
         <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4"/>
-        <PackageReference Include="Sekiban.Pure.AspNetCore" Version="1.0.2-preview08"/>
+        <PackageReference Include="Sekiban.Pure.AspNetCore" Version="1.0.2-preview09"/>
         <PackageReference Include="System.Configuration.ConfigurationManager" Version="9.0.8"/>
         <PackageReference Include="Microsoft.Sbom.Targets" Version="4.1.2">
             <PrivateAssets>all</PrivateAssets>

--- a/src/Sekiban.Pure.ReadModel/Sekiban.Pure.ReadModel.csproj
+++ b/src/Sekiban.Pure.ReadModel/Sekiban.Pure.ReadModel.csproj
@@ -6,12 +6,12 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <PackageId>Sekiban.Pure.ReadModel</PackageId>
-        <Version>1.0.2-preview08</Version>
+        <Version>1.0.2-preview09</Version>
         <Authors>J-Tech Group</Authors>
         <Company>J-Tech-Japan</Company>
         <PackageDescription>Sekiban - Pure Event Sourcing Framework Orleans Integration</PackageDescription>
         <RepositoryUrl>https://github.com/J-Tech-Japan/Sekiban</RepositoryUrl>
-        <PackageVersion>1.0.2-preview08</PackageVersion>
+        <PackageVersion>1.0.2-preview09</PackageVersion>
         <Description>Multi Blob saving and reading issue resolved</Description>
         <AssemblyName>Sekiban.Pure.ReadModel</AssemblyName>
         <RootNamespace>Sekiban.Pure.ReadModel</RootNamespace>
@@ -25,7 +25,7 @@
 
     <ItemGroup>
         <ProjectReference Include="..\Sekiban.Pure\Sekiban.Pure.csproj"/>
-        <PackageReference Include="Sekiban.Pure" Version="1.0.2-preview08"/>
+        <PackageReference Include="Sekiban.Pure" Version="1.0.2-preview09"/>
         <None Include="..\README.md" Pack="true" PackagePath="\"/>
         <PackageReference Include="Microsoft.Sbom.Targets" Version="4.1.2">
             <PrivateAssets>all</PrivateAssets>

--- a/src/Sekiban.Pure.SourceGenerator/Sekiban.Pure.SourceGenerator.csproj
+++ b/src/Sekiban.Pure.SourceGenerator/Sekiban.Pure.SourceGenerator.csproj
@@ -4,12 +4,12 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <PackageId>Sekiban.Pure.SourceGenerator</PackageId>
-        <Version>1.0.2-preview08</Version>
+        <Version>1.0.2-preview09</Version>
         <Authors>J-Tech Group</Authors>
         <Company>J-Tech-Japan</Company>
         <PackageDescription>Sekiban - Pure Event Sourcing Framework Source Generator</PackageDescription>
         <RepositoryUrl>https://github.com/J-Tech-Japan/Sekiban</RepositoryUrl>
-        <PackageVersion>1.0.2-preview08</PackageVersion>
+        <PackageVersion>1.0.2-preview09</PackageVersion>
         <Description>Multi Blob saving and reading issue resolved</Description>
         <AssemblyName>Sekiban.Pure.SourceGenerator</AssemblyName>
         <RootNamespace>Sekiban.Pure.SourceGenerator</RootNamespace>

--- a/src/Sekiban.Pure.xUnit/Sekiban.Pure.xUnit.csproj
+++ b/src/Sekiban.Pure.xUnit/Sekiban.Pure.xUnit.csproj
@@ -5,12 +5,12 @@
         <Nullable>enable</Nullable>
         <LangVersion>preview</LangVersion>
         <PackageId>Sekiban.Pure.xUnit</PackageId>
-        <Version>1.0.2-preview08</Version>
+        <Version>1.0.2-preview09</Version>
         <Authors>J-Tech Group</Authors>
         <Company>J-Tech-Japan</Company>
         <PackageDescription>Sekiban - Pure Event Sourcing Framework xUnit Integration</PackageDescription>
         <RepositoryUrl>https://github.com/J-Tech-Japan/Sekiban</RepositoryUrl>
-        <PackageVersion>1.0.2-preview08</PackageVersion>
+        <PackageVersion>1.0.2-preview09</PackageVersion>
         <Description>Multi Blob saving and reading issue resolved</Description>
         <AssemblyName>Sekiban.Pure.xUnit</AssemblyName>
         <RootNamespace>Sekiban.Pure.xUnit</RootNamespace>
@@ -34,7 +34,7 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <None Include="..\README.md" Pack="true" PackagePath="\"/>
-        <PackageReference Include="Sekiban.Pure.AspNetCore" Version="1.0.2-preview08"/>
+        <PackageReference Include="Sekiban.Pure.AspNetCore" Version="1.0.2-preview09"/>
     </ItemGroup>
 
 </Project>

--- a/src/Sekiban.Pure/Sekiban.Pure.csproj
+++ b/src/Sekiban.Pure/Sekiban.Pure.csproj
@@ -5,12 +5,12 @@
         <Nullable>enable</Nullable>
         <LangVersion>preview</LangVersion>
         <PackageId>Sekiban.Pure</PackageId>
-        <Version>1.0.2-preview08</Version>
+        <Version>1.0.2-preview09</Version>
         <Authors>J-Tech Group</Authors>
         <Company>J-Tech-Japan</Company>
         <PackageDescription>Sekiban - Pure Event Sourcing Framework</PackageDescription>
         <RepositoryUrl>https://github.com/J-Tech-Japan/Sekiban</RepositoryUrl>
-        <PackageVersion>1.0.2-preview08</PackageVersion>
+        <PackageVersion>1.0.2-preview09</PackageVersion>
         <Description>Multi Blob saving and reading issue resolved</Description>
         <AssemblyName>Sekiban.Pure</AssemblyName>
         <RootNamespace>Sekiban.Pure</RootNamespace>


### PR DESCRIPTION
Upgrade several package versions to 1.0.2-preview09 and introduce new interfaces for tag groups, enhancing the framework's extensibility.