### PR TITLE
feat: Add SQLite support for multi-projection states and optimize memory for large projections

### DIFF
--- a/.github/workflows/packagesDcb.yml
+++ b/.github/workflows/packagesDcb.yml
@@ -55,6 +55,7 @@ jobs:
           dotnet pack dcb/src/Sekiban.Dcb.Orleans.WithoutResult/Sekiban.Dcb.Orleans.WithoutResult.csproj -c Release -o out -p:PackageVersion=$VERSION --no-build
           dotnet pack dcb/src/Sekiban.Dcb.Postgres/Sekiban.Dcb.Postgres.csproj -c Release -o out -p:PackageVersion=$VERSION --no-build
           dotnet pack dcb/src/Sekiban.Dcb.CosmosDb/Sekiban.Dcb.CosmosDb.csproj -c Release -o out -p:PackageVersion=$VERSION --no-build
+          dotnet pack dcb/src/Sekiban.Dcb.Sqlite/Sekiban.Dcb.Sqlite.csproj -c Release -o out -p:PackageVersion=$VERSION --no-build
           dotnet pack dcb/src/Sekiban.Dcb.BlobStorage.AzureStorage/Sekiban.Dcb.BlobStorage.AzureStorage.csproj -c Release -o out -p:PackageVersion=$VERSION --no-build
 
       - name: Push to NuGet.org

--- a/Sekiban.slnx
+++ b/Sekiban.slnx
@@ -49,6 +49,7 @@
     <Project Path="dcb/src/Sekiban.Dcb.Core.Model/Sekiban.Dcb.Core.Model.csproj" />
     <Project Path="dcb/src/Sekiban.Dcb.Core/Sekiban.Dcb.Core.csproj" />
     <Project Path="dcb/src/Sekiban.Dcb.WithResult/Sekiban.Dcb.WithResult.csproj" />
+    <Project Path="dcb/src/Sekiban.Dcb.Sqlite/Sekiban.Dcb.Sqlite.csproj" />
     <Project Path="dcb/src/Sekiban.Dcb.WithoutResult/Sekiban.Dcb.WithoutResult.csproj" />
     <Project Path="dcb/src/Sekiban.Dcb.Orleans.Core/Sekiban.Dcb.Orleans.Core.csproj" />
     <Project Path="dcb/src/Sekiban.Dcb.Orleans.WithResult/Sekiban.Dcb.Orleans.WithResult.csproj" />

--- a/dcb/internalUsages/DcbOrleans.Cli/DcbOrleans.Cli.csproj
+++ b/dcb/internalUsages/DcbOrleans.Cli/DcbOrleans.Cli.csproj
@@ -29,6 +29,7 @@
         <ProjectReference Include="..\..\src\Sekiban.Dcb.WithResult\Sekiban.Dcb.WithResult.csproj"/>
         <ProjectReference Include="..\..\src\Sekiban.Dcb.Postgres\Sekiban.Dcb.Postgres.csproj"/>
         <ProjectReference Include="..\..\src\Sekiban.Dcb.CosmosDb\Sekiban.Dcb.CosmosDb.csproj"/>
+        <ProjectReference Include="..\..\src\Sekiban.Dcb.Sqlite\Sekiban.Dcb.Sqlite.csproj"/>
         <ProjectReference Include="..\Dcb.Domain\Dcb.Domain.csproj"/>
         <ProjectReference Include="..\DcbOrleans.ServiceDefaults\DcbOrleans.ServiceDefaults.csproj"/>
     </ItemGroup>

--- a/dcb/src/Sekiban.Dcb.Sqlite/CacheMetadata.cs
+++ b/dcb/src/Sekiban.Dcb.Sqlite/CacheMetadata.cs
@@ -1,0 +1,47 @@
+namespace Sekiban.Dcb.Sqlite;
+
+/// <summary>
+///     Metadata about the cache state, used for synchronization
+/// </summary>
+public record CacheMetadata
+{
+    /// <summary>
+    ///     Remote endpoint identifier (e.g., Cosmos DB endpoint URL)
+    /// </summary>
+    public string RemoteEndpoint { get; init; } = "";
+
+    /// <summary>
+    ///     Database name on the remote endpoint
+    /// </summary>
+    public string DatabaseName { get; init; } = "";
+
+    /// <summary>
+    ///     Schema version for cache invalidation
+    /// </summary>
+    public string SchemaVersion { get; init; } = "1.0";
+
+    /// <summary>
+    ///     Total event count at last fetch
+    /// </summary>
+    public long TotalCountAtFetch { get; init; }
+
+    /// <summary>
+    ///     Last cached SortableUniqueId
+    /// </summary>
+    public string? LastCachedSortableUniqueId { get; init; }
+
+    /// <summary>
+    ///     Last safe window threshold UTC
+    /// </summary>
+    public DateTime? LastSafeWindowUtc { get; init; }
+
+    /// <summary>
+    ///     When this cache was created
+    /// </summary>
+    public DateTime CreatedUtc { get; init; }
+
+    /// <summary>
+    ///     When this cache was last updated
+    /// </summary>
+    public DateTime UpdatedUtc { get; init; }
+}

--- a/dcb/src/Sekiban.Dcb.Sqlite/CacheSyncOptions.cs
+++ b/dcb/src/Sekiban.Dcb.Sqlite/CacheSyncOptions.cs
@@ -1,0 +1,28 @@
+namespace Sekiban.Dcb.Sqlite;
+
+/// <summary>
+///     Configuration options for cache synchronization
+/// </summary>
+public class CacheSyncOptions
+{
+    /// <summary>
+    ///     Time window to exclude from caching.
+    ///     Events within this window are considered "unsafe" and will be fetched from remote.
+    /// </summary>
+    public TimeSpan SafeWindow { get; set; } = TimeSpan.FromMinutes(10);
+
+    /// <summary>
+    ///     Remote endpoint identifier (for cache key construction and validation)
+    /// </summary>
+    public string RemoteEndpoint { get; set; } = "";
+
+    /// <summary>
+    ///     Database name (for cache key construction and validation)
+    /// </summary>
+    public string DatabaseName { get; set; } = "";
+
+    /// <summary>
+    ///     Schema version for cache invalidation
+    /// </summary>
+    public string SchemaVersion { get; set; } = "1.0";
+}

--- a/dcb/src/Sekiban.Dcb.Sqlite/CacheSyncResult.cs
+++ b/dcb/src/Sekiban.Dcb.Sqlite/CacheSyncResult.cs
@@ -1,0 +1,97 @@
+namespace Sekiban.Dcb.Sqlite;
+
+/// <summary>
+///     Result of a cache synchronization operation
+/// </summary>
+public record CacheSyncResult
+{
+    /// <summary>
+    ///     Whether the sync operation succeeded
+    /// </summary>
+    public bool IsSuccess { get; init; }
+
+    /// <summary>
+    ///     Number of events synced in this operation
+    /// </summary>
+    public int EventsSynced { get; init; }
+
+    /// <summary>
+    ///     Total events in cache after sync
+    /// </summary>
+    public long TotalEventsInCache { get; init; }
+
+    /// <summary>
+    ///     Action taken during sync
+    /// </summary>
+    public CacheSyncAction Action { get; init; }
+
+    /// <summary>
+    ///     Error message if sync failed
+    /// </summary>
+    public string? ErrorMessage { get; init; }
+
+    /// <summary>
+    ///     Duration of the sync operation
+    /// </summary>
+    public TimeSpan Duration { get; init; }
+
+    public static CacheSyncResult Success(int eventsSynced, long totalEvents, CacheSyncAction action, TimeSpan duration) =>
+        new()
+        {
+            IsSuccess = true,
+            EventsSynced = eventsSynced,
+            TotalEventsInCache = totalEvents,
+            Action = action,
+            Duration = duration
+        };
+
+    public static CacheSyncResult NoChanges(long totalEvents, TimeSpan duration) =>
+        new()
+        {
+            IsSuccess = true,
+            EventsSynced = 0,
+            TotalEventsInCache = totalEvents,
+            Action = CacheSyncAction.NoActionNeeded,
+            Duration = duration
+        };
+
+    public static CacheSyncResult Failed(string error, TimeSpan duration) =>
+        new()
+        {
+            IsSuccess = false,
+            ErrorMessage = error,
+            Action = CacheSyncAction.Failed,
+            Duration = duration
+        };
+}
+
+/// <summary>
+///     Action taken during cache sync
+/// </summary>
+public enum CacheSyncAction
+{
+    /// <summary>
+    ///     No sync was needed
+    /// </summary>
+    NoActionNeeded,
+
+    /// <summary>
+    ///     New events were appended to cache
+    /// </summary>
+    AppendedNewEvents,
+
+    /// <summary>
+    ///     Cache was rebuilt from scratch
+    /// </summary>
+    RebuiltFromScratch,
+
+    /// <summary>
+    ///     Cache was cleared
+    /// </summary>
+    CacheCleared,
+
+    /// <summary>
+    ///     Sync operation failed
+    /// </summary>
+    Failed
+}

--- a/dcb/src/Sekiban.Dcb.Sqlite/EventStoreCacheSync.cs
+++ b/dcb/src/Sekiban.Dcb.Sqlite/EventStoreCacheSync.cs
@@ -1,0 +1,327 @@
+using System.Diagnostics;
+using Microsoft.Extensions.Logging;
+using Sekiban.Dcb.Common;
+using Sekiban.Dcb.Storage;
+
+namespace Sekiban.Dcb.Sqlite;
+
+/// <summary>
+///     Synchronizes events from any IEventStore to a local SqliteEventStore.
+///     Works with Cosmos DB, PostgreSQL, or any other IEventStore implementation.
+/// </summary>
+public class EventStoreCacheSync
+{
+    private readonly SqliteEventStore _localStore;
+    private readonly IEventStore _remoteStore;
+    private readonly CacheSyncOptions _options;
+    private readonly ILogger<EventStoreCacheSync>? _logger;
+
+    public EventStoreCacheSync(
+        SqliteEventStore localStore,
+        IEventStore remoteStore,
+        CacheSyncOptions? options = null,
+        ILogger<EventStoreCacheSync>? logger = null)
+    {
+        _localStore = localStore;
+        _remoteStore = remoteStore;
+        _options = options ?? new CacheSyncOptions();
+        _logger = logger;
+    }
+
+    /// <summary>
+    ///     Synchronize the local cache with the remote event store.
+    /// </summary>
+    public async Task<CacheSyncResult> SyncAsync(CancellationToken cancellationToken = default)
+    {
+        var stopwatch = Stopwatch.StartNew();
+
+        try
+        {
+            _logger?.LogInformation("Starting cache sync...");
+
+            // 1. Get cache metadata and validate
+            var metadata = await _localStore.GetMetadataAsync();
+
+            if (!ValidateMetadata(metadata))
+            {
+                _logger?.LogInformation("Cache metadata invalid or changed, clearing cache...");
+                await _localStore.ClearAsync();
+                metadata = null;
+            }
+
+            // 2. Get event counts
+            var remoteCountResult = await _remoteStore.GetEventCountAsync();
+            if (!remoteCountResult.IsSuccess)
+            {
+                return CacheSyncResult.Failed(
+                    $"Failed to get remote event count: {remoteCountResult.GetException().Message}",
+                    stopwatch.Elapsed);
+            }
+
+            var remoteCount = remoteCountResult.GetValue();
+
+            var localCountResult = await _localStore.GetEventCountAsync();
+            var localCount = localCountResult.IsSuccess ? localCountResult.GetValue() : 0;
+
+            _logger?.LogInformation("Remote: {RemoteCount} events, Local: {LocalCount} events", remoteCount, localCount);
+
+            // 3. Check if we need to rebuild (local > remote means deletion occurred)
+            if (localCount > remoteCount)
+            {
+                _logger?.LogWarning("Local cache has more events than remote ({LocalCount} > {RemoteCount}), rebuilding...",
+                    localCount, remoteCount);
+                await _localStore.ClearAsync();
+                return await RebuildFromScratchAsync(remoteCount, stopwatch, cancellationToken);
+            }
+
+            // 4. Check if up to date
+            if (localCount == remoteCount)
+            {
+                _logger?.LogInformation("Cache is up to date");
+                return CacheSyncResult.NoChanges(localCount, stopwatch.Elapsed);
+            }
+
+            // 5. Incremental sync
+            var since = metadata?.LastCachedSortableUniqueId != null
+                ? new SortableUniqueId(metadata.LastCachedSortableUniqueId)
+                : null;
+            var until = GetSafeWindowThreshold();
+
+            _logger?.LogInformation("Fetching events since {Since} until {Until}",
+                since?.Value ?? "(beginning)", until?.Value ?? "(now)");
+
+            var remoteEventsResult = await _remoteStore.ReadAllEventsAsync(since);
+            if (!remoteEventsResult.IsSuccess)
+            {
+                return CacheSyncResult.Failed(
+                    $"Failed to read remote events: {remoteEventsResult.GetException().Message}",
+                    stopwatch.Elapsed);
+            }
+
+            var remoteEvents = remoteEventsResult.GetValue().ToList();
+
+            // Filter by safe window
+            var eventsToCache = until != null
+                ? remoteEvents.Where(e => new SortableUniqueId(e.SortableUniqueIdValue).IsEarlierThanOrEqual(until)).ToList()
+                : remoteEvents;
+
+            if (eventsToCache.Count == 0)
+            {
+                _logger?.LogInformation("No new events to cache (all within safe window)");
+                return CacheSyncResult.NoChanges(localCount, stopwatch.Elapsed);
+            }
+
+            // 6. Write to local cache
+            _logger?.LogInformation("Caching {Count} events...", eventsToCache.Count);
+
+            var writeResult = await _localStore.WriteEventsAsync(eventsToCache);
+            if (!writeResult.IsSuccess)
+            {
+                return CacheSyncResult.Failed(
+                    $"Failed to write events to cache: {writeResult.GetException().Message}",
+                    stopwatch.Elapsed);
+            }
+
+            // 7. Update metadata
+            var newLocalCount = localCount + eventsToCache.Count;
+            await _localStore.SetMetadataAsync(new CacheMetadata
+            {
+                RemoteEndpoint = _options.RemoteEndpoint,
+                DatabaseName = _options.DatabaseName,
+                SchemaVersion = _options.SchemaVersion,
+                TotalCountAtFetch = remoteCount,
+                LastCachedSortableUniqueId = eventsToCache.Last().SortableUniqueIdValue,
+                LastSafeWindowUtc = until?.GetDateTime(),
+                CreatedUtc = metadata?.CreatedUtc ?? DateTime.UtcNow,
+                UpdatedUtc = DateTime.UtcNow
+            });
+
+            _logger?.LogInformation("Cache sync completed: {Count} events added, {Total} total",
+                eventsToCache.Count, newLocalCount);
+
+            return CacheSyncResult.Success(
+                eventsToCache.Count,
+                newLocalCount,
+                CacheSyncAction.AppendedNewEvents,
+                stopwatch.Elapsed);
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogError(ex, "Cache sync failed");
+            return CacheSyncResult.Failed(ex.Message, stopwatch.Elapsed);
+        }
+    }
+
+    /// <summary>
+    ///     Clear the local cache
+    /// </summary>
+    public async Task ClearAsync()
+    {
+        await _localStore.ClearAsync();
+        _logger?.LogInformation("Cache cleared");
+    }
+
+    /// <summary>
+    ///     Get cache statistics
+    /// </summary>
+    public async Task<CacheStatistics> GetStatisticsAsync()
+    {
+        var metadata = await _localStore.GetMetadataAsync();
+        var eventCountResult = await _localStore.GetEventCountAsync();
+        var eventCount = eventCountResult.IsSuccess ? eventCountResult.GetValue() : 0;
+
+        var fileInfo = new FileInfo(_localStore.DatabasePath);
+        var databaseSize = fileInfo.Exists ? fileInfo.Length : 0;
+
+        return new CacheStatistics
+        {
+            EventCount = eventCount,
+            DatabaseSizeBytes = databaseSize,
+            RemoteEndpoint = metadata?.RemoteEndpoint,
+            DatabaseName = metadata?.DatabaseName,
+            LastCachedSortableUniqueId = metadata?.LastCachedSortableUniqueId,
+            LastSyncUtc = metadata?.UpdatedUtc,
+            CreatedUtc = metadata?.CreatedUtc
+        };
+    }
+
+    private async Task<CacheSyncResult> RebuildFromScratchAsync(
+        long remoteCount,
+        Stopwatch stopwatch,
+        CancellationToken cancellationToken)
+    {
+        var until = GetSafeWindowThreshold();
+
+        _logger?.LogInformation("Rebuilding cache from scratch...");
+
+        var remoteEventsResult = await _remoteStore.ReadAllEventsAsync();
+        if (!remoteEventsResult.IsSuccess)
+        {
+            return CacheSyncResult.Failed(
+                $"Failed to read remote events: {remoteEventsResult.GetException().Message}",
+                stopwatch.Elapsed);
+        }
+
+        var remoteEvents = remoteEventsResult.GetValue().ToList();
+
+        // Filter by safe window
+        var eventsToCache = until != null
+            ? remoteEvents.Where(e => new SortableUniqueId(e.SortableUniqueIdValue).IsEarlierThanOrEqual(until)).ToList()
+            : remoteEvents;
+
+        if (eventsToCache.Count == 0)
+        {
+            _logger?.LogInformation("No events to cache (all within safe window)");
+            return CacheSyncResult.Success(0, 0, CacheSyncAction.RebuiltFromScratch, stopwatch.Elapsed);
+        }
+
+        _logger?.LogInformation("Caching {Count} events...", eventsToCache.Count);
+
+        var writeResult = await _localStore.WriteEventsAsync(eventsToCache);
+        if (!writeResult.IsSuccess)
+        {
+            return CacheSyncResult.Failed(
+                $"Failed to write events to cache: {writeResult.GetException().Message}",
+                stopwatch.Elapsed);
+        }
+
+        // Update metadata
+        await _localStore.SetMetadataAsync(new CacheMetadata
+        {
+            RemoteEndpoint = _options.RemoteEndpoint,
+            DatabaseName = _options.DatabaseName,
+            SchemaVersion = _options.SchemaVersion,
+            TotalCountAtFetch = remoteCount,
+            LastCachedSortableUniqueId = eventsToCache.Last().SortableUniqueIdValue,
+            LastSafeWindowUtc = until?.GetDateTime(),
+            CreatedUtc = DateTime.UtcNow,
+            UpdatedUtc = DateTime.UtcNow
+        });
+
+        _logger?.LogInformation("Cache rebuilt: {Count} events cached", eventsToCache.Count);
+
+        return CacheSyncResult.Success(
+            eventsToCache.Count,
+            eventsToCache.Count,
+            CacheSyncAction.RebuiltFromScratch,
+            stopwatch.Elapsed);
+    }
+
+    private bool ValidateMetadata(CacheMetadata? metadata)
+    {
+        if (metadata == null)
+        {
+            return false;
+        }
+
+        // Check if remote endpoint matches
+        if (!string.IsNullOrEmpty(_options.RemoteEndpoint) &&
+            metadata.RemoteEndpoint != _options.RemoteEndpoint)
+        {
+            _logger?.LogWarning("Remote endpoint changed: {Old} -> {New}",
+                metadata.RemoteEndpoint, _options.RemoteEndpoint);
+            return false;
+        }
+
+        // Check if database name matches
+        if (!string.IsNullOrEmpty(_options.DatabaseName) &&
+            metadata.DatabaseName != _options.DatabaseName)
+        {
+            _logger?.LogWarning("Database name changed: {Old} -> {New}",
+                metadata.DatabaseName, _options.DatabaseName);
+            return false;
+        }
+
+        // Check schema version
+        if (!string.IsNullOrEmpty(_options.SchemaVersion) &&
+            metadata.SchemaVersion != _options.SchemaVersion)
+        {
+            _logger?.LogWarning("Schema version changed: {Old} -> {New}",
+                metadata.SchemaVersion, _options.SchemaVersion);
+            return false;
+        }
+
+        return true;
+    }
+
+    private SortableUniqueId? GetSafeWindowThreshold()
+    {
+        if (_options.SafeWindow == TimeSpan.Zero)
+        {
+            return null;
+        }
+
+        var threshold = DateTime.UtcNow - _options.SafeWindow;
+        return new SortableUniqueId(SortableUniqueId.Generate(threshold, Guid.Empty));
+    }
+}
+
+/// <summary>
+///     Cache statistics
+/// </summary>
+public record CacheStatistics
+{
+    public long EventCount { get; init; }
+    public long DatabaseSizeBytes { get; init; }
+    public string? RemoteEndpoint { get; init; }
+    public string? DatabaseName { get; init; }
+    public string? LastCachedSortableUniqueId { get; init; }
+    public DateTime? LastSyncUtc { get; init; }
+    public DateTime? CreatedUtc { get; init; }
+
+    public string FormattedDatabaseSize
+    {
+        get
+        {
+            string[] sizes = ["B", "KB", "MB", "GB"];
+            double len = DatabaseSizeBytes;
+            var order = 0;
+            while (len >= 1024 && order < sizes.Length - 1)
+            {
+                order++;
+                len /= 1024;
+            }
+            return $"{len:0.##} {sizes[order]}";
+        }
+    }
+}

--- a/dcb/src/Sekiban.Dcb.Sqlite/Sekiban.Dcb.Sqlite.csproj
+++ b/dcb/src/Sekiban.Dcb.Sqlite/Sekiban.Dcb.Sqlite.csproj
@@ -1,0 +1,40 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <LangVersion>preview</LangVersion>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <AssemblyName>Sekiban.Dcb.Sqlite</AssemblyName>
+        <RootNamespace>Sekiban.Dcb.Sqlite</RootNamespace>
+        <PackageId>Sekiban.Dcb.Sqlite</PackageId>
+        <Authors>J-Tech Group</Authors>
+        <Company>J-Tech-Japan</Company>
+        <Copyright>Copyright (c) J-Tech-Japan 2025</Copyright>
+        <PackageDescription>Sekiban DCB SQLite - SQLite event store implementation with local cache support</PackageDescription>
+        <RepositoryUrl>https://github.com/J-Tech-Japan/Sekiban</RepositoryUrl>
+        <PackageProjectUrl>https://github.com/J-Tech-Japan/Sekiban</PackageProjectUrl>
+        <PackageVersion>10.0.2-preview03</PackageVersion>
+        <Description>SQLite event store and multi-projection state store for Sekiban DCB. Includes cache sync helper for use with remote backends (Cosmos DB, PostgreSQL).</Description>
+        <PackageTags>event-sourcing;cqrs;ddd;dcb;sekiban;sqlite;cache;local</PackageTags>
+        <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+        <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+        <IncludeSymbols>true</IncludeSymbols>
+        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+        <GenerateSBOM>true</GenerateSBOM>
+        <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.1" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.1" />
+        <PackageReference Include="Microsoft.Sbom.Targets" Version="4.1.5">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\Sekiban.Dcb.Core\Sekiban.Dcb.Core.csproj"/>
+    </ItemGroup>
+
+</Project>

--- a/dcb/src/Sekiban.Dcb.Sqlite/SekibanDcbSqliteExtensions.cs
+++ b/dcb/src/Sekiban.Dcb.Sqlite/SekibanDcbSqliteExtensions.cs
@@ -1,0 +1,91 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Sekiban.Dcb.Sqlite.Services;
+using Sekiban.Dcb.Storage;
+
+namespace Sekiban.Dcb.Sqlite;
+
+/// <summary>
+///     Extension methods for registering Sekiban DCB SQLite services
+/// </summary>
+public static class SekibanDcbSqliteExtensions
+{
+    /// <summary>
+    ///     Add SQLite event store as the primary event store
+    /// </summary>
+    /// <param name="services">Service collection</param>
+    /// <param name="databasePath">Path to the SQLite database file</param>
+    /// <param name="configure">Optional configuration action</param>
+    /// <returns>Service collection for chaining</returns>
+    public static IServiceCollection AddSekibanDcbSqlite(
+        this IServiceCollection services,
+        string databasePath,
+        Action<SqliteEventStoreOptions>? configure = null)
+    {
+        var options = new SqliteEventStoreOptions();
+        configure?.Invoke(options);
+
+        services.AddSingleton(options);
+        services.AddSingleton<IEventStore>(sp =>
+        {
+            var domainTypes = sp.GetRequiredService<DcbDomainTypes>();
+            var logger = sp.GetService<ILogger<SqliteEventStore>>();
+            return new SqliteEventStore(databasePath, domainTypes, options, logger);
+        });
+
+        services.AddSingleton<IMultiProjectionStateStore>(sp =>
+        {
+            var logger = sp.GetService<ILogger<SqliteMultiProjectionStateStore>>();
+            return new SqliteMultiProjectionStateStore(databasePath, logger);
+        });
+
+        return services;
+    }
+
+    /// <summary>
+    ///     Add CLI services for tag operations
+    /// </summary>
+    /// <param name="services">Service collection</param>
+    /// <returns>Service collection for chaining</returns>
+    public static IServiceCollection AddSekibanDcbCliServices(this IServiceCollection services)
+    {
+        services.AddSingleton<TagEventService>();
+        services.AddSingleton<TagStateService>();
+        services.AddSingleton<TagListService>();
+        return services;
+    }
+
+    /// <summary>
+    ///     Create a SqliteEventStore instance for use as a local cache
+    /// </summary>
+    /// <param name="databasePath">Path to the SQLite database file</param>
+    /// <param name="domainTypes">Domain types for serialization</param>
+    /// <param name="options">Optional configuration</param>
+    /// <param name="logger">Optional logger</param>
+    /// <returns>SqliteEventStore instance</returns>
+    public static SqliteEventStore CreateSqliteCache(
+        string databasePath,
+        DcbDomainTypes domainTypes,
+        SqliteEventStoreOptions? options = null,
+        ILogger<SqliteEventStore>? logger = null)
+    {
+        return new SqliteEventStore(databasePath, domainTypes, options, logger);
+    }
+
+    /// <summary>
+    ///     Create a cache sync helper for synchronizing a remote store to local SQLite cache
+    /// </summary>
+    /// <param name="localStore">Local SQLite event store</param>
+    /// <param name="remoteStore">Remote event store (Cosmos, Postgres, etc.)</param>
+    /// <param name="options">Sync options</param>
+    /// <param name="logger">Optional logger</param>
+    /// <returns>EventStoreCacheSync instance</returns>
+    public static EventStoreCacheSync CreateCacheSync(
+        SqliteEventStore localStore,
+        IEventStore remoteStore,
+        CacheSyncOptions? options = null,
+        ILogger<EventStoreCacheSync>? logger = null)
+    {
+        return new EventStoreCacheSync(localStore, remoteStore, options, logger);
+    }
+}

--- a/dcb/src/Sekiban.Dcb.Sqlite/Services/TagEventService.cs
+++ b/dcb/src/Sekiban.Dcb.Sqlite/Services/TagEventService.cs
@@ -1,0 +1,55 @@
+using ResultBoxes;
+using Sekiban.Dcb.Common;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.Storage;
+using Sekiban.Dcb.Tags;
+
+namespace Sekiban.Dcb.Sqlite.Services;
+
+/// <summary>
+///     Service for fetching events by tag
+/// </summary>
+public class TagEventService
+{
+    private readonly IEventStore _eventStore;
+    private readonly DcbDomainTypes _domainTypes;
+
+    public TagEventService(IEventStore eventStore, DcbDomainTypes domainTypes)
+    {
+        _eventStore = eventStore;
+        _domainTypes = domainTypes;
+    }
+
+    /// <summary>
+    ///     Parse a tag string into an ITag instance
+    /// </summary>
+    /// <param name="tagString">Tag string in format 'group:content'</param>
+    /// <returns>Parsed tag</returns>
+    public ITag ParseTag(string tagString) => _domainTypes.TagTypes.GetTag(tagString);
+
+    /// <summary>
+    ///     Fetch all events for a specific tag
+    /// </summary>
+    /// <param name="tag">The tag to fetch events for</param>
+    /// <param name="since">Optional: Only return events after this ID</param>
+    /// <returns>List of events for the tag</returns>
+    public Task<ResultBox<IEnumerable<Event>>> GetEventsByTagAsync(ITag tag, SortableUniqueId? since = null)
+        => _eventStore.ReadEventsByTagAsync(tag, since);
+
+    /// <summary>
+    ///     Fetch all events for a tag specified by string
+    /// </summary>
+    /// <param name="tagString">Tag string in format 'group:content'</param>
+    /// <param name="since">Optional: Only return events after this ID</param>
+    /// <returns>List of events for the tag</returns>
+    public Task<ResultBox<IEnumerable<Event>>> GetEventsByTagStringAsync(string tagString, SortableUniqueId? since = null)
+    {
+        var tag = ParseTag(tagString);
+        return GetEventsByTagAsync(tag, since);
+    }
+
+    /// <summary>
+    ///     Get the JSON serializer options from domain types
+    /// </summary>
+    public System.Text.Json.JsonSerializerOptions JsonSerializerOptions => _domainTypes.JsonSerializerOptions;
+}

--- a/dcb/src/Sekiban.Dcb.Sqlite/Services/TagListService.cs
+++ b/dcb/src/Sekiban.Dcb.Sqlite/Services/TagListService.cs
@@ -1,0 +1,149 @@
+using System.Text.Json;
+using ResultBoxes;
+using Sekiban.Dcb.Storage;
+
+namespace Sekiban.Dcb.Sqlite.Services;
+
+/// <summary>
+///     Result of exporting a tag list
+/// </summary>
+public record TagListExportResult(
+    int TotalTags,
+    int TotalTagGroups,
+    long TotalEvents,
+    string? OutputFilePath,
+    IReadOnlyList<TagGroupSummary> TagGroups);
+
+/// <summary>
+///     Summary of a tag group
+/// </summary>
+public record TagGroupSummary(
+    string TagGroup,
+    int TagCount,
+    long TotalEvents,
+    IReadOnlyList<TagInfo> Tags);
+
+/// <summary>
+///     Service for listing and exporting tags from the event store
+/// </summary>
+public class TagListService
+{
+    private readonly IEventStore _eventStore;
+    private readonly DcbDomainTypes _domainTypes;
+
+    public TagListService(IEventStore eventStore, DcbDomainTypes domainTypes)
+    {
+        _eventStore = eventStore;
+        _domainTypes = domainTypes;
+    }
+
+    /// <summary>
+    ///     Get all tags from the event store
+    /// </summary>
+    /// <param name="tagGroup">Optional: Filter by tag group name</param>
+    /// <returns>List of tag information</returns>
+    public Task<ResultBox<IEnumerable<TagInfo>>> GetAllTagsAsync(string? tagGroup = null)
+        => _eventStore.GetAllTagsAsync(tagGroup);
+
+    /// <summary>
+    ///     Get all tags grouped by tag group
+    /// </summary>
+    /// <param name="tagGroup">Optional: Filter by tag group name</param>
+    /// <returns>List of tag group summaries</returns>
+    public async Task<ResultBox<IReadOnlyList<TagGroupSummary>>> GetTagsByGroupAsync(string? tagGroup = null)
+    {
+        var tagsResult = await _eventStore.GetAllTagsAsync(tagGroup);
+        if (!tagsResult.IsSuccess)
+        {
+            return ResultBox.Error<IReadOnlyList<TagGroupSummary>>(tagsResult.GetException());
+        }
+
+        var tags = tagsResult.GetValue().ToList();
+        var grouped = tags
+            .GroupBy(t => t.TagGroup)
+            .Select(g => new TagGroupSummary(
+                g.Key,
+                g.Count(),
+                g.Sum(t => t.EventCount),
+                g.OrderBy(t => t.Tag).ToList()))
+            .OrderBy(g => g.TagGroup)
+            .ToList();
+
+        return ResultBox.FromValue<IReadOnlyList<TagGroupSummary>>(grouped);
+    }
+
+    /// <summary>
+    ///     Export tag list to a JSON file
+    /// </summary>
+    /// <param name="outputPath">Output file path (if null, returns result without saving)</param>
+    /// <param name="tagGroup">Optional: Filter by tag group name</param>
+    /// <returns>Export result with tag information</returns>
+    public async Task<ResultBox<TagListExportResult>> ExportTagListAsync(string? outputPath = null, string? tagGroup = null)
+    {
+        var groupsResult = await GetTagsByGroupAsync(tagGroup);
+        if (!groupsResult.IsSuccess)
+        {
+            return ResultBox.Error<TagListExportResult>(groupsResult.GetException());
+        }
+
+        var groups = groupsResult.GetValue();
+        var totalTags = groups.Sum(g => g.TagCount);
+        var totalEvents = groups.Sum(g => g.TotalEvents);
+
+        var result = new TagListExportResult(
+            totalTags,
+            groups.Count,
+            totalEvents,
+            outputPath,
+            groups);
+
+        if (!string.IsNullOrEmpty(outputPath))
+        {
+            var directory = Path.GetDirectoryName(outputPath);
+            if (!string.IsNullOrEmpty(directory))
+            {
+                Directory.CreateDirectory(directory);
+            }
+
+            var exportData = new
+            {
+                ExportedAt = DateTime.UtcNow,
+                TotalTags = totalTags,
+                TotalTagGroups = groups.Count,
+                TotalEvents = totalEvents,
+                TagGroups = groups.Select(g => new
+                {
+                    g.TagGroup,
+                    g.TagCount,
+                    g.TotalEvents,
+                    Tags = g.Tags.Select(t => new
+                    {
+                        t.Tag,
+                        t.EventCount,
+                        t.FirstSortableUniqueId,
+                        t.LastSortableUniqueId,
+                        t.FirstEventAt,
+                        t.LastEventAt
+                    })
+                })
+            };
+
+            var jsonOptions = new JsonSerializerOptions { WriteIndented = true };
+            var json = JsonSerializer.Serialize(exportData, jsonOptions);
+            await File.WriteAllTextAsync(outputPath, json);
+        }
+
+        return ResultBox.FromValue(result);
+    }
+
+    /// <summary>
+    ///     Get all registered tag group names from domain types
+    /// </summary>
+    public IReadOnlyList<string> GetRegisteredTagGroupNames()
+        => _domainTypes.TagTypes.GetAllTagGroupNames();
+
+    /// <summary>
+    ///     Get the JSON serializer options from domain types
+    /// </summary>
+    public JsonSerializerOptions JsonSerializerOptions => _domainTypes.JsonSerializerOptions;
+}

--- a/dcb/src/Sekiban.Dcb.Sqlite/Services/TagStateService.cs
+++ b/dcb/src/Sekiban.Dcb.Sqlite/Services/TagStateService.cs
@@ -1,0 +1,166 @@
+using ResultBoxes;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.Storage;
+using Sekiban.Dcb.Tags;
+
+namespace Sekiban.Dcb.Sqlite.Services;
+
+/// <summary>
+///     Result of projecting a tag state
+/// </summary>
+public record TagStateProjectionResult(
+    ITag Tag,
+    string ProjectorName,
+    string ProjectorVersion,
+    ITagStatePayload State,
+    int EventCount,
+    string? LastSortableUniqueId);
+
+/// <summary>
+///     Service for getting and projecting tag states
+/// </summary>
+public class TagStateService
+{
+    private readonly IEventStore _eventStore;
+    private readonly DcbDomainTypes _domainTypes;
+
+    public TagStateService(IEventStore eventStore, DcbDomainTypes domainTypes)
+    {
+        _eventStore = eventStore;
+        _domainTypes = domainTypes;
+    }
+
+    /// <summary>
+    ///     Parse a tag string into an ITag instance
+    /// </summary>
+    public ITag ParseTag(string tagString) => _domainTypes.TagTypes.GetTag(tagString);
+
+    /// <summary>
+    ///     Get the latest stored tag state from the event store
+    /// </summary>
+    public Task<ResultBox<TagState>> GetLatestTagStateAsync(ITag tag)
+        => _eventStore.GetLatestTagAsync(tag);
+
+    /// <summary>
+    ///     Get the latest stored tag state by tag string
+    /// </summary>
+    public Task<ResultBox<TagState>> GetLatestTagStateByStringAsync(string tagString)
+    {
+        var tag = ParseTag(tagString);
+        return GetLatestTagStateAsync(tag);
+    }
+
+    /// <summary>
+    ///     Project events for a tag using a specified projector
+    /// </summary>
+    /// <param name="tagString">Tag string in format 'group:content'</param>
+    /// <param name="projectorName">Name of the tag projector to use</param>
+    /// <returns>Projected tag state result</returns>
+    public async Task<ResultBox<TagStateProjectionResult>> ProjectTagStateAsync(string tagString, string projectorName)
+    {
+        var tag = ParseTag(tagString);
+        return await ProjectTagStateAsync(tag, projectorName);
+    }
+
+    /// <summary>
+    ///     Project events for a tag, automatically inferring the projector from the tag group name.
+    ///     Tries "{TagGroupName}Projector" convention.
+    /// </summary>
+    /// <param name="tagString">Tag string in format 'group:content'</param>
+    /// <returns>Projected tag state result</returns>
+    public async Task<ResultBox<TagStateProjectionResult>> ProjectTagStateAsync(string tagString)
+    {
+        var tag = ParseTag(tagString);
+        return await ProjectTagStateAsync(tag);
+    }
+
+    /// <summary>
+    ///     Project events for a tag, automatically inferring the projector from the tag group name.
+    ///     Tries "{TagGroupName}Projector" convention.
+    /// </summary>
+    /// <param name="tag">The tag to project</param>
+    /// <returns>Projected tag state result</returns>
+    public async Task<ResultBox<TagStateProjectionResult>> ProjectTagStateAsync(ITag tag)
+    {
+        var tagGroup = tag.GetTagGroup();
+        var projectorName = _domainTypes.TagProjectorTypes.TryGetProjectorForTagGroup(tagGroup);
+
+        if (projectorName == null)
+        {
+            return ResultBox.Error<TagStateProjectionResult>(
+                new InvalidOperationException(
+                    $"Could not find a projector for tag group '{tagGroup}'. " +
+                    $"Tried '{tagGroup}Projector'. " +
+                    $"Available projectors: {string.Join(", ", GetAllTagProjectorNames())}"));
+        }
+
+        return await ProjectTagStateAsync(tag, projectorName);
+    }
+
+    /// <summary>
+    ///     Project events for a tag using a specified projector
+    /// </summary>
+    /// <param name="tag">The tag to project</param>
+    /// <param name="projectorName">Name of the tag projector to use</param>
+    /// <returns>Projected tag state result</returns>
+    public async Task<ResultBox<TagStateProjectionResult>> ProjectTagStateAsync(ITag tag, string projectorName)
+    {
+        // Get the projector function
+        var projectorFuncResult = _domainTypes.TagProjectorTypes.GetProjectorFunction(projectorName);
+        if (!projectorFuncResult.IsSuccess)
+        {
+            return ResultBox.Error<TagStateProjectionResult>(projectorFuncResult.GetException());
+        }
+
+        // Get the projector version
+        var projectorVersionResult = _domainTypes.TagProjectorTypes.GetProjectorVersion(projectorName);
+        var projectorVersion = projectorVersionResult.IsSuccess ? projectorVersionResult.GetValue() : "unknown";
+
+        // Fetch events for the tag
+        var eventsResult = await _eventStore.ReadEventsByTagAsync(tag);
+        if (!eventsResult.IsSuccess)
+        {
+            return ResultBox.Error<TagStateProjectionResult>(eventsResult.GetException());
+        }
+
+        var events = eventsResult.GetValue().ToList();
+        var projectorFunc = projectorFuncResult.GetValue();
+
+        // Project all events
+        ITagStatePayload state = new EmptyTagStatePayload();
+        string? lastSortableUniqueId = null;
+
+        foreach (var evt in events)
+        {
+            state = projectorFunc(state, evt);
+            lastSortableUniqueId = evt.SortableUniqueIdValue;
+        }
+
+        var result = new TagStateProjectionResult(
+            tag,
+            projectorName,
+            projectorVersion,
+            state,
+            events.Count,
+            lastSortableUniqueId);
+
+        return ResultBox.FromValue(result);
+    }
+
+    /// <summary>
+    ///     Get all registered tag projector names
+    /// </summary>
+    public IReadOnlyList<string> GetAllTagProjectorNames()
+        => _domainTypes.TagProjectorTypes.GetAllProjectorNames();
+
+    /// <summary>
+    ///     Get all registered tag group names
+    /// </summary>
+    public IReadOnlyList<string> GetAllTagGroupNames()
+        => _domainTypes.TagTypes.GetAllTagGroupNames();
+
+    /// <summary>
+    ///     Get the JSON serializer options from domain types
+    /// </summary>
+    public System.Text.Json.JsonSerializerOptions JsonSerializerOptions => _domainTypes.JsonSerializerOptions;
+}

--- a/dcb/src/Sekiban.Dcb.Sqlite/SqliteEventStore.cs
+++ b/dcb/src/Sekiban.Dcb.Sqlite/SqliteEventStore.cs
@@ -1,0 +1,692 @@
+using System.Text.Json;
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Logging;
+using ResultBoxes;
+using Sekiban.Dcb.Common;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.Storage;
+using Sekiban.Dcb.Tags;
+
+namespace Sekiban.Dcb.Sqlite;
+
+/// <summary>
+///     SQLite implementation of IEventStore.
+///     Can be used as a standalone event store or as a local cache for remote stores.
+/// </summary>
+public class SqliteEventStore : IEventStore
+{
+    private const string SchemaVersion = "1.0";
+    private readonly string _connectionString;
+    private readonly string _databasePath;
+    private readonly DcbDomainTypes _domainTypes;
+    private readonly SqliteEventStoreOptions _options;
+    private readonly ILogger<SqliteEventStore>? _logger;
+    private readonly object _lock = new();
+
+    public SqliteEventStore(
+        string databasePath,
+        DcbDomainTypes domainTypes,
+        SqliteEventStoreOptions? options = null,
+        ILogger<SqliteEventStore>? logger = null)
+    {
+        _databasePath = databasePath;
+        _connectionString = $"Data Source={databasePath}";
+        _domainTypes = domainTypes;
+        _options = options ?? new SqliteEventStoreOptions();
+        _logger = logger;
+
+        if (_options.AutoCreateDatabase)
+        {
+            InitializeDatabase();
+        }
+    }
+
+    /// <summary>
+    ///     Gets the database file path
+    /// </summary>
+    public string DatabasePath => _databasePath;
+
+    private void InitializeDatabase()
+    {
+        var directory = Path.GetDirectoryName(_databasePath);
+        if (!string.IsNullOrEmpty(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+
+        using var connection = new SqliteConnection(_connectionString);
+        connection.Open();
+
+        if (_options.UseWalMode)
+        {
+            using var walCmd = connection.CreateCommand();
+            walCmd.CommandText = "PRAGMA journal_mode=WAL;";
+            walCmd.ExecuteNonQuery();
+        }
+
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = """
+            CREATE TABLE IF NOT EXISTS dcb_events (
+                Id TEXT PRIMARY KEY,
+                SortableUniqueId TEXT NOT NULL UNIQUE,
+                EventType TEXT NOT NULL,
+                PayloadJson TEXT NOT NULL,
+                TagsJson TEXT,
+                Timestamp TEXT NOT NULL,
+                CausationId TEXT,
+                CorrelationId TEXT,
+                ExecutedUser TEXT
+            );
+            CREATE INDEX IF NOT EXISTS IX_Events_SortableUniqueId ON dcb_events(SortableUniqueId);
+            CREATE INDEX IF NOT EXISTS IX_Events_EventType ON dcb_events(EventType);
+
+            CREATE TABLE IF NOT EXISTS dcb_tags (
+                Id INTEGER PRIMARY KEY AUTOINCREMENT,
+                Tag TEXT NOT NULL,
+                TagGroup TEXT NOT NULL,
+                SortableUniqueId TEXT NOT NULL,
+                EventId TEXT NOT NULL,
+                EventType TEXT NOT NULL,
+                CreatedAt TEXT NOT NULL
+            );
+            CREATE INDEX IF NOT EXISTS IX_Tags_Tag ON dcb_tags(Tag);
+            CREATE INDEX IF NOT EXISTS IX_Tags_TagGroup ON dcb_tags(TagGroup);
+            CREATE INDEX IF NOT EXISTS IX_Tags_Tag_SortableUniqueId ON dcb_tags(Tag, SortableUniqueId);
+
+            CREATE TABLE IF NOT EXISTS dcb_meta (
+                Key TEXT PRIMARY KEY,
+                Value TEXT NOT NULL
+            );
+            """;
+        cmd.ExecuteNonQuery();
+
+        // Set schema version
+        SetMetaValue(connection, "schemaVersion", SchemaVersion);
+    }
+
+    public async Task<ResultBox<IEnumerable<Event>>> ReadAllEventsAsync(SortableUniqueId? since = null)
+    {
+        try
+        {
+            var events = new List<Event>();
+
+            await using var connection = new SqliteConnection(_connectionString);
+            await connection.OpenAsync();
+
+            await using var cmd = connection.CreateCommand();
+            if (since != null)
+            {
+                cmd.CommandText = """
+                    SELECT Id, SortableUniqueId, EventType, PayloadJson, TagsJson, Timestamp, CausationId, CorrelationId, ExecutedUser
+                    FROM dcb_events
+                    WHERE SortableUniqueId > @since
+                    ORDER BY SortableUniqueId
+                    """;
+                cmd.Parameters.AddWithValue("@since", since.Value);
+            }
+            else
+            {
+                cmd.CommandText = """
+                    SELECT Id, SortableUniqueId, EventType, PayloadJson, TagsJson, Timestamp, CausationId, CorrelationId, ExecutedUser
+                    FROM dcb_events
+                    ORDER BY SortableUniqueId
+                    """;
+            }
+
+            await using var reader = await cmd.ExecuteReaderAsync();
+            var eventsRead = 0;
+
+            while (await reader.ReadAsync())
+            {
+                var evt = ReadEvent(reader);
+                if (evt != null)
+                {
+                    events.Add(evt);
+                    eventsRead++;
+
+                    if (_options.ReadProgressCallback != null && eventsRead % 1000 == 0)
+                    {
+                        _options.ReadProgressCallback(eventsRead, 0);
+                    }
+                }
+            }
+
+            return ResultBox.FromValue<IEnumerable<Event>>(events);
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogError(ex, "Error reading all events from SQLite");
+            return ResultBox.Error<IEnumerable<Event>>(ex);
+        }
+    }
+
+    public async Task<ResultBox<IEnumerable<Event>>> ReadEventsByTagAsync(ITag tag, SortableUniqueId? since = null)
+    {
+        try
+        {
+            var events = new List<Event>();
+            var tagString = tag.GetTag();
+
+            await using var connection = new SqliteConnection(_connectionString);
+            await connection.OpenAsync();
+
+            await using var cmd = connection.CreateCommand();
+            if (since != null)
+            {
+                cmd.CommandText = """
+                    SELECT DISTINCT e.Id, e.SortableUniqueId, e.EventType, e.PayloadJson, e.TagsJson, e.Timestamp, e.CausationId, e.CorrelationId, e.ExecutedUser
+                    FROM dcb_events e
+                    INNER JOIN dcb_tags t ON e.Id = t.EventId
+                    WHERE t.Tag = @tag AND e.SortableUniqueId > @since
+                    ORDER BY e.SortableUniqueId
+                    """;
+                cmd.Parameters.AddWithValue("@tag", tagString);
+                cmd.Parameters.AddWithValue("@since", since.Value);
+            }
+            else
+            {
+                cmd.CommandText = """
+                    SELECT DISTINCT e.Id, e.SortableUniqueId, e.EventType, e.PayloadJson, e.TagsJson, e.Timestamp, e.CausationId, e.CorrelationId, e.ExecutedUser
+                    FROM dcb_events e
+                    INNER JOIN dcb_tags t ON e.Id = t.EventId
+                    WHERE t.Tag = @tag
+                    ORDER BY e.SortableUniqueId
+                    """;
+                cmd.Parameters.AddWithValue("@tag", tagString);
+            }
+
+            await using var reader = await cmd.ExecuteReaderAsync();
+
+            while (await reader.ReadAsync())
+            {
+                var evt = ReadEvent(reader);
+                if (evt != null)
+                {
+                    events.Add(evt);
+                }
+            }
+
+            return ResultBox.FromValue<IEnumerable<Event>>(events);
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogError(ex, "Error reading events by tag from SQLite: {Tag}", tag.GetTag());
+            return ResultBox.Error<IEnumerable<Event>>(ex);
+        }
+    }
+
+    public async Task<ResultBox<Event>> ReadEventAsync(Guid eventId)
+    {
+        try
+        {
+            await using var connection = new SqliteConnection(_connectionString);
+            await connection.OpenAsync();
+
+            await using var cmd = connection.CreateCommand();
+            cmd.CommandText = """
+                SELECT Id, SortableUniqueId, EventType, PayloadJson, TagsJson, Timestamp, CausationId, CorrelationId, ExecutedUser
+                FROM dcb_events
+                WHERE Id = @id
+                """;
+            cmd.Parameters.AddWithValue("@id", eventId.ToString());
+
+            await using var reader = await cmd.ExecuteReaderAsync();
+
+            if (await reader.ReadAsync())
+            {
+                var evt = ReadEvent(reader);
+                if (evt != null)
+                {
+                    return ResultBox.FromValue(evt);
+                }
+            }
+
+            return ResultBox.Error<Event>(new KeyNotFoundException($"Event not found: {eventId}"));
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogError(ex, "Error reading event from SQLite: {EventId}", eventId);
+            return ResultBox.Error<Event>(ex);
+        }
+    }
+
+    public async Task<ResultBox<(IReadOnlyList<Event> Events, IReadOnlyList<TagWriteResult> TagWrites)>> WriteEventsAsync(
+        IEnumerable<Event> events)
+    {
+        try
+        {
+            var eventList = events.ToList();
+            if (eventList.Count == 0)
+            {
+                return ResultBox.FromValue<(IReadOnlyList<Event>, IReadOnlyList<TagWriteResult>)>(
+                    (Array.Empty<Event>(), Array.Empty<TagWriteResult>()));
+            }
+
+            var tagWrites = new List<TagWriteResult>();
+
+            await using var connection = new SqliteConnection(_connectionString);
+            await connection.OpenAsync();
+
+            await using var transaction = await connection.BeginTransactionAsync();
+
+            try
+            {
+                foreach (var evt in eventList)
+                {
+                    // Insert event
+                    await using var eventCmd = connection.CreateCommand();
+                    eventCmd.Transaction = (SqliteTransaction)transaction;
+                    eventCmd.CommandText = """
+                        INSERT OR REPLACE INTO dcb_events (Id, SortableUniqueId, EventType, PayloadJson, TagsJson, Timestamp, CausationId, CorrelationId, ExecutedUser)
+                        VALUES (@id, @sortableUniqueId, @eventType, @payloadJson, @tagsJson, @timestamp, @causationId, @correlationId, @executedUser)
+                        """;
+
+                    var payloadJson = JsonSerializer.Serialize(evt.Payload, evt.Payload.GetType(), _domainTypes.JsonSerializerOptions);
+                    var tagsJson = JsonSerializer.Serialize(evt.Tags);
+
+                    eventCmd.Parameters.AddWithValue("@id", evt.Id.ToString());
+                    eventCmd.Parameters.AddWithValue("@sortableUniqueId", evt.SortableUniqueIdValue);
+                    eventCmd.Parameters.AddWithValue("@eventType", evt.EventType);
+                    eventCmd.Parameters.AddWithValue("@payloadJson", payloadJson);
+                    eventCmd.Parameters.AddWithValue("@tagsJson", tagsJson);
+                    eventCmd.Parameters.AddWithValue("@timestamp", new SortableUniqueId(evt.SortableUniqueIdValue).GetDateTime().ToString("O"));
+                    eventCmd.Parameters.AddWithValue("@causationId", (object?)evt.EventMetadata.CausationId ?? DBNull.Value);
+                    eventCmd.Parameters.AddWithValue("@correlationId", (object?)evt.EventMetadata.CorrelationId ?? DBNull.Value);
+                    eventCmd.Parameters.AddWithValue("@executedUser", (object?)evt.EventMetadata.ExecutedUser ?? DBNull.Value);
+
+                    await eventCmd.ExecuteNonQueryAsync();
+
+                    // Insert tags
+                    foreach (var tagString in evt.Tags)
+                    {
+                        var tagGroup = tagString.Contains(':') ? tagString.Split(':')[0] : tagString;
+
+                        await using var tagCmd = connection.CreateCommand();
+                        tagCmd.Transaction = (SqliteTransaction)transaction;
+                        tagCmd.CommandText = """
+                            INSERT INTO dcb_tags (Tag, TagGroup, SortableUniqueId, EventId, EventType, CreatedAt)
+                            VALUES (@tag, @tagGroup, @sortableUniqueId, @eventId, @eventType, @createdAt)
+                            """;
+                        tagCmd.Parameters.AddWithValue("@tag", tagString);
+                        tagCmd.Parameters.AddWithValue("@tagGroup", tagGroup);
+                        tagCmd.Parameters.AddWithValue("@sortableUniqueId", evt.SortableUniqueIdValue);
+                        tagCmd.Parameters.AddWithValue("@eventId", evt.Id.ToString());
+                        tagCmd.Parameters.AddWithValue("@eventType", evt.EventType);
+                        tagCmd.Parameters.AddWithValue("@createdAt", DateTime.UtcNow.ToString("O"));
+
+                        await tagCmd.ExecuteNonQueryAsync();
+
+                        tagWrites.Add(new TagWriteResult(tagString, 1, DateTimeOffset.UtcNow));
+                    }
+                }
+
+                await transaction.CommitAsync();
+
+                return ResultBox.FromValue<(IReadOnlyList<Event>, IReadOnlyList<TagWriteResult>)>(
+                    (eventList, tagWrites));
+            }
+            catch
+            {
+                await transaction.RollbackAsync();
+                throw;
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogError(ex, "Error writing events to SQLite");
+            return ResultBox.Error<(IReadOnlyList<Event>, IReadOnlyList<TagWriteResult>)>(ex);
+        }
+    }
+
+    public async Task<ResultBox<IEnumerable<TagStream>>> ReadTagsAsync(ITag tag)
+    {
+        try
+        {
+            var streams = new List<TagStream>();
+            var tagString = tag.GetTag();
+
+            await using var connection = new SqliteConnection(_connectionString);
+            await connection.OpenAsync();
+
+            await using var cmd = connection.CreateCommand();
+            cmd.CommandText = """
+                SELECT EventId, SortableUniqueId, EventType
+                FROM dcb_tags
+                WHERE Tag = @tag
+                ORDER BY SortableUniqueId
+                """;
+            cmd.Parameters.AddWithValue("@tag", tagString);
+
+            await using var reader = await cmd.ExecuteReaderAsync();
+
+            while (await reader.ReadAsync())
+            {
+                var eventId = Guid.Parse(reader.GetString(0));
+                var sortableUniqueId = reader.GetString(1);
+
+                streams.Add(new TagStream(tagString, eventId, sortableUniqueId));
+            }
+
+            return ResultBox.FromValue<IEnumerable<TagStream>>(streams);
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogError(ex, "Error reading tags from SQLite: {Tag}", tag.GetTag());
+            return ResultBox.Error<IEnumerable<TagStream>>(ex);
+        }
+    }
+
+    public async Task<ResultBox<TagState>> GetLatestTagAsync(ITag tag)
+    {
+        try
+        {
+            var tagString = tag.GetTag();
+            var tagGroup = tag.GetTagGroup();
+            var tagContent = tag.GetTagContent();
+
+            await using var connection = new SqliteConnection(_connectionString);
+            await connection.OpenAsync();
+
+            // Get count for version
+            await using var countCmd = connection.CreateCommand();
+            countCmd.CommandText = "SELECT COUNT(*) FROM dcb_tags WHERE Tag = @tag";
+            countCmd.Parameters.AddWithValue("@tag", tagString);
+            var version = Convert.ToInt32(await countCmd.ExecuteScalarAsync());
+
+            await using var cmd = connection.CreateCommand();
+            cmd.CommandText = """
+                SELECT EventId, SortableUniqueId, EventType
+                FROM dcb_tags
+                WHERE Tag = @tag
+                ORDER BY SortableUniqueId DESC
+                LIMIT 1
+                """;
+            cmd.Parameters.AddWithValue("@tag", tagString);
+
+            await using var reader = await cmd.ExecuteReaderAsync();
+
+            if (await reader.ReadAsync())
+            {
+                var sortableUniqueId = reader.GetString(1);
+                return ResultBox.FromValue(new TagState(
+                    new EmptyTagStatePayload(),
+                    version,
+                    sortableUniqueId,
+                    tagGroup,
+                    tagContent,
+                    "SqliteProjector",
+                    string.Empty));
+            }
+
+            // No events found - return empty state
+            return ResultBox.FromValue(new TagState(
+                new EmptyTagStatePayload(),
+                0,
+                string.Empty,
+                tagGroup,
+                tagContent,
+                "SqliteProjector",
+                string.Empty));
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogError(ex, "Error getting latest tag from SQLite: {Tag}", tag.GetTag());
+            return ResultBox.Error<TagState>(ex);
+        }
+    }
+
+    public async Task<ResultBox<bool>> TagExistsAsync(ITag tag)
+    {
+        try
+        {
+            var tagString = tag.GetTag();
+
+            await using var connection = new SqliteConnection(_connectionString);
+            await connection.OpenAsync();
+
+            await using var cmd = connection.CreateCommand();
+            cmd.CommandText = "SELECT COUNT(*) FROM dcb_tags WHERE Tag = @tag LIMIT 1";
+            cmd.Parameters.AddWithValue("@tag", tagString);
+
+            var count = Convert.ToInt64(await cmd.ExecuteScalarAsync());
+            return ResultBox.FromValue(count > 0);
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogError(ex, "Error checking tag existence in SQLite: {Tag}", tag.GetTag());
+            return ResultBox.Error<bool>(ex);
+        }
+    }
+
+    public async Task<ResultBox<long>> GetEventCountAsync(SortableUniqueId? since = null)
+    {
+        try
+        {
+            await using var connection = new SqliteConnection(_connectionString);
+            await connection.OpenAsync();
+
+            await using var cmd = connection.CreateCommand();
+            if (since != null)
+            {
+                cmd.CommandText = "SELECT COUNT(*) FROM dcb_events WHERE SortableUniqueId > @since";
+                cmd.Parameters.AddWithValue("@since", since.Value);
+            }
+            else
+            {
+                cmd.CommandText = "SELECT COUNT(*) FROM dcb_events";
+            }
+
+            var count = Convert.ToInt64(await cmd.ExecuteScalarAsync());
+            return ResultBox.FromValue(count);
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogError(ex, "Error getting event count from SQLite");
+            return ResultBox.Error<long>(ex);
+        }
+    }
+
+    public async Task<ResultBox<IEnumerable<TagInfo>>> GetAllTagsAsync(string? tagGroup = null)
+    {
+        try
+        {
+            var tags = new List<TagInfo>();
+
+            await using var connection = new SqliteConnection(_connectionString);
+            await connection.OpenAsync();
+
+            await using var cmd = connection.CreateCommand();
+            if (!string.IsNullOrEmpty(tagGroup))
+            {
+                cmd.CommandText = """
+                    SELECT Tag, TagGroup, COUNT(*) as EventCount,
+                           MIN(SortableUniqueId) as FirstId, MAX(SortableUniqueId) as LastId
+                    FROM dcb_tags
+                    WHERE TagGroup = @tagGroup
+                    GROUP BY Tag, TagGroup
+                    ORDER BY Tag
+                    """;
+                cmd.Parameters.AddWithValue("@tagGroup", tagGroup);
+            }
+            else
+            {
+                cmd.CommandText = """
+                    SELECT Tag, TagGroup, COUNT(*) as EventCount,
+                           MIN(SortableUniqueId) as FirstId, MAX(SortableUniqueId) as LastId
+                    FROM dcb_tags
+                    GROUP BY Tag, TagGroup
+                    ORDER BY TagGroup, Tag
+                    """;
+            }
+
+            await using var reader = await cmd.ExecuteReaderAsync();
+
+            while (await reader.ReadAsync())
+            {
+                var tag = reader.GetString(0);
+                var group = reader.GetString(1);
+                var eventCount = reader.GetInt32(2);
+                var firstId = reader.IsDBNull(3) ? null : reader.GetString(3);
+                var lastId = reader.IsDBNull(4) ? null : reader.GetString(4);
+
+                DateTime? firstEventAt = null;
+                DateTime? lastEventAt = null;
+
+                if (firstId != null)
+                {
+                    firstEventAt = new SortableUniqueId(firstId).GetDateTime();
+                }
+                if (lastId != null)
+                {
+                    lastEventAt = new SortableUniqueId(lastId).GetDateTime();
+                }
+
+                tags.Add(new TagInfo(tag, group, eventCount, firstId, lastId, firstEventAt, lastEventAt));
+            }
+
+            return ResultBox.FromValue<IEnumerable<TagInfo>>(tags);
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogError(ex, "Error getting all tags from SQLite");
+            return ResultBox.Error<IEnumerable<TagInfo>>(ex);
+        }
+    }
+
+    // Cache-specific methods
+
+    /// <summary>
+    ///     Clear all data from the cache
+    /// </summary>
+    public async Task ClearAsync()
+    {
+        await using var connection = new SqliteConnection(_connectionString);
+        await connection.OpenAsync();
+
+        await using var cmd = connection.CreateCommand();
+        cmd.CommandText = """
+            DELETE FROM dcb_events;
+            DELETE FROM dcb_tags;
+            DELETE FROM dcb_meta;
+            """;
+        await cmd.ExecuteNonQueryAsync();
+
+        _logger?.LogInformation("SQLite cache cleared");
+    }
+
+    /// <summary>
+    ///     Get cache metadata
+    /// </summary>
+    public async Task<CacheMetadata?> GetMetadataAsync()
+    {
+        try
+        {
+            await using var connection = new SqliteConnection(_connectionString);
+            await connection.OpenAsync();
+
+            var remoteEndpoint = GetMetaValue(connection, "remoteEndpoint");
+            if (string.IsNullOrEmpty(remoteEndpoint))
+            {
+                return null;
+            }
+
+            return new CacheMetadata
+            {
+                RemoteEndpoint = remoteEndpoint,
+                DatabaseName = GetMetaValue(connection, "databaseName") ?? "",
+                SchemaVersion = GetMetaValue(connection, "schemaVersion") ?? "",
+                TotalCountAtFetch = long.TryParse(GetMetaValue(connection, "totalCountAtFetch"), out var count) ? count : 0,
+                LastCachedSortableUniqueId = GetMetaValue(connection, "lastCachedSortableUniqueId"),
+                LastSafeWindowUtc = DateTime.TryParse(GetMetaValue(connection, "lastSafeWindowUtc"), out var dt) ? dt : null,
+                CreatedUtc = DateTime.TryParse(GetMetaValue(connection, "createdUtc"), out var created) ? created : DateTime.UtcNow,
+                UpdatedUtc = DateTime.TryParse(GetMetaValue(connection, "updatedUtc"), out var updated) ? updated : DateTime.UtcNow
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogError(ex, "Error getting cache metadata");
+            return null;
+        }
+    }
+
+    /// <summary>
+    ///     Set cache metadata
+    /// </summary>
+    public async Task SetMetadataAsync(CacheMetadata metadata)
+    {
+        await using var connection = new SqliteConnection(_connectionString);
+        await connection.OpenAsync();
+
+        SetMetaValue(connection, "remoteEndpoint", metadata.RemoteEndpoint);
+        SetMetaValue(connection, "databaseName", metadata.DatabaseName);
+        SetMetaValue(connection, "schemaVersion", metadata.SchemaVersion);
+        SetMetaValue(connection, "totalCountAtFetch", metadata.TotalCountAtFetch.ToString());
+        SetMetaValue(connection, "lastCachedSortableUniqueId", metadata.LastCachedSortableUniqueId ?? "");
+        SetMetaValue(connection, "lastSafeWindowUtc", metadata.LastSafeWindowUtc?.ToString("O") ?? "");
+        SetMetaValue(connection, "createdUtc", metadata.CreatedUtc.ToString("O"));
+        SetMetaValue(connection, "updatedUtc", metadata.UpdatedUtc.ToString("O"));
+    }
+
+    /// <summary>
+    ///     Get the last cached SortableUniqueId
+    /// </summary>
+    public async Task<string?> GetLastCachedIdAsync()
+    {
+        await using var connection = new SqliteConnection(_connectionString);
+        await connection.OpenAsync();
+
+        await using var cmd = connection.CreateCommand();
+        cmd.CommandText = "SELECT MAX(SortableUniqueId) FROM dcb_events";
+        var result = await cmd.ExecuteScalarAsync();
+        return result as string;
+    }
+
+    private Event? ReadEvent(SqliteDataReader reader)
+    {
+        try
+        {
+            var id = Guid.Parse(reader.GetString(0));
+            var sortableUniqueId = reader.GetString(1);
+            var eventType = reader.GetString(2);
+            var payloadJson = reader.GetString(3);
+            var tagsJson = reader.IsDBNull(4) ? "[]" : reader.GetString(4);
+            var causationId = reader.IsDBNull(6) ? null : reader.GetString(6);
+            var correlationId = reader.IsDBNull(7) ? null : reader.GetString(7);
+            var executedUser = reader.IsDBNull(8) ? null : reader.GetString(8);
+
+            var payload = _domainTypes.EventTypes.DeserializeEventPayload(eventType, payloadJson);
+            if (payload == null)
+            {
+                _logger?.LogWarning("Failed to deserialize event payload: {EventType}", eventType);
+                return null;
+            }
+
+            var tags = JsonSerializer.Deserialize<List<string>>(tagsJson) ?? [];
+            var metadata = new EventMetadata(causationId ?? "", correlationId ?? "", executedUser ?? "");
+
+            return new Event(payload, sortableUniqueId, eventType, id, metadata, tags);
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogError(ex, "Error reading event from SQLite reader");
+            return null;
+        }
+    }
+
+    private static string? GetMetaValue(SqliteConnection connection, string key)
+    {
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = "SELECT Value FROM dcb_meta WHERE Key = @key";
+        cmd.Parameters.AddWithValue("@key", key);
+        return cmd.ExecuteScalar() as string;
+    }
+
+    private static void SetMetaValue(SqliteConnection connection, string key, string value)
+    {
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = "INSERT OR REPLACE INTO dcb_meta (Key, Value) VALUES (@key, @value)";
+        cmd.Parameters.AddWithValue("@key", key);
+        cmd.Parameters.AddWithValue("@value", value);
+        cmd.ExecuteNonQuery();
+    }
+}

--- a/dcb/src/Sekiban.Dcb.Sqlite/SqliteEventStoreOptions.cs
+++ b/dcb/src/Sekiban.Dcb.Sqlite/SqliteEventStoreOptions.cs
@@ -1,0 +1,28 @@
+namespace Sekiban.Dcb.Sqlite;
+
+/// <summary>
+///     Configuration options for SqliteEventStore
+/// </summary>
+public class SqliteEventStoreOptions
+{
+    /// <summary>
+    ///     Enable WAL (Write-Ahead Logging) mode for better concurrent access
+    /// </summary>
+    public bool UseWalMode { get; set; } = true;
+
+    /// <summary>
+    ///     Automatically create database and tables if they don't exist
+    /// </summary>
+    public bool AutoCreateDatabase { get; set; } = true;
+
+    /// <summary>
+    ///     Batch size for writing events
+    /// </summary>
+    public int BatchWriteSize { get; set; } = 1000;
+
+    /// <summary>
+    ///     Optional callback for progress reporting during long reads
+    ///     Parameters: (eventsRead, percentComplete)
+    /// </summary>
+    public Action<int, double>? ReadProgressCallback { get; set; }
+}

--- a/dcb/src/Sekiban.Dcb.Sqlite/SqliteMultiProjectionStateStore.cs
+++ b/dcb/src/Sekiban.Dcb.Sqlite/SqliteMultiProjectionStateStore.cs
@@ -1,0 +1,320 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Logging;
+using ResultBoxes;
+using Sekiban.Dcb.MultiProjections;
+using Sekiban.Dcb.Storage;
+
+namespace Sekiban.Dcb.Sqlite;
+
+/// <summary>
+///     SQLite implementation of IMultiProjectionStateStore
+/// </summary>
+public class SqliteMultiProjectionStateStore : IMultiProjectionStateStore
+{
+    private readonly string _connectionString;
+    private readonly string _databasePath;
+    private readonly ILogger<SqliteMultiProjectionStateStore>? _logger;
+
+    public SqliteMultiProjectionStateStore(
+        string databasePath,
+        ILogger<SqliteMultiProjectionStateStore>? logger = null)
+    {
+        _databasePath = databasePath;
+        _connectionString = $"Data Source={databasePath}";
+        _logger = logger;
+
+        InitializeDatabase();
+    }
+
+    private void InitializeDatabase()
+    {
+        var directory = Path.GetDirectoryName(_databasePath);
+        if (!string.IsNullOrEmpty(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+
+        using var connection = new SqliteConnection(_connectionString);
+        connection.Open();
+
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = """
+            CREATE TABLE IF NOT EXISTS dcb_multi_projection_states (
+                ProjectorName TEXT NOT NULL,
+                ProjectorVersion TEXT NOT NULL,
+                PayloadType TEXT NOT NULL,
+                LastSortableUniqueId TEXT NOT NULL,
+                EventsProcessed INTEGER NOT NULL,
+                StateData BLOB,
+                IsOffloaded INTEGER NOT NULL DEFAULT 0,
+                OffloadKey TEXT,
+                OffloadProvider TEXT,
+                OriginalSizeBytes INTEGER NOT NULL,
+                CompressedSizeBytes INTEGER NOT NULL,
+                SafeWindowThreshold TEXT,
+                CreatedAt TEXT NOT NULL,
+                UpdatedAt TEXT NOT NULL,
+                BuildSource TEXT,
+                BuildHost TEXT,
+                PRIMARY KEY (ProjectorName, ProjectorVersion)
+            );
+            """;
+        cmd.ExecuteNonQuery();
+    }
+
+    public async Task<ResultBox<OptionalValue<MultiProjectionStateRecord>>> GetLatestForVersionAsync(
+        string projectorName,
+        string projectorVersion,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            await using var connection = new SqliteConnection(_connectionString);
+            await connection.OpenAsync(cancellationToken);
+
+            await using var cmd = connection.CreateCommand();
+            cmd.CommandText = """
+                SELECT ProjectorName, ProjectorVersion, PayloadType, LastSortableUniqueId, EventsProcessed,
+                       StateData, IsOffloaded, OffloadKey, OffloadProvider, OriginalSizeBytes, CompressedSizeBytes,
+                       SafeWindowThreshold, CreatedAt, UpdatedAt, BuildSource, BuildHost
+                FROM dcb_multi_projection_states
+                WHERE ProjectorName = @projectorName AND ProjectorVersion = @projectorVersion
+                """;
+            cmd.Parameters.AddWithValue("@projectorName", projectorName);
+            cmd.Parameters.AddWithValue("@projectorVersion", projectorVersion);
+
+            await using var reader = await cmd.ExecuteReaderAsync(cancellationToken);
+
+            if (await reader.ReadAsync(cancellationToken))
+            {
+                var record = ReadRecord(reader);
+                return ResultBox.FromValue(OptionalValue.FromValue(record));
+            }
+
+            return ResultBox.FromValue(OptionalValue<MultiProjectionStateRecord>.Empty);
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogError(ex, "Error getting projection state for {ProjectorName}:{ProjectorVersion}", projectorName, projectorVersion);
+            return ResultBox.Error<OptionalValue<MultiProjectionStateRecord>>(ex);
+        }
+    }
+
+    public async Task<ResultBox<OptionalValue<MultiProjectionStateRecord>>> GetLatestAnyVersionAsync(
+        string projectorName,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            await using var connection = new SqliteConnection(_connectionString);
+            await connection.OpenAsync(cancellationToken);
+
+            await using var cmd = connection.CreateCommand();
+            cmd.CommandText = """
+                SELECT ProjectorName, ProjectorVersion, PayloadType, LastSortableUniqueId, EventsProcessed,
+                       StateData, IsOffloaded, OffloadKey, OffloadProvider, OriginalSizeBytes, CompressedSizeBytes,
+                       SafeWindowThreshold, CreatedAt, UpdatedAt, BuildSource, BuildHost
+                FROM dcb_multi_projection_states
+                WHERE ProjectorName = @projectorName
+                ORDER BY EventsProcessed DESC
+                LIMIT 1
+                """;
+            cmd.Parameters.AddWithValue("@projectorName", projectorName);
+
+            await using var reader = await cmd.ExecuteReaderAsync(cancellationToken);
+
+            if (await reader.ReadAsync(cancellationToken))
+            {
+                var record = ReadRecord(reader);
+                return ResultBox.FromValue(OptionalValue.FromValue(record));
+            }
+
+            return ResultBox.FromValue(OptionalValue<MultiProjectionStateRecord>.Empty);
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogError(ex, "Error getting latest projection state for {ProjectorName}", projectorName);
+            return ResultBox.Error<OptionalValue<MultiProjectionStateRecord>>(ex);
+        }
+    }
+
+    public async Task<ResultBox<bool>> UpsertAsync(
+        MultiProjectionStateRecord record,
+        int offloadThresholdBytes = 1_000_000,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            await using var connection = new SqliteConnection(_connectionString);
+            await connection.OpenAsync(cancellationToken);
+
+            await using var cmd = connection.CreateCommand();
+            cmd.CommandText = """
+                INSERT OR REPLACE INTO dcb_multi_projection_states
+                (ProjectorName, ProjectorVersion, PayloadType, LastSortableUniqueId, EventsProcessed,
+                 StateData, IsOffloaded, OffloadKey, OffloadProvider, OriginalSizeBytes, CompressedSizeBytes,
+                 SafeWindowThreshold, CreatedAt, UpdatedAt, BuildSource, BuildHost)
+                VALUES
+                (@projectorName, @projectorVersion, @payloadType, @lastSortableUniqueId, @eventsProcessed,
+                 @stateData, @isOffloaded, @offloadKey, @offloadProvider, @originalSizeBytes, @compressedSizeBytes,
+                 @safeWindowThreshold, @createdAt, @updatedAt, @buildSource, @buildHost)
+                """;
+
+            cmd.Parameters.AddWithValue("@projectorName", record.ProjectorName);
+            cmd.Parameters.AddWithValue("@projectorVersion", record.ProjectorVersion);
+            cmd.Parameters.AddWithValue("@payloadType", record.PayloadType);
+            cmd.Parameters.AddWithValue("@lastSortableUniqueId", record.LastSortableUniqueId);
+            cmd.Parameters.AddWithValue("@eventsProcessed", record.EventsProcessed);
+            cmd.Parameters.AddWithValue("@stateData", (object?)record.StateData ?? DBNull.Value);
+            cmd.Parameters.AddWithValue("@isOffloaded", record.IsOffloaded ? 1 : 0);
+            cmd.Parameters.AddWithValue("@offloadKey", (object?)record.OffloadKey ?? DBNull.Value);
+            cmd.Parameters.AddWithValue("@offloadProvider", (object?)record.OffloadProvider ?? DBNull.Value);
+            cmd.Parameters.AddWithValue("@originalSizeBytes", record.OriginalSizeBytes);
+            cmd.Parameters.AddWithValue("@compressedSizeBytes", record.CompressedSizeBytes);
+            cmd.Parameters.AddWithValue("@safeWindowThreshold", record.SafeWindowThreshold);
+            cmd.Parameters.AddWithValue("@createdAt", record.CreatedAt.ToString("O"));
+            cmd.Parameters.AddWithValue("@updatedAt", record.UpdatedAt.ToString("O"));
+            cmd.Parameters.AddWithValue("@buildSource", (object?)record.BuildSource ?? DBNull.Value);
+            cmd.Parameters.AddWithValue("@buildHost", (object?)record.BuildHost ?? DBNull.Value);
+
+            await cmd.ExecuteNonQueryAsync(cancellationToken);
+
+            return ResultBox.FromValue(true);
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogError(ex, "Error upserting projection state for {ProjectorName}:{ProjectorVersion}",
+                record.ProjectorName, record.ProjectorVersion);
+            return ResultBox.Error<bool>(ex);
+        }
+    }
+
+    public async Task<ResultBox<IReadOnlyList<ProjectorStateInfo>>> ListAllAsync(
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var states = new List<ProjectorStateInfo>();
+
+            await using var connection = new SqliteConnection(_connectionString);
+            await connection.OpenAsync(cancellationToken);
+
+            await using var cmd = connection.CreateCommand();
+            cmd.CommandText = """
+                SELECT ProjectorName, ProjectorVersion, EventsProcessed, UpdatedAt,
+                       OriginalSizeBytes, CompressedSizeBytes, LastSortableUniqueId
+                FROM dcb_multi_projection_states
+                ORDER BY ProjectorName, ProjectorVersion
+                """;
+
+            await using var reader = await cmd.ExecuteReaderAsync(cancellationToken);
+
+            while (await reader.ReadAsync(cancellationToken))
+            {
+                var projectorName = reader.GetString(0);
+                var projectorVersion = reader.GetString(1);
+                var eventsProcessed = reader.GetInt64(2);
+                var updatedAt = DateTime.Parse(reader.GetString(3));
+                var originalSizeBytes = reader.GetInt64(4);
+                var compressedSizeBytes = reader.GetInt64(5);
+                var lastSortableUniqueId = reader.GetString(6);
+
+                states.Add(new ProjectorStateInfo(
+                    projectorName,
+                    projectorVersion,
+                    eventsProcessed,
+                    updatedAt,
+                    originalSizeBytes,
+                    compressedSizeBytes,
+                    lastSortableUniqueId));
+            }
+
+            return ResultBox.FromValue<IReadOnlyList<ProjectorStateInfo>>(states);
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogError(ex, "Error listing all projection states");
+            return ResultBox.Error<IReadOnlyList<ProjectorStateInfo>>(ex);
+        }
+    }
+
+    public async Task<ResultBox<bool>> DeleteAsync(
+        string projectorName,
+        string projectorVersion,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            await using var connection = new SqliteConnection(_connectionString);
+            await connection.OpenAsync(cancellationToken);
+
+            await using var cmd = connection.CreateCommand();
+            cmd.CommandText = """
+                DELETE FROM dcb_multi_projection_states
+                WHERE ProjectorName = @projectorName AND ProjectorVersion = @projectorVersion
+                """;
+            cmd.Parameters.AddWithValue("@projectorName", projectorName);
+            cmd.Parameters.AddWithValue("@projectorVersion", projectorVersion);
+
+            var deleted = await cmd.ExecuteNonQueryAsync(cancellationToken);
+            return ResultBox.FromValue(deleted > 0);
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogError(ex, "Error deleting projection state for {ProjectorName}:{ProjectorVersion}",
+                projectorName, projectorVersion);
+            return ResultBox.Error<bool>(ex);
+        }
+    }
+
+    public async Task<ResultBox<int>> DeleteAllAsync(
+        string? projectorName = null,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            await using var connection = new SqliteConnection(_connectionString);
+            await connection.OpenAsync(cancellationToken);
+
+            await using var cmd = connection.CreateCommand();
+            if (!string.IsNullOrEmpty(projectorName))
+            {
+                cmd.CommandText = "DELETE FROM dcb_multi_projection_states WHERE ProjectorName = @projectorName";
+                cmd.Parameters.AddWithValue("@projectorName", projectorName);
+            }
+            else
+            {
+                cmd.CommandText = "DELETE FROM dcb_multi_projection_states";
+            }
+
+            var deleted = await cmd.ExecuteNonQueryAsync(cancellationToken);
+            return ResultBox.FromValue(deleted);
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogError(ex, "Error deleting all projection states");
+            return ResultBox.Error<int>(ex);
+        }
+    }
+
+    private static MultiProjectionStateRecord ReadRecord(SqliteDataReader reader)
+    {
+        return new MultiProjectionStateRecord(
+            ProjectorName: reader.GetString(0),
+            ProjectorVersion: reader.GetString(1),
+            PayloadType: reader.GetString(2),
+            LastSortableUniqueId: reader.GetString(3),
+            EventsProcessed: reader.GetInt64(4),
+            StateData: reader.IsDBNull(5) ? null : (byte[])reader.GetValue(5),
+            IsOffloaded: reader.GetInt32(6) == 1,
+            OffloadKey: reader.IsDBNull(7) ? null : reader.GetString(7),
+            OffloadProvider: reader.IsDBNull(8) ? null : reader.GetString(8),
+            OriginalSizeBytes: reader.GetInt64(9),
+            CompressedSizeBytes: reader.GetInt64(10),
+            SafeWindowThreshold: reader.GetString(11),
+            CreatedAt: DateTime.Parse(reader.GetString(12)),
+            UpdatedAt: DateTime.Parse(reader.GetString(13)),
+            BuildSource: reader.IsDBNull(14) ? "" : reader.GetString(14),
+            BuildHost: reader.IsDBNull(15) ? null : reader.GetString(15));
+    }
+}

--- a/docs/dcb_llm/18_cli_tool.md
+++ b/docs/dcb_llm/18_cli_tool.md
@@ -1,0 +1,458 @@
+# CLI Tool - Sekiban DCB
+
+> **Navigation**
+> - [Core Concepts](01_core_concepts.md)
+> - [Getting Started](02_getting_started.md)
+> - [Commands, Events, Tags, Projectors](03_aggregate_command_events.md)
+> - [MultiProjection](04_multiple_aggregate_projector.md)
+> - [Query](05_query.md)
+> - [Command Workflow](06_workflow.md)
+> - [Serialization & Domain Types](07_json_orleans_serialization.md)
+> - [API Implementation](08_api_implementation.md)
+> - [Client UI (Blazor)](09_client_api_blazor.md)
+> - [Orleans Setup](10_orleans_setup.md)
+> - [Storage Providers](11_dapr_setup.md)
+> - [Testing](12_unit_testing.md)
+> - [Common Issues and Solutions](13_common_issues.md)
+> - [ResultBox](14_result_box.md)
+> - [Value Objects](15_value_object.md)
+> - [Deployment Guide](16_deployment.md)
+> - [Custom MultiProjector Serialization](17_custom_multiprojector_serialization.md)
+> - [CLI Tool](18_cli_tool.md) (You are here)
+
+## Overview
+
+Sekiban DCB provides a command-line interface (CLI) tool for managing projection states, inspecting events, and working with local SQLite caches. The CLI is particularly useful for:
+
+- Building and rebuilding multi-projection states
+- Debugging by inspecting events and projection states
+- Managing local SQLite cache for offline development
+- Working with multiple environments via profiles
+
+## Project Setup
+
+### Creating a CLI Project
+
+Create a new console application and add the necessary references:
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFrameworks>net10.0;net9.0</TargetFrameworks>
+        <Nullable>enable</Nullable>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <UserSecretsId>your-cli-secrets-id</UserSecretsId>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.1" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.1" />
+        <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <!-- Your domain project -->
+        <ProjectReference Include="..\YourApp.Domain\YourApp.Domain.csproj"/>
+
+        <!-- Sekiban DCB packages -->
+        <ProjectReference Include="..\..\src\Sekiban.Dcb.WithResult\Sekiban.Dcb.WithResult.csproj"/>
+        <ProjectReference Include="..\..\src\Sekiban.Dcb.Postgres\Sekiban.Dcb.Postgres.csproj"/>
+        <ProjectReference Include="..\..\src\Sekiban.Dcb.CosmosDb\Sekiban.Dcb.CosmosDb.csproj"/>
+        <ProjectReference Include="..\..\src\Sekiban.Dcb.Sqlite\Sekiban.Dcb.Sqlite.csproj"/>
+    </ItemGroup>
+</Project>
+```
+
+### Basic Program Structure
+
+```csharp
+using System.CommandLine;
+using System.Reflection;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Sekiban.Dcb;
+using Sekiban.Dcb.CosmosDb;
+using Sekiban.Dcb.Postgres;
+using Sekiban.Dcb.Sqlite;
+using Sekiban.Dcb.Sqlite.Services;
+using Sekiban.Dcb.Storage;
+using YourApp.Domain;
+
+// Build configuration
+var configuration = new ConfigurationBuilder()
+    .AddEnvironmentVariables()
+    .AddUserSecrets(Assembly.GetExecutingAssembly(), optional: true)
+    .Build();
+
+// Create root command
+var rootCommand = new RootCommand("Your CLI Tool - Manage projections and events");
+
+// Add commands...
+rootCommand.AddCommand(buildCommand);
+rootCommand.AddCommand(statusCommand);
+// etc.
+
+return await rootCommand.InvokeAsync(args);
+```
+
+## Multi-Profile Configuration
+
+The CLI supports multiple profiles for connecting to different environments (dev, staging, production).
+
+### Setting Up Profiles with User Secrets
+
+```bash
+# Initialize user secrets
+dotnet user-secrets init
+
+# Set up a "dev" profile
+dotnet user-secrets set "Profiles:dev:Database" "postgres"
+dotnet user-secrets set "Profiles:dev:ConnectionString" "Host=localhost;Database=sekiban;..."
+
+# Set up a "staging" profile with Cosmos DB
+dotnet user-secrets set "Profiles:stg:Database" "cosmos"
+dotnet user-secrets set "Profiles:stg:CosmosConnectionString" "AccountEndpoint=https://...;AccountKey=...;"
+dotnet user-secrets set "Profiles:stg:CosmosDatabase" "SekibanDcb"
+
+# Set default profile
+dotnet user-secrets set "DefaultProfile" "dev"
+```
+
+### Profile Configuration Structure
+
+```json
+{
+  "Profiles": {
+    "dev": {
+      "Database": "postgres",
+      "ConnectionString": "Host=localhost;Database=sekiban;Username=..."
+    },
+    "stg": {
+      "Database": "cosmos",
+      "CosmosConnectionString": "AccountEndpoint=https://...;AccountKey=...;",
+      "CosmosDatabase": "SekibanDcbStaging"
+    },
+    "prod": {
+      "Database": "cosmos",
+      "CosmosConnectionString": "AccountEndpoint=https://...;AccountKey=...;",
+      "CosmosDatabase": "SekibanDcbProd"
+    }
+  },
+  "DefaultProfile": "dev"
+}
+```
+
+### Profile Alias Keys
+
+The following aliases are supported for convenience:
+
+| Alias Key | Maps To |
+|-----------|---------|
+| `Database` | `Sekiban:Database` |
+| `ConnectionString` | `ConnectionStrings:DcbPostgres` |
+| `PostgresConnectionString` | `ConnectionStrings:DcbPostgres` |
+| `CosmosConnectionString` | `ConnectionStrings:SekibanDcbCosmos` |
+| `CosmosDatabase` | `CosmosDb:DatabaseName` |
+
+### Implementing Profile Resolution
+
+```csharp
+static IConfiguration? ResolveProfile(IConfiguration configuration, string? profileName)
+{
+    var profilesSection = configuration.GetSection("Profiles");
+    var profileEntries = profilesSection.GetChildren().ToList();
+    var hasProfiles = profileEntries.Count > 0;
+
+    var resolvedProfile = profileName;
+    if (string.IsNullOrWhiteSpace(resolvedProfile))
+    {
+        var defaultProfile = configuration["DefaultProfile"];
+        if (!string.IsNullOrWhiteSpace(defaultProfile))
+        {
+            resolvedProfile = defaultProfile;
+        }
+        else if (hasProfiles)
+        {
+            Console.WriteLine("Error: No profile specified. Use --profile option.");
+            Console.WriteLine($"Available profiles: {string.Join(", ", profileEntries.Select(p => p.Key))}");
+            return null;
+        }
+        else
+        {
+            return configuration;
+        }
+    }
+
+    if (!hasProfiles)
+    {
+        Console.WriteLine($"Error: Profile '{resolvedProfile}' is not defined.");
+        return null;
+    }
+
+    var profileSection = profilesSection.GetSection(resolvedProfile!);
+    if (!profileSection.Exists())
+    {
+        Console.WriteLine($"Error: Profile '{resolvedProfile}' not found.");
+        return null;
+    }
+
+    // Build configuration with profile overrides
+    var prefix = $"Profiles:{resolvedProfile}:";
+    var overrides = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
+
+    foreach (var pair in profileSection.AsEnumerable())
+    {
+        if (pair.Value == null) continue;
+        var key = pair.Key.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)
+            ? pair.Key[prefix.Length..]
+            : pair.Key;
+        overrides[key] = pair.Value;
+    }
+
+    // Map aliases
+    void MapAlias(string aliasKey, string targetKey)
+    {
+        if (overrides.TryGetValue(aliasKey, out var value) && !overrides.ContainsKey(targetKey))
+            overrides[targetKey] = value;
+    }
+
+    MapAlias("Database", "Sekiban:Database");
+    MapAlias("CosmosConnectionString", "ConnectionStrings:SekibanDcbCosmos");
+    MapAlias("CosmosDatabase", "CosmosDb:DatabaseName");
+    MapAlias("ConnectionString", "ConnectionStrings:DcbPostgres");
+
+    return new ConfigurationBuilder()
+        .AddConfiguration(configuration)
+        .AddInMemoryCollection(overrides!)
+        .Build();
+}
+```
+
+## Available Commands
+
+### profiles
+
+List all available profiles:
+
+```bash
+dotnet run -- profiles
+```
+
+Output:
+```
+=== Available Profiles ===
+
+  - dev (default)
+  - stg
+  - prod
+```
+
+### status
+
+Show the status of all projection states:
+
+```bash
+dotnet run -- status --profile dev
+```
+
+Options:
+- `--profile, -P` - Profile name
+- `--database, -d` - Database type (postgres/cosmos)
+- `--connection-string, -c` - PostgreSQL connection string
+- `--cosmos-connection-string` - Cosmos DB connection string
+- `--cosmos-database` - Cosmos DB database name
+
+### build
+
+Build or rebuild multi-projection states:
+
+```bash
+dotnet run -- build --profile dev --force --verbose
+```
+
+Options:
+- `--profile, -P` - Profile name
+- `--min-events, -m` - Minimum events before building (default: 3000)
+- `--projector, -p` - Specific projector to build
+- `--force, -f` - Force rebuild even if state exists
+- `--verbose, -v` - Show verbose output
+
+### save
+
+Export projection state JSON to files:
+
+```bash
+dotnet run -- save --profile dev --projector MyProjector --output-dir ./output
+```
+
+### delete
+
+Delete projection states:
+
+```bash
+dotnet run -- delete --profile dev --projector MyProjector
+```
+
+### tag-events
+
+Fetch and export all events for a specific tag:
+
+```bash
+dotnet run -- tag-events --profile dev --tag "User:12345" --output-dir ./output
+```
+
+### tag-state
+
+Project and display the current state for a specific tag:
+
+```bash
+dotnet run -- tag-state --profile dev --tag "User:12345" --projector UserProjector
+```
+
+### tag-list
+
+List all tags in the event store:
+
+```bash
+dotnet run -- tag-list --profile dev --tag-group User --output-dir ./output
+```
+
+### projection
+
+Display the current state of a projection:
+
+```bash
+dotnet run -- projection --profile dev --projector MyProjector
+```
+
+## Local SQLite Cache
+
+The CLI includes support for caching remote events to a local SQLite database for faster development.
+
+### Sekiban.Dcb.Sqlite Package
+
+The `Sekiban.Dcb.Sqlite` package provides:
+
+- `SqliteEventStore` - Full `IEventStore` implementation
+- `SqliteMultiProjectionStateStore` - Full `IMultiProjectionStateStore` implementation
+- `EventStoreCacheSync` - Helper for syncing remote to local
+- CLI services for tag operations
+
+### cache-sync
+
+Sync remote events to local SQLite cache:
+
+```bash
+dotnet run -- cache-sync --profile dev --cache-dir ./cache --safe-window 10
+```
+
+Options:
+- `--cache-dir, -C` - Cache directory (default: ./cache)
+- `--safe-window` - Minutes of events to exclude from cache (default: 10)
+
+The safe window prevents caching events that may still be in flight or not yet committed.
+
+### cache-stats
+
+Show local cache statistics:
+
+```bash
+dotnet run -- cache-stats --cache-dir ./cache
+```
+
+Output:
+```
+=== Cache Statistics ===
+
+Cache Directory: ./cache
+
+Cache File: ./cache/events.db
+File Size: 15.2 MB
+Last Modified: 2025-01-17 09:30:45 UTC
+
+Total Events: 42,000
+
+Cache Metadata:
+  Remote Endpoint: https://myaccount.documents.azure.com
+  Database Name: SekibanDcb
+  Last Sync: 2025-01-17 09:30:45 UTC
+  Schema Version: 1.0
+
+Tags: 150 total across 5 groups
+  User: 100 tags
+  Order: 30 tags
+  Product: 20 tags
+```
+
+### cache-clear
+
+Clear the local cache:
+
+```bash
+dotnet run -- cache-clear --cache-dir ./cache
+```
+
+## Building Services
+
+```csharp
+static IServiceProvider BuildServices(string connectionString, string databaseType, string cosmosDatabaseName)
+{
+    var services = new ServiceCollection();
+    var domainTypes = YourDomainType.GetDomainTypes();
+
+    services.AddSingleton(domainTypes);
+
+    if (databaseType.ToLowerInvariant() == "cosmos")
+    {
+        services.AddSingleton<IEventStore>(sp =>
+        {
+            var client = new CosmosClient(connectionString);
+            return new CosmosEventStore(client, cosmosDatabaseName, domainTypes);
+        });
+        services.AddSingleton<IMultiProjectionStateStore>(sp =>
+        {
+            var client = new CosmosClient(connectionString);
+            return new CosmosMultiProjectionStateStore(client, cosmosDatabaseName, domainTypes);
+        });
+    }
+    else
+    {
+        services.AddSekibanDcbPostgres(connectionString);
+    }
+
+    // Add CLI services
+    services.AddSekibanDcbCliServices();
+
+    return services.BuildServiceProvider();
+}
+```
+
+## Usage Examples
+
+```bash
+# List profiles
+dotnet run --framework net9.0 -- profiles
+
+# Check status with default profile
+dotnet run --framework net9.0 -- status
+
+# Check status with specific profile
+dotnet run --framework net9.0 -- status --profile prod
+
+# Build projections with force rebuild
+dotnet run --framework net9.0 -- build --profile dev -f -v
+
+# Sync to local cache
+dotnet run --framework net9.0 -- cache-sync --profile prod
+
+# Work offline with local cache
+dotnet run --framework net9.0 -- tag-list -d sqlite -c "./cache/events.db"
+```
+
+## Reference Implementation
+
+For a complete reference implementation, see:
+- `dcb/internalUsages/DcbOrleans.Cli/Program.cs`
+
+This implementation includes all commands, profile support, and cache management features.

--- a/docs/dcb_llm_ja/18_cli_tool.md
+++ b/docs/dcb_llm_ja/18_cli_tool.md
@@ -1,0 +1,458 @@
+# CLIツール - Sekiban DCB
+
+> **ナビゲーション**
+> - [コアコンセプト](01_core_concepts.md)
+> - [はじめに](02_getting_started.md)
+> - [コマンド、イベント、タグ、プロジェクター](03_aggregate_command_events.md)
+> - [マルチプロジェクション](04_multiple_aggregate_projector.md)
+> - [クエリ](05_query.md)
+> - [コマンドワークフロー](06_workflow.md)
+> - [シリアライゼーションとドメイン型](07_json_orleans_serialization.md)
+> - [API実装](08_api_implementation.md)
+> - [クライアントUI（Blazor）](09_client_api_blazor.md)
+> - [Orleansセットアップ](10_orleans_setup.md)
+> - [ストレージプロバイダー](11_dapr_setup.md)
+> - [テスト](12_unit_testing.md)
+> - [よくある問題と解決策](13_common_issues.md)
+> - [ResultBox](14_result_box.md)
+> - [値オブジェクト](15_value_object.md)
+> - [デプロイメントガイド](16_deployment.md)
+> - [カスタムマルチプロジェクターシリアライゼーション](17_custom_multiprojector_serialization.md)
+> - [CLIツール](18_cli_tool.md) (現在のページ)
+
+## 概要
+
+Sekiban DCBは、プロジェクション状態の管理、イベントの検査、ローカルSQLiteキャッシュの操作のためのコマンドラインインターフェース（CLI）ツールを提供します。CLIは以下の用途に特に有用です：
+
+- マルチプロジェクション状態のビルドと再ビルド
+- イベントとプロジェクション状態の検査によるデバッグ
+- オフライン開発のためのローカルSQLiteキャッシュの管理
+- プロファイルを使用した複数環境の切り替え
+
+## プロジェクトセットアップ
+
+### CLIプロジェクトの作成
+
+新しいコンソールアプリケーションを作成し、必要な参照を追加します：
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFrameworks>net10.0;net9.0</TargetFrameworks>
+        <Nullable>enable</Nullable>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <UserSecretsId>your-cli-secrets-id</UserSecretsId>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.1" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.1" />
+        <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <!-- ドメインプロジェクト -->
+        <ProjectReference Include="..\YourApp.Domain\YourApp.Domain.csproj"/>
+
+        <!-- Sekiban DCBパッケージ -->
+        <ProjectReference Include="..\..\src\Sekiban.Dcb.WithResult\Sekiban.Dcb.WithResult.csproj"/>
+        <ProjectReference Include="..\..\src\Sekiban.Dcb.Postgres\Sekiban.Dcb.Postgres.csproj"/>
+        <ProjectReference Include="..\..\src\Sekiban.Dcb.CosmosDb\Sekiban.Dcb.CosmosDb.csproj"/>
+        <ProjectReference Include="..\..\src\Sekiban.Dcb.Sqlite\Sekiban.Dcb.Sqlite.csproj"/>
+    </ItemGroup>
+</Project>
+```
+
+### 基本的なプログラム構造
+
+```csharp
+using System.CommandLine;
+using System.Reflection;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Sekiban.Dcb;
+using Sekiban.Dcb.CosmosDb;
+using Sekiban.Dcb.Postgres;
+using Sekiban.Dcb.Sqlite;
+using Sekiban.Dcb.Sqlite.Services;
+using Sekiban.Dcb.Storage;
+using YourApp.Domain;
+
+// 設定をビルド
+var configuration = new ConfigurationBuilder()
+    .AddEnvironmentVariables()
+    .AddUserSecrets(Assembly.GetExecutingAssembly(), optional: true)
+    .Build();
+
+// ルートコマンドを作成
+var rootCommand = new RootCommand("CLIツール - プロジェクションとイベントの管理");
+
+// コマンドを追加...
+rootCommand.AddCommand(buildCommand);
+rootCommand.AddCommand(statusCommand);
+// など
+
+return await rootCommand.InvokeAsync(args);
+```
+
+## マルチプロファイル設定
+
+CLIは複数のプロファイルをサポートし、異なる環境（開発、ステージング、本番）への接続を切り替えることができます。
+
+### User Secretsでプロファイルを設定
+
+```bash
+# User Secretsを初期化
+dotnet user-secrets init
+
+# "dev"プロファイルをセットアップ
+dotnet user-secrets set "Profiles:dev:Database" "postgres"
+dotnet user-secrets set "Profiles:dev:ConnectionString" "Host=localhost;Database=sekiban;..."
+
+# Cosmos DBを使用する"stg"プロファイルをセットアップ
+dotnet user-secrets set "Profiles:stg:Database" "cosmos"
+dotnet user-secrets set "Profiles:stg:CosmosConnectionString" "AccountEndpoint=https://...;AccountKey=...;"
+dotnet user-secrets set "Profiles:stg:CosmosDatabase" "SekibanDcb"
+
+# デフォルトプロファイルを設定
+dotnet user-secrets set "DefaultProfile" "dev"
+```
+
+### プロファイル設定構造
+
+```json
+{
+  "Profiles": {
+    "dev": {
+      "Database": "postgres",
+      "ConnectionString": "Host=localhost;Database=sekiban;Username=..."
+    },
+    "stg": {
+      "Database": "cosmos",
+      "CosmosConnectionString": "AccountEndpoint=https://...;AccountKey=...;",
+      "CosmosDatabase": "SekibanDcbStaging"
+    },
+    "prod": {
+      "Database": "cosmos",
+      "CosmosConnectionString": "AccountEndpoint=https://...;AccountKey=...;",
+      "CosmosDatabase": "SekibanDcbProd"
+    }
+  },
+  "DefaultProfile": "dev"
+}
+```
+
+### プロファイルエイリアスキー
+
+以下のエイリアスが便利に使用できます：
+
+| エイリアスキー | マップ先 |
+|---------------|---------|
+| `Database` | `Sekiban:Database` |
+| `ConnectionString` | `ConnectionStrings:DcbPostgres` |
+| `PostgresConnectionString` | `ConnectionStrings:DcbPostgres` |
+| `CosmosConnectionString` | `ConnectionStrings:SekibanDcbCosmos` |
+| `CosmosDatabase` | `CosmosDb:DatabaseName` |
+
+### プロファイル解決の実装
+
+```csharp
+static IConfiguration? ResolveProfile(IConfiguration configuration, string? profileName)
+{
+    var profilesSection = configuration.GetSection("Profiles");
+    var profileEntries = profilesSection.GetChildren().ToList();
+    var hasProfiles = profileEntries.Count > 0;
+
+    var resolvedProfile = profileName;
+    if (string.IsNullOrWhiteSpace(resolvedProfile))
+    {
+        var defaultProfile = configuration["DefaultProfile"];
+        if (!string.IsNullOrWhiteSpace(defaultProfile))
+        {
+            resolvedProfile = defaultProfile;
+        }
+        else if (hasProfiles)
+        {
+            Console.WriteLine("Error: プロファイルが指定されていません。--profileオプションを使用してください。");
+            Console.WriteLine($"利用可能なプロファイル: {string.Join(", ", profileEntries.Select(p => p.Key))}");
+            return null;
+        }
+        else
+        {
+            return configuration;
+        }
+    }
+
+    if (!hasProfiles)
+    {
+        Console.WriteLine($"Error: プロファイル '{resolvedProfile}' が定義されていません。");
+        return null;
+    }
+
+    var profileSection = profilesSection.GetSection(resolvedProfile!);
+    if (!profileSection.Exists())
+    {
+        Console.WriteLine($"Error: プロファイル '{resolvedProfile}' が見つかりません。");
+        return null;
+    }
+
+    // プロファイルオーバーライドで設定をビルド
+    var prefix = $"Profiles:{resolvedProfile}:";
+    var overrides = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
+
+    foreach (var pair in profileSection.AsEnumerable())
+    {
+        if (pair.Value == null) continue;
+        var key = pair.Key.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)
+            ? pair.Key[prefix.Length..]
+            : pair.Key;
+        overrides[key] = pair.Value;
+    }
+
+    // エイリアスをマップ
+    void MapAlias(string aliasKey, string targetKey)
+    {
+        if (overrides.TryGetValue(aliasKey, out var value) && !overrides.ContainsKey(targetKey))
+            overrides[targetKey] = value;
+    }
+
+    MapAlias("Database", "Sekiban:Database");
+    MapAlias("CosmosConnectionString", "ConnectionStrings:SekibanDcbCosmos");
+    MapAlias("CosmosDatabase", "CosmosDb:DatabaseName");
+    MapAlias("ConnectionString", "ConnectionStrings:DcbPostgres");
+
+    return new ConfigurationBuilder()
+        .AddConfiguration(configuration)
+        .AddInMemoryCollection(overrides!)
+        .Build();
+}
+```
+
+## 利用可能なコマンド
+
+### profiles
+
+利用可能なすべてのプロファイルを一覧表示：
+
+```bash
+dotnet run -- profiles
+```
+
+出力：
+```
+=== Available Profiles ===
+
+  - dev (default)
+  - stg
+  - prod
+```
+
+### status
+
+すべてのプロジェクション状態のステータスを表示：
+
+```bash
+dotnet run -- status --profile dev
+```
+
+オプション：
+- `--profile, -P` - プロファイル名
+- `--database, -d` - データベースタイプ（postgres/cosmos）
+- `--connection-string, -c` - PostgreSQL接続文字列
+- `--cosmos-connection-string` - Cosmos DB接続文字列
+- `--cosmos-database` - Cosmos DBデータベース名
+
+### build
+
+マルチプロジェクション状態をビルドまたは再ビルド：
+
+```bash
+dotnet run -- build --profile dev --force --verbose
+```
+
+オプション：
+- `--profile, -P` - プロファイル名
+- `--min-events, -m` - ビルド前の最小イベント数（デフォルト: 3000）
+- `--projector, -p` - ビルドする特定のプロジェクター
+- `--force, -f` - 状態が存在しても強制的に再ビルド
+- `--verbose, -v` - 詳細出力を表示
+
+### save
+
+プロジェクション状態のJSONをファイルにエクスポート：
+
+```bash
+dotnet run -- save --profile dev --projector MyProjector --output-dir ./output
+```
+
+### delete
+
+プロジェクション状態を削除：
+
+```bash
+dotnet run -- delete --profile dev --projector MyProjector
+```
+
+### tag-events
+
+特定のタグのすべてのイベントを取得してエクスポート：
+
+```bash
+dotnet run -- tag-events --profile dev --tag "User:12345" --output-dir ./output
+```
+
+### tag-state
+
+特定のタグの現在の状態をプロジェクトして表示：
+
+```bash
+dotnet run -- tag-state --profile dev --tag "User:12345" --projector UserProjector
+```
+
+### tag-list
+
+イベントストア内のすべてのタグを一覧表示：
+
+```bash
+dotnet run -- tag-list --profile dev --tag-group User --output-dir ./output
+```
+
+### projection
+
+プロジェクションの現在の状態を表示：
+
+```bash
+dotnet run -- projection --profile dev --projector MyProjector
+```
+
+## ローカルSQLiteキャッシュ
+
+CLIは、より高速な開発のためにリモートイベントをローカルSQLiteデータベースにキャッシュする機能をサポートしています。
+
+### Sekiban.Dcb.Sqliteパッケージ
+
+`Sekiban.Dcb.Sqlite`パッケージは以下を提供します：
+
+- `SqliteEventStore` - 完全な`IEventStore`実装
+- `SqliteMultiProjectionStateStore` - 完全な`IMultiProjectionStateStore`実装
+- `EventStoreCacheSync` - リモートからローカルへの同期ヘルパー
+- タグ操作のためのCLIサービス
+
+### cache-sync
+
+リモートイベントをローカルSQLiteキャッシュに同期：
+
+```bash
+dotnet run -- cache-sync --profile dev --cache-dir ./cache --safe-window 10
+```
+
+オプション：
+- `--cache-dir, -C` - キャッシュディレクトリ（デフォルト: ./cache）
+- `--safe-window` - キャッシュから除外するイベントの分数（デフォルト: 10）
+
+セーフウィンドウは、まだ進行中またはコミットされていないイベントのキャッシュを防止します。
+
+### cache-stats
+
+ローカルキャッシュの統計情報を表示：
+
+```bash
+dotnet run -- cache-stats --cache-dir ./cache
+```
+
+出力：
+```
+=== Cache Statistics ===
+
+Cache Directory: ./cache
+
+Cache File: ./cache/events.db
+File Size: 15.2 MB
+Last Modified: 2025-01-17 09:30:45 UTC
+
+Total Events: 42,000
+
+Cache Metadata:
+  Remote Endpoint: https://myaccount.documents.azure.com
+  Database Name: SekibanDcb
+  Last Sync: 2025-01-17 09:30:45 UTC
+  Schema Version: 1.0
+
+Tags: 150 total across 5 groups
+  User: 100 tags
+  Order: 30 tags
+  Product: 20 tags
+```
+
+### cache-clear
+
+ローカルキャッシュをクリア：
+
+```bash
+dotnet run -- cache-clear --cache-dir ./cache
+```
+
+## サービスのビルド
+
+```csharp
+static IServiceProvider BuildServices(string connectionString, string databaseType, string cosmosDatabaseName)
+{
+    var services = new ServiceCollection();
+    var domainTypes = YourDomainType.GetDomainTypes();
+
+    services.AddSingleton(domainTypes);
+
+    if (databaseType.ToLowerInvariant() == "cosmos")
+    {
+        services.AddSingleton<IEventStore>(sp =>
+        {
+            var client = new CosmosClient(connectionString);
+            return new CosmosEventStore(client, cosmosDatabaseName, domainTypes);
+        });
+        services.AddSingleton<IMultiProjectionStateStore>(sp =>
+        {
+            var client = new CosmosClient(connectionString);
+            return new CosmosMultiProjectionStateStore(client, cosmosDatabaseName, domainTypes);
+        });
+    }
+    else
+    {
+        services.AddSekibanDcbPostgres(connectionString);
+    }
+
+    // CLIサービスを追加
+    services.AddSekibanDcbCliServices();
+
+    return services.BuildServiceProvider();
+}
+```
+
+## 使用例
+
+```bash
+# プロファイル一覧
+dotnet run --framework net9.0 -- profiles
+
+# デフォルトプロファイルでステータス確認
+dotnet run --framework net9.0 -- status
+
+# 特定のプロファイルでステータス確認
+dotnet run --framework net9.0 -- status --profile prod
+
+# 強制再ビルドでプロジェクションをビルド
+dotnet run --framework net9.0 -- build --profile dev -f -v
+
+# ローカルキャッシュに同期
+dotnet run --framework net9.0 -- cache-sync --profile prod
+
+# ローカルキャッシュでオフライン作業
+dotnet run --framework net9.0 -- tag-list -d sqlite -c "./cache/events.db"
+```
+
+## リファレンス実装
+
+完全なリファレンス実装については、以下を参照してください：
+- `dcb/internalUsages/DcbOrleans.Cli/Program.cs`
+
+この実装には、すべてのコマンド、プロファイルサポート、キャッシュ管理機能が含まれています。


### PR DESCRIPTION
## Summary
This PR introduces SQLite support for multi-projection state management and improves memory handling for large projections.

## New Features

### SQLite Multi-Projection State Store
- Introduced `SqliteEventStoreOptions` class for configuring SQLite event store options
- Implemented `SqliteMultiProjectionStateStore` class for managing multi-projection states in SQLite
- Added `EventStoreCacheSync` for syncing events from remote stores to local SQLite cache
- Added supporting services: `TagEventService`, `TagListService`, `TagStateService`

### CLI Tool Documentation
- Added comprehensive CLI tool documentation for managing projection states
- Includes setup instructions, commands, and usage examples
- Translated documentation into Japanese for broader accessibility

## Performance Improvements

### Memory Optimization for Large Projections
- **Problem**: KanyushaListProjection (90k+ records, 200k events) caused OutOfMemoryException during snapshot persistence
- **Solution**: 
  - Use streaming serialization (`JsonSerializer.SerializeAsync`) to avoid intermediate string allocation
  - Reduces peak memory by ~50% for large objects

### GC Trigger Optimization
- Changed GC trigger from event count (100k) to payload size threshold (10MB)
- More accurate memory pressure detection based on actual data size rather than event count

## Files Changed
- Added new `Sekiban.Dcb.Sqlite` project with SQLite implementation
- Updated `MultiProjectionGrain.cs` for memory optimizations
- Added CLI documentation in `docs/dcb_llm/18_cli_tool.md` and Japanese version
