### PR TITLE
Add GetTimestamp() extension method to Event

### DIFF
--- a/dcb/src/Sekiban.Dcb.Core/Events/EventExtensions.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Events/EventExtensions.cs
@@ -1,0 +1,24 @@
+using Sekiban.Dcb.Common;
+
+namespace Sekiban.Dcb.Events;
+
+/// <summary>
+///     Extension methods for Event
+/// </summary>
+public static class EventExtensions
+{
+    /// <summary>
+    ///     Gets the timestamp of the event from its SortableUniqueId.
+    ///     This represents when the event was created, not when it was persisted.
+    /// </summary>
+    /// <param name="evt">The event to get the timestamp from</param>
+    /// <returns>The event timestamp as a UTC DateTimeOffset</returns>
+    public static DateTimeOffset GetTimestamp(this Event evt)
+    {
+        var sortableId = new SortableUniqueId(evt.SortableUniqueIdValue);
+        var dateTime = sortableId.GetDateTime();
+        // GetDateTime() returns DateTime with DateTimeKind.Utc,
+        // so we use the single-parameter constructor which preserves the Kind
+        return new DateTimeOffset(dateTime);
+    }
+}

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/EventExtensionsTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/EventExtensionsTests.cs
@@ -1,0 +1,132 @@
+using Dcb.Domain.Student;
+using Sekiban.Dcb.Common;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.Tags;
+
+namespace Sekiban.Dcb.Tests;
+
+/// <summary>
+///     Tests for EventExtensions
+/// </summary>
+public class EventExtensionsTests
+{
+    [Fact]
+    public void GetTimestamp_Should_Return_DateTimeOffset_From_SortableUniqueId()
+    {
+        // Arrange
+        var studentId = Guid.NewGuid();
+        var eventPayload = new StudentCreated(studentId, "John Doe");
+        var sortableId = SortableUniqueId.GenerateNew();
+        var tags = new List<string> { new StudentTag(studentId).GetTag() };
+
+        var evt = new Event(
+            eventPayload,
+            sortableId,
+            nameof(StudentCreated),
+            Guid.NewGuid(),
+            new EventMetadata(Guid.NewGuid().ToString(), "TestCommand", "TestUser"),
+            tags);
+
+        // Act
+        var timestamp = evt.GetTimestamp();
+
+        // Assert
+        // DateTimeOffset.DateTime.Kind is typically Unspecified even when created from UTC DateTime
+        // What matters is the Offset, which should be Zero for UTC
+        Assert.Equal(TimeSpan.Zero, timestamp.Offset);
+
+        // Verify it matches the SortableUniqueId's embedded timestamp
+        var sortableIdObj = new SortableUniqueId(evt.SortableUniqueIdValue);
+        var expectedDateTime = sortableIdObj.GetDateTime();
+        Assert.Equal(expectedDateTime, timestamp.DateTime);
+    }
+
+    [Fact]
+    public void GetTimestamp_Should_Match_SortableUniqueId_GetDateTime()
+    {
+        // Arrange
+        var studentId = Guid.NewGuid();
+        var eventPayload = new StudentCreated(studentId, "Jane Doe");
+        var sortableId = SortableUniqueId.GenerateNew();
+        var tags = new List<string> { new StudentTag(studentId).GetTag() };
+
+        var evt = new Event(
+            eventPayload,
+            sortableId,
+            nameof(StudentCreated),
+            Guid.NewGuid(),
+            new EventMetadata(Guid.NewGuid().ToString(), "TestCommand", "TestUser"),
+            tags);
+
+        // Act
+        var timestampFromExtension = evt.GetTimestamp();
+        var sortableIdObj = new SortableUniqueId(evt.SortableUniqueIdValue);
+        var timestampFromSortableId = new DateTimeOffset(sortableIdObj.GetDateTime(), TimeSpan.Zero);
+
+        // Assert
+        Assert.Equal(timestampFromSortableId, timestampFromExtension);
+    }
+
+    [Fact]
+    public void GetTimestamp_Should_Be_Consistent_Across_Multiple_Calls()
+    {
+        // Arrange
+        var studentId = Guid.NewGuid();
+        var eventPayload = new StudentCreated(studentId, "Bob Smith");
+        var sortableId = SortableUniqueId.GenerateNew();
+        var tags = new List<string> { new StudentTag(studentId).GetTag() };
+
+        var evt = new Event(
+            eventPayload,
+            sortableId,
+            nameof(StudentCreated),
+            Guid.NewGuid(),
+            new EventMetadata(Guid.NewGuid().ToString(), "TestCommand", "TestUser"),
+            tags);
+
+        // Act
+        var timestamp1 = evt.GetTimestamp();
+        var timestamp2 = evt.GetTimestamp();
+
+        // Assert
+        Assert.Equal(timestamp1, timestamp2);
+    }
+
+    [Fact]
+    public void GetTimestamp_Should_Return_Earlier_Time_For_Earlier_Events()
+    {
+        // Arrange
+        var studentId1 = Guid.NewGuid();
+        var studentId2 = Guid.NewGuid();
+
+        // Create first event
+        var sortableId1 = SortableUniqueId.GenerateNew();
+        var event1 = new Event(
+            new StudentCreated(studentId1, "First Student"),
+            sortableId1,
+            nameof(StudentCreated),
+            Guid.NewGuid(),
+            new EventMetadata(Guid.NewGuid().ToString(), "TestCommand", "TestUser"),
+            new List<string> { new StudentTag(studentId1).GetTag() });
+
+        // Wait a tiny bit to ensure different timestamps
+        Thread.Sleep(2);
+
+        // Create second event
+        var sortableId2 = SortableUniqueId.GenerateNew();
+        var event2 = new Event(
+            new StudentCreated(studentId2, "Second Student"),
+            sortableId2,
+            nameof(StudentCreated),
+            Guid.NewGuid(),
+            new EventMetadata(Guid.NewGuid().ToString(), "TestCommand", "TestUser"),
+            new List<string> { new StudentTag(studentId2).GetTag() });
+
+        // Act
+        var timestamp1 = event1.GetTimestamp();
+        var timestamp2 = event2.GetTimestamp();
+
+        // Assert
+        Assert.True(timestamp1 < timestamp2, "First event should have earlier timestamp");
+    }
+}


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR adds a `GetTimestamp()` extension method to the `Event` class that returns the event's creation timestamp as a `DateTimeOffset`.

### Implementation

**New file**: `dcb/src/Sekiban.Dcb.Core/Events/EventExtensions.cs`

```csharp
public static DateTimeOffset GetTimestamp(this Event evt)
{
    var sortableId = new SortableUniqueId(evt.SortableUniqueIdValue);
    var dateTime = sortableId.GetDateTime();
    return new DateTimeOffset(dateTime);
}
```

**Test file**: `dcb/tests/Sekiban.Dcb.WithResult.Tests/EventExtensionsTests.cs`
- 4 comprehensive test cases covering functionality, consistency, and ordering

### Benefits

- **Cleaner API**: `evt.GetTimestamp()` vs `new SortableUniqueId(evt.SortableUniqueIdValue).GetDateTime()`
- **Better discoverability**: Extension method appears in IntelliSense
- **Single source of truth**: Establishes `SortableUniqueId` as authoritative timestamp source
- **Modern API**: Returns `DateTimeOffset` (matches `TagWriteResult` pattern)

### Design Decisions

| Decision | Choice | Rationale |
|----------|--------|-----------|
| Return Type | `DateTimeOffset` | Modern API pattern, better timezone semantics |
| Method Name | `GetTimestamp()` | Simple, clear, matches `DbEvent.Timestamp` |
| Implementation | Extension Method | Follows library patterns, keeps `Event` record clean |
| Location | New `EventExtensions.cs` | Separates timestamp logic from serialization |

### Compatibility

- ✅ Non-breaking: Extension method is additive
- ✅ No changes to `Event` record itself
- ✅ Fully compatible with existing data
- ✅ All existing tests pass

## Related Tickets & Documents

- Closes #828

## QA Instructions, Screenshots, Recordings

### Build & Test Verification

```bash
# Build
dotnet build dcb/src/Sekiban.Dcb.Core/Sekiban.Dcb.Core.csproj

# Run tests
dotnet test dcb/tests/Sekiban.Dcb.WithResult.Tests --filter "FullyQualifiedName~EventExtensionsTests"
```

**Result**: All 4 tests passed ✅

### Test Coverage

1. ✅ Returns correct `DateTimeOffset` from `SortableUniqueId`
2. ✅ Matches `SortableUniqueId.GetDateTime()` output
3. ✅ Consistent results across multiple calls
4. ✅ Preserves event ordering

## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests have not been included_
- [ ] I need help with writing tests

**Test Details**: Created `EventExtensionsTests.cs` with 4 comprehensive test cases validating all aspects of the `GetTimestamp()` method.

## [optional] Are there any post deployment tasks we need to perform?

No post-deployment tasks required. The extension method is purely additive and does not affect existing functionality.