### PR TITLE
Add multi-tenant ServiceId design docs

### DIFF
--- a/tasks/service-deployable-design/review-claude.md
+++ b/tasks/service-deployable-design/review-claude.md
@@ -1,0 +1,244 @@
+# Claude Review: Sekiban DCB Multi-Tenant ServiceId Design
+
+## Executive Summary
+
+This review evaluates the multi-tenant ServiceId design for Sekiban DCB storage. The design is well-structured and addresses the core requirements for SaaS deployment. The improvement document provides valuable refinements that should be incorporated. Overall assessment: **Approved with required changes**.
+
+---
+
+## Document Quality Assessment
+
+### Base Design (`sekiban-dcb-multitenant-serviceid-design.md`)
+
+**Strengths**:
+- Clear scope definition with explicit non-goals
+- Comprehensive coverage of both Cosmos DB and Postgres providers
+- Well-considered DI registration patterns for different deployment scenarios
+- Risk/trade-off section demonstrates mature engineering thinking
+
+**Areas for Improvement**:
+- Open questions should be resolved before implementation begins
+- Migration strategy needs a clear recommendation rather than four options
+
+### Improvement Document (`sekiban-dcb-multitenant-serviceid-improvement.md`)
+
+**Strengths**:
+- Addresses critical gaps in the base design
+- Provides concrete validation rules and code examples
+- Clear recommendations with rationale
+
+**Note**: Written in Japanese, which is acceptable for internal discussion but should be consolidated into English for the final design per project guidelines.
+
+---
+
+## Critical Review Points
+
+### 1. ServiceId Specification - MUST RESOLVE
+
+**Issue**: ServiceId format is listed as an open question but is foundational to the design.
+
+**Required Decision**:
+```
+Pattern: ^[a-z0-9-]{1,64}$
+Allowed: lowercase letters, digits, hyphens
+Forbidden: | / (space) (control chars)
+```
+
+**Implementation Requirement**: `IServiceIdProvider.GetCurrentServiceId()` must validate and normalize (lowercase) input before returning.
+
+**Failure Mode**: Without validation, a ServiceId containing `|` would corrupt the composite partition key `"{serviceId}|{key}"`.
+
+### 2. Default Fallback Behavior - MUST CHANGE
+
+**Current Design**:
+```
+HTTP + Orleans → Fallback to DefaultServiceIdProvider when HTTP context missing
+```
+
+**Problem**: Silent fallback enables accidental writes to `default` tenant from:
+- Background jobs
+- Message handlers
+- Misconfigured Orleans grains
+- Timer callbacks
+
+**Required Change**:
+```csharp
+// Replace DefaultServiceIdProvider fallback with:
+public sealed class RequiredServiceIdProvider : IServiceIdProvider
+{
+    public string GetCurrentServiceId() =>
+        throw new InvalidOperationException(
+            "ServiceId must be explicitly provided. " +
+            "Use FixedServiceIdProvider for background operations.");
+}
+```
+
+### 3. Cosmos DB Container Routing - NEEDS CLARIFICATION
+
+**Current Design**: Four migration options without clear recommendation.
+
+**Required Clarification**:
+| Tenant | Container Set | Rationale |
+|--------|---------------|-----------|
+| `default` | Legacy (`/id`, `/tag`, `/partitionKey`) | Backward compatibility |
+| All others | v2 (`/pk`) | Clean multi-tenant design |
+
+**Implementation**: Add explicit routing interface:
+```csharp
+public interface ICosmosContainerResolver
+{
+    string ResolveEventsContainer(string serviceId);
+    string ResolveTagsContainer(string serviceId);
+    string ResolveStatesContainer(string serviceId);
+}
+```
+
+### 4. Postgres Constraint Gaps - MUST ADDRESS
+
+**Base Design Gap**: Focuses on indexes but omits UNIQUE/PRIMARY KEY constraint updates.
+
+**Required Schema Changes**:
+```sql
+-- events: ensure tenant isolation
+ALTER TABLE events DROP CONSTRAINT events_pkey;
+ALTER TABLE events ADD PRIMARY KEY (service_id, id);
+
+-- tags: prevent cross-tenant collision
+ALTER TABLE tags DROP CONSTRAINT IF EXISTS tags_unique;
+ALTER TABLE tags ADD CONSTRAINT tags_unique
+    UNIQUE (service_id, tag, sortable_unique_id);
+
+-- multi_projection_states: tenant-scoped uniqueness
+ALTER TABLE multi_projection_states DROP CONSTRAINT IF EXISTS mps_unique;
+ALTER TABLE multi_projection_states ADD CONSTRAINT mps_unique
+    UNIQUE (service_id, projector_name);
+```
+
+**Migration Order**: Constraint changes must be applied BEFORE deploying application changes to prevent duplicate key violations.
+
+---
+
+## Design Validation
+
+### Scenario: Single-Tenant Deployment
+- Uses `DefaultServiceIdProvider` returning `"default"`
+- No code changes required for existing users
+- **Verdict**: ✅ Supported
+
+### Scenario: Multi-Tenant HTTP API
+- Uses `JwtServiceIdProvider` scoped per request
+- ServiceId extracted from JWT claim
+- **Verdict**: ✅ Supported (with validation requirement)
+
+### Scenario: Orleans Grain with ServiceId
+- Grain key format: `"{serviceId}/{entityId}"`
+- Factory creates `FixedServiceIdProvider` at activation
+- **Verdict**: ✅ Supported
+
+### Scenario: Background Job Processing
+- **Current Design**: Falls back to `default`
+- **After Fix**: Throws exception, requires explicit ServiceId
+- **Verdict**: ⚠️ Requires implementation change
+
+### Scenario: Cross-Tenant Admin Query
+- Listed as open question
+- **Recommendation**: Create separate admin-only interface, not exposed via standard `IEventStore`
+- **Verdict**: ⏳ Deferred (acceptable)
+
+---
+
+## Testing Requirements
+
+### Unit Tests (Required Before Merge)
+1. ServiceId validation - accept valid, reject invalid patterns
+2. ServiceId normalization - uppercase input converted to lowercase
+3. `RequiredServiceIdProvider` throws `InvalidOperationException`
+4. Container routing - `default` → legacy, others → v2
+
+### Integration Tests (Required Before Release)
+1. Write event with ServiceId A, verify not readable with ServiceId B
+2. Tag query isolation between tenants
+3. Multi-projection state isolation
+4. Orleans grain ServiceId extraction from compound key
+
+### Migration Tests (Required Before Production)
+1. Cosmos: Data copied correctly with new partition keys
+2. Cosmos: Legacy container still works for `default` tenant
+3. Postgres: Constraint migration successful with existing data
+4. Postgres: `service_id='default'` applied to existing rows
+
+---
+
+## Implementation Checklist
+
+### Phase 1: Core Interfaces (Week 1)
+- [ ] Add `IServiceIdProvider` to `Sekiban.Dcb.Core`
+- [ ] Implement `DefaultServiceIdProvider` with validation
+- [ ] Implement `FixedServiceIdProvider` with validation
+- [ ] Implement `RequiredServiceIdProvider` (throws)
+- [ ] Add `IEventStoreFactory` and `IMultiProjectionStateStoreFactory`
+
+### Phase 2: Cosmos DB (Week 2)
+- [ ] Add `pk`, `serviceId` fields to Cosmos models
+- [ ] Implement `ICosmosContainerResolver`
+- [ ] Update `CosmosDbEventStore` with ServiceId filtering
+- [ ] Update `CosmosDbMultiProjectionStateStore`
+- [ ] Implement `CosmosDbEventStoreFactory`
+- [ ] Update container creation with composite indexes
+
+### Phase 3: Postgres (Week 2-3)
+- [ ] Add `service_id` column with migration script
+- [ ] Update UNIQUE/PK constraints
+- [ ] Update all queries with ServiceId filter
+- [ ] Implement `PostgresEventStoreFactory`
+- [ ] (Optional) Add RLS policy
+
+### Phase 4: DI and Testing (Week 3)
+- [ ] Add extension methods per deployment pattern
+- [ ] Implement `JwtServiceIdProvider`
+- [ ] Write unit tests
+- [ ] Write integration tests
+- [ ] Create migration documentation
+
+---
+
+## Comparison with OpenCode Review
+
+The existing `review-opencode.md` covers similar ground. Key differences in this review:
+
+| Topic | OpenCode Review | This Review |
+|-------|-----------------|-------------|
+| ServiceId validation | Recommends adoption | Marks as MUST RESOLVE |
+| Fallback behavior | `MissingServiceIdProvider` | `RequiredServiceIdProvider` (same concept) |
+| Container routing | `ICosmosContainerResolver` | Same recommendation |
+| Postgres constraints | Lists required changes | Provides SQL examples |
+| Implementation priority | P0/P1/P2 table | Phase-based checklist |
+
+**Alignment**: Both reviews agree on critical issues. This review adds concrete SQL examples and a phased implementation plan.
+
+---
+
+## Final Recommendations
+
+1. **Merge the improvement proposals** into the base design document
+2. **Resolve open questions** before implementation:
+   - ServiceId format: Use `^[a-z0-9-]{1,64}$`
+   - Admin cross-tenant API: Defer to separate design
+   - Postgres RLS: Keep optional
+3. **Implement in phases** to enable incremental validation
+4. **Consolidate documentation** into English per project guidelines
+5. **Add ServiceId to observability**: Logs, metrics, and traces should include ServiceId for debugging tenant-specific issues
+
+---
+
+## Verdict
+
+**Approved with Required Changes**
+
+The design is sound and ready for implementation after addressing:
+1. ✅ ServiceId validation rules (adopt improvement proposal)
+2. ✅ Default fallback replacement (adopt improvement proposal)
+3. ✅ Container routing clarification (add interface)
+4. ✅ Postgres constraint updates (add to schema migration)
+
+No fundamental architectural changes required. Proceed to implementation with the noted refinements.

--- a/tasks/service-deployable-design/review-opencode.md
+++ b/tasks/service-deployable-design/review-opencode.md
@@ -1,0 +1,133 @@
+# Review: Sekiban DCB Multi-Tenant ServiceId Design & Improvement
+
+## Overview
+
+The design documents provide a comprehensive approach to implementing multi-tenant isolation for Sekiban DCB storage through ServiceId abstraction. This review covers both the base design and the improvement recommendations.
+
+---
+
+## Strengths
+
+### Architecture
+- **Clean abstraction**: `IServiceIdProvider` interface enables pluggable tenant resolution (default, fixed, JWT)
+- **Domain model preserved**: ServiceId remains storage-only, avoiding pollution of `Event` and `Tag` entities
+- **Backwards compatibility**: Single-tenant deployments continue working without code changes
+- **Factory pattern for Orleans**: `IEventStoreFactory` enables grain-scoped store creation
+
+### Cosmos DB Design
+- **Composite partition key strategy**: `"{serviceId}|{key}"` avoids hot partitions for the default tenant
+- **Explicit routing**: Recommendation to limit legacy containers to `default` tenant only prevents mixing concerns
+- **Parameterization**: Mandating `QueryDefinition` over string interpolation prevents injection risks
+
+### Postgres Design
+- **Online schema evolution**: Additive changes with default values minimize downtime
+- **Constraint awareness**: Improvement doc correctly identifies need to include `service_id` in UNIQUE/PK constraints
+- **Optional RLS**: Row-Level Security available for high-risk SaaS scenarios without forcing overhead on all users
+
+---
+
+## Critical Issues & Recommendations
+
+### 1. ServiceId Validation (HIGH PRIORITY)
+
+**Gap**: Base design acknowledges ServiceId format as an "Open Question" but doesn't mandate validation.
+
+**Recommendation**: Adopt improvement proposal's validation rules immediately:
+```
+Format: ^[a-z0-9-]{1,64}$
+- Characters: a-z, 0-9, hyphen only
+- Length: 1-64 characters
+- Forbidden: |, /, whitespace, control characters
+```
+
+**Rationale**: Without strict validation, the composite partition key `"{serviceId}|{key}"` risks collision if ServiceId contains the delimiter.
+
+### 2. Default ServiceId Fallback Risk (HIGH PRIORITY)
+
+**Gap**: Base design's "Combined (HTTP + Orleans)" pattern falls back to `DefaultServiceIdProvider` when HTTP context is absent.
+
+**Risk**: Background jobs or misconfigured Orleans grains could inadvertently write to `default` tenant.
+
+**Recommendation**: Implement `MissingServiceIdProvider` as suggested in improvement doc:
+```csharp
+public sealed class MissingServiceIdProvider : IServiceIdProvider
+{
+    public string GetCurrentServiceId() => throw new InvalidOperationException(
+        "ServiceId is required in non-HTTP context");
+}
+```
+
+### 3. Cosmos DB Migration Complexity (MEDIUM PRIORITY)
+
+**Gap**: Four migration options provided but no clear default recommendation.
+
+**Recommendation**: Standardize on "Side-by-side (new SaaS tenants)" approach:
+- `default` tenant → legacy containers (backward compatibility)
+- All other tenants → v2 containers with `/pk` partition key
+
+**Implementation**: Create `ICosmosContainerResolver` interface to route ServiceId to appropriate container names.
+
+### 4. Query Correctness Verification (MEDIUM PRIORITY)
+
+**Gap**: Every query must include ServiceId filter; missing filters cause data leakage.
+
+**Mitigation in design**: Defense-in-depth checks (verify ServiceId on read).
+
+**Additional recommendation**: 
+- Add ServiceId predicate enforcement at the repository layer
+- Consider code analyzer or unit test that verifies all queries include ServiceId filter
+- Integration tests must verify cross-tenant data isolation
+
+### 5. Postgres Constraint Updates (MEDIUM PRIORITY)
+
+**Gap**: Base design mentions indexes but doesn't emphasize UNIQUE/PK constraint changes.
+
+**Required changes**:
+- `events`: `PRIMARY KEY (service_id, id)` or keep `id` unique with composite index
+- `tags`: `UNIQUE (service_id, tag, sortable_unique_id)`
+- `multi_projection_states`: `UNIQUE (service_id, projector_name)`
+
+**Migration order**: Update constraints BEFORE deploying application changes to prevent duplicate key errors.
+
+---
+
+## Minor Suggestions
+
+### Documentation
+- Add concrete code example for grain key parsing: `"{serviceId}/{entityId}"`
+- Document performance implications: composite indexes add write overhead but prevent cross-tenant leaks
+
+### Testing
+- Add test case: ServiceId with special characters (should fail validation)
+- Add test case: Verify Orleans grain using `FixedServiceIdProvider` cannot access other tenants' data
+
+### Operational
+- Provide migration script template for Cosmos DB data copy
+- Document monitoring query to detect cross-tenant access attempts (Postgres RLS log analysis)
+
+---
+
+## Implementation Priority
+
+| Priority | Item | Effort | Impact |
+|----------|------|--------|--------|
+| P0 | ServiceId validation | Small | Prevents data corruption |
+| P0 | Remove default fallback | Small | Prevents accidental writes |
+| P1 | Cosmos container routing | Medium | Enables safe migration |
+| P1 | Postgres constraint updates | Medium | Prevents tenant collisions |
+| P2 | Query verification tests | Medium | Catches developer errors |
+| P2 | Migration tooling | Large | Operational readiness |
+
+---
+
+## Summary
+
+The design provides a solid foundation for multi-tenant isolation. The improvement document addresses the most critical gaps (validation, fallback behavior, routing clarity). 
+
+**Key action items**:
+1. Implement strict ServiceId validation before any storage operations
+2. Replace implicit default fallback with explicit exception-throwing provider
+3. Build container routing layer for Cosmos DB to enforce legacy/v2 separation
+4. Update Postgres constraints to include `service_id` before application deployment
+
+With these changes, the design achieves both safety (preventing data leaks and corruption) and practicality (supporting gradual migration without breaking existing deployments).

--- a/tasks/service-deployable-design/sekiban-dcb-multitenant-serviceid-design.md
+++ b/tasks/service-deployable-design/sekiban-dcb-multitenant-serviceid-design.md
@@ -1,0 +1,350 @@
+# Sekiban DCB Multi-Tenant ServiceId Design
+
+## Status
+Draft
+
+## Purpose
+Enable multi-tenant (service/tenant) isolation for Sekiban DCB storage while keeping existing single-tenant deployments working. The design adds a ServiceId abstraction and scopes storage operations by tenant, primarily for SekibanAsAService.
+
+## Scope
+- DCB Core: add ServiceId provider and factory interfaces.
+- Cosmos DB provider: add ServiceId-aware partition key, models, queries, and container configuration.
+- Postgres provider: add ServiceId columns, indexes, and query filters.
+- DI patterns for single-tenant, HTTP API multi-tenant, and Orleans grain usage.
+- Migration strategy for Cosmos DB and Postgres.
+
+## Non-Goals
+- No change to domain objects (`Event`, `Tag`) to carry ServiceId.
+- No new authentication/authorization framework design (only ServiceId extraction point).
+- No changes to non-DCB packages (Pure, TS).
+
+## Terminology
+- ServiceId: tenant identifier used to isolate data.
+- Tenant: a service/customer in SekibanAsAService.
+- Composite partition key (PK): `"{serviceId}|{originalKey}"`.
+
+## Requirements
+1. All storage reads/writes must be scoped to the current ServiceId.
+2. Existing single-tenant deployments must keep working without code changes.
+3. Orleans grains must be able to create ServiceId-scoped stores from grain keys.
+4. Cosmos DB partition keys must avoid hot partitions for the default tenant.
+5. ServiceId must be validated and normalized before use.
+
+## High-Level Design
+### 1) ServiceId Provider (Core)
+Introduce a small interface in `Sekiban.Dcb.Core/ServiceId`:
+
+```csharp
+public interface IServiceIdProvider
+{
+    string GetCurrentServiceId(); // never null/empty
+}
+```
+
+Implementations:
+- `DefaultServiceIdProvider`: returns `"default"` (single-tenant). Keep a public constant `DefaultServiceId = "default"` for reuse.
+- `FixedServiceIdProvider`: returns a fixed ServiceId (used by grains).
+- `JwtServiceIdProvider`: extracts ServiceId from a JWT claim via `IHttpContextAccessor`. Claim type should be configurable (default: `"service_id"`).
+- `RequiredServiceIdProvider`: throws `InvalidOperationException` when ServiceId is missing (use for non-HTTP contexts where explicit ServiceId is required).
+
+Notes:
+- Multi-tenant usage should register `IServiceIdProvider` as scoped.
+- The provider must throw on null/empty ServiceId.
+- Providers must validate and normalize ServiceId before returning.
+
+#### 1.1 ServiceId Validation (Resolved)
+Adopt strict validation to protect composite PK and query safety.
+
+**Rules**:
+- Pattern: `^[a-z0-9-]{1,64}$`
+- Normalize: lowercase
+- Forbidden: `|`, `/`, whitespace, control characters
+
+**Rationale**:
+- Prevents composite PK collisions with `"{serviceId}|{key}"`.
+- Ensures safe routing and logging.
+
+### 2) Event Store Factory (Core)
+Grains need a factory to create ServiceId-scoped stores:
+
+```csharp
+public interface IEventStoreFactory
+{
+    IEventStore CreateForService(string serviceId);
+}
+
+public interface IMultiProjectionStateStoreFactory
+{
+    IMultiProjectionStateStore CreateForService(string serviceId);
+}
+```
+
+### 3) Cosmos DB Changes
+#### 3.1 Models
+Add `pk` and `serviceId` to all Cosmos documents:
+- `CosmosEvent`: `pk = "{serviceId}|{eventId}"`
+- `CosmosTag`: `pk = "{serviceId}|{tag}"`
+- `CosmosMultiProjectionState`: `pk = "{serviceId}|{partitionKey}"`
+
+The domain objects remain unchanged. ServiceId is storage-only.
+Keep existing `partitionKey` fields where present for compatibility with current logic, but use `pk` for the actual Cosmos partition key.
+
+#### 3.2 Partition Key Strategy
+Change all Cosmos containers to use `/pk` as the partition key path.
+
+Container PK mapping:
+- events: `/pk` with `"{serviceId}|{eventId}"`
+- tags: `/pk` with `"{serviceId}|{tag}"`
+- multiProjectionStates: `/pk` with `"{serviceId}|MultiProjectionState_{projectorName}"`
+
+Rationale:
+- Avoid hierarchical PK with a fixed first key (`serviceId`) that would cause hot partitions for `default`.
+- Allow cross-tenant queries via WHERE when needed (admin use only).
+
+#### 3.3 CosmosDbContext
+Update container creation to use `/pk` and add composite indexes:
+- events: index on `serviceId` + `sortableUniqueId`
+- tags: index on `serviceId` + `tag` + `sortableUniqueId`
+
+Add options to `CosmosDbEventStoreOptions`:
+- `EventsContainerName`, `TagsContainerName`, `MultiProjectionStatesContainerName`
+- `UseLegacyPartitionKeyPaths` (default: false)
+  - When true, keep legacy PK paths (`/id`, `/tag`, `/partitionKey`) for existing containers.
+  - Multi-tenant usage: legacy paths are allowed only for `serviceId == "default"`.
+
+#### 3.4 CosmosDbEventStore
+Inject `IServiceIdProvider` and apply ServiceId everywhere:
+- ReadAllEventsAsync: filter by `serviceId`.
+- ReadEventAsync: partition key = `"{serviceId}|{eventId}"` and verify ServiceId.
+- ReadEventsByTagAsync: use `"{serviceId}|{tag}"` PK for tag query, then read events by `"{serviceId}|{eventId}"` PK.
+- WriteEventsAsync: include ServiceId in CosmosEvent and PK.
+- WriteTagsWithBatchAsync: group by ServiceId-aware tag PK and include ServiceId in CosmosTag.
+- Tag-related queries (`GetAllTagsAsync`, `GetLatestTagAsync`, `TagExistsAsync`) must filter by ServiceId.
+- Prefer `QueryDefinition` parameters (not string interpolation) to avoid escaping issues.
+
+#### 3.5 CosmosDbMultiProjectionStateStore
+Apply `IServiceIdProvider` and composite PK for multi-projection state reads/writes:
+- `pk = "{serviceId}|{partitionKey}"` for storage.
+- Filter reads by `serviceId` where queries exist.
+
+#### 3.6 Cosmos Container Routing (Resolved)
+Adopt explicit routing to prevent legacy/v2 mixing.
+
+**Rule**:
+- `serviceId == "default"` → legacy containers (old PK paths)
+- All other ServiceIds → v2 containers (`/pk`)
+
+**Interface**:
+```csharp
+public interface ICosmosContainerResolver
+{
+    string ResolveEventsContainer(string serviceId);
+    string ResolveTagsContainer(string serviceId);
+    string ResolveStatesContainer(string serviceId);
+}
+```
+
+#### 3.7 Cosmos DB Factory Implementations
+Add factory types similar to:
+- `CosmosDbEventStoreFactory`
+- `CosmosDbMultiProjectionStateStoreFactory`
+
+Each factory constructs a store with a `FixedServiceIdProvider`.
+
+### 4) Postgres Changes
+Postgres supports online schema evolution; use columns + indexes.
+
+#### 4.1 Schema
+Add `service_id` columns with default `"default"`:
+- `events`: add `service_id`, index on `service_id`, and composite index on `(service_id, sortable_unique_id)`
+- `tags`: add `service_id`, index on `(service_id, tag)` and `(service_id, tag, sortable_unique_id)`
+- `multi_projection_states`: add `service_id`, index on `(service_id, projector_name)`
+
+Update UNIQUE/PK constraints to include `service_id` where needed:
+- `events`: consider `PRIMARY KEY (service_id, id)` if `id` is only unique within a tenant.
+- `tags`: `UNIQUE (service_id, tag, sortable_unique_id)`
+- `multi_projection_states`: `UNIQUE (service_id, projector_name)`
+ 
+Migration order: apply constraint changes **before** deploying application changes to avoid cross-tenant collisions during rollout.
+
+#### 4.2 Query Changes
+Inject `IServiceIdProvider` and add `service_id` filters to all reads and writes.
+
+#### 4.3 Factory
+Provide `PostgresEventStoreFactory` to construct ServiceId-scoped stores (for grains).
+
+#### 4.4 Optional Row-Level Security
+Optionally enable RLS to enforce tenant isolation at the DB level:
+- `USING (service_id = current_setting('app.service_id'))`
+
+### 5) DI Registration Patterns
+#### Single-Tenant (default)
+- Register `DefaultServiceIdProvider` as singleton.
+- Register `IEventStore` and `IMultiProjectionStateStore` as singleton.
+- Suggested extension method name: `AddSekibanDcbCosmosDb`.
+
+#### Multi-Tenant HTTP API
+- Register `IHttpContextAccessor`.
+- Register `JwtServiceIdProvider` as scoped.
+- Register stores as scoped (new instance per request).
+- Suggested extension method name: `AddSekibanDcbCosmosDbMultiTenant` with `serviceIdClaimType` parameter.
+
+#### Orleans Grains
+- Register `IEventStoreFactory` and `IMultiProjectionStateStoreFactory` as singleton.
+- Grains extract ServiceId from grain key and create a fixed store at activation.
+- Suggested extension method name: `AddSekibanDcbCosmosDbWithFactories`.
+
+#### Combined (HTTP + Orleans)
+- Factories as singleton.
+- `IServiceIdProvider` as scoped: use JWT if HTTP context exists, else use `RequiredServiceIdProvider` to force explicit ServiceId in non-HTTP contexts.
+- Stores as scoped.
+- Suggested extension method name: `AddSekibanDcbCosmosDbFull`.
+
+## Migration Strategy
+### Cosmos DB Constraints
+Cosmos DB does not allow changing partition key paths on existing containers. Migration is required.
+
+### Options
+1) New containers with `/pk` (recommended for SaaS)
+- Create `events_v2`, `tags_v2`, `multiProjectionStates_v2`.
+- Migrate data from old containers.
+- Switch app config to new container names.
+
+2) New database
+- Create a new DB with the new containers.
+- Update connection strings.
+
+3) Dual-write (zero-downtime)
+- Temporarily write to both old and new containers.
+- Read from old during backfill; switch to new after verification.
+
+4) Side-by-side (recommended for new SaaS tenants)
+- Keep legacy containers for `default` tenant.
+- Use new containers for new tenants.
+  - Achieve with `UseLegacyPartitionKeyPaths = true` for legacy paths or by using container name overrides for v2 containers.
+
+### Recommended Default
+Adopt **side-by-side** for SaaS:
+- `default` → legacy containers (backward compatibility)
+- others → v2 containers (`/pk`)
+This avoids breaking existing deployments while enabling safe multi-tenant rollout.
+
+### Postgres
+Schema changes are additive and online. Existing rows get `service_id = 'default'` automatically.
+
+## Benefits
+- Strong tenant isolation at the storage layer without changing domain models.
+- Backwards compatibility for existing single-tenant deployments.
+- Cosmos DB partition key design avoids hot partitions for the default tenant.
+- Clear support for Orleans grain activation and ServiceId scoping.
+- Extensible to multiple storage backends.
+
+## Risks and Trade-offs
+1) Cosmos migration complexity
+- Requires new containers or database; data copy is operationally heavy.
+- Risk of mismatched data if migration is partial or fails mid-way.
+
+2) Query correctness risk
+- Every query must include ServiceId filter; missing filters can leak data.
+- Mitigation: defense-in-depth checks (e.g., read item verifies ServiceId).
+
+3) Partition key changes
+- Old containers cannot be reused with new `/pk` path.
+- Side-by-side increases operational footprint.
+
+4) Performance considerations
+- Additional filtering by ServiceId adds query predicates and may affect RU usage.
+- Composite indexes should mitigate common queries.
+
+5) DI lifetime complexity
+- Incorrect DI scope (singleton vs scoped) can cause ServiceId leakage.
+
+6) Optional RLS (Postgres)
+- Improves isolation but adds operational and performance overhead.
+ 
+7) Cosmos query parameterization
+- String interpolation in SQL queries risks escaping issues if ServiceId contains special characters.
+- Mitigation: use `QueryDefinition` parameters for ServiceId and sortable IDs.
+
+8) Observability gap
+- Without ServiceId in logs/metrics/traces, tenant-specific incidents are hard to triage.
+- Mitigation: include ServiceId in structured logs and metrics labels (where safe).
+
+## Rollout Plan (Suggested)
+1) Add Core interfaces and default implementations.
+2) Update Cosmos models and context with `/pk` support and options.
+3) Update Cosmos event store queries and tag writes with ServiceId.
+4) Add factories and DI patterns.
+5) Update Postgres schema and queries.
+6) Provide migration tools or scripts for Cosmos.
+7) Deploy to staging with a sample multi-tenant workload.
+8) Add observability: include ServiceId in logs/metrics/traces.
+
+## Testing Plan
+- Unit tests for ServiceId providers (default, fixed, JWT, required).
+- ServiceId validation tests: accept valid, reject invalid, normalize to lowercase.
+- Container routing tests: `default` → legacy, others → v2.
+- Integration tests per provider:
+  - Writes/reads scoped to ServiceId.
+  - Cross-tenant data isolation.
+  - Tag queries scoped to ServiceId.
+  - Multi-projection state isolation.
+- Migration tests:
+  - Data copied from legacy containers to v2 containers.
+  - Counts and spot-checks match.
+  - Postgres constraint migration with existing data.
+
+### Query Correctness Guardrails (Recommended)
+- Add unit tests or static checks to ensure all queries include ServiceId filters.
+- Consider a thin repository layer that enforces ServiceId predicates centrally.
+
+## Open Questions
+1) Whether to enforce ServiceId in all tag list queries via SDK LINQ vs SQL.
+2) Whether to add explicit admin-only cross-tenant query APIs (recommended to be separate from `IEventStore`).
+3) Whether to enable Postgres RLS by default or keep it optional.
+
+## Implementation Priority
+- P0: ServiceId validation and normalization.
+- P0: Replace default fallback with `RequiredServiceIdProvider` for non-HTTP contexts.
+- P1: Cosmos container routing via `ICosmosContainerResolver`.
+- P1: Postgres constraint updates including `service_id`.
+- P2: Query correctness guardrails and migration tooling.
+
+## Implementation Checklist (Phased)
+### Phase 1: Core Interfaces
+- Add `IServiceIdProvider` and implementations (`Default`, `Fixed`, `Jwt`, `Required`).
+- Add `IEventStoreFactory` and `IMultiProjectionStateStoreFactory`.
+- Add ServiceId validation/normalization.
+
+### Phase 2: Cosmos DB
+- Add `pk`/`serviceId` to Cosmos models.
+- Implement `ICosmosContainerResolver` and routing.
+- Update `CosmosDbEventStore` and `CosmosDbMultiProjectionStateStore` to use ServiceId and parameterized queries.
+- Add composite indexes and options for container naming/legacy paths.
+
+### Phase 3: Postgres
+- Add `service_id` column and indexes.
+- Update UNIQUE/PK constraints to include `service_id`.
+- Update all queries with ServiceId filtering.
+- Implement `PostgresEventStoreFactory`.
+
+### Phase 4: DI and Tests
+- Add DI extension methods per deployment pattern.
+- Add unit/integration tests described above.
+- Add migration documentation and scripts.
+
+## Appendix: Example Grain Pattern
+- Grain key contains `"{serviceId}/{entityId}"`.
+- `OnActivateAsync`: extract ServiceId from the prefix before `/`.
+- If no `/` exists, fallback to `DefaultServiceIdProvider.DefaultServiceId` for single-tenant compatibility.
+
+## Appendix: Example Options
+```csharp
+public class CosmosDbEventStoreOptions
+{
+    public string EventsContainerName { get; set; } = "events";
+    public string TagsContainerName { get; set; } = "tags";
+    public string MultiProjectionStatesContainerName { get; set; } = "multiProjectionStates";
+    public bool UseLegacyPartitionKeyPaths { get; set; } = false;
+}
+```

--- a/tasks/service-deployable-design/sekiban-dcb-multitenant-serviceid-improvement.md
+++ b/tasks/service-deployable-design/sekiban-dcb-multitenant-serviceid-improvement.md
@@ -1,0 +1,115 @@
+# 改善案（推奨）: ServiceId マルチテナント設計
+
+## 目的
+既存設計のリスク（PK衝突、legacy混在、ルーティング不明確、Postgres制約漏れ、defaultへの誤書き込み）を最小化しつつ、現在の情報だけで最も実装可能性が高い推奨構成を示す。
+
+## 推奨方針（結論）
+1) **ServiceId を厳格に正規化・検証**し、PK構成子として安全に利用できる形式に限定する。
+2) **Cosmos は新規テナントを常に /pk コンテナへ**、legacy は **`default` だけ**に限定し、明示的ルーティングで混在を排除する。
+3) **Cosmos の SQL は必ずパラメータ化**して ServiceId を埋め込みで使わない。
+4) **Postgres のユニーク制約・PKに service_id を含める**（必要箇所のみ）ことでテナント衝突を防ぐ。
+5) **非HTTPコンテキストでの default への暗黙書き込みを禁止**し、明示 ServiceId を必須化する。
+
+この組み合わせが、運用事故とデータリークの確率を最小化しつつ、段階移行を可能にする現実的な最短ルート。
+
+---
+
+## 1. ServiceId 仕様（必須）
+**推奨ルール**
+- 文字種: `a-z`, `0-9`, `-` のみ（小文字化）
+- 長さ: 1〜64
+- 禁止文字: `|`, `/`, 空白, 制御文字
+- 形式: `^[a-z0-9-]{1,64}$`
+
+**理由**
+- Cosmos の複合 PK（`{serviceId}|{key}`）で区切り衝突を回避。
+- SQL/ログ/診断で扱いやすく、正規化が容易。
+
+**実装指針**
+- `IServiceIdProvider` 実装内で検証し、違反は例外。
+- `DefaultServiceIdProvider.DefaultServiceId = "default"` を唯一の既定値として固定。
+
+---
+
+## 2. Cosmos DB の推奨運用
+### 2.1 ルーティング規則（明文化）
+- **`serviceId == "default"` のみ legacy を許可**。
+- それ以外の ServiceId は **必ず /pk コンテナ**。
+
+**具体的手段**
+- `UseLegacyPartitionKeyPaths = true` は **単一テナント専用**と明記。
+- マルチテナント環境では **container name override** により `events_v2` 等へ切替。
+
+### 2.2 ルーティングの実装方針
+- `ICosmosContainerResolver`（または options の `Func<string, ContainerNames>`）を導入し、
+  ServiceId からコンテナ名を決定。
+- `default` は legacy container、それ以外は v2 container へ。
+
+### 2.3 SQL パラメータ化
+- `QueryDefinition` に `@serviceId`, `@since` 等を渡す。
+- 文字列補間は完全禁止。
+
+**理由**
+- 文字列補間は ServiceId に特殊文字が混入した場合の障害要因。
+
+---
+
+## 3. Postgres の推奨運用
+### 3.1 制約の見直し
+- 既存 UNIQUE/PK がテナント境界を跨ぐ場合は `(service_id, ...)` へ拡張。
+
+例:
+- `events(id)` が一意なら `PRIMARY KEY (service_id, id)` を検討。
+- `tags(tag, sortable_unique_id)` が一意なら `(service_id, tag, sortable_unique_id)` へ。
+
+### 3.2 RLS（推奨: 任意で導入）
+- SaaS で運用リスクが高い場合は RLS を有効化。
+- ただし導入コストと監視（`current_setting` の設定漏れ）に注意。
+
+---
+
+## 4. DI・実行時の安全策
+### 4.1 default への暗黙書き込み禁止
+- `AddSekibanDcbCosmosDbFull` の fallback を `DefaultServiceIdProvider` ではなく
+  **例外を投げる Provider** に変更することを推奨。
+
+例:
+```csharp
+public sealed class MissingServiceIdProvider : IServiceIdProvider
+{
+    public string GetCurrentServiceId() => throw new InvalidOperationException(
+        "ServiceId is required in non-HTTP context");
+}
+```
+
+### 4.2 明示 ServiceId の注入
+- バックグラウンド処理や Orleans 側は `FixedServiceIdProvider` を強制。
+
+---
+
+## 5. 推奨移行パターン（現状情報で最適）
+### Cosmos
+- **新規 SaaS は v2 コンテナから開始**（`/pk`）。
+- 既存 `default` のみ legacy 維持。
+- 将来的に `default` を v2 へ移行する場合は、段階的バックフィルを行う。
+
+### Postgres
+- 既存データは `service_id='default'` で維持。
+- 制約変更（PK/UNIQUE拡張）を先行し、アプリ変更を後追い。
+
+---
+
+## 6. 追加テスト（最低限）
+- ServiceId バリデーションの単体テスト。
+- `default` と `tenant-xxx` のデータが混線しないことの結合テスト。
+- ルーティング（legacy/v2）判定のテスト。
+
+---
+
+## まとめ
+- **ServiceId 仕様の明確化＋legacyを default 限定**が最も重要。
+- Cosmos は **v2コンテナ固定＋SQLパラメータ化**で安全性を確保。
+- Postgres は **service_id を含む制約**でテナント衝突を防止。
+- 非HTTP時の default フォールバック禁止で事故を抑止。
+
+この改善案は、現在提示済み情報を前提に実装コストとリスク低減のバランスが最良の構成。


### PR DESCRIPTION
## Summary
- add multi-tenant ServiceId design document
- include improvement recommendations and reviews
- document validation, routing, migration, and testing guidance

## Testing
- not run (docs only)
