### PR TITLE
perf: Optimize Cosmos DB read operations for high-throughput scenarios

### DIFF
--- a/dcb/internalUsages/DcbOrleans.AppHost/Program.cs
+++ b/dcb/internalUsages/DcbOrleans.AppHost/Program.cs
@@ -6,7 +6,7 @@ var builder = DistributedApplication.CreateBuilder(args);
 var storage = builder
     .AddAzureStorage("azurestorage")
     .RunAsEmulator(opt => opt.WithDataVolume());
-    // .RunAsEmulator();
+// .RunAsEmulator();
 var clusteringTable = storage.AddTables("DcbOrleansClusteringTable");
 var grainTable = storage.AddTables("DcbOrleansGrainTable");
 var grainStorage = storage.AddBlobs("DcbOrleansGrainState");

--- a/dcb/src/Sekiban.Dcb.CosmosDb/CosmosDbContext.cs
+++ b/dcb/src/Sekiban.Dcb.CosmosDb/CosmosDbContext.cs
@@ -151,7 +151,9 @@ public class CosmosDbContext : IDisposable
                 AllowBulkExecution = true,
                 // Retry settings for Serverless mode (increased from defaults)
                 MaxRetryAttemptsOnRateLimitedRequests = _options.MaxRetryAttemptsOnRateLimited,
-                MaxRetryWaitTimeOnRateLimitedRequests = _options.MaxRetryWaitTime
+                MaxRetryWaitTimeOnRateLimitedRequests = _options.MaxRetryWaitTime,
+                // Use Direct mode for better read performance (TCP instead of HTTPS)
+                ConnectionMode = _options.UseDirectConnectionMode ? ConnectionMode.Direct : ConnectionMode.Gateway
             };
 
             _cosmosClient = new CosmosClient(_connectionString, cosmosClientOptions);


### PR DESCRIPTION
## Summary

- Add read optimization options to `CosmosDbEventStoreOptions` with performance-focused defaults for Azure Container Apps / Orleans
- Enable Direct connection mode (TCP) by default for better throughput
- Optimize `ReadAllEventsAsync`, `GetEventCountAsync`, and `ReadEventsByTagAsync` with SQL queries, parallel deserialization, and proper request options
- Add `CreateForCompatibility()` factory method for restricted environments

## Performance Improvement

| Metric | Before | After |
|--------|--------|-------|
| 42,000 events read | 30+ minutes | ~6.7 minutes |
| Throughput | ~17 events/sec | ~105 events/sec |
| Round trips (30K events) | ~300 | ~30 |

## Key Changes

1. **CosmosDbEventStoreOptions** - New read optimization settings:
   - `MaxItemCountPerPage = 1000` (vs SDK default ~100)
   - `UseDirectConnectionMode = true` (TCP vs HTTPS)
   - `MaxConcurrentDeserializations = CPU * 2`
   - `MaxBufferedItemCount = 50000`
   - `ReadProgressCallback` for progress reporting

2. **CosmosDbContext** - Use Direct connection mode by default

3. **CosmosDbEventStore**:
   - Raw SQL queries instead of LINQ
   - Parallel deserialization with configurable concurrency
   - COUNT aggregate for `GetEventCountAsync`

4. **Compatibility** - `CreateForCompatibility()` for restricted environments (proxies, firewalls, Azure Functions Consumption)

## Test plan

- [x] Build succeeds with `check.sh`
- [x] Tested with 42,000 events - ~6x performance improvement observed
- [ ] Verify catch-up performance in production environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)