### PR TITLE
Bump package versions to 9.1.2 and add generic method for tag state retrieval

### DIFF
--- a/src/Sekiban.Dcb.BlobStorage.AzureStorage/Sekiban.Dcb.BlobStorage.AzureStorage.csproj
+++ b/src/Sekiban.Dcb.BlobStorage.AzureStorage/Sekiban.Dcb.BlobStorage.AzureStorage.csproj
@@ -8,14 +8,14 @@
         <AssemblyName>Sekiban.Dcb.BlobStorage.AzureStorage</AssemblyName>
         <RootNamespace>Sekiban.Dcb.BlobStorage.AzureStorage</RootNamespace>
         <PackageId>Sekiban.Dcb.BlobStorage.AzureStorage</PackageId>
-        <Version>9.1.1</Version>
+        <Version>9.1.2</Version>
         <Authors>J-Tech Group</Authors>
         <Company>J-Tech-Japan</Company>
         <Copyright>Copyright (c) J-Tech-Japan 2025</Copyright>
         <PackageDescription>Sekiban - Dynamic Consistency Boundary Azure Blob Storage Integration</PackageDescription>
         <RepositoryUrl>https://github.com/J-Tech-Japan/Sekiban</RepositoryUrl>
         <PackageProjectUrl>https://github.com/J-Tech-Japan/Sekiban</PackageProjectUrl>
-        <PackageVersion>9.1.1</PackageVersion>
+        <PackageVersion>9.1.2</PackageVersion>
         <Description>Azure Blob Storage snapshot offloading for Sekiban DCB MultiProjection. Provides efficient binary snapshot storage for large projection states.</Description>
         <PackageTags>event-sourcing;cqrs;ddd;dcb;sekiban;azure;blob-storage;snapshots</PackageTags>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>

--- a/src/Sekiban.Dcb.CosmosDb/Sekiban.Dcb.CosmosDb.csproj
+++ b/src/Sekiban.Dcb.CosmosDb/Sekiban.Dcb.CosmosDb.csproj
@@ -8,14 +8,14 @@
         <AssemblyName>Sekiban.Dcb.CosmosDb</AssemblyName>
         <RootNamespace>Sekiban.Dcb.CosmosDb</RootNamespace>
         <PackageId>Sekiban.Dcb.CosmosDb</PackageId>
-        <Version>9.1.1</Version>
+        <Version>9.1.2</Version>
         <Authors>J-Tech Group</Authors>
         <Company>J-Tech-Japan</Company>
         <Copyright>Copyright (c) J-Tech-Japan 2025</Copyright>
         <PackageDescription>Sekiban - Dynamic Consistency Boundary CosmosDB Integration</PackageDescription>
         <RepositoryUrl>https://github.com/J-Tech-Japan/Sekiban</RepositoryUrl>
         <PackageProjectUrl>https://github.com/J-Tech-Japan/Sekiban</PackageProjectUrl>
-        <PackageVersion>9.1.1</PackageVersion>
+        <PackageVersion>9.1.2</PackageVersion>
         <Description>CosmosDB event store and persistence layer for Sekiban DCB</Description>
         <PackageTags>event-sourcing;cqrs;ddd;dcb;sekiban;cosmosdb;azure</PackageTags>
         <AnalysisLevel>latest-All</AnalysisLevel>

--- a/src/Sekiban.Dcb.Orleans/Sekiban.Dcb.Orleans.csproj
+++ b/src/Sekiban.Dcb.Orleans/Sekiban.Dcb.Orleans.csproj
@@ -8,14 +8,14 @@
         <AssemblyName>Sekiban.Dcb.Orleans</AssemblyName>
         <RootNamespace>Sekiban.Dcb.Orleans</RootNamespace>
         <PackageId>Sekiban.Dcb.Orleans</PackageId>
-        <Version>9.1.1</Version>
+        <Version>9.1.2</Version>
         <Authors>J-Tech Group</Authors>
         <Company>J-Tech-Japan</Company>
         <Copyright>Copyright (c) J-Tech-Japan 2025</Copyright>
         <PackageDescription>Sekiban - Dynamic Consistency Boundary Orleans Integration</PackageDescription>
         <RepositoryUrl>https://github.com/J-Tech-Japan/Sekiban</RepositoryUrl>
         <PackageProjectUrl>https://github.com/J-Tech-Japan/Sekiban</PackageProjectUrl>
-        <PackageVersion>9.1.1</PackageVersion>
+        <PackageVersion>9.1.2</PackageVersion>
         <Description>Orleans integration for Sekiban DCB with Multi-Projection Grains and Event Streaming</Description>
         <PackageTags>event-sourcing;cqrs;ddd;dcb;sekiban;orleans;actor-model</PackageTags>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/src/Sekiban.Dcb.Postgres/Sekiban.Dcb.Postgres.csproj
+++ b/src/Sekiban.Dcb.Postgres/Sekiban.Dcb.Postgres.csproj
@@ -8,14 +8,14 @@
         <AssemblyName>Sekiban.Dcb.Postgres</AssemblyName>
         <RootNamespace>Sekiban.Dcb.Postgres</RootNamespace>
         <PackageId>Sekiban.Dcb.Postgres</PackageId>
-        <Version>9.1.1</Version>
+        <Version>9.1.2</Version>
         <Authors>J-Tech Group</Authors>
         <Company>J-Tech-Japan</Company>
         <Copyright>Copyright (c) J-Tech-Japan 2025</Copyright>
         <PackageDescription>Sekiban - Dynamic Consistency Boundary PostgreSQL Integration</PackageDescription>
         <RepositoryUrl>https://github.com/J-Tech-Japan/Sekiban</RepositoryUrl>
         <PackageProjectUrl>https://github.com/J-Tech-Japan/Sekiban</PackageProjectUrl>
-        <PackageVersion>9.1.1</PackageVersion>
+        <PackageVersion>9.1.2</PackageVersion>
         <Description>PostgreSQL event store and persistence layer for Sekiban DCB</Description>
         <PackageTags>event-sourcing;cqrs;ddd;dcb;sekiban;postgresql;postgres</PackageTags>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>

--- a/src/Sekiban.Dcb/ISekibanExecutor.cs
+++ b/src/Sekiban.Dcb/ISekibanExecutor.cs
@@ -16,6 +16,7 @@ public interface ISekibanExecutor : ICommandExecutor
     /// <param name="tagStateId">The tag state identifier</param>
     /// <returns>ResultBox containing the tag state or error</returns>
     Task<ResultBox<TagState>> GetTagStateAsync(TagStateId tagStateId);
+    Task<ResultBox<TagState>> GetTagStateAsync<TProjector>(ITag tag) where TProjector : ITagProjector<TProjector> => GetTagStateAsync(TagStateId.FromProjector<TProjector>(tag));
 
     /// <summary>
     ///     Execute a single-result query

--- a/src/Sekiban.Dcb/Sekiban.Dcb.csproj
+++ b/src/Sekiban.Dcb/Sekiban.Dcb.csproj
@@ -8,14 +8,14 @@
         <AssemblyName>Sekiban.Dcb</AssemblyName>
         <RootNamespace>Sekiban.Dcb</RootNamespace>
         <PackageId>Sekiban.Dcb</PackageId>
-        <Version>9.1.1</Version>
+        <Version>9.1.2</Version>
         <Authors>J-Tech Group</Authors>
         <Company>J-Tech-Japan</Company>
         <Copyright>Copyright (c) J-Tech-Japan 2025</Copyright>
         <PackageDescription>Sekiban - Dynamic Consistency Boundary Event Sourcing Framework</PackageDescription>
         <RepositoryUrl>https://github.com/J-Tech-Japan/Sekiban</RepositoryUrl>
         <PackageProjectUrl>https://github.com/J-Tech-Japan/Sekiban</PackageProjectUrl>
-        <PackageVersion>9.1.1</PackageVersion>
+        <PackageVersion>9.1.2</PackageVersion>
         <Description>Dynamic Consistency Boundary implementation for Event Sourcing with Multi-Projection support</Description>
         <PackageTags>event-sourcing;cqrs;ddd;dcb;sekiban</PackageTags>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>


### PR DESCRIPTION
Update all project package versions to 9.1.2 and introduce a generic method in `ISekibanExecutor` for retrieving tag states.