### PR TITLE
feat: Add CLI tool for Multi Projection State management with Cosmos and PostgreSQL support

### DIFF
--- a/Sekiban.slnx
+++ b/Sekiban.slnx
@@ -70,7 +70,7 @@
     <Project Path="dcb/internalUsages/DcbOrleans.ApiService/DcbOrleans.ApiService.csproj" />
     <Project Path="dcb/internalUsages/DcbOrleans.AppHost/DcbOrleans.AppHost.csproj" />
     <Project Path="dcb/internalUsages/DcbOrleans.Benchmark/DcbOrleans.Benchmark.csproj" />
-    <Project Path="dcb/internalUsages/DcbOrleans.MakeMultiProjectionState/DcbOrleans.MakeMultiProjectionState.csproj" />
+    <Project Path="dcb/internalUsages/DcbOrleans.Cli/DcbOrleans.Cli.csproj" />
     <Project Path="dcb/internalUsages/DcbOrleans.ServiceDefaults/DcbOrleans.ServiceDefaults.csproj" />
     <Project Path="dcb/internalUsages/DcbOrleans.Web/DcbOrleans.Web.csproj" />
     <Project Path="dcb/internalUsages/DcbOrleans.WithoutResult.ApiService/DcbOrleans.WithoutResult.ApiService.csproj" />

--- a/dcb/Sekiban.Dcb.slnx
+++ b/dcb/Sekiban.Dcb.slnx
@@ -33,7 +33,7 @@
     <Project Path="internalUsages/DcbOrleans.ServiceDefaults/DcbOrleans.ServiceDefaults.csproj" />
     <Project Path="internalUsages/DcbOrleans.Web/DcbOrleans.Web.csproj" />
     <Project Path="internalUsages/DcbOrleans.WithoutResult.ApiService/DcbOrleans.WithoutResult.ApiService.csproj" />
-    <Project Path="internalUsages/DcbOrleans.MakeMultiProjectionState/DcbOrleans.MakeMultiProjectionState.csproj" />
+    <Project Path="internalUsages/DcbOrleans.Cli/DcbOrleans.Cli.csproj" />
   </Folder>
   <Folder Name="/tests/">
     <Project Path="tests/Sekiban.Dcb.BlobStorage.AzureStorage.Unit/Sekiban.Dcb.BlobStorage.AzureStorage.Unit.csproj" />

--- a/dcb/internalUsages/DcbOrleans.AppHost/DcbOrleans.AppHost.csproj
+++ b/dcb/internalUsages/DcbOrleans.AppHost/DcbOrleans.AppHost.csproj
@@ -26,7 +26,7 @@
         <ProjectReference Include="..\DcbOrleans.WithoutResult.ApiService\DcbOrleans.WithoutResult.ApiService.csproj"/>
         <ProjectReference Include="..\DcbOrleans.Web\DcbOrleans.Web.csproj"/>
         <ProjectReference Include="..\DcbOrleans.Benchmark\DcbOrleans.Benchmark.csproj"/>
-        <ProjectReference Include="..\DcbOrleans.MakeMultiProjectionState\DcbOrleans.MakeMultiProjectionState.csproj"/>
+        <ProjectReference Include="..\DcbOrleans.Cli\DcbOrleans.Cli.csproj"/>
     </ItemGroup>
 
 </Project>

--- a/dcb/internalUsages/DcbOrleans.AppHost/Program.cs
+++ b/dcb/internalUsages/DcbOrleans.AppHost/Program.cs
@@ -89,10 +89,10 @@ var bench = builder
 
 #endif
 
-// Multi Projection State CLI Tools (manual execution only)
+// Sekiban DCB CLI Tools (manual execution only)
 // Use Aspire dashboard "Start" button to run these tools
 builder
-    .AddProject<DcbOrleans_MakeMultiProjectionState>("projection-status")
+    .AddProject<DcbOrleans_Cli>("projection-status")
     .WithReference(postgres)
     .WaitFor(postgres)
     .WithArgs("status")
@@ -100,12 +100,12 @@ builder
     .WithExplicitStart();
 
 builder
-    .AddProject<DcbOrleans_MakeMultiProjectionState>("projection-list")
+    .AddProject<DcbOrleans_Cli>("projection-list")
     .WithArgs("list")
     .WithExplicitStart();
 
 builder
-    .AddProject<DcbOrleans_MakeMultiProjectionState>("projection-build")
+    .AddProject<DcbOrleans_Cli>("projection-build")
     .WithReference(postgres)
     .WaitFor(postgres)
     .WithArgs("build", "--verbose")
@@ -113,7 +113,7 @@ builder
     .WithExplicitStart();
 
 builder
-    .AddProject<DcbOrleans_MakeMultiProjectionState>("projection-build-force")
+    .AddProject<DcbOrleans_Cli>("projection-build-force")
     .WithReference(postgres)
     .WaitFor(postgres)
     .WithArgs("build", "--force", "--verbose")

--- a/dcb/internalUsages/DcbOrleans.Cli/DcbOrleans.Cli.csproj
+++ b/dcb/internalUsages/DcbOrleans.Cli/DcbOrleans.Cli.csproj
@@ -7,7 +7,7 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <LangVersion>default</LangVersion>
         <NoWarn>$(NoWarn);CS0618</NoWarn>
-        <UserSecretsId>dcb-make-multiprojection-state</UserSecretsId>
+        <UserSecretsId>dcb-cli</UserSecretsId>
     </PropertyGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">

--- a/dcb/internalUsages/DcbOrleans.Cli/output/tag_events_WeatherForecast_3c3cbd62-d2c4-4392-a1c2-f05104375e8e_20260105031302.json
+++ b/dcb/internalUsages/DcbOrleans.Cli/output/tag_events_WeatherForecast_3c3cbd62-d2c4-4392-a1c2-f05104375e8e_20260105031302.json
@@ -1,0 +1,27 @@
+{
+  "Tag": "WeatherForecast:3c3cbd62-d2c4-4392-a1c2-f05104375e8e",
+  "EventCount": 2,
+  "FetchedAt": "2026-01-05T03:13:02.306449Z",
+  "Events": [
+    {
+      "Id": "019b8c1d-434d-7b16-aa7a-edc48ab99ce9",
+      "SortableUniqueId": "063903179086669068000690435981",
+      "EventType": "WeatherForecastCreated",
+      "Tags": [
+        "WeatherForecast:3c3cbd62-d2c4-4392-a1c2-f05104375e8e"
+      ],
+      "PayloadJson": "{\u0022forecastId\u0022:\u00223c3cbd62-d2c4-4392-a1c2-f05104375e8e\u0022,\u0022location\u0022:\u0022Loc-b5c140b15c24446688ba24c62d88514f\u0022,\u0022date\u0022:\u00222026-02-03\u0022,\u0022temperatureC\u0022:12,\u0022summary\u0022:\u0022bench\u0022}",
+      "Payload": {}
+    },
+    {
+      "Id": "019b8c1d-449d-7676-8f9d-c4e39013d64b",
+      "SortableUniqueId": "063903179087005670001088628266",
+      "EventType": "LocationNameChanged",
+      "Tags": [
+        "WeatherForecast:3c3cbd62-d2c4-4392-a1c2-f05104375e8e"
+      ],
+      "PayloadJson": "{\u0022forecastId\u0022:\u00223c3cbd62-d2c4-4392-a1c2-f05104375e8e\u0022,\u0022newLocationName\u0022:\u0022Loc-b5c140b15c24446688ba24c62d88514f-U\u0022,\u0022oldLocationName\u0022:\u0022Loc-b5c140b15c24446688ba24c62d88514f\u0022}",
+      "Payload": {}
+    }
+  ]
+}

--- a/dcb/src/Sekiban.Dcb.BlobStorage.AzureStorage/Sekiban.Dcb.BlobStorage.AzureStorage.csproj
+++ b/dcb/src/Sekiban.Dcb.BlobStorage.AzureStorage/Sekiban.Dcb.BlobStorage.AzureStorage.csproj
@@ -7,14 +7,14 @@
         <AssemblyName>Sekiban.Dcb.BlobStorage.AzureStorage</AssemblyName>
         <RootNamespace>Sekiban.Dcb.BlobStorage.AzureStorage</RootNamespace>
         <PackageId>Sekiban.Dcb.BlobStorage.AzureStorage</PackageId>
-        <Version>10.0.2-preview01</Version>
+        <Version>10.0.2-preview02</Version>
         <Authors>J-Tech Group</Authors>
         <Company>J-Tech-Japan</Company>
         <Copyright>Copyright (c) J-Tech-Japan 2025</Copyright>
         <PackageDescription>Sekiban - Dynamic Consistency Boundary Azure Blob Storage Integration</PackageDescription>
         <RepositoryUrl>https://github.com/J-Tech-Japan/Sekiban</RepositoryUrl>
         <PackageProjectUrl>https://github.com/J-Tech-Japan/Sekiban</PackageProjectUrl>
-        <PackageVersion>10.0.2-preview01</PackageVersion>
+        <PackageVersion>10.0.2-preview02</PackageVersion>
         <Description>Azure Blob Storage snapshot offloading for Sekiban DCB MultiProjection. Provides efficient binary snapshot storage for large projection states.</Description>
         <PackageTags>event-sourcing;cqrs;ddd;dcb;sekiban;azure;blob-storage;snapshots</PackageTags>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>

--- a/dcb/src/Sekiban.Dcb.Core.Model/Sekiban.Dcb.Core.Model.csproj
+++ b/dcb/src/Sekiban.Dcb.Core.Model/Sekiban.Dcb.Core.Model.csproj
@@ -7,14 +7,14 @@
         <AssemblyName>Sekiban.Dcb.Core.Model</AssemblyName>
         <RootNamespace>Sekiban.Dcb</RootNamespace>
         <PackageId>Sekiban.Dcb.Core.Model</PackageId>
-        <Version>10.0.2-preview01</Version>
+        <Version>10.0.2-preview02</Version>
         <Authors>J-Tech Group</Authors>
         <Company>J-Tech-Japan</Company>
         <Copyright>Copyright (c) J-Tech-Japan 2025</Copyright>
         <PackageDescription>Sekiban DCB Core Model - Core interfaces and types for defining domain models with Dynamic Consistency Boundary</PackageDescription>
         <RepositoryUrl>https://github.com/J-Tech-Japan/Sekiban</RepositoryUrl>
         <PackageProjectUrl>https://github.com/J-Tech-Japan/Sekiban</PackageProjectUrl>
-        <PackageVersion>10.0.2-preview01</PackageVersion>
+        <PackageVersion>10.0.2-preview02</PackageVersion>
         <Description>Core interfaces and types for defining domain models in Sekiban Dynamic Consistency Boundary - IEventPayload, ITagStatePayload, ITag, ITagGroup, ITagProjector, and related types</Description>
         <PackageTags>event-sourcing;cqrs;ddd;dcb;sekiban;model;core</PackageTags>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>

--- a/dcb/src/Sekiban.Dcb.Core/Domains/ITagProjectorTypes.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Domains/ITagProjectorTypes.cs
@@ -17,4 +17,9 @@ public interface ITagProjectorTypes
     ///     Gets the version of a projector by its name
     /// </summary>
     ResultBox<string> GetProjectorVersion(string tagProjectorName);
+
+    /// <summary>
+    ///     Gets all registered tag projector names
+    /// </summary>
+    IReadOnlyList<string> GetAllProjectorNames();
 }

--- a/dcb/src/Sekiban.Dcb.Core/Domains/ITagTypes.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Domains/ITagTypes.cs
@@ -13,4 +13,9 @@ public interface ITagTypes
     /// <param name="tag">group:content 形式の文字列。</param>
     /// <returns>復元されたタグ、またはフォールバックタグ。</returns>
     ITag GetTag(string tag);
+
+    /// <summary>
+    ///     Gets all registered tag group names
+    /// </summary>
+    IReadOnlyList<string> GetAllTagGroupNames();
 }

--- a/dcb/src/Sekiban.Dcb.Core/Domains/SimpleTagProjectorTypes.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Domains/SimpleTagProjectorTypes.cs
@@ -36,6 +36,8 @@ public class SimpleTagProjectorTypes : ITagProjectorTypes
         return ResultBox.Error<string>(new Exception($"Tag projector '{tagProjectorName}' not found"));
     }
 
+    public IReadOnlyList<string> GetAllProjectorNames() => _projectorFunctions.Keys.ToList();
+
     /// <summary>
     ///     Register a tag projector type using its static ProjectorName
     /// </summary>

--- a/dcb/src/Sekiban.Dcb.Core/Domains/SimpleTagTypes.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Domains/SimpleTagTypes.cs
@@ -29,6 +29,11 @@ public class SimpleTagTypes : ITagTypes
     }
 
     /// <summary>
+    ///     Gets all registered tag group names
+    /// </summary>
+    public IReadOnlyList<string> GetAllTagGroupNames() => _tagGroupFactories.Keys.ToList();
+
+    /// <summary>
     ///     ITagGroup 実装型を登録します。
     /// </summary>
     public void RegisterTagGroupType<TTagGroup>() where TTagGroup : ITagGroup<TTagGroup>

--- a/dcb/src/Sekiban.Dcb.Core/Sekiban.Dcb.Core.csproj
+++ b/dcb/src/Sekiban.Dcb.Core/Sekiban.Dcb.Core.csproj
@@ -7,14 +7,14 @@
         <AssemblyName>Sekiban.Dcb.Core</AssemblyName>
         <RootNamespace>Sekiban.Dcb</RootNamespace>
         <PackageId>Sekiban.Dcb.Core</PackageId>
-        <Version>10.0.2-preview01</Version>
+        <Version>10.0.2-preview02</Version>
         <Authors>J-Tech Group</Authors>
         <Company>J-Tech-Japan</Company>
         <Copyright>Copyright (c) J-Tech-Japan 2025</Copyright>
         <PackageDescription>Sekiban DCB Core - Common types and interfaces for Dynamic Consistency Boundary</PackageDescription>
         <RepositoryUrl>https://github.com/J-Tech-Japan/Sekiban</RepositoryUrl>
         <PackageProjectUrl>https://github.com/J-Tech-Japan/Sekiban</PackageProjectUrl>
-        <PackageVersion>10.0.2-preview01</PackageVersion>
+        <PackageVersion>10.0.2-preview02</PackageVersion>
         <Description>Core types and interfaces for Sekiban Dynamic Consistency Boundary - shared between ResultBox and exception-based implementations</Description>
         <PackageTags>event-sourcing;cqrs;ddd;dcb;sekiban;core</PackageTags>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>

--- a/dcb/src/Sekiban.Dcb.Core/Services/TagEventService.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Services/TagEventService.cs
@@ -1,0 +1,54 @@
+using ResultBoxes;
+using Sekiban.Dcb.Common;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.Storage;
+using Sekiban.Dcb.Tags;
+namespace Sekiban.Dcb.Services;
+
+/// <summary>
+///     Service for fetching events by tag
+/// </summary>
+public class TagEventService
+{
+    private readonly IEventStore _eventStore;
+    private readonly DcbDomainTypes _domainTypes;
+
+    public TagEventService(IEventStore eventStore, DcbDomainTypes domainTypes)
+    {
+        _eventStore = eventStore;
+        _domainTypes = domainTypes;
+    }
+
+    /// <summary>
+    ///     Parse a tag string into an ITag instance
+    /// </summary>
+    /// <param name="tagString">Tag string in format 'group:content'</param>
+    /// <returns>Parsed tag</returns>
+    public ITag ParseTag(string tagString) => _domainTypes.TagTypes.GetTag(tagString);
+
+    /// <summary>
+    ///     Fetch all events for a specific tag
+    /// </summary>
+    /// <param name="tag">The tag to fetch events for</param>
+    /// <param name="since">Optional: Only return events after this ID</param>
+    /// <returns>List of events for the tag</returns>
+    public Task<ResultBox<IEnumerable<Event>>> GetEventsByTagAsync(ITag tag, SortableUniqueId? since = null)
+        => _eventStore.ReadEventsByTagAsync(tag, since);
+
+    /// <summary>
+    ///     Fetch all events for a tag specified by string
+    /// </summary>
+    /// <param name="tagString">Tag string in format 'group:content'</param>
+    /// <param name="since">Optional: Only return events after this ID</param>
+    /// <returns>List of events for the tag</returns>
+    public Task<ResultBox<IEnumerable<Event>>> GetEventsByTagStringAsync(string tagString, SortableUniqueId? since = null)
+    {
+        var tag = ParseTag(tagString);
+        return GetEventsByTagAsync(tag, since);
+    }
+
+    /// <summary>
+    ///     Get the JSON serializer options from domain types
+    /// </summary>
+    public System.Text.Json.JsonSerializerOptions JsonSerializerOptions => _domainTypes.JsonSerializerOptions;
+}

--- a/dcb/src/Sekiban.Dcb.Core/Services/TagStateService.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Services/TagStateService.cs
@@ -1,0 +1,136 @@
+using ResultBoxes;
+using Sekiban.Dcb.Common;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.Storage;
+using Sekiban.Dcb.Tags;
+namespace Sekiban.Dcb.Services;
+
+/// <summary>
+///     Result of projecting a tag state
+/// </summary>
+public record TagStateProjectionResult(
+    ITag Tag,
+    string ProjectorName,
+    string ProjectorVersion,
+    ITagStatePayload State,
+    int EventCount,
+    string? LastSortableUniqueId);
+
+/// <summary>
+///     Service for getting and projecting tag states
+/// </summary>
+public class TagStateService
+{
+    private readonly IEventStore _eventStore;
+    private readonly DcbDomainTypes _domainTypes;
+
+    public TagStateService(IEventStore eventStore, DcbDomainTypes domainTypes)
+    {
+        _eventStore = eventStore;
+        _domainTypes = domainTypes;
+    }
+
+    /// <summary>
+    ///     Parse a tag string into an ITag instance
+    /// </summary>
+    public ITag ParseTag(string tagString) => _domainTypes.TagTypes.GetTag(tagString);
+
+    /// <summary>
+    ///     Get the latest stored tag state from the event store
+    /// </summary>
+    public Task<ResultBox<TagState>> GetLatestTagStateAsync(ITag tag)
+        => _eventStore.GetLatestTagAsync(tag);
+
+    /// <summary>
+    ///     Get the latest stored tag state by tag string
+    /// </summary>
+    public Task<ResultBox<TagState>> GetLatestTagStateByStringAsync(string tagString)
+    {
+        var tag = ParseTag(tagString);
+        return GetLatestTagStateAsync(tag);
+    }
+
+    /// <summary>
+    ///     Project events for a tag using a specified projector
+    /// </summary>
+    /// <param name="tagString">Tag string in format 'group:content'</param>
+    /// <param name="projectorName">Name of the tag projector to use</param>
+    /// <returns>Projected tag state result</returns>
+    public async Task<ResultBox<TagStateProjectionResult>> ProjectTagStateAsync(string tagString, string projectorName)
+    {
+        var tag = ParseTag(tagString);
+        return await ProjectTagStateAsync(tag, projectorName);
+    }
+
+    /// <summary>
+    ///     Project events for a tag using a specified projector
+    /// </summary>
+    /// <param name="tag">The tag to project</param>
+    /// <param name="projectorName">Name of the tag projector to use</param>
+    /// <returns>Projected tag state result</returns>
+    public async Task<ResultBox<TagStateProjectionResult>> ProjectTagStateAsync(ITag tag, string projectorName)
+    {
+        // Get the projector function
+        var projectorFuncResult = _domainTypes.TagProjectorTypes.GetProjectorFunction(projectorName);
+        if (!projectorFuncResult.IsSuccess)
+        {
+            return ResultBox.Error<TagStateProjectionResult>(projectorFuncResult.GetException());
+        }
+
+        // Get the projector version
+        var projectorVersionResult = _domainTypes.TagProjectorTypes.GetProjectorVersion(projectorName);
+        var projectorVersion = projectorVersionResult.IsSuccess ? projectorVersionResult.GetValue() : "unknown";
+
+        // Fetch events for the tag
+        var eventsResult = await _eventStore.ReadEventsByTagAsync(tag);
+        if (!eventsResult.IsSuccess)
+        {
+            return ResultBox.Error<TagStateProjectionResult>(eventsResult.GetException());
+        }
+
+        var events = eventsResult.GetValue().ToList();
+        var projectorFunc = projectorFuncResult.GetValue();
+
+        // Project all events
+        ITagStatePayload state = new EmptyTagStatePayload();
+        string? lastSortableUniqueId = null;
+
+        foreach (var evt in events)
+        {
+            state = projectorFunc(state, evt);
+            lastSortableUniqueId = evt.SortableUniqueIdValue;
+        }
+
+        var result = new TagStateProjectionResult(
+            tag,
+            projectorName,
+            projectorVersion,
+            state,
+            events.Count,
+            lastSortableUniqueId);
+
+        return ResultBox.FromValue(result);
+    }
+
+    /// <summary>
+    ///     Get all registered tag projector names
+    /// </summary>
+    public IReadOnlyList<string> GetAllTagProjectorNames()
+        => _domainTypes.TagProjectorTypes.GetAllProjectorNames();
+
+    /// <summary>
+    ///     Get all registered tag group names
+    /// </summary>
+    public IReadOnlyList<string> GetAllTagGroupNames()
+        => _domainTypes.TagTypes.GetAllTagGroupNames();
+
+    /// <summary>
+    ///     Get the JSON serializer options from domain types
+    /// </summary>
+    public System.Text.Json.JsonSerializerOptions JsonSerializerOptions => _domainTypes.JsonSerializerOptions;
+}
+
+/// <summary>
+///     Empty tag state payload used as initial state
+/// </summary>
+public record EmptyTagStatePayload : ITagStatePayload;

--- a/dcb/src/Sekiban.Dcb.CosmosDb/Sekiban.Dcb.CosmosDb.csproj
+++ b/dcb/src/Sekiban.Dcb.CosmosDb/Sekiban.Dcb.CosmosDb.csproj
@@ -7,14 +7,14 @@
         <AssemblyName>Sekiban.Dcb.CosmosDb</AssemblyName>
         <RootNamespace>Sekiban.Dcb.CosmosDb</RootNamespace>
         <PackageId>Sekiban.Dcb.CosmosDb</PackageId>
-        <Version>10.0.2-preview01</Version>
+        <Version>10.0.2-preview02</Version>
         <Authors>J-Tech Group</Authors>
         <Company>J-Tech-Japan</Company>
         <Copyright>Copyright (c) J-Tech-Japan 2025</Copyright>
         <PackageDescription>Sekiban - Dynamic Consistency Boundary CosmosDB Integration</PackageDescription>
         <RepositoryUrl>https://github.com/J-Tech-Japan/Sekiban</RepositoryUrl>
         <PackageProjectUrl>https://github.com/J-Tech-Japan/Sekiban</PackageProjectUrl>
-        <PackageVersion>10.0.2-preview01</PackageVersion>
+        <PackageVersion>10.0.2-preview02</PackageVersion>
         <Description>CosmosDB event store and persistence layer for Sekiban DCB</Description>
         <PackageTags>event-sourcing;cqrs;ddd;dcb;sekiban;cosmosdb;azure</PackageTags>
         <AnalysisLevel>latest-All</AnalysisLevel>

--- a/dcb/src/Sekiban.Dcb.Orleans.Core/Sekiban.Dcb.Orleans.Core.csproj
+++ b/dcb/src/Sekiban.Dcb.Orleans.Core/Sekiban.Dcb.Orleans.Core.csproj
@@ -7,14 +7,14 @@
         <AssemblyName>Sekiban.Dcb.Orleans.Core</AssemblyName>
         <RootNamespace>Sekiban.Dcb.Orleans</RootNamespace>
         <PackageId>Sekiban.Dcb.Orleans.Core</PackageId>
-        <Version>10.0.2-preview01</Version>
+        <Version>10.0.2-preview02</Version>
         <Authors>J-Tech Group</Authors>
         <Company>J-Tech-Japan</Company>
         <Copyright>Copyright (c) J-Tech-Japan 2025</Copyright>
         <PackageDescription>Sekiban DCB Orleans Core - Shared Orleans infrastructure for Dynamic Consistency Boundary</PackageDescription>
         <RepositoryUrl>https://github.com/J-Tech-Japan/Sekiban</RepositoryUrl>
         <PackageProjectUrl>https://github.com/J-Tech-Japan/Sekiban</PackageProjectUrl>
-        <PackageVersion>10.0.2-preview01</PackageVersion>
+        <PackageVersion>10.0.2-preview02</PackageVersion>
         <Description>Core Orleans integration for Sekiban DCB with Grains, Streams, and Serialization</Description>
         <PackageTags>event-sourcing;cqrs;ddd;dcb;sekiban;orleans;actor-model</PackageTags>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/dcb/src/Sekiban.Dcb.Orleans.WithResult/Sekiban.Dcb.Orleans.WithResult.csproj
+++ b/dcb/src/Sekiban.Dcb.Orleans.WithResult/Sekiban.Dcb.Orleans.WithResult.csproj
@@ -7,14 +7,14 @@
         <AssemblyName>Sekiban.Dcb.Orleans.WithResult</AssemblyName>
         <RootNamespace>Sekiban.Dcb.Orleans</RootNamespace>
         <PackageId>Sekiban.Dcb.Orleans.WithResult</PackageId>
-        <Version>10.0.2-preview01</Version>
+        <Version>10.0.2-preview02</Version>
         <Authors>J-Tech Group</Authors>
         <Company>J-Tech-Japan</Company>
         <Copyright>Copyright (c) J-Tech-Japan 2025</Copyright>
         <PackageDescription>Sekiban DCB Orleans WithResult - Orleans integration with ResultBox-based error handling</PackageDescription>
         <RepositoryUrl>https://github.com/J-Tech-Japan/Sekiban</RepositoryUrl>
         <PackageProjectUrl>https://github.com/J-Tech-Japan/Sekiban</PackageProjectUrl>
-        <PackageVersion>10.0.2-preview01</PackageVersion>
+        <PackageVersion>10.0.2-preview02</PackageVersion>
         <Description>Orleans integration for Sekiban DCB with ResultBox-based error handling</Description>
         <PackageTags>event-sourcing;cqrs;ddd;dcb;sekiban;orleans;actor-model;resultbox</PackageTags>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/dcb/src/Sekiban.Dcb.Orleans.WithoutResult/Sekiban.Dcb.Orleans.WithoutResult.csproj
+++ b/dcb/src/Sekiban.Dcb.Orleans.WithoutResult/Sekiban.Dcb.Orleans.WithoutResult.csproj
@@ -7,14 +7,14 @@
         <AssemblyName>Sekiban.Dcb.Orleans.WithoutResult</AssemblyName>
         <RootNamespace>Sekiban.Dcb.Orleans</RootNamespace>
         <PackageId>Sekiban.Dcb.Orleans.WithoutResult</PackageId>
-        <Version>10.0.2-preview01</Version>
+        <Version>10.0.2-preview02</Version>
         <Authors>J-Tech Group</Authors>
         <Company>J-Tech-Japan</Company>
         <Copyright>Copyright (c) J-Tech-Japan 2025</Copyright>
         <PackageDescription>Sekiban DCB Orleans WithoutResult - Orleans integration with exception-based error handling</PackageDescription>
         <RepositoryUrl>https://github.com/J-Tech-Japan/Sekiban</RepositoryUrl>
         <PackageProjectUrl>https://github.com/J-Tech-Japan/Sekiban</PackageProjectUrl>
-        <PackageVersion>10.0.2-preview01</PackageVersion>
+        <PackageVersion>10.0.2-preview02</PackageVersion>
         <Description>Orleans integration for Sekiban DCB with exception-based error handling</Description>
         <PackageTags>event-sourcing;cqrs;ddd;dcb;sekiban;orleans;actor-model;exceptions</PackageTags>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/dcb/src/Sekiban.Dcb.Postgres/Sekiban.Dcb.Postgres.csproj
+++ b/dcb/src/Sekiban.Dcb.Postgres/Sekiban.Dcb.Postgres.csproj
@@ -7,14 +7,14 @@
         <AssemblyName>Sekiban.Dcb.Postgres</AssemblyName>
         <RootNamespace>Sekiban.Dcb.Postgres</RootNamespace>
         <PackageId>Sekiban.Dcb.Postgres</PackageId>
-        <Version>10.0.2-preview01</Version>
+        <Version>10.0.2-preview02</Version>
         <Authors>J-Tech Group</Authors>
         <Company>J-Tech-Japan</Company>
         <Copyright>Copyright (c) J-Tech-Japan 2025</Copyright>
         <PackageDescription>Sekiban - Dynamic Consistency Boundary PostgreSQL Integration</PackageDescription>
         <RepositoryUrl>https://github.com/J-Tech-Japan/Sekiban</RepositoryUrl>
         <PackageProjectUrl>https://github.com/J-Tech-Japan/Sekiban</PackageProjectUrl>
-        <PackageVersion>10.0.2-preview01</PackageVersion>
+        <PackageVersion>10.0.2-preview02</PackageVersion>
         <Description>PostgreSQL event store and persistence layer for Sekiban DCB</Description>
         <PackageTags>event-sourcing;cqrs;ddd;dcb;sekiban;postgresql;postgres</PackageTags>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>

--- a/dcb/src/Sekiban.Dcb.WithResult/Sekiban.Dcb.WithResult.csproj
+++ b/dcb/src/Sekiban.Dcb.WithResult/Sekiban.Dcb.WithResult.csproj
@@ -7,14 +7,14 @@
         <AssemblyName>Sekiban.Dcb.WithResult</AssemblyName>
         <RootNamespace>Sekiban.Dcb</RootNamespace>
         <PackageId>Sekiban.Dcb.WithResult</PackageId>
-        <Version>10.0.2-preview01</Version>
+        <Version>10.0.2-preview02</Version>
         <Authors>J-Tech Group</Authors>
         <Company>J-Tech-Japan</Company>
         <Copyright>Copyright (c) J-Tech-Japan 2025</Copyright>
         <PackageDescription>Sekiban DCB WithResult - ResultBox-based API for Dynamic Consistency Boundary</PackageDescription>
         <RepositoryUrl>https://github.com/J-Tech-Japan/Sekiban</RepositoryUrl>
         <PackageProjectUrl>https://github.com/J-Tech-Japan/Sekiban</PackageProjectUrl>
-        <PackageVersion>10.0.2-preview01</PackageVersion>
+        <PackageVersion>10.0.2-preview02</PackageVersion>
         <Description>ResultBox-based API for Sekiban Dynamic Consistency Boundary - safe error handling without exceptions</Description>
         <PackageTags>event-sourcing;cqrs;ddd;dcb;sekiban;resultbox</PackageTags>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>

--- a/dcb/src/Sekiban.Dcb.WithoutResult/Sekiban.Dcb.WithoutResult.csproj
+++ b/dcb/src/Sekiban.Dcb.WithoutResult/Sekiban.Dcb.WithoutResult.csproj
@@ -7,14 +7,14 @@
         <AssemblyName>Sekiban.Dcb.WithoutResult</AssemblyName>
         <RootNamespace>Sekiban.Dcb</RootNamespace>
         <PackageId>Sekiban.Dcb.WithoutResult</PackageId>
-        <Version>10.0.2-preview01</Version>
+        <Version>10.0.2-preview02</Version>
         <Authors>J-Tech Group</Authors>
         <Company>J-Tech-Japan</Company>
         <Copyright>Copyright (c) J-Tech-Japan 2025</Copyright>
         <PackageDescription>Sekiban DCB WithoutResult - Exception-based API for Dynamic Consistency Boundary</PackageDescription>
         <RepositoryUrl>https://github.com/J-Tech-Japan/Sekiban</RepositoryUrl>
         <PackageProjectUrl>https://github.com/J-Tech-Japan/Sekiban</PackageProjectUrl>
-        <PackageVersion>10.0.2-preview01</PackageVersion>
+        <PackageVersion>10.0.2-preview02</PackageVersion>
         <Description>Exception-based API for Sekiban Dynamic Consistency Boundary - traditional error handling with exceptions</Description>
         <PackageTags>event-sourcing;cqrs;ddd;dcb;sekiban;exceptions</PackageTags>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.ApiService/SekibanDcbOrleans.ApiService.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.ApiService/SekibanDcbOrleans.ApiService.csproj
@@ -31,11 +31,11 @@
         <PackageReference Include="Microsoft.Orleans.Streaming.AzureStorage" Version="9.2.1" />
         <PackageReference Include="Microsoft.Orleans.Streaming.EventHubs" Version="9.2.1" />
         <PackageReference Include="Scalar.AspNetCore" Version="2.11.10" />
-        <PackageReference Include="Sekiban.Dcb.BlobStorage.AzureStorage" Version="10.0.1-preview12" />
-        <PackageReference Include="Sekiban.Dcb.Orleans.WithoutResult" Version="10.0.1-preview12" />
+        <PackageReference Include="Sekiban.Dcb.BlobStorage.AzureStorage" Version="10.0.2-preview01" />
+        <PackageReference Include="Sekiban.Dcb.Orleans.WithoutResult" Version="10.0.2-preview01" />
         <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.0" />
-        <PackageReference Include="Sekiban.Dcb.Postgres" Version="10.0.1-preview12" />
-        <PackageReference Include="Sekiban.Dcb.CosmosDb" Version="10.0.1-preview12" />
+        <PackageReference Include="Sekiban.Dcb.Postgres" Version="10.0.2-preview01" />
+        <PackageReference Include="Sekiban.Dcb.CosmosDb" Version="10.0.2-preview01" />
     </ItemGroup>
 
 </Project>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.Cli/Program.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.Cli/Program.cs
@@ -1,0 +1,563 @@
+using System.CommandLine;
+using System.Reflection;
+using Dcb.Domain.WithoutResult;
+using Microsoft.Azure.Cosmos;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Sekiban.Dcb;
+using Sekiban.Dcb.Common;
+using Sekiban.Dcb.CosmosDb;
+using Sekiban.Dcb.MultiProjections;
+using Sekiban.Dcb.Postgres;
+using Sekiban.Dcb.Storage;
+
+// Build configuration from environment variables and user secrets
+var configuration = new ConfigurationBuilder()
+    .AddEnvironmentVariables()
+    .AddUserSecrets(Assembly.GetExecutingAssembly(), optional: true)
+    .Build();
+
+// Create the root command
+var rootCommand = new RootCommand("Multi Projection State Builder CLI - Pre-build projection states for faster startup");
+
+// Database type option (shared across commands)
+var databaseOption = new Option<string?>(
+    name: "--database",
+    description: "Database type: postgres or cosmos (defaults to Sekiban:Database config or DATABASE_TYPE env var)");
+databaseOption.AddAlias("-d");
+
+// Connection string option for Postgres
+var connectionStringOption = new Option<string?>(
+    name: "--connection-string",
+    description: "PostgreSQL connection string (defaults to ConnectionStrings:DcbPostgres config)");
+connectionStringOption.AddAlias("-c");
+
+// Connection string option for Cosmos
+var cosmosConnectionStringOption = new Option<string?>(
+    name: "--cosmos-connection-string",
+    description: "Cosmos DB connection string (defaults to ConnectionStrings:SekibanDcbCosmos config)");
+
+// Cosmos database name option
+var cosmosDatabaseNameOption = new Option<string?>(
+    name: "--cosmos-database",
+    description: "Cosmos DB database name (defaults to CosmosDb:DatabaseName config or 'SekibanDcb')");
+
+// Min events option
+var minEventsOption = new Option<int>(
+    name: "--min-events",
+    getDefaultValue: () => int.TryParse(configuration["MIN_EVENTS"], out var val) ? val : 3000,
+    description: "Minimum events required before building state");
+minEventsOption.AddAlias("-m");
+
+// Projector name option
+var projectorNameOption = new Option<string?>(
+    name: "--projector",
+    getDefaultValue: () => configuration["PROJECTOR_NAME"],
+    description: "Specific projector name to build (if not specified, builds all)");
+projectorNameOption.AddAlias("-p");
+
+// Force rebuild option
+var forceRebuildOption = new Option<bool>(
+    name: "--force",
+    getDefaultValue: () => configuration["FORCE_REBUILD"]?.ToLowerInvariant() == "true",
+    description: "Force rebuild even if state exists");
+forceRebuildOption.AddAlias("-f");
+
+// Verbose option
+var verboseOption = new Option<bool>(
+    name: "--verbose",
+    getDefaultValue: () => configuration["VERBOSE"]?.ToLowerInvariant() == "true",
+    description: "Show verbose output");
+verboseOption.AddAlias("-v");
+
+// Build command
+var buildCommand = new Command("build", "Build multi projection states")
+{
+    databaseOption,
+    connectionStringOption,
+    cosmosConnectionStringOption,
+    cosmosDatabaseNameOption,
+    minEventsOption,
+    projectorNameOption,
+    forceRebuildOption,
+    verboseOption
+};
+
+buildCommand.SetHandler(async (context) =>
+{
+    var database = context.ParseResult.GetValueForOption(databaseOption);
+    var connectionString = context.ParseResult.GetValueForOption(connectionStringOption);
+    var cosmosConnectionString = context.ParseResult.GetValueForOption(cosmosConnectionStringOption);
+    var cosmosDatabaseName = context.ParseResult.GetValueForOption(cosmosDatabaseNameOption);
+    var minEvents = context.ParseResult.GetValueForOption(minEventsOption);
+    var projectorName = context.ParseResult.GetValueForOption(projectorNameOption);
+    var forceRebuild = context.ParseResult.GetValueForOption(forceRebuildOption);
+    var verbose = context.ParseResult.GetValueForOption(verboseOption);
+
+    var resolvedDatabase = ResolveDatabaseType(configuration, database);
+    var resolvedConnectionString = ResolveConnectionString(configuration, resolvedDatabase, connectionString, cosmosConnectionString);
+    var resolvedCosmosDatabaseName = ResolveCosmosDatabaseName(configuration, cosmosDatabaseName);
+
+    await BuildProjectionStatesAsync(resolvedConnectionString, resolvedDatabase, resolvedCosmosDatabaseName, minEvents, projectorName, forceRebuild, verbose);
+});
+
+// List command
+var listCommand = new Command("list", "List all registered projectors");
+listCommand.SetHandler(async () => await ListProjectorsAsync());
+
+// Status command
+var statusCommand = new Command("status", "Show status of all projection states")
+{
+    databaseOption,
+    connectionStringOption,
+    cosmosConnectionStringOption,
+    cosmosDatabaseNameOption
+};
+
+statusCommand.SetHandler(async (context) =>
+{
+    var database = context.ParseResult.GetValueForOption(databaseOption);
+    var connectionString = context.ParseResult.GetValueForOption(connectionStringOption);
+    var cosmosConnectionString = context.ParseResult.GetValueForOption(cosmosConnectionStringOption);
+    var cosmosDatabaseName = context.ParseResult.GetValueForOption(cosmosDatabaseNameOption);
+
+    var resolvedDatabase = ResolveDatabaseType(configuration, database);
+    var resolvedConnectionString = ResolveConnectionString(configuration, resolvedDatabase, connectionString, cosmosConnectionString);
+    var resolvedCosmosDatabaseName = ResolveCosmosDatabaseName(configuration, cosmosDatabaseName);
+
+    await ShowStatusAsync(resolvedConnectionString, resolvedDatabase, resolvedCosmosDatabaseName);
+});
+
+// Save command
+var outputDirOption = new Option<string?>(
+    name: "--output-dir",
+    getDefaultValue: () => configuration["OUTPUT_DIR"] ?? "./output",
+    description: "Output directory for saved state files");
+outputDirOption.AddAlias("-o");
+
+var saveCommand = new Command("save", "Save projection state JSON to files for debugging")
+{
+    databaseOption,
+    connectionStringOption,
+    cosmosConnectionStringOption,
+    cosmosDatabaseNameOption,
+    projectorNameOption,
+    outputDirOption
+};
+
+saveCommand.SetHandler(async (context) =>
+{
+    var database = context.ParseResult.GetValueForOption(databaseOption);
+    var connectionString = context.ParseResult.GetValueForOption(connectionStringOption);
+    var cosmosConnectionString = context.ParseResult.GetValueForOption(cosmosConnectionStringOption);
+    var cosmosDatabaseName = context.ParseResult.GetValueForOption(cosmosDatabaseNameOption);
+    var projectorName = context.ParseResult.GetValueForOption(projectorNameOption);
+    var outputDir = context.ParseResult.GetValueForOption(outputDirOption) ?? "./output";
+
+    var resolvedDatabase = ResolveDatabaseType(configuration, database);
+    var resolvedConnectionString = ResolveConnectionString(configuration, resolvedDatabase, connectionString, cosmosConnectionString);
+    var resolvedCosmosDatabaseName = ResolveCosmosDatabaseName(configuration, cosmosDatabaseName);
+
+    await SaveStateJsonAsync(resolvedConnectionString, resolvedDatabase, resolvedCosmosDatabaseName, projectorName, outputDir);
+});
+
+rootCommand.AddCommand(buildCommand);
+rootCommand.AddCommand(listCommand);
+rootCommand.AddCommand(statusCommand);
+rootCommand.AddCommand(saveCommand);
+
+return await rootCommand.InvokeAsync(args);
+
+// Helper to resolve database type
+static string ResolveDatabaseType(IConfiguration config, string? cliOption)
+{
+    if (!string.IsNullOrEmpty(cliOption))
+        return cliOption;
+
+    var sekibanDatabase = config["Sekiban:Database"];
+    if (!string.IsNullOrEmpty(sekibanDatabase))
+        return sekibanDatabase;
+
+    var envDatabaseType = config["DATABASE_TYPE"];
+    if (!string.IsNullOrEmpty(envDatabaseType))
+        return envDatabaseType;
+
+    return "postgres";
+}
+
+// Helper to resolve Cosmos database name
+static string ResolveCosmosDatabaseName(IConfiguration config, string? cliOption)
+{
+    if (!string.IsNullOrEmpty(cliOption))
+        return cliOption;
+
+    var cosmosDbName = config["CosmosDb:DatabaseName"];
+    if (!string.IsNullOrEmpty(cosmosDbName))
+        return cosmosDbName;
+
+    var envDbName = config["COSMOS_DATABASE_NAME"];
+    if (!string.IsNullOrEmpty(envDbName))
+        return envDbName;
+
+    return "SekibanDcb";
+}
+
+// Helper to resolve connection string
+static string ResolveConnectionString(IConfiguration config, string databaseType, string? connectionString, string? cosmosConnectionString)
+{
+    if (databaseType.ToLowerInvariant() == "cosmos")
+    {
+        if (!string.IsNullOrEmpty(cosmosConnectionString))
+            return cosmosConnectionString;
+
+        var configConnStr = config["ConnectionStrings:SekibanDcbCosmos"];
+        if (!string.IsNullOrEmpty(configConnStr))
+            return configConnStr;
+
+        var envConnStr = config["COSMOS_CONNECTION_STRING"];
+        if (!string.IsNullOrEmpty(envConnStr))
+            return envConnStr;
+
+        throw new InvalidOperationException(
+            "Cosmos DB connection string not provided.\n" +
+            "Options:\n" +
+            "  1. Use --cosmos-connection-string option\n" +
+            "  2. Set user secret: dotnet user-secrets set \"ConnectionStrings:SekibanDcbCosmos\" \"your-connection-string\"\n" +
+            "  3. Set environment variable: COSMOS_CONNECTION_STRING");
+    }
+    else
+    {
+        if (!string.IsNullOrEmpty(connectionString))
+            return connectionString;
+
+        var configConnStr = config["ConnectionStrings:DcbPostgres"];
+        if (!string.IsNullOrEmpty(configConnStr))
+            return configConnStr;
+
+        var envConnStr = config["CONNECTION_STRING"];
+        if (!string.IsNullOrEmpty(envConnStr))
+            return envConnStr;
+
+        throw new InvalidOperationException(
+            "PostgreSQL connection string not provided.\n" +
+            "Options:\n" +
+            "  1. Use --connection-string option\n" +
+            "  2. Set user secret: dotnet user-secrets set \"ConnectionStrings:DcbPostgres\" \"your-connection-string\"\n" +
+            "  3. Set environment variable: CONNECTION_STRING");
+    }
+}
+
+// Implementation methods
+static async Task BuildProjectionStatesAsync(
+    string connectionString,
+    string databaseType,
+    string cosmosDatabaseName,
+    int minEvents,
+    string? projectorName,
+    bool forceRebuild,
+    bool verbose)
+{
+    Console.WriteLine("=== Multi Projection State Builder ===");
+    Console.WriteLine($"Database: {databaseType}");
+    Console.WriteLine($"Connection: {connectionString[..Math.Min(50, connectionString.Length)]}...");
+    if (databaseType.ToLowerInvariant() == "cosmos")
+    {
+        Console.WriteLine($"Cosmos Database: {cosmosDatabaseName}");
+    }
+    Console.WriteLine($"Min Events: {minEvents}");
+    Console.WriteLine($"Force Rebuild: {forceRebuild}");
+    Console.WriteLine();
+
+    var services = BuildServices(connectionString, databaseType, cosmosDatabaseName);
+    var builder = services.GetRequiredService<MultiProjectionStateBuilder>();
+
+    var options = new MultiProjectionBuildOptions
+    {
+        MinEventThreshold = minEvents,
+        Force = forceRebuild,
+        SpecificProjector = projectorName
+    };
+
+    if (!string.IsNullOrEmpty(projectorName))
+    {
+        Console.WriteLine($"Building projector: {projectorName}");
+        var result = await builder.BuildProjectorAsync(projectorName, options);
+        PrintBuildResult(result, verbose);
+    }
+    else
+    {
+        Console.WriteLine("Building all projectors...");
+        var buildResult = await builder.BuildAllAsync(options);
+        var results = buildResult.Results;
+        Console.WriteLine($"\nResults: {results.Count} projector(s) processed");
+        Console.WriteLine(new string('-', 80));
+
+        foreach (var result in results)
+        {
+            PrintBuildResult(result, verbose);
+        }
+
+        var succeeded = results.Count(r => r.Status == BuildStatus.Success);
+        var skipped = results.Count(r => r.Status == BuildStatus.Skipped);
+        var failed = results.Count(r => r.Status == BuildStatus.Failed);
+
+        Console.WriteLine(new string('=', 80));
+        Console.WriteLine($"Summary: {succeeded} succeeded, {skipped} skipped, {failed} failed");
+    }
+}
+
+static async Task ListProjectorsAsync()
+{
+    Console.WriteLine("=== Registered Projectors ===\n");
+
+    var domainTypes = DomainType.GetDomainTypes();
+    var projectorNames = domainTypes.MultiProjectorTypes.GetAllProjectorNames();
+
+    Console.WriteLine($"Total: {projectorNames.Count} projector(s)\n");
+
+    foreach (var name in projectorNames)
+    {
+        var versionResult = domainTypes.MultiProjectorTypes.GetProjectorVersion(name);
+        var version = versionResult.IsSuccess ? versionResult.GetValue() : "unknown";
+        Console.WriteLine($"  - {name} (version: {version})");
+    }
+
+    await Task.CompletedTask;
+}
+
+static async Task ShowStatusAsync(string connectionString, string databaseType, string cosmosDatabaseName)
+{
+    Console.WriteLine("=== Projection State Status ===\n");
+    Console.WriteLine($"Database: {databaseType}");
+    if (databaseType.ToLowerInvariant() == "cosmos")
+    {
+        Console.WriteLine($"Cosmos Database: {cosmosDatabaseName}");
+    }
+    Console.WriteLine();
+
+    var services = BuildServices(connectionString, databaseType, cosmosDatabaseName);
+    var stateStore = services.GetRequiredService<IMultiProjectionStateStore>();
+    var eventStore = services.GetRequiredService<IEventStore>();
+    var domainTypes = services.GetRequiredService<DcbDomainTypes>();
+
+    var eventCountResult = await eventStore.GetEventCountAsync();
+    var totalEvents = eventCountResult.IsSuccess ? eventCountResult.GetValue() : 0;
+    Console.WriteLine($"Total Events in Store: {totalEvents:N0}\n");
+
+    var listResult = await stateStore.ListAllAsync();
+    if (!listResult.IsSuccess)
+    {
+        Console.WriteLine($"Error listing states: {listResult.GetException().Message}");
+        return;
+    }
+
+    var states = listResult.GetValue();
+    if (states.Count == 0)
+    {
+        Console.WriteLine("No projection states found.\n");
+    }
+    else
+    {
+        Console.WriteLine($"{"Projector",-50} {"Version",-15} {"Events",-12} {"Size",-15} {"Updated"}");
+        Console.WriteLine(new string('-', 120));
+
+        foreach (var state in states)
+        {
+            var sizeStr = FormatBytes(state.CompressedSizeBytes);
+            Console.WriteLine($"{state.ProjectorName,-50} {state.ProjectorVersion,-15} {state.EventsProcessed,-12:N0} {sizeStr,-15} {state.UpdatedAt:yyyy-MM-dd HH:mm:ss}");
+        }
+    }
+
+    var projectorNames = domainTypes.MultiProjectorTypes.GetAllProjectorNames();
+    var projectorsWithState = states.Select(s => s.ProjectorName).ToHashSet();
+    var projectorsWithoutState = projectorNames.Where(n => !projectorsWithState.Contains(n)).ToList();
+
+    if (projectorsWithoutState.Count > 0)
+    {
+        Console.WriteLine($"\nProjectors without stored state:");
+        foreach (var name in projectorsWithoutState)
+        {
+            var versionResult = domainTypes.MultiProjectorTypes.GetProjectorVersion(name);
+            var version = versionResult.IsSuccess ? versionResult.GetValue() : "unknown";
+            Console.WriteLine($"  - {name} (version: {version})");
+        }
+    }
+}
+
+static void PrintBuildResult(ProjectorBuildResult result, bool verbose)
+{
+    var statusIcon = result.Status switch
+    {
+        BuildStatus.Success => "[OK]",
+        BuildStatus.Skipped => "[SKIP]",
+        BuildStatus.Failed => "[FAIL]",
+        _ => "[?]"
+    };
+
+    Console.WriteLine($"{statusIcon} {result.ProjectorName} (v{result.ProjectorVersion})");
+
+    if (verbose || result.Status == BuildStatus.Failed)
+    {
+        Console.WriteLine($"    Status: {result.Status}");
+        Console.WriteLine($"    Reason: {result.Reason}");
+        Console.WriteLine($"    Events Processed: {result.EventsProcessed:N0}");
+    }
+}
+
+static string FormatBytes(long bytes)
+{
+    string[] sizes = ["B", "KB", "MB", "GB"];
+    double len = bytes;
+    int order = 0;
+    while (len >= 1024 && order < sizes.Length - 1)
+    {
+        order++;
+        len /= 1024;
+    }
+    return $"{len:0.##} {sizes[order]}";
+}
+
+static async Task SaveStateJsonAsync(string connectionString, string databaseType, string cosmosDatabaseName, string? projectorName, string outputDir)
+{
+    Console.WriteLine("=== Save Projection State JSON ===\n");
+    Console.WriteLine($"Database: {databaseType}");
+    Console.WriteLine($"Output Directory: {outputDir}");
+    Console.WriteLine();
+
+    var services = BuildServices(connectionString, databaseType, cosmosDatabaseName);
+    var stateStore = services.GetRequiredService<IMultiProjectionStateStore>();
+
+    Directory.CreateDirectory(outputDir);
+
+    var listResult = await stateStore.ListAllAsync();
+    if (!listResult.IsSuccess)
+    {
+        Console.WriteLine($"Error listing states: {listResult.GetException().Message}");
+        return;
+    }
+
+    var stateInfos = listResult.GetValue();
+    if (!string.IsNullOrEmpty(projectorName))
+    {
+        stateInfos = stateInfos.Where(s => s.ProjectorName == projectorName).ToList();
+    }
+
+    if (stateInfos.Count == 0)
+    {
+        Console.WriteLine("No projection states found.");
+        return;
+    }
+
+    var timestamp = DateTime.UtcNow.ToString("yyyyMMddHHmmss");
+    var savedCount = 0;
+
+    foreach (var info in stateInfos)
+    {
+        Console.WriteLine($"Saving: {info.ProjectorName} (v{info.ProjectorVersion})");
+
+        var recordResult = await stateStore.GetLatestForVersionAsync(info.ProjectorName, info.ProjectorVersion);
+        if (!recordResult.IsSuccess || !recordResult.GetValue().HasValue)
+        {
+            Console.WriteLine($"  Error: Could not fetch full record");
+            continue;
+        }
+
+        var state = recordResult.GetValue().GetValue();
+
+        var metadataFileName = $"{state.ProjectorName}_{timestamp}_metadata.json";
+        var metadataPath = Path.Combine(outputDir, metadataFileName);
+        var metadata = new
+        {
+            state.ProjectorName,
+            state.ProjectorVersion,
+            state.PayloadType,
+            state.LastSortableUniqueId,
+            state.EventsProcessed,
+            state.IsOffloaded,
+            state.OffloadKey,
+            state.OriginalSizeBytes,
+            state.CompressedSizeBytes,
+            state.SafeWindowThreshold,
+            state.CreatedAt,
+            state.UpdatedAt,
+            state.BuildSource,
+            state.BuildHost
+        };
+        await File.WriteAllTextAsync(metadataPath, System.Text.Json.JsonSerializer.Serialize(metadata, new System.Text.Json.JsonSerializerOptions { WriteIndented = true }));
+        Console.WriteLine($"  Metadata: {metadataFileName}");
+
+        if (state.StateData != null)
+        {
+            var stateFileName = $"{state.ProjectorName}_{timestamp}_state.json";
+            var statePath = Path.Combine(outputDir, stateFileName);
+
+            try
+            {
+                string jsonContent;
+
+                if (state.StateData.Length >= 2 && state.StateData[0] == 0x1f && state.StateData[1] == 0x8b)
+                {
+                    jsonContent = GzipCompression.DecompressToString(state.StateData);
+                }
+                else
+                {
+                    jsonContent = System.Text.Encoding.UTF8.GetString(state.StateData);
+                }
+
+                var jsonDoc = System.Text.Json.JsonDocument.Parse(jsonContent);
+                var prettyJson = System.Text.Json.JsonSerializer.Serialize(jsonDoc, new System.Text.Json.JsonSerializerOptions { WriteIndented = true });
+                await File.WriteAllTextAsync(statePath, prettyJson);
+                Console.WriteLine($"  State: {stateFileName} ({FormatBytes(state.StateData.LongLength)})");
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"  Error decompressing state: {ex.Message}");
+                var rawFileName = $"{state.ProjectorName}_{timestamp}_state.bin";
+                var rawPath = Path.Combine(outputDir, rawFileName);
+                await File.WriteAllBytesAsync(rawPath, state.StateData);
+                Console.WriteLine($"  Raw state saved: {rawFileName}");
+            }
+        }
+        else if (state.IsOffloaded)
+        {
+            Console.WriteLine($"  State is offloaded to: {state.OffloadKey}");
+        }
+
+        Console.WriteLine();
+        savedCount++;
+    }
+
+    Console.WriteLine($"Saved {savedCount} projection state(s) to {outputDir}");
+}
+
+static ServiceProvider BuildServices(string connectionString, string databaseType, string cosmosDatabaseName)
+{
+    var services = new ServiceCollection();
+
+    var domainTypes = DomainType.GetDomainTypes();
+    services.AddSingleton(domainTypes);
+
+    if (databaseType.ToLowerInvariant() == "cosmos")
+    {
+        var cosmosClient = new CosmosClient(connectionString);
+        var cosmosContext = new CosmosDbContext(cosmosClient, cosmosDatabaseName);
+        services.AddSingleton(cosmosContext);
+        services.AddSingleton<IEventStore, CosmosDbEventStore>();
+        services.AddSingleton<IMultiProjectionStateStore, CosmosMultiProjectionStateStore>();
+    }
+    else
+    {
+        services.AddPooledDbContextFactory<SekibanDcbDbContext>(options =>
+        {
+            options.UseNpgsql(connectionString);
+        });
+
+        services.AddSingleton<IEventStore, PostgresEventStore>();
+        services.AddSingleton<IMultiProjectionStateStore, PostgresMultiProjectionStateStore>();
+    }
+
+    services.AddSingleton<MultiProjectionStateBuilder>();
+
+    return services.BuildServiceProvider();
+}

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.Cli/SekibanDcbOrleans.Cli.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.Cli/SekibanDcbOrleans.Cli.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net10.0</TargetFramework>
+        <Nullable>enable</Nullable>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <UserSecretsId>sekiban-dcb-cli</UserSecretsId>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.56.0"/>
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.1"/>
+        <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.1"/>
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.1"/>
+        <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1"/>
+        <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.0.2-preview01" />
+        <PackageReference Include="Sekiban.Dcb.Postgres" Version="10.0.2-preview01" />
+        <PackageReference Include="Sekiban.Dcb.CosmosDb" Version="10.0.2-preview01" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\SekibanDcbOrleans.Domain\SekibanDcbOrleans.Domain.csproj"/>
+    </ItemGroup>
+
+</Project>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.Domain/SekibanDcbOrleans.Domain.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.Domain/SekibanDcbOrleans.Domain.csproj
@@ -7,7 +7,7 @@
     <IsPackable>true</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.0.1-preview12" />
+    <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.0.2-preview01" />
     <PackageReference Include="ResultBoxes" Version="0.3.31" />
     <PackageReference Include="Microsoft.Orleans.Serialization" Version="9.2.1" />
   </ItemGroup>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.slnx
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.slnx
@@ -1,6 +1,7 @@
 <Solution>
   <Project Path="SekibanDcbOrleans.ApiService/SekibanDcbOrleans.ApiService.csproj" />
   <Project Path="SekibanDcbOrleans.AppHost/SekibanDcbOrleans.AppHost.csproj" />
+  <Project Path="SekibanDcbOrleans.Cli/SekibanDcbOrleans.Cli.csproj" />
   <Project Path="SekibanDcbOrleans.Domain/SekibanDcbOrleans.Domain.csproj" />
   <Project Path="SekibanDcbOrleans.ServiceDefaults/SekibanDcbOrleans.ServiceDefaults.csproj" />
   <Project Path="SekibanDcbOrleans.Unit/SekibanDcbOrleans.Unit.csproj" />

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans/SekibanDcbOrleans.ApiService/Program.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans/SekibanDcbOrleans.ApiService/Program.cs
@@ -420,11 +420,13 @@ var databaseType = builder.Configuration.GetSection("Sekiban").GetValue<string>(
 if (databaseType == "cosmos")
 {
     builder.Services.AddSekibanDcbCosmosDbWithAspire();
+    builder.Services.AddSingleton<IMultiProjectionStateStore, Sekiban.Dcb.CosmosDb.CosmosMultiProjectionStateStore>();
 }
 else
 {
     builder.Services.AddSingleton<IEventStore, PostgresEventStore>();
     builder.Services.AddSekibanDcbPostgresWithAspire();
+    builder.Services.AddSingleton<IMultiProjectionStateStore, Sekiban.Dcb.Postgres.PostgresMultiProjectionStateStore>();
 }
 
 builder.Services.AddTransient<IGrainStorageSerializer, NewtonsoftJsonDcbOrleansSerializer>();
@@ -475,8 +477,7 @@ apiRoute
                     });
             return Results.BadRequest(new { error = result.GetException().Message });
         })
-    .WithOpenApi()
-    .WithName("CreateStudent");
+        .WithName("CreateStudent");
 apiRoute
     .MapGet(
         "/students",
@@ -501,8 +502,7 @@ apiRoute
 
             return Results.BadRequest(new { error = result.GetException().Message });
         })
-    .WithOpenApi()
-    .WithName("GetStudentList");
+        .WithName("GetStudentList");
 apiRoute
     .MapGet(
         "/students/{studentId:guid}",
@@ -525,8 +525,7 @@ apiRoute
 
             return Results.NotFound(new { error = $"Student {studentId} not found" });
         })
-    .WithOpenApi()
-    .WithName("GetStudent");
+        .WithName("GetStudent");
 apiRoute
     .MapPost(
         "/classrooms",
@@ -544,8 +543,7 @@ apiRoute
                     });
             return Results.BadRequest(new { error = result.GetException().Message });
         })
-    .WithOpenApi()
-    .WithName("CreateClassRoom");
+        .WithName("CreateClassRoom");
 apiRoute
     .MapGet(
         "/classrooms",
@@ -570,8 +568,7 @@ apiRoute
 
             return Results.BadRequest(new { error = result.GetException().Message });
         })
-    .WithOpenApi()
-    .WithName("GetClassRoomList");
+        .WithName("GetClassRoomList");
 apiRoute
     .MapGet(
         "/classrooms/{classRoomId:guid}",
@@ -594,8 +591,7 @@ apiRoute
 
             return Results.NotFound(new { error = $"ClassRoom {classRoomId} not found" });
         })
-    .WithOpenApi()
-    .WithName("GetClassRoom");
+        .WithName("GetClassRoom");
 apiRoute
     .MapPost(
         "/enrollments/add",
@@ -614,8 +610,7 @@ apiRoute
                     });
             return Results.BadRequest(new { error = result.GetException().Message });
         })
-    .WithOpenApi()
-    .WithName("EnrollStudent");
+        .WithName("EnrollStudent");
 apiRoute
     .MapPost(
         "/enrollments/drop",
@@ -634,8 +629,7 @@ apiRoute
                     });
             return Results.BadRequest(new { error = result.GetException().Message });
         })
-    .WithOpenApi()
-    .WithName("DropStudent");
+        .WithName("DropStudent");
 apiRoute
     .MapGet(
         "/debug/events",
@@ -668,8 +662,7 @@ apiRoute
                 return Results.Problem(ex.Message);
             }
         })
-    .WithOpenApi()
-    .WithName("DebugGetEvents");
+        .WithName("DebugGetEvents");
 apiRoute
     .MapGet(
         "/weatherforecast",
@@ -696,8 +689,7 @@ apiRoute
 
             return Results.BadRequest(new { error = result.GetException()?.Message });
         })
-    .WithOpenApi()
-    .WithName("GetWeatherForecast");
+        .WithName("GetWeatherForecast");
 apiRoute
     .MapGet(
         "/weatherforecastgeneric",
@@ -724,8 +716,7 @@ apiRoute
 
             return Results.BadRequest(new { error = result.GetException()?.Message });
         })
-    .WithOpenApi()
-    .WithName("GetWeatherForecastGeneric");
+        .WithName("GetWeatherForecastGeneric");
 apiRoute
     .MapGet(
         "/weatherforecastsingle",
@@ -752,8 +743,7 @@ apiRoute
 
             return Results.BadRequest(new { error = result.GetException()?.Message });
         })
-    .WithOpenApi()
-    .WithName("GetWeatherForecastSingle");
+        .WithName("GetWeatherForecastSingle");
 apiRoute
     .MapPost(
         "/inputweatherforecast",
@@ -776,8 +766,8 @@ apiRoute
                     error = result.GetException()?.Message
                 });
         })
-    .WithName("InputWeatherForecast")
-    .WithOpenApi();
+    .WithName("InputWeatherForecast");
+
 apiRoute
     .MapPost(
         "/updateweatherforecastlocation",
@@ -800,8 +790,8 @@ apiRoute
                     error = result.GetException()?.Message
                 });
         })
-    .WithName("UpdateWeatherForecastLocation")
-    .WithOpenApi();
+    .WithName("UpdateWeatherForecastLocation");
+
 apiRoute
     .MapGet(
         "/weatherforecast/count",
@@ -827,8 +817,7 @@ apiRoute
 
             return Results.BadRequest(new { error = result.GetException()?.Message ?? "Query failed" });
         })
-    .WithOpenApi()
-    .WithName("GetWeatherForecastCount");
+        .WithName("GetWeatherForecastCount");
 apiRoute
     .MapGet(
         "/weatherforecastgeneric/count",
@@ -855,8 +844,7 @@ apiRoute
 
             return Results.BadRequest(new { error = result.GetException()?.Message ?? "Query failed" });
         })
-    .WithOpenApi()
-    .WithName("GetWeatherForecastCountGeneric");
+        .WithName("GetWeatherForecastCountGeneric");
 apiRoute
     .MapGet(
         "/weatherforecastsingle/count",
@@ -883,8 +871,7 @@ apiRoute
 
             return Results.BadRequest(new { error = result.GetException()?.Message ?? "Query failed" });
         })
-    .WithOpenApi()
-    .WithName("GetWeatherForecastCountSingle");
+        .WithName("GetWeatherForecastCountSingle");
 apiRoute
     .MapGet(
         "/weatherforecast/event-statistics",
@@ -894,8 +881,7 @@ apiRoute
             var stats = await grain.GetEventDeliveryStatisticsAsync();
             return Results.Ok(stats);
         })
-    .WithOpenApi()
-    .WithName("GetEventDeliveryStatistics");
+        .WithName("GetEventDeliveryStatistics");
 apiRoute
     .MapGet(
         "/weatherforecastgeneric/event-statistics",
@@ -906,8 +892,7 @@ apiRoute
             var stats = await grain.GetEventDeliveryStatisticsAsync();
             return Results.Ok(stats);
         })
-    .WithOpenApi()
-    .WithName("GetEventDeliveryStatisticsGeneric");
+        .WithName("GetEventDeliveryStatisticsGeneric");
 apiRoute
     .MapGet(
         "/weatherforecastsingle/event-statistics",
@@ -917,8 +902,7 @@ apiRoute
             var stats = await grain.GetEventDeliveryStatisticsAsync();
             return Results.Ok(stats);
         })
-    .WithOpenApi()
-    .WithName("GetEventDeliveryStatisticsSingle");
+        .WithName("GetEventDeliveryStatisticsSingle");
 apiRoute
     .MapGet(
         "/weatherforecast/status",
@@ -935,8 +919,7 @@ apiRoute
                 return Results.BadRequest(new { projector = "WeatherForecastProjection", error = ex.Message });
             }
         })
-    .WithOpenApi()
-    .WithName("GetWeatherForecastStatus");
+        .WithName("GetWeatherForecastStatus");
 apiRoute
     .MapGet(
         "/weatherforecastgeneric/status",
@@ -947,8 +930,7 @@ apiRoute
             var status = await grain.GetStatusAsync();
             return Results.Ok(status);
         })
-    .WithOpenApi()
-    .WithName("GetWeatherForecastGenericStatus");
+        .WithName("GetWeatherForecastGenericStatus");
 apiRoute
     .MapGet(
         "/weatherforecastsingle/status",
@@ -958,8 +940,7 @@ apiRoute
             var status = await grain.GetStatusAsync();
             return Results.Ok(status);
         })
-    .WithOpenApi()
-    .WithName("GetWeatherForecastSingleStatus");
+        .WithName("GetWeatherForecastSingleStatus");
 apiRoute
     .MapPost(
         "/projections/persist",
@@ -981,8 +962,7 @@ apiRoute
                 return Results.BadRequest(new { error = ex.Message });
             }
         })
-    .WithOpenApi()
-    .WithName("PersistProjectionState");
+        .WithName("PersistProjectionState");
 apiRoute
     .MapPost(
         "/projections/deactivate",
@@ -999,8 +979,7 @@ apiRoute
                 return Results.BadRequest(new { error = ex.Message });
             }
         })
-    .WithOpenApi()
-    .WithName("DeactivateProjection");
+        .WithName("DeactivateProjection");
 apiRoute
     .MapPost(
         "/projections/refresh",
@@ -1017,8 +996,7 @@ apiRoute
                 return Results.BadRequest(new { error = ex.Message });
             }
         })
-    .WithOpenApi()
-    .WithName("RefreshProjection");
+        .WithName("RefreshProjection");
 apiRoute
     .MapGet(
         "/projections/snapshot",
@@ -1036,8 +1014,7 @@ apiRoute
                 return Results.BadRequest(new { error = ex.Message });
             }
         })
-    .WithOpenApi()
-    .WithName("GetProjectionSnapshot");
+        .WithName("GetProjectionSnapshot");
 apiRoute
     .MapPost(
         "/projections/overwrite-version",
@@ -1056,8 +1033,7 @@ apiRoute
                 return Results.BadRequest(new { error = ex.Message });
             }
         })
-    .WithOpenApi()
-    .WithName("OverwriteProjectionPersistedVersion");
+        .WithName("OverwriteProjectionPersistedVersion");
 apiRoute
     .MapPost(
         "/removeweatherforecast",
@@ -1080,9 +1056,9 @@ apiRoute
                     error = result.GetException()?.Message
                 });
         })
-    .WithName("RemoveWeatherForecast")
-    .WithOpenApi();
-apiRoute.MapGet("/health", () => Results.Ok("Healthy")).WithOpenApi().WithName("HealthCheck");
+    .WithName("RemoveWeatherForecast");
+
+apiRoute.MapGet("/health", () => Results.Ok("Healthy")).WithName("HealthCheck");
 apiRoute
     .MapGet(
         "/orleans/test",
@@ -1119,7 +1095,6 @@ apiRoute
                     });
             }
         })
-    .WithOpenApi()
-    .WithName("TestOrleans");
+        .WithName("TestOrleans");
 app.MapDefaultEndpoints();
 app.Run();

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans/SekibanDcbOrleans.ApiService/SekibanDcbOrleans.ApiService.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans/SekibanDcbOrleans.ApiService/SekibanDcbOrleans.ApiService.csproj
@@ -28,11 +28,11 @@
   <PackageReference Include="Microsoft.Orleans.Streaming.AzureStorage" Version="9.2.1" />
   <PackageReference Include="Microsoft.Orleans.Streaming.EventHubs" Version="9.2.1" />
   <PackageReference Include="Scalar.AspNetCore" Version="2.11.10" />
-  <PackageReference Include="Sekiban.Dcb.BlobStorage.AzureStorage" Version="10.0.1-preview01" />
-  <PackageReference Include="Sekiban.Dcb.Orleans.WithResult" Version="10.0.1-preview05" />
+  <PackageReference Include="Sekiban.Dcb.BlobStorage.AzureStorage" Version="10.0.2-preview01" />
+  <PackageReference Include="Sekiban.Dcb.Orleans.WithResult" Version="10.0.2-preview01" />
   <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.0" />
-  <PackageReference Include="Sekiban.Dcb.Postgres" Version="10.0.1-preview05" />
-  <PackageReference Include="Sekiban.Dcb.CosmosDb" Version="10.0.1-preview01" />
+  <PackageReference Include="Sekiban.Dcb.Postgres" Version="10.0.2-preview01" />
+  <PackageReference Include="Sekiban.Dcb.CosmosDb" Version="10.0.2-preview01" />
   <!-- Sekiban.Dcb.BlobStorage.AzureStorage package not yet published to NuGet; remove for now -->
   </ItemGroup>
 </Project>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans/SekibanDcbOrleans.Cli/Program.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans/SekibanDcbOrleans.Cli/Program.cs
@@ -1,0 +1,563 @@
+using System.CommandLine;
+using System.Reflection;
+using Dcb.Domain;
+using Microsoft.Azure.Cosmos;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Sekiban.Dcb;
+using Sekiban.Dcb.Common;
+using Sekiban.Dcb.CosmosDb;
+using Sekiban.Dcb.MultiProjections;
+using Sekiban.Dcb.Postgres;
+using Sekiban.Dcb.Storage;
+
+// Build configuration from environment variables and user secrets
+var configuration = new ConfigurationBuilder()
+    .AddEnvironmentVariables()
+    .AddUserSecrets(Assembly.GetExecutingAssembly(), optional: true)
+    .Build();
+
+// Create the root command
+var rootCommand = new RootCommand("Multi Projection State Builder CLI - Pre-build projection states for faster startup");
+
+// Database type option (shared across commands)
+var databaseOption = new Option<string?>(
+    name: "--database",
+    description: "Database type: postgres or cosmos (defaults to Sekiban:Database config or DATABASE_TYPE env var)");
+databaseOption.AddAlias("-d");
+
+// Connection string option for Postgres
+var connectionStringOption = new Option<string?>(
+    name: "--connection-string",
+    description: "PostgreSQL connection string (defaults to ConnectionStrings:DcbPostgres config)");
+connectionStringOption.AddAlias("-c");
+
+// Connection string option for Cosmos
+var cosmosConnectionStringOption = new Option<string?>(
+    name: "--cosmos-connection-string",
+    description: "Cosmos DB connection string (defaults to ConnectionStrings:SekibanDcbCosmos config)");
+
+// Cosmos database name option
+var cosmosDatabaseNameOption = new Option<string?>(
+    name: "--cosmos-database",
+    description: "Cosmos DB database name (defaults to CosmosDb:DatabaseName config or 'SekibanDcb')");
+
+// Min events option
+var minEventsOption = new Option<int>(
+    name: "--min-events",
+    getDefaultValue: () => int.TryParse(configuration["MIN_EVENTS"], out var val) ? val : 3000,
+    description: "Minimum events required before building state");
+minEventsOption.AddAlias("-m");
+
+// Projector name option
+var projectorNameOption = new Option<string?>(
+    name: "--projector",
+    getDefaultValue: () => configuration["PROJECTOR_NAME"],
+    description: "Specific projector name to build (if not specified, builds all)");
+projectorNameOption.AddAlias("-p");
+
+// Force rebuild option
+var forceRebuildOption = new Option<bool>(
+    name: "--force",
+    getDefaultValue: () => configuration["FORCE_REBUILD"]?.ToLowerInvariant() == "true",
+    description: "Force rebuild even if state exists");
+forceRebuildOption.AddAlias("-f");
+
+// Verbose option
+var verboseOption = new Option<bool>(
+    name: "--verbose",
+    getDefaultValue: () => configuration["VERBOSE"]?.ToLowerInvariant() == "true",
+    description: "Show verbose output");
+verboseOption.AddAlias("-v");
+
+// Build command
+var buildCommand = new Command("build", "Build multi projection states")
+{
+    databaseOption,
+    connectionStringOption,
+    cosmosConnectionStringOption,
+    cosmosDatabaseNameOption,
+    minEventsOption,
+    projectorNameOption,
+    forceRebuildOption,
+    verboseOption
+};
+
+buildCommand.SetHandler(async (context) =>
+{
+    var database = context.ParseResult.GetValueForOption(databaseOption);
+    var connectionString = context.ParseResult.GetValueForOption(connectionStringOption);
+    var cosmosConnectionString = context.ParseResult.GetValueForOption(cosmosConnectionStringOption);
+    var cosmosDatabaseName = context.ParseResult.GetValueForOption(cosmosDatabaseNameOption);
+    var minEvents = context.ParseResult.GetValueForOption(minEventsOption);
+    var projectorName = context.ParseResult.GetValueForOption(projectorNameOption);
+    var forceRebuild = context.ParseResult.GetValueForOption(forceRebuildOption);
+    var verbose = context.ParseResult.GetValueForOption(verboseOption);
+
+    var resolvedDatabase = ResolveDatabaseType(configuration, database);
+    var resolvedConnectionString = ResolveConnectionString(configuration, resolvedDatabase, connectionString, cosmosConnectionString);
+    var resolvedCosmosDatabaseName = ResolveCosmosDatabaseName(configuration, cosmosDatabaseName);
+
+    await BuildProjectionStatesAsync(resolvedConnectionString, resolvedDatabase, resolvedCosmosDatabaseName, minEvents, projectorName, forceRebuild, verbose);
+});
+
+// List command
+var listCommand = new Command("list", "List all registered projectors");
+listCommand.SetHandler(async () => await ListProjectorsAsync());
+
+// Status command
+var statusCommand = new Command("status", "Show status of all projection states")
+{
+    databaseOption,
+    connectionStringOption,
+    cosmosConnectionStringOption,
+    cosmosDatabaseNameOption
+};
+
+statusCommand.SetHandler(async (context) =>
+{
+    var database = context.ParseResult.GetValueForOption(databaseOption);
+    var connectionString = context.ParseResult.GetValueForOption(connectionStringOption);
+    var cosmosConnectionString = context.ParseResult.GetValueForOption(cosmosConnectionStringOption);
+    var cosmosDatabaseName = context.ParseResult.GetValueForOption(cosmosDatabaseNameOption);
+
+    var resolvedDatabase = ResolveDatabaseType(configuration, database);
+    var resolvedConnectionString = ResolveConnectionString(configuration, resolvedDatabase, connectionString, cosmosConnectionString);
+    var resolvedCosmosDatabaseName = ResolveCosmosDatabaseName(configuration, cosmosDatabaseName);
+
+    await ShowStatusAsync(resolvedConnectionString, resolvedDatabase, resolvedCosmosDatabaseName);
+});
+
+// Save command
+var outputDirOption = new Option<string?>(
+    name: "--output-dir",
+    getDefaultValue: () => configuration["OUTPUT_DIR"] ?? "./output",
+    description: "Output directory for saved state files");
+outputDirOption.AddAlias("-o");
+
+var saveCommand = new Command("save", "Save projection state JSON to files for debugging")
+{
+    databaseOption,
+    connectionStringOption,
+    cosmosConnectionStringOption,
+    cosmosDatabaseNameOption,
+    projectorNameOption,
+    outputDirOption
+};
+
+saveCommand.SetHandler(async (context) =>
+{
+    var database = context.ParseResult.GetValueForOption(databaseOption);
+    var connectionString = context.ParseResult.GetValueForOption(connectionStringOption);
+    var cosmosConnectionString = context.ParseResult.GetValueForOption(cosmosConnectionStringOption);
+    var cosmosDatabaseName = context.ParseResult.GetValueForOption(cosmosDatabaseNameOption);
+    var projectorName = context.ParseResult.GetValueForOption(projectorNameOption);
+    var outputDir = context.ParseResult.GetValueForOption(outputDirOption) ?? "./output";
+
+    var resolvedDatabase = ResolveDatabaseType(configuration, database);
+    var resolvedConnectionString = ResolveConnectionString(configuration, resolvedDatabase, connectionString, cosmosConnectionString);
+    var resolvedCosmosDatabaseName = ResolveCosmosDatabaseName(configuration, cosmosDatabaseName);
+
+    await SaveStateJsonAsync(resolvedConnectionString, resolvedDatabase, resolvedCosmosDatabaseName, projectorName, outputDir);
+});
+
+rootCommand.AddCommand(buildCommand);
+rootCommand.AddCommand(listCommand);
+rootCommand.AddCommand(statusCommand);
+rootCommand.AddCommand(saveCommand);
+
+return await rootCommand.InvokeAsync(args);
+
+// Helper to resolve database type
+static string ResolveDatabaseType(IConfiguration config, string? cliOption)
+{
+    if (!string.IsNullOrEmpty(cliOption))
+        return cliOption;
+
+    var sekibanDatabase = config["Sekiban:Database"];
+    if (!string.IsNullOrEmpty(sekibanDatabase))
+        return sekibanDatabase;
+
+    var envDatabaseType = config["DATABASE_TYPE"];
+    if (!string.IsNullOrEmpty(envDatabaseType))
+        return envDatabaseType;
+
+    return "postgres";
+}
+
+// Helper to resolve Cosmos database name
+static string ResolveCosmosDatabaseName(IConfiguration config, string? cliOption)
+{
+    if (!string.IsNullOrEmpty(cliOption))
+        return cliOption;
+
+    var cosmosDbName = config["CosmosDb:DatabaseName"];
+    if (!string.IsNullOrEmpty(cosmosDbName))
+        return cosmosDbName;
+
+    var envDbName = config["COSMOS_DATABASE_NAME"];
+    if (!string.IsNullOrEmpty(envDbName))
+        return envDbName;
+
+    return "SekibanDcb";
+}
+
+// Helper to resolve connection string
+static string ResolveConnectionString(IConfiguration config, string databaseType, string? connectionString, string? cosmosConnectionString)
+{
+    if (databaseType.ToLowerInvariant() == "cosmos")
+    {
+        if (!string.IsNullOrEmpty(cosmosConnectionString))
+            return cosmosConnectionString;
+
+        var configConnStr = config["ConnectionStrings:SekibanDcbCosmos"];
+        if (!string.IsNullOrEmpty(configConnStr))
+            return configConnStr;
+
+        var envConnStr = config["COSMOS_CONNECTION_STRING"];
+        if (!string.IsNullOrEmpty(envConnStr))
+            return envConnStr;
+
+        throw new InvalidOperationException(
+            "Cosmos DB connection string not provided.\n" +
+            "Options:\n" +
+            "  1. Use --cosmos-connection-string option\n" +
+            "  2. Set user secret: dotnet user-secrets set \"ConnectionStrings:SekibanDcbCosmos\" \"your-connection-string\"\n" +
+            "  3. Set environment variable: COSMOS_CONNECTION_STRING");
+    }
+    else
+    {
+        if (!string.IsNullOrEmpty(connectionString))
+            return connectionString;
+
+        var configConnStr = config["ConnectionStrings:DcbPostgres"];
+        if (!string.IsNullOrEmpty(configConnStr))
+            return configConnStr;
+
+        var envConnStr = config["CONNECTION_STRING"];
+        if (!string.IsNullOrEmpty(envConnStr))
+            return envConnStr;
+
+        throw new InvalidOperationException(
+            "PostgreSQL connection string not provided.\n" +
+            "Options:\n" +
+            "  1. Use --connection-string option\n" +
+            "  2. Set user secret: dotnet user-secrets set \"ConnectionStrings:DcbPostgres\" \"your-connection-string\"\n" +
+            "  3. Set environment variable: CONNECTION_STRING");
+    }
+}
+
+// Implementation methods
+static async Task BuildProjectionStatesAsync(
+    string connectionString,
+    string databaseType,
+    string cosmosDatabaseName,
+    int minEvents,
+    string? projectorName,
+    bool forceRebuild,
+    bool verbose)
+{
+    Console.WriteLine("=== Multi Projection State Builder ===");
+    Console.WriteLine($"Database: {databaseType}");
+    Console.WriteLine($"Connection: {connectionString[..Math.Min(50, connectionString.Length)]}...");
+    if (databaseType.ToLowerInvariant() == "cosmos")
+    {
+        Console.WriteLine($"Cosmos Database: {cosmosDatabaseName}");
+    }
+    Console.WriteLine($"Min Events: {minEvents}");
+    Console.WriteLine($"Force Rebuild: {forceRebuild}");
+    Console.WriteLine();
+
+    var services = BuildServices(connectionString, databaseType, cosmosDatabaseName);
+    var builder = services.GetRequiredService<MultiProjectionStateBuilder>();
+
+    var options = new MultiProjectionBuildOptions
+    {
+        MinEventThreshold = minEvents,
+        Force = forceRebuild,
+        SpecificProjector = projectorName
+    };
+
+    if (!string.IsNullOrEmpty(projectorName))
+    {
+        Console.WriteLine($"Building projector: {projectorName}");
+        var result = await builder.BuildProjectorAsync(projectorName, options);
+        PrintBuildResult(result, verbose);
+    }
+    else
+    {
+        Console.WriteLine("Building all projectors...");
+        var buildResult = await builder.BuildAllAsync(options);
+        var results = buildResult.Results;
+        Console.WriteLine($"\nResults: {results.Count} projector(s) processed");
+        Console.WriteLine(new string('-', 80));
+
+        foreach (var result in results)
+        {
+            PrintBuildResult(result, verbose);
+        }
+
+        var succeeded = results.Count(r => r.Status == BuildStatus.Success);
+        var skipped = results.Count(r => r.Status == BuildStatus.Skipped);
+        var failed = results.Count(r => r.Status == BuildStatus.Failed);
+
+        Console.WriteLine(new string('=', 80));
+        Console.WriteLine($"Summary: {succeeded} succeeded, {skipped} skipped, {failed} failed");
+    }
+}
+
+static async Task ListProjectorsAsync()
+{
+    Console.WriteLine("=== Registered Projectors ===\n");
+
+    var domainTypes = DomainType.GetDomainTypes();
+    var projectorNames = domainTypes.MultiProjectorTypes.GetAllProjectorNames();
+
+    Console.WriteLine($"Total: {projectorNames.Count} projector(s)\n");
+
+    foreach (var name in projectorNames)
+    {
+        var versionResult = domainTypes.MultiProjectorTypes.GetProjectorVersion(name);
+        var version = versionResult.IsSuccess ? versionResult.GetValue() : "unknown";
+        Console.WriteLine($"  - {name} (version: {version})");
+    }
+
+    await Task.CompletedTask;
+}
+
+static async Task ShowStatusAsync(string connectionString, string databaseType, string cosmosDatabaseName)
+{
+    Console.WriteLine("=== Projection State Status ===\n");
+    Console.WriteLine($"Database: {databaseType}");
+    if (databaseType.ToLowerInvariant() == "cosmos")
+    {
+        Console.WriteLine($"Cosmos Database: {cosmosDatabaseName}");
+    }
+    Console.WriteLine();
+
+    var services = BuildServices(connectionString, databaseType, cosmosDatabaseName);
+    var stateStore = services.GetRequiredService<IMultiProjectionStateStore>();
+    var eventStore = services.GetRequiredService<IEventStore>();
+    var domainTypes = services.GetRequiredService<DcbDomainTypes>();
+
+    var eventCountResult = await eventStore.GetEventCountAsync();
+    var totalEvents = eventCountResult.IsSuccess ? eventCountResult.GetValue() : 0;
+    Console.WriteLine($"Total Events in Store: {totalEvents:N0}\n");
+
+    var listResult = await stateStore.ListAllAsync();
+    if (!listResult.IsSuccess)
+    {
+        Console.WriteLine($"Error listing states: {listResult.GetException().Message}");
+        return;
+    }
+
+    var states = listResult.GetValue();
+    if (states.Count == 0)
+    {
+        Console.WriteLine("No projection states found.\n");
+    }
+    else
+    {
+        Console.WriteLine($"{"Projector",-50} {"Version",-15} {"Events",-12} {"Size",-15} {"Updated"}");
+        Console.WriteLine(new string('-', 120));
+
+        foreach (var state in states)
+        {
+            var sizeStr = FormatBytes(state.CompressedSizeBytes);
+            Console.WriteLine($"{state.ProjectorName,-50} {state.ProjectorVersion,-15} {state.EventsProcessed,-12:N0} {sizeStr,-15} {state.UpdatedAt:yyyy-MM-dd HH:mm:ss}");
+        }
+    }
+
+    var projectorNames = domainTypes.MultiProjectorTypes.GetAllProjectorNames();
+    var projectorsWithState = states.Select(s => s.ProjectorName).ToHashSet();
+    var projectorsWithoutState = projectorNames.Where(n => !projectorsWithState.Contains(n)).ToList();
+
+    if (projectorsWithoutState.Count > 0)
+    {
+        Console.WriteLine($"\nProjectors without stored state:");
+        foreach (var name in projectorsWithoutState)
+        {
+            var versionResult = domainTypes.MultiProjectorTypes.GetProjectorVersion(name);
+            var version = versionResult.IsSuccess ? versionResult.GetValue() : "unknown";
+            Console.WriteLine($"  - {name} (version: {version})");
+        }
+    }
+}
+
+static void PrintBuildResult(ProjectorBuildResult result, bool verbose)
+{
+    var statusIcon = result.Status switch
+    {
+        BuildStatus.Success => "[OK]",
+        BuildStatus.Skipped => "[SKIP]",
+        BuildStatus.Failed => "[FAIL]",
+        _ => "[?]"
+    };
+
+    Console.WriteLine($"{statusIcon} {result.ProjectorName} (v{result.ProjectorVersion})");
+
+    if (verbose || result.Status == BuildStatus.Failed)
+    {
+        Console.WriteLine($"    Status: {result.Status}");
+        Console.WriteLine($"    Reason: {result.Reason}");
+        Console.WriteLine($"    Events Processed: {result.EventsProcessed:N0}");
+    }
+}
+
+static string FormatBytes(long bytes)
+{
+    string[] sizes = ["B", "KB", "MB", "GB"];
+    double len = bytes;
+    int order = 0;
+    while (len >= 1024 && order < sizes.Length - 1)
+    {
+        order++;
+        len /= 1024;
+    }
+    return $"{len:0.##} {sizes[order]}";
+}
+
+static async Task SaveStateJsonAsync(string connectionString, string databaseType, string cosmosDatabaseName, string? projectorName, string outputDir)
+{
+    Console.WriteLine("=== Save Projection State JSON ===\n");
+    Console.WriteLine($"Database: {databaseType}");
+    Console.WriteLine($"Output Directory: {outputDir}");
+    Console.WriteLine();
+
+    var services = BuildServices(connectionString, databaseType, cosmosDatabaseName);
+    var stateStore = services.GetRequiredService<IMultiProjectionStateStore>();
+
+    Directory.CreateDirectory(outputDir);
+
+    var listResult = await stateStore.ListAllAsync();
+    if (!listResult.IsSuccess)
+    {
+        Console.WriteLine($"Error listing states: {listResult.GetException().Message}");
+        return;
+    }
+
+    var stateInfos = listResult.GetValue();
+    if (!string.IsNullOrEmpty(projectorName))
+    {
+        stateInfos = stateInfos.Where(s => s.ProjectorName == projectorName).ToList();
+    }
+
+    if (stateInfos.Count == 0)
+    {
+        Console.WriteLine("No projection states found.");
+        return;
+    }
+
+    var timestamp = DateTime.UtcNow.ToString("yyyyMMddHHmmss");
+    var savedCount = 0;
+
+    foreach (var info in stateInfos)
+    {
+        Console.WriteLine($"Saving: {info.ProjectorName} (v{info.ProjectorVersion})");
+
+        var recordResult = await stateStore.GetLatestForVersionAsync(info.ProjectorName, info.ProjectorVersion);
+        if (!recordResult.IsSuccess || !recordResult.GetValue().HasValue)
+        {
+            Console.WriteLine($"  Error: Could not fetch full record");
+            continue;
+        }
+
+        var state = recordResult.GetValue().GetValue();
+
+        var metadataFileName = $"{state.ProjectorName}_{timestamp}_metadata.json";
+        var metadataPath = Path.Combine(outputDir, metadataFileName);
+        var metadata = new
+        {
+            state.ProjectorName,
+            state.ProjectorVersion,
+            state.PayloadType,
+            state.LastSortableUniqueId,
+            state.EventsProcessed,
+            state.IsOffloaded,
+            state.OffloadKey,
+            state.OriginalSizeBytes,
+            state.CompressedSizeBytes,
+            state.SafeWindowThreshold,
+            state.CreatedAt,
+            state.UpdatedAt,
+            state.BuildSource,
+            state.BuildHost
+        };
+        await File.WriteAllTextAsync(metadataPath, System.Text.Json.JsonSerializer.Serialize(metadata, new System.Text.Json.JsonSerializerOptions { WriteIndented = true }));
+        Console.WriteLine($"  Metadata: {metadataFileName}");
+
+        if (state.StateData != null)
+        {
+            var stateFileName = $"{state.ProjectorName}_{timestamp}_state.json";
+            var statePath = Path.Combine(outputDir, stateFileName);
+
+            try
+            {
+                string jsonContent;
+
+                if (state.StateData.Length >= 2 && state.StateData[0] == 0x1f && state.StateData[1] == 0x8b)
+                {
+                    jsonContent = GzipCompression.DecompressToString(state.StateData);
+                }
+                else
+                {
+                    jsonContent = System.Text.Encoding.UTF8.GetString(state.StateData);
+                }
+
+                var jsonDoc = System.Text.Json.JsonDocument.Parse(jsonContent);
+                var prettyJson = System.Text.Json.JsonSerializer.Serialize(jsonDoc, new System.Text.Json.JsonSerializerOptions { WriteIndented = true });
+                await File.WriteAllTextAsync(statePath, prettyJson);
+                Console.WriteLine($"  State: {stateFileName} ({FormatBytes(state.StateData.LongLength)})");
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"  Error decompressing state: {ex.Message}");
+                var rawFileName = $"{state.ProjectorName}_{timestamp}_state.bin";
+                var rawPath = Path.Combine(outputDir, rawFileName);
+                await File.WriteAllBytesAsync(rawPath, state.StateData);
+                Console.WriteLine($"  Raw state saved: {rawFileName}");
+            }
+        }
+        else if (state.IsOffloaded)
+        {
+            Console.WriteLine($"  State is offloaded to: {state.OffloadKey}");
+        }
+
+        Console.WriteLine();
+        savedCount++;
+    }
+
+    Console.WriteLine($"Saved {savedCount} projection state(s) to {outputDir}");
+}
+
+static ServiceProvider BuildServices(string connectionString, string databaseType, string cosmosDatabaseName)
+{
+    var services = new ServiceCollection();
+
+    var domainTypes = DomainType.GetDomainTypes();
+    services.AddSingleton(domainTypes);
+
+    if (databaseType.ToLowerInvariant() == "cosmos")
+    {
+        var cosmosClient = new CosmosClient(connectionString);
+        var cosmosContext = new CosmosDbContext(cosmosClient, cosmosDatabaseName);
+        services.AddSingleton(cosmosContext);
+        services.AddSingleton<IEventStore, CosmosDbEventStore>();
+        services.AddSingleton<IMultiProjectionStateStore, CosmosMultiProjectionStateStore>();
+    }
+    else
+    {
+        services.AddPooledDbContextFactory<SekibanDcbDbContext>(options =>
+        {
+            options.UseNpgsql(connectionString);
+        });
+
+        services.AddSingleton<IEventStore, PostgresEventStore>();
+        services.AddSingleton<IMultiProjectionStateStore, PostgresMultiProjectionStateStore>();
+    }
+
+    services.AddSingleton<MultiProjectionStateBuilder>();
+
+    return services.BuildServiceProvider();
+}

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans/SekibanDcbOrleans.Cli/SekibanDcbOrleans.Cli.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans/SekibanDcbOrleans.Cli/SekibanDcbOrleans.Cli.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net10.0</TargetFramework>
+        <Nullable>enable</Nullable>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <UserSecretsId>sekiban-dcb-cli</UserSecretsId>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.56.0"/>
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.1"/>
+        <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.1"/>
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.1"/>
+        <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1"/>
+        <PackageReference Include="Sekiban.Dcb.WithResult" Version="10.0.2-preview01" />
+        <PackageReference Include="Sekiban.Dcb.Postgres" Version="10.0.2-preview01" />
+        <PackageReference Include="Sekiban.Dcb.CosmosDb" Version="10.0.2-preview01" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\SekibanDcbOrleans.Domain\SekibanDcbOrleans.Domain.csproj"/>
+    </ItemGroup>
+
+</Project>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans/SekibanDcbOrleans.Domain/SekibanDcbOrleans.Domain.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans/SekibanDcbOrleans.Domain/SekibanDcbOrleans.Domain.csproj
@@ -7,7 +7,7 @@
     <IsPackable>true</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Sekiban.Dcb.WithResult" Version="10.0.1-preview05" />
+    <PackageReference Include="Sekiban.Dcb.WithResult" Version="10.0.2-preview01" />
     <PackageReference Include="ResultBoxes" Version="0.3.31" />
   </ItemGroup>
 </Project>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans/SekibanDcbOrleans.slnx
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans/SekibanDcbOrleans.slnx
@@ -1,6 +1,7 @@
 <Solution>
   <Project Path="SekibanDcbOrleans.ApiService/SekibanDcbOrleans.ApiService.csproj" />
   <Project Path="SekibanDcbOrleans.AppHost/SekibanDcbOrleans.AppHost.csproj" />
+  <Project Path="SekibanDcbOrleans.Cli/SekibanDcbOrleans.Cli.csproj" />
   <Project Path="SekibanDcbOrleans.Domain/SekibanDcbOrleans.Domain.csproj" />
   <Project Path="SekibanDcbOrleans.ServiceDefaults/SekibanDcbOrleans.ServiceDefaults.csproj" />
   <Project Path="SekibanDcbOrleans.Unit/SekibanDcbOrleans.Unit.csproj" />


### PR DESCRIPTION
## Summary
This PR adds a CLI tool for managing Multi Projection States, supporting both CosmosDB and PostgreSQL backends.

## Changes

### New CLI Tool (`DcbOrleans.Cli`)
- Implemented comprehensive CLI for multi-projection state building, listing, status checking, and JSON export
- Command-line options include:
  - Database type selection (Cosmos/PostgreSQL)
  - Connection string configuration
  - Minimum events threshold
  - Projector name filtering
  - Force rebuild option
  - Verbosity control

### Core Services
- Added `TagEventService` for tag-based event retrieval
- Added `TagStateService` for tag-based state management
- Introduced `ITagProjectorTypes` and `ITagTypes` interfaces
- Implemented `SimpleTagProjectorTypes` and `SimpleTagTypes`

### Template Updates
- Added CLI project to both `Sekiban.Dcb.Orleans` and `Sekiban.Dcb.Orleans.WithoutResult` templates
- Updated template API service configurations
- Refactored `WeatherForecastProjectorWithTagStateProjector` for better organization

### Infrastructure
- Service registration for Cosmos and PostgreSQL databases
- Helper methods for resolving database types, connection strings, and Cosmos database names
- JSON export functionality for debugging projection states

## Related Issue
Closes #838