### PR TITLE
Add DynamoDB and S3 packages to DCB release workflow

### DIFF
--- a/.github/workflows/packagesDcb.yml
+++ b/.github/workflows/packagesDcb.yml
@@ -57,6 +57,8 @@ jobs:
           dotnet pack dcb/src/Sekiban.Dcb.CosmosDb/Sekiban.Dcb.CosmosDb.csproj -c Release -o out -p:PackageVersion=$VERSION --no-build
           dotnet pack dcb/src/Sekiban.Dcb.Sqlite/Sekiban.Dcb.Sqlite.csproj -c Release -o out -p:PackageVersion=$VERSION --no-build
           dotnet pack dcb/src/Sekiban.Dcb.BlobStorage.AzureStorage/Sekiban.Dcb.BlobStorage.AzureStorage.csproj -c Release -o out -p:PackageVersion=$VERSION --no-build
+          dotnet pack dcb/src/Sekiban.Dcb.DynamoDB/Sekiban.Dcb.DynamoDB.csproj -c Release -o out -p:PackageVersion=$VERSION --no-build
+          dotnet pack dcb/src/Sekiban.Dcb.BlobStorage.S3/Sekiban.Dcb.BlobStorage.S3.csproj -c Release -o out -p:PackageVersion=$VERSION --no-build
 
       - name: Push to NuGet.org
         run: dotnet nuget push out/*.nupkg --api-key ${{ secrets.NUGET_APIKEY }} --source https://api.nuget.org/v3/index.json


### PR DESCRIPTION
## Summary
- Add `Sekiban.Dcb.DynamoDB` package to NuGet release workflow
- Add `Sekiban.Dcb.BlobStorage.S3` package to NuGet release workflow

These packages were added as part of the DynamoDB support but were missing from the release workflow.

## Test plan
- [x] Verify workflow YAML syntax is valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)