### PR TITLE
feat: Enhance DualStateProjectionWrapper with snapshot restoration and incremental event application

### DIFF
--- a/dcb/src/Sekiban.Dcb.Core/Actors/GeneralMultiProjectionActor.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Actors/GeneralMultiProjectionActor.cs
@@ -161,7 +161,8 @@ public class GeneralMultiProjectionActor
                 _jsonOptions,
                 state.Version,
                 state.LastEventId,
-                state.LastSortableUniqueId) as IMultiProjectionPayload;
+                state.LastSortableUniqueId,
+                true) as IMultiProjectionPayload;
 
             if (_singleStateAccessor == null)
             {
@@ -216,7 +217,8 @@ public class GeneralMultiProjectionActor
                 _jsonOptions,
                 state.Version,
                 state.LastEventId,
-                state.LastSortableUniqueId) as IMultiProjectionPayload;
+                state.LastSortableUniqueId,
+                true) as IMultiProjectionPayload;
             if (_singleStateAccessor == null)
             {
                 throw new InvalidOperationException($"Failed to create wrapper for projector {_projectorName}");


### PR DESCRIPTION
## Summary
This PR enhances `DualStateProjectionWrapper` to support snapshot restoration and incremental event application, improving the efficiency of state recovery operations.

## Changes

### DualStateProjectionWrapper Enhancements
- Added support for snapshot restoration
- Implemented incremental event application on top of restored snapshots
- Improved state recovery efficiency by avoiding full replay from scratch

### GeneralMultiProjectionActor Updates
- Updated to leverage the new DualStateProjectionWrapper capabilities

### New Tests
- Added `GeneralMultiProjectionActorSafeWindowTests` to verify snapshot restoration and incremental event application behavior

## Benefits
- Faster state recovery from snapshots
- Reduced event replay overhead
- More efficient MultiProjection state management

## Related Issue
Closes #838