### PR TITLE
fix: Change local event store from SQLite to PostgreSQL for Azure templates

### DIFF
--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.ApiService/appsettings.json
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.ApiService/appsettings.json
@@ -17,7 +17,7 @@
   },
   "AllowedHosts": "*",
   "Sekiban": {
-    "Database": "sqlite"
+    "Database": "postgres"
   },
   "Jwt": {
     "SecretKey": "SekibanDcbOrleansSecretKeyForJwtTokenGeneration2024!",

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.ApiService/appsettings.json
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.ApiService/appsettings.json
@@ -14,6 +14,6 @@
   },
   "AllowedHosts": "*",
   "Sekiban": {
-    "Database": "sqlite"
+    "Database": "postgres"
   }
 }

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans/SekibanDcbOrleans.ApiService/appsettings.json
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans/SekibanDcbOrleans.ApiService/appsettings.json
@@ -19,6 +19,6 @@
   },
   "AllowedHosts": "*",
   "Sekiban": {
-    "Database": "sqlite"
+    "Database": "postgres"
   }
 }


### PR DESCRIPTION
## Summary
- Updated appsettings.json in Orleans, Decider, and WithoutResult templates to use PostgreSQL instead of SQLite for local development
- This matches the production Azure deployment configuration

## Test plan
- [x] Verified Sekiban.Dcb.Orleans template works locally with PostgreSQL
- [ ] Verify Decider template (APIService startup issue observed during testing)
- [ ] Verify WithoutResult template (APIService startup issue observed during testing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)