### PR TITLE
Upgrade Orleans packages to 10.0

### DIFF
--- a/dcb/internalUsages/DcbOrleans.ApiService/DcbOrleans.ApiService.csproj
+++ b/dcb/internalUsages/DcbOrleans.ApiService/DcbOrleans.ApiService.csproj
@@ -27,15 +27,15 @@
         <PackageReference Include="Aspire.Azure.Storage.Blobs" Version="13.1.0" />
         <PackageReference Include="Aspire.Azure.Storage.Queues" Version="13.1.0" />
         <PackageReference Include="Aspire.Microsoft.Azure.Cosmos" Version="13.1.0" />
-        <PackageReference Include="Microsoft.Orleans.Clustering.AzureStorage" Version="9.2.1"/>
-        <PackageReference Include="Microsoft.Orleans.Clustering.Cosmos" Version="9.2.1" />
-        <PackageReference Include="Microsoft.Orleans.Persistence.AzureStorage" Version="9.2.1"/>
-        <PackageReference Include="Microsoft.Orleans.Persistence.Cosmos" Version="9.2.1" />
-        <PackageReference Include="Microsoft.Orleans.Persistence.Memory" Version="9.2.1"/>
-        <PackageReference Include="Microsoft.Orleans.Server" Version="9.2.1"/>
-        <PackageReference Include="Microsoft.Orleans.Streaming" Version="9.2.1"/>
-        <PackageReference Include="Microsoft.Orleans.Streaming.AzureStorage" Version="9.2.1"/>
-        <PackageReference Include="Scalar.AspNetCore" Version="2.12.11" />
+        <PackageReference Include="Microsoft.Orleans.Clustering.AzureStorage" Version="10.0.0" />
+        <PackageReference Include="Microsoft.Orleans.Clustering.Cosmos" Version="10.0.0" />
+        <PackageReference Include="Microsoft.Orleans.Persistence.AzureStorage" Version="10.0.0" />
+        <PackageReference Include="Microsoft.Orleans.Persistence.Cosmos" Version="10.0.0" />
+        <PackageReference Include="Microsoft.Orleans.Persistence.Memory" Version="10.0.0" />
+        <PackageReference Include="Microsoft.Orleans.Server" Version="10.0.0" />
+        <PackageReference Include="Microsoft.Orleans.Streaming" Version="10.0.0" />
+        <PackageReference Include="Microsoft.Orleans.Streaming.AzureStorage" Version="10.0.0" />
+        <PackageReference Include="Scalar.AspNetCore" Version="2.12.12" />
     </ItemGroup>
 
     <ItemGroup>

--- a/dcb/internalUsages/DcbOrleans.ServiceDefaults/DcbOrleans.ServiceDefaults.csproj
+++ b/dcb/internalUsages/DcbOrleans.ServiceDefaults/DcbOrleans.ServiceDefaults.csproj
@@ -12,8 +12,8 @@
 
         <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.2.0" />
         <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="10.2.0" />
-        <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.14.0" />
-        <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.14.0" />
+        <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.0" />
+        <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.0" />
         <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.14.0" />
         <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.14.0" />
         <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.14.0" />

--- a/dcb/internalUsages/DcbOrleans.WithoutResult.ApiService/DcbOrleans.WithoutResult.ApiService.csproj
+++ b/dcb/internalUsages/DcbOrleans.WithoutResult.ApiService/DcbOrleans.WithoutResult.ApiService.csproj
@@ -14,15 +14,15 @@
         <PackageReference Include="Aspire.Azure.Storage.Queues" Version="13.1.0" />
         <PackageReference Include="Aspire.Microsoft.Azure.Cosmos" Version="13.1.0" />
         <PackageReference Include="Aspire.Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.4.2" />
-        <PackageReference Include="Microsoft.Orleans.Clustering.AzureStorage" Version="9.2.1"/>
-        <PackageReference Include="Microsoft.Orleans.Clustering.Cosmos" Version="9.2.1" />
-        <PackageReference Include="Microsoft.Orleans.Persistence.AzureStorage" Version="9.2.1"/>
-        <PackageReference Include="Microsoft.Orleans.Persistence.Cosmos" Version="9.2.1" />
-        <PackageReference Include="Microsoft.Orleans.Persistence.Memory" Version="9.2.1"/>
-        <PackageReference Include="Microsoft.Orleans.Server" Version="9.2.1"/>
-        <PackageReference Include="Microsoft.Orleans.Streaming" Version="9.2.1"/>
-        <PackageReference Include="Microsoft.Orleans.Streaming.AzureStorage" Version="9.2.1"/>
-        <PackageReference Include="Scalar.AspNetCore" Version="2.12.11" />
+        <PackageReference Include="Microsoft.Orleans.Clustering.AzureStorage" Version="10.0.0" />
+        <PackageReference Include="Microsoft.Orleans.Clustering.Cosmos" Version="10.0.0" />
+        <PackageReference Include="Microsoft.Orleans.Persistence.AzureStorage" Version="10.0.0" />
+        <PackageReference Include="Microsoft.Orleans.Persistence.Cosmos" Version="10.0.0" />
+        <PackageReference Include="Microsoft.Orleans.Persistence.Memory" Version="10.0.0" />
+        <PackageReference Include="Microsoft.Orleans.Server" Version="10.0.0" />
+        <PackageReference Include="Microsoft.Orleans.Streaming" Version="10.0.0" />
+        <PackageReference Include="Microsoft.Orleans.Streaming.AzureStorage" Version="10.0.0" />
+        <PackageReference Include="Scalar.AspNetCore" Version="2.12.12" />
         <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.102" />
     </ItemGroup>
 

--- a/dcb/src/Sekiban.Dcb.Orleans.Core/Sekiban.Dcb.Orleans.Core.csproj
+++ b/dcb/src/Sekiban.Dcb.Orleans.Core/Sekiban.Dcb.Orleans.Core.csproj
@@ -26,8 +26,8 @@
 
     <ItemGroup>
         <PackageReference Include="Sekiban.Dcb.Core" Version="$(PackageVersion)" />
-        <PackageReference Include="Microsoft.Orleans.Server" Version="9.2.1"/>
-        <PackageReference Include="Microsoft.Orleans.Streaming" Version="9.2.1"/>
+        <PackageReference Include="Microsoft.Orleans.Server" Version="10.0.0" />
+        <PackageReference Include="Microsoft.Orleans.Streaming" Version="10.0.0" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
         <PackageReference Include="Microsoft.Sbom.Targets" Version="4.1.3">
             <PrivateAssets>all</PrivateAssets>

--- a/dcb/tests/Sekiban.Dcb.Orleans.Tests/Sekiban.Dcb.Orleans.Tests.csproj
+++ b/dcb/tests/Sekiban.Dcb.Orleans.Tests/Sekiban.Dcb.Orleans.Tests.csproj
@@ -19,7 +19,7 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.Orleans.TestingHost" Version="9.2.1"/>
+        <PackageReference Include="Microsoft.Orleans.TestingHost" Version="10.0.0" />
         <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.102" />
     </ItemGroup>
 


### PR DESCRIPTION
## Summary
- bump Orleans packages to 10.0.0 in internal Dcb Orleans projects
- align Orleans test project package version
- update Orleans Core package reference
- fix nullable warning in MultiProjectionGrain

## Testing
- not run