### PR TITLE
Remove [GenerateSerializer] attributes from domain types and templates

### DIFF
--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.EventSource/ClassRoom/ClassRoomItem.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.EventSource/ClassRoom/ClassRoomItem.cs
@@ -5,7 +5,6 @@ namespace Dcb.EventSource.ClassRoom;
 /// <summary>
 /// Unified representation of a classroom for list display
 /// </summary>
-[GenerateSerializer]
 public record ClassRoomItem
 {
     [Id(0)]

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.EventSource/MeetingRoom/Queries/GetApprovalInboxQuery.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.EventSource/MeetingRoom/Queries/GetApprovalInboxQuery.cs
@@ -16,7 +16,6 @@ public record ApprovalInboxItem(
     DateTime RequestedAt,
     string Status);
 
-[GenerateSerializer]
 public record GetApprovalInboxQuery :
     IMultiProjectionListQuery<ApprovalRequestListProjection, GetApprovalInboxQuery, ApprovalInboxItem>,
     IWaitForSortableUniqueId,

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.EventSource/MeetingRoom/Queries/GetEquipmentTypeListQuery.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.EventSource/MeetingRoom/Queries/GetEquipmentTypeListQuery.cs
@@ -13,7 +13,6 @@ public record EquipmentTypeListItem(
     int TotalQuantity,
     int MaxPerReservation);
 
-[GenerateSerializer]
 public record GetEquipmentTypeListQuery :
     IMultiProjectionListQuery<EquipmentTypeListProjection, GetEquipmentTypeListQuery, EquipmentTypeListItem>,
     IWaitForSortableUniqueId,

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.EventSource/MeetingRoom/Queries/GetReservationListQuery.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.EventSource/MeetingRoom/Queries/GetReservationListQuery.cs
@@ -21,7 +21,6 @@ public record ReservationListItem(
     string? ApprovalRequestComment,
     string? ApprovalDecisionComment);
 
-[GenerateSerializer]
 public record GetReservationListQuery :
     IMultiProjectionListQuery<ReservationListProjection, GetReservationListQuery, ReservationListItem>,
     IWaitForSortableUniqueId,

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.EventSource/MeetingRoom/Queries/GetRoomListQuery.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.EventSource/MeetingRoom/Queries/GetRoomListQuery.cs
@@ -15,7 +15,6 @@ public record RoomListItem(
     bool RequiresApproval,
     bool IsActive);
 
-[GenerateSerializer]
 public record GetRoomListQuery :
     IMultiProjectionListQuery<RoomListProjection, GetRoomListQuery, RoomListItem>,
     IWaitForSortableUniqueId,

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.EventSource/MeetingRoom/Queries/GetUserAccessListQuery.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.EventSource/MeetingRoom/Queries/GetUserAccessListQuery.cs
@@ -12,7 +12,6 @@ public record UserAccessListItem(
     bool IsActive,
     DateTime GrantedAt);
 
-[GenerateSerializer]
 public record GetUserAccessListQuery :
     IMultiProjectionListQuery<UserAccessListProjection, GetUserAccessListQuery, UserAccessListItem>,
     IWaitForSortableUniqueId,

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.EventSource/MeetingRoom/Queries/GetUserDirectoryListQuery.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.EventSource/MeetingRoom/Queries/GetUserDirectoryListQuery.cs
@@ -24,7 +24,6 @@ public record UserDirectoryListItem(
         this with { Roles = roles };
 }
 
-[GenerateSerializer]
 public record GetUserDirectoryListQuery :
     IMultiProjectionListQuery<UserDirectoryListProjection, GetUserDirectoryListQuery, UserDirectoryListItem>,
     IWaitForSortableUniqueId,

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.EventSource/Projections/WeatherForecastItem.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.EventSource/Projections/WeatherForecastItem.cs
@@ -4,7 +4,6 @@ namespace Dcb.EventSource.Projections;
 /// <summary>
 ///     Weather forecast item in projection
 /// </summary>
-[GenerateSerializer]
 public record WeatherForecastItem(
     [property: Id(0)]
     Guid ForecastId,

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.EventSource/Projections/WeatherForecastProjection.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.EventSource/Projections/WeatherForecastProjection.cs
@@ -15,7 +15,6 @@ namespace Dcb.EventSource.Projections;
 /// <summary>
 ///     Simple weather forecast projection for testing DualStateProjectionWrapper
 /// </summary>
-[GenerateSerializer]
 public record WeatherForecastProjection : IMultiProjector<WeatherForecastProjection>
 {
     /// <summary>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.EventSource/Queries/GetClassRoomListQuery.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.EventSource/Queries/GetClassRoomListQuery.cs
@@ -6,7 +6,6 @@ using Sekiban.Dcb.MultiProjections;
 using Sekiban.Dcb.Queries;
 namespace Dcb.EventSource.Queries;
 
-[GenerateSerializer]
 public record GetClassRoomListQuery :
     IMultiProjectionListQuery<ClassRoomListProjection, GetClassRoomListQuery, ClassRoomItem>,
     IWaitForSortableUniqueId,

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.EventSource/Queries/GetStudentListQuery.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.EventSource/Queries/GetStudentListQuery.cs
@@ -5,7 +5,6 @@ using Sekiban.Dcb.MultiProjections;
 using Sekiban.Dcb.Queries;
 namespace Dcb.EventSource.Queries;
 
-[GenerateSerializer]
 public record GetStudentListQuery :
     IMultiProjectionListQuery<StudentListProjection, GetStudentListQuery, StudentState>,
     IWaitForSortableUniqueId,

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.EventSource/Queries/GetWeatherForecastCountGenericQuery.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.EventSource/Queries/GetWeatherForecastCountGenericQuery.cs
@@ -8,7 +8,6 @@ namespace Dcb.EventSource.Queries;
 /// <summary>
 /// Count query for WeatherForecastProjection-based Weather
 /// </summary>
-[GenerateSerializer]
 public record GetWeatherForecastCountGenericQuery :
     IMultiProjectionQuery<WeatherForecastProjection, GetWeatherForecastCountGenericQuery, WeatherForecastCountResult>,
     IWaitForSortableUniqueId

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.EventSource/Queries/GetWeatherForecastCountQuery.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.EventSource/Queries/GetWeatherForecastCountQuery.cs
@@ -7,7 +7,6 @@ namespace Dcb.EventSource.Queries;
 /// <summary>
 /// Query to get the total count of weather forecasts
 /// </summary>
-[GenerateSerializer]
 public record GetWeatherForecastCountQuery :
     IMultiProjectionQuery<WeatherForecastProjection, GetWeatherForecastCountQuery, WeatherForecastCountResult>,
     IWaitForSortableUniqueId

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.EventSource/Queries/GetWeatherForecastCountSingleQuery.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.EventSource/Queries/GetWeatherForecastCountSingleQuery.cs
@@ -7,7 +7,6 @@ namespace Dcb.EventSource.Queries;
 /// <summary>
 /// Count query for the TagState-based projector
 /// </summary>
-[GenerateSerializer]
 public record GetWeatherForecastCountSingleQuery :
     IMultiProjectionQuery<WeatherForecastProjectorWithTagStateProjector, GetWeatherForecastCountSingleQuery, WeatherForecastCountResult>,
     IWaitForSortableUniqueId

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.EventSource/Queries/GetWeatherForecastListGenericQuery.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.EventSource/Queries/GetWeatherForecastListGenericQuery.cs
@@ -5,7 +5,6 @@ using Sekiban.Dcb.Queries;
 
 namespace Dcb.EventSource.Queries;
 
-[GenerateSerializer]
 public record GetWeatherForecastListGenericQuery :
     IMultiProjectionListQuery<WeatherForecastProjection, GetWeatherForecastListGenericQuery, WeatherForecastItem>,
     IWaitForSortableUniqueId,

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.EventSource/Queries/GetWeatherForecastListQuery.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.EventSource/Queries/GetWeatherForecastListQuery.cs
@@ -3,7 +3,6 @@ using Orleans;
 using Sekiban.Dcb.Queries;
 namespace Dcb.EventSource.Queries;
 
-[GenerateSerializer]
 public record GetWeatherForecastListQuery :
     IMultiProjectionListQuery<WeatherForecastProjection, GetWeatherForecastListQuery, WeatherForecastItem>,
     IWaitForSortableUniqueId,

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.EventSource/Queries/GetWeatherForecastListSingleQuery.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.EventSource/Queries/GetWeatherForecastListSingleQuery.cs
@@ -8,7 +8,6 @@ using Sekiban.Dcb.Tags;
 
 namespace Dcb.EventSource.Queries;
 
-[GenerateSerializer]
 public record GetWeatherForecastListSingleQuery :
     IMultiProjectionListQuery<WeatherForecastProjectorWithTagStateProjector, GetWeatherForecastListSingleQuery, WeatherForecastItem>,
     IWaitForSortableUniqueId,

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.EventSource/Queries/WeatherForecastCountResult.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.EventSource/Queries/WeatherForecastCountResult.cs
@@ -4,7 +4,6 @@ namespace Dcb.EventSource.Queries;
 /// <summary>
 /// Result containing weather forecast counts
 /// </summary>
-[GenerateSerializer]
 public record WeatherForecastCountResult(
     [property: Id(0)] int SafeVersion,
     [property: Id(1)] int UnsafeVersion,

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.EventSource/ClassRoom/ClassRoomItem.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.EventSource/ClassRoom/ClassRoomItem.cs
@@ -5,7 +5,6 @@ namespace Dcb.EventSource.ClassRoom;
 /// <summary>
 /// Unified representation of a classroom for list display
 /// </summary>
-[GenerateSerializer]
 public record ClassRoomItem
 {
     [Id(0)]

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.EventSource/MeetingRoom/Queries/GetApprovalInboxQuery.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.EventSource/MeetingRoom/Queries/GetApprovalInboxQuery.cs
@@ -16,7 +16,6 @@ public record ApprovalInboxItem(
     DateTime RequestedAt,
     string Status);
 
-[GenerateSerializer]
 public record GetApprovalInboxQuery :
     IMultiProjectionListQuery<ApprovalRequestListProjection, GetApprovalInboxQuery, ApprovalInboxItem>,
     IWaitForSortableUniqueId,

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.EventSource/MeetingRoom/Queries/GetEquipmentTypeListQuery.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.EventSource/MeetingRoom/Queries/GetEquipmentTypeListQuery.cs
@@ -13,7 +13,6 @@ public record EquipmentTypeListItem(
     int TotalQuantity,
     int MaxPerReservation);
 
-[GenerateSerializer]
 public record GetEquipmentTypeListQuery :
     IMultiProjectionListQuery<EquipmentTypeListProjection, GetEquipmentTypeListQuery, EquipmentTypeListItem>,
     IWaitForSortableUniqueId,

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.EventSource/MeetingRoom/Queries/GetReservationListQuery.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.EventSource/MeetingRoom/Queries/GetReservationListQuery.cs
@@ -21,7 +21,6 @@ public record ReservationListItem(
     string? ApprovalRequestComment,
     string? ApprovalDecisionComment);
 
-[GenerateSerializer]
 public record GetReservationListQuery :
     IMultiProjectionListQuery<ReservationListProjection, GetReservationListQuery, ReservationListItem>,
     IWaitForSortableUniqueId,

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.EventSource/MeetingRoom/Queries/GetRoomListQuery.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.EventSource/MeetingRoom/Queries/GetRoomListQuery.cs
@@ -15,7 +15,6 @@ public record RoomListItem(
     bool RequiresApproval,
     bool IsActive);
 
-[GenerateSerializer]
 public record GetRoomListQuery :
     IMultiProjectionListQuery<RoomListProjection, GetRoomListQuery, RoomListItem>,
     IWaitForSortableUniqueId,

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.EventSource/MeetingRoom/Queries/GetUserAccessListQuery.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.EventSource/MeetingRoom/Queries/GetUserAccessListQuery.cs
@@ -12,7 +12,6 @@ public record UserAccessListItem(
     bool IsActive,
     DateTime GrantedAt);
 
-[GenerateSerializer]
 public record GetUserAccessListQuery :
     IMultiProjectionListQuery<UserAccessListProjection, GetUserAccessListQuery, UserAccessListItem>,
     IWaitForSortableUniqueId,

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.EventSource/MeetingRoom/Queries/GetUserDirectoryListQuery.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.EventSource/MeetingRoom/Queries/GetUserDirectoryListQuery.cs
@@ -24,7 +24,6 @@ public record UserDirectoryListItem(
         this with { Roles = roles };
 }
 
-[GenerateSerializer]
 public record GetUserDirectoryListQuery :
     IMultiProjectionListQuery<UserDirectoryListProjection, GetUserDirectoryListQuery, UserDirectoryListItem>,
     IWaitForSortableUniqueId,

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.EventSource/Projections/WeatherForecastItem.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.EventSource/Projections/WeatherForecastItem.cs
@@ -4,7 +4,6 @@ namespace Dcb.EventSource.Projections;
 /// <summary>
 ///     Weather forecast item in projection
 /// </summary>
-[GenerateSerializer]
 public record WeatherForecastItem(
     [property: Id(0)]
     Guid ForecastId,

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.EventSource/Projections/WeatherForecastProjection.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.EventSource/Projections/WeatherForecastProjection.cs
@@ -15,7 +15,6 @@ namespace Dcb.EventSource.Projections;
 /// <summary>
 ///     Simple weather forecast projection for testing DualStateProjectionWrapper
 /// </summary>
-[GenerateSerializer]
 public record WeatherForecastProjection : IMultiProjector<WeatherForecastProjection>
 {
     /// <summary>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.EventSource/Queries/GetClassRoomListQuery.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.EventSource/Queries/GetClassRoomListQuery.cs
@@ -6,7 +6,6 @@ using Sekiban.Dcb.MultiProjections;
 using Sekiban.Dcb.Queries;
 namespace Dcb.EventSource.Queries;
 
-[GenerateSerializer]
 public record GetClassRoomListQuery :
     IMultiProjectionListQuery<ClassRoomListProjection, GetClassRoomListQuery, ClassRoomItem>,
     IWaitForSortableUniqueId,

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.EventSource/Queries/GetStudentListQuery.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.EventSource/Queries/GetStudentListQuery.cs
@@ -5,7 +5,6 @@ using Sekiban.Dcb.MultiProjections;
 using Sekiban.Dcb.Queries;
 namespace Dcb.EventSource.Queries;
 
-[GenerateSerializer]
 public record GetStudentListQuery :
     IMultiProjectionListQuery<StudentListProjection, GetStudentListQuery, StudentState>,
     IWaitForSortableUniqueId,

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.EventSource/Queries/GetWeatherForecastCountGenericQuery.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.EventSource/Queries/GetWeatherForecastCountGenericQuery.cs
@@ -8,7 +8,6 @@ namespace Dcb.EventSource.Queries;
 /// <summary>
 /// Count query for WeatherForecastProjection-based Weather
 /// </summary>
-[GenerateSerializer]
 public record GetWeatherForecastCountGenericQuery :
     IMultiProjectionQuery<WeatherForecastProjection, GetWeatherForecastCountGenericQuery, WeatherForecastCountResult>,
     IWaitForSortableUniqueId

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.EventSource/Queries/GetWeatherForecastCountQuery.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.EventSource/Queries/GetWeatherForecastCountQuery.cs
@@ -7,7 +7,6 @@ namespace Dcb.EventSource.Queries;
 /// <summary>
 /// Query to get the total count of weather forecasts
 /// </summary>
-[GenerateSerializer]
 public record GetWeatherForecastCountQuery :
     IMultiProjectionQuery<WeatherForecastProjection, GetWeatherForecastCountQuery, WeatherForecastCountResult>,
     IWaitForSortableUniqueId

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.EventSource/Queries/GetWeatherForecastCountSingleQuery.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.EventSource/Queries/GetWeatherForecastCountSingleQuery.cs
@@ -7,7 +7,6 @@ namespace Dcb.EventSource.Queries;
 /// <summary>
 /// Count query for the TagState-based projector
 /// </summary>
-[GenerateSerializer]
 public record GetWeatherForecastCountSingleQuery :
     IMultiProjectionQuery<WeatherForecastProjectorWithTagStateProjector, GetWeatherForecastCountSingleQuery, WeatherForecastCountResult>,
     IWaitForSortableUniqueId

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.EventSource/Queries/GetWeatherForecastListGenericQuery.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.EventSource/Queries/GetWeatherForecastListGenericQuery.cs
@@ -5,7 +5,6 @@ using Sekiban.Dcb.Queries;
 
 namespace Dcb.EventSource.Queries;
 
-[GenerateSerializer]
 public record GetWeatherForecastListGenericQuery :
     IMultiProjectionListQuery<WeatherForecastProjection, GetWeatherForecastListGenericQuery, WeatherForecastItem>,
     IWaitForSortableUniqueId,

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.EventSource/Queries/GetWeatherForecastListQuery.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.EventSource/Queries/GetWeatherForecastListQuery.cs
@@ -3,7 +3,6 @@ using Orleans;
 using Sekiban.Dcb.Queries;
 namespace Dcb.EventSource.Queries;
 
-[GenerateSerializer]
 public record GetWeatherForecastListQuery :
     IMultiProjectionListQuery<WeatherForecastProjection, GetWeatherForecastListQuery, WeatherForecastItem>,
     IWaitForSortableUniqueId,

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.EventSource/Queries/GetWeatherForecastListSingleQuery.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.EventSource/Queries/GetWeatherForecastListSingleQuery.cs
@@ -8,7 +8,6 @@ using Sekiban.Dcb.Tags;
 
 namespace Dcb.EventSource.Queries;
 
-[GenerateSerializer]
 public record GetWeatherForecastListSingleQuery :
     IMultiProjectionListQuery<WeatherForecastProjectorWithTagStateProjector, GetWeatherForecastListSingleQuery, WeatherForecastItem>,
     IWaitForSortableUniqueId,

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.EventSource/Queries/WeatherForecastCountResult.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.EventSource/Queries/WeatherForecastCountResult.cs
@@ -4,7 +4,6 @@ namespace Dcb.EventSource.Queries;
 /// <summary>
 /// Result containing weather forecast counts
 /// </summary>
-[GenerateSerializer]
 public record WeatherForecastCountResult(
     [property: Id(0)] int SafeVersion,
     [property: Id(1)] int UnsafeVersion,

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult.Aws/SekibanDcbOrleansAws.Domain/ClassRoom/AvailableClassRoomState.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult.Aws/SekibanDcbOrleansAws.Domain/ClassRoom/AvailableClassRoomState.cs
@@ -2,7 +2,6 @@ using Orleans;
 using Sekiban.Dcb.Tags;
 namespace Dcb.Domain.WithoutResult.ClassRoom;
 
-[GenerateSerializer]
 public record AvailableClassRoomState(Guid ClassRoomId, string Name, int MaxStudents, List<Guid> EnrolledStudentIds)
     : ITagStatePayload
 {

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult.Aws/SekibanDcbOrleansAws.Domain/ClassRoom/ClassRoomItem.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult.Aws/SekibanDcbOrleansAws.Domain/ClassRoom/ClassRoomItem.cs
@@ -5,7 +5,6 @@ namespace Dcb.Domain.WithoutResult.ClassRoom;
 /// <summary>
 /// Unified representation of a classroom for list display
 /// </summary>
-[GenerateSerializer]
 public record ClassRoomItem
 {
     [Id(0)]

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult.Aws/SekibanDcbOrleansAws.Domain/ClassRoom/FilledClassRoomState.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult.Aws/SekibanDcbOrleansAws.Domain/ClassRoom/FilledClassRoomState.cs
@@ -2,7 +2,6 @@ using Orleans;
 using Sekiban.Dcb.Tags;
 namespace Dcb.Domain.WithoutResult.ClassRoom;
 
-[GenerateSerializer]
 public record FilledClassRoomState(Guid ClassRoomId, string Name, List<Guid> EnrolledStudentIds, bool IsFull)
     : ITagStatePayload
 {

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult.Aws/SekibanDcbOrleansAws.Domain/Projections/WeatherForecastItem.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult.Aws/SekibanDcbOrleansAws.Domain/Projections/WeatherForecastItem.cs
@@ -4,7 +4,6 @@ namespace Dcb.Domain.WithoutResult.Projections;
 /// <summary>
 ///     Weather forecast item in projection
 /// </summary>
-[GenerateSerializer]
 public record WeatherForecastItem(
     [property: Id(0)]
     Guid ForecastId,

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult.Aws/SekibanDcbOrleansAws.Domain/Projections/WeatherForecastProjection.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult.Aws/SekibanDcbOrleansAws.Domain/Projections/WeatherForecastProjection.cs
@@ -12,7 +12,6 @@ namespace Dcb.Domain.WithoutResult.Projections;
 /// <summary>
 ///     Simple weather forecast projection for testing DualStateProjectionWrapper
 /// </summary>
-[GenerateSerializer]
 public record WeatherForecastProjection : IMultiProjector<WeatherForecastProjection>
 {
     /// <summary>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult.Aws/SekibanDcbOrleansAws.Domain/Queries/GetClassRoomListQuery.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult.Aws/SekibanDcbOrleansAws.Domain/Queries/GetClassRoomListQuery.cs
@@ -4,7 +4,6 @@ using Sekiban.Dcb.MultiProjections;
 using Sekiban.Dcb.Queries;
 namespace Dcb.Domain.WithoutResult.Queries;
 
-[GenerateSerializer]
 public record GetClassRoomListQuery :
     IMultiProjectionListQuery<GenericTagMultiProjector<ClassRoomProjector, ClassRoomTag>, GetClassRoomListQuery, ClassRoomItem>,
     IWaitForSortableUniqueId,

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult.Aws/SekibanDcbOrleansAws.Domain/Queries/GetStudentListQuery.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult.Aws/SekibanDcbOrleansAws.Domain/Queries/GetStudentListQuery.cs
@@ -4,7 +4,6 @@ using Sekiban.Dcb.MultiProjections;
 using Sekiban.Dcb.Queries;
 namespace Dcb.Domain.WithoutResult.Queries;
 
-[GenerateSerializer]
 public record GetStudentListQuery :
     IMultiProjectionListQuery<GenericTagMultiProjector<StudentProjector, StudentTag>, GetStudentListQuery, StudentState>,
     IWaitForSortableUniqueId,

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult.Aws/SekibanDcbOrleansAws.Domain/Queries/GetWeatherForecastCountGenericQuery.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult.Aws/SekibanDcbOrleansAws.Domain/Queries/GetWeatherForecastCountGenericQuery.cs
@@ -9,7 +9,6 @@ namespace Dcb.Domain.WithoutResult.Queries;
 /// <summary>
 /// Count query for GenericTagMultiProjector-based Weather
 /// </summary>
-[GenerateSerializer]
 public record GetWeatherForecastCountGenericQuery :
     IMultiProjectionQuery<GenericTagMultiProjector<WeatherForecastProjector, WeatherForecastTag>, GetWeatherForecastCountGenericQuery, WeatherForecastCountResult>,
     IWaitForSortableUniqueId

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult.Aws/SekibanDcbOrleansAws.Domain/Queries/GetWeatherForecastCountQuery.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult.Aws/SekibanDcbOrleansAws.Domain/Queries/GetWeatherForecastCountQuery.cs
@@ -7,7 +7,6 @@ namespace Dcb.Domain.WithoutResult.Queries;
 /// <summary>
 /// Query to get the total count of weather forecasts
 /// </summary>
-[GenerateSerializer]
 public record GetWeatherForecastCountQuery :
     IMultiProjectionQuery<WeatherForecastProjection, GetWeatherForecastCountQuery, WeatherForecastCountResult>,
     IWaitForSortableUniqueId

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult.Aws/SekibanDcbOrleansAws.Domain/Queries/GetWeatherForecastCountSingleQuery.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult.Aws/SekibanDcbOrleansAws.Domain/Queries/GetWeatherForecastCountSingleQuery.cs
@@ -7,7 +7,6 @@ namespace Dcb.Domain.WithoutResult.Queries;
 /// <summary>
 /// Count query for the TagState-based projector
 /// </summary>
-[GenerateSerializer]
 public record GetWeatherForecastCountSingleQuery :
     IMultiProjectionQuery<WeatherForecastProjectorWithTagStateProjector, GetWeatherForecastCountSingleQuery, WeatherForecastCountResult>,
     IWaitForSortableUniqueId

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult.Aws/SekibanDcbOrleansAws.Domain/Queries/GetWeatherForecastListGenericQuery.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult.Aws/SekibanDcbOrleansAws.Domain/Queries/GetWeatherForecastListGenericQuery.cs
@@ -6,7 +6,6 @@ using Sekiban.Dcb.Queries;
 
 namespace Dcb.Domain.WithoutResult.Queries;
 
-[GenerateSerializer]
 public record GetWeatherForecastListGenericQuery :
     IMultiProjectionListQuery<GenericTagMultiProjector<WeatherForecastProjector, WeatherForecastTag>, GetWeatherForecastListGenericQuery, WeatherForecastItem>,
     IWaitForSortableUniqueId,

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult.Aws/SekibanDcbOrleansAws.Domain/Queries/GetWeatherForecastListQuery.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult.Aws/SekibanDcbOrleansAws.Domain/Queries/GetWeatherForecastListQuery.cs
@@ -3,7 +3,6 @@ using Orleans;
 using Sekiban.Dcb.Queries;
 namespace Dcb.Domain.WithoutResult.Queries;
 
-[GenerateSerializer]
 public record GetWeatherForecastListQuery :
     IMultiProjectionListQuery<WeatherForecastProjection, GetWeatherForecastListQuery, WeatherForecastItem>,
     IWaitForSortableUniqueId,

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult.Aws/SekibanDcbOrleansAws.Domain/Queries/GetWeatherForecastListSingleQuery.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult.Aws/SekibanDcbOrleansAws.Domain/Queries/GetWeatherForecastListSingleQuery.cs
@@ -7,7 +7,6 @@ using Sekiban.Dcb.Tags;
 
 namespace Dcb.Domain.WithoutResult.Queries;
 
-[GenerateSerializer]
 public record GetWeatherForecastListSingleQuery :
     IMultiProjectionListQuery<WeatherForecastProjectorWithTagStateProjector, GetWeatherForecastListSingleQuery, WeatherForecastItem>,
     IWaitForSortableUniqueId,

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult.Aws/SekibanDcbOrleansAws.Domain/Queries/WeatherForecastCountResult.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult.Aws/SekibanDcbOrleansAws.Domain/Queries/WeatherForecastCountResult.cs
@@ -4,7 +4,6 @@ namespace Dcb.Domain.WithoutResult.Queries;
 /// <summary>
 /// Result containing weather forecast counts
 /// </summary>
-[GenerateSerializer]
 public record WeatherForecastCountResult(
     [property: Id(0)] int SafeVersion,
     [property: Id(1)] int UnsafeVersion,

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult.Aws/SekibanDcbOrleansAws.Domain/Student/StudentState.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult.Aws/SekibanDcbOrleansAws.Domain/Student/StudentState.cs
@@ -2,7 +2,6 @@ using Orleans;
 using Sekiban.Dcb.Tags;
 namespace Dcb.Domain.WithoutResult.Student;
 
-[GenerateSerializer]
 public record StudentState(Guid StudentId, string Name, int MaxClassCount, List<Guid> EnrolledClassRoomIds)
     : ITagStatePayload
 {

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult.Aws/SekibanDcbOrleansAws.Domain/Weather/WeatherForecastState.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult.Aws/SekibanDcbOrleansAws.Domain/Weather/WeatherForecastState.cs
@@ -2,7 +2,6 @@ using Orleans;
 using Sekiban.Dcb.Tags;
 namespace Dcb.Domain.WithoutResult.Weather;
 
-[GenerateSerializer]
 public record WeatherForecastState : ITagStatePayload
 {
     [Id(0)] public Guid ForecastId { get; init; }

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.Domain/ClassRoom/AvailableClassRoomState.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.Domain/ClassRoom/AvailableClassRoomState.cs
@@ -2,7 +2,6 @@ using Orleans;
 using Sekiban.Dcb.Tags;
 namespace Dcb.Domain.WithoutResult.ClassRoom;
 
-[GenerateSerializer]
 public record AvailableClassRoomState(Guid ClassRoomId, string Name, int MaxStudents, List<Guid> EnrolledStudentIds)
     : ITagStatePayload
 {

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.Domain/ClassRoom/ClassRoomItem.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.Domain/ClassRoom/ClassRoomItem.cs
@@ -5,7 +5,6 @@ namespace Dcb.Domain.WithoutResult.ClassRoom;
 /// <summary>
 /// Unified representation of a classroom for list display
 /// </summary>
-[GenerateSerializer]
 public record ClassRoomItem
 {
     [Id(0)]

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.Domain/ClassRoom/FilledClassRoomState.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.Domain/ClassRoom/FilledClassRoomState.cs
@@ -2,7 +2,6 @@ using Orleans;
 using Sekiban.Dcb.Tags;
 namespace Dcb.Domain.WithoutResult.ClassRoom;
 
-[GenerateSerializer]
 public record FilledClassRoomState(Guid ClassRoomId, string Name, List<Guid> EnrolledStudentIds, bool IsFull)
     : ITagStatePayload
 {

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.Domain/Projections/WeatherForecastItem.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.Domain/Projections/WeatherForecastItem.cs
@@ -4,7 +4,6 @@ namespace Dcb.Domain.WithoutResult.Projections;
 /// <summary>
 ///     Weather forecast item in projection
 /// </summary>
-[GenerateSerializer]
 public record WeatherForecastItem(
     [property: Id(0)]
     Guid ForecastId,

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.Domain/Projections/WeatherForecastProjection.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.Domain/Projections/WeatherForecastProjection.cs
@@ -12,7 +12,6 @@ namespace Dcb.Domain.WithoutResult.Projections;
 /// <summary>
 ///     Simple weather forecast projection for testing DualStateProjectionWrapper
 /// </summary>
-[GenerateSerializer]
 public record WeatherForecastProjection : IMultiProjector<WeatherForecastProjection>
 {
     /// <summary>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.Domain/Queries/GetClassRoomListQuery.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.Domain/Queries/GetClassRoomListQuery.cs
@@ -4,7 +4,6 @@ using Sekiban.Dcb.MultiProjections;
 using Sekiban.Dcb.Queries;
 namespace Dcb.Domain.WithoutResult.Queries;
 
-[GenerateSerializer]
 public record GetClassRoomListQuery :
     IMultiProjectionListQuery<GenericTagMultiProjector<ClassRoomProjector, ClassRoomTag>, GetClassRoomListQuery, ClassRoomItem>,
     IWaitForSortableUniqueId,

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.Domain/Queries/GetStudentListQuery.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.Domain/Queries/GetStudentListQuery.cs
@@ -4,7 +4,6 @@ using Sekiban.Dcb.MultiProjections;
 using Sekiban.Dcb.Queries;
 namespace Dcb.Domain.WithoutResult.Queries;
 
-[GenerateSerializer]
 public record GetStudentListQuery :
     IMultiProjectionListQuery<GenericTagMultiProjector<StudentProjector, StudentTag>, GetStudentListQuery, StudentState>,
     IWaitForSortableUniqueId,

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.Domain/Queries/GetWeatherForecastCountGenericQuery.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.Domain/Queries/GetWeatherForecastCountGenericQuery.cs
@@ -9,7 +9,6 @@ namespace Dcb.Domain.WithoutResult.Queries;
 /// <summary>
 /// Count query for GenericTagMultiProjector-based Weather
 /// </summary>
-[GenerateSerializer]
 public record GetWeatherForecastCountGenericQuery :
     IMultiProjectionQuery<GenericTagMultiProjector<WeatherForecastProjector, WeatherForecastTag>, GetWeatherForecastCountGenericQuery, WeatherForecastCountResult>,
     IWaitForSortableUniqueId

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.Domain/Queries/GetWeatherForecastCountQuery.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.Domain/Queries/GetWeatherForecastCountQuery.cs
@@ -7,7 +7,6 @@ namespace Dcb.Domain.WithoutResult.Queries;
 /// <summary>
 /// Query to get the total count of weather forecasts
 /// </summary>
-[GenerateSerializer]
 public record GetWeatherForecastCountQuery :
     IMultiProjectionQuery<WeatherForecastProjection, GetWeatherForecastCountQuery, WeatherForecastCountResult>,
     IWaitForSortableUniqueId

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.Domain/Queries/GetWeatherForecastCountSingleQuery.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.Domain/Queries/GetWeatherForecastCountSingleQuery.cs
@@ -7,7 +7,6 @@ namespace Dcb.Domain.WithoutResult.Queries;
 /// <summary>
 /// Count query for the TagState-based projector
 /// </summary>
-[GenerateSerializer]
 public record GetWeatherForecastCountSingleQuery :
     IMultiProjectionQuery<WeatherForecastProjectorWithTagStateProjector, GetWeatherForecastCountSingleQuery, WeatherForecastCountResult>,
     IWaitForSortableUniqueId

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.Domain/Queries/GetWeatherForecastListGenericQuery.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.Domain/Queries/GetWeatherForecastListGenericQuery.cs
@@ -6,7 +6,6 @@ using Sekiban.Dcb.Queries;
 
 namespace Dcb.Domain.WithoutResult.Queries;
 
-[GenerateSerializer]
 public record GetWeatherForecastListGenericQuery :
     IMultiProjectionListQuery<GenericTagMultiProjector<WeatherForecastProjector, WeatherForecastTag>, GetWeatherForecastListGenericQuery, WeatherForecastItem>,
     IWaitForSortableUniqueId,

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.Domain/Queries/GetWeatherForecastListQuery.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.Domain/Queries/GetWeatherForecastListQuery.cs
@@ -3,7 +3,6 @@ using Orleans;
 using Sekiban.Dcb.Queries;
 namespace Dcb.Domain.WithoutResult.Queries;
 
-[GenerateSerializer]
 public record GetWeatherForecastListQuery :
     IMultiProjectionListQuery<WeatherForecastProjection, GetWeatherForecastListQuery, WeatherForecastItem>,
     IWaitForSortableUniqueId,

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.Domain/Queries/GetWeatherForecastListSingleQuery.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.Domain/Queries/GetWeatherForecastListSingleQuery.cs
@@ -7,7 +7,6 @@ using Sekiban.Dcb.Tags;
 
 namespace Dcb.Domain.WithoutResult.Queries;
 
-[GenerateSerializer]
 public record GetWeatherForecastListSingleQuery :
     IMultiProjectionListQuery<WeatherForecastProjectorWithTagStateProjector, GetWeatherForecastListSingleQuery, WeatherForecastItem>,
     IWaitForSortableUniqueId,

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.Domain/Queries/WeatherForecastCountResult.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.Domain/Queries/WeatherForecastCountResult.cs
@@ -4,7 +4,6 @@ namespace Dcb.Domain.WithoutResult.Queries;
 /// <summary>
 /// Result containing weather forecast counts
 /// </summary>
-[GenerateSerializer]
 public record WeatherForecastCountResult(
     [property: Id(0)] int SafeVersion,
     [property: Id(1)] int UnsafeVersion,

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.Domain/Student/StudentState.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.Domain/Student/StudentState.cs
@@ -2,7 +2,6 @@ using Orleans;
 using Sekiban.Dcb.Tags;
 namespace Dcb.Domain.WithoutResult.Student;
 
-[GenerateSerializer]
 public record StudentState(Guid StudentId, string Name, int MaxClassCount, List<Guid> EnrolledClassRoomIds)
     : ITagStatePayload
 {

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.Domain/Weather/WeatherForecastState.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.Domain/Weather/WeatherForecastState.cs
@@ -2,7 +2,6 @@ using Orleans;
 using Sekiban.Dcb.Tags;
 namespace Dcb.Domain.WithoutResult.Weather;
 
-[GenerateSerializer]
 public record WeatherForecastState : ITagStatePayload
 {
     [Id(0)] public Guid ForecastId { get; init; }


### PR DESCRIPTION
## Summary
- Remove unnecessary `[GenerateSerializer]` attributes from domain types in `Dcb.Domain.WithoutResult`
- Apply the same cleanup to all template projects (Decider, Decider.Aws, WithoutResult, WithoutResult.Aws)
- Add `.worktrees/` to `.gitignore`

## Changes
This PR removes the `[GenerateSerializer]` Orleans attribute from:
- Projection types and items
- Query types and result records
- State records (AvailableClassRoomState, FilledClassRoomState, StudentState, WeatherForecastState)
- ClassRoomItem records

These attributes are not needed as Orleans can serialize these types without explicit generation markers.

## Test plan
- [ ] Verify template projects still build correctly
- [ ] Verify domain types serialize properly in Orleans grain communication

🤖 Generated with [Claude Code](https://claude.com/claude-code)