### PR TITLE
Reduce remaining console logging

### DIFF
--- a/dcb/src/Sekiban.Dcb.Core/Actors/GeneralMultiProjectionActor.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Actors/GeneralMultiProjectionActor.cs
@@ -138,7 +138,7 @@ public class GeneralMultiProjectionActor
         if (!deserializeResult.IsSuccess) throw deserializeResult.GetException();
 
         var loadedPayload = deserializeResult.GetValue();
-        Console.WriteLine($"[{_projectorName}] Deserialize: via ICoreMultiProjectorTypes");
+        _logger.LogDebug("[{ProjectorName}] Deserialize: via ICoreMultiProjectorTypes", _projectorName);
 
         // Check if the payload type implements ISafeAndUnsafeStateAccessor
         var payloadType = loadedPayload.GetType();
@@ -199,7 +199,7 @@ public class GeneralMultiProjectionActor
         if (!deserializeResult.IsSuccess) throw deserializeResult.GetException();
 
         var loadedPayload = deserializeResult.GetValue();
-        Console.WriteLine($"[{_projectorName}] Deserialize(ignoreVersion): via ICoreMultiProjectorTypes");
+        _logger.LogDebug("[{ProjectorName}] Deserialize(ignoreVersion): via ICoreMultiProjectorTypes", _projectorName);
 
         var payloadType = loadedPayload.GetType();
         var accessorInterfaces = payloadType
@@ -261,7 +261,12 @@ public class GeneralMultiProjectionActor
             }
 
             var result = serializeResult.GetValue();
-            Console.WriteLine($"[{_projectorName}] Serialize(binary): via ICoreMultiProjectorTypes len={result.CompressedSizeBytes} (original={result.OriginalSizeBytes}, ratio={result.CompressionRatio:P1})");
+            _logger.LogDebug(
+                "[{ProjectorName}] Serialize(binary): via ICoreMultiProjectorTypes len={CompressedBytes} (original={OriginalBytes}, ratio={CompressionRatio:P1})",
+                _projectorName,
+                result.CompressedSizeBytes,
+                result.OriginalSizeBytes,
+                result.CompressionRatio);
             var payloadType = payload.GetType();
             var state = SerializableMultiProjectionState.FromBytes(
                 result.Data,
@@ -483,7 +488,10 @@ public class GeneralMultiProjectionActor
                 // Use MaxValue threshold so全イベントが IsEarlierThanOrEqual となり昇格
                 var maxThreshold = SortableUniqueId.MaxValue;
                 _ = getSafeMethod.Invoke(_singleStateAccessor, new object[] { maxThreshold, _domain });
-                Console.WriteLine($"[SafePromotion] projector={_projectorName} force-promote-all invoked threshold={maxThreshold.Value}");
+                _logger.LogDebug(
+                    "[SafePromotion] projector={ProjectorName} force-promote-all invoked threshold={Threshold}",
+                    _projectorName,
+                    maxThreshold.Value);
             }
         }
         catch { }

--- a/dcb/src/Sekiban.Dcb.Core/Domains/SimpleMultiProjectorTypes.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Domains/SimpleMultiProjectorTypes.cs
@@ -196,7 +196,6 @@ internal class SimpleMultiProjectorTypes : ICoreMultiProjectorTypes
                     }
                     catch (Exception ex)
                     {
-                        Console.WriteLine($"[RegisterProjectorWithoutResult] Error: {ex.Message}");
                         return ResultBox.Error<IMultiProjectionPayload>(ex);
                     }
                 }

--- a/dcb/src/Sekiban.Dcb.Core/MultiProjections/DualStateProjectionWrapper.cs
+++ b/dcb/src/Sekiban.Dcb.Core/MultiProjections/DualStateProjectionWrapper.cs
@@ -103,16 +103,7 @@ public class DualStateProjectionWrapper<T> : ISafeAndUnsafeStateAccessor<T>, IMu
         var eventTime = new SortableUniqueId(evt.SortableUniqueIdValue);
         var isInSafeWindow = !eventTime.IsEarlierThanOrEqual(safeWindowThreshold);
 
-        // Debug logging for safe window evaluation
-        if (_projectorName == "WeatherForecastProjection" && _unsafeVersion % 1000 == 0)
-        {
-            var eventDateTime = eventTime.GetDateTime();
-            var thresholdDateTime = safeWindowThreshold.GetDateTime();
-            var ageMs = (thresholdDateTime - eventDateTime).TotalMilliseconds;
-            Console.WriteLine($"[DualStateWrapper-{_projectorName}] Event age: {ageMs:F0}ms, " +
-                             $"isInSafeWindow: {isInSafeWindow}, " +
-                             $"safeVersion: {_safeVersion}, unsafeVersion: {_unsafeVersion}");
-        }
+        // Debug logging removed to avoid noisy console output.
 
         // Check if event already exists in either safe events or buffered events
         if (_allSafeEvents.ContainsKey(evt.Id) || _bufferedEvents.ContainsKey(evt.Id))
@@ -185,12 +176,6 @@ public class DualStateProjectionWrapper<T> : ISafeAndUnsafeStateAccessor<T>, IMu
         var eventsToProcess = new List<Event>();
         var keysToRemove = new List<Guid>();
 
-        // Debug logging
-        if (_projectorName == "WeatherForecastProjection" && _bufferedEvents.Count > 0)
-        {
-            Console.WriteLine($"[ProcessBufferedEvents-{_projectorName}] Checking {_bufferedEvents.Count} buffered events for promotion");
-        }
-
         // Find events that are now outside safe window
         foreach (var kvp in _bufferedEvents)
         {
@@ -202,13 +187,6 @@ public class DualStateProjectionWrapper<T> : ISafeAndUnsafeStateAccessor<T>, IMu
                 eventsToProcess.Add(ev);
                 keysToRemove.Add(kvp.Key);
             }
-        }
-
-        // Debug logging
-        if (_projectorName == "WeatherForecastProjection" && eventsToProcess.Count > 0)
-        {
-            Console.WriteLine($"[ProcessBufferedEvents-{_projectorName}] Promoting {eventsToProcess.Count} events to safe, " +
-                             $"{_bufferedEvents.Count - eventsToProcess.Count} remain buffered");
         }
 
         // Remove processed events from buffer
@@ -250,7 +228,6 @@ public class DualStateProjectionWrapper<T> : ISafeAndUnsafeStateAccessor<T>, IMu
         // restored _safeProjector with an empty initial state, causing data loss.
         if (_allSafeEvents.Count == 0)
         {
-            Console.WriteLine($"[RebuildSafeState] Skipped for {_projectorName}: no safe events to rebuild from (preserving existing safe state)");
             return;
         }
 

--- a/dcb/src/Sekiban.Dcb.WithResult/Domains/SimpleMultiProjectorTypes.cs
+++ b/dcb/src/Sekiban.Dcb.WithResult/Domains/SimpleMultiProjectorTypes.cs
@@ -196,7 +196,6 @@ public class SimpleMultiProjectorTypes : IMultiProjectorTypes
                     }
                     catch (Exception ex)
                     {
-                        Console.WriteLine($"[RegisterProjectorWithoutResult] Error: {ex.Message}");
                         return ResultBox.Error<IMultiProjectionPayload>(ex);
                     }
                 }


### PR DESCRIPTION
## Summary\n- switch remaining projection-related Console.WriteLine calls to ILogger (or remove debug-only console output)\n- add logger support to tag state and projection state builder flows\n- log Postgres event store write failures via ILogger\n\n## Testing\n- not run