### PR TITLE
feat: Enhance CLI with new commands for projections, tags, and events management

### DIFF
--- a/dcb/src/Sekiban.Dcb.Core/Services/TagListService.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Services/TagListService.cs
@@ -1,0 +1,149 @@
+using ResultBoxes;
+using Sekiban.Dcb.Common;
+using Sekiban.Dcb.Storage;
+using System.Text.Json;
+namespace Sekiban.Dcb.Services;
+
+/// <summary>
+///     Result of exporting a tag list
+/// </summary>
+public record TagListExportResult(
+    int TotalTags,
+    int TotalTagGroups,
+    long TotalEvents,
+    string? OutputFilePath,
+    IReadOnlyList<TagGroupSummary> TagGroups);
+
+/// <summary>
+///     Summary of a tag group
+/// </summary>
+public record TagGroupSummary(
+    string TagGroup,
+    int TagCount,
+    long TotalEvents,
+    IReadOnlyList<TagInfo> Tags);
+
+/// <summary>
+///     Service for listing and exporting tags from the event store
+/// </summary>
+public class TagListService
+{
+    private readonly IEventStore _eventStore;
+    private readonly DcbDomainTypes _domainTypes;
+
+    public TagListService(IEventStore eventStore, DcbDomainTypes domainTypes)
+    {
+        _eventStore = eventStore;
+        _domainTypes = domainTypes;
+    }
+
+    /// <summary>
+    ///     Get all tags from the event store
+    /// </summary>
+    /// <param name="tagGroup">Optional: Filter by tag group name</param>
+    /// <returns>List of tag information</returns>
+    public Task<ResultBox<IEnumerable<TagInfo>>> GetAllTagsAsync(string? tagGroup = null)
+        => _eventStore.GetAllTagsAsync(tagGroup);
+
+    /// <summary>
+    ///     Get all tags grouped by tag group
+    /// </summary>
+    /// <param name="tagGroup">Optional: Filter by tag group name</param>
+    /// <returns>List of tag group summaries</returns>
+    public async Task<ResultBox<IReadOnlyList<TagGroupSummary>>> GetTagsByGroupAsync(string? tagGroup = null)
+    {
+        var tagsResult = await _eventStore.GetAllTagsAsync(tagGroup);
+        if (!tagsResult.IsSuccess)
+        {
+            return ResultBox.Error<IReadOnlyList<TagGroupSummary>>(tagsResult.GetException());
+        }
+
+        var tags = tagsResult.GetValue().ToList();
+        var grouped = tags
+            .GroupBy(t => t.TagGroup)
+            .Select(g => new TagGroupSummary(
+                g.Key,
+                g.Count(),
+                g.Sum(t => t.EventCount),
+                g.OrderBy(t => t.Tag).ToList()))
+            .OrderBy(g => g.TagGroup)
+            .ToList();
+
+        return ResultBox.FromValue<IReadOnlyList<TagGroupSummary>>(grouped);
+    }
+
+    /// <summary>
+    ///     Export tag list to a JSON file
+    /// </summary>
+    /// <param name="outputPath">Output file path (if null, returns result without saving)</param>
+    /// <param name="tagGroup">Optional: Filter by tag group name</param>
+    /// <returns>Export result with tag information</returns>
+    public async Task<ResultBox<TagListExportResult>> ExportTagListAsync(string? outputPath = null, string? tagGroup = null)
+    {
+        var groupsResult = await GetTagsByGroupAsync(tagGroup);
+        if (!groupsResult.IsSuccess)
+        {
+            return ResultBox.Error<TagListExportResult>(groupsResult.GetException());
+        }
+
+        var groups = groupsResult.GetValue();
+        var totalTags = groups.Sum(g => g.TagCount);
+        var totalEvents = groups.Sum(g => g.TotalEvents);
+
+        var result = new TagListExportResult(
+            totalTags,
+            groups.Count,
+            totalEvents,
+            outputPath,
+            groups);
+
+        if (!string.IsNullOrEmpty(outputPath))
+        {
+            var directory = Path.GetDirectoryName(outputPath);
+            if (!string.IsNullOrEmpty(directory))
+            {
+                Directory.CreateDirectory(directory);
+            }
+
+            var exportData = new
+            {
+                ExportedAt = DateTime.UtcNow,
+                TotalTags = totalTags,
+                TotalTagGroups = groups.Count,
+                TotalEvents = totalEvents,
+                TagGroups = groups.Select(g => new
+                {
+                    g.TagGroup,
+                    g.TagCount,
+                    g.TotalEvents,
+                    Tags = g.Tags.Select(t => new
+                    {
+                        t.Tag,
+                        t.EventCount,
+                        t.FirstSortableUniqueId,
+                        t.LastSortableUniqueId,
+                        t.FirstEventAt,
+                        t.LastEventAt
+                    })
+                })
+            };
+
+            var jsonOptions = new JsonSerializerOptions { WriteIndented = true };
+            var json = JsonSerializer.Serialize(exportData, jsonOptions);
+            await File.WriteAllTextAsync(outputPath, json);
+        }
+
+        return ResultBox.FromValue(result);
+    }
+
+    /// <summary>
+    ///     Get all registered tag group names from domain types
+    /// </summary>
+    public IReadOnlyList<string> GetRegisteredTagGroupNames()
+        => _domainTypes.TagTypes.GetAllTagGroupNames();
+
+    /// <summary>
+    ///     Get the JSON serializer options from domain types
+    /// </summary>
+    public JsonSerializerOptions JsonSerializerOptions => _domainTypes.JsonSerializerOptions;
+}

--- a/dcb/src/Sekiban.Dcb.Core/Storage/IEventStore.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Storage/IEventStore.cs
@@ -58,4 +58,23 @@ public interface IEventStore
     ///     Gets total event count, optionally after a position.
     /// </summary>
     Task<ResultBox<long>> GetEventCountAsync(SortableUniqueId? since = null);
+
+    /// <summary>
+    ///     Gets all unique tags in the event store
+    /// </summary>
+    /// <param name="tagGroup">Optional: Filter by tag group name</param>
+    /// <returns>List of unique tag information</returns>
+    Task<ResultBox<IEnumerable<TagInfo>>> GetAllTagsAsync(string? tagGroup = null);
 }
+
+/// <summary>
+///     Information about a tag in the event store
+/// </summary>
+public record TagInfo(
+    string Tag,
+    string TagGroup,
+    int EventCount,
+    string? FirstSortableUniqueId,
+    string? LastSortableUniqueId,
+    DateTime? FirstEventAt,
+    DateTime? LastEventAt);

--- a/dcb/src/Sekiban.Dcb.WithResult/InMemory/InMemoryDcbExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.WithResult/InMemory/InMemoryDcbExecutor.cs
@@ -272,6 +272,38 @@ public class InMemoryDcbExecutor : ISekibanExecutor
             }
         }
 
+        public Task<ResultBox<IEnumerable<TagInfo>>> GetAllTagsAsync(string? tagGroup = null)
+        {
+            lock (_lock)
+            {
+                var allTags = _events
+                    .SelectMany(e => e.Tags)
+                    .Distinct()
+                    .Where(t => string.IsNullOrEmpty(tagGroup) || t.StartsWith(tagGroup + ":"))
+                    .ToList();
+
+                var tagInfos = allTags.Select(tagString =>
+                {
+                    var group = tagString.Contains(':') ? tagString.Split(':')[0] : tagString;
+                    var tagEvents = _events.Where(e => e.Tags.Contains(tagString)).ToList();
+
+                    return new TagInfo(
+                        tagString,
+                        group,
+                        tagEvents.Count,
+                        tagEvents.Min(e => e.SortableUniqueIdValue),
+                        tagEvents.Max(e => e.SortableUniqueIdValue),
+                        null, // InMemory doesn't track timestamps
+                        null);
+                })
+                .OrderBy(t => t.TagGroup)
+                .ThenBy(t => t.Tag)
+                .ToList();
+
+                return Task.FromResult(ResultBox.FromValue(tagInfos.AsEnumerable()));
+            }
+        }
+
         private string SerializeEvent(Event ev)
         {
             return _domainTypes.EventTypes.SerializeEventPayload(ev.Payload);

--- a/dcb/src/Sekiban.Dcb.WithoutResult/InMemory/InMemoryDcbExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.WithoutResult/InMemory/InMemoryDcbExecutor.cs
@@ -276,6 +276,38 @@ public class InMemoryDcbExecutor : ISekibanExecutor
             }
         }
 
+        public Task<ResultBox<IEnumerable<TagInfo>>> GetAllTagsAsync(string? tagGroup = null)
+        {
+            lock (_lock)
+            {
+                var allTags = _events
+                    .SelectMany(e => e.Tags)
+                    .Distinct()
+                    .Where(t => string.IsNullOrEmpty(tagGroup) || t.StartsWith(tagGroup + ":"))
+                    .ToList();
+
+                var tagInfos = allTags.Select(tagString =>
+                {
+                    var group = tagString.Contains(':') ? tagString.Split(':')[0] : tagString;
+                    var tagEvents = _events.Where(e => e.Tags.Contains(tagString)).ToList();
+
+                    return new TagInfo(
+                        tagString,
+                        group,
+                        tagEvents.Count,
+                        tagEvents.Min(e => e.SortableUniqueIdValue),
+                        tagEvents.Max(e => e.SortableUniqueIdValue),
+                        null, // InMemory doesn't track timestamps
+                        null);
+                })
+                .OrderBy(t => t.TagGroup)
+                .ThenBy(t => t.Tag)
+                .ToList();
+
+                return Task.FromResult(ResultBox.FromValue(tagInfos.AsEnumerable()));
+            }
+        }
+
         private string SerializeEvent(Event ev)
         {
             return _domainTypes.EventTypes.SerializeEventPayload(ev.Payload);

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.ApiService/SekibanDcbOrleans.ApiService.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.ApiService/SekibanDcbOrleans.ApiService.csproj
@@ -31,11 +31,11 @@
         <PackageReference Include="Microsoft.Orleans.Streaming.AzureStorage" Version="9.2.1" />
         <PackageReference Include="Microsoft.Orleans.Streaming.EventHubs" Version="9.2.1" />
         <PackageReference Include="Scalar.AspNetCore" Version="2.11.10" />
-        <PackageReference Include="Sekiban.Dcb.BlobStorage.AzureStorage" Version="10.0.2-preview01" />
-        <PackageReference Include="Sekiban.Dcb.Orleans.WithoutResult" Version="10.0.2-preview01" />
+        <PackageReference Include="Sekiban.Dcb.BlobStorage.AzureStorage" Version="10.0.2-preview02" />
+        <PackageReference Include="Sekiban.Dcb.Orleans.WithoutResult" Version="10.0.2-preview02" />
         <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.0" />
-        <PackageReference Include="Sekiban.Dcb.Postgres" Version="10.0.2-preview01" />
-        <PackageReference Include="Sekiban.Dcb.CosmosDb" Version="10.0.2-preview01" />
+        <PackageReference Include="Sekiban.Dcb.Postgres" Version="10.0.2-preview02" />
+        <PackageReference Include="Sekiban.Dcb.CosmosDb" Version="10.0.2-preview02" />
     </ItemGroup>
 
 </Project>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.Cli/SekibanDcbOrleans.Cli.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.Cli/SekibanDcbOrleans.Cli.csproj
@@ -14,9 +14,9 @@
         <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.1"/>
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.1"/>
         <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1"/>
-        <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.0.2-preview01" />
-        <PackageReference Include="Sekiban.Dcb.Postgres" Version="10.0.2-preview01" />
-        <PackageReference Include="Sekiban.Dcb.CosmosDb" Version="10.0.2-preview01" />
+        <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.0.2-preview02" />
+        <PackageReference Include="Sekiban.Dcb.Postgres" Version="10.0.2-preview02" />
+        <PackageReference Include="Sekiban.Dcb.CosmosDb" Version="10.0.2-preview02" />
     </ItemGroup>
 
     <ItemGroup>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.Domain/SekibanDcbOrleans.Domain.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.Domain/SekibanDcbOrleans.Domain.csproj
@@ -7,7 +7,7 @@
     <IsPackable>true</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.0.2-preview01" />
+    <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.0.2-preview02" />
     <PackageReference Include="ResultBoxes" Version="0.3.31" />
     <PackageReference Include="Microsoft.Orleans.Serialization" Version="9.2.1" />
   </ItemGroup>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans/SekibanDcbOrleans.ApiService/SekibanDcbOrleans.ApiService.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans/SekibanDcbOrleans.ApiService/SekibanDcbOrleans.ApiService.csproj
@@ -28,11 +28,11 @@
   <PackageReference Include="Microsoft.Orleans.Streaming.AzureStorage" Version="9.2.1" />
   <PackageReference Include="Microsoft.Orleans.Streaming.EventHubs" Version="9.2.1" />
   <PackageReference Include="Scalar.AspNetCore" Version="2.11.10" />
-  <PackageReference Include="Sekiban.Dcb.BlobStorage.AzureStorage" Version="10.0.2-preview01" />
-  <PackageReference Include="Sekiban.Dcb.Orleans.WithResult" Version="10.0.2-preview01" />
+  <PackageReference Include="Sekiban.Dcb.BlobStorage.AzureStorage" Version="10.0.2-preview02" />
+  <PackageReference Include="Sekiban.Dcb.Orleans.WithResult" Version="10.0.2-preview02" />
   <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.0" />
-  <PackageReference Include="Sekiban.Dcb.Postgres" Version="10.0.2-preview01" />
-  <PackageReference Include="Sekiban.Dcb.CosmosDb" Version="10.0.2-preview01" />
+  <PackageReference Include="Sekiban.Dcb.Postgres" Version="10.0.2-preview02" />
+  <PackageReference Include="Sekiban.Dcb.CosmosDb" Version="10.0.2-preview02" />
   <!-- Sekiban.Dcb.BlobStorage.AzureStorage package not yet published to NuGet; remove for now -->
   </ItemGroup>
 </Project>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans/SekibanDcbOrleans.Cli/SekibanDcbOrleans.Cli.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans/SekibanDcbOrleans.Cli/SekibanDcbOrleans.Cli.csproj
@@ -14,9 +14,9 @@
         <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.1"/>
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.1"/>
         <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1"/>
-        <PackageReference Include="Sekiban.Dcb.WithResult" Version="10.0.2-preview01" />
-        <PackageReference Include="Sekiban.Dcb.Postgres" Version="10.0.2-preview01" />
-        <PackageReference Include="Sekiban.Dcb.CosmosDb" Version="10.0.2-preview01" />
+        <PackageReference Include="Sekiban.Dcb.WithResult" Version="10.0.2-preview02" />
+        <PackageReference Include="Sekiban.Dcb.Postgres" Version="10.0.2-preview02" />
+        <PackageReference Include="Sekiban.Dcb.CosmosDb" Version="10.0.2-preview02" />
     </ItemGroup>
 
     <ItemGroup>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans/SekibanDcbOrleans.Domain/SekibanDcbOrleans.Domain.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans/SekibanDcbOrleans.Domain/SekibanDcbOrleans.Domain.csproj
@@ -7,7 +7,7 @@
     <IsPackable>true</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Sekiban.Dcb.WithResult" Version="10.0.2-preview01" />
+    <PackageReference Include="Sekiban.Dcb.WithResult" Version="10.0.2-preview02" />
     <PackageReference Include="ResultBoxes" Version="0.3.31" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
This PR enhances the CLI tool with new commands for managing projections, tags, and events, and updates packages to version 10.0.2-preview02.

## Changes

### New CLI Commands
- `delete`: Deletes projection states
- `tag-events`: Fetches and saves events for a specific tag
- `projection`: Displays the current state of a projection
- `tag-state`: Projects and displays the current state for a specific tag
- `tag-list`: Lists all tags in the event store and exports to JSON

### Core Services
- Added `TagListService` for managing and exporting tag information
- Extended `IEventStore` interface with new methods for tag listing

### Storage Implementations
- Added tag listing support to PostgreSQL event store
- Added tag listing support to CosmosDB event store
- Added tag listing support to In-Memory event stores

### Package Updates
- Updated Sekiban.Dcb packages to version 10.0.2-preview02

### Template Updates
- Enhanced CLI in both `Sekiban.Dcb.Orleans` and `Sekiban.Dcb.Orleans.WithoutResult` templates
- Improved CLI help documentation with usage examples

## Related Issue
Closes #838