### PR TITLE
MigrateDcbCosmosEventsTags: ignore output and fix import counts

### DIFF
--- a/tools/MigrateDcbCosmosEventsTags/.gitignore
+++ b/tools/MigrateDcbCosmosEventsTags/.gitignore
@@ -1,1 +1,2 @@
 cosmos-backup/
+output/


### PR DESCRIPTION
## What
- `tools/MigrateDcbCosmosEventsTags/output/` (migration output artifacts) をツール内 `.gitignore` で無視
- JSONL インポート時のカウント/進捗ログを並列実行でも安定するよう修正
  - `UpsertConvertedAsync` は行ごとの結果 `(success, skipped)` を返す
  - `Task.WhenAll` のバッチ完了後に集計し、約 1000 件ごとに進捗を表示

## Why
- 生成物 (`*.jsonl`) が誤ってコミットされるのを防ぐ
- 並列実行時に imported/skipped の集計とログを一貫させる

## How to test
- `dotnet build tools/MigrateDcbCosmosEventsTags/MigrateDcbCosmosEventsTags.csproj -c Release`
