### PR TITLE
Route DCB projection logs through ILogger

### DIFF
--- a/dcb/internalUsages/Dcb.Domain.WithoutResult/Dcb.Domain.WithoutResult.csproj
+++ b/dcb/internalUsages/Dcb.Domain.WithoutResult/Dcb.Domain.WithoutResult.csproj
@@ -10,7 +10,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="ResultBoxes" Version="0.3.31" />
-    <PackageReference Include="Microsoft.Orleans.Serialization" Version="9.2.1" />
+    <PackageReference Include="Microsoft.Orleans.Serialization" Version="10.0.0" />
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.102" />
   </ItemGroup>
 </Project>

--- a/dcb/src/Sekiban.Dcb.Core/Sekiban.Dcb.Core.csproj
+++ b/dcb/src/Sekiban.Dcb.Core/Sekiban.Dcb.Core.csproj
@@ -26,6 +26,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.2" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.2" />
         <PackageReference Include="ResultBoxes" Version="0.3.31"/>
         <PackageReference Include="Sekiban.Dcb.Core.Model" Version="10.0.2-preview05" />
         <PackageReference Include="Microsoft.Sbom.Targets" Version="4.1.5">

--- a/dcb/src/Sekiban.Dcb.Sqlite/Sekiban.Dcb.Sqlite.csproj
+++ b/dcb/src/Sekiban.Dcb.Sqlite/Sekiban.Dcb.Sqlite.csproj
@@ -26,7 +26,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.1" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.1" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.2" />
         <PackageReference Include="Microsoft.Sbom.Targets" Version="4.1.5">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
## Summary\n- replace Console.WriteLine usage in Orleans projection flow with ILogger at appropriate levels\n- pass logger into GeneralMultiProjectionActor for SafeWindow debug output\n- align logging abstraction package versions\n- update Orleans serialization package version for internal without-result domain\n\n## Testing\n- dcb/check.sh\n- dotnet test dcb/Sekiban.Dcb.slnx