### PR TITLE
Implement chunked retrieval for IndexedDB to prevent Out of Memory errors

### DIFF
--- a/src/Sekiban.Aspire.Infrastructure.Cosmos/Sekiban.Aspire.Infrastructure.Cosmos.csproj
+++ b/src/Sekiban.Aspire.Infrastructure.Cosmos/Sekiban.Aspire.Infrastructure.Cosmos.csproj
@@ -5,11 +5,11 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <PackageId>Sekiban.Aspire.Infrastructure.Cosmos</PackageId>
-        <Version>0.23.8</Version>
+        <Version>0.23.9</Version>
         <Authors>J-Tech Group</Authors>
         <Company>J-Tech-Japan</Company>
         <PackageDescription>Sekiban - Event Sourcing Framework Cosmos Aspire Connector</PackageDescription>
-        <PackageVersion>0.23.8</PackageVersion>
+        <PackageVersion>0.23.9</PackageVersion>
         <Description>Add Indexed DB as infrastructure</Description>
         <RepositoryUrl>https://github.com/J-Tech-Japan/Sekiban</RepositoryUrl>
         <RootNamespace>Sekiban.Aspire.Infrastructure.Cosmos</RootNamespace>
@@ -28,8 +28,8 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Sekiban.Infrastructure.Cosmos" Version="0.23.8"/>
-        <PackageReference Include="Sekiban.Web" Version="0.23.8"/>
+        <PackageReference Include="Sekiban.Infrastructure.Cosmos" Version="0.23.9"/>
+        <PackageReference Include="Sekiban.Web" Version="0.23.9"/>
         <ProjectReference Include="..\Sekiban.Infrastructure.Cosmos\Sekiban.Infrastructure.Cosmos.csproj"/>
         <ProjectReference Include="..\Sekiban.Web\Sekiban.Web.csproj"/>
         <None Include="..\README.md" Pack="true" PackagePath="\"/>

--- a/src/Sekiban.Core.DotNet/Sekiban.Core.DotNet.csproj
+++ b/src/Sekiban.Core.DotNet/Sekiban.Core.DotNet.csproj
@@ -5,12 +5,12 @@
         <Nullable>enable</Nullable>
         <LangVersion>preview</LangVersion>
         <PackageId>Sekiban.Core.DotNet</PackageId>
-        <Version>0.23.8</Version>
+        <Version>0.23.9</Version>
         <Authors>J-Tech Group</Authors>
         <Company>J-Tech-Japan</Company>
         <PackageDescription>Sekiban - Event Sourcing Framework Core</PackageDescription>
         <RepositoryUrl>https://github.com/J-Tech-Japan/Sekiban</RepositoryUrl>
-        <PackageVersion>0.23.8</PackageVersion>
+        <PackageVersion>0.23.9</PackageVersion>
         <Description>Add Indexed DB as infrastructure</Description>
         <AssemblyName>Sekiban.Core.DotNet</AssemblyName>
         <RootNamespace>Sekiban.Core</RootNamespace>

--- a/src/Sekiban.Core/Sekiban.Core.csproj
+++ b/src/Sekiban.Core/Sekiban.Core.csproj
@@ -5,12 +5,12 @@
         <Nullable>enable</Nullable>
         <LangVersion>preview</LangVersion>
         <PackageId>Sekiban.Core</PackageId>
-        <Version>0.23.8</Version>
+        <Version>0.23.9</Version>
         <Authors>J-Tech Group</Authors>
         <Company>J-Tech-Japan</Company>
         <PackageDescription>Sekiban - Event Sourcing Framework Core</PackageDescription>
         <RepositoryUrl>https://github.com/J-Tech-Japan/Sekiban</RepositoryUrl>
-        <PackageVersion>0.23.8</PackageVersion>
+        <PackageVersion>0.23.9</PackageVersion>
         <Description>Add Indexed DB as infrastructure</Description>
         <AssemblyName>Sekiban.Core</AssemblyName>
         <RootNamespace>Sekiban.Core</RootNamespace>
@@ -32,7 +32,7 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <None Include="..\README.md" Pack="true" PackagePath="\"/>
-        <PackageReference Include="Sekiban.Core.DotNet" Version="0.23.8"/>
+        <PackageReference Include="Sekiban.Core.DotNet" Version="0.23.9"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Sekiban.Infrastructure.Aws.S3/Sekiban.Infrastructure.Aws.S3.csproj
+++ b/src/Sekiban.Infrastructure.Aws.S3/Sekiban.Infrastructure.Aws.S3.csproj
@@ -4,12 +4,12 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <PackageId>Sekiban.Infrastructure.Aws.S3</PackageId>
-        <Version>0.23.8</Version>
+        <Version>0.23.9</Version>
         <Authors>J-Tech Group</Authors>
         <Company>J-Tech-Japan</Company>
         <PackageDescription>Sekiban - Event Sourcing Framework AWS S3 Infrastructure</PackageDescription>
         <RepositoryUrl>https://github.com/J-Tech-Japan/Sekiban</RepositoryUrl>
-        <PackageVersion>0.23.8</PackageVersion>
+        <PackageVersion>0.23.9</PackageVersion>
         <Description>Add Indexed DB as infrastructure</Description>
         <LangVersion>preview</LangVersion>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
@@ -27,7 +27,7 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="SharpZipLib" Version="1.4.2"/>
-        <PackageReference Include="Sekiban.Core.DotNet" Version="0.23.8"/>
+        <PackageReference Include="Sekiban.Core.DotNet" Version="0.23.9"/>
         <None Include="..\README.md" Pack="true" PackagePath="\"/>
         <PackageReference Include="System.Configuration.ConfigurationManager" Version="9.0.1"/>
     </ItemGroup>

--- a/src/Sekiban.Infrastructure.Azure.Storage.Blobs/Sekiban.Infrastructure.Azure.Storage.Blobs.csproj
+++ b/src/Sekiban.Infrastructure.Azure.Storage.Blobs/Sekiban.Infrastructure.Azure.Storage.Blobs.csproj
@@ -4,12 +4,12 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <PackageId>Sekiban.Infrastructure.Azure.Storage.Blobs</PackageId>
-        <Version>0.23.8</Version>
+        <Version>0.23.9</Version>
         <Authors>J-Tech Group</Authors>
         <Company>J-Tech-Japan</Company>
         <PackageDescription>Sekiban - Event Sourcing Framework Azure Storage Blob</PackageDescription>
         <RepositoryUrl>https://github.com/J-Tech-Japan/Sekiban</RepositoryUrl>
-        <PackageVersion>0.23.8</PackageVersion>
+        <PackageVersion>0.23.9</PackageVersion>
         <Description>Add Indexed DB as infrastructure</Description>
         <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
         <LangVersion>preview</LangVersion>
@@ -29,7 +29,7 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Sekiban.Core.DotNet" Version="0.23.8"/>
+        <PackageReference Include="Sekiban.Core.DotNet" Version="0.23.9"/>
         <PackageReference Include="System.Configuration.ConfigurationManager" Version="9.0.1"/>
     </ItemGroup>
 

--- a/src/Sekiban.Infrastructure.Cosmos/Sekiban.Infrastructure.Cosmos.csproj
+++ b/src/Sekiban.Infrastructure.Cosmos/Sekiban.Infrastructure.Cosmos.csproj
@@ -4,12 +4,12 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <PackageId>Sekiban.Infrastructure.Cosmos</PackageId>
-        <Version>0.23.8</Version>
+        <Version>0.23.9</Version>
         <Authors>J-Tech Group</Authors>
         <Company>J-Tech-Japan</Company>
         <PackageDescription>Sekiban - Event Sourcing Framework CosmosInfrastructure</PackageDescription>
         <RepositoryUrl>https://github.com/J-Tech-Japan/Sekiban</RepositoryUrl>
-        <PackageVersion>0.23.8</PackageVersion>
+        <PackageVersion>0.23.9</PackageVersion>
         <Description>Add Indexed DB as infrastructure</Description>
         <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
         <LangVersion>preview</LangVersion>
@@ -30,8 +30,8 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="Newtonsoft.Json" Version="13.0.3"/>
-        <PackageReference Include="Sekiban.Core.DotNet" Version="0.23.8"/>
-        <PackageReference Include="Sekiban.Infrastructure.Azure.Storage.Blobs" Version="0.23.8"/>
+        <PackageReference Include="Sekiban.Core.DotNet" Version="0.23.9"/>
+        <PackageReference Include="Sekiban.Infrastructure.Azure.Storage.Blobs" Version="0.23.9"/>
         <None Include="..\README.md" Pack="true" PackagePath="\"/>
     </ItemGroup>
 

--- a/src/Sekiban.Infrastructure.Dynamo/Sekiban.Infrastructure.Dynamo.csproj
+++ b/src/Sekiban.Infrastructure.Dynamo/Sekiban.Infrastructure.Dynamo.csproj
@@ -4,12 +4,12 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <PackageId>Sekiban.Infrastructure.Dynamo</PackageId>
-        <Version>0.23.8</Version>
+        <Version>0.23.9</Version>
         <Authors>J-Tech Group</Authors>
         <Company>J-Tech-Japan</Company>
         <PackageDescription>Sekiban - Event Sourcing Framework Dynamo Infrastructure</PackageDescription>
         <RepositoryUrl>https://github.com/J-Tech-Japan/Sekiban</RepositoryUrl>
-        <PackageVersion>0.23.8</PackageVersion>
+        <PackageVersion>0.23.9</PackageVersion>
         <Description>Add Indexed DB as infrastructure</Description>
         <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
         <LangVersion>preview</LangVersion>
@@ -26,8 +26,8 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Sekiban.Core.DotNet" Version="0.23.8"/>
-        <PackageReference Include="Sekiban.Infrastructure.Aws.S3" Version="0.23.8"/>
+        <PackageReference Include="Sekiban.Core.DotNet" Version="0.23.9"/>
+        <PackageReference Include="Sekiban.Infrastructure.Aws.S3" Version="0.23.9"/>
         <None Include="..\README.md" Pack="true" PackagePath="\"/>
         <PackageReference Include="System.Configuration.ConfigurationManager" Version="9.0.1"/>
     </ItemGroup>

--- a/src/Sekiban.Infrastructure.IndexedDb/Databases/DbEventQuery.cs
+++ b/src/Sekiban.Infrastructure.IndexedDb/Databases/DbEventQuery.cs
@@ -13,6 +13,12 @@ public record DbEventQuery
 
     public int? MaxCount { get; private set; }
 
+    public DbEventQuery WithSortableIdStart(string? sortableIdStart) =>
+        this with { SortableIdStart = sortableIdStart };
+
+    public DbEventQuery WithMaxCount(int? maxCount) =>
+        this with { MaxCount = maxCount };
+
     public static DbEventQuery FromEventRetrievalInfo(EventRetrievalInfo eventRetrievalInfo)
     {
         var query = new DbEventQuery();

--- a/src/Sekiban.Infrastructure.IndexedDb/Sekiban.Infrastructure.IndexedDb.csproj
+++ b/src/Sekiban.Infrastructure.IndexedDb/Sekiban.Infrastructure.IndexedDb.csproj
@@ -5,12 +5,12 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <PackageId>Sekiban.Infrastructure.IndexedDb</PackageId>
-        <Version>0.23.8</Version>
+        <Version>0.23.9</Version>
         <Authors>J-Tech Group</Authors>
         <Company>J-Tech-Japan</Company>
         <PackageDescription>Sekiban - Event Sourcing Framework IndexedDB Infrastructure</PackageDescription>
         <RepositoryUrl>https://github.com/J-Tech-Japan/Sekiban</RepositoryUrl>
-        <PackageVersion>0.23.8</PackageVersion>
+        <PackageVersion>0.23.9</PackageVersion>
         <Description>Add Indexed DB as infrastructure</Description>
         <LangVersion>preview</LangVersion>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
@@ -29,7 +29,7 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="System.Configuration.ConfigurationManager" Version="9.0.1"/>
-        <PackageReference Include="Sekiban.Core.DotNet" Version="0.23.8"/>
+        <PackageReference Include="Sekiban.Core.DotNet" Version="0.23.9"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Sekiban.Infrastructure.Postgres/Sekiban.Infrastructure.Postgres.csproj
+++ b/src/Sekiban.Infrastructure.Postgres/Sekiban.Infrastructure.Postgres.csproj
@@ -5,12 +5,12 @@
         <Nullable>enable</Nullable>
         <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
         <PackageId>Sekiban.Infrastructure.Postgres</PackageId>
-        <Version>0.23.8</Version>
+        <Version>0.23.9</Version>
         <Authors>J-Tech Group</Authors>
         <Company>J-Tech-Japan</Company>
         <PackageDescription>Sekiban - Event Sourcing Framework Dynamo Infrastructure</PackageDescription>
         <RepositoryUrl>https://github.com/J-Tech-Japan/Sekiban</RepositoryUrl>
-        <PackageVersion>0.23.8</PackageVersion>
+        <PackageVersion>0.23.9</PackageVersion>
         <Description>Add Indexed DB as infrastructure</Description>
         <LangVersion>preview</LangVersion>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
@@ -30,7 +30,7 @@
         <None Include="..\README.md" Pack="true" PackagePath="\"/>
         <ProjectReference Include="..\Sekiban.Infrastructure.Aws.S3\Sekiban.Infrastructure.Aws.S3.csproj"/>
         <ProjectReference Include="..\Sekiban.Infrastructure.Azure.Storage.Blobs\Sekiban.Infrastructure.Azure.Storage.Blobs.csproj"/>
-        <PackageReference Include="Sekiban.Core.DotNet" Version="0.23.8"/>
+        <PackageReference Include="Sekiban.Core.DotNet" Version="0.23.9"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Sekiban.Testing/Sekiban.Testing.csproj
+++ b/src/Sekiban.Testing/Sekiban.Testing.csproj
@@ -5,12 +5,12 @@
         <Nullable>enable</Nullable>
         <LangVersion>preview</LangVersion>
         <PackageId>Sekiban.Testing</PackageId>
-        <Version>0.23.8</Version>
+        <Version>0.23.9</Version>
         <Authors>J-Tech Group</Authors>
         <Company>J-Tech-Japan</Company>
         <PackageDescription>Sekiban - Event Sourcing Framework Testing</PackageDescription>
         <RepositoryUrl>https://github.com/J-Tech-Japan/Sekiban</RepositoryUrl>
-        <PackageVersion>0.23.8</PackageVersion>
+        <PackageVersion>0.23.9</PackageVersion>
         <Description>Add Indexed DB as infrastructure</Description>
         <AssemblyName>Sekiban.Testing</AssemblyName>
         <RootNamespace>Sekiban.Testing</RootNamespace>
@@ -29,7 +29,7 @@
         </PackageReference>
         <PackageReference Include="xunit.assert" Version="2.9.3"/>
         <PackageReference Include="xunit.extensibility.core" Version="2.9.3"/>
-        <PackageReference Include="Sekiban.Core.DotNet" Version="0.23.8"/>
+        <PackageReference Include="Sekiban.Core.DotNet" Version="0.23.9"/>
         <None Include="..\README.md" Pack="true" PackagePath="\"/>
         <PackageReference Include="xunit.extensibility.execution" Version="2.9.3"/>
     </ItemGroup>

--- a/src/Sekiban.Web/Sekiban.Web.csproj
+++ b/src/Sekiban.Web/Sekiban.Web.csproj
@@ -5,12 +5,12 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <OutputType>Library</OutputType>
         <PackageId>Sekiban.Web</PackageId>
-        <Version>0.23.8</Version>
+        <Version>0.23.9</Version>
         <Authors>J-Tech Group</Authors>
         <Company>J-Tech-Japan</Company>
         <PackageDescription>Sekiban - Event Sourcing Framework WebHelper</PackageDescription>
         <RepositoryUrl>https://github.com/J-Tech-Japan/Sekiban</RepositoryUrl>
-        <PackageVersion>0.23.8</PackageVersion>
+        <PackageVersion>0.23.9</PackageVersion>
         <Description>Add Indexed DB as infrastructure</Description>
         <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
         <LangVersion>preview</LangVersion>
@@ -30,7 +30,7 @@
         </PackageReference>
         <PackageReference Include="Swashbuckle.AspNetCore" Version="7.2.0"/>
         <None Include="..\README.md" Pack="true" PackagePath="\"/>
-        <PackageReference Include="Sekiban.Core" Version="0.23.8"/>
+        <PackageReference Include="Sekiban.Core" Version="0.23.9"/>
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
IndexedDB now sends events in chunks, addressing the out of memory errors previously encountered. This change enhances the efficiency of event delivery and improves overall application stability.

Fixes #784