### PR TITLE
Remove [GenerateSerializer] attributes from domain types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -420,3 +420,6 @@ dcb/internalUsages/DcbOrleansDynamoDB.Infrastructure/config/dev2.json
 *.local.json
 .claude/settings.local.json
 .worktrees/
+
+# TAKT config (user data)
+.takt/

--- a/dcb/internalUsages/Dcb.Domain.WithoutResult/ClassRoom/AvailableClassRoomState.cs
+++ b/dcb/internalUsages/Dcb.Domain.WithoutResult/ClassRoom/AvailableClassRoomState.cs
@@ -1,8 +1,5 @@
-using Orleans;
 using Sekiban.Dcb.Tags;
 namespace Dcb.Domain.WithoutResult.ClassRoom;
-
-[GenerateSerializer]
 public record AvailableClassRoomState(Guid ClassRoomId, string Name, int MaxStudents, List<Guid> EnrolledStudentIds)
     : ITagStatePayload
 {

--- a/dcb/internalUsages/Dcb.Domain.WithoutResult/ClassRoom/ClassRoomItem.cs
+++ b/dcb/internalUsages/Dcb.Domain.WithoutResult/ClassRoom/ClassRoomItem.cs
@@ -5,7 +5,6 @@ namespace Dcb.Domain.WithoutResult.ClassRoom;
 /// <summary>
 /// Unified representation of a classroom for list display
 /// </summary>
-[GenerateSerializer]
 public record ClassRoomItem
 {
     [Id(0)]

--- a/dcb/internalUsages/Dcb.Domain.WithoutResult/ClassRoom/FilledClassRoomState.cs
+++ b/dcb/internalUsages/Dcb.Domain.WithoutResult/ClassRoom/FilledClassRoomState.cs
@@ -1,8 +1,5 @@
-using Orleans;
 using Sekiban.Dcb.Tags;
 namespace Dcb.Domain.WithoutResult.ClassRoom;
-
-[GenerateSerializer]
 public record FilledClassRoomState(Guid ClassRoomId, string Name, List<Guid> EnrolledStudentIds, bool IsFull)
     : ITagStatePayload
 {

--- a/dcb/internalUsages/Dcb.Domain.WithoutResult/Projections/WeatherForecastItem.cs
+++ b/dcb/internalUsages/Dcb.Domain.WithoutResult/Projections/WeatherForecastItem.cs
@@ -4,7 +4,6 @@ namespace Dcb.Domain.WithoutResult.Projections;
 /// <summary>
 ///     Weather forecast item in projection
 /// </summary>
-[GenerateSerializer]
 public record WeatherForecastItem(
     [property: Id(0)]
     Guid ForecastId,

--- a/dcb/internalUsages/Dcb.Domain.WithoutResult/Projections/WeatherForecastProjection.cs
+++ b/dcb/internalUsages/Dcb.Domain.WithoutResult/Projections/WeatherForecastProjection.cs
@@ -12,7 +12,6 @@ namespace Dcb.Domain.WithoutResult.Projections;
 /// <summary>
 ///     Simple weather forecast projection for testing DualStateProjectionWrapper
 /// </summary>
-[GenerateSerializer]
 public record WeatherForecastProjection : IMultiProjector<WeatherForecastProjection>
 {
     /// <summary>

--- a/dcb/internalUsages/Dcb.Domain.WithoutResult/Queries/GetClassRoomListQuery.cs
+++ b/dcb/internalUsages/Dcb.Domain.WithoutResult/Queries/GetClassRoomListQuery.cs
@@ -3,8 +3,6 @@ using Orleans;
 using Sekiban.Dcb.MultiProjections;
 using Sekiban.Dcb.Queries;
 namespace Dcb.Domain.WithoutResult.Queries;
-
-[GenerateSerializer]
 public record GetClassRoomListQuery :
     IMultiProjectionListQuery<GenericTagMultiProjector<ClassRoomProjector, ClassRoomTag>, GetClassRoomListQuery, ClassRoomItem>,
     IWaitForSortableUniqueId,

--- a/dcb/internalUsages/Dcb.Domain.WithoutResult/Queries/GetStudentListQuery.cs
+++ b/dcb/internalUsages/Dcb.Domain.WithoutResult/Queries/GetStudentListQuery.cs
@@ -3,8 +3,6 @@ using Orleans;
 using Sekiban.Dcb.MultiProjections;
 using Sekiban.Dcb.Queries;
 namespace Dcb.Domain.WithoutResult.Queries;
-
-[GenerateSerializer]
 public record GetStudentListQuery :
     IMultiProjectionListQuery<GenericTagMultiProjector<StudentProjector, StudentTag>, GetStudentListQuery, StudentState>,
     IWaitForSortableUniqueId,

--- a/dcb/internalUsages/Dcb.Domain.WithoutResult/Queries/GetWeatherForecastCountGenericQuery.cs
+++ b/dcb/internalUsages/Dcb.Domain.WithoutResult/Queries/GetWeatherForecastCountGenericQuery.cs
@@ -9,7 +9,6 @@ namespace Dcb.Domain.WithoutResult.Queries;
 /// <summary>
 /// Count query for GenericTagMultiProjector-based Weather
 /// </summary>
-[GenerateSerializer]
 public record GetWeatherForecastCountGenericQuery :
     IMultiProjectionQuery<GenericTagMultiProjector<WeatherForecastProjector, WeatherForecastTag>, GetWeatherForecastCountGenericQuery, WeatherForecastCountResult>,
     IWaitForSortableUniqueId

--- a/dcb/internalUsages/Dcb.Domain.WithoutResult/Queries/GetWeatherForecastCountQuery.cs
+++ b/dcb/internalUsages/Dcb.Domain.WithoutResult/Queries/GetWeatherForecastCountQuery.cs
@@ -7,7 +7,6 @@ namespace Dcb.Domain.WithoutResult.Queries;
 /// <summary>
 /// Query to get the total count of weather forecasts
 /// </summary>
-[GenerateSerializer]
 public record GetWeatherForecastCountQuery :
     IMultiProjectionQuery<WeatherForecastProjection, GetWeatherForecastCountQuery, WeatherForecastCountResult>,
     IWaitForSortableUniqueId

--- a/dcb/internalUsages/Dcb.Domain.WithoutResult/Queries/GetWeatherForecastCountSingleQuery.cs
+++ b/dcb/internalUsages/Dcb.Domain.WithoutResult/Queries/GetWeatherForecastCountSingleQuery.cs
@@ -7,7 +7,6 @@ namespace Dcb.Domain.WithoutResult.Queries;
 /// <summary>
 /// Count query for the TagState-based projector
 /// </summary>
-[GenerateSerializer]
 public record GetWeatherForecastCountSingleQuery :
     IMultiProjectionQuery<WeatherForecastProjectorWithTagStateProjector, GetWeatherForecastCountSingleQuery, WeatherForecastCountResult>,
     IWaitForSortableUniqueId

--- a/dcb/internalUsages/Dcb.Domain.WithoutResult/Queries/GetWeatherForecastListGenericQuery.cs
+++ b/dcb/internalUsages/Dcb.Domain.WithoutResult/Queries/GetWeatherForecastListGenericQuery.cs
@@ -5,8 +5,6 @@ using Sekiban.Dcb.MultiProjections;
 using Sekiban.Dcb.Queries;
 
 namespace Dcb.Domain.WithoutResult.Queries;
-
-[GenerateSerializer]
 public record GetWeatherForecastListGenericQuery :
     IMultiProjectionListQuery<GenericTagMultiProjector<WeatherForecastProjector, WeatherForecastTag>, GetWeatherForecastListGenericQuery, WeatherForecastItem>,
     IWaitForSortableUniqueId,

--- a/dcb/internalUsages/Dcb.Domain.WithoutResult/Queries/GetWeatherForecastListQuery.cs
+++ b/dcb/internalUsages/Dcb.Domain.WithoutResult/Queries/GetWeatherForecastListQuery.cs
@@ -2,8 +2,6 @@ using Dcb.Domain.WithoutResult.Projections;
 using Orleans;
 using Sekiban.Dcb.Queries;
 namespace Dcb.Domain.WithoutResult.Queries;
-
-[GenerateSerializer]
 public record GetWeatherForecastListQuery :
     IMultiProjectionListQuery<WeatherForecastProjection, GetWeatherForecastListQuery, WeatherForecastItem>,
     IWaitForSortableUniqueId,

--- a/dcb/internalUsages/Dcb.Domain.WithoutResult/Queries/GetWeatherForecastListSingleQuery.cs
+++ b/dcb/internalUsages/Dcb.Domain.WithoutResult/Queries/GetWeatherForecastListSingleQuery.cs
@@ -6,8 +6,6 @@ using Sekiban.Dcb.Queries;
 using Sekiban.Dcb.Tags;
 
 namespace Dcb.Domain.WithoutResult.Queries;
-
-[GenerateSerializer]
 public record GetWeatherForecastListSingleQuery :
     IMultiProjectionListQuery<WeatherForecastProjectorWithTagStateProjector, GetWeatherForecastListSingleQuery, WeatherForecastItem>,
     IWaitForSortableUniqueId,

--- a/dcb/internalUsages/Dcb.Domain.WithoutResult/Queries/WeatherForecastCountResult.cs
+++ b/dcb/internalUsages/Dcb.Domain.WithoutResult/Queries/WeatherForecastCountResult.cs
@@ -4,7 +4,6 @@ namespace Dcb.Domain.WithoutResult.Queries;
 /// <summary>
 /// Result containing weather forecast counts
 /// </summary>
-[GenerateSerializer]
 public record WeatherForecastCountResult(
     [property: Id(0)] int SafeVersion,
     [property: Id(1)] int UnsafeVersion,

--- a/dcb/internalUsages/Dcb.Domain.WithoutResult/Student/StudentState.cs
+++ b/dcb/internalUsages/Dcb.Domain.WithoutResult/Student/StudentState.cs
@@ -1,8 +1,5 @@
-using Orleans;
 using Sekiban.Dcb.Tags;
 namespace Dcb.Domain.WithoutResult.Student;
-
-[GenerateSerializer]
 public record StudentState(Guid StudentId, string Name, int MaxClassCount, List<Guid> EnrolledClassRoomIds)
     : ITagStatePayload
 {

--- a/dcb/internalUsages/Dcb.Domain.WithoutResult/Weather/WeatherForecastState.cs
+++ b/dcb/internalUsages/Dcb.Domain.WithoutResult/Weather/WeatherForecastState.cs
@@ -1,8 +1,6 @@
 using Orleans;
 using Sekiban.Dcb.Tags;
 namespace Dcb.Domain.WithoutResult.Weather;
-
-[GenerateSerializer]
 public record WeatherForecastState : ITagStatePayload
 {
     [Id(0)] public Guid ForecastId { get; init; }


### PR DESCRIPTION
## Summary
- Remove Orleans `[GenerateSerializer]` attributes from `Dcb.Domain.WithoutResult` types as they are no longer needed
- Add `.takt/` directory to `.gitignore` for user configuration data

## Test plan
- [ ] Verify solution builds successfully
- [ ] Verify Orleans serialization still works without explicit attributes

🤖 Generated with [Claude Code](https://claude.com/claude-code)