### PR TITLE
Improve JSON serialization of events in CLI programs

### DIFF
--- a/dcb/internalUsages/DcbOrleans.Cli/Program.cs
+++ b/dcb/internalUsages/DcbOrleans.Cli/Program.cs
@@ -832,14 +832,19 @@ static async Task FetchTagEventsAsync(string connectionString, string databaseTy
     };
 
     // Prepare events for JSON serialization
-    var eventsForJson = events.Select(e => new
+    var eventsForJson = events.Select(e =>
     {
-        e.Id,
-        SortableUniqueId = e.SortableUniqueIdValue,
-        e.EventType,
-        e.Tags,
-        PayloadJson = System.Text.Json.JsonSerializer.Serialize(e.Payload, e.Payload.GetType(), jsonOptions),
-        e.Payload
+        var payloadJsonString = System.Text.Json.JsonSerializer.Serialize(e.Payload, e.Payload.GetType(), jsonOptions);
+        // Parse the JSON string back to JsonElement for proper serialization
+        var payloadElement = System.Text.Json.JsonDocument.Parse(payloadJsonString).RootElement;
+        return new
+        {
+            e.Id,
+            SortableUniqueId = e.SortableUniqueIdValue,
+            e.EventType,
+            e.Tags,
+            Payload = payloadElement
+        };
     }).ToList();
 
     // Save to file

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.Cli/Program.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.Cli/Program.cs
@@ -860,14 +860,19 @@ static async Task FetchTagEventsAsync(string connectionString, string databaseTy
 
     Directory.CreateDirectory(outputDir);
 
-    var eventsForJson = events.Select(e => new
+    var eventsForJson = events.Select(e =>
     {
-        e.Id,
-        SortableUniqueId = e.SortableUniqueIdValue,
-        e.EventType,
-        e.Tags,
-        PayloadJson = System.Text.Json.JsonSerializer.Serialize(e.Payload, e.Payload.GetType(), tagEventService.JsonSerializerOptions),
-        e.Payload
+        var payloadJsonString = System.Text.Json.JsonSerializer.Serialize(e.Payload, e.Payload.GetType(), tagEventService.JsonSerializerOptions);
+        // Parse the JSON string back to JsonElement for proper serialization
+        var payloadElement = System.Text.Json.JsonDocument.Parse(payloadJsonString).RootElement;
+        return new
+        {
+            e.Id,
+            SortableUniqueId = e.SortableUniqueIdValue,
+            e.EventType,
+            e.Tags,
+            Payload = payloadElement
+        };
     }).ToList();
 
     var timestamp = DateTime.UtcNow.ToString("yyyyMMddHHmmss");

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.Cli/SekibanDcbDecider.Cli.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.Cli/SekibanDcbDecider.Cli.csproj
@@ -23,4 +23,8 @@
         <ProjectReference Include="..\SekibanDcbDecider.Interactions\SekibanDcbDecider.Interactions.csproj" />
     </ItemGroup>
 
+    <ItemGroup>
+      <Folder Include="output\" />
+    </ItemGroup>
+
 </Project>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.Cli/Program.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.Cli/Program.cs
@@ -834,14 +834,19 @@ static async Task FetchTagEventsAsync(string connectionString, string databaseTy
 
     Directory.CreateDirectory(outputDir);
 
-    var eventsForJson = events.Select(e => new
+    var eventsForJson = events.Select(e =>
     {
-        e.Id,
-        SortableUniqueId = e.SortableUniqueIdValue,
-        e.EventType,
-        e.Tags,
-        PayloadJson = System.Text.Json.JsonSerializer.Serialize(e.Payload, e.Payload.GetType(), tagEventService.JsonSerializerOptions),
-        e.Payload
+        var payloadJsonString = System.Text.Json.JsonSerializer.Serialize(e.Payload, e.Payload.GetType(), tagEventService.JsonSerializerOptions);
+        // Parse the JSON string back to JsonElement for proper serialization
+        var payloadElement = System.Text.Json.JsonDocument.Parse(payloadJsonString).RootElement;
+        return new
+        {
+            e.Id,
+            SortableUniqueId = e.SortableUniqueIdValue,
+            e.EventType,
+            e.Tags,
+            Payload = payloadElement
+        };
     }).ToList();
 
     var timestamp = DateTime.UtcNow.ToString("yyyyMMddHHmmss");

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans/SekibanDcbOrleans.Cli/Program.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans/SekibanDcbOrleans.Cli/Program.cs
@@ -834,14 +834,19 @@ static async Task FetchTagEventsAsync(string connectionString, string databaseTy
 
     Directory.CreateDirectory(outputDir);
 
-    var eventsForJson = events.Select(e => new
+    var eventsForJson = events.Select(e =>
     {
-        e.Id,
-        SortableUniqueId = e.SortableUniqueIdValue,
-        e.EventType,
-        e.Tags,
-        PayloadJson = System.Text.Json.JsonSerializer.Serialize(e.Payload, e.Payload.GetType(), tagEventService.JsonSerializerOptions),
-        e.Payload
+        var payloadJsonString = System.Text.Json.JsonSerializer.Serialize(e.Payload, e.Payload.GetType(), tagEventService.JsonSerializerOptions);
+        // Parse the JSON string back to JsonElement for proper serialization
+        var payloadElement = System.Text.Json.JsonDocument.Parse(payloadJsonString).RootElement;
+        return new
+        {
+            e.Id,
+            SortableUniqueId = e.SortableUniqueIdValue,
+            e.EventType,
+            e.Tags,
+            Payload = payloadElement
+        };
     }).ToList();
 
     var timestamp = DateTime.UtcNow.ToString("yyyyMMddHHmmss");


### PR DESCRIPTION
Enhance the JSON serialization process for events in CLI programs by converting payloads to `JsonElement` for better structure and consistency. This refactor aims to improve the handling of event data during serialization.

