### PR TITLE
Update package versions to 10.0.1-preview06

### DIFF
--- a/dcb/internalUsages/DcbOrleans.ApiService/DcbOrleans.ApiService.csproj
+++ b/dcb/internalUsages/DcbOrleans.ApiService/DcbOrleans.ApiService.csproj
@@ -9,22 +9,22 @@
     </PropertyGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-        <PackageReference Include="Aspire.Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.5.2" />
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.0"/>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.0-rc.2"/>
+        <PackageReference Include="Aspire.Npgsql.EntityFrameworkCore.PostgreSQL" Version="13.1.0" />
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.1" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.1"/>
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-        <PackageReference Include="Aspire.Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.5.2" />
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.8"/>
+        <PackageReference Include="Aspire.Npgsql.EntityFrameworkCore.PostgreSQL" Version="13.1.0" />
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.11" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.11"/>
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Aspire.Azure.Data.Tables" Version="13.0.0" />
-        <PackageReference Include="Aspire.Azure.Storage.Blobs" Version="13.0.0" />
-        <PackageReference Include="Aspire.Azure.Storage.Queues" Version="13.0.0" />
-        <PackageReference Include="Aspire.Microsoft.Azure.Cosmos" Version="13.0.0" />
+        <PackageReference Include="Aspire.Azure.Data.Tables" Version="13.1.0" />
+        <PackageReference Include="Aspire.Azure.Storage.Blobs" Version="13.1.0" />
+        <PackageReference Include="Aspire.Azure.Storage.Queues" Version="13.1.0" />
+        <PackageReference Include="Aspire.Microsoft.Azure.Cosmos" Version="13.1.0" />
         <PackageReference Include="Microsoft.Orleans.Clustering.AzureStorage" Version="9.2.1"/>
         <PackageReference Include="Microsoft.Orleans.Clustering.Cosmos" Version="9.2.1" />
         <PackageReference Include="Microsoft.Orleans.Persistence.AzureStorage" Version="9.2.1"/>
@@ -33,7 +33,7 @@
         <PackageReference Include="Microsoft.Orleans.Server" Version="9.2.1"/>
         <PackageReference Include="Microsoft.Orleans.Streaming" Version="9.2.1"/>
         <PackageReference Include="Microsoft.Orleans.Streaming.AzureStorage" Version="9.2.1"/>
-        <PackageReference Include="Scalar.AspNetCore" Version="2.10.3" />
+        <PackageReference Include="Scalar.AspNetCore" Version="2.11.10" />
     </ItemGroup>
 
     <ItemGroup>

--- a/dcb/internalUsages/DcbOrleans.AppHost/DcbOrleans.AppHost.csproj
+++ b/dcb/internalUsages/DcbOrleans.AppHost/DcbOrleans.AppHost.csproj
@@ -13,11 +13,11 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Aspire.Hosting" Version="13.0.0" />
-        <PackageReference Include="Aspire.Hosting.AppHost" Version="13.0.0" />
-        <PackageReference Include="Aspire.Hosting.Azure.Storage" Version="13.0.0" />
-        <PackageReference Include="Aspire.Hosting.Orleans" Version="13.0.0" />
-        <PackageReference Include="Aspire.Hosting.PostgreSQL" Version="13.0.0" />
+        <PackageReference Include="Aspire.Hosting" Version="13.1.0" />
+        <PackageReference Include="Aspire.Hosting.AppHost" Version="13.1.0" />
+        <PackageReference Include="Aspire.Hosting.Azure.Storage" Version="13.1.0" />
+        <PackageReference Include="Aspire.Hosting.Orleans" Version="13.1.0" />
+        <PackageReference Include="Aspire.Hosting.PostgreSQL" Version="13.1.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/dcb/internalUsages/DcbOrleans.ServiceDefaults/DcbOrleans.ServiceDefaults.csproj
+++ b/dcb/internalUsages/DcbOrleans.ServiceDefaults/DcbOrleans.ServiceDefaults.csproj
@@ -12,7 +12,7 @@
 
         <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="9.8.0"/>
         <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="9.4.2" />
-        <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.9.0"/>
+        <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.14.0" />
         <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.9.0"/>
         <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.9.0"/>
         <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.9.0"/>

--- a/dcb/internalUsages/DcbOrleans.WithoutResult.ApiService/DcbOrleans.WithoutResult.ApiService.csproj
+++ b/dcb/internalUsages/DcbOrleans.WithoutResult.ApiService/DcbOrleans.WithoutResult.ApiService.csproj
@@ -8,12 +8,11 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Aspire.Azure.Data.Tables" Version="9.4.2" />
-        <PackageReference Include="Aspire.Azure.Storage.Blobs" Version="9.4.2" />
-        <PackageReference Include="Aspire.Azure.Storage.Queues" Version="9.4.2" />
-        <PackageReference Include="Aspire.Microsoft.Azure.Cosmos" Version="9.4.2" />
+        <PackageReference Include="Aspire.Azure.Data.Tables" Version="13.1.0" />
+        <PackageReference Include="Aspire.Azure.Storage.Blobs" Version="13.1.0" />
+        <PackageReference Include="Aspire.Azure.Storage.Queues" Version="13.1.0" />
+        <PackageReference Include="Aspire.Microsoft.Azure.Cosmos" Version="13.1.0" />
         <PackageReference Include="Aspire.Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.4.2" />
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.8"/>
         <PackageReference Include="Microsoft.Orleans.Clustering.AzureStorage" Version="9.2.1"/>
         <PackageReference Include="Microsoft.Orleans.Clustering.Cosmos" Version="9.2.1" />
         <PackageReference Include="Microsoft.Orleans.Persistence.AzureStorage" Version="9.2.1"/>
@@ -26,10 +25,12 @@
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.11" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.11"/>
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.1" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.0"/>
     </ItemGroup>
 

--- a/dcb/src/Sekiban.Dcb.BlobStorage.AzureStorage/Sekiban.Dcb.BlobStorage.AzureStorage.csproj
+++ b/dcb/src/Sekiban.Dcb.BlobStorage.AzureStorage/Sekiban.Dcb.BlobStorage.AzureStorage.csproj
@@ -7,14 +7,14 @@
         <AssemblyName>Sekiban.Dcb.BlobStorage.AzureStorage</AssemblyName>
         <RootNamespace>Sekiban.Dcb.BlobStorage.AzureStorage</RootNamespace>
         <PackageId>Sekiban.Dcb.BlobStorage.AzureStorage</PackageId>
-        <Version>10.0.1-preview05</Version>
+        <Version>10.0.1-preview06</Version>
         <Authors>J-Tech Group</Authors>
         <Company>J-Tech-Japan</Company>
         <Copyright>Copyright (c) J-Tech-Japan 2025</Copyright>
         <PackageDescription>Sekiban - Dynamic Consistency Boundary Azure Blob Storage Integration</PackageDescription>
         <RepositoryUrl>https://github.com/J-Tech-Japan/Sekiban</RepositoryUrl>
         <PackageProjectUrl>https://github.com/J-Tech-Japan/Sekiban</PackageProjectUrl>
-        <PackageVersion>10.0.1-preview05</PackageVersion>
+        <PackageVersion>10.0.1-preview06</PackageVersion>
         <Description>Azure Blob Storage snapshot offloading for Sekiban DCB MultiProjection. Provides efficient binary snapshot storage for large projection states.</Description>
         <PackageTags>event-sourcing;cqrs;ddd;dcb;sekiban;azure;blob-storage;snapshots</PackageTags>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
@@ -29,10 +29,10 @@
     <ItemGroup>
         <PackageReference Include="Sekiban.Dcb.Core" Version="$(PackageVersion)" />
         <PackageReference Include="Azure.Storage.Blobs" Version="12.26.0" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0"/>
-        <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.0"/>
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0"/>
-        <PackageReference Include="Microsoft.Sbom.Targets" Version="4.1.3">
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.1"/>
+        <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.1"/>
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.1"/>
+        <PackageReference Include="Microsoft.Sbom.Targets" Version="4.1.5">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/dcb/src/Sekiban.Dcb.Core.Model/Sekiban.Dcb.Core.Model.csproj
+++ b/dcb/src/Sekiban.Dcb.Core.Model/Sekiban.Dcb.Core.Model.csproj
@@ -7,14 +7,14 @@
         <AssemblyName>Sekiban.Dcb.Core.Model</AssemblyName>
         <RootNamespace>Sekiban.Dcb</RootNamespace>
         <PackageId>Sekiban.Dcb.Core.Model</PackageId>
-        <Version>10.0.1-preview05</Version>
+        <Version>10.0.1-preview06</Version>
         <Authors>J-Tech Group</Authors>
         <Company>J-Tech-Japan</Company>
         <Copyright>Copyright (c) J-Tech-Japan 2025</Copyright>
         <PackageDescription>Sekiban DCB Core Model - Core interfaces and types for defining domain models with Dynamic Consistency Boundary</PackageDescription>
         <RepositoryUrl>https://github.com/J-Tech-Japan/Sekiban</RepositoryUrl>
         <PackageProjectUrl>https://github.com/J-Tech-Japan/Sekiban</PackageProjectUrl>
-        <PackageVersion>10.0.1-preview05</PackageVersion>
+        <PackageVersion>10.0.1-preview06</PackageVersion>
         <Description>Core interfaces and types for defining domain models in Sekiban Dynamic Consistency Boundary - IEventPayload, ITagStatePayload, ITag, ITagGroup, ITagProjector, and related types</Description>
         <PackageTags>event-sourcing;cqrs;ddd;dcb;sekiban;model;core</PackageTags>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
@@ -27,7 +27,7 @@
 
     <ItemGroup>
         <PackageReference Include="ResultBoxes" Version="0.3.31"/>
-        <PackageReference Include="Microsoft.Sbom.Targets" Version="4.1.2">
+        <PackageReference Include="Microsoft.Sbom.Targets" Version="4.1.5">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/dcb/src/Sekiban.Dcb.Core/Sekiban.Dcb.Core.csproj
+++ b/dcb/src/Sekiban.Dcb.Core/Sekiban.Dcb.Core.csproj
@@ -7,14 +7,14 @@
         <AssemblyName>Sekiban.Dcb.Core</AssemblyName>
         <RootNamespace>Sekiban.Dcb</RootNamespace>
         <PackageId>Sekiban.Dcb.Core</PackageId>
-        <Version>10.0.1-preview05</Version>
+        <Version>10.0.1-preview06</Version>
         <Authors>J-Tech Group</Authors>
         <Company>J-Tech-Japan</Company>
         <Copyright>Copyright (c) J-Tech-Japan 2025</Copyright>
         <PackageDescription>Sekiban DCB Core - Common types and interfaces for Dynamic Consistency Boundary</PackageDescription>
         <RepositoryUrl>https://github.com/J-Tech-Japan/Sekiban</RepositoryUrl>
         <PackageProjectUrl>https://github.com/J-Tech-Japan/Sekiban</PackageProjectUrl>
-        <PackageVersion>10.0.1-preview05</PackageVersion>
+        <PackageVersion>10.0.1-preview06</PackageVersion>
         <Description>Core types and interfaces for Sekiban Dynamic Consistency Boundary - shared between ResultBox and exception-based implementations</Description>
         <PackageTags>event-sourcing;cqrs;ddd;dcb;sekiban;core</PackageTags>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
@@ -26,10 +26,10 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0"/>
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.1" />
         <PackageReference Include="ResultBoxes" Version="0.3.31"/>
         <PackageReference Include="Sekiban.Dcb.Core.Model" Version="$(PackageVersion)"/>
-        <PackageReference Include="Microsoft.Sbom.Targets" Version="4.1.2">
+        <PackageReference Include="Microsoft.Sbom.Targets" Version="4.1.5">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/dcb/src/Sekiban.Dcb.CosmosDb/Sekiban.Dcb.CosmosDb.csproj
+++ b/dcb/src/Sekiban.Dcb.CosmosDb/Sekiban.Dcb.CosmosDb.csproj
@@ -7,14 +7,14 @@
         <AssemblyName>Sekiban.Dcb.CosmosDb</AssemblyName>
         <RootNamespace>Sekiban.Dcb.CosmosDb</RootNamespace>
         <PackageId>Sekiban.Dcb.CosmosDb</PackageId>
-        <Version>10.0.1-preview05</Version>
+        <Version>10.0.1-preview06</Version>
         <Authors>J-Tech Group</Authors>
         <Company>J-Tech-Japan</Company>
         <Copyright>Copyright (c) J-Tech-Japan 2025</Copyright>
         <PackageDescription>Sekiban - Dynamic Consistency Boundary CosmosDB Integration</PackageDescription>
         <RepositoryUrl>https://github.com/J-Tech-Japan/Sekiban</RepositoryUrl>
         <PackageProjectUrl>https://github.com/J-Tech-Japan/Sekiban</PackageProjectUrl>
-        <PackageVersion>10.0.1-preview05</PackageVersion>
+        <PackageVersion>10.0.1-preview06</PackageVersion>
         <Description>CosmosDB event store and persistence layer for Sekiban DCB</Description>
         <PackageTags>event-sourcing;cqrs;ddd;dcb;sekiban;cosmosdb;azure</PackageTags>
         <AnalysisLevel>latest-All</AnalysisLevel>
@@ -30,13 +30,13 @@
 
     <ItemGroup>
         <PackageReference Include="Sekiban.Dcb.Core" Version="$(PackageVersion)" />
-        <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.54.1" />
+        <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.56.0" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0"/>
-        <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.0"/>
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0"/>
-        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.0" />
-        <PackageReference Include="Microsoft.Sbom.Targets" Version="4.1.3">
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.1"/>
+        <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.1"/>
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.1"/>
+        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.1" />
+        <PackageReference Include="Microsoft.Sbom.Targets" Version="4.1.5">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/dcb/src/Sekiban.Dcb.Orleans.Core/Sekiban.Dcb.Orleans.Core.csproj
+++ b/dcb/src/Sekiban.Dcb.Orleans.Core/Sekiban.Dcb.Orleans.Core.csproj
@@ -7,14 +7,14 @@
         <AssemblyName>Sekiban.Dcb.Orleans.Core</AssemblyName>
         <RootNamespace>Sekiban.Dcb.Orleans</RootNamespace>
         <PackageId>Sekiban.Dcb.Orleans.Core</PackageId>
-        <Version>10.0.1-preview05</Version>
+        <Version>10.0.1-preview06</Version>
         <Authors>J-Tech Group</Authors>
         <Company>J-Tech-Japan</Company>
         <Copyright>Copyright (c) J-Tech-Japan 2025</Copyright>
         <PackageDescription>Sekiban DCB Orleans Core - Shared Orleans infrastructure for Dynamic Consistency Boundary</PackageDescription>
         <RepositoryUrl>https://github.com/J-Tech-Japan/Sekiban</RepositoryUrl>
         <PackageProjectUrl>https://github.com/J-Tech-Japan/Sekiban</PackageProjectUrl>
-        <PackageVersion>10.0.1-preview05</PackageVersion>
+        <PackageVersion>10.0.1-preview06</PackageVersion>
         <Description>Core Orleans integration for Sekiban DCB with Grains, Streams, and Serialization</Description>
         <PackageTags>event-sourcing;cqrs;ddd;dcb;sekiban;orleans;actor-model</PackageTags>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/dcb/src/Sekiban.Dcb.Orleans.WithResult/Sekiban.Dcb.Orleans.WithResult.csproj
+++ b/dcb/src/Sekiban.Dcb.Orleans.WithResult/Sekiban.Dcb.Orleans.WithResult.csproj
@@ -7,14 +7,14 @@
         <AssemblyName>Sekiban.Dcb.Orleans.WithResult</AssemblyName>
         <RootNamespace>Sekiban.Dcb.Orleans</RootNamespace>
         <PackageId>Sekiban.Dcb.Orleans.WithResult</PackageId>
-        <Version>10.0.1-preview05</Version>
+        <Version>10.0.1-preview06</Version>
         <Authors>J-Tech Group</Authors>
         <Company>J-Tech-Japan</Company>
         <Copyright>Copyright (c) J-Tech-Japan 2025</Copyright>
         <PackageDescription>Sekiban DCB Orleans WithResult - Orleans integration with ResultBox-based error handling</PackageDescription>
         <RepositoryUrl>https://github.com/J-Tech-Japan/Sekiban</RepositoryUrl>
         <PackageProjectUrl>https://github.com/J-Tech-Japan/Sekiban</PackageProjectUrl>
-        <PackageVersion>10.0.1-preview05</PackageVersion>
+        <PackageVersion>10.0.1-preview06</PackageVersion>
         <Description>Orleans integration for Sekiban DCB with ResultBox-based error handling</Description>
         <PackageTags>event-sourcing;cqrs;ddd;dcb;sekiban;orleans;actor-model;resultbox</PackageTags>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/dcb/src/Sekiban.Dcb.Orleans.WithoutResult/Sekiban.Dcb.Orleans.WithoutResult.csproj
+++ b/dcb/src/Sekiban.Dcb.Orleans.WithoutResult/Sekiban.Dcb.Orleans.WithoutResult.csproj
@@ -7,14 +7,14 @@
         <AssemblyName>Sekiban.Dcb.Orleans.WithoutResult</AssemblyName>
         <RootNamespace>Sekiban.Dcb.Orleans</RootNamespace>
         <PackageId>Sekiban.Dcb.Orleans.WithoutResult</PackageId>
-        <Version>10.0.1-preview05</Version>
+        <Version>10.0.1-preview06</Version>
         <Authors>J-Tech Group</Authors>
         <Company>J-Tech-Japan</Company>
         <Copyright>Copyright (c) J-Tech-Japan 2025</Copyright>
         <PackageDescription>Sekiban DCB Orleans WithoutResult - Orleans integration with exception-based error handling</PackageDescription>
         <RepositoryUrl>https://github.com/J-Tech-Japan/Sekiban</RepositoryUrl>
         <PackageProjectUrl>https://github.com/J-Tech-Japan/Sekiban</PackageProjectUrl>
-        <PackageVersion>10.0.1-preview05</PackageVersion>
+        <PackageVersion>10.0.1-preview06</PackageVersion>
         <Description>Orleans integration for Sekiban DCB with exception-based error handling</Description>
         <PackageTags>event-sourcing;cqrs;ddd;dcb;sekiban;orleans;actor-model;exceptions</PackageTags>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/dcb/src/Sekiban.Dcb.Postgres/Sekiban.Dcb.Postgres.csproj
+++ b/dcb/src/Sekiban.Dcb.Postgres/Sekiban.Dcb.Postgres.csproj
@@ -7,14 +7,14 @@
         <AssemblyName>Sekiban.Dcb.Postgres</AssemblyName>
         <RootNamespace>Sekiban.Dcb.Postgres</RootNamespace>
         <PackageId>Sekiban.Dcb.Postgres</PackageId>
-        <Version>10.0.1-preview05</Version>
+        <Version>10.0.1-preview06</Version>
         <Authors>J-Tech Group</Authors>
         <Company>J-Tech-Japan</Company>
         <Copyright>Copyright (c) J-Tech-Japan 2025</Copyright>
         <PackageDescription>Sekiban - Dynamic Consistency Boundary PostgreSQL Integration</PackageDescription>
         <RepositoryUrl>https://github.com/J-Tech-Japan/Sekiban</RepositoryUrl>
         <PackageProjectUrl>https://github.com/J-Tech-Japan/Sekiban</PackageProjectUrl>
-        <PackageVersion>10.0.1-preview05</PackageVersion>
+        <PackageVersion>10.0.1-preview06</PackageVersion>
         <Description>PostgreSQL event store and persistence layer for Sekiban DCB</Description>
         <PackageTags>event-sourcing;cqrs;ddd;dcb;sekiban;postgresql;postgres</PackageTags>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
@@ -28,12 +28,12 @@
     </PropertyGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.0"/>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.0">
+        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.1"/>
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.1">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.0-rc.2"/>
+        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.0"/>
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
@@ -48,11 +48,11 @@
     <ItemGroup>
         <FrameworkReference Include="Microsoft.AspNetCore.App"/>
         <PackageReference Include="Sekiban.Dcb.Core" Version="$(PackageVersion)" />
-        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.0"/>
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0"/>
-        <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.0"/>
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0"/>
-        <PackageReference Include="Microsoft.Sbom.Targets" Version="4.1.3">
+        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.1"/>
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.1"/>
+        <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.1"/>
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.1"/>
+        <PackageReference Include="Microsoft.Sbom.Targets" Version="4.1.5">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/dcb/src/Sekiban.Dcb.WithResult/Sekiban.Dcb.WithResult.csproj
+++ b/dcb/src/Sekiban.Dcb.WithResult/Sekiban.Dcb.WithResult.csproj
@@ -7,14 +7,14 @@
         <AssemblyName>Sekiban.Dcb.WithResult</AssemblyName>
         <RootNamespace>Sekiban.Dcb</RootNamespace>
         <PackageId>Sekiban.Dcb.WithResult</PackageId>
-        <Version>10.0.1-preview05</Version>
+        <Version>10.0.1-preview06</Version>
         <Authors>J-Tech Group</Authors>
         <Company>J-Tech-Japan</Company>
         <Copyright>Copyright (c) J-Tech-Japan 2025</Copyright>
         <PackageDescription>Sekiban DCB WithResult - ResultBox-based API for Dynamic Consistency Boundary</PackageDescription>
         <RepositoryUrl>https://github.com/J-Tech-Japan/Sekiban</RepositoryUrl>
         <PackageProjectUrl>https://github.com/J-Tech-Japan/Sekiban</PackageProjectUrl>
-        <PackageVersion>10.0.1-preview05</PackageVersion>
+        <PackageVersion>10.0.1-preview06</PackageVersion>
         <Description>ResultBox-based API for Sekiban Dynamic Consistency Boundary - safe error handling without exceptions</Description>
         <PackageTags>event-sourcing;cqrs;ddd;dcb;sekiban;resultbox</PackageTags>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
@@ -32,7 +32,7 @@
     <ItemGroup>
         <PackageReference Include="Sekiban.Dcb.Core" Version="$(PackageVersion)" />
         <PackageReference Include="ResultBoxes" Version="0.3.31"/>
-        <PackageReference Include="Microsoft.Sbom.Targets" Version="4.1.2">
+        <PackageReference Include="Microsoft.Sbom.Targets" Version="4.1.5">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/dcb/src/Sekiban.Dcb.WithoutResult/Sekiban.Dcb.WithoutResult.csproj
+++ b/dcb/src/Sekiban.Dcb.WithoutResult/Sekiban.Dcb.WithoutResult.csproj
@@ -7,14 +7,14 @@
         <AssemblyName>Sekiban.Dcb.WithoutResult</AssemblyName>
         <RootNamespace>Sekiban.Dcb</RootNamespace>
         <PackageId>Sekiban.Dcb.WithoutResult</PackageId>
-        <Version>10.0.1-preview05</Version>
+        <Version>10.0.1-preview06</Version>
         <Authors>J-Tech Group</Authors>
         <Company>J-Tech-Japan</Company>
         <Copyright>Copyright (c) J-Tech-Japan 2025</Copyright>
         <PackageDescription>Sekiban DCB WithoutResult - Exception-based API for Dynamic Consistency Boundary</PackageDescription>
         <RepositoryUrl>https://github.com/J-Tech-Japan/Sekiban</RepositoryUrl>
         <PackageProjectUrl>https://github.com/J-Tech-Japan/Sekiban</PackageProjectUrl>
-        <PackageVersion>10.0.1-preview05</PackageVersion>
+        <PackageVersion>10.0.1-preview06</PackageVersion>
         <Description>Exception-based API for Sekiban Dynamic Consistency Boundary - traditional error handling with exceptions</Description>
         <PackageTags>event-sourcing;cqrs;ddd;dcb;sekiban;exceptions</PackageTags>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
@@ -32,7 +32,7 @@
     <ItemGroup>
         <PackageReference Include="Sekiban.Dcb.Core" Version="$(PackageVersion)" />
         <PackageReference Include="ResultBoxes" Version="0.3.31" PrivateAssets="All" />
-        <PackageReference Include="Microsoft.Sbom.Targets" Version="4.1.2">
+        <PackageReference Include="Microsoft.Sbom.Targets" Version="4.1.5">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/dcb/tests/Sekiban.Dcb.Postgres.Tests/Sekiban.Dcb.Postgres.Tests.csproj
+++ b/dcb/tests/Sekiban.Dcb.Postgres.Tests/Sekiban.Dcb.Postgres.Tests.csproj
@@ -9,11 +9,11 @@
     </PropertyGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.0"/>
+        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.1"/>
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.8"/>
+        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.11"/>
     </ItemGroup>
 
     <ItemGroup>
@@ -27,7 +27,7 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="Testcontainers.PostgreSql" Version="4.8.1" />
+        <PackageReference Include="Testcontainers.PostgreSql" Version="4.9.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/Sekiban.Dcb.WithResult.Tests.csproj
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/Sekiban.Dcb.WithResult.Tests.csproj
@@ -12,7 +12,7 @@
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.1" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
         <PackageReference Include="xunit" Version="2.9.3" />
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/dcb/tests/Sekiban.Dcb.WithoutResult.Tests/Sekiban.Dcb.WithoutResult.Tests.csproj
+++ b/dcb/tests/Sekiban.Dcb.WithoutResult.Tests/Sekiban.Dcb.WithoutResult.Tests.csproj
@@ -12,7 +12,7 @@
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.1" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
         <PackageReference Include="xunit" Version="2.9.3" />
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">


### PR DESCRIPTION
Update various package references to their latest versions, including Microsoft.Extensions.DependencyInjection and OpenTelemetry packages, ensuring compatibility and access to the latest features and fixes.

