### PR TITLE
fix: Replace string.Compare with CompareTo for Cosmos DB LINQ compatibility

### DIFF
--- a/dcb/src/Sekiban.Dcb.CosmosDb/CosmosDbEventStore.cs
+++ b/dcb/src/Sekiban.Dcb.CosmosDb/CosmosDbEventStore.cs
@@ -42,7 +42,8 @@ public class CosmosDbEventStore : IEventStore
 
             if (since != null)
             {
-                query = query.Where(e => string.Compare(e.SortableUniqueId, since.Value, StringComparison.Ordinal) > 0)
+                // Use CompareTo instead of string.Compare for Cosmos DB LINQ compatibility
+                query = query.Where(e => e.SortableUniqueId.CompareTo(since.Value) > 0)
                     .OrderBy(e => e.SortableUniqueId);
             }
 
@@ -100,7 +101,8 @@ public class CosmosDbEventStore : IEventStore
 
             if (since != null)
             {
-                tagQuery = tagQuery.Where(t => string.Compare(t.SortableUniqueId, since.Value, StringComparison.Ordinal) > 0);
+                // Use CompareTo instead of string.Compare for Cosmos DB LINQ compatibility
+                tagQuery = tagQuery.Where(t => t.SortableUniqueId.CompareTo(since.Value) > 0);
             }
 
             var eventIds = new List<string>();


### PR DESCRIPTION
## Summary

- Fix `string.Compare()` not supported error in Cosmos DB LINQ provider
- Replace with `CompareTo()` which is officially supported for range comparisons
- Affects `ReadAllEventsAsync` and `ReadEventsByTagAsync` methods

## Problem

MultiProjection catch-up processing fails in Azure environment with:
```
Catch-up batch error: Method 'Compare' is not supported., Linux/24.04 cosmos-netstandard-sdk/3.41.0
```

## Solution

Replace `string.Compare()` with `CompareTo()` in `CosmosDbEventStore.cs`:
- Line 45: `e.SortableUniqueId.CompareTo(since.Value) > 0`
- Line 103: `t.SortableUniqueId.CompareTo(since.Value) > 0`

## Reference

- Microsoft Docs confirms `CompareTo` is supported: https://learn.microsoft.com/en-us/cosmos-db/query/linq-to-sql#supported-linq-operators

Fixes #832

🤖 Generated with [Claude Code](https://claude.com/claude-code)