### PR TITLE
feat: Enhance MultiProjection state management with delete functionality and payload size tracking

### DIFF
--- a/dcb/src/Sekiban.Dcb.Core/Storage/IMultiProjectionStateStore.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Storage/IMultiProjectionStateStore.cs
@@ -24,4 +24,13 @@ public interface IMultiProjectionStateStore
 
     Task<ResultBox<IReadOnlyList<ProjectorStateInfo>>> ListAllAsync(
         CancellationToken cancellationToken = default);
+
+    Task<ResultBox<bool>> DeleteAsync(
+        string projectorName,
+        string projectorVersion,
+        CancellationToken cancellationToken = default);
+
+    Task<ResultBox<int>> DeleteAllAsync(
+        string? projectorName = null,
+        CancellationToken cancellationToken = default);
 }


### PR DESCRIPTION
## Summary
This PR enhances the MultiProjection state management and storage capabilities across the Sekiban DCB framework.

## Changes

### Core Changes
- Updated `MultiProjectionGrainState` to streamline state properties and improve migration handling
- Introduced `MultiProjectionStateBuilder` for efficient state building with configurable options
- Added `MultiProjectionStateRecord` and `ProjectorStateInfo` models for better state tracking
- Enhanced `SerializableMultiProjectionState` with additional functionality
- Refactored MultiProjector serialization to use `SerializationResult` for size tracking and compression control

### Storage Layer
- **PostgreSQL**: Added `DbMultiProjectionState` model and `PostgresMultiProjectionStateStore` for efficient state storage
- **CosmosDB**: Implemented `CosmosMultiProjectionStateStore` and `CosmosMultiProjectionState` model
- **In-Memory**: Added `InMemoryMultiProjectionStateStore` for testing scenarios
- Added migration scripts to create the `dcb_multi_projection_states` table in PostgreSQL
- Implemented delete functionality for multi-projection states in all storage implementations

### Event Store Enhancements
- Added `GetEventCountAsync` method to `IEventStore` interface for counting events based on sortable unique ID
- Implemented event counting in PostgreSQL, CosmosDB, and In-Memory event stores

### Orleans Integration
- Enhanced `MultiProjectionGrain` with improved state management and offloading logic
- Updated grain state to support better state serialization

### Payload Size Tracking
- Added support for tracking original and compressed payload sizes in multi-projection state management

### Version Update
- Updated package versions to 10.0.2-preview01 across all projects

### Testing
- Added comprehensive tests for multi-projection state management and event counting functionality
- Added utility project `DcbOrleans.MakeMultiProjectionState` for state migration testing

## Related Issue
Closes #838