### PR TITLE
feat: Add GenericStringTagMultiProjector and GenericIntTagMultiProjector

### DIFF
--- a/dcb/src/Sekiban.Dcb.WithResult/MultiProjections/GenericIntTagMultiProjector.cs
+++ b/dcb/src/Sekiban.Dcb.WithResult/MultiProjections/GenericIntTagMultiProjector.cs
@@ -1,0 +1,373 @@
+using ResultBoxes;
+using Sekiban.Dcb.Common;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.Tags;
+namespace Sekiban.Dcb.MultiProjections;
+
+/// <summary>
+///     Generic multi-projector that works with integer-keyed tag groups.
+///     This variant uses IIntTagGroup for tags that have integer identifiers.
+///     Implements custom serialization to properly handle SafeUnsafeProjectionState with int keys.
+/// </summary>
+/// <typeparam name="TTagProjector">The tag projector type that projects individual tag states</typeparam>
+/// <typeparam name="TTagGroup">The integer-keyed tag group type (must implement IIntTagGroup)</typeparam>
+/// <example>
+/// <code>
+/// // Example usage with YearlyStudentsTag (int-based)
+/// var projector = GenericIntTagMultiProjector&lt;StudentProjector, YearlyStudentsTag&gt;.GenerateInitialPayload();
+///
+/// // Process event with int-keyed tag
+/// var year = 2024;
+/// var tag = new YearlyStudentsTag(year);
+/// var result = GenericIntTagMultiProjector&lt;StudentProjector, YearlyStudentsTag&gt;.Project(
+///     projector,
+///     eventData,
+///     new List&lt;ITag&gt; { tag },
+///     domainTypes,
+///     safeThreshold);
+///
+/// // Access state by int key
+/// var states = result.GetValue().GetCurrentTagStates();
+/// var yearState = states[year];
+/// </code>
+/// </example>
+public record
+    GenericIntTagMultiProjector<TTagProjector, TTagGroup> :
+    IMultiProjector<GenericIntTagMultiProjector<TTagProjector, TTagGroup>>,
+    IMultiProjectorWithCustomSerialization<GenericIntTagMultiProjector<TTagProjector, TTagGroup>>,
+    ISafeAndUnsafeStateAccessor<GenericIntTagMultiProjector<TTagProjector, TTagGroup>>
+    where TTagProjector : ITagProjector<TTagProjector> where TTagGroup : IIntTagGroup<TTagGroup>
+{
+    /// <summary>
+    ///     SafeWindow は外部 (Actor) が SortableUniqueId safeWindowThreshold として計算し ProcessEvent 経由で渡す前提。
+    ///     ここでは固定値や内部計算を持たない。
+    /// </summary>
+
+    /// <summary>
+    ///     Internal state managed by SafeUnsafeProjectionState for TagState with int keys
+    /// </summary>
+    public SafeUnsafeProjectionState<int, TagState> State { get; init; } = new();
+
+    public static string MultiProjectorName =>
+        $"GenericIntTagMultiProjector_{TTagProjector.ProjectorName}_{TTagGroup.TagGroupName}";
+
+    public static string MultiProjectorVersion => TTagProjector.ProjectorVersion;
+
+    public static GenericIntTagMultiProjector<TTagProjector, TTagGroup> GenerateInitialPayload() => new();
+
+    public static byte[] Serialize(DcbDomainTypes domainTypes, string safeWindowThreshold, GenericIntTagMultiProjector<TTagProjector, TTagGroup> payload)
+    {
+        if (string.IsNullOrWhiteSpace(safeWindowThreshold)) throw new ArgumentException("safeWindowThreshold must be supplied", nameof(safeWindowThreshold));
+        Func<Event, IEnumerable<int>> getAffectedIds = _ => Enumerable.Empty<int>();
+        Func<int, TagState?, Event, TagState?> projectItem = (_, current, _) => current;
+        var safeDict = payload.State.GetSafeState(safeWindowThreshold, getAffectedIds, projectItem);
+        var items = new List<object>(safeDict.Count);
+        foreach (var (id, ts) in safeDict)
+        {
+            var payloadType = ts.Payload.GetType();
+            var payloadName = payloadType.Name;
+            var payloadJson = System.Text.Json.JsonSerializer.Serialize(ts.Payload, payloadType, domainTypes.JsonSerializerOptions);
+            items.Add(new
+            {
+                id,
+                type = payloadName,
+                payload = payloadJson,
+                version = ts.Version,
+                last = ts.LastSortedUniqueId
+            });
+        }
+        var dto = new { v = 1, items };
+        var json = System.Text.Json.JsonSerializer.Serialize(dto, domainTypes.JsonSerializerOptions);
+        return GzipCompression.CompressString(json);
+    }
+
+    public static GenericIntTagMultiProjector<TTagProjector, TTagGroup> Deserialize(DcbDomainTypes domainTypes, ReadOnlySpan<byte> data)
+    {
+        var json = GzipCompression.DecompressToString(data);
+        var obj = System.Text.Json.JsonSerializer.Deserialize<System.Text.Json.Nodes.JsonObject>(json, domainTypes.JsonSerializerOptions);
+        var map = new Dictionary<int, TagState>();
+        var tagProjectorName = TTagProjector.ProjectorName;
+        if (obj != null && obj.TryGetPropertyValue("items", out var itemsNode) && itemsNode is System.Text.Json.Nodes.JsonArray arr)
+        {
+            foreach (var n in arr)
+            {
+                if (n is System.Text.Json.Nodes.JsonObject item)
+                {
+                    var id = item["id"]?.GetValue<int>() ?? 0;
+                    var type = item["type"]?.GetValue<string>() ?? string.Empty;
+                    var payloadJson = item["payload"]?.GetValue<string>() ?? "{}";
+                    var version = item["version"]?.GetValue<int>() ?? 0;
+                    var last = item["last"]?.GetValue<string>() ?? string.Empty;
+                    var payloadBytes = System.Text.Encoding.UTF8.GetBytes(payloadJson);
+                    var rb = domainTypes.TagStatePayloadTypes.DeserializePayload(type, payloadBytes);
+                    if (!rb.IsSuccess) continue;
+                    var payload = rb.GetValue();
+                    var tag = TTagGroup.FromContent(id.ToString());
+                    var tagStateId = new TagStateId(tag, tagProjectorName);
+                    var ts = TagState.GetEmpty(tagStateId) with
+                    {
+                        Payload = payload,
+                        Version = version,
+                        LastSortedUniqueId = last,
+                        ProjectorVersion = TTagProjector.ProjectorVersion
+                    };
+                    map[id] = ts;
+                }
+            }
+        }
+        var state = SafeUnsafeProjectionState<int, TagState>.FromCurrentData(map);
+        return new GenericIntTagMultiProjector<TTagProjector, TTagGroup> { State = state };
+    }
+
+    /// <summary>
+    ///     Project with tag filtering - processes events based on tags
+    /// </summary>
+    public static ResultBox<GenericIntTagMultiProjector<TTagProjector, TTagGroup>> Project(
+        GenericIntTagMultiProjector<TTagProjector, TTagGroup> payload,
+        Event ev,
+        List<ITag> tags,
+        DcbDomainTypes domainTypes,
+        SortableUniqueId safeWindowThreshold)
+    {
+        // Filter tags to only process tags of the specified tag group type
+        var relevantTags = tags.OfType<TTagGroup>().Cast<ITag>().ToList();
+
+        if (relevantTags.Count == 0)
+        {
+            // No tags of the specified group, skip this event
+            return ResultBox.FromValue(payload);
+        }
+
+        // Get affected IDs from the passed tags for fallback
+        var affectedIds = relevantTags
+            .Select(tag => GetTagId(tag))
+            .Where(id => id.HasValue)
+            .Select(id => id!.Value)
+            .ToList();
+
+        // Function to get affected item IDs from the actual event being processed
+        // First check evt.Tags for runtime, but fallback to passed tags for tests
+        Func<Event, IEnumerable<int>> getAffectedItemIds = evt =>
+        {
+            var eventTagIds = evt.Tags
+                .Select(domainTypes.TagTypes.GetTag)
+                .OfType<TTagGroup>()
+                .Select(tag => GetTagId(tag))
+                .Where(id => id.HasValue)
+                .Select(id => id!.Value)
+                .ToList();
+
+            // If no tags in event, use the affected IDs from the passed tags
+            return eventTagIds.Count > 0 ? eventTagIds : affectedIds;
+        };
+
+        // Function to project a single item (independent of captured tag list)
+        Func<int, TagState?, Event, TagState?> projectItem = (tagId, current, evt) =>
+            ProjectTagState(tagId, current, evt);
+
+        // safeWindowThreshold を文字列として State へ渡し safe/unsafe 判定を内部に委譲
+        var updatedState = payload.State.ProcessEvent(
+            ev,
+            getAffectedItemIds,
+            projectItem,
+            safeWindowThreshold.Value);
+
+        var newPayload = payload with { State = updatedState };
+
+        return ResultBox.FromValue(newPayload);
+    }
+
+    /// <summary>
+    ///     Project a single tag state
+    /// </summary>
+    private static TagState? ProjectTagState(int tagId, TagState? current, Event ev)
+    {
+        // Create TagStateId for this tagId by constructing the tag from content via generic interface
+        var tagGroup = TTagGroup.FromContent(tagId.ToString());
+        var tagStateId = new TagStateId(tagGroup, TTagProjector.ProjectorName);
+
+        // If current is null, create empty TagState
+        var tagState = current ?? TagState.GetEmpty(tagStateId);
+
+        // Use the tag projector to project the event
+        var newPayload = TTagProjector.Project(tagState.Payload, ev);
+
+        // Check if the item should be removed (e.g., deleted items)
+        if (ShouldRemoveItem(newPayload))
+        {
+            return null; // Remove the item
+        }
+
+        // Return updated TagState
+        return tagState with
+        {
+            Payload = newPayload,
+            Version = tagState.Version + 1,
+            LastSortedUniqueId = ev.SortableUniqueIdValue,
+            ProjectorVersion = TTagProjector.ProjectorVersion
+        };
+    }
+
+    /// <summary>
+    ///     Get unique ID for a tag (only for TTagGroup tags)
+    /// </summary>
+    private static int? GetTagId(ITag tag)
+    {
+        // Only process tags of our specific TTagGroup type
+        if (tag is TTagGroup intTag)
+        {
+            return intTag.GetId();
+        }
+
+        // Ignore all other tags
+        return null;
+    }
+
+    /// <summary>
+    ///     Check if an item should be removed based on the payload state
+    /// </summary>
+    private static bool ShouldRemoveItem(ITagStatePayload payload)
+    {
+        // Check if the payload has an IsDeleted property set to true
+        var deletedProperty = payload.GetType().GetProperty("IsDeleted");
+        if (deletedProperty?.PropertyType == typeof(bool))
+        {
+            var isDeleted = deletedProperty.GetValue(payload) as bool?;
+            return isDeleted == true;
+        }
+
+        return false;
+    }
+
+    // SafeWindow threshold の生成ロジックは削除。Actor が提供する値を使う設計へ移行。
+
+    /// <summary>
+    ///     Get all current tag states (including unsafe)
+    /// </summary>
+    public IReadOnlyDictionary<int, TagState> GetCurrentTagStates() => State.GetCurrentState();
+
+    /// <summary>
+    ///     Get only safe tag states
+    /// </summary>
+    public IReadOnlyDictionary<int, TagState> GetSafeTagStates(
+        string safeWindowThreshold,
+        Func<Event, IEnumerable<int>> getAffectedItemKeys,
+        Func<int, TagState?, Event, TagState?> projectItem) =>
+        State.GetSafeState(safeWindowThreshold, getAffectedItemKeys, projectItem);
+
+    /// <summary>
+    ///     Check if a specific tag state has unsafe modifications
+    /// </summary>
+    public bool IsTagStateUnsafe(int id) => State.IsItemUnsafe(id);
+
+    /// <summary>
+    ///     Get all state payloads from current tag states
+    /// </summary>
+    public IEnumerable<ITagStatePayload> GetStatePayloads()
+    {
+        var currentStates = GetCurrentTagStates();
+        var payloads = currentStates.Values.Select(ts => ts.Payload).Where(p => !ShouldRemoveItem(p)).ToList();
+        return payloads;
+    }
+
+    /// <summary>
+    ///     Get only safe state payloads
+    /// </summary>
+    public IEnumerable<ITagStatePayload> GetSafeStatePayloads(
+        string safeWindowThreshold,
+        Func<Event, IEnumerable<int>> getAffectedItemKeys,
+        Func<int, TagState?, Event, TagState?> projectItem)
+    {
+        return GetSafeTagStates(safeWindowThreshold, getAffectedItemKeys, projectItem)
+            .Values.Select(ts => ts.Payload).Where(p => !ShouldRemoveItem(p));
+    }
+
+    #region ISafeAndUnsafeStateAccessor Implementation
+    private Guid LastEventId { get; init; } = Guid.Empty;
+    private string LastSortableUniqueId { get; init; } = string.Empty;
+    private int Version { get; init; }
+    public int SafeVersion
+    {
+        get
+        {
+            var current = State.GetCurrentState();
+            return current.Values.Sum(ts => ts.Version);
+        }
+    }
+
+    /// <summary>
+    ///     ISafeAndUnsafeStateAccessor - Get safe state
+    /// </summary>
+    public SafeProjection<GenericIntTagMultiProjector<TTagProjector, TTagGroup>> GetSafeProjection(
+        SortableUniqueId safeWindowThreshold,
+        DcbDomainTypes domainTypes)
+    {
+        // Build safe view to compute safe last position and version
+        Func<Event, IEnumerable<int>> getIds = evt => evt.Tags
+            .Select(domainTypes.TagTypes.GetTag)
+            .OfType<TTagGroup>()
+            .Select(tag => GetTagId(tag))
+            .Where(id => id.HasValue)
+            .Select(id => id!.Value);
+
+        Func<int, TagState?, Event, TagState?> projectItem = (tagId, current, evt) => ProjectTagState(tagId, current, evt);
+
+        var safeDict = State.GetSafeState(safeWindowThreshold.Value, getIds, projectItem);
+        var safeLast = safeDict.Count > 0
+            ? safeDict.Values.Max(ts => ts.LastSortedUniqueId) ?? string.Empty
+            : string.Empty;
+        var version = safeDict.Values.Sum(ts => ts.Version);
+        return new SafeProjection<GenericIntTagMultiProjector<TTagProjector, TTagGroup>>(this, safeLast, version);
+    }
+
+    /// <summary>
+    ///     ISafeAndUnsafeStateAccessor - Get unsafe state
+    /// </summary>
+    public UnsafeProjection<GenericIntTagMultiProjector<TTagProjector, TTagGroup>> GetUnsafeProjection(DcbDomainTypes domainTypes)
+    {
+        var current = State.GetCurrentState();
+        var last = current.Count > 0
+            ? current.Values.Max(ts => ts.LastSortedUniqueId) ?? string.Empty
+            : string.Empty;
+        // LastEventId is not tracked here; return Guid.Empty
+        var version = current.Values.Sum(ts => ts.Version);
+        return new UnsafeProjection<GenericIntTagMultiProjector<TTagProjector, TTagGroup>>(this, last, Guid.Empty, version);
+    }
+
+    /// <summary>
+    ///     ISafeAndUnsafeStateAccessor - Process event
+    /// </summary>
+    public ISafeAndUnsafeStateAccessor<GenericIntTagMultiProjector<TTagProjector, TTagGroup>> ProcessEvent(
+        Event evt,
+        SortableUniqueId safeWindowThreshold,
+        DcbDomainTypes domainTypes)
+    {
+        // Parse tag strings into ITag instances using DomainTypes - only keep tags belonging to our tag group
+        var tags = evt.Tags
+            .Select(domainTypes.TagTypes.GetTag)
+            .ToList();
+
+        // Actor から渡された safeWindowThreshold をそのまま State.ProcessEvent に渡すため
+        // Project 内部での SafeWindow 再計算は行わない。
+        var result = Project(this, evt, tags, domainTypes, safeWindowThreshold);
+        if (!result.IsSuccess)
+        {
+            throw new InvalidOperationException($"Failed to project event: {result.GetException()}");
+        }
+
+        var projected = result.GetValue();
+        var updated = projected with { };
+        return updated with
+        {
+            LastEventId = evt.Id,
+            LastSortableUniqueId = evt.SortableUniqueIdValue,
+            Version = Version + 1
+        };
+    }
+
+    public Guid GetLastEventId() => LastEventId;
+    public string GetLastSortableUniqueId() => LastSortableUniqueId;
+    public int GetVersion() => Version;
+
+    #endregion
+}

--- a/dcb/src/Sekiban.Dcb.WithResult/MultiProjections/GenericStringTagMultiProjector.cs
+++ b/dcb/src/Sekiban.Dcb.WithResult/MultiProjections/GenericStringTagMultiProjector.cs
@@ -1,0 +1,373 @@
+using ResultBoxes;
+using Sekiban.Dcb.Common;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.Tags;
+namespace Sekiban.Dcb.MultiProjections;
+
+/// <summary>
+///     Generic multi-projector that works with string-keyed tag groups.
+///     This variant uses IStringTagGroup for tags that have string identifiers.
+///     Implements custom serialization to properly handle SafeUnsafeProjectionState with string keys.
+/// </summary>
+/// <typeparam name="TTagProjector">The tag projector type that projects individual tag states</typeparam>
+/// <typeparam name="TTagGroup">The string-keyed tag group type (must implement IStringTagGroup)</typeparam>
+/// <example>
+/// <code>
+/// // Example usage with StudentCodeTag (string-based)
+/// var projector = GenericStringTagMultiProjector&lt;StudentProjector, StudentCodeTag&gt;.GenerateInitialPayload();
+///
+/// // Process event with string-keyed tag
+/// var studentCode = "STU001";
+/// var tag = new StudentCodeTag(studentCode);
+/// var result = GenericStringTagMultiProjector&lt;StudentProjector, StudentCodeTag&gt;.Project(
+///     projector,
+///     eventData,
+///     new List&lt;ITag&gt; { tag },
+///     domainTypes,
+///     safeThreshold);
+///
+/// // Access state by string key
+/// var states = result.GetValue().GetCurrentTagStates();
+/// var studentState = states[studentCode];
+/// </code>
+/// </example>
+public record
+    GenericStringTagMultiProjector<TTagProjector, TTagGroup> :
+    IMultiProjector<GenericStringTagMultiProjector<TTagProjector, TTagGroup>>,
+    IMultiProjectorWithCustomSerialization<GenericStringTagMultiProjector<TTagProjector, TTagGroup>>,
+    ISafeAndUnsafeStateAccessor<GenericStringTagMultiProjector<TTagProjector, TTagGroup>>
+    where TTagProjector : ITagProjector<TTagProjector> where TTagGroup : IStringTagGroup<TTagGroup>
+{
+    /// <summary>
+    ///     SafeWindow は外部 (Actor) が SortableUniqueId safeWindowThreshold として計算し ProcessEvent 経由で渡す前提。
+    ///     ここでは固定値や内部計算を持たない。
+    /// </summary>
+
+    /// <summary>
+    ///     Internal state managed by SafeUnsafeProjectionState for TagState with string keys
+    /// </summary>
+    public SafeUnsafeProjectionState<string, TagState> State { get; init; } = new();
+
+    public static string MultiProjectorName =>
+        $"GenericStringTagMultiProjector_{TTagProjector.ProjectorName}_{TTagGroup.TagGroupName}";
+
+    public static string MultiProjectorVersion => TTagProjector.ProjectorVersion;
+
+    public static GenericStringTagMultiProjector<TTagProjector, TTagGroup> GenerateInitialPayload() => new();
+
+    public static byte[] Serialize(DcbDomainTypes domainTypes, string safeWindowThreshold, GenericStringTagMultiProjector<TTagProjector, TTagGroup> payload)
+    {
+        if (string.IsNullOrWhiteSpace(safeWindowThreshold)) throw new ArgumentException("safeWindowThreshold must be supplied", nameof(safeWindowThreshold));
+        Func<Event, IEnumerable<string>> getAffectedIds = _ => Enumerable.Empty<string>();
+        Func<string, TagState?, Event, TagState?> projectItem = (_, current, _) => current;
+        var safeDict = payload.State.GetSafeState(safeWindowThreshold, getAffectedIds, projectItem);
+        var items = new List<object>(safeDict.Count);
+        foreach (var (id, ts) in safeDict)
+        {
+            var payloadType = ts.Payload.GetType();
+            var payloadName = payloadType.Name;
+            var payloadJson = System.Text.Json.JsonSerializer.Serialize(ts.Payload, payloadType, domainTypes.JsonSerializerOptions);
+            items.Add(new
+            {
+                id,
+                type = payloadName,
+                payload = payloadJson,
+                version = ts.Version,
+                last = ts.LastSortedUniqueId
+            });
+        }
+        var dto = new { v = 1, items };
+        var json = System.Text.Json.JsonSerializer.Serialize(dto, domainTypes.JsonSerializerOptions);
+        return GzipCompression.CompressString(json);
+    }
+
+    public static GenericStringTagMultiProjector<TTagProjector, TTagGroup> Deserialize(DcbDomainTypes domainTypes, ReadOnlySpan<byte> data)
+    {
+        var json = GzipCompression.DecompressToString(data);
+        var obj = System.Text.Json.JsonSerializer.Deserialize<System.Text.Json.Nodes.JsonObject>(json, domainTypes.JsonSerializerOptions);
+        var map = new Dictionary<string, TagState>();
+        var tagProjectorName = TTagProjector.ProjectorName;
+        if (obj != null && obj.TryGetPropertyValue("items", out var itemsNode) && itemsNode is System.Text.Json.Nodes.JsonArray arr)
+        {
+            foreach (var n in arr)
+            {
+                if (n is System.Text.Json.Nodes.JsonObject item)
+                {
+                    var id = item["id"]?.GetValue<string>() ?? string.Empty;
+                    var type = item["type"]?.GetValue<string>() ?? string.Empty;
+                    var payloadJson = item["payload"]?.GetValue<string>() ?? "{}";
+                    var version = item["version"]?.GetValue<int>() ?? 0;
+                    var last = item["last"]?.GetValue<string>() ?? string.Empty;
+                    var payloadBytes = System.Text.Encoding.UTF8.GetBytes(payloadJson);
+                    var rb = domainTypes.TagStatePayloadTypes.DeserializePayload(type, payloadBytes);
+                    if (!rb.IsSuccess) continue;
+                    var payload = rb.GetValue();
+                    var tag = TTagGroup.FromContent(id);
+                    var tagStateId = new TagStateId(tag, tagProjectorName);
+                    var ts = TagState.GetEmpty(tagStateId) with
+                    {
+                        Payload = payload,
+                        Version = version,
+                        LastSortedUniqueId = last,
+                        ProjectorVersion = TTagProjector.ProjectorVersion
+                    };
+                    map[id] = ts;
+                }
+            }
+        }
+        var state = SafeUnsafeProjectionState<string, TagState>.FromCurrentData(map);
+        return new GenericStringTagMultiProjector<TTagProjector, TTagGroup> { State = state };
+    }
+
+    /// <summary>
+    ///     Project with tag filtering - processes events based on tags
+    /// </summary>
+    public static ResultBox<GenericStringTagMultiProjector<TTagProjector, TTagGroup>> Project(
+        GenericStringTagMultiProjector<TTagProjector, TTagGroup> payload,
+        Event ev,
+        List<ITag> tags,
+        DcbDomainTypes domainTypes,
+        SortableUniqueId safeWindowThreshold)
+    {
+        // Filter tags to only process tags of the specified tag group type
+        var relevantTags = tags.OfType<TTagGroup>().Cast<ITag>().ToList();
+
+        if (relevantTags.Count == 0)
+        {
+            // No tags of the specified group, skip this event
+            return ResultBox.FromValue(payload);
+        }
+
+        // Get affected IDs from the passed tags for fallback
+        var affectedIds = relevantTags
+            .Select(tag => GetTagId(tag))
+            .Where(id => id != null)
+            .Select(id => id!)
+            .ToList();
+
+        // Function to get affected item IDs from the actual event being processed
+        // First check evt.Tags for runtime, but fallback to passed tags for tests
+        Func<Event, IEnumerable<string>> getAffectedItemIds = evt =>
+        {
+            var eventTagIds = evt.Tags
+                .Select(domainTypes.TagTypes.GetTag)
+                .OfType<TTagGroup>()
+                .Select(tag => GetTagId(tag))
+                .Where(id => id != null)
+                .Select(id => id!)
+                .ToList();
+
+            // If no tags in event, use the affected IDs from the passed tags
+            return eventTagIds.Count > 0 ? eventTagIds : affectedIds;
+        };
+
+        // Function to project a single item (independent of captured tag list)
+        Func<string, TagState?, Event, TagState?> projectItem = (tagId, current, evt) =>
+            ProjectTagState(tagId, current, evt);
+
+        // safeWindowThreshold を文字列として State へ渡し safe/unsafe 判定を内部に委譲
+        var updatedState = payload.State.ProcessEvent(
+            ev,
+            getAffectedItemIds,
+            projectItem,
+            safeWindowThreshold.Value);
+
+        var newPayload = payload with { State = updatedState };
+
+        return ResultBox.FromValue(newPayload);
+    }
+
+    /// <summary>
+    ///     Project a single tag state
+    /// </summary>
+    private static TagState? ProjectTagState(string tagId, TagState? current, Event ev)
+    {
+        // Create TagStateId for this tagId by constructing the tag from content via generic interface
+        var tagGroup = TTagGroup.FromContent(tagId);
+        var tagStateId = new TagStateId(tagGroup, TTagProjector.ProjectorName);
+
+        // If current is null, create empty TagState
+        var tagState = current ?? TagState.GetEmpty(tagStateId);
+
+        // Use the tag projector to project the event
+        var newPayload = TTagProjector.Project(tagState.Payload, ev);
+
+        // Check if the item should be removed (e.g., deleted items)
+        if (ShouldRemoveItem(newPayload))
+        {
+            return null; // Remove the item
+        }
+
+        // Return updated TagState
+        return tagState with
+        {
+            Payload = newPayload,
+            Version = tagState.Version + 1,
+            LastSortedUniqueId = ev.SortableUniqueIdValue,
+            ProjectorVersion = TTagProjector.ProjectorVersion
+        };
+    }
+
+    /// <summary>
+    ///     Get unique ID for a tag (only for TTagGroup tags)
+    /// </summary>
+    private static string? GetTagId(ITag tag)
+    {
+        // Only process tags of our specific TTagGroup type
+        if (tag is TTagGroup stringTag)
+        {
+            return stringTag.GetId();
+        }
+
+        // Ignore all other tags
+        return null;
+    }
+
+    /// <summary>
+    ///     Check if an item should be removed based on the payload state
+    /// </summary>
+    private static bool ShouldRemoveItem(ITagStatePayload payload)
+    {
+        // Check if the payload has an IsDeleted property set to true
+        var deletedProperty = payload.GetType().GetProperty("IsDeleted");
+        if (deletedProperty?.PropertyType == typeof(bool))
+        {
+            var isDeleted = deletedProperty.GetValue(payload) as bool?;
+            return isDeleted == true;
+        }
+
+        return false;
+    }
+
+    // SafeWindow threshold の生成ロジックは削除。Actor が提供する値を使う設計へ移行。
+
+    /// <summary>
+    ///     Get all current tag states (including unsafe)
+    /// </summary>
+    public IReadOnlyDictionary<string, TagState> GetCurrentTagStates() => State.GetCurrentState();
+
+    /// <summary>
+    ///     Get only safe tag states
+    /// </summary>
+    public IReadOnlyDictionary<string, TagState> GetSafeTagStates(
+        string safeWindowThreshold,
+        Func<Event, IEnumerable<string>> getAffectedItemKeys,
+        Func<string, TagState?, Event, TagState?> projectItem) =>
+        State.GetSafeState(safeWindowThreshold, getAffectedItemKeys, projectItem);
+
+    /// <summary>
+    ///     Check if a specific tag state has unsafe modifications
+    /// </summary>
+    public bool IsTagStateUnsafe(string id) => State.IsItemUnsafe(id);
+
+    /// <summary>
+    ///     Get all state payloads from current tag states
+    /// </summary>
+    public IEnumerable<ITagStatePayload> GetStatePayloads()
+    {
+        var currentStates = GetCurrentTagStates();
+        var payloads = currentStates.Values.Select(ts => ts.Payload).Where(p => !ShouldRemoveItem(p)).ToList();
+        return payloads;
+    }
+
+    /// <summary>
+    ///     Get only safe state payloads
+    /// </summary>
+    public IEnumerable<ITagStatePayload> GetSafeStatePayloads(
+        string safeWindowThreshold,
+        Func<Event, IEnumerable<string>> getAffectedItemKeys,
+        Func<string, TagState?, Event, TagState?> projectItem)
+    {
+        return GetSafeTagStates(safeWindowThreshold, getAffectedItemKeys, projectItem)
+            .Values.Select(ts => ts.Payload).Where(p => !ShouldRemoveItem(p));
+    }
+
+    #region ISafeAndUnsafeStateAccessor Implementation
+    private Guid LastEventId { get; init; } = Guid.Empty;
+    private string LastSortableUniqueId { get; init; } = string.Empty;
+    private int Version { get; init; }
+    public int SafeVersion
+    {
+        get
+        {
+            var current = State.GetCurrentState();
+            return current.Values.Sum(ts => ts.Version);
+        }
+    }
+
+    /// <summary>
+    ///     ISafeAndUnsafeStateAccessor - Get safe state
+    /// </summary>
+    public SafeProjection<GenericStringTagMultiProjector<TTagProjector, TTagGroup>> GetSafeProjection(
+        SortableUniqueId safeWindowThreshold,
+        DcbDomainTypes domainTypes)
+    {
+        // Build safe view to compute safe last position and version
+        Func<Event, IEnumerable<string>> getIds = evt => evt.Tags
+            .Select(domainTypes.TagTypes.GetTag)
+            .OfType<TTagGroup>()
+            .Select(tag => GetTagId(tag))
+            .Where(id => id != null)
+            .Select(id => id!);
+
+        Func<string, TagState?, Event, TagState?> projectItem = (tagId, current, evt) => ProjectTagState(tagId, current, evt);
+
+        var safeDict = State.GetSafeState(safeWindowThreshold.Value, getIds, projectItem);
+        var safeLast = safeDict.Count > 0
+            ? safeDict.Values.Max(ts => ts.LastSortedUniqueId) ?? string.Empty
+            : string.Empty;
+        var version = safeDict.Values.Sum(ts => ts.Version);
+        return new SafeProjection<GenericStringTagMultiProjector<TTagProjector, TTagGroup>>(this, safeLast, version);
+    }
+
+    /// <summary>
+    ///     ISafeAndUnsafeStateAccessor - Get unsafe state
+    /// </summary>
+    public UnsafeProjection<GenericStringTagMultiProjector<TTagProjector, TTagGroup>> GetUnsafeProjection(DcbDomainTypes domainTypes)
+    {
+        var current = State.GetCurrentState();
+        var last = current.Count > 0
+            ? current.Values.Max(ts => ts.LastSortedUniqueId) ?? string.Empty
+            : string.Empty;
+        // LastEventId is not tracked here; return Guid.Empty
+        var version = current.Values.Sum(ts => ts.Version);
+        return new UnsafeProjection<GenericStringTagMultiProjector<TTagProjector, TTagGroup>>(this, last, Guid.Empty, version);
+    }
+
+    /// <summary>
+    ///     ISafeAndUnsafeStateAccessor - Process event
+    /// </summary>
+    public ISafeAndUnsafeStateAccessor<GenericStringTagMultiProjector<TTagProjector, TTagGroup>> ProcessEvent(
+        Event evt,
+        SortableUniqueId safeWindowThreshold,
+        DcbDomainTypes domainTypes)
+    {
+        // Parse tag strings into ITag instances using DomainTypes - only keep tags belonging to our tag group
+        var tags = evt.Tags
+            .Select(domainTypes.TagTypes.GetTag)
+            .ToList();
+
+        // Actor から渡された safeWindowThreshold をそのまま State.ProcessEvent に渡すため
+        // Project 内部での SafeWindow 再計算は行わない。
+        var result = Project(this, evt, tags, domainTypes, safeWindowThreshold);
+        if (!result.IsSuccess)
+        {
+            throw new InvalidOperationException($"Failed to project event: {result.GetException()}");
+        }
+
+        var projected = result.GetValue();
+        var updated = projected with { };
+        return updated with
+        {
+            LastEventId = evt.Id,
+            LastSortableUniqueId = evt.SortableUniqueIdValue,
+            Version = Version + 1
+        };
+    }
+
+    public Guid GetLastEventId() => LastEventId;
+    public string GetLastSortableUniqueId() => LastSortableUniqueId;
+    public int GetVersion() => Version;
+
+    #endregion
+}

--- a/dcb/src/Sekiban.Dcb.WithoutResult/MultiProjections/GenericIntTagMultiProjector.cs
+++ b/dcb/src/Sekiban.Dcb.WithoutResult/MultiProjections/GenericIntTagMultiProjector.cs
@@ -1,0 +1,380 @@
+using ResultBoxes;
+using Sekiban.Dcb.Common;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.Tags;
+namespace Sekiban.Dcb.MultiProjections;
+
+/// <summary>
+///     Generic multi-projector that works with integer-keyed tag groups.
+///     This variant uses IIntTagGroup for tags that have integer identifiers.
+///     Implements custom serialization to properly handle SafeUnsafeProjectionState with int keys.
+/// </summary>
+/// <typeparam name="TTagProjector">The tag projector type that projects individual tag states</typeparam>
+/// <typeparam name="TTagGroup">The integer-keyed tag group type (must implement IIntTagGroup)</typeparam>
+/// <example>
+/// <code>
+/// // Example usage with YearlyStudentsTag (int-based)
+/// var projector = GenericIntTagMultiProjector&lt;StudentProjector, YearlyStudentsTag&gt;.GenerateInitialPayload();
+///
+/// // Process event with int-keyed tag
+/// var year = 2024;
+/// var tag = new YearlyStudentsTag(year);
+/// var result = GenericIntTagMultiProjector&lt;StudentProjector, YearlyStudentsTag&gt;.Project(
+///     projector,
+///     eventData,
+///     new List&lt;ITag&gt; { tag },
+///     domainTypes,
+///     safeThreshold);
+///
+/// // Access state by int key
+/// var states = result.GetCurrentTagStates();
+/// var yearState = states[year];
+/// </code>
+/// </example>
+public record
+    GenericIntTagMultiProjector<TTagProjector, TTagGroup> :
+    IMultiProjectorWithCustomSerialization<GenericIntTagMultiProjector<TTagProjector, TTagGroup>>,
+    ISafeAndUnsafeStateAccessor<GenericIntTagMultiProjector<TTagProjector, TTagGroup>>
+    where TTagProjector : ITagProjector<TTagProjector> where TTagGroup : IIntTagGroup<TTagGroup>
+{
+    /// <summary>
+    ///     SafeWindow は外部 (Actor) が SortableUniqueId safeWindowThreshold として計算し ProcessEvent 経由で渡す前提。
+    ///     ここでは固定値や内部計算を持たない。
+    /// </summary>
+
+    /// <summary>
+    ///     Internal state managed by SafeUnsafeProjectionState for TagState with int keys
+    /// </summary>
+    public SafeUnsafeProjectionState<int, TagState> State { get; init; } = new();
+
+    public static string MultiProjectorName =>
+        $"GenericIntTagMultiProjector_{TTagProjector.ProjectorName}_{TTagGroup.TagGroupName}";
+
+    public static string MultiProjectorVersion => TTagProjector.ProjectorVersion;
+
+    public static GenericIntTagMultiProjector<TTagProjector, TTagGroup> GenerateInitialPayload() => new();
+
+    public static byte[] Serialize(DcbDomainTypes domainTypes, string safeWindowThreshold, GenericIntTagMultiProjector<TTagProjector, TTagGroup> payload)
+    {
+        if (string.IsNullOrWhiteSpace(safeWindowThreshold)) throw new ArgumentException("safeWindowThreshold must be supplied", nameof(safeWindowThreshold));
+        Func<Event, IEnumerable<int>> getAffectedIds = _ => Enumerable.Empty<int>();
+        Func<int, TagState?, Event, TagState?> projectItem = (_, current, _) => current;
+        var safeDict = payload.State.GetSafeState(safeWindowThreshold, getAffectedIds, projectItem);
+        var items = new List<object>(safeDict.Count);
+        foreach (var (id, ts) in safeDict)
+        {
+            var payloadType = ts.Payload.GetType();
+            var payloadName = payloadType.Name;
+            var payloadJson = System.Text.Json.JsonSerializer.Serialize(ts.Payload, payloadType, domainTypes.JsonSerializerOptions);
+            items.Add(new
+            {
+                id,
+                type = payloadName,
+                payload = payloadJson,
+                version = ts.Version,
+                last = ts.LastSortedUniqueId
+            });
+        }
+        var dto = new { v = 1, items };
+        var json = System.Text.Json.JsonSerializer.Serialize(dto, domainTypes.JsonSerializerOptions);
+        return GzipCompression.CompressString(json);
+    }
+
+    public static GenericIntTagMultiProjector<TTagProjector, TTagGroup> Deserialize(DcbDomainTypes domainTypes, ReadOnlySpan<byte> data)
+    {
+        var json = GzipCompression.DecompressToString(data);
+        var obj = System.Text.Json.JsonSerializer.Deserialize<System.Text.Json.Nodes.JsonObject>(json, domainTypes.JsonSerializerOptions);
+        var map = new Dictionary<int, TagState>();
+        var tagProjectorName = TTagProjector.ProjectorName;
+        if (obj != null && obj.TryGetPropertyValue("items", out var itemsNode) && itemsNode is System.Text.Json.Nodes.JsonArray arr)
+        {
+            foreach (var n in arr)
+            {
+                if (n is System.Text.Json.Nodes.JsonObject item)
+                {
+                    var id = item["id"]?.GetValue<int>() ?? 0;
+                    var type = item["type"]?.GetValue<string>() ?? string.Empty;
+                    var payloadJson = item["payload"]?.GetValue<string>() ?? "{}";
+                    var version = item["version"]?.GetValue<int>() ?? 0;
+                    var last = item["last"]?.GetValue<string>() ?? string.Empty;
+                    var payloadBytes = System.Text.Encoding.UTF8.GetBytes(payloadJson);
+                    var rb = domainTypes.TagStatePayloadTypes.DeserializePayload(type, payloadBytes);
+                    if (!rb.IsSuccess) continue;
+                    var payload = rb.GetValue();
+                    var tag = TTagGroup.FromContent(id.ToString());
+                    var tagStateId = new TagStateId(tag, tagProjectorName);
+                    var ts = TagState.GetEmpty(tagStateId) with
+                    {
+                        Payload = payload,
+                        Version = version,
+                        LastSortedUniqueId = last,
+                        ProjectorVersion = TTagProjector.ProjectorVersion
+                    };
+                    map[id] = ts;
+                }
+            }
+        }
+        var state = SafeUnsafeProjectionState<int, TagState>.FromCurrentData(map);
+        return new GenericIntTagMultiProjector<TTagProjector, TTagGroup> { State = state };
+    }
+
+    /// <summary>
+    ///     Project with tag filtering - processes events based on tags (internal ResultBox version)
+    /// </summary>
+    private static ResultBox<GenericIntTagMultiProjector<TTagProjector, TTagGroup>> ProjectInternal(
+        GenericIntTagMultiProjector<TTagProjector, TTagGroup> payload,
+        Event ev,
+        List<ITag> tags,
+        DcbDomainTypes domainTypes,
+        SortableUniqueId safeWindowThreshold)
+    {
+        // Filter tags to only process tags of the specified tag group type
+        var relevantTags = tags.OfType<TTagGroup>().Cast<ITag>().ToList();
+
+        if (relevantTags.Count == 0)
+        {
+            // No tags of the specified group, skip this event
+            return ResultBox.FromValue(payload);
+        }
+
+        // Get affected IDs from the passed tags for fallback
+        var affectedIds = relevantTags
+            .Select(tag => GetTagId(tag))
+            .Where(id => id.HasValue)
+            .Select(id => id!.Value)
+            .ToList();
+
+        // Function to get affected item IDs from the actual event being processed
+        // First check evt.Tags for runtime, but fallback to passed tags for tests
+        Func<Event, IEnumerable<int>> getAffectedItemIds = evt =>
+        {
+            var eventTagIds = evt.Tags
+                .Select(domainTypes.TagTypes.GetTag)
+                .OfType<TTagGroup>()
+                .Select(tag => GetTagId(tag))
+                .Where(id => id.HasValue)
+                .Select(id => id!.Value)
+                .ToList();
+
+            // If no tags in event, use the affected IDs from the passed tags
+            return eventTagIds.Count > 0 ? eventTagIds : affectedIds;
+        };
+
+        // Function to project a single item (independent of captured tag list)
+        Func<int, TagState?, Event, TagState?> projectItem = (tagId, current, evt) =>
+            ProjectTagState(tagId, current, evt);
+
+        // safeWindowThreshold を文字列として State へ渡し safe/unsafe 判定を内部に委譲
+        var updatedState = payload.State.ProcessEvent(
+            ev,
+            getAffectedItemIds,
+            projectItem,
+            safeWindowThreshold.Value);
+
+        var newPayload = payload with { State = updatedState };
+
+        return ResultBox.FromValue(newPayload);
+    }
+
+    /// <summary>
+    ///     Project with tag filtering - processes events based on tags (exception-based)
+    /// </summary>
+    public static GenericIntTagMultiProjector<TTagProjector, TTagGroup> Project(
+        GenericIntTagMultiProjector<TTagProjector, TTagGroup> payload,
+        Event ev,
+        List<ITag> tags,
+        DcbDomainTypes domainTypes,
+        SortableUniqueId safeWindowThreshold)
+    {
+        var result = ProjectInternal(payload, ev, tags, domainTypes, safeWindowThreshold);
+        return result.UnwrapBox();
+    }
+
+    /// <summary>
+    ///     Project a single tag state
+    /// </summary>
+    private static TagState? ProjectTagState(int tagId, TagState? current, Event ev)
+    {
+        // Create TagStateId for this tagId by constructing the tag from content via generic interface
+        var tagGroup = TTagGroup.FromContent(tagId.ToString());
+        var tagStateId = new TagStateId(tagGroup, TTagProjector.ProjectorName);
+
+        // If current is null, create empty TagState
+        var tagState = current ?? TagState.GetEmpty(tagStateId);
+
+        // Use the tag projector to project the event
+        var newPayload = TTagProjector.Project(tagState.Payload, ev);
+
+        // Check if the item should be removed (e.g., deleted items)
+        if (ShouldRemoveItem(newPayload))
+        {
+            return null; // Remove the item
+        }
+
+        // Return updated TagState
+        return tagState with
+        {
+            Payload = newPayload,
+            Version = tagState.Version + 1,
+            LastSortedUniqueId = ev.SortableUniqueIdValue,
+            ProjectorVersion = TTagProjector.ProjectorVersion
+        };
+    }
+
+    /// <summary>
+    ///     Get unique ID for a tag (only for TTagGroup tags)
+    /// </summary>
+    private static int? GetTagId(ITag tag)
+    {
+        // Only process tags of our specific TTagGroup type
+        if (tag is TTagGroup intTag)
+        {
+            return intTag.GetId();
+        }
+
+        // Ignore all other tags
+        return null;
+    }
+
+    /// <summary>
+    ///     Check if an item should be removed based on the payload state
+    /// </summary>
+    private static bool ShouldRemoveItem(ITagStatePayload payload)
+    {
+        // Check if the payload has an IsDeleted property set to true
+        var deletedProperty = payload.GetType().GetProperty("IsDeleted");
+        if (deletedProperty?.PropertyType == typeof(bool))
+        {
+            var isDeleted = deletedProperty.GetValue(payload) as bool?;
+            return isDeleted == true;
+        }
+
+        return false;
+    }
+
+    // SafeWindow threshold の生成ロジックは削除。Actor が提供する値を使う設計へ移行。
+
+    /// <summary>
+    ///     Get all current tag states (including unsafe)
+    /// </summary>
+    public IReadOnlyDictionary<int, TagState> GetCurrentTagStates() => State.GetCurrentState();
+
+    /// <summary>
+    ///     Get only safe tag states
+    /// </summary>
+    public IReadOnlyDictionary<int, TagState> GetSafeTagStates(
+        string safeWindowThreshold,
+        Func<Event, IEnumerable<int>> getAffectedItemKeys,
+        Func<int, TagState?, Event, TagState?> projectItem) =>
+        State.GetSafeState(safeWindowThreshold, getAffectedItemKeys, projectItem);
+
+    /// <summary>
+    ///     Check if a specific tag state has unsafe modifications
+    /// </summary>
+    public bool IsTagStateUnsafe(int id) => State.IsItemUnsafe(id);
+
+    /// <summary>
+    ///     Get all state payloads from current tag states
+    /// </summary>
+    public IEnumerable<ITagStatePayload> GetStatePayloads()
+    {
+        var currentStates = GetCurrentTagStates();
+        var payloads = currentStates.Values.Select(ts => ts.Payload).Where(p => !ShouldRemoveItem(p)).ToList();
+        return payloads;
+    }
+
+    /// <summary>
+    ///     Get only safe state payloads
+    /// </summary>
+    public IEnumerable<ITagStatePayload> GetSafeStatePayloads(
+        string safeWindowThreshold,
+        Func<Event, IEnumerable<int>> getAffectedItemKeys,
+        Func<int, TagState?, Event, TagState?> projectItem)
+    {
+        return GetSafeTagStates(safeWindowThreshold, getAffectedItemKeys, projectItem)
+            .Values.Select(ts => ts.Payload).Where(p => !ShouldRemoveItem(p));
+    }
+
+    #region ISafeAndUnsafeStateAccessor Implementation
+    private Guid LastEventId { get; init; } = Guid.Empty;
+    private string LastSortableUniqueId { get; init; } = string.Empty;
+    private int Version { get; init; }
+    public int SafeVersion
+    {
+        get
+        {
+            var current = State.GetCurrentState();
+            return current.Values.Sum(ts => ts.Version);
+        }
+    }
+
+    /// <summary>
+    ///     ISafeAndUnsafeStateAccessor - Get safe state
+    /// </summary>
+    public SafeProjection<GenericIntTagMultiProjector<TTagProjector, TTagGroup>> GetSafeProjection(
+        SortableUniqueId safeWindowThreshold,
+        DcbDomainTypes domainTypes)
+    {
+        // Build safe view to compute safe last position and version
+        Func<Event, IEnumerable<int>> getIds = evt => evt.Tags
+            .Select(domainTypes.TagTypes.GetTag)
+            .OfType<TTagGroup>()
+            .Select(tag => GetTagId(tag))
+            .Where(id => id.HasValue)
+            .Select(id => id!.Value);
+
+        Func<int, TagState?, Event, TagState?> projectItem = (tagId, current, evt) => ProjectTagState(tagId, current, evt);
+
+        var safeDict = State.GetSafeState(safeWindowThreshold.Value, getIds, projectItem);
+        var safeLast = safeDict.Count > 0
+            ? safeDict.Values.Max(ts => ts.LastSortedUniqueId) ?? string.Empty
+            : string.Empty;
+        var version = safeDict.Values.Sum(ts => ts.Version);
+        return new SafeProjection<GenericIntTagMultiProjector<TTagProjector, TTagGroup>>(this, safeLast, version);
+    }
+
+    /// <summary>
+    ///     ISafeAndUnsafeStateAccessor - Get unsafe state
+    /// </summary>
+    public UnsafeProjection<GenericIntTagMultiProjector<TTagProjector, TTagGroup>> GetUnsafeProjection(DcbDomainTypes domainTypes)
+    {
+        var current = State.GetCurrentState();
+        var last = current.Count > 0
+            ? current.Values.Max(ts => ts.LastSortedUniqueId) ?? string.Empty
+            : string.Empty;
+        // LastEventId is not tracked here; return Guid.Empty
+        var version = current.Values.Sum(ts => ts.Version);
+        return new UnsafeProjection<GenericIntTagMultiProjector<TTagProjector, TTagGroup>>(this, last, Guid.Empty, version);
+    }
+
+    /// <summary>
+    ///     ISafeAndUnsafeStateAccessor - Process event
+    /// </summary>
+    public ISafeAndUnsafeStateAccessor<GenericIntTagMultiProjector<TTagProjector, TTagGroup>> ProcessEvent(
+        Event evt,
+        SortableUniqueId safeWindowThreshold,
+        DcbDomainTypes domainTypes)
+    {
+        // Parse tag strings into ITag instances using DomainTypes - only keep tags belonging to our tag group
+        var tags = evt.Tags
+            .Select(domainTypes.TagTypes.GetTag)
+            .ToList();
+
+        // Actor から渡された safeWindowThreshold をそのまま State.ProcessEvent に渡すため
+        // Project 内部での SafeWindow 再計算は行わない。
+        var projected = Project(this, evt, tags, domainTypes, safeWindowThreshold);
+
+        return projected with
+        {
+            LastEventId = evt.Id,
+            LastSortableUniqueId = evt.SortableUniqueIdValue,
+            Version = Version + 1
+        };
+    }
+
+    public Guid GetLastEventId() => LastEventId;
+    public string GetLastSortableUniqueId() => LastSortableUniqueId;
+    public int GetVersion() => Version;
+
+    #endregion
+}

--- a/dcb/src/Sekiban.Dcb.WithoutResult/MultiProjections/GenericStringTagMultiProjector.cs
+++ b/dcb/src/Sekiban.Dcb.WithoutResult/MultiProjections/GenericStringTagMultiProjector.cs
@@ -1,0 +1,380 @@
+using ResultBoxes;
+using Sekiban.Dcb.Common;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.Tags;
+namespace Sekiban.Dcb.MultiProjections;
+
+/// <summary>
+///     Generic multi-projector that works with string-keyed tag groups.
+///     This variant uses IStringTagGroup for tags that have string identifiers.
+///     Implements custom serialization to properly handle SafeUnsafeProjectionState with string keys.
+/// </summary>
+/// <typeparam name="TTagProjector">The tag projector type that projects individual tag states</typeparam>
+/// <typeparam name="TTagGroup">The string-keyed tag group type (must implement IStringTagGroup)</typeparam>
+/// <example>
+/// <code>
+/// // Example usage with StudentCodeTag (string-based)
+/// var projector = GenericStringTagMultiProjector&lt;StudentProjector, StudentCodeTag&gt;.GenerateInitialPayload();
+///
+/// // Process event with string-keyed tag
+/// var studentCode = "STU001";
+/// var tag = new StudentCodeTag(studentCode);
+/// var result = GenericStringTagMultiProjector&lt;StudentProjector, StudentCodeTag&gt;.Project(
+///     projector,
+///     eventData,
+///     new List&lt;ITag&gt; { tag },
+///     domainTypes,
+///     safeThreshold);
+///
+/// // Access state by string key
+/// var states = result.GetCurrentTagStates();
+/// var studentState = states[studentCode];
+/// </code>
+/// </example>
+public record
+    GenericStringTagMultiProjector<TTagProjector, TTagGroup> :
+    IMultiProjectorWithCustomSerialization<GenericStringTagMultiProjector<TTagProjector, TTagGroup>>,
+    ISafeAndUnsafeStateAccessor<GenericStringTagMultiProjector<TTagProjector, TTagGroup>>
+    where TTagProjector : ITagProjector<TTagProjector> where TTagGroup : IStringTagGroup<TTagGroup>
+{
+    /// <summary>
+    ///     SafeWindow は外部 (Actor) が SortableUniqueId safeWindowThreshold として計算し ProcessEvent 経由で渡す前提。
+    ///     ここでは固定値や内部計算を持たない。
+    /// </summary>
+
+    /// <summary>
+    ///     Internal state managed by SafeUnsafeProjectionState for TagState with string keys
+    /// </summary>
+    public SafeUnsafeProjectionState<string, TagState> State { get; init; } = new();
+
+    public static string MultiProjectorName =>
+        $"GenericStringTagMultiProjector_{TTagProjector.ProjectorName}_{TTagGroup.TagGroupName}";
+
+    public static string MultiProjectorVersion => TTagProjector.ProjectorVersion;
+
+    public static GenericStringTagMultiProjector<TTagProjector, TTagGroup> GenerateInitialPayload() => new();
+
+    public static byte[] Serialize(DcbDomainTypes domainTypes, string safeWindowThreshold, GenericStringTagMultiProjector<TTagProjector, TTagGroup> payload)
+    {
+        if (string.IsNullOrWhiteSpace(safeWindowThreshold)) throw new ArgumentException("safeWindowThreshold must be supplied", nameof(safeWindowThreshold));
+        Func<Event, IEnumerable<string>> getAffectedIds = _ => Enumerable.Empty<string>();
+        Func<string, TagState?, Event, TagState?> projectItem = (_, current, _) => current;
+        var safeDict = payload.State.GetSafeState(safeWindowThreshold, getAffectedIds, projectItem);
+        var items = new List<object>(safeDict.Count);
+        foreach (var (id, ts) in safeDict)
+        {
+            var payloadType = ts.Payload.GetType();
+            var payloadName = payloadType.Name;
+            var payloadJson = System.Text.Json.JsonSerializer.Serialize(ts.Payload, payloadType, domainTypes.JsonSerializerOptions);
+            items.Add(new
+            {
+                id,
+                type = payloadName,
+                payload = payloadJson,
+                version = ts.Version,
+                last = ts.LastSortedUniqueId
+            });
+        }
+        var dto = new { v = 1, items };
+        var json = System.Text.Json.JsonSerializer.Serialize(dto, domainTypes.JsonSerializerOptions);
+        return GzipCompression.CompressString(json);
+    }
+
+    public static GenericStringTagMultiProjector<TTagProjector, TTagGroup> Deserialize(DcbDomainTypes domainTypes, ReadOnlySpan<byte> data)
+    {
+        var json = GzipCompression.DecompressToString(data);
+        var obj = System.Text.Json.JsonSerializer.Deserialize<System.Text.Json.Nodes.JsonObject>(json, domainTypes.JsonSerializerOptions);
+        var map = new Dictionary<string, TagState>();
+        var tagProjectorName = TTagProjector.ProjectorName;
+        if (obj != null && obj.TryGetPropertyValue("items", out var itemsNode) && itemsNode is System.Text.Json.Nodes.JsonArray arr)
+        {
+            foreach (var n in arr)
+            {
+                if (n is System.Text.Json.Nodes.JsonObject item)
+                {
+                    var id = item["id"]?.GetValue<string>() ?? string.Empty;
+                    var type = item["type"]?.GetValue<string>() ?? string.Empty;
+                    var payloadJson = item["payload"]?.GetValue<string>() ?? "{}";
+                    var version = item["version"]?.GetValue<int>() ?? 0;
+                    var last = item["last"]?.GetValue<string>() ?? string.Empty;
+                    var payloadBytes = System.Text.Encoding.UTF8.GetBytes(payloadJson);
+                    var rb = domainTypes.TagStatePayloadTypes.DeserializePayload(type, payloadBytes);
+                    if (!rb.IsSuccess) continue;
+                    var payload = rb.GetValue();
+                    var tag = TTagGroup.FromContent(id);
+                    var tagStateId = new TagStateId(tag, tagProjectorName);
+                    var ts = TagState.GetEmpty(tagStateId) with
+                    {
+                        Payload = payload,
+                        Version = version,
+                        LastSortedUniqueId = last,
+                        ProjectorVersion = TTagProjector.ProjectorVersion
+                    };
+                    map[id] = ts;
+                }
+            }
+        }
+        var state = SafeUnsafeProjectionState<string, TagState>.FromCurrentData(map);
+        return new GenericStringTagMultiProjector<TTagProjector, TTagGroup> { State = state };
+    }
+
+    /// <summary>
+    ///     Project with tag filtering - processes events based on tags (internal ResultBox version)
+    /// </summary>
+    private static ResultBox<GenericStringTagMultiProjector<TTagProjector, TTagGroup>> ProjectInternal(
+        GenericStringTagMultiProjector<TTagProjector, TTagGroup> payload,
+        Event ev,
+        List<ITag> tags,
+        DcbDomainTypes domainTypes,
+        SortableUniqueId safeWindowThreshold)
+    {
+        // Filter tags to only process tags of the specified tag group type
+        var relevantTags = tags.OfType<TTagGroup>().Cast<ITag>().ToList();
+
+        if (relevantTags.Count == 0)
+        {
+            // No tags of the specified group, skip this event
+            return ResultBox.FromValue(payload);
+        }
+
+        // Get affected IDs from the passed tags for fallback
+        var affectedIds = relevantTags
+            .Select(tag => GetTagId(tag))
+            .Where(id => id != null)
+            .Select(id => id!)
+            .ToList();
+
+        // Function to get affected item IDs from the actual event being processed
+        // First check evt.Tags for runtime, but fallback to passed tags for tests
+        Func<Event, IEnumerable<string>> getAffectedItemIds = evt =>
+        {
+            var eventTagIds = evt.Tags
+                .Select(domainTypes.TagTypes.GetTag)
+                .OfType<TTagGroup>()
+                .Select(tag => GetTagId(tag))
+                .Where(id => id != null)
+                .Select(id => id!)
+                .ToList();
+
+            // If no tags in event, use the affected IDs from the passed tags
+            return eventTagIds.Count > 0 ? eventTagIds : affectedIds;
+        };
+
+        // Function to project a single item (independent of captured tag list)
+        Func<string, TagState?, Event, TagState?> projectItem = (tagId, current, evt) =>
+            ProjectTagState(tagId, current, evt);
+
+        // safeWindowThreshold を文字列として State へ渡し safe/unsafe 判定を内部に委譲
+        var updatedState = payload.State.ProcessEvent(
+            ev,
+            getAffectedItemIds,
+            projectItem,
+            safeWindowThreshold.Value);
+
+        var newPayload = payload with { State = updatedState };
+
+        return ResultBox.FromValue(newPayload);
+    }
+
+    /// <summary>
+    ///     Project with tag filtering - processes events based on tags (exception-based)
+    /// </summary>
+    public static GenericStringTagMultiProjector<TTagProjector, TTagGroup> Project(
+        GenericStringTagMultiProjector<TTagProjector, TTagGroup> payload,
+        Event ev,
+        List<ITag> tags,
+        DcbDomainTypes domainTypes,
+        SortableUniqueId safeWindowThreshold)
+    {
+        var result = ProjectInternal(payload, ev, tags, domainTypes, safeWindowThreshold);
+        return result.UnwrapBox();
+    }
+
+    /// <summary>
+    ///     Project a single tag state
+    /// </summary>
+    private static TagState? ProjectTagState(string tagId, TagState? current, Event ev)
+    {
+        // Create TagStateId for this tagId by constructing the tag from content via generic interface
+        var tagGroup = TTagGroup.FromContent(tagId);
+        var tagStateId = new TagStateId(tagGroup, TTagProjector.ProjectorName);
+
+        // If current is null, create empty TagState
+        var tagState = current ?? TagState.GetEmpty(tagStateId);
+
+        // Use the tag projector to project the event
+        var newPayload = TTagProjector.Project(tagState.Payload, ev);
+
+        // Check if the item should be removed (e.g., deleted items)
+        if (ShouldRemoveItem(newPayload))
+        {
+            return null; // Remove the item
+        }
+
+        // Return updated TagState
+        return tagState with
+        {
+            Payload = newPayload,
+            Version = tagState.Version + 1,
+            LastSortedUniqueId = ev.SortableUniqueIdValue,
+            ProjectorVersion = TTagProjector.ProjectorVersion
+        };
+    }
+
+    /// <summary>
+    ///     Get unique ID for a tag (only for TTagGroup tags)
+    /// </summary>
+    private static string? GetTagId(ITag tag)
+    {
+        // Only process tags of our specific TTagGroup type
+        if (tag is TTagGroup stringTag)
+        {
+            return stringTag.GetId();
+        }
+
+        // Ignore all other tags
+        return null;
+    }
+
+    /// <summary>
+    ///     Check if an item should be removed based on the payload state
+    /// </summary>
+    private static bool ShouldRemoveItem(ITagStatePayload payload)
+    {
+        // Check if the payload has an IsDeleted property set to true
+        var deletedProperty = payload.GetType().GetProperty("IsDeleted");
+        if (deletedProperty?.PropertyType == typeof(bool))
+        {
+            var isDeleted = deletedProperty.GetValue(payload) as bool?;
+            return isDeleted == true;
+        }
+
+        return false;
+    }
+
+    // SafeWindow threshold の生成ロジックは削除。Actor が提供する値を使う設計へ移行。
+
+    /// <summary>
+    ///     Get all current tag states (including unsafe)
+    /// </summary>
+    public IReadOnlyDictionary<string, TagState> GetCurrentTagStates() => State.GetCurrentState();
+
+    /// <summary>
+    ///     Get only safe tag states
+    /// </summary>
+    public IReadOnlyDictionary<string, TagState> GetSafeTagStates(
+        string safeWindowThreshold,
+        Func<Event, IEnumerable<string>> getAffectedItemKeys,
+        Func<string, TagState?, Event, TagState?> projectItem) =>
+        State.GetSafeState(safeWindowThreshold, getAffectedItemKeys, projectItem);
+
+    /// <summary>
+    ///     Check if a specific tag state has unsafe modifications
+    /// </summary>
+    public bool IsTagStateUnsafe(string id) => State.IsItemUnsafe(id);
+
+    /// <summary>
+    ///     Get all state payloads from current tag states
+    /// </summary>
+    public IEnumerable<ITagStatePayload> GetStatePayloads()
+    {
+        var currentStates = GetCurrentTagStates();
+        var payloads = currentStates.Values.Select(ts => ts.Payload).Where(p => !ShouldRemoveItem(p)).ToList();
+        return payloads;
+    }
+
+    /// <summary>
+    ///     Get only safe state payloads
+    /// </summary>
+    public IEnumerable<ITagStatePayload> GetSafeStatePayloads(
+        string safeWindowThreshold,
+        Func<Event, IEnumerable<string>> getAffectedItemKeys,
+        Func<string, TagState?, Event, TagState?> projectItem)
+    {
+        return GetSafeTagStates(safeWindowThreshold, getAffectedItemKeys, projectItem)
+            .Values.Select(ts => ts.Payload).Where(p => !ShouldRemoveItem(p));
+    }
+
+    #region ISafeAndUnsafeStateAccessor Implementation
+    private Guid LastEventId { get; init; } = Guid.Empty;
+    private string LastSortableUniqueId { get; init; } = string.Empty;
+    private int Version { get; init; }
+    public int SafeVersion
+    {
+        get
+        {
+            var current = State.GetCurrentState();
+            return current.Values.Sum(ts => ts.Version);
+        }
+    }
+
+    /// <summary>
+    ///     ISafeAndUnsafeStateAccessor - Get safe state
+    /// </summary>
+    public SafeProjection<GenericStringTagMultiProjector<TTagProjector, TTagGroup>> GetSafeProjection(
+        SortableUniqueId safeWindowThreshold,
+        DcbDomainTypes domainTypes)
+    {
+        // Build safe view to compute safe last position and version
+        Func<Event, IEnumerable<string>> getIds = evt => evt.Tags
+            .Select(domainTypes.TagTypes.GetTag)
+            .OfType<TTagGroup>()
+            .Select(tag => GetTagId(tag))
+            .Where(id => id != null)
+            .Select(id => id!);
+
+        Func<string, TagState?, Event, TagState?> projectItem = (tagId, current, evt) => ProjectTagState(tagId, current, evt);
+
+        var safeDict = State.GetSafeState(safeWindowThreshold.Value, getIds, projectItem);
+        var safeLast = safeDict.Count > 0
+            ? safeDict.Values.Max(ts => ts.LastSortedUniqueId) ?? string.Empty
+            : string.Empty;
+        var version = safeDict.Values.Sum(ts => ts.Version);
+        return new SafeProjection<GenericStringTagMultiProjector<TTagProjector, TTagGroup>>(this, safeLast, version);
+    }
+
+    /// <summary>
+    ///     ISafeAndUnsafeStateAccessor - Get unsafe state
+    /// </summary>
+    public UnsafeProjection<GenericStringTagMultiProjector<TTagProjector, TTagGroup>> GetUnsafeProjection(DcbDomainTypes domainTypes)
+    {
+        var current = State.GetCurrentState();
+        var last = current.Count > 0
+            ? current.Values.Max(ts => ts.LastSortedUniqueId) ?? string.Empty
+            : string.Empty;
+        // LastEventId is not tracked here; return Guid.Empty
+        var version = current.Values.Sum(ts => ts.Version);
+        return new UnsafeProjection<GenericStringTagMultiProjector<TTagProjector, TTagGroup>>(this, last, Guid.Empty, version);
+    }
+
+    /// <summary>
+    ///     ISafeAndUnsafeStateAccessor - Process event
+    /// </summary>
+    public ISafeAndUnsafeStateAccessor<GenericStringTagMultiProjector<TTagProjector, TTagGroup>> ProcessEvent(
+        Event evt,
+        SortableUniqueId safeWindowThreshold,
+        DcbDomainTypes domainTypes)
+    {
+        // Parse tag strings into ITag instances using DomainTypes - only keep tags belonging to our tag group
+        var tags = evt.Tags
+            .Select(domainTypes.TagTypes.GetTag)
+            .ToList();
+
+        // Actor から渡された safeWindowThreshold をそのまま State.ProcessEvent に渡すため
+        // Project 内部での SafeWindow 再計算は行わない。
+        var projected = Project(this, evt, tags, domainTypes, safeWindowThreshold);
+
+        return projected with
+        {
+            LastEventId = evt.Id,
+            LastSortableUniqueId = evt.SortableUniqueIdValue,
+            Version = Version + 1
+        };
+    }
+
+    public Guid GetLastEventId() => LastEventId;
+    public string GetLastSortableUniqueId() => LastSortableUniqueId;
+    public int GetVersion() => Version;
+
+    #endregion
+}

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/GenericIntTagMultiProjectorTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/GenericIntTagMultiProjectorTests.cs
@@ -1,0 +1,240 @@
+using Dcb.Domain.Student;
+using Sekiban.Dcb.Common;
+using Sekiban.Dcb.Domains;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.MultiProjections;
+using Sekiban.Dcb.Queries;
+using Sekiban.Dcb.Tags;
+namespace Sekiban.Dcb.Tests;
+
+public class GenericIntTagMultiProjectorTests
+{
+    private readonly DcbDomainTypes _domainTypes;
+
+    public GenericIntTagMultiProjectorTests()
+    {
+        var eventTypes = new SimpleEventTypes();
+        eventTypes.RegisterEventType<StudentCreated>("StudentCreated");
+
+        var tagTypes = new SimpleTagTypes();
+        tagTypes.RegisterTagGroupType<YearlyStudentsTag>();
+
+        var tagProjectorTypes = new SimpleTagProjectorTypes();
+        tagProjectorTypes.RegisterProjector<StudentProjector>();
+
+        var tagStatePayloadTypes = new SimpleTagStatePayloadTypes();
+        tagStatePayloadTypes.RegisterPayloadType<StudentState>();
+
+        var multiProjectorTypes = new SimpleMultiProjectorTypes();
+        multiProjectorTypes.RegisterProjectorWithCustomSerialization<
+            GenericIntTagMultiProjector<StudentProjector, YearlyStudentsTag>>();
+
+        _domainTypes = new DcbDomainTypes(
+            eventTypes,
+            tagTypes,
+            tagProjectorTypes,
+            tagStatePayloadTypes,
+            multiProjectorTypes,
+            new SimpleQueryTypes());
+    }
+
+    [Fact]
+    public void IntKeyProjector_ProcessesIntTags()
+    {
+        // Arrange
+        var projector = GenericIntTagMultiProjector<StudentProjector, YearlyStudentsTag>.GenerateInitialPayload();
+
+        var year = 2024;
+
+        // Create event with YearlyStudentsTag
+        var studentEvent = CreateEvent(new StudentCreated(Guid.NewGuid(), "Alice"));
+
+        // Act - Process event with YearlyStudentsTag
+        var safeThreshold = SortableUniqueId.Generate(DateTime.UtcNow.AddSeconds(-20), Guid.Empty);
+        var result = GenericIntTagMultiProjector<StudentProjector, YearlyStudentsTag>.Project(
+            projector,
+            studentEvent,
+            new List<ITag> { new YearlyStudentsTag(year) },
+            _domainTypes,
+            safeThreshold);
+
+        Assert.True(result.IsSuccess);
+        var updatedProjector = result.GetValue();
+
+        // Assert
+        var tagStates = updatedProjector.GetCurrentTagStates();
+
+        Assert.NotNull(tagStates);
+        Assert.NotEmpty(tagStates);
+        Assert.Contains(year, tagStates.Keys);
+
+        var tagState = tagStates[year];
+        Assert.NotNull(tagState);
+
+        var studentState = tagState.Payload as StudentState;
+        Assert.NotNull(studentState);
+        Assert.Equal("Alice", studentState.Name);
+    }
+
+    [Fact]
+    public void IntKeyProjector_HandlesMultipleIntKeys()
+    {
+        // Arrange
+        var projector = GenericIntTagMultiProjector<StudentProjector, YearlyStudentsTag>.GenerateInitialPayload();
+
+        var year1 = 2024;
+        var year2 = 2025;
+        var year3 = 2026;
+
+        var event1 = CreateEvent(new StudentCreated(Guid.NewGuid(), "Alice"));
+        var event2 = CreateEvent(new StudentCreated(Guid.NewGuid(), "Bob"));
+        var event3 = CreateEvent(new StudentCreated(Guid.NewGuid(), "Charlie"));
+
+        var safeThreshold = SortableUniqueId.Generate(DateTime.UtcNow.AddSeconds(-20), Guid.Empty);
+
+        // Act
+        var result1 = GenericIntTagMultiProjector<StudentProjector, YearlyStudentsTag>.Project(
+            projector,
+            event1,
+            new List<ITag> { new YearlyStudentsTag(year1) },
+            _domainTypes,
+            safeThreshold);
+        var projector1 = result1.GetValue();
+
+        var result2 = GenericIntTagMultiProjector<StudentProjector, YearlyStudentsTag>.Project(
+            projector1,
+            event2,
+            new List<ITag> { new YearlyStudentsTag(year2) },
+            _domainTypes,
+            safeThreshold);
+        var projector2 = result2.GetValue();
+
+        var result3 = GenericIntTagMultiProjector<StudentProjector, YearlyStudentsTag>.Project(
+            projector2,
+            event3,
+            new List<ITag> { new YearlyStudentsTag(year3) },
+            _domainTypes,
+            safeThreshold);
+        var projector3 = result3.GetValue();
+
+        // Assert
+        var tagStates = projector3.GetCurrentTagStates();
+
+        Assert.Equal(3, tagStates.Count);
+        Assert.Contains(year1, tagStates.Keys);
+        Assert.Contains(year2, tagStates.Keys);
+        Assert.Contains(year3, tagStates.Keys);
+
+        var aliceState = tagStates[year1].Payload as StudentState;
+        Assert.NotNull(aliceState);
+        Assert.Equal("Alice", aliceState.Name);
+
+        var bobState = tagStates[year2].Payload as StudentState;
+        Assert.NotNull(bobState);
+        Assert.Equal("Bob", bobState.Name);
+
+        var charlieState = tagStates[year3].Payload as StudentState;
+        Assert.NotNull(charlieState);
+        Assert.Equal("Charlie", charlieState.Name);
+    }
+
+    [Fact]
+    public void IntKeyProjector_SerializationRoundTrip()
+    {
+        // Arrange
+        var projector = GenericIntTagMultiProjector<StudentProjector, YearlyStudentsTag>.GenerateInitialPayload();
+
+        var year1 = 2024;
+        var year2 = 2025;
+
+        var event1 = CreateEvent(new StudentCreated(Guid.NewGuid(), "Alice"));
+        var event2 = CreateEvent(new StudentCreated(Guid.NewGuid(), "Bob"));
+
+        var safeThreshold = SortableUniqueId.Generate(DateTime.UtcNow.AddSeconds(20), Guid.Empty);
+
+        var result1 = GenericIntTagMultiProjector<StudentProjector, YearlyStudentsTag>.Project(
+            projector,
+            event1,
+            new List<ITag> { new YearlyStudentsTag(year1) },
+            _domainTypes,
+            safeThreshold);
+        var projector1 = result1.GetValue();
+
+        var result2 = GenericIntTagMultiProjector<StudentProjector, YearlyStudentsTag>.Project(
+            projector1,
+            event2,
+            new List<ITag> { new YearlyStudentsTag(year2) },
+            _domainTypes,
+            safeThreshold);
+        var projector2 = result2.GetValue();
+
+        // Act - Serialize
+        var serialized = GenericIntTagMultiProjector<StudentProjector, YearlyStudentsTag>.Serialize(
+            _domainTypes,
+            safeThreshold,
+            projector2);
+
+        Assert.NotNull(serialized);
+        Assert.NotEmpty(serialized);
+
+        // Act - Deserialize
+        var deserialized = GenericIntTagMultiProjector<StudentProjector, YearlyStudentsTag>.Deserialize(
+            _domainTypes,
+            serialized);
+
+        // Assert
+        var originalStates = projector2.GetCurrentTagStates();
+        var deserializedStates = deserialized.GetCurrentTagStates();
+
+        Assert.Equal(originalStates.Count, deserializedStates.Count);
+        Assert.Contains(year1, deserializedStates.Keys);
+        Assert.Contains(year2, deserializedStates.Keys);
+
+        var aliceState = deserializedStates[year1].Payload as StudentState;
+        Assert.NotNull(aliceState);
+        Assert.Equal("Alice", aliceState.Name);
+
+        var bobState = deserializedStates[year2].Payload as StudentState;
+        Assert.NotNull(bobState);
+        Assert.Equal("Bob", bobState.Name);
+    }
+
+    [Fact]
+    public void IntKeyProjector_GetTagId_ReturnsIntId()
+    {
+        // Arrange
+        var year = 2030;
+        var tag = new YearlyStudentsTag(year);
+
+        // Act
+        var id = tag.GetId();
+
+        // Assert
+        Assert.Equal(year, id);
+        Assert.IsType<int>(id);
+    }
+
+    [Fact]
+    public void IntKeyProjector_MultiProjectorName_ContainsIntTag()
+    {
+        // Act
+        var name = GenericIntTagMultiProjector<StudentProjector, YearlyStudentsTag>.MultiProjectorName;
+
+        // Assert
+        Assert.Contains("GenericIntTagMultiProjector", name);
+        Assert.Contains("StudentProjector", name);
+        Assert.Contains("YearlyStudents", name);
+    }
+
+    private Event CreateEvent(IEventPayload payload)
+    {
+        var sortableId = SortableUniqueId.Generate(DateTime.UtcNow, Guid.NewGuid());
+        return new Event(
+            payload,
+            sortableId,
+            payload.GetType().Name,
+            Guid.NewGuid(),
+            new EventMetadata(Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), "TestUser"),
+            new List<string>());
+    }
+}

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/GenericStringTagMultiProjectorTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/GenericStringTagMultiProjectorTests.cs
@@ -1,0 +1,240 @@
+using Dcb.Domain.Student;
+using Sekiban.Dcb.Common;
+using Sekiban.Dcb.Domains;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.MultiProjections;
+using Sekiban.Dcb.Queries;
+using Sekiban.Dcb.Tags;
+namespace Sekiban.Dcb.Tests;
+
+public class GenericStringTagMultiProjectorTests
+{
+    private readonly DcbDomainTypes _domainTypes;
+
+    public GenericStringTagMultiProjectorTests()
+    {
+        var eventTypes = new SimpleEventTypes();
+        eventTypes.RegisterEventType<StudentCreated>("StudentCreated");
+
+        var tagTypes = new SimpleTagTypes();
+        tagTypes.RegisterTagGroupType<StudentCodeTag>();
+
+        var tagProjectorTypes = new SimpleTagProjectorTypes();
+        tagProjectorTypes.RegisterProjector<StudentProjector>();
+
+        var tagStatePayloadTypes = new SimpleTagStatePayloadTypes();
+        tagStatePayloadTypes.RegisterPayloadType<StudentState>();
+
+        var multiProjectorTypes = new SimpleMultiProjectorTypes();
+        multiProjectorTypes.RegisterProjectorWithCustomSerialization<
+            GenericStringTagMultiProjector<StudentProjector, StudentCodeTag>>();
+
+        _domainTypes = new DcbDomainTypes(
+            eventTypes,
+            tagTypes,
+            tagProjectorTypes,
+            tagStatePayloadTypes,
+            multiProjectorTypes,
+            new SimpleQueryTypes());
+    }
+
+    [Fact]
+    public void StringKeyProjector_ProcessesStringTags()
+    {
+        // Arrange
+        var projector = GenericStringTagMultiProjector<StudentProjector, StudentCodeTag>.GenerateInitialPayload();
+
+        var studentCode = "STU001";
+
+        // Create event with StudentCodeTag
+        var studentEvent = CreateEvent(new StudentCreated(Guid.NewGuid(), "Alice"));
+
+        // Act - Process event with StudentCodeTag
+        var safeThreshold = SortableUniqueId.Generate(DateTime.UtcNow.AddSeconds(-20), Guid.Empty);
+        var result = GenericStringTagMultiProjector<StudentProjector, StudentCodeTag>.Project(
+            projector,
+            studentEvent,
+            new List<ITag> { new StudentCodeTag(studentCode) },
+            _domainTypes,
+            safeThreshold);
+
+        Assert.True(result.IsSuccess);
+        var updatedProjector = result.GetValue();
+
+        // Assert
+        var tagStates = updatedProjector.GetCurrentTagStates();
+
+        Assert.NotNull(tagStates);
+        Assert.NotEmpty(tagStates);
+        Assert.Contains(studentCode, tagStates.Keys);
+
+        var tagState = tagStates[studentCode];
+        Assert.NotNull(tagState);
+
+        var studentState = tagState.Payload as StudentState;
+        Assert.NotNull(studentState);
+        Assert.Equal("Alice", studentState.Name);
+    }
+
+    [Fact]
+    public void StringKeyProjector_HandlesMultipleStringKeys()
+    {
+        // Arrange
+        var projector = GenericStringTagMultiProjector<StudentProjector, StudentCodeTag>.GenerateInitialPayload();
+
+        var studentCode1 = "STU001";
+        var studentCode2 = "STU002";
+        var studentCode3 = "STU003";
+
+        var event1 = CreateEvent(new StudentCreated(Guid.NewGuid(), "Alice"));
+        var event2 = CreateEvent(new StudentCreated(Guid.NewGuid(), "Bob"));
+        var event3 = CreateEvent(new StudentCreated(Guid.NewGuid(), "Charlie"));
+
+        var safeThreshold = SortableUniqueId.Generate(DateTime.UtcNow.AddSeconds(-20), Guid.Empty);
+
+        // Act
+        var result1 = GenericStringTagMultiProjector<StudentProjector, StudentCodeTag>.Project(
+            projector,
+            event1,
+            new List<ITag> { new StudentCodeTag(studentCode1) },
+            _domainTypes,
+            safeThreshold);
+        var projector1 = result1.GetValue();
+
+        var result2 = GenericStringTagMultiProjector<StudentProjector, StudentCodeTag>.Project(
+            projector1,
+            event2,
+            new List<ITag> { new StudentCodeTag(studentCode2) },
+            _domainTypes,
+            safeThreshold);
+        var projector2 = result2.GetValue();
+
+        var result3 = GenericStringTagMultiProjector<StudentProjector, StudentCodeTag>.Project(
+            projector2,
+            event3,
+            new List<ITag> { new StudentCodeTag(studentCode3) },
+            _domainTypes,
+            safeThreshold);
+        var projector3 = result3.GetValue();
+
+        // Assert
+        var tagStates = projector3.GetCurrentTagStates();
+
+        Assert.Equal(3, tagStates.Count);
+        Assert.Contains(studentCode1, tagStates.Keys);
+        Assert.Contains(studentCode2, tagStates.Keys);
+        Assert.Contains(studentCode3, tagStates.Keys);
+
+        var aliceState = tagStates[studentCode1].Payload as StudentState;
+        Assert.NotNull(aliceState);
+        Assert.Equal("Alice", aliceState.Name);
+
+        var bobState = tagStates[studentCode2].Payload as StudentState;
+        Assert.NotNull(bobState);
+        Assert.Equal("Bob", bobState.Name);
+
+        var charlieState = tagStates[studentCode3].Payload as StudentState;
+        Assert.NotNull(charlieState);
+        Assert.Equal("Charlie", charlieState.Name);
+    }
+
+    [Fact]
+    public void StringKeyProjector_SerializationRoundTrip()
+    {
+        // Arrange
+        var projector = GenericStringTagMultiProjector<StudentProjector, StudentCodeTag>.GenerateInitialPayload();
+
+        var studentCode1 = "STU001";
+        var studentCode2 = "STU002";
+
+        var event1 = CreateEvent(new StudentCreated(Guid.NewGuid(), "Alice"));
+        var event2 = CreateEvent(new StudentCreated(Guid.NewGuid(), "Bob"));
+
+        var safeThreshold = SortableUniqueId.Generate(DateTime.UtcNow.AddSeconds(20), Guid.Empty);
+
+        var result1 = GenericStringTagMultiProjector<StudentProjector, StudentCodeTag>.Project(
+            projector,
+            event1,
+            new List<ITag> { new StudentCodeTag(studentCode1) },
+            _domainTypes,
+            safeThreshold);
+        var projector1 = result1.GetValue();
+
+        var result2 = GenericStringTagMultiProjector<StudentProjector, StudentCodeTag>.Project(
+            projector1,
+            event2,
+            new List<ITag> { new StudentCodeTag(studentCode2) },
+            _domainTypes,
+            safeThreshold);
+        var projector2 = result2.GetValue();
+
+        // Act - Serialize
+        var serialized = GenericStringTagMultiProjector<StudentProjector, StudentCodeTag>.Serialize(
+            _domainTypes,
+            safeThreshold,
+            projector2);
+
+        Assert.NotNull(serialized);
+        Assert.NotEmpty(serialized);
+
+        // Act - Deserialize
+        var deserialized = GenericStringTagMultiProjector<StudentProjector, StudentCodeTag>.Deserialize(
+            _domainTypes,
+            serialized);
+
+        // Assert
+        var originalStates = projector2.GetCurrentTagStates();
+        var deserializedStates = deserialized.GetCurrentTagStates();
+
+        Assert.Equal(originalStates.Count, deserializedStates.Count);
+        Assert.Contains(studentCode1, deserializedStates.Keys);
+        Assert.Contains(studentCode2, deserializedStates.Keys);
+
+        var aliceState = deserializedStates[studentCode1].Payload as StudentState;
+        Assert.NotNull(aliceState);
+        Assert.Equal("Alice", aliceState.Name);
+
+        var bobState = deserializedStates[studentCode2].Payload as StudentState;
+        Assert.NotNull(bobState);
+        Assert.Equal("Bob", bobState.Name);
+    }
+
+    [Fact]
+    public void StringKeyProjector_GetTagId_ReturnsStringId()
+    {
+        // Arrange
+        var studentCode = "STU999";
+        var tag = new StudentCodeTag(studentCode);
+
+        // Act
+        var id = tag.GetId();
+
+        // Assert
+        Assert.Equal(studentCode, id);
+        Assert.IsType<string>(id);
+    }
+
+    [Fact]
+    public void StringKeyProjector_MultiProjectorName_ContainsStringTag()
+    {
+        // Act
+        var name = GenericStringTagMultiProjector<StudentProjector, StudentCodeTag>.MultiProjectorName;
+
+        // Assert
+        Assert.Contains("GenericStringTagMultiProjector", name);
+        Assert.Contains("StudentProjector", name);
+        Assert.Contains("StudentCode", name);
+    }
+
+    private Event CreateEvent(IEventPayload payload)
+    {
+        var sortableId = SortableUniqueId.Generate(DateTime.UtcNow, Guid.NewGuid());
+        return new Event(
+            payload,
+            sortableId,
+            payload.GetType().Name,
+            Guid.NewGuid(),
+            new EventMetadata(Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), "TestUser"),
+            new List<string>());
+    }
+}

--- a/dcb/tests/Sekiban.Dcb.WithoutResult.Tests/GenericIntTagMultiProjectorTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithoutResult.Tests/GenericIntTagMultiProjectorTests.cs
@@ -1,0 +1,232 @@
+using Dcb.Domain.WithoutResult.Student;
+using Sekiban.Dcb.Common;
+using Sekiban.Dcb.Domains;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.MultiProjections;
+using Sekiban.Dcb.Queries;
+using Sekiban.Dcb.Tags;
+namespace Sekiban.Dcb.WithoutResult.Tests;
+
+public class GenericIntTagMultiProjectorTests
+{
+    private readonly DcbDomainTypes _domainTypes;
+
+    public GenericIntTagMultiProjectorTests()
+    {
+        var eventTypes = new SimpleEventTypes();
+        eventTypes.RegisterEventType<StudentCreated>("StudentCreated");
+
+        var tagTypes = new SimpleTagTypes();
+        tagTypes.RegisterTagGroupType<YearlyStudentsTag>();
+
+        var tagProjectorTypes = new SimpleTagProjectorTypes();
+        tagProjectorTypes.RegisterProjector<StudentProjector>();
+
+        var tagStatePayloadTypes = new SimpleTagStatePayloadTypes();
+        tagStatePayloadTypes.RegisterPayloadType<StudentState>();
+
+        var multiProjectorTypes = new SimpleMultiProjectorTypes();
+        multiProjectorTypes.RegisterProjectorWithCustomSerialization<
+            GenericIntTagMultiProjector<StudentProjector, YearlyStudentsTag>>();
+
+        _domainTypes = new DcbDomainTypes(
+            eventTypes,
+            tagTypes,
+            tagProjectorTypes,
+            tagStatePayloadTypes,
+            multiProjectorTypes,
+            new SimpleQueryTypes());
+    }
+
+    [Fact]
+    public void IntKeyProjector_ProcessesIntTags()
+    {
+        // Arrange
+        var projector = GenericIntTagMultiProjector<StudentProjector, YearlyStudentsTag>.GenerateInitialPayload();
+
+        var year = 2024;
+
+        // Create event with YearlyStudentsTag
+        var studentEvent = CreateEvent(new StudentCreated(Guid.NewGuid(), "Alice"));
+
+        // Act - Process event with YearlyStudentsTag
+        var safeThreshold = SortableUniqueId.Generate(DateTime.UtcNow.AddSeconds(-20), Guid.Empty);
+        var updatedProjector = GenericIntTagMultiProjector<StudentProjector, YearlyStudentsTag>.Project(
+            projector,
+            studentEvent,
+            new List<ITag> { new YearlyStudentsTag(year) },
+            _domainTypes,
+            safeThreshold);
+
+        // Assert
+        var tagStates = updatedProjector.GetCurrentTagStates();
+
+        Assert.NotNull(tagStates);
+        Assert.NotEmpty(tagStates);
+        Assert.Contains(year, tagStates.Keys);
+
+        var tagState = tagStates[year];
+        Assert.NotNull(tagState);
+
+        var studentState = tagState.Payload as StudentState;
+        Assert.NotNull(studentState);
+        Assert.Equal("Alice", studentState.Name);
+    }
+
+    [Fact]
+    public void IntKeyProjector_HandlesMultipleIntKeys()
+    {
+        // Arrange
+        var projector = GenericIntTagMultiProjector<StudentProjector, YearlyStudentsTag>.GenerateInitialPayload();
+
+        var year1 = 2024;
+        var year2 = 2025;
+        var year3 = 2026;
+
+        var event1 = CreateEvent(new StudentCreated(Guid.NewGuid(), "Alice"));
+        var event2 = CreateEvent(new StudentCreated(Guid.NewGuid(), "Bob"));
+        var event3 = CreateEvent(new StudentCreated(Guid.NewGuid(), "Charlie"));
+
+        var safeThreshold = SortableUniqueId.Generate(DateTime.UtcNow.AddSeconds(-20), Guid.Empty);
+
+        // Act
+        var projector1 = GenericIntTagMultiProjector<StudentProjector, YearlyStudentsTag>.Project(
+            projector,
+            event1,
+            new List<ITag> { new YearlyStudentsTag(year1) },
+            _domainTypes,
+            safeThreshold);
+
+        var projector2 = GenericIntTagMultiProjector<StudentProjector, YearlyStudentsTag>.Project(
+            projector1,
+            event2,
+            new List<ITag> { new YearlyStudentsTag(year2) },
+            _domainTypes,
+            safeThreshold);
+
+        var projector3 = GenericIntTagMultiProjector<StudentProjector, YearlyStudentsTag>.Project(
+            projector2,
+            event3,
+            new List<ITag> { new YearlyStudentsTag(year3) },
+            _domainTypes,
+            safeThreshold);
+
+        // Assert
+        var tagStates = projector3.GetCurrentTagStates();
+
+        Assert.Equal(3, tagStates.Count);
+        Assert.Contains(year1, tagStates.Keys);
+        Assert.Contains(year2, tagStates.Keys);
+        Assert.Contains(year3, tagStates.Keys);
+
+        var aliceState = tagStates[year1].Payload as StudentState;
+        Assert.NotNull(aliceState);
+        Assert.Equal("Alice", aliceState.Name);
+
+        var bobState = tagStates[year2].Payload as StudentState;
+        Assert.NotNull(bobState);
+        Assert.Equal("Bob", bobState.Name);
+
+        var charlieState = tagStates[year3].Payload as StudentState;
+        Assert.NotNull(charlieState);
+        Assert.Equal("Charlie", charlieState.Name);
+    }
+
+    [Fact]
+    public void IntKeyProjector_SerializationRoundTrip()
+    {
+        // Arrange
+        var projector = GenericIntTagMultiProjector<StudentProjector, YearlyStudentsTag>.GenerateInitialPayload();
+
+        var year1 = 2024;
+        var year2 = 2025;
+
+        var event1 = CreateEvent(new StudentCreated(Guid.NewGuid(), "Alice"));
+        var event2 = CreateEvent(new StudentCreated(Guid.NewGuid(), "Bob"));
+
+        var safeThreshold = SortableUniqueId.Generate(DateTime.UtcNow.AddSeconds(20), Guid.Empty);
+
+        var projector1 = GenericIntTagMultiProjector<StudentProjector, YearlyStudentsTag>.Project(
+            projector,
+            event1,
+            new List<ITag> { new YearlyStudentsTag(year1) },
+            _domainTypes,
+            safeThreshold);
+
+        var projector2 = GenericIntTagMultiProjector<StudentProjector, YearlyStudentsTag>.Project(
+            projector1,
+            event2,
+            new List<ITag> { new YearlyStudentsTag(year2) },
+            _domainTypes,
+            safeThreshold);
+
+        // Act - Serialize
+        var serialized = GenericIntTagMultiProjector<StudentProjector, YearlyStudentsTag>.Serialize(
+            _domainTypes,
+            safeThreshold,
+            projector2);
+
+        Assert.NotNull(serialized);
+        Assert.NotEmpty(serialized);
+
+        // Act - Deserialize
+        var deserialized = GenericIntTagMultiProjector<StudentProjector, YearlyStudentsTag>.Deserialize(
+            _domainTypes,
+            serialized);
+
+        // Assert
+        var originalStates = projector2.GetCurrentTagStates();
+        var deserializedStates = deserialized.GetCurrentTagStates();
+
+        Assert.Equal(originalStates.Count, deserializedStates.Count);
+        Assert.Contains(year1, deserializedStates.Keys);
+        Assert.Contains(year2, deserializedStates.Keys);
+
+        var aliceState = deserializedStates[year1].Payload as StudentState;
+        Assert.NotNull(aliceState);
+        Assert.Equal("Alice", aliceState.Name);
+
+        var bobState = deserializedStates[year2].Payload as StudentState;
+        Assert.NotNull(bobState);
+        Assert.Equal("Bob", bobState.Name);
+    }
+
+    [Fact]
+    public void IntKeyProjector_GetTagId_ReturnsIntId()
+    {
+        // Arrange
+        var year = 2030;
+        var tag = new YearlyStudentsTag(year);
+
+        // Act
+        var id = tag.GetId();
+
+        // Assert
+        Assert.Equal(year, id);
+        Assert.IsType<int>(id);
+    }
+
+    [Fact]
+    public void IntKeyProjector_MultiProjectorName_ContainsIntTag()
+    {
+        // Act
+        var name = GenericIntTagMultiProjector<StudentProjector, YearlyStudentsTag>.MultiProjectorName;
+
+        // Assert
+        Assert.Contains("GenericIntTagMultiProjector", name);
+        Assert.Contains("StudentProjector", name);
+        Assert.Contains("YearlyStudents", name);
+    }
+
+    private Event CreateEvent(IEventPayload payload)
+    {
+        var sortableId = SortableUniqueId.Generate(DateTime.UtcNow, Guid.NewGuid());
+        return new Event(
+            payload,
+            sortableId,
+            payload.GetType().Name,
+            Guid.NewGuid(),
+            new EventMetadata(Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), "TestUser"),
+            new List<string>());
+    }
+}

--- a/dcb/tests/Sekiban.Dcb.WithoutResult.Tests/GenericStringTagMultiProjectorTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithoutResult.Tests/GenericStringTagMultiProjectorTests.cs
@@ -1,0 +1,232 @@
+using Dcb.Domain.WithoutResult.Student;
+using Sekiban.Dcb.Common;
+using Sekiban.Dcb.Domains;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.MultiProjections;
+using Sekiban.Dcb.Queries;
+using Sekiban.Dcb.Tags;
+namespace Sekiban.Dcb.WithoutResult.Tests;
+
+public class GenericStringTagMultiProjectorTests
+{
+    private readonly DcbDomainTypes _domainTypes;
+
+    public GenericStringTagMultiProjectorTests()
+    {
+        var eventTypes = new SimpleEventTypes();
+        eventTypes.RegisterEventType<StudentCreated>("StudentCreated");
+
+        var tagTypes = new SimpleTagTypes();
+        tagTypes.RegisterTagGroupType<StudentCodeTag>();
+
+        var tagProjectorTypes = new SimpleTagProjectorTypes();
+        tagProjectorTypes.RegisterProjector<StudentProjector>();
+
+        var tagStatePayloadTypes = new SimpleTagStatePayloadTypes();
+        tagStatePayloadTypes.RegisterPayloadType<StudentState>();
+
+        var multiProjectorTypes = new SimpleMultiProjectorTypes();
+        multiProjectorTypes.RegisterProjectorWithCustomSerialization<
+            GenericStringTagMultiProjector<StudentProjector, StudentCodeTag>>();
+
+        _domainTypes = new DcbDomainTypes(
+            eventTypes,
+            tagTypes,
+            tagProjectorTypes,
+            tagStatePayloadTypes,
+            multiProjectorTypes,
+            new SimpleQueryTypes());
+    }
+
+    [Fact]
+    public void StringKeyProjector_ProcessesStringTags()
+    {
+        // Arrange
+        var projector = GenericStringTagMultiProjector<StudentProjector, StudentCodeTag>.GenerateInitialPayload();
+
+        var studentCode = "STU001";
+
+        // Create event with StudentCodeTag
+        var studentEvent = CreateEvent(new StudentCreated(Guid.NewGuid(), "Alice"));
+
+        // Act - Process event with StudentCodeTag
+        var safeThreshold = SortableUniqueId.Generate(DateTime.UtcNow.AddSeconds(-20), Guid.Empty);
+        var updatedProjector = GenericStringTagMultiProjector<StudentProjector, StudentCodeTag>.Project(
+            projector,
+            studentEvent,
+            new List<ITag> { new StudentCodeTag(studentCode) },
+            _domainTypes,
+            safeThreshold);
+
+        // Assert
+        var tagStates = updatedProjector.GetCurrentTagStates();
+
+        Assert.NotNull(tagStates);
+        Assert.NotEmpty(tagStates);
+        Assert.Contains(studentCode, tagStates.Keys);
+
+        var tagState = tagStates[studentCode];
+        Assert.NotNull(tagState);
+
+        var studentState = tagState.Payload as StudentState;
+        Assert.NotNull(studentState);
+        Assert.Equal("Alice", studentState.Name);
+    }
+
+    [Fact]
+    public void StringKeyProjector_HandlesMultipleStringKeys()
+    {
+        // Arrange
+        var projector = GenericStringTagMultiProjector<StudentProjector, StudentCodeTag>.GenerateInitialPayload();
+
+        var studentCode1 = "STU001";
+        var studentCode2 = "STU002";
+        var studentCode3 = "STU003";
+
+        var event1 = CreateEvent(new StudentCreated(Guid.NewGuid(), "Alice"));
+        var event2 = CreateEvent(new StudentCreated(Guid.NewGuid(), "Bob"));
+        var event3 = CreateEvent(new StudentCreated(Guid.NewGuid(), "Charlie"));
+
+        var safeThreshold = SortableUniqueId.Generate(DateTime.UtcNow.AddSeconds(-20), Guid.Empty);
+
+        // Act
+        var projector1 = GenericStringTagMultiProjector<StudentProjector, StudentCodeTag>.Project(
+            projector,
+            event1,
+            new List<ITag> { new StudentCodeTag(studentCode1) },
+            _domainTypes,
+            safeThreshold);
+
+        var projector2 = GenericStringTagMultiProjector<StudentProjector, StudentCodeTag>.Project(
+            projector1,
+            event2,
+            new List<ITag> { new StudentCodeTag(studentCode2) },
+            _domainTypes,
+            safeThreshold);
+
+        var projector3 = GenericStringTagMultiProjector<StudentProjector, StudentCodeTag>.Project(
+            projector2,
+            event3,
+            new List<ITag> { new StudentCodeTag(studentCode3) },
+            _domainTypes,
+            safeThreshold);
+
+        // Assert
+        var tagStates = projector3.GetCurrentTagStates();
+
+        Assert.Equal(3, tagStates.Count);
+        Assert.Contains(studentCode1, tagStates.Keys);
+        Assert.Contains(studentCode2, tagStates.Keys);
+        Assert.Contains(studentCode3, tagStates.Keys);
+
+        var aliceState = tagStates[studentCode1].Payload as StudentState;
+        Assert.NotNull(aliceState);
+        Assert.Equal("Alice", aliceState.Name);
+
+        var bobState = tagStates[studentCode2].Payload as StudentState;
+        Assert.NotNull(bobState);
+        Assert.Equal("Bob", bobState.Name);
+
+        var charlieState = tagStates[studentCode3].Payload as StudentState;
+        Assert.NotNull(charlieState);
+        Assert.Equal("Charlie", charlieState.Name);
+    }
+
+    [Fact]
+    public void StringKeyProjector_SerializationRoundTrip()
+    {
+        // Arrange
+        var projector = GenericStringTagMultiProjector<StudentProjector, StudentCodeTag>.GenerateInitialPayload();
+
+        var studentCode1 = "STU001";
+        var studentCode2 = "STU002";
+
+        var event1 = CreateEvent(new StudentCreated(Guid.NewGuid(), "Alice"));
+        var event2 = CreateEvent(new StudentCreated(Guid.NewGuid(), "Bob"));
+
+        var safeThreshold = SortableUniqueId.Generate(DateTime.UtcNow.AddSeconds(20), Guid.Empty);
+
+        var projector1 = GenericStringTagMultiProjector<StudentProjector, StudentCodeTag>.Project(
+            projector,
+            event1,
+            new List<ITag> { new StudentCodeTag(studentCode1) },
+            _domainTypes,
+            safeThreshold);
+
+        var projector2 = GenericStringTagMultiProjector<StudentProjector, StudentCodeTag>.Project(
+            projector1,
+            event2,
+            new List<ITag> { new StudentCodeTag(studentCode2) },
+            _domainTypes,
+            safeThreshold);
+
+        // Act - Serialize
+        var serialized = GenericStringTagMultiProjector<StudentProjector, StudentCodeTag>.Serialize(
+            _domainTypes,
+            safeThreshold,
+            projector2);
+
+        Assert.NotNull(serialized);
+        Assert.NotEmpty(serialized);
+
+        // Act - Deserialize
+        var deserialized = GenericStringTagMultiProjector<StudentProjector, StudentCodeTag>.Deserialize(
+            _domainTypes,
+            serialized);
+
+        // Assert
+        var originalStates = projector2.GetCurrentTagStates();
+        var deserializedStates = deserialized.GetCurrentTagStates();
+
+        Assert.Equal(originalStates.Count, deserializedStates.Count);
+        Assert.Contains(studentCode1, deserializedStates.Keys);
+        Assert.Contains(studentCode2, deserializedStates.Keys);
+
+        var aliceState = deserializedStates[studentCode1].Payload as StudentState;
+        Assert.NotNull(aliceState);
+        Assert.Equal("Alice", aliceState.Name);
+
+        var bobState = deserializedStates[studentCode2].Payload as StudentState;
+        Assert.NotNull(bobState);
+        Assert.Equal("Bob", bobState.Name);
+    }
+
+    [Fact]
+    public void StringKeyProjector_GetTagId_ReturnsStringId()
+    {
+        // Arrange
+        var studentCode = "STU999";
+        var tag = new StudentCodeTag(studentCode);
+
+        // Act
+        var id = tag.GetId();
+
+        // Assert
+        Assert.Equal(studentCode, id);
+        Assert.IsType<string>(id);
+    }
+
+    [Fact]
+    public void StringKeyProjector_MultiProjectorName_ContainsStringTag()
+    {
+        // Act
+        var name = GenericStringTagMultiProjector<StudentProjector, StudentCodeTag>.MultiProjectorName;
+
+        // Assert
+        Assert.Contains("GenericStringTagMultiProjector", name);
+        Assert.Contains("StudentProjector", name);
+        Assert.Contains("StudentCode", name);
+    }
+
+    private Event CreateEvent(IEventPayload payload)
+    {
+        var sortableId = SortableUniqueId.Generate(DateTime.UtcNow, Guid.NewGuid());
+        return new Event(
+            payload,
+            sortableId,
+            payload.GetType().Name,
+            Guid.NewGuid(),
+            new EventMetadata(Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), "TestUser"),
+            new List<string>());
+    }
+}


### PR DESCRIPTION
## Summary

Implements string and int tag variants of `GenericTagMultiProjector` to support `IStringTagGroup` and `IIntTagGroup` tag types.

This enhancement extends the multi-projector pattern to work with different tag ID types beyond just GUIDs, enabling more flexible tag-based projections.

## Changes

### Core Implementations (4 files)
- ✅ `GenericStringTagMultiProjector` (WithResult/WithoutResult) - String-keyed tag groups
- ✅ `GenericIntTagMultiProjector` (WithResult/WithoutResult) - Integer-keyed tag groups

### Tests (4 files)
- ✅ Comprehensive test coverage for both variants
- ✅ 20 new tests added (10 per project)
- ✅ All tests pass with no regressions

## Features

- **Generic support for `IStringTagGroup`** - Multi-projectors using string-based tag IDs
- **Generic support for `IIntTagGroup`** - Multi-projectors using integer-based tag IDs
- **Custom serialization** - Efficient serialization with proper key type handling
- **Safe/Unsafe state tracking** - Full support for SafeUnsafeProjectionState pattern
- **Complete backward compatibility** - No changes required to existing code

## Test Results

### WithResult.Tests
- **368 tests passed** (includes 10 new tests)
- 0 failed
- 0 skipped

### WithoutResult.Tests
- **23 tests passed** (includes 10 new tests)
- 0 failed
- 0 skipped

## Build Status

✅ Both projects build successfully with 0 warnings, 0 errors
- Sekiban.Dcb.WithResult
- Sekiban.Dcb.WithoutResult
- NuGet packages generated successfully

## Example Usage

### String Tag Example
```csharp
// Define tag
public record StudentCodeTag(string StudentCode) : IStringTagGroup<StudentCodeTag>
{
    public string GetId() => StudentCode;
    public static StudentCodeTag FromContent(string content) => new(content);
}

// Register
types.MultiProjectorTypes
    .RegisterProjectorWithCustomSerialization<
        GenericStringTagMultiProjector<StudentProjector, StudentCodeTag>>();

// Use in query
var states = projector.GetCurrentTagStates(); // Dictionary<string, TagState>
var studentState = states["STU001"];
```

### Int Tag Example
```csharp
// Define tag
public record YearlyStudentsTag(int Year) : IIntTagGroup<YearlyStudentsTag>
{
    public int GetId() => Year;
    public static YearlyStudentsTag FromContent(string content) => new(int.Parse(content));
}

// Register
types.MultiProjectorTypes
    .RegisterProjectorWithCustomSerialization<
        GenericIntTagMultiProjector<StudentProjector, YearlyStudentsTag>>();

// Use in query
var states = projector.GetCurrentTagStates(); // Dictionary<int, TagState>
var yearState = states[2024];
```

## Related Issue

Closes #830

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>