### PR TITLE
feat: Add non-blocking catch-up support to prevent Orleans grain timeouts

### DIFF
--- a/dcb/src/Sekiban.Dcb.Core/MultiProjections/MultiProjectionState.cs
+++ b/dcb/src/Sekiban.Dcb.Core/MultiProjections/MultiProjectionState.cs
@@ -11,4 +11,12 @@ public record MultiProjectionState(
     Guid LastEventId,
     int Version,
     bool IsCatchedUp = true,
-    bool IsSafeState = true);
+    bool IsSafeState = true,
+    /// <summary>Whether catch-up from event store is currently in progress.</summary>
+    bool IsCatchUpInProgress = false,
+    /// <summary>Current position in catch-up process (SortableUniqueId value).</summary>
+    string? CatchUpCurrentPosition = null,
+    /// <summary>Target position for catch-up completion (SortableUniqueId value).</summary>
+    string? CatchUpTargetPosition = null,
+    /// <summary>Estimated catch-up progress percentage (0-100), null if not calculable.</summary>
+    double? CatchUpProgressPercent = null);

--- a/dcb/src/Sekiban.Dcb.Orleans.Core/Grains/IMultiProjectionGrain.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.Core/Grains/IMultiProjectionGrain.cs
@@ -16,8 +16,11 @@ public interface IMultiProjectionGrain : IGrainWithStringKey
     ///     Get the current state of the multi-projection
     /// </summary>
     /// <param name="canGetUnsafeState">Whether to return unsafe state (default: true)</param>
-    /// <returns>The current multi-projection state</returns>
-    Task<ResultBox<MultiProjectionState>> GetStateAsync(bool canGetUnsafeState = true);
+    /// <param name="waitForCatchUp">Whether to wait for catch-up completion.
+    /// If false (default), returns immediately with current state and catch-up progress info.
+    /// If true, waits up to 30 seconds for catch-up to complete before returning.</param>
+    /// <returns>The current multi-projection state, including catch-up progress if in progress</returns>
+    Task<ResultBox<MultiProjectionState>> GetStateAsync(bool canGetUnsafeState = true, bool waitForCatchUp = false);
 
     /// <summary>
     ///     Get snapshot envelope (inline or offloaded) as JSON according to actor policy.


### PR DESCRIPTION
## Summary

- Add catch-up progress fields to `MultiProjectionState` to expose catch-up status to clients
- Modify `GetStateAsync` to return immediately during catch-up instead of blocking
- Add `waitForCatchUp` parameter for cases where waiting is desired
- Add race condition protection in catch-up initiation

## Problem

When Orleans grains start with a large event store (200k+ events), the initial catch-up process takes longer than Orleans' default timeout (30 seconds). This causes:

1. `GetStateAsync` blocks waiting for catch-up completion
2. Orleans times out the grain call
3. Grain restarts and catch-up begins from the beginning
4. Infinite loop - service never starts

## Solution

`GetStateAsync` now:
- Starts catch-up in the background (fire-and-forget)
- Returns immediately with current state + catch-up progress info
- Clients can check `IsCatchUpInProgress` to show appropriate UI ("Service is warming up...")

### New fields in `MultiProjectionState`

| Field | Type | Description |
|-------|------|-------------|
| `IsCatchUpInProgress` | `bool` | Whether catch-up is currently running |
| `CatchUpCurrentPosition` | `string?` | Current position in catch-up |
| `CatchUpTargetPosition` | `string?` | Target position for completion |
| `CatchUpProgressPercent` | `double?` | Estimated progress (0-100) |

### New parameter in `GetStateAsync`

```csharp
Task<ResultBox<MultiProjectionState>> GetStateAsync(
    bool canGetUnsafeState = true, 
    bool waitForCatchUp = false);  // NEW: default false for non-blocking
```

## Test plan

- [x] Build succeeds
- [x] Orleans tests pass (26 tests)
- [ ] Manual test with large event store to verify non-blocking behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)