### PR TITLE
Fix DCB package workflow to use DCB-specific solution

### DIFF
--- a/.github/workflows/packagesDcb.yml
+++ b/.github/workflows/packagesDcb.yml
@@ -39,10 +39,10 @@ jobs:
       - name: Restore dependencies
         run: |
           dotnet nuget add source -n benchmarknightly https://www.myget.org/F/benchmarkdotnet/api/v3/index.json
-          dotnet restore Sekiban.slnx
+          dotnet restore dcb/Sekiban.Dcb.slnx
 
       - name: Build with dotnet
-        run: dotnet build Sekiban.slnx -c Release
+        run: dotnet build dcb/Sekiban.Dcb.slnx -c Release
 
       - name: Pack NuGet packages
         run: |


### PR DESCRIPTION
## Summary
- DCBパッケージリリース用のワークフローで `Sekiban.slnx` の代わりに `dcb/Sekiban.Dcb.slnx` を使用するように変更
- これによりビルド時間が大幅に短縮され、GitHub Actionsのタイムアウト問題を回避

## Test plan
- [x] ローカルで `dotnet build dcb/Sekiban.Dcb.slnx -c Release` が成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)