### PR TITLE
Add .worktrees/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -419,3 +419,4 @@ dcb/internalUsages/DcbOrleansDynamoDB.Infrastructure/config/dev2.json
 # Local configuration files
 *.local.json
 .claude/settings.local.json
+.worktrees/


### PR DESCRIPTION
## Summary
- Add `.worktrees/` directory to `.gitignore` to support git worktree workflow

## Test plan
- [x] Verify `.worktrees/` is ignored by git

🤖 Generated with [Claude Code](https://claude.com/claude-code)