### PR TITLE
Add AOT-compatible Model packages for domain definitions

### DIFF
--- a/dcb/Sekiban.Dcb.slnx
+++ b/dcb/Sekiban.Dcb.slnx
@@ -7,6 +7,8 @@
   <Folder Name="/src/">
     <Project Path="src/Sekiban.Dcb.Core.Model/Sekiban.Dcb.Core.Model.csproj" />
     <Project Path="src/Sekiban.Dcb.Core/Sekiban.Dcb.Core.csproj" />
+    <Project Path="src/Sekiban.Dcb.WithResult.Model/Sekiban.Dcb.WithResult.Model.csproj" />
+    <Project Path="src/Sekiban.Dcb.WithoutResult.Model/Sekiban.Dcb.WithoutResult.Model.csproj" />
     <Project Path="src/Sekiban.Dcb.WithResult/Sekiban.Dcb.WithResult.csproj" />
     <Project Path="src/Sekiban.Dcb.WithoutResult/Sekiban.Dcb.WithoutResult.csproj" />
     <Project Path="src/Sekiban.Dcb.Orleans.Core/Sekiban.Dcb.Orleans.Core.csproj" />


### PR DESCRIPTION
## Summary

- Add `Sekiban.Dcb.WithResult.Model` and `Sekiban.Dcb.WithoutResult.Model` packages for AOT-compatible domain definitions
- Move core command and tag types to `Sekiban.Dcb.Core.Model` for minimal dependency footprint
- Fix NuGet package workflow to include the new Model packages in builds

## Changes

### New Packages
- **Sekiban.Dcb.WithResult.Model**: Minimal package with command handlers and multi-projector interfaces (with ResultBox)
- **Sekiban.Dcb.WithoutResult.Model**: Same interfaces without ResultBox dependency

### Core.Model Enhancements
- Moved `ICommand`, `ICoreCommandContext`, and related types from Core to Core.Model
- These types now have zero external dependencies, enabling AOT compilation

### Build Fixes
- Added new Model projects to `Sekiban.Dcb.slnx` to fix CI build failures
- Updated NuGet package workflow to include the new packages

## Test plan
- [x] Local build succeeds with `dotnet build dcb/Sekiban.Dcb.slnx -c Release`
- [x] All tests pass
- [ ] CI/CD pipeline builds and packages successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)