### PR TITLE
feat: Enhance MultiProjectionGrain logging with detailed persist and restore events

### DIFF
--- a/dcb/src/Sekiban.Dcb.Orleans.Core/Grains/MultiProjectionLogEvents.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.Core/Grains/MultiProjectionLogEvents.cs
@@ -55,4 +55,16 @@ public static class MultiProjectionLogEvents
 
     /// <summary>State persistence cancelled during deactivation.</summary>
     public static readonly EventId DeactivationPersistCancelled = new(1016, "DeactivationPersistCancelled");
+
+    /// <summary>Persist details for debugging.</summary>
+    public static readonly EventId PersistDetails = new(1017, "PersistDetails");
+
+    /// <summary>Restore details for debugging.</summary>
+    public static readonly EventId RestoreDetails = new(1018, "RestoreDetails");
+
+    /// <summary>Suspiciously small payload detected.</summary>
+    public static readonly EventId SuspiciousPayload = new(1019, "SuspiciousPayload");
+
+    /// <summary>Safe version is zero after restore.</summary>
+    public static readonly EventId SafeVersionZero = new(1020, "SafeVersionZero");
 }


### PR DESCRIPTION
## Summary
This PR enhances the `MultiProjectionGrain` with detailed logging for state persistence and restoration operations.

## Changes

### MultiProjectionGrain Logging Enhancements
- Added detailed logging for state persist operations
- Added detailed logging for state restore operations
- Improved visibility into grain lifecycle events

### New Log Events
Added new log event IDs in `MultiProjectionLogEvents`:
- Persist operation events
- Restore operation events
- Enhanced diagnostic information

## Benefits
- Better observability for MultiProjection grain operations
- Easier debugging of state management issues
- Improved monitoring capabilities in production environments

## Related Issue
Closes #838