### PR TITLE
Add tests for OptionalDate queries and results

### DIFF
--- a/tests/Sekiban.Dcb.Orleans.Tests/ListQueryOptionalValueOrleansTests.cs
+++ b/tests/Sekiban.Dcb.Orleans.Tests/ListQueryOptionalValueOrleansTests.cs
@@ -1,0 +1,154 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Orleans.TestingHost;
+using Sekiban.Dcb.Actors;
+using Sekiban.Dcb.MultiProjections;
+using Sekiban.Dcb.Orleans.Streams;
+using Sekiban.Dcb.Snapshots;
+using Sekiban.Dcb.Storage;
+using Sekiban.Dcb.Tests;
+using Xunit;
+using Xunit.Sdk;
+namespace Sekiban.Dcb.Orleans.Tests;
+
+public class ListQueryOptionalValueOrleansTests : IAsyncLifetime
+{
+    private static IEventStore SharedEventStore = new InMemoryEventStore();
+    private TestCluster _cluster = null!;
+    private DcbDomainTypes _domainTypes = null!;
+    private IEventStore _eventStore = null!;
+    private ISekibanExecutor _executor = null!;
+    private bool _initialized;
+
+    public async Task InitializeAsync()
+    {
+        SharedEventStore = new InMemoryEventStore();
+
+        var builder = new TestClusterBuilder
+        {
+            Options =
+            {
+                InitialSilosCount = 1
+            }
+        };
+        var uniqueId = Guid.NewGuid().ToString("N")[..8];
+        builder.Options.ClusterId = $"OptionalDateCluster-{uniqueId}";
+        builder.Options.ServiceId = $"OptionalDateService-{uniqueId}";
+        builder.AddSiloBuilderConfigurator<TestSiloConfigurator>();
+        builder.AddClientBuilderConfigurator<TestClientConfigurator>();
+
+        _cluster = builder.Build();
+        await _cluster.DeployAsync();
+
+        _domainTypes = CreateDomainTypes();
+        _eventStore = SharedEventStore;
+        _executor = new OrleansDcbExecutor(_cluster.Client, _eventStore, _domainTypes);
+        _initialized = true;
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_cluster != null)
+        {
+            await _cluster.StopAllSilosAsync();
+            _cluster.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task OrleansExecutor_Should_Return_Items_With_OptionalValue()
+    {
+        await EnsureInitializedAsync();
+
+        var query = new OptionalDateListQuery();
+        var result = await _executor.QueryAsync(query);
+
+        if (!result.IsSuccess)
+        {
+            throw new XunitException(result.GetException()?.ToString() ?? "List query failed without exception detail");
+        }
+
+        var items = result.GetValue().Items.ToList();
+        Assert.Equal(OptionalDateFixtures.SeedResults.Count, items.Count);
+        Assert.Contains(items, item => item.Date.HasValue && item.Date.GetValue() == OptionalDateFixtures.ExpectedDate);
+        Assert.Contains(items, item => !item.Date.HasValue);
+    }
+
+    private async Task EnsureInitializedAsync()
+    {
+        if (_initialized && _executor is not null)
+        {
+            return;
+        }
+
+        if (_cluster == null)
+        {
+            var builder = new TestClusterBuilder
+            {
+                Options =
+                {
+                    InitialSilosCount = 1
+                }
+            };
+            var uniqueId = Guid.NewGuid().ToString("N")[..8];
+            builder.Options.ClusterId = $"FallbackOptionalDateCluster-{uniqueId}";
+            builder.Options.ServiceId = $"FallbackOptionalDateService-{uniqueId}";
+            builder.AddSiloBuilderConfigurator<TestSiloConfigurator>();
+            builder.AddClientBuilderConfigurator<TestClientConfigurator>();
+            _cluster = builder.Build();
+            await _cluster.DeployAsync();
+        }
+
+        if (_executor == null)
+        {
+            _domainTypes = CreateDomainTypes();
+            _eventStore = SharedEventStore;
+            _executor = new OrleansDcbExecutor(_cluster.Client, _eventStore, _domainTypes);
+        }
+
+        _initialized = true;
+    }
+
+    private static DcbDomainTypes CreateDomainTypes() =>
+        DcbDomainTypes.Simple(types =>
+        {
+            types.MultiProjectorTypes.RegisterProjector<TestOptionalDateMultiProjector>();
+            types.QueryTypes.RegisterListQuery<OptionalDateListQuery>();
+        });
+
+    private class TestSiloConfigurator : ISiloConfigurator
+    {
+        public void Configure(ISiloBuilder siloBuilder)
+        {
+            siloBuilder
+                .ConfigureServices(services =>
+                {
+                    services.AddSingleton<IEventStore>(_ => SharedEventStore);
+                    services.AddSingleton<DcbDomainTypes>(_ => CreateDomainTypes());
+                    services.AddSingleton<IEventSubscriptionResolver>(
+                        new DefaultOrleansEventSubscriptionResolver("EventStreamProvider", "AllEvents", Guid.Empty));
+                    services.AddSingleton<IActorObjectAccessor, OrleansActorObjectAccessor>();
+                    services.AddSingleton<IBlobStorageSnapshotAccessor, MockBlobStorageSnapshotAccessor>();
+                    services.AddTransient<IMultiProjectionEventStatistics, Sekiban.Dcb.MultiProjections.NoOpMultiProjectionEventStatistics>();
+                    services.AddTransient(_ => new GeneralMultiProjectionActorOptions
+                    {
+                        SafeWindowMs = 20000,
+                        SnapshotOffloadThresholdBytes = 2 * 1024 * 1024
+                    });
+                })
+                .AddMemoryGrainStorageAsDefault()
+                .AddMemoryGrainStorage("OrleansStorage")
+                .AddMemoryGrainStorage("PubSubStore")
+                .AddMemoryStreams("EventStreamProvider")
+                .AddMemoryGrainStorage("EventStreamProvider");
+        }
+    }
+
+    private class TestClientConfigurator : IClientBuilderConfigurator
+    {
+        public void Configure(IConfiguration configuration, IClientBuilder clientBuilder)
+        {
+            clientBuilder.AddMemoryStreams("EventStreamProvider");
+        }
+    }
+}

--- a/tests/Sekiban.Dcb.Orleans.Tests/ListQueryOptionalValueTests.cs
+++ b/tests/Sekiban.Dcb.Orleans.Tests/ListQueryOptionalValueTests.cs
@@ -1,0 +1,54 @@
+using Microsoft.Extensions.DependencyInjection;
+using Orleans;
+using Orleans.Serialization;
+using ResultBoxes;
+using Sekiban.Dcb;
+using Sekiban.Dcb.Domains;
+using Sekiban.Dcb.MultiProjections;
+using Sekiban.Dcb.Orleans;
+using Sekiban.Dcb.Orleans.Grains;
+using Sekiban.Dcb.Queries;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Sekiban.Dcb.Orleans.Tests;
+
+public class ListQueryOptionalValueTests
+{
+    [Fact]
+    public async Task ListQuery_WithOptionalDateOnlyItem_ShouldRoundTripThroughGeneralResult()
+    {
+        var queryTypes = new SimpleQueryTypes();
+        queryTypes.RegisterListQuery<TestOptionalDateMultiProjector, OptionalDateListQuery, OptionalDateResult>();
+
+        var services = new ServiceCollection().BuildServiceProvider();
+        var projector = new TestOptionalDateMultiProjector(new List<OptionalDateResult>(OptionalDateFixtures.SeedResults));
+        var query = new OptionalDateListQuery();
+
+        var generalResult = await queryTypes.ExecuteListQueryAsGeneralAsync(
+            query,
+            () => Task.FromResult(ResultBox.FromValue<IMultiProjectionPayload>(projector)),
+            services,
+            safeVersion: null,
+            safeWindowThreshold: null,
+            safeWindowThresholdTime: null,
+            unsafeVersion: null);
+
+        Assert.True(generalResult.IsSuccess);
+        var payload = generalResult.GetValue();
+
+        Assert.Equal(OptionalDateFixtures.SeedResults.Count, payload.Items.Count());
+        Assert.Contains(nameof(OptionalDateResult), payload.RecordType);
+
+        var typedResult = payload.ToTypedResult<OptionalDateResult>();
+        Assert.True(typedResult.IsSuccess);
+
+        var items = typedResult.GetValue().Items.ToList();
+        Assert.Equal(OptionalDateFixtures.SeedResults.Count, items.Count);
+        Assert.Contains(items, item => item.Date.HasValue && item.Date.GetValue() == OptionalDateFixtures.ExpectedDate);
+        Assert.Contains(items, item => !item.Date.HasValue);
+    }
+}

--- a/tests/Sekiban.Dcb.Orleans.Tests/OptionalDateFixtures.cs
+++ b/tests/Sekiban.Dcb.Orleans.Tests/OptionalDateFixtures.cs
@@ -1,0 +1,13 @@
+using ResultBoxes;
+namespace Sekiban.Dcb.Orleans.Tests;
+
+public static class OptionalDateFixtures
+{
+    public static readonly DateOnly ExpectedDate = new(2024, 1, 23);
+
+    public static readonly IReadOnlyList<OptionalDateResult> SeedResults = new[]
+    {
+        new OptionalDateResult(new OptionalValue<DateOnly>(ExpectedDate)),
+        new OptionalDateResult(OptionalValue<DateOnly>.Empty)
+    };
+}

--- a/tests/Sekiban.Dcb.Orleans.Tests/OptionalDateListQuery.cs
+++ b/tests/Sekiban.Dcb.Orleans.Tests/OptionalDateListQuery.cs
@@ -1,0 +1,25 @@
+using ResultBoxes;
+using Sekiban.Dcb.Queries;
+namespace Sekiban.Dcb.Orleans.Tests;
+
+[
+    GenerateSerializer
+]
+public record OptionalDateListQuery
+    : IMultiProjectionListQuery<TestOptionalDateMultiProjector, OptionalDateListQuery, OptionalDateResult>
+{
+    [Id(0)]
+    public int? PageNumber { get; init; } = 1;
+    [Id(1)]
+    public int? PageSize { get; init; } = 10;
+
+    public static ResultBox<IEnumerable<OptionalDateResult>> HandleFilter(
+        TestOptionalDateMultiProjector projector,
+        OptionalDateListQuery query,
+        IQueryContext context) => ResultBox.FromValue(projector.Results.AsEnumerable());
+
+    public static ResultBox<IEnumerable<OptionalDateResult>> HandleSort(
+        IEnumerable<OptionalDateResult> filteredList,
+        OptionalDateListQuery query,
+        IQueryContext context) => ResultBox.FromValue(filteredList);
+}

--- a/tests/Sekiban.Dcb.Orleans.Tests/OptionalDateResult.cs
+++ b/tests/Sekiban.Dcb.Orleans.Tests/OptionalDateResult.cs
@@ -1,0 +1,4 @@
+using ResultBoxes;
+namespace Sekiban.Dcb.Orleans.Tests;
+
+public record OptionalDateResult(OptionalValue<DateOnly> Date);

--- a/tests/Sekiban.Dcb.Orleans.Tests/OptionalDateResultConverter.cs
+++ b/tests/Sekiban.Dcb.Orleans.Tests/OptionalDateResultConverter.cs
@@ -1,0 +1,17 @@
+using ResultBoxes;
+namespace Sekiban.Dcb.Orleans.Tests;
+
+[RegisterConverter]
+public sealed class OptionalDateResultConverter : IConverter<OptionalDateResult, OptionalDateResultSurrogate>
+{
+    public OptionalDateResult ConvertFromSurrogate(in OptionalDateResultSurrogate surrogate) =>
+        new OptionalDateResult(
+            surrogate.HasValue
+                ? OptionalValue<DateOnly>.FromValue(surrogate.Value)
+                : OptionalValue<DateOnly>.Empty);
+
+    public OptionalDateResultSurrogate ConvertToSurrogate(in OptionalDateResult value) =>
+        value.Date.HasValue
+            ? new OptionalDateResultSurrogate(true, value.Date.GetValue())
+            : new OptionalDateResultSurrogate(false, default);
+}

--- a/tests/Sekiban.Dcb.Orleans.Tests/OptionalDateResultSurrogate.cs
+++ b/tests/Sekiban.Dcb.Orleans.Tests/OptionalDateResultSurrogate.cs
@@ -1,0 +1,6 @@
+namespace Sekiban.Dcb.Orleans.Tests;
+
+[GenerateSerializer]
+public readonly record struct OptionalDateResultSurrogate(
+    [property: Id(0)] bool HasValue,
+    [property: Id(1)] DateOnly Value);

--- a/tests/Sekiban.Dcb.Orleans.Tests/TestOptionalDateMultiProjector.cs
+++ b/tests/Sekiban.Dcb.Orleans.Tests/TestOptionalDateMultiProjector.cs
@@ -1,0 +1,28 @@
+using ResultBoxes;
+using Sekiban.Dcb.Common;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.MultiProjections;
+using Sekiban.Dcb.Tags;
+namespace Sekiban.Dcb.Orleans.Tests;
+
+[
+    GenerateSerializer
+]
+public record TestOptionalDateMultiProjector([property: Id(0)] List<OptionalDateResult> Results)
+    : IMultiProjector<TestOptionalDateMultiProjector>
+{
+    public TestOptionalDateMultiProjector() : this(new List<OptionalDateResult>()) { }
+
+    public static string MultiProjectorName => "OptionalDateProjector";
+    public static string MultiProjectorVersion => "1.0";
+
+    public static TestOptionalDateMultiProjector GenerateInitialPayload() =>
+        new(new List<OptionalDateResult>(OptionalDateFixtures.SeedResults));
+
+    public static ResultBox<TestOptionalDateMultiProjector> Project(
+        TestOptionalDateMultiProjector payload,
+        Event ev,
+        List<ITag> tags,
+        DcbDomainTypes domainTypes,
+        SortableUniqueId safeWindowThreshold) => ResultBox.FromValue(payload);
+}


### PR DESCRIPTION
Introduce comprehensive tests for the OptionalDate queries and results, ensuring proper functionality across multi-projector and serialization scenarios. These tests validate the expected behavior of the system when handling optional date values.