### PR TITLE
Refactor Azure Storage emulator configuration

### DIFF
--- a/dcb/internalUsages/DcbOrleans.AppHost/Program.cs
+++ b/dcb/internalUsages/DcbOrleans.AppHost/Program.cs
@@ -5,8 +5,8 @@ var builder = DistributedApplication.CreateBuilder(args);
 // Add Azure Storage emulator for Orleans
 var storage = builder
     .AddAzureStorage("azurestorage")
-    .RunAsEmulator(opt => opt.WithDataVolume());
-// .RunAsEmulator();
+    // .RunAsEmulator(opt => opt.WithDataVolume());
+    .RunAsEmulator();
 var clusteringTable = storage.AddTables("DcbOrleansClusteringTable");
 var grainTable = storage.AddTables("DcbOrleansGrainTable");
 var grainStorage = storage.AddBlobs("DcbOrleansGrainState");
@@ -20,7 +20,7 @@ var postgres = builder
     .AddPostgres("dcbOrleansPostgres")
     .WithPgAdmin()
     .WithDbGate()
-    .WithDataVolume()
+    // .WithDataVolume()
     .AddDatabase("DcbPostgres");
 
 // Configure Orleans


### PR DESCRIPTION
Refactor the Azure Storage emulator configuration by disabling the data volume option for both the emulator and Postgres setup. This change simplifies the configuration process.

