### PR TITLE
Add runtime abstraction Phase 1 (#906)

### DIFF
--- a/dcb/src/Sekiban.Dcb.Core/MultiProjections/DualStateProjectionWrapperFactory.cs
+++ b/dcb/src/Sekiban.Dcb.Core/MultiProjections/DualStateProjectionWrapperFactory.cs
@@ -1,0 +1,46 @@
+using Sekiban.Dcb.Domains;
+using System.Text.Json;
+
+namespace Sekiban.Dcb.MultiProjections;
+
+/// <summary>
+///     Factory for creating DualStateProjectionWrapper instances when the generic
+///     type parameter T is not known at compile time.
+///     Co-located with DualStateProjectionWrapper so constructor changes are easy to track.
+/// </summary>
+public static class DualStateProjectionWrapperFactory
+{
+    public static IMultiProjectionPayload? Create(
+        IMultiProjectionPayload payload,
+        string projectorName,
+        ICoreMultiProjectorTypes multiProjectorTypes,
+        JsonSerializerOptions jsonOptions,
+        bool isRestoredFromSnapshot = false)
+    {
+        var wrapperType = typeof(DualStateProjectionWrapper<>).MakeGenericType(payload.GetType());
+
+        if (isRestoredFromSnapshot)
+        {
+            return Activator.CreateInstance(
+                wrapperType,
+                payload,
+                projectorName,
+                multiProjectorTypes,
+                jsonOptions,
+                0,
+                Guid.Empty,
+                (string?)null,
+                true) as IMultiProjectionPayload;
+        }
+
+        return Activator.CreateInstance(
+            wrapperType,
+            payload,
+            projectorName,
+            multiProjectorTypes,
+            jsonOptions,
+            0,
+            Guid.Empty,
+            (string?)null) as IMultiProjectionPayload;
+    }
+}

--- a/dcb/src/Sekiban.Dcb.Core/MultiProjections/IDualStateAccessor.cs
+++ b/dcb/src/Sekiban.Dcb.Core/MultiProjections/IDualStateAccessor.cs
@@ -1,0 +1,25 @@
+using Sekiban.Dcb.Common;
+using Sekiban.Dcb.Events;
+
+namespace Sekiban.Dcb.MultiProjections;
+
+/// <summary>
+///     Non-generic accessor for DualStateProjectionWrapper{T} internal state.
+///     Eliminates the need for reflection when the generic type parameter T
+///     is unknown at compile time.
+/// </summary>
+public interface IDualStateAccessor
+{
+    int SafeVersion { get; }
+    int UnsafeVersion { get; }
+    Guid UnsafeLastEventId { get; }
+    string UnsafeLastSortableUniqueId { get; }
+    string? SafeLastSortableUniqueId { get; }
+    object GetSafeProjectorPayload();
+    object GetUnsafeProjectorPayload();
+
+    IDualStateAccessor ProcessEventAs(
+        Event evt,
+        SortableUniqueId safeWindowThreshold,
+        DcbDomainTypes domainTypes);
+}

--- a/dcb/src/Sekiban.Dcb.Orleans.Core/Runtimes/CompositeProjectionRuntime.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.Core/Runtimes/CompositeProjectionRuntime.cs
@@ -1,0 +1,102 @@
+using ResultBoxes;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.Orleans.Serialization;
+using Sekiban.Dcb.Queries;
+
+namespace Sekiban.Dcb.Runtime.Native;
+
+/// <summary>
+///     Composite IProjectionRuntime that routes projectorName through an IProjectorRuntimeResolver.
+///     This allows mixing native and WASM runtimes for different projectors.
+/// </summary>
+public class CompositeProjectionRuntime : IProjectionRuntime
+{
+    private readonly IProjectorRuntimeResolver _resolver;
+
+    public CompositeProjectionRuntime(IProjectorRuntimeResolver resolver)
+    {
+        _resolver = resolver;
+    }
+
+    public ResultBox<IProjectionState> GenerateInitialState(string projectorName) =>
+        _resolver.Resolve(projectorName).GenerateInitialState(projectorName);
+
+    public ResultBox<string> GetProjectorVersion(string projectorName) =>
+        _resolver.Resolve(projectorName).GetProjectorVersion(projectorName);
+
+    public IReadOnlyList<string> GetAllProjectorNames()
+    {
+        var allNames = new List<string>();
+        foreach (var runtime in _resolver.GetAllRuntimes())
+        {
+            allNames.AddRange(runtime.GetAllProjectorNames());
+        }
+        return allNames;
+    }
+
+    public ResultBox<IProjectionState> ApplyEvent(
+        string projectorName,
+        IProjectionState currentState,
+        Event ev,
+        string safeWindowThreshold) =>
+        _resolver.Resolve(projectorName)
+            .ApplyEvent(projectorName, currentState, ev, safeWindowThreshold);
+
+    public ResultBox<IProjectionState> ApplyEvents(
+        string projectorName,
+        IProjectionState currentState,
+        IReadOnlyList<Event> events,
+        string safeWindowThreshold) =>
+        _resolver.Resolve(projectorName)
+            .ApplyEvents(projectorName, currentState, events, safeWindowThreshold);
+
+    public Task<ResultBox<SerializableQueryResult>> ExecuteQueryAsync(
+        string projectorName,
+        IProjectionState state,
+        SerializableQueryParameter query,
+        IServiceProvider serviceProvider) =>
+        _resolver.Resolve(projectorName)
+            .ExecuteQueryAsync(projectorName, state, query, serviceProvider);
+
+    public Task<ResultBox<SerializableListQueryResult>> ExecuteListQueryAsync(
+        string projectorName,
+        IProjectionState state,
+        SerializableQueryParameter query,
+        IServiceProvider serviceProvider) =>
+        _resolver.Resolve(projectorName)
+            .ExecuteListQueryAsync(projectorName, state, query, serviceProvider);
+
+    public ResultBox<byte[]> SerializeState(string projectorName, IProjectionState state) =>
+        _resolver.Resolve(projectorName).SerializeState(projectorName, state);
+
+    public ResultBox<IProjectionState> DeserializeState(
+        string projectorName,
+        byte[] data,
+        string safeWindowThreshold) =>
+        _resolver.Resolve(projectorName)
+            .DeserializeState(projectorName, data, safeWindowThreshold);
+
+    public ResultBox<string> ResolveProjectorName(IQueryCommon query)
+    {
+        foreach (var runtime in _resolver.GetAllRuntimes())
+        {
+            var result = runtime.ResolveProjectorName(query);
+            if (result.IsSuccess) return result;
+        }
+        return ResultBox.Error<string>(
+            new InvalidOperationException(
+                $"No runtime can resolve projector for query '{query.GetType().Name}'"));
+    }
+
+    public ResultBox<string> ResolveProjectorName(IListQueryCommon query)
+    {
+        foreach (var runtime in _resolver.GetAllRuntimes())
+        {
+            var result = runtime.ResolveProjectorName(query);
+            if (result.IsSuccess) return result;
+        }
+        return ResultBox.Error<string>(
+            new InvalidOperationException(
+                $"No runtime can resolve projector for list query '{query.GetType().Name}'"));
+    }
+}

--- a/dcb/src/Sekiban.Dcb.Orleans.Core/Runtimes/DualStateWrapperHelper.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.Core/Runtimes/DualStateWrapperHelper.cs
@@ -1,0 +1,41 @@
+using ResultBoxes;
+using Sekiban.Dcb.Common;
+using Sekiban.Dcb.Domains;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.MultiProjections;
+
+namespace Sekiban.Dcb.Runtime.Native;
+
+/// <summary>
+///     Encapsulates operations on DualStateProjectionWrapper{T}.
+///     Uses IDualStateAccessor for type-safe access.
+///     Construction is delegated to DualStateProjectionWrapperFactory in Sekiban.Dcb.Core.
+/// </summary>
+internal static class DualStateWrapperHelper
+{
+    public static IMultiProjectionPayload? CreateWrapper(
+        IMultiProjectionPayload payload,
+        string projectorName,
+        ICoreMultiProjectorTypes multiProjectorTypes,
+        DcbDomainTypes domainTypes,
+        bool isRestoredFromSnapshot = false) =>
+        DualStateProjectionWrapperFactory.Create(
+            payload,
+            projectorName,
+            multiProjectorTypes,
+            domainTypes.JsonSerializerOptions,
+            isRestoredFromSnapshot);
+
+    public static ResultBox<IProjectionState> ApplyEvent(
+        IDualStateAccessor accessor,
+        Event ev,
+        string safeWindowThreshold,
+        DcbDomainTypes domainTypes)
+    {
+        var threshold = new SortableUniqueId(safeWindowThreshold);
+        var updated = accessor.ProcessEventAs(ev, threshold, domainTypes);
+
+        return ResultBox.FromValue<IProjectionState>(
+            NativeProjectionState.FromDualStateAccessor(updated));
+    }
+}

--- a/dcb/src/Sekiban.Dcb.Orleans.Core/Runtimes/IEventRuntime.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.Core/Runtimes/IEventRuntime.cs
@@ -1,0 +1,14 @@
+using Sekiban.Dcb.Events;
+
+namespace Sekiban.Dcb.Runtime;
+
+/// <summary>
+///     Event type management runtime.
+///     Used by the Grain layer to serialize/deserialize events.
+/// </summary>
+public interface IEventRuntime
+{
+    string SerializeEventPayload(IEventPayload payload);
+    IEventPayload? DeserializeEventPayload(string eventTypeName, string json);
+    Type? GetEventType(string eventTypeName);
+}

--- a/dcb/src/Sekiban.Dcb.Orleans.Core/Runtimes/IProjectionRuntime.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.Core/Runtimes/IProjectionRuntime.cs
@@ -1,0 +1,51 @@
+using ResultBoxes;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.Orleans.Serialization;
+using Sekiban.Dcb.Queries;
+
+namespace Sekiban.Dcb.Runtime;
+
+/// <summary>
+///     Multi-projection execution runtime.
+///     Both C# native and WASM implementations implement this interface.
+/// </summary>
+public interface IProjectionRuntime
+{
+    ResultBox<IProjectionState> GenerateInitialState(string projectorName);
+    ResultBox<string> GetProjectorVersion(string projectorName);
+    IReadOnlyList<string> GetAllProjectorNames();
+
+    ResultBox<IProjectionState> ApplyEvent(
+        string projectorName,
+        IProjectionState currentState,
+        Event ev,
+        string safeWindowThreshold);
+
+    ResultBox<IProjectionState> ApplyEvents(
+        string projectorName,
+        IProjectionState currentState,
+        IReadOnlyList<Event> events,
+        string safeWindowThreshold);
+
+    Task<ResultBox<SerializableQueryResult>> ExecuteQueryAsync(
+        string projectorName,
+        IProjectionState state,
+        SerializableQueryParameter query,
+        IServiceProvider serviceProvider);
+
+    Task<ResultBox<SerializableListQueryResult>> ExecuteListQueryAsync(
+        string projectorName,
+        IProjectionState state,
+        SerializableQueryParameter query,
+        IServiceProvider serviceProvider);
+
+    ResultBox<byte[]> SerializeState(string projectorName, IProjectionState state);
+
+    ResultBox<IProjectionState> DeserializeState(
+        string projectorName,
+        byte[] data,
+        string safeWindowThreshold);
+
+    ResultBox<string> ResolveProjectorName(IQueryCommon query);
+    ResultBox<string> ResolveProjectorName(IListQueryCommon query);
+}

--- a/dcb/src/Sekiban.Dcb.Orleans.Core/Runtimes/IProjectionState.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.Core/Runtimes/IProjectionState.cs
@@ -1,0 +1,20 @@
+using System.Text.Json;
+
+namespace Sekiban.Dcb.Runtime;
+
+/// <summary>
+///     Abstracts the projection state for both C# native and WASM runtimes.
+///     C# implementation wraps DualStateProjectionWrapper.
+///     WASM implementation manages metadata while state lives in the WASM instance.
+/// </summary>
+public interface IProjectionState
+{
+    int SafeVersion { get; }
+    int UnsafeVersion { get; }
+    string? SafeLastSortableUniqueId { get; }
+    string? LastSortableUniqueId { get; }
+    Guid? LastEventId { get; }
+    object? GetSafePayload();
+    object? GetUnsafePayload();
+    long EstimatePayloadSizeBytes(JsonSerializerOptions? options);
+}

--- a/dcb/src/Sekiban.Dcb.Orleans.Core/Runtimes/IProjectorRuntimeResolver.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.Core/Runtimes/IProjectorRuntimeResolver.cs
@@ -1,0 +1,10 @@
+namespace Sekiban.Dcb.Runtime;
+
+/// <summary>
+///     Routes projectorName to the appropriate IProjectionRuntime.
+/// </summary>
+public interface IProjectorRuntimeResolver
+{
+    IProjectionRuntime Resolve(string projectorName);
+    IEnumerable<IProjectionRuntime> GetAllRuntimes();
+}

--- a/dcb/src/Sekiban.Dcb.Orleans.Core/Runtimes/ITagProjectionRuntime.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.Core/Runtimes/ITagProjectionRuntime.cs
@@ -1,0 +1,18 @@
+using ResultBoxes;
+using Sekiban.Dcb.Tags;
+
+namespace Sekiban.Dcb.Runtime;
+
+/// <summary>
+///     Tag projection execution runtime.
+/// </summary>
+public interface ITagProjectionRuntime
+{
+    ResultBox<ITagProjector> GetProjector(string tagProjectorName);
+    ResultBox<string> GetProjectorVersion(string tagProjectorName);
+    IReadOnlyList<string> GetAllProjectorNames();
+    string? TryGetProjectorForTagGroup(string tagGroupName);
+    ITag ResolveTag(string tagString);
+    ResultBox<byte[]> SerializePayload(ITagStatePayload payload);
+    ResultBox<ITagStatePayload> DeserializePayload(string payloadName, byte[] data);
+}

--- a/dcb/src/Sekiban.Dcb.Orleans.Core/Runtimes/ITagProjector.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.Core/Runtimes/ITagProjector.cs
@@ -1,0 +1,15 @@
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.Tags;
+
+namespace Sekiban.Dcb.Runtime;
+
+/// <summary>
+///     Individual tag projector instance (non-generic, instance-based).
+///     Distinct from Tags.ITagProjector{T} which uses static abstract members.
+///     C# implementation wraps Func{ITagStatePayload, Event, ITagStatePayload}.
+///     WASM implementation calls into the WASM module.
+/// </summary>
+public interface ITagProjector
+{
+    ITagStatePayload Apply(ITagStatePayload? currentState, Event ev);
+}

--- a/dcb/src/Sekiban.Dcb.Orleans.Core/Runtimes/NativeEventRuntime.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.Core/Runtimes/NativeEventRuntime.cs
@@ -1,0 +1,27 @@
+using Sekiban.Dcb.Domains;
+using Sekiban.Dcb.Events;
+
+namespace Sekiban.Dcb.Runtime.Native;
+
+/// <summary>
+///     Native C# implementation of IEventRuntime.
+///     Delegates to DcbDomainTypes.EventTypes for event serialization/deserialization.
+/// </summary>
+public class NativeEventRuntime : IEventRuntime
+{
+    private readonly IEventTypes _eventTypes;
+
+    public NativeEventRuntime(DcbDomainTypes domainTypes)
+    {
+        _eventTypes = domainTypes.EventTypes;
+    }
+
+    public string SerializeEventPayload(IEventPayload payload) =>
+        _eventTypes.SerializeEventPayload(payload);
+
+    public IEventPayload? DeserializeEventPayload(string eventTypeName, string json) =>
+        _eventTypes.DeserializeEventPayload(eventTypeName, json);
+
+    public Type? GetEventType(string eventTypeName) =>
+        _eventTypes.GetEventType(eventTypeName);
+}

--- a/dcb/src/Sekiban.Dcb.Orleans.Core/Runtimes/NativeProjectionRuntime.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.Core/Runtimes/NativeProjectionRuntime.cs
@@ -1,0 +1,318 @@
+using ResultBoxes;
+using Sekiban.Dcb.Common;
+using Sekiban.Dcb.Domains;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.MultiProjections;
+using Sekiban.Dcb.Orleans.Serialization;
+using Sekiban.Dcb.Queries;
+
+namespace Sekiban.Dcb.Runtime.Native;
+
+/// <summary>
+///     Native C# implementation of IProjectionRuntime.
+///     Delegates to DcbDomainTypes for projection management, event application, and query execution.
+/// </summary>
+public class NativeProjectionRuntime : IProjectionRuntime
+{
+    private readonly DcbDomainTypes _domainTypes;
+    private readonly ICoreMultiProjectorTypes _multiProjectorTypes;
+    private readonly ICoreQueryTypes _queryTypes;
+
+    public NativeProjectionRuntime(DcbDomainTypes domainTypes)
+    {
+        _domainTypes = domainTypes;
+        _multiProjectorTypes = domainTypes.MultiProjectorTypes;
+        _queryTypes = domainTypes.QueryTypes;
+    }
+
+    public ResultBox<IProjectionState> GenerateInitialState(string projectorName)
+    {
+        var payloadResult = _multiProjectorTypes.GenerateInitialPayload(projectorName);
+        if (!payloadResult.IsSuccess)
+        {
+            return ResultBox.Error<IProjectionState>(payloadResult.GetException());
+        }
+
+        var payload = payloadResult.GetValue();
+        var wrapper = DualStateWrapperHelper.CreateWrapper(
+            payload, projectorName, _multiProjectorTypes, _domainTypes);
+        if (wrapper is not IDualStateAccessor accessor)
+        {
+            return ResultBox.Error<IProjectionState>(
+                new InvalidOperationException(
+                    $"Failed to create DualStateProjectionWrapper for '{projectorName}'"));
+        }
+
+        return ResultBox.FromValue<IProjectionState>(
+            NativeProjectionState.FromDualStateAccessor(accessor));
+    }
+
+    public ResultBox<string> GetProjectorVersion(string projectorName) =>
+        _multiProjectorTypes.GetProjectorVersion(projectorName);
+
+    public IReadOnlyList<string> GetAllProjectorNames() =>
+        _multiProjectorTypes.GetAllProjectorNames();
+
+    public ResultBox<IProjectionState> ApplyEvent(
+        string projectorName,
+        IProjectionState currentState,
+        Event ev,
+        string safeWindowThreshold)
+    {
+        if (currentState is not NativeProjectionState nativeState)
+        {
+            return ResultBox.Error<IProjectionState>(
+                new InvalidOperationException("State must be a NativeProjectionState"));
+        }
+
+        var payload = nativeState.Payload;
+
+        if (payload is IDualStateAccessor accessor)
+        {
+            return DualStateWrapperHelper.ApplyEvent(
+                accessor, ev, safeWindowThreshold, _domainTypes);
+        }
+
+        return ApplyEventViaProjectorTypes(
+            projectorName, nativeState, payload, ev, safeWindowThreshold);
+    }
+
+    public ResultBox<IProjectionState> ApplyEvents(
+        string projectorName,
+        IProjectionState currentState,
+        IReadOnlyList<Event> events,
+        string safeWindowThreshold)
+    {
+        var state = currentState;
+        foreach (var ev in events)
+        {
+            var result = ApplyEvent(projectorName, state, ev, safeWindowThreshold);
+            if (!result.IsSuccess)
+            {
+                return result;
+            }
+            state = result.GetValue();
+        }
+        return ResultBox.FromValue(state);
+    }
+
+    public async Task<ResultBox<SerializableQueryResult>> ExecuteQueryAsync(
+        string projectorName,
+        IProjectionState state,
+        SerializableQueryParameter query,
+        IServiceProvider serviceProvider)
+    {
+        if (state is not NativeProjectionState nativeState)
+        {
+            return ResultBox.Error<SerializableQueryResult>(
+                new InvalidOperationException("State must be a NativeProjectionState"));
+        }
+
+        var queryResult = await query.ToQueryAsync(_domainTypes);
+        if (!queryResult.IsSuccess)
+        {
+            return ResultBox.Error<SerializableQueryResult>(queryResult.GetException());
+        }
+
+        var queryObj = queryResult.GetValue();
+        if (queryObj is not IQueryCommon queryCommon)
+        {
+            return ResultBox.Error<SerializableQueryResult>(
+                new InvalidOperationException("Deserialized query is not IQueryCommon"));
+        }
+
+        if (nativeState.GetUnsafePayload() is not IMultiProjectionPayload payload)
+        {
+            return ResultBox.Error<SerializableQueryResult>(
+                new InvalidOperationException("Unsafe payload is null or not IMultiProjectionPayload"));
+        }
+
+        var projectorProvider = () => Task.FromResult(ResultBox.FromValue(payload));
+
+        var result = await _queryTypes.ExecuteQueryAsync(
+            queryCommon,
+            projectorProvider,
+            serviceProvider,
+            nativeState.SafeVersion,
+            nativeState.SafeLastSortableUniqueId,
+            null,
+            nativeState.UnsafeVersion);
+
+        return await SerializableQueryResult.CreateFromResultBoxAsync(
+            result,
+            queryCommon,
+            _domainTypes.JsonSerializerOptions);
+    }
+
+    public async Task<ResultBox<SerializableListQueryResult>> ExecuteListQueryAsync(
+        string projectorName,
+        IProjectionState state,
+        SerializableQueryParameter query,
+        IServiceProvider serviceProvider)
+    {
+        if (state is not NativeProjectionState nativeState)
+        {
+            return ResultBox.Error<SerializableListQueryResult>(
+                new InvalidOperationException("State must be a NativeProjectionState"));
+        }
+
+        var queryResult = await query.ToQueryAsync(_domainTypes);
+        if (!queryResult.IsSuccess)
+        {
+            return ResultBox.Error<SerializableListQueryResult>(queryResult.GetException());
+        }
+
+        var queryObj = queryResult.GetValue();
+        if (queryObj is not IListQueryCommon listQuery)
+        {
+            return ResultBox.Error<SerializableListQueryResult>(
+                new InvalidOperationException("Deserialized query is not IListQueryCommon"));
+        }
+
+        if (nativeState.GetUnsafePayload() is not IMultiProjectionPayload payload)
+        {
+            return ResultBox.Error<SerializableListQueryResult>(
+                new InvalidOperationException("Unsafe payload is null or not IMultiProjectionPayload"));
+        }
+
+        var projectorProvider = () => Task.FromResult(ResultBox.FromValue(payload));
+
+        var result = await _queryTypes.ExecuteListQueryAsGeneralAsync(
+            listQuery,
+            projectorProvider,
+            serviceProvider,
+            nativeState.SafeVersion,
+            nativeState.SafeLastSortableUniqueId,
+            null,
+            nativeState.UnsafeVersion);
+
+        if (!result.IsSuccess)
+        {
+            return ResultBox.Error<SerializableListQueryResult>(result.GetException());
+        }
+
+        var general = result.GetValue();
+        return ResultBox.FromValue(
+            await SerializableListQueryResult.CreateFromAsync(
+                general,
+                _domainTypes.JsonSerializerOptions));
+    }
+
+    public ResultBox<byte[]> SerializeState(string projectorName, IProjectionState state)
+    {
+        if (state is not NativeProjectionState nativeState)
+        {
+            return ResultBox.Error<byte[]>(
+                new InvalidOperationException("State must be a NativeProjectionState"));
+        }
+
+        var safeThreshold = nativeState.SafeLastSortableUniqueId
+            ?? SortableUniqueId.MinValue.Value;
+
+        var serResult = _multiProjectorTypes.Serialize(
+            projectorName,
+            _domainTypes,
+            safeThreshold,
+            nativeState.Payload);
+
+        if (!serResult.IsSuccess)
+        {
+            return ResultBox.Error<byte[]>(serResult.GetException());
+        }
+
+        return ResultBox.FromValue(serResult.GetValue().Data);
+    }
+
+    public ResultBox<IProjectionState> DeserializeState(
+        string projectorName,
+        byte[] data,
+        string safeWindowThreshold)
+    {
+        var payloadResult = _multiProjectorTypes.Deserialize(
+            projectorName,
+            _domainTypes,
+            safeWindowThreshold,
+            data);
+
+        if (!payloadResult.IsSuccess)
+        {
+            return ResultBox.Error<IProjectionState>(payloadResult.GetException());
+        }
+
+        var payload = payloadResult.GetValue();
+        var wrapper = DualStateWrapperHelper.CreateWrapper(
+            payload, projectorName, _multiProjectorTypes, _domainTypes,
+            isRestoredFromSnapshot: true);
+
+        if (wrapper is IDualStateAccessor restoredAccessor)
+        {
+            return ResultBox.FromValue<IProjectionState>(
+                NativeProjectionState.FromDualStateAccessor(restoredAccessor));
+        }
+
+        return ResultBox.FromValue<IProjectionState>(
+            NativeProjectionState.FromInitialPayload(payload));
+    }
+
+    public ResultBox<string> ResolveProjectorName(IQueryCommon query) =>
+        ResolveProjectorNameFromType(_queryTypes.GetMultiProjectorType(query));
+
+    public ResultBox<string> ResolveProjectorName(IListQueryCommon query) =>
+        ResolveProjectorNameFromType(_queryTypes.GetMultiProjectorType(query));
+
+    private ResultBox<string> ResolveProjectorNameFromType(ResultBox<Type> typeResult)
+    {
+        if (!typeResult.IsSuccess)
+        {
+            return ResultBox.Error<string>(typeResult.GetException());
+        }
+
+        var projectorType = typeResult.GetValue();
+        foreach (var name in _multiProjectorTypes.GetAllProjectorNames())
+        {
+            var ptResult = _multiProjectorTypes.GetProjectorType(name);
+            if (ptResult.IsSuccess && ptResult.GetValue() == projectorType)
+            {
+                return ResultBox.FromValue(name);
+            }
+        }
+
+        return ResultBox.Error<string>(
+            new InvalidOperationException(
+                $"No projector found for type '{projectorType.Name}'"));
+    }
+
+    private ResultBox<IProjectionState> ApplyEventViaProjectorTypes(
+        string projectorName,
+        NativeProjectionState nativeState,
+        IMultiProjectionPayload payload,
+        Event ev,
+        string safeWindowThreshold)
+    {
+        var tags = ev.Tags
+            .Select(tagString => _domainTypes.TagTypes.GetTag(tagString))
+            .ToList();
+        var projected = _multiProjectorTypes.Project(
+            projectorName,
+            payload,
+            ev,
+            tags,
+            _domainTypes,
+            new SortableUniqueId(safeWindowThreshold));
+
+        if (!projected.IsSuccess)
+        {
+            return ResultBox.Error<IProjectionState>(projected.GetException());
+        }
+
+        var newPayload = projected.GetValue();
+        return ResultBox.FromValue<IProjectionState>(
+            new NativeProjectionState(
+                newPayload,
+                nativeState.SafeVersion,
+                nativeState.UnsafeVersion + 1,
+                nativeState.SafeLastSortableUniqueId,
+                ev.SortableUniqueIdValue,
+                ev.Id));
+    }
+}

--- a/dcb/src/Sekiban.Dcb.Orleans.Core/Runtimes/NativeProjectionState.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.Core/Runtimes/NativeProjectionState.cs
@@ -1,0 +1,83 @@
+using System.Text;
+using System.Text.Json;
+using Sekiban.Dcb.MultiProjections;
+
+namespace Sekiban.Dcb.Runtime.Native;
+
+/// <summary>
+///     Native C# implementation of IProjectionState.
+///     Wraps a DualStateProjectionWrapper (accessed via IDualStateAccessor) to provide
+///     safe/unsafe version and payload information.
+/// </summary>
+public class NativeProjectionState : IProjectionState
+{
+    private readonly IMultiProjectionPayload _payload;
+    private readonly object? _safePayload;
+    private readonly object? _unsafePayload;
+
+    public NativeProjectionState(
+        IMultiProjectionPayload payload,
+        int safeVersion,
+        int unsafeVersion,
+        string? safeLastSortableUniqueId,
+        string? lastSortableUniqueId,
+        Guid? lastEventId,
+        object? safePayload = null,
+        object? unsafePayload = null)
+    {
+        _payload = payload;
+        SafeVersion = safeVersion;
+        UnsafeVersion = unsafeVersion;
+        SafeLastSortableUniqueId = safeLastSortableUniqueId;
+        LastSortableUniqueId = lastSortableUniqueId;
+        LastEventId = lastEventId;
+        _safePayload = safePayload;
+        _unsafePayload = unsafePayload;
+    }
+
+    /// <summary>
+    ///     Create from a DualStateProjectionWrapper via IDualStateAccessor interface.
+    /// </summary>
+    public static NativeProjectionState FromDualStateAccessor(IDualStateAccessor accessor)
+    {
+        var wrapper = accessor as IMultiProjectionPayload
+            ?? throw new InvalidOperationException(
+                "IDualStateAccessor must also implement IMultiProjectionPayload");
+
+        return new NativeProjectionState(
+            wrapper,
+            accessor.SafeVersion,
+            accessor.UnsafeVersion,
+            accessor.SafeLastSortableUniqueId,
+            accessor.UnsafeLastSortableUniqueId,
+            accessor.UnsafeLastEventId,
+            safePayload: accessor.GetSafeProjectorPayload(),
+            unsafePayload: accessor.GetUnsafeProjectorPayload());
+    }
+
+    public static NativeProjectionState FromInitialPayload(IMultiProjectionPayload payload) =>
+        new(payload, 0, 0, null, null, null, payload, payload);
+
+    public int SafeVersion { get; }
+    public int UnsafeVersion { get; }
+    public string? SafeLastSortableUniqueId { get; }
+    public string? LastSortableUniqueId { get; }
+    public Guid? LastEventId { get; }
+
+    /// <summary>
+    ///     The underlying IMultiProjectionPayload (DualStateProjectionWrapper or raw payload).
+    /// </summary>
+    public IMultiProjectionPayload Payload => _payload;
+
+    public object? GetSafePayload() => _safePayload;
+    public object? GetUnsafePayload() => _unsafePayload;
+
+    public long EstimatePayloadSizeBytes(JsonSerializerOptions? options)
+    {
+        var json = JsonSerializer.Serialize(
+            _payload,
+            _payload.GetType(),
+            options ?? JsonSerializerOptions.Default);
+        return Encoding.UTF8.GetByteCount(json);
+    }
+}

--- a/dcb/src/Sekiban.Dcb.Orleans.Core/Runtimes/NativeTagProjectionRuntime.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.Core/Runtimes/NativeTagProjectionRuntime.cs
@@ -1,0 +1,52 @@
+using ResultBoxes;
+using Sekiban.Dcb.Domains;
+using Sekiban.Dcb.Tags;
+
+namespace Sekiban.Dcb.Runtime.Native;
+
+/// <summary>
+///     Native C# implementation of ITagProjectionRuntime.
+///     Delegates to DcbDomainTypes for tag projector management.
+/// </summary>
+public class NativeTagProjectionRuntime : ITagProjectionRuntime
+{
+    private readonly ITagProjectorTypes _tagProjectorTypes;
+    private readonly ITagTypes _tagTypes;
+    private readonly ITagStatePayloadTypes _tagStatePayloadTypes;
+
+    public NativeTagProjectionRuntime(DcbDomainTypes domainTypes)
+    {
+        _tagProjectorTypes = domainTypes.TagProjectorTypes;
+        _tagTypes = domainTypes.TagTypes;
+        _tagStatePayloadTypes = domainTypes.TagStatePayloadTypes;
+    }
+
+    public ResultBox<ITagProjector> GetProjector(string tagProjectorName)
+    {
+        var funcResult = _tagProjectorTypes.GetProjectorFunction(tagProjectorName);
+        if (!funcResult.IsSuccess)
+        {
+            return ResultBox.Error<ITagProjector>(funcResult.GetException());
+        }
+
+        return ResultBox.FromValue<ITagProjector>(new NativeTagProjector(funcResult.GetValue()));
+    }
+
+    public ResultBox<string> GetProjectorVersion(string tagProjectorName) =>
+        _tagProjectorTypes.GetProjectorVersion(tagProjectorName);
+
+    public IReadOnlyList<string> GetAllProjectorNames() =>
+        _tagProjectorTypes.GetAllProjectorNames();
+
+    public string? TryGetProjectorForTagGroup(string tagGroupName) =>
+        _tagProjectorTypes.TryGetProjectorForTagGroup(tagGroupName);
+
+    public ITag ResolveTag(string tagString) =>
+        _tagTypes.GetTag(tagString);
+
+    public ResultBox<byte[]> SerializePayload(ITagStatePayload payload) =>
+        _tagStatePayloadTypes.SerializePayload(payload);
+
+    public ResultBox<ITagStatePayload> DeserializePayload(string payloadName, byte[] data) =>
+        _tagStatePayloadTypes.DeserializePayload(payloadName, data);
+}

--- a/dcb/src/Sekiban.Dcb.Orleans.Core/Runtimes/NativeTagProjector.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.Core/Runtimes/NativeTagProjector.cs
@@ -1,0 +1,24 @@
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.Tags;
+
+namespace Sekiban.Dcb.Runtime.Native;
+
+/// <summary>
+///     Native C# implementation of ITagProjector.
+///     Wraps a Func{ITagStatePayload, Event, ITagStatePayload} as an ITagProjector.
+/// </summary>
+public class NativeTagProjector : ITagProjector
+{
+    private readonly Func<ITagStatePayload, Event, ITagStatePayload> _projectFunc;
+
+    public NativeTagProjector(Func<ITagStatePayload, Event, ITagStatePayload> projectFunc)
+    {
+        _projectFunc = projectFunc;
+    }
+
+    public ITagStatePayload Apply(ITagStatePayload? currentState, Event ev)
+    {
+        var state = currentState ?? new EmptyTagStatePayload();
+        return _projectFunc(state, ev);
+    }
+}

--- a/dcb/src/Sekiban.Dcb.Orleans.Core/Runtimes/ProjectorRuntimeResolver.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.Core/Runtimes/ProjectorRuntimeResolver.cs
@@ -1,0 +1,38 @@
+namespace Sekiban.Dcb.Runtime.Native;
+
+/// <summary>
+///     Default implementation of IProjectorRuntimeResolver.
+///     Routes projector names to the appropriate IProjectionRuntime using a dictionary,
+///     with a default runtime for unregistered projectors.
+///     Immutable after construction.
+/// </summary>
+public class ProjectorRuntimeResolver : IProjectorRuntimeResolver
+{
+    private readonly IReadOnlyDictionary<string, IProjectionRuntime> _runtimeMap;
+    private readonly IProjectionRuntime _defaultRuntime;
+
+    public ProjectorRuntimeResolver(
+        IProjectionRuntime defaultRuntime,
+        Dictionary<string, IProjectionRuntime>? runtimeMap = null)
+    {
+        _defaultRuntime = defaultRuntime;
+        _runtimeMap = runtimeMap != null
+            ? new Dictionary<string, IProjectionRuntime>(runtimeMap)
+            : new Dictionary<string, IProjectionRuntime>();
+    }
+
+    public IProjectionRuntime Resolve(string projectorName)
+    {
+        if (_runtimeMap.TryGetValue(projectorName, out var runtime))
+        {
+            return runtime;
+        }
+        return _defaultRuntime;
+    }
+
+    public IEnumerable<IProjectionRuntime> GetAllRuntimes()
+    {
+        var runtimes = new HashSet<IProjectionRuntime>(_runtimeMap.Values) { _defaultRuntime };
+        return runtimes;
+    }
+}

--- a/dcb/tests/Sekiban.Dcb.Orleans.Tests/Runtimes/CompositeProjectionRuntimeTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Orleans.Tests/Runtimes/CompositeProjectionRuntimeTests.cs
@@ -1,0 +1,93 @@
+using Dcb.Domain;
+using Dcb.Domain.Weather;
+using Sekiban.Dcb.Common;
+using Sekiban.Dcb.Runtime.Native;
+using Sekiban.Dcb.Tests;
+using Xunit;
+
+namespace Sekiban.Dcb.Orleans.Tests.Runtimes;
+
+public class CompositeProjectionRuntimeTests
+{
+    private readonly DcbDomainTypes _domainTypes = DomainType.GetDomainTypes();
+
+    [Fact]
+    public void GetAllProjectorNames_should_aggregate_from_all_runtimes()
+    {
+        // Given
+        var nativeRuntime = new NativeProjectionRuntime(_domainTypes);
+        var resolver = new ProjectorRuntimeResolver(nativeRuntime);
+        var composite = new CompositeProjectionRuntime(resolver);
+
+        // When
+        var names = composite.GetAllProjectorNames();
+
+        // Then
+        Assert.NotEmpty(names);
+        Assert.Contains("WeatherForecastProjection", names);
+    }
+
+    [Fact]
+    public void GenerateInitialState_should_delegate_to_resolved_runtime()
+    {
+        // Given
+        var nativeRuntime = new NativeProjectionRuntime(_domainTypes);
+        var resolver = new ProjectorRuntimeResolver(nativeRuntime);
+        var composite = new CompositeProjectionRuntime(resolver);
+
+        // When
+        var result = composite.GenerateInitialState("WeatherForecastProjection");
+
+        // Then
+        Assert.True(result.IsSuccess);
+        var state = result.GetValue();
+        Assert.Equal(0, state.SafeVersion);
+        Assert.Equal(0, state.UnsafeVersion);
+    }
+
+    [Fact]
+    public void ApplyEvent_should_delegate_to_resolved_runtime()
+    {
+        // Given
+        var nativeRuntime = new NativeProjectionRuntime(_domainTypes);
+        var resolver = new ProjectorRuntimeResolver(nativeRuntime);
+        var composite = new CompositeProjectionRuntime(resolver);
+
+        var initialState = composite.GenerateInitialState("WeatherForecastProjection");
+        Assert.True(initialState.IsSuccess);
+
+        var forecastId = Guid.NewGuid();
+        var payload = new WeatherForecastCreated(
+            forecastId, "Tokyo", new DateOnly(2026, 1, 1), 25, "Sunny");
+        var tag = new WeatherForecastTag(forecastId);
+        var ev = EventTestHelper.CreateEvent(payload, tag);
+
+        var threshold = SortableUniqueId.GetSafeIdFromUtc();
+
+        // When
+        var result = composite.ApplyEvent(
+            "WeatherForecastProjection",
+            initialState.GetValue(),
+            ev,
+            threshold);
+
+        // Then
+        Assert.True(result.IsSuccess);
+    }
+
+    [Fact]
+    public void GetProjectorVersion_should_delegate()
+    {
+        // Given
+        var nativeRuntime = new NativeProjectionRuntime(_domainTypes);
+        var resolver = new ProjectorRuntimeResolver(nativeRuntime);
+        var composite = new CompositeProjectionRuntime(resolver);
+
+        // When
+        var result = composite.GetProjectorVersion("WeatherForecastProjection");
+
+        // Then
+        Assert.True(result.IsSuccess);
+        Assert.Equal("1.0.0", result.GetValue());
+    }
+}

--- a/dcb/tests/Sekiban.Dcb.Orleans.Tests/Runtimes/NativeEventRuntimeTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Orleans.Tests/Runtimes/NativeEventRuntimeTests.cs
@@ -1,0 +1,87 @@
+using Dcb.Domain;
+using Dcb.Domain.Weather;
+using Sekiban.Dcb.Runtime.Native;
+using Xunit;
+
+namespace Sekiban.Dcb.Orleans.Tests.Runtimes;
+
+public class NativeEventRuntimeTests
+{
+    private readonly DcbDomainTypes _domainTypes = DomainType.GetDomainTypes();
+    private readonly NativeEventRuntime _runtime;
+
+    public NativeEventRuntimeTests()
+    {
+        _runtime = new NativeEventRuntime(_domainTypes);
+    }
+
+    [Fact]
+    public void SerializeEventPayload_should_produce_valid_json()
+    {
+        // Given
+        var payload = new WeatherForecastCreated(
+            Guid.NewGuid(), "Tokyo", new DateOnly(2026, 1, 1), 25, "Sunny");
+
+        // When
+        var json = _runtime.SerializeEventPayload(payload);
+
+        // Then
+        Assert.NotNull(json);
+        Assert.NotEmpty(json);
+        Assert.Contains("Tokyo", json);
+    }
+
+    [Fact]
+    public void DeserializeEventPayload_should_reconstruct_payload()
+    {
+        // Given
+        var original = new WeatherForecastCreated(
+            Guid.NewGuid(), "Osaka", new DateOnly(2026, 6, 15), 30, "Hot");
+        var json = _runtime.SerializeEventPayload(original);
+
+        // When
+        var deserialized = _runtime.DeserializeEventPayload(
+            nameof(WeatherForecastCreated), json);
+
+        // Then
+        Assert.NotNull(deserialized);
+        var typed = Assert.IsType<WeatherForecastCreated>(deserialized);
+        Assert.Equal(original.ForecastId, typed.ForecastId);
+        Assert.Equal(original.Location, typed.Location);
+        Assert.Equal(original.TemperatureC, typed.TemperatureC);
+    }
+
+    [Fact]
+    public void DeserializeEventPayload_should_return_null_for_unknown_type()
+    {
+        // Given
+        var json = """{"foo":"bar"}""";
+
+        // When
+        var result = _runtime.DeserializeEventPayload("NonExistentEvent", json);
+
+        // Then
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void GetEventType_should_return_type_for_known_event()
+    {
+        // When
+        var type = _runtime.GetEventType(nameof(WeatherForecastCreated));
+
+        // Then
+        Assert.NotNull(type);
+        Assert.Equal(typeof(WeatherForecastCreated), type);
+    }
+
+    [Fact]
+    public void GetEventType_should_return_null_for_unknown_event()
+    {
+        // When
+        var type = _runtime.GetEventType("NonExistentEvent");
+
+        // Then
+        Assert.Null(type);
+    }
+}

--- a/dcb/tests/Sekiban.Dcb.Orleans.Tests/Runtimes/NativeProjectionRuntimeTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Orleans.Tests/Runtimes/NativeProjectionRuntimeTests.cs
@@ -1,0 +1,330 @@
+using Dcb.Domain;
+using Dcb.Domain.Projections;
+using Dcb.Domain.Queries;
+using Dcb.Domain.Weather;
+using Microsoft.Extensions.DependencyInjection;
+using Sekiban.Dcb.Common;
+using Sekiban.Dcb.Orleans.Serialization;
+using Sekiban.Dcb.Runtime;
+using Sekiban.Dcb.Runtime.Native;
+using Sekiban.Dcb.Tests;
+using Xunit;
+
+namespace Sekiban.Dcb.Orleans.Tests.Runtimes;
+
+public class NativeProjectionRuntimeTests
+{
+    private readonly DcbDomainTypes _domainTypes = DomainType.GetDomainTypes();
+    private readonly NativeProjectionRuntime _runtime;
+
+    public NativeProjectionRuntimeTests()
+    {
+        _runtime = new NativeProjectionRuntime(_domainTypes);
+    }
+
+    [Fact]
+    public void GetAllProjectorNames_should_return_registered_projectors()
+    {
+        // When
+        var names = _runtime.GetAllProjectorNames();
+
+        // Then
+        Assert.NotEmpty(names);
+        Assert.Contains("WeatherForecastProjection", names);
+    }
+
+    [Fact]
+    public void GetProjectorVersion_should_return_version_for_known_projector()
+    {
+        // When
+        var result = _runtime.GetProjectorVersion("WeatherForecastProjection");
+
+        // Then
+        Assert.True(result.IsSuccess);
+        Assert.Equal("1.0.0", result.GetValue());
+    }
+
+    [Fact]
+    public void GetProjectorVersion_should_fail_for_unknown_projector()
+    {
+        // When
+        var result = _runtime.GetProjectorVersion("NonExistentProjector");
+
+        // Then
+        Assert.False(result.IsSuccess);
+    }
+
+    [Fact]
+    public void GenerateInitialState_should_create_empty_state()
+    {
+        // When
+        var result = _runtime.GenerateInitialState("WeatherForecastProjection");
+
+        // Then
+        Assert.True(result.IsSuccess);
+        var state = result.GetValue();
+        Assert.Equal(0, state.SafeVersion);
+        Assert.Equal(0, state.UnsafeVersion);
+        Assert.Null(state.SafeLastSortableUniqueId);
+    }
+
+    [Fact]
+    public void GenerateInitialState_should_fail_for_unknown_projector()
+    {
+        // When
+        var result = _runtime.GenerateInitialState("NonExistentProjector");
+
+        // Then
+        Assert.False(result.IsSuccess);
+    }
+
+    [Fact]
+    public void ApplyEvent_should_update_state()
+    {
+        // Given
+        var initialState = _runtime.GenerateInitialState("WeatherForecastProjection");
+        Assert.True(initialState.IsSuccess);
+
+        var forecastId = Guid.NewGuid();
+        var payload = new WeatherForecastCreated(
+            forecastId, "Tokyo", new DateOnly(2026, 1, 1), 25, "Sunny");
+        var tag = new WeatherForecastTag(forecastId);
+        var ev = EventTestHelper.CreateEvent(payload, tag);
+
+        var threshold = SortableUniqueId.GetSafeIdFromUtc();
+
+        // When
+        var result = _runtime.ApplyEvent(
+            "WeatherForecastProjection",
+            initialState.GetValue(),
+            ev,
+            threshold);
+
+        // Then
+        Assert.True(result.IsSuccess);
+        var state = result.GetValue();
+        Assert.NotNull(state.LastSortableUniqueId);
+    }
+
+    [Fact]
+    public void ApplyEvents_should_apply_multiple_events()
+    {
+        // Given
+        var initialState = _runtime.GenerateInitialState("WeatherForecastProjection");
+        Assert.True(initialState.IsSuccess);
+
+        var forecastId1 = Guid.NewGuid();
+        var forecastId2 = Guid.NewGuid();
+        var threshold = SortableUniqueId.GetSafeIdFromUtc();
+
+        var events = new[]
+        {
+            EventTestHelper.CreateEvent(
+                new WeatherForecastCreated(forecastId1, "Tokyo", new DateOnly(2026, 1, 1), 25, "Sunny"),
+                new WeatherForecastTag(forecastId1)),
+            EventTestHelper.CreateEvent(
+                new WeatherForecastCreated(forecastId2, "Osaka", new DateOnly(2026, 2, 1), 20, "Cloudy"),
+                new WeatherForecastTag(forecastId2))
+        };
+
+        // When
+        var result = _runtime.ApplyEvents(
+            "WeatherForecastProjection",
+            initialState.GetValue(),
+            events,
+            threshold);
+
+        // Then
+        Assert.True(result.IsSuccess);
+    }
+
+    [Fact]
+    public void ApplyEvents_should_fail_if_state_type_is_wrong()
+    {
+        // Given
+        var wrongState = new FakeProjectionState();
+
+        var ev = EventTestHelper.CreateEvent(
+            new WeatherForecastCreated(
+                Guid.NewGuid(), "Tokyo", new DateOnly(2026, 1, 1), 25, "Sunny"),
+            new WeatherForecastTag(Guid.NewGuid()));
+
+        // When
+        var result = _runtime.ApplyEvent(
+            "WeatherForecastProjection",
+            wrongState,
+            ev,
+            SortableUniqueId.GetSafeIdFromUtc());
+
+        // Then
+        Assert.False(result.IsSuccess);
+    }
+
+    [Fact]
+    public void SerializeState_and_DeserializeState_should_round_trip()
+    {
+        // Given
+        var initialState = _runtime.GenerateInitialState("WeatherForecastProjection");
+        Assert.True(initialState.IsSuccess);
+
+        var forecastId = Guid.NewGuid();
+        var ev = EventTestHelper.CreateEvent(
+            new WeatherForecastCreated(forecastId, "Tokyo", new DateOnly(2026, 1, 1), 25, "Sunny"),
+            new WeatherForecastTag(forecastId));
+
+        var threshold = SortableUniqueId.GetSafeIdFromUtc();
+        var afterApply = _runtime.ApplyEvent(
+            "WeatherForecastProjection",
+            initialState.GetValue(),
+            ev,
+            threshold);
+        Assert.True(afterApply.IsSuccess);
+
+        // When - Serialize
+        var serialized = _runtime.SerializeState(
+            "WeatherForecastProjection", afterApply.GetValue());
+        Assert.True(serialized.IsSuccess);
+
+        // When - Deserialize
+        var deserialized = _runtime.DeserializeState(
+            "WeatherForecastProjection",
+            serialized.GetValue(),
+            threshold);
+
+        // Then
+        Assert.True(deserialized.IsSuccess);
+        var state = deserialized.GetValue();
+        Assert.Equal(0, state.SafeVersion);
+    }
+
+    [Fact]
+    public void ResolveProjectorName_should_find_projector_for_query()
+    {
+        // Given
+        var query = new GetWeatherForecastCountQuery();
+
+        // When
+        var result = _runtime.ResolveProjectorName(query);
+
+        // Then
+        Assert.True(result.IsSuccess);
+        Assert.Equal("WeatherForecastProjection", result.GetValue());
+    }
+
+    [Fact]
+    public void ResolveProjectorName_should_find_projector_for_list_query()
+    {
+        // Given
+        var listQuery = new GetWeatherForecastListQuery();
+
+        // When
+        var result = _runtime.ResolveProjectorName(listQuery);
+
+        // Then
+        Assert.True(result.IsSuccess);
+        Assert.Equal("WeatherForecastProjection", result.GetValue());
+    }
+
+    [Fact]
+    public async Task ExecuteQueryAsync_should_return_result()
+    {
+        // Given
+        var initialState = _runtime.GenerateInitialState("WeatherForecastProjection");
+        Assert.True(initialState.IsSuccess);
+
+        var forecastId = Guid.NewGuid();
+        var ev = EventTestHelper.CreateEvent(
+            new WeatherForecastCreated(forecastId, "Tokyo", new DateOnly(2026, 1, 1), 25, "Sunny"),
+            new WeatherForecastTag(forecastId));
+
+        var threshold = SortableUniqueId.GetSafeIdFromUtc();
+        var afterApply = _runtime.ApplyEvent(
+            "WeatherForecastProjection",
+            initialState.GetValue(),
+            ev,
+            threshold);
+        Assert.True(afterApply.IsSuccess);
+
+        var query = new GetWeatherForecastCountQuery();
+        var queryParam = await SerializableQueryParameter.CreateFromAsync(
+            query, _domainTypes.JsonSerializerOptions);
+
+        var services = new ServiceCollection().BuildServiceProvider();
+
+        // When
+        var result = await _runtime.ExecuteQueryAsync(
+            "WeatherForecastProjection",
+            afterApply.GetValue(),
+            queryParam,
+            services);
+
+        // Then
+        Assert.True(result.IsSuccess);
+    }
+
+    [Fact]
+    public async Task ExecuteListQueryAsync_should_return_result()
+    {
+        // Given
+        var initialState = _runtime.GenerateInitialState("WeatherForecastProjection");
+        Assert.True(initialState.IsSuccess);
+
+        var forecastId = Guid.NewGuid();
+        var ev = EventTestHelper.CreateEvent(
+            new WeatherForecastCreated(forecastId, "Tokyo", new DateOnly(2026, 1, 1), 25, "Sunny"),
+            new WeatherForecastTag(forecastId));
+
+        var threshold = SortableUniqueId.GetSafeIdFromUtc();
+        var afterApply = _runtime.ApplyEvent(
+            "WeatherForecastProjection",
+            initialState.GetValue(),
+            ev,
+            threshold);
+        Assert.True(afterApply.IsSuccess);
+
+        var listQuery = new GetWeatherForecastListQuery();
+        var queryParam = await SerializableQueryParameter.CreateFromAsync(
+            listQuery, _domainTypes.JsonSerializerOptions);
+
+        var services = new ServiceCollection().BuildServiceProvider();
+
+        // When
+        var result = await _runtime.ExecuteListQueryAsync(
+            "WeatherForecastProjection",
+            afterApply.GetValue(),
+            queryParam,
+            services);
+
+        // Then
+        Assert.True(result.IsSuccess);
+    }
+
+    [Fact]
+    public void NativeProjectionState_should_expose_payload_metadata()
+    {
+        // Given
+        var initialState = _runtime.GenerateInitialState("WeatherForecastProjection");
+        Assert.True(initialState.IsSuccess);
+        var state = initialState.GetValue();
+
+        // Then
+        Assert.NotNull(state.GetSafePayload());
+        Assert.NotNull(state.GetUnsafePayload());
+        Assert.True(state.EstimatePayloadSizeBytes(null) > 0);
+    }
+
+    /// <summary>
+    ///     Fake IProjectionState for testing type-check error paths.
+    /// </summary>
+    private class FakeProjectionState : IProjectionState
+    {
+        public int SafeVersion => 0;
+        public int UnsafeVersion => 0;
+        public string? SafeLastSortableUniqueId => null;
+        public string? LastSortableUniqueId => null;
+        public Guid? LastEventId => null;
+        public object? GetSafePayload() => null;
+        public object? GetUnsafePayload() => null;
+        public long EstimatePayloadSizeBytes(System.Text.Json.JsonSerializerOptions? options) => 0;
+    }
+}

--- a/dcb/tests/Sekiban.Dcb.Orleans.Tests/Runtimes/NativeTagProjectionRuntimeTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Orleans.Tests/Runtimes/NativeTagProjectionRuntimeTests.cs
@@ -1,0 +1,149 @@
+using Dcb.Domain;
+using Dcb.Domain.Weather;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.Runtime.Native;
+using Sekiban.Dcb.Tags;
+using Sekiban.Dcb.Tests;
+using Xunit;
+
+namespace Sekiban.Dcb.Orleans.Tests.Runtimes;
+
+public class NativeTagProjectionRuntimeTests
+{
+    private readonly DcbDomainTypes _domainTypes = DomainType.GetDomainTypes();
+    private readonly NativeTagProjectionRuntime _runtime;
+
+    public NativeTagProjectionRuntimeTests()
+    {
+        _runtime = new NativeTagProjectionRuntime(_domainTypes);
+    }
+
+    [Fact]
+    public void GetProjector_should_return_projector_for_known_name()
+    {
+        // When
+        var result = _runtime.GetProjector(nameof(WeatherForecastProjector));
+
+        // Then
+        Assert.True(result.IsSuccess);
+    }
+
+    [Fact]
+    public void GetProjector_should_fail_for_unknown_name()
+    {
+        // When
+        var result = _runtime.GetProjector("NonExistentProjector");
+
+        // Then
+        Assert.False(result.IsSuccess);
+    }
+
+    [Fact]
+    public void GetProjectorVersion_should_return_version()
+    {
+        // When
+        var result = _runtime.GetProjectorVersion(nameof(WeatherForecastProjector));
+
+        // Then
+        Assert.True(result.IsSuccess);
+        Assert.Equal("1.0.0", result.GetValue());
+    }
+
+    [Fact]
+    public void GetAllProjectorNames_should_include_known_projectors()
+    {
+        // When
+        var names = _runtime.GetAllProjectorNames();
+
+        // Then
+        Assert.Contains(nameof(WeatherForecastProjector), names);
+    }
+
+    [Fact]
+    public void TryGetProjectorForTagGroup_should_return_projector_name()
+    {
+        // When
+        var projectorName = _runtime.TryGetProjectorForTagGroup("WeatherForecast");
+
+        // Then
+        Assert.NotNull(projectorName);
+        Assert.Equal(nameof(WeatherForecastProjector), projectorName);
+    }
+
+    [Fact]
+    public void TryGetProjectorForTagGroup_should_return_null_for_unknown_group()
+    {
+        // When
+        var projectorName = _runtime.TryGetProjectorForTagGroup("NonExistentGroup");
+
+        // Then
+        Assert.Null(projectorName);
+    }
+
+    [Fact]
+    public void ResolveTag_should_return_tag_for_valid_string()
+    {
+        // Given
+        var forecastId = Guid.NewGuid();
+        var tagString = $"WeatherForecast:{forecastId}";
+
+        // When
+        var tag = _runtime.ResolveTag(tagString);
+
+        // Then
+        Assert.NotNull(tag);
+        Assert.Equal("WeatherForecast", tag.GetTagGroup());
+    }
+
+    [Fact]
+    public void Projector_Apply_should_project_event()
+    {
+        // Given
+        var projectorResult = _runtime.GetProjector(nameof(WeatherForecastProjector));
+        Assert.True(projectorResult.IsSuccess);
+        var projector = projectorResult.GetValue();
+
+        var forecastId = Guid.NewGuid();
+        var payload = new WeatherForecastCreated(
+            forecastId, "Tokyo", new DateOnly(2026, 1, 1), 25, "Sunny");
+        var tag = new WeatherForecastTag(forecastId);
+        var ev = EventTestHelper.CreateEvent(payload, tag);
+
+        // When
+        var state = projector.Apply(null, ev);
+
+        // Then
+        Assert.NotNull(state);
+        var typed = Assert.IsType<WeatherForecastState>(state);
+        Assert.Equal(forecastId, typed.ForecastId);
+        Assert.Equal("Tokyo", typed.Location);
+        Assert.Equal(25, typed.TemperatureC);
+    }
+
+    [Fact]
+    public void SerializePayload_and_DeserializePayload_should_round_trip()
+    {
+        // Given
+        var state = new WeatherForecastState
+        {
+            ForecastId = Guid.NewGuid(),
+            Location = "Tokyo",
+            Date = new DateOnly(2026, 1, 1),
+            TemperatureC = 25,
+            Summary = "Sunny"
+        };
+
+        // When
+        var serializeResult = _runtime.SerializePayload(state);
+        Assert.True(serializeResult.IsSuccess);
+
+        var deserializeResult = _runtime.DeserializePayload(
+            nameof(WeatherForecastState), serializeResult.GetValue());
+
+        // Then
+        Assert.True(deserializeResult.IsSuccess);
+        var deserialized = Assert.IsType<WeatherForecastState>(deserializeResult.GetValue());
+        Assert.Equal(state.ForecastId, deserialized.ForecastId);
+        Assert.Equal(state.Location, deserialized.Location);
+    }
+}

--- a/dcb/tests/Sekiban.Dcb.Orleans.Tests/Runtimes/ProjectorRuntimeResolverTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Orleans.Tests/Runtimes/ProjectorRuntimeResolverTests.cs
@@ -1,0 +1,102 @@
+using Dcb.Domain;
+using Sekiban.Dcb.Runtime;
+using Sekiban.Dcb.Runtime.Native;
+using Xunit;
+
+namespace Sekiban.Dcb.Orleans.Tests.Runtimes;
+
+public class ProjectorRuntimeResolverTests
+{
+    private readonly DcbDomainTypes _domainTypes = DomainType.GetDomainTypes();
+
+    [Fact]
+    public void Resolve_should_return_default_runtime_for_unregistered_projector()
+    {
+        // Given
+        var defaultRuntime = new NativeProjectionRuntime(_domainTypes);
+        var resolver = new ProjectorRuntimeResolver(defaultRuntime);
+
+        // When
+        var resolved = resolver.Resolve("SomeUnregisteredProjector");
+
+        // Then
+        Assert.Same(defaultRuntime, resolved);
+    }
+
+    [Fact]
+    public void Resolve_should_return_registered_runtime()
+    {
+        // Given
+        var defaultRuntime = new NativeProjectionRuntime(_domainTypes);
+        var specialRuntime = new NativeProjectionRuntime(_domainTypes);
+        var runtimeMap = new Dictionary<string, IProjectionRuntime>
+        {
+            ["WeatherForecastProjection"] = specialRuntime
+        };
+        var resolver = new ProjectorRuntimeResolver(defaultRuntime, runtimeMap);
+
+        // When
+        var resolved = resolver.Resolve("WeatherForecastProjection");
+
+        // Then
+        Assert.Same(specialRuntime, resolved);
+    }
+
+    [Fact]
+    public void GetAllRuntimes_should_include_default_and_registered()
+    {
+        // Given
+        var defaultRuntime = new NativeProjectionRuntime(_domainTypes);
+        var specialRuntime = new NativeProjectionRuntime(_domainTypes);
+        var runtimeMap = new Dictionary<string, IProjectionRuntime>
+        {
+            ["WeatherForecastProjection"] = specialRuntime
+        };
+        var resolver = new ProjectorRuntimeResolver(defaultRuntime, runtimeMap);
+
+        // When
+        var runtimes = resolver.GetAllRuntimes().ToList();
+
+        // Then
+        Assert.Contains(defaultRuntime, runtimes);
+        Assert.Contains(specialRuntime, runtimes);
+    }
+
+    [Fact]
+    public void GetAllRuntimes_should_deduplicate()
+    {
+        // Given
+        var runtime = new NativeProjectionRuntime(_domainTypes);
+        var runtimeMap = new Dictionary<string, IProjectionRuntime>
+        {
+            ["Proj1"] = runtime,
+            ["Proj2"] = runtime
+        };
+        var resolver = new ProjectorRuntimeResolver(runtime, runtimeMap);
+
+        // When
+        var runtimes = resolver.GetAllRuntimes().ToList();
+
+        // Then
+        Assert.Single(runtimes);
+    }
+
+    [Fact]
+    public void Constructor_runtimeMap_should_use_last_value_for_duplicate_keys()
+    {
+        // Given
+        var defaultRuntime = new NativeProjectionRuntime(_domainTypes);
+        var runtimeB = new NativeProjectionRuntime(_domainTypes);
+        var runtimeMap = new Dictionary<string, IProjectionRuntime>
+        {
+            ["TestProjector"] = runtimeB
+        };
+        var resolver = new ProjectorRuntimeResolver(defaultRuntime, runtimeMap);
+
+        // When
+        var resolved = resolver.Resolve("TestProjector");
+
+        // Then
+        Assert.Same(runtimeB, resolved);
+    }
+}


### PR DESCRIPTION
## Summary
- **Phase 1** of #906: Runtime abstraction interfaces + native implementations + tests
- Introduces `IProjectionRuntime`, `IEventRuntime`, `ITagProjectionRuntime` and related abstractions for future WASM runtime support
- Native C# implementations delegate to existing `DcbDomainTypes` projection/query infrastructure
- Added `IDualStateAccessor` interface to eliminate reflection-based access to `DualStateProjectionWrapper<T>` private state
- Co-located `DualStateProjectionWrapperFactory` for safer wrapper construction

## Changes
### New interfaces (`Sekiban.Dcb.Orleans.Core/Runtimes/`)
- `IProjectionRuntime`, `IProjectionState`, `IEventRuntime`, `ITagProjectionRuntime`, `ITagProjector`, `IProjectorRuntimeResolver`

### Native implementations (`Sekiban.Dcb.Orleans.Core/Runtimes/`)
- `NativeProjectionRuntime`, `NativeProjectionState`, `NativeEventRuntime`, `NativeTagProjectionRuntime`, `NativeTagProjector`, `CompositeProjectionRuntime`, `ProjectorRuntimeResolver`, `DualStateWrapperHelper`

### Core additions (`Sekiban.Dcb.Core/MultiProjections/`)
- `IDualStateAccessor` — non-generic accessor eliminating reflection
- `DualStateProjectionWrapperFactory` — co-located factory for wrapper construction
- `DualStateProjectionWrapper<T>` — added `IDualStateAccessor` implementation (explicit, additive only)

### Tests (`Sekiban.Dcb.Orleans.Tests/Runtimes/`)
- `NativeProjectionRuntimeTests`, `CompositeProjectionRuntimeTests`, `NativeEventRuntimeTests`, `NativeTagProjectionRuntimeTests`, `ProjectorRuntimeResolverTests`

## Test plan
- [x] `dotnet test` Runtimes tests: 37/37 passed (net9.0 + net10.0)
- [x] `dotnet test` WithResult.Tests: 390/390 passed (net9.0 + net10.0) — no regressions
- [ ] Manual verification with `DcbOrleans.AppHost`

🤖 Generated with [Claude Code](https://claude.com/claude-code)