### PR TITLE
fix: Prevent Orleans activation timeout during catch-up with large event stores

### DIFF
--- a/dcb/src/Sekiban.Dcb.Orleans.Core/Grains/MultiProjectionLogEvents.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.Core/Grains/MultiProjectionLogEvents.cs
@@ -76,4 +76,7 @@ public static class MultiProjectionLogEvents
 
     /// <summary>Full catch-up initiated due to integrity violation.</summary>
     public static readonly EventId FullCatchUpInitiated = new(1023, "FullCatchUpInitiated");
+
+    /// <summary>Grain activation completed (catch-up may still be running in background).</summary>
+    public static readonly EventId ActivationCompleted = new(1024, "ActivationCompleted");
 }


### PR DESCRIPTION
## Problem
When using Orleans grains with large event stores (200k+ events), the grain activation would timeout because:
- `OnActivateAsync` awaited `CatchUpFromEventStoreAsync`, blocking activation
- `InitiateCatchUpIfNeeded` read ALL events just to find the latest position
- With the default 30-second Orleans activation timeout, this caused failures

## Solution
- **Non-blocking catch-up**: `OnActivateAsync` now starts catch-up as fire-and-forget, allowing grain activation to complete immediately
- **Lazy position determination**: `InitiateCatchUpIfNeeded` no longer reads all events upfront; target position is determined dynamically during catch-up batches
- **Better observability**: Added `ActivationCompleted` log event for monitoring

## Behavior During Catch-up
Queries during catch-up will return partial data with `IsCatchUpInProgress=true`, allowing clients to handle this state appropriately.

## Files Changed
- `MultiProjectionGrain.cs`: Refactored activation and catch-up logic
- `MultiProjectionLogEvents.cs`: Added new log event
