### PR TITLE
fix(dcb): remove domain/DI/serializer leaks from MultiProjectionGrain

### DIFF
--- a/dcb/internalUsages/DcbOrleans.ApiService/Program.cs
+++ b/dcb/internalUsages/DcbOrleans.ApiService/Program.cs
@@ -389,6 +389,7 @@ builder.Services.AddSingleton(domainTypes);
 builder.Services.AddSingleton<Sekiban.Dcb.Runtime.IEventRuntime, Sekiban.Dcb.Runtime.Native.NativeEventRuntime>();
 builder.Services.AddSingleton<Sekiban.Dcb.Runtime.IProjectionRuntime, Sekiban.Dcb.Runtime.Native.NativeProjectionRuntime>();
 builder.Services.AddSingleton<Sekiban.Dcb.Runtime.ITagProjectionRuntime, Sekiban.Dcb.Runtime.Native.NativeTagProjectionRuntime>();
+builder.Services.AddSingleton<Sekiban.Dcb.Runtime.IProjectionActorHostFactory, Sekiban.Dcb.Runtime.Native.NativeProjectionActorHostFactory>();
 
 // Configure database storage based on configuration
 if (databaseType == "cosmos")

--- a/dcb/internalUsages/DcbOrleans.WithoutResult.ApiService/Program.cs
+++ b/dcb/internalUsages/DcbOrleans.WithoutResult.ApiService/Program.cs
@@ -393,6 +393,7 @@ builder.Services.AddSingleton(domainTypes);
 builder.Services.AddSingleton<Sekiban.Dcb.Runtime.IEventRuntime, Sekiban.Dcb.Runtime.Native.NativeEventRuntime>();
 builder.Services.AddSingleton<Sekiban.Dcb.Runtime.IProjectionRuntime, Sekiban.Dcb.Runtime.Native.NativeProjectionRuntime>();
 builder.Services.AddSingleton<Sekiban.Dcb.Runtime.ITagProjectionRuntime, Sekiban.Dcb.Runtime.Native.NativeTagProjectionRuntime>();
+builder.Services.AddSingleton<Sekiban.Dcb.Runtime.IProjectionActorHostFactory, Sekiban.Dcb.Runtime.Native.NativeProjectionActorHostFactory>();
 
 // Configure database storage based on configuration
 if (databaseType == "cosmos")

--- a/dcb/internalUsages/DcbOrleansDynamoDB.WithoutResult.ApiService/Program.cs
+++ b/dcb/internalUsages/DcbOrleansDynamoDB.WithoutResult.ApiService/Program.cs
@@ -227,6 +227,7 @@ builder.Services.AddSingleton(domainTypes);
 builder.Services.AddSingleton<Sekiban.Dcb.Runtime.IEventRuntime, Sekiban.Dcb.Runtime.Native.NativeEventRuntime>();
 builder.Services.AddSingleton<Sekiban.Dcb.Runtime.IProjectionRuntime, Sekiban.Dcb.Runtime.Native.NativeProjectionRuntime>();
 builder.Services.AddSingleton<Sekiban.Dcb.Runtime.ITagProjectionRuntime, Sekiban.Dcb.Runtime.Native.NativeTagProjectionRuntime>();
+builder.Services.AddSingleton<Sekiban.Dcb.Runtime.IProjectionActorHostFactory, Sekiban.Dcb.Runtime.Native.NativeProjectionActorHostFactory>();
 
 // Configure database storage based on configuration
 if (databaseType != "dynamodb")

--- a/dcb/src/Sekiban.Dcb.Orleans.Core/Runtimes/IProjectionActorHost.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.Core/Runtimes/IProjectionActorHost.cs
@@ -1,0 +1,113 @@
+using ResultBoxes;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.MultiProjections;
+using Sekiban.Dcb.Orleans.Serialization;
+
+namespace Sekiban.Dcb.Runtime;
+
+/// <summary>
+///     Grain-facing projection host abstraction.
+///     Engine-agnostic: operates on SerializableEvent, SerializableQuery*, byte[] snapshots,
+///     and primitive metadata only. No DcbDomainTypes, JsonSerializerOptions, or IServiceProvider.
+/// </summary>
+public interface IProjectionActorHost
+{
+    /// <summary>
+    ///     Ingest a batch of serializable events into the projection.
+    /// </summary>
+    Task AddSerializableEventsAsync(
+        IReadOnlyList<SerializableEvent> events,
+        bool finishedCatchUp = true);
+
+    /// <summary>
+    ///     Ingest a batch of deserialized events (e.g. from EventStore catch-up).
+    ///     The host converts them internally; the Grain does not need DcbDomainTypes.
+    /// </summary>
+    Task AddEventsFromCatchUpAsync(
+        IReadOnlyList<Event> events,
+        bool finishedCatchUp = true);
+
+    /// <summary>
+    ///     Get primitive metadata about the projection state.
+    /// </summary>
+    Task<ResultBox<ProjectionStateMetadata>> GetStateMetadataAsync(bool includeUnsafe = true);
+
+    /// <summary>
+    ///     Get the full projection state (including domain payload).
+    ///     The Grain passes this through opaquely to callers.
+    /// </summary>
+    Task<ResultBox<MultiProjectionState>> GetStateAsync(bool canGetUnsafeState = true);
+
+    /// <summary>
+    ///     Get the snapshot as opaque bytes. Format is owned by the implementation.
+    /// </summary>
+    Task<ResultBox<byte[]>> GetSnapshotBytesAsync(bool canGetUnsafeState = true);
+
+    /// <summary>
+    ///     Restore projection state from opaque snapshot bytes.
+    /// </summary>
+    Task<ResultBox<bool>> RestoreSnapshotAsync(byte[] snapshotData);
+
+    /// <summary>
+    ///     Execute a single-result query. The host deserializes the query and
+    ///     serializes the result internally.
+    /// </summary>
+    Task<ResultBox<SerializableQueryResult>> ExecuteQueryAsync(
+        SerializableQueryParameter query,
+        int? safeVersion,
+        string? safeThreshold,
+        DateTime? safeThresholdTime,
+        int? unsafeVersion);
+
+    /// <summary>
+    ///     Execute a list query. The host deserializes the query and
+    ///     serializes the result internally.
+    /// </summary>
+    Task<ResultBox<SerializableListQueryResult>> ExecuteListQueryAsync(
+        SerializableQueryParameter query,
+        int? safeVersion,
+        string? safeThreshold,
+        DateTime? safeThresholdTime,
+        int? unsafeVersion);
+
+    /// <summary>
+    ///     Force promotion of buffered events within the safe window.
+    /// </summary>
+    void ForcePromoteBufferedEvents();
+
+    /// <summary>
+    ///     Force promotion of ALL buffered events regardless of window.
+    /// </summary>
+    void ForcePromoteAllBufferedEvents();
+
+    /// <summary>
+    ///     Get the last safe (committed) sortable unique ID.
+    /// </summary>
+    Task<string> GetSafeLastSortableUniqueIdAsync();
+
+    /// <summary>
+    ///     Check whether a specific sortable unique ID has been received.
+    /// </summary>
+    Task<bool> IsSortableUniqueIdReceivedAsync(string sortableUniqueId);
+
+    /// <summary>
+    ///     Estimate the in-memory state size in bytes.
+    /// </summary>
+    long EstimateStateSizeBytes(bool includeUnsafeDetails);
+
+    /// <summary>
+    ///     Peek at the current safe window threshold without mutating state.
+    /// </summary>
+    string PeekCurrentSafeWindowThreshold();
+
+    /// <summary>
+    ///     Get the projector version string.
+    /// </summary>
+    string GetProjectorVersion();
+
+    /// <summary>
+    ///     Rewrite the projector version in a serialized snapshot.
+    ///     Returns updated snapshot bytes.
+    /// </summary>
+    byte[] RewriteSnapshotVersion(byte[] snapshotData, string newVersion);
+}

--- a/dcb/src/Sekiban.Dcb.Orleans.Core/Runtimes/IProjectionActorHostFactory.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.Core/Runtimes/IProjectionActorHostFactory.cs
@@ -1,0 +1,17 @@
+using Microsoft.Extensions.Logging;
+using Sekiban.Dcb.Actors;
+
+namespace Sekiban.Dcb.Runtime;
+
+/// <summary>
+///     Factory for creating IProjectionActorHost instances.
+///     Resolved via DI. The native factory captures DcbDomainTypes and IServiceProvider internally;
+///     the Grain never sees them.
+/// </summary>
+public interface IProjectionActorHostFactory
+{
+    IProjectionActorHost Create(
+        string projectorName,
+        GeneralMultiProjectionActorOptions? options = null,
+        ILogger? logger = null);
+}

--- a/dcb/src/Sekiban.Dcb.Orleans.Core/Runtimes/NativeProjectionActorHost.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.Core/Runtimes/NativeProjectionActorHost.cs
@@ -1,0 +1,405 @@
+using System.Text;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using ResultBoxes;
+using Sekiban.Dcb.Actors;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.MultiProjections;
+using Sekiban.Dcb.Orleans.Serialization;
+using Sekiban.Dcb.Queries;
+using Sekiban.Dcb.Snapshots;
+
+namespace Sekiban.Dcb.Runtime.Native;
+
+/// <summary>
+///     Native C# implementation of IProjectionActorHost.
+///     Wraps GeneralMultiProjectionActor and hides all domain-specific dependencies
+///     (DcbDomainTypes, JsonSerializerOptions, IServiceProvider) from the Grain.
+/// </summary>
+public class NativeProjectionActorHost : IProjectionActorHost
+{
+    private readonly DcbDomainTypes _domainTypes;
+    private readonly JsonSerializerOptions _jsonOptions;
+    private readonly IServiceProvider _serviceProvider;
+    private readonly GeneralMultiProjectionActor _actor;
+    private readonly string _projectorName;
+    private readonly ILogger _logger;
+
+    public NativeProjectionActorHost(
+        DcbDomainTypes domainTypes,
+        IServiceProvider serviceProvider,
+        string projectorName,
+        GeneralMultiProjectionActorOptions? options,
+        ILogger? logger)
+    {
+        _domainTypes = domainTypes;
+        _jsonOptions = domainTypes.JsonSerializerOptions;
+        _serviceProvider = serviceProvider;
+        _projectorName = projectorName;
+        _logger = logger ?? Microsoft.Extensions.Logging.Abstractions.NullLogger.Instance;
+
+        _actor = new GeneralMultiProjectionActor(domainTypes, projectorName, options, logger);
+    }
+
+    public Task AddSerializableEventsAsync(
+        IReadOnlyList<SerializableEvent> events,
+        bool finishedCatchUp = true)
+    {
+        return _actor.AddSerializableEventsAsync(events, finishedCatchUp);
+    }
+
+    public Task AddEventsFromCatchUpAsync(
+        IReadOnlyList<Event> events,
+        bool finishedCatchUp = true)
+    {
+        return _actor.AddEventsAsync(events, finishedCatchUp, EventSource.CatchUp);
+    }
+
+    public async Task<ResultBox<ProjectionStateMetadata>> GetStateMetadataAsync(bool includeUnsafe = true)
+    {
+        var unsafeResult = await _actor.GetStateAsync(canGetUnsafeState: true);
+        var safeResult = await _actor.GetStateAsync(canGetUnsafeState: false);
+
+        if (!safeResult.IsSuccess)
+        {
+            return ResultBox.Error<ProjectionStateMetadata>(safeResult.GetException());
+        }
+
+        var safeState = safeResult.GetValue();
+        var versionResult = _domainTypes.MultiProjectorTypes.GetProjectorVersion(_projectorName);
+        var projectorVersion = versionResult.IsSuccess ? versionResult.GetValue() : "unknown";
+
+        int unsafeVersion = 0;
+        string? unsafeLastSortableUniqueId = null;
+        Guid? unsafeLastEventId = null;
+
+        if (includeUnsafe && unsafeResult.IsSuccess)
+        {
+            var unsafeState = unsafeResult.GetValue();
+            unsafeVersion = unsafeState.Version;
+            unsafeLastSortableUniqueId = unsafeState.LastSortableUniqueId;
+            unsafeLastEventId = unsafeState.LastEventId;
+        }
+
+        return ResultBox.FromValue(new ProjectionStateMetadata(
+            ProjectorName: _projectorName,
+            ProjectorVersion: projectorVersion,
+            IsCatchedUp: safeState.IsCatchedUp,
+            UnsafeVersion: unsafeVersion,
+            UnsafeLastSortableUniqueId: unsafeLastSortableUniqueId,
+            UnsafeLastEventId: unsafeLastEventId,
+            SafeVersion: safeState.Version,
+            SafeLastSortableUniqueId: safeState.LastSortableUniqueId));
+    }
+
+    public Task<ResultBox<MultiProjectionState>> GetStateAsync(bool canGetUnsafeState = true)
+    {
+        return _actor.GetStateAsync(canGetUnsafeState);
+    }
+
+    public async Task<ResultBox<byte[]>> GetSnapshotBytesAsync(bool canGetUnsafeState = true)
+    {
+        var snapshotResult = await _actor.GetSnapshotAsync(canGetUnsafeState);
+        if (!snapshotResult.IsSuccess)
+        {
+            return ResultBox.Error<byte[]>(snapshotResult.GetException());
+        }
+
+        var envelope = snapshotResult.GetValue();
+        using var memoryStream = new MemoryStream();
+        await JsonSerializer.SerializeAsync(memoryStream, envelope, _jsonOptions);
+        return ResultBox.FromValue(memoryStream.ToArray());
+    }
+
+    public async Task<ResultBox<bool>> RestoreSnapshotAsync(byte[] snapshotData)
+    {
+        try
+        {
+            // Auto-detect format: v9 (Gzip) or v10 (plain JSON)
+            string envelopeJson;
+            if (snapshotData.Length >= 2 && snapshotData[0] == 0x1f && snapshotData[1] == 0x8b)
+            {
+                envelopeJson = GzipCompression.DecompressToString(snapshotData);
+            }
+            else
+            {
+                envelopeJson = Encoding.UTF8.GetString(snapshotData);
+            }
+
+            var envelope = JsonSerializer.Deserialize<SerializableMultiProjectionStateEnvelope>(
+                envelopeJson, _jsonOptions)!;
+
+            await _actor.SetSnapshotAsync(envelope);
+            return ResultBox.FromValue(true);
+        }
+        catch (Exception ex)
+        {
+            return ResultBox.Error<bool>(ex);
+        }
+    }
+
+    public async Task<ResultBox<SerializableQueryResult>> ExecuteQueryAsync(
+        SerializableQueryParameter query,
+        int? safeVersion,
+        string? safeThreshold,
+        DateTime? safeThresholdTime,
+        int? unsafeVersion)
+    {
+        try
+        {
+            var queryBox = await query.ToQueryAsync(_domainTypes);
+            if (!queryBox.IsSuccess)
+            {
+                return ResultBox.Error<SerializableQueryResult>(queryBox.GetException());
+            }
+
+            if (queryBox.GetValue() is not IQueryCommon typedQuery)
+            {
+                return ResultBox.Error<SerializableQueryResult>(
+                    new InvalidOperationException(
+                        $"Deserialized query does not implement IQueryCommon: {queryBox.GetValue().GetType().FullName}"));
+            }
+
+            var stateResult = await _actor.GetStateAsync();
+            if (!stateResult.IsSuccess)
+            {
+                var emptyResult = await SerializableQueryResult.CreateFromAsync(
+                    new QueryResultGeneral(null!, string.Empty, typedQuery),
+                    _jsonOptions);
+                return ResultBox.FromValue(emptyResult);
+            }
+
+            var state = stateResult.GetValue();
+            var projectorProvider = () => Task.FromResult(ResultBox.FromValue(state.Payload!));
+
+            var result = await _domainTypes.QueryTypes.ExecuteQueryAsync(
+                typedQuery,
+                projectorProvider,
+                _serviceProvider,
+                safeVersion,
+                safeThreshold,
+                safeThresholdTime,
+                unsafeVersion);
+
+            object? value = null;
+            string resultType = string.Empty;
+
+            if (result.IsSuccess)
+            {
+                value = result.GetValue();
+                resultType = value?.GetType().FullName ?? string.Empty;
+            }
+
+            var serialized = await SerializableQueryResult.CreateFromAsync(
+                new QueryResultGeneral(value ?? null!, resultType, typedQuery),
+                _jsonOptions);
+            return ResultBox.FromValue(serialized);
+        }
+        catch (Exception ex)
+        {
+            return ResultBox.Error<SerializableQueryResult>(ex);
+        }
+    }
+
+    public async Task<ResultBox<SerializableListQueryResult>> ExecuteListQueryAsync(
+        SerializableQueryParameter query,
+        int? safeVersion,
+        string? safeThreshold,
+        DateTime? safeThresholdTime,
+        int? unsafeVersion)
+    {
+        try
+        {
+            var queryBox = await query.ToQueryAsync(_domainTypes);
+            if (!queryBox.IsSuccess)
+            {
+                return ResultBox.Error<SerializableListQueryResult>(queryBox.GetException());
+            }
+
+            if (queryBox.GetValue() is not IListQueryCommon listQuery)
+            {
+                return ResultBox.Error<SerializableListQueryResult>(
+                    new InvalidOperationException(
+                        $"Deserialized query does not implement IListQueryCommon: {queryBox.GetValue().GetType().FullName}"));
+            }
+
+            var stateResult = await _actor.GetStateAsync();
+            if (!stateResult.IsSuccess)
+            {
+                var emptyGeneral = new ListQueryResultGeneral(
+                    0, 0, 0, 0, Array.Empty<object>(), string.Empty, listQuery);
+                var emptyResult = await SerializableListQueryResult.CreateFromAsync(
+                    emptyGeneral, _jsonOptions);
+                return ResultBox.FromValue(emptyResult);
+            }
+
+            var state = stateResult.GetValue();
+            var projectorProvider = () => Task.FromResult(ResultBox.FromValue(state.Payload!));
+
+            var result = await _domainTypes.QueryTypes.ExecuteListQueryAsGeneralAsync(
+                listQuery,
+                projectorProvider,
+                _serviceProvider,
+                safeVersion,
+                safeThreshold,
+                safeThresholdTime,
+                unsafeVersion);
+
+            var general = result.IsSuccess
+                ? result.GetValue()
+                : new ListQueryResultGeneral(
+                    0, 0, 0, 0, Array.Empty<object>(), string.Empty, listQuery);
+
+            var serialized = await SerializableListQueryResult.CreateFromAsync(
+                general, _jsonOptions);
+            return ResultBox.FromValue(serialized);
+        }
+        catch (Exception ex)
+        {
+            return ResultBox.Error<SerializableListQueryResult>(ex);
+        }
+    }
+
+    public void ForcePromoteBufferedEvents()
+    {
+        _actor.ForcePromoteBufferedEvents();
+    }
+
+    public void ForcePromoteAllBufferedEvents()
+    {
+        _actor.ForcePromoteAllBufferedEvents();
+    }
+
+    public Task<string> GetSafeLastSortableUniqueIdAsync()
+    {
+        return _actor.GetSafeLastSortableUniqueIdAsync();
+    }
+
+    public Task<bool> IsSortableUniqueIdReceivedAsync(string sortableUniqueId)
+    {
+        return _actor.IsSortableUniqueIdReceived(sortableUniqueId);
+    }
+
+    public long EstimateStateSizeBytes(bool includeUnsafeDetails)
+    {
+        try
+        {
+            var stateResult = _actor.GetStateAsync(canGetUnsafeState: includeUnsafeDetails).GetAwaiter().GetResult();
+            if (!stateResult.IsSuccess) return 0;
+
+            var payload = stateResult.GetValue().Payload;
+
+            // Special handling for TagState-based projectors
+            var payloadType = payload.GetType();
+            var stateProp = payloadType.GetProperty("State");
+            if (stateProp != null)
+            {
+                var stateObj = stateProp.GetValue(payload);
+                if (stateObj != null && stateObj.GetType().Name.StartsWith("SafeUnsafeProjectionState"))
+                {
+                    var stateType = stateObj.GetType();
+                    var currentDataField = stateType.GetField("_currentData",
+                        System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+                    var safeBackupField = stateType.GetField("_safeBackup",
+                        System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+
+                    var currentData = currentDataField?.GetValue(stateObj) as System.Collections.IDictionary;
+                    var safeBackup = safeBackupField?.GetValue(stateObj) as System.Collections.IDictionary;
+
+                    var safeKeys = new List<string>();
+                    var unsafeKeys = new List<string>();
+
+                    if (currentData != null)
+                    {
+                        foreach (System.Collections.DictionaryEntry de in currentData)
+                        {
+                            safeKeys.Add(de.Key?.ToString() ?? string.Empty);
+                        }
+                    }
+                    if (safeBackup != null)
+                    {
+                        var backupKeys = new HashSet<string>();
+                        foreach (System.Collections.DictionaryEntry de in safeBackup)
+                        {
+                            backupKeys.Add(de.Key?.ToString() ?? string.Empty);
+                        }
+                        unsafeKeys.AddRange(backupKeys);
+                        safeKeys = safeKeys.Where(k => !backupKeys.Contains(k)).ToList();
+                    }
+
+                    object dto = includeUnsafeDetails
+                        ? new { safeKeys, unsafeKeys }
+                        : new { safeKeys };
+                    var json = JsonSerializer.Serialize(dto, _jsonOptions);
+                    return Encoding.UTF8.GetByteCount(json);
+                }
+            }
+
+            var defJson = JsonSerializer.Serialize(payload, payload.GetType(), _jsonOptions);
+            return Encoding.UTF8.GetByteCount(defJson);
+        }
+        catch
+        {
+            return 0;
+        }
+    }
+
+    public string PeekCurrentSafeWindowThreshold()
+    {
+        return _actor.PeekCurrentSafeWindowThreshold().Value;
+    }
+
+    public string GetProjectorVersion()
+    {
+        var versionResult = _domainTypes.MultiProjectorTypes.GetProjectorVersion(_projectorName);
+        return versionResult.IsSuccess ? versionResult.GetValue() : "unknown";
+    }
+
+    public byte[] RewriteSnapshotVersion(byte[] snapshotData, string newVersion)
+    {
+        // Auto-detect format: v9 (Gzip) or v10 (plain JSON)
+        string envelopeJson;
+        if (snapshotData.Length >= 2 && snapshotData[0] == 0x1f && snapshotData[1] == 0x8b)
+        {
+            envelopeJson = GzipCompression.DecompressToString(snapshotData);
+        }
+        else
+        {
+            envelopeJson = Encoding.UTF8.GetString(snapshotData);
+        }
+
+        var envelope = JsonSerializer.Deserialize<SerializableMultiProjectionStateEnvelope>(
+            envelopeJson, _jsonOptions)!;
+
+        SerializableMultiProjectionStateEnvelope modified;
+        if (!envelope.IsOffloaded && envelope.InlineState != null)
+        {
+            var s = envelope.InlineState;
+            modified = new SerializableMultiProjectionStateEnvelope(
+                false,
+                SerializableMultiProjectionState.FromBytes(
+                    s.GetPayloadBytes(), s.MultiProjectionPayloadType, s.ProjectorName, newVersion,
+                    s.LastSortableUniqueId, s.LastEventId, s.Version, s.IsCatchedUp, s.IsSafeState,
+                    s.OriginalSizeBytes, s.CompressedSizeBytes),
+                null);
+        }
+        else if (envelope.OffloadedState != null)
+        {
+            var o = envelope.OffloadedState;
+            modified = new SerializableMultiProjectionStateEnvelope(
+                true,
+                null,
+                new SerializableMultiProjectionStateOffloaded(
+                    o.OffloadKey, o.StorageProvider, o.MultiProjectionPayloadType, o.ProjectorName,
+                    newVersion, o.LastSortableUniqueId, o.LastEventId, o.Version, o.IsCatchedUp, o.IsSafeState,
+                    o.PayloadLength));
+        }
+        else
+        {
+            throw new InvalidOperationException("Cannot rewrite version: envelope has no inline or offloaded state");
+        }
+
+        var modifiedJson = JsonSerializer.Serialize(modified, _jsonOptions);
+        return Encoding.UTF8.GetBytes(modifiedJson);
+    }
+}

--- a/dcb/src/Sekiban.Dcb.Orleans.Core/Runtimes/NativeProjectionActorHostFactory.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.Core/Runtimes/NativeProjectionActorHostFactory.cs
@@ -1,0 +1,36 @@
+using Microsoft.Extensions.Logging;
+using Sekiban.Dcb.Actors;
+
+namespace Sekiban.Dcb.Runtime.Native;
+
+/// <summary>
+///     Native C# factory for creating NativeProjectionActorHost instances.
+///     Captures DcbDomainTypes and IServiceProvider via DI constructor injection;
+///     the Grain never sees these dependencies.
+/// </summary>
+public class NativeProjectionActorHostFactory : IProjectionActorHostFactory
+{
+    private readonly DcbDomainTypes _domainTypes;
+    private readonly IServiceProvider _serviceProvider;
+
+    public NativeProjectionActorHostFactory(
+        DcbDomainTypes domainTypes,
+        IServiceProvider serviceProvider)
+    {
+        _domainTypes = domainTypes;
+        _serviceProvider = serviceProvider;
+    }
+
+    public IProjectionActorHost Create(
+        string projectorName,
+        GeneralMultiProjectionActorOptions? options = null,
+        ILogger? logger = null)
+    {
+        return new NativeProjectionActorHost(
+            _domainTypes,
+            _serviceProvider,
+            projectorName,
+            options,
+            logger);
+    }
+}

--- a/dcb/src/Sekiban.Dcb.Orleans.Core/Runtimes/ProjectionStateMetadata.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.Core/Runtimes/ProjectionStateMetadata.cs
@@ -1,0 +1,15 @@
+namespace Sekiban.Dcb.Runtime;
+
+/// <summary>
+///     Primitive-only metadata about the projection state.
+///     No domain types, no framework dependencies.
+/// </summary>
+public sealed record ProjectionStateMetadata(
+    string ProjectorName,
+    string ProjectorVersion,
+    bool IsCatchedUp,
+    int UnsafeVersion,
+    string? UnsafeLastSortableUniqueId,
+    Guid? UnsafeLastEventId,
+    int SafeVersion,
+    string? SafeLastSortableUniqueId);

--- a/dcb/tests/Sekiban.Dcb.Orleans.Tests/ListQueryOptionalValueOrleansTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Orleans.Tests/ListQueryOptionalValueOrleansTests.cs
@@ -139,6 +139,7 @@ public class ListQueryOptionalValueOrleansTests : IAsyncLifetime
                     services.AddSingleton<Sekiban.Dcb.Runtime.IEventRuntime, Sekiban.Dcb.Runtime.Native.NativeEventRuntime>();
                     services.AddSingleton<Sekiban.Dcb.Runtime.IProjectionRuntime, Sekiban.Dcb.Runtime.Native.NativeProjectionRuntime>();
                     services.AddSingleton<Sekiban.Dcb.Runtime.ITagProjectionRuntime, Sekiban.Dcb.Runtime.Native.NativeTagProjectionRuntime>();
+                    services.AddSingleton<Sekiban.Dcb.Runtime.IProjectionActorHostFactory, Sekiban.Dcb.Runtime.Native.NativeProjectionActorHostFactory>();
                 })
                 .AddMemoryGrainStorageAsDefault()
                 .AddMemoryGrainStorage("OrleansStorage")

--- a/dcb/tests/Sekiban.Dcb.Orleans.Tests/MinimalOrleansTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Orleans.Tests/MinimalOrleansTests.cs
@@ -250,6 +250,7 @@ public class MinimalOrleansTests : IAsyncLifetime
                     services.AddSingleton<Sekiban.Dcb.Runtime.IEventRuntime, Sekiban.Dcb.Runtime.Native.NativeEventRuntime>();
                     services.AddSingleton<Sekiban.Dcb.Runtime.IProjectionRuntime, Sekiban.Dcb.Runtime.Native.NativeProjectionRuntime>();
                     services.AddSingleton<Sekiban.Dcb.Runtime.ITagProjectionRuntime, Sekiban.Dcb.Runtime.Native.NativeTagProjectionRuntime>();
+                    services.AddSingleton<Sekiban.Dcb.Runtime.IProjectionActorHostFactory, Sekiban.Dcb.Runtime.Native.NativeProjectionActorHostFactory>();
                 })
                 .AddMemoryGrainStorageAsDefault()
                 .AddMemoryGrainStorage("OrleansStorage")

--- a/dcb/tests/Sekiban.Dcb.Orleans.Tests/SimpleOrleansCommandQueryTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Orleans.Tests/SimpleOrleansCommandQueryTests.cs
@@ -545,6 +545,7 @@ public class SimpleOrleansCommandQueryTests : IAsyncLifetime
                     services.AddSingleton<Sekiban.Dcb.Runtime.IEventRuntime, Sekiban.Dcb.Runtime.Native.NativeEventRuntime>();
                     services.AddSingleton<Sekiban.Dcb.Runtime.IProjectionRuntime, Sekiban.Dcb.Runtime.Native.NativeProjectionRuntime>();
                     services.AddSingleton<Sekiban.Dcb.Runtime.ITagProjectionRuntime, Sekiban.Dcb.Runtime.Native.NativeTagProjectionRuntime>();
+                    services.AddSingleton<Sekiban.Dcb.Runtime.IProjectionActorHostFactory, Sekiban.Dcb.Runtime.Native.NativeProjectionActorHostFactory>();
                 })
                 .AddMemoryGrainStorageAsDefault()
                 .AddMemoryGrainStorage("OrleansStorage")

--- a/dcb/tests/Sekiban.Dcb.Orleans.Tests/SnapshotVersioningTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Orleans.Tests/SnapshotVersioningTests.cs
@@ -195,6 +195,7 @@ public class SnapshotVersioningTests : IAsyncLifetime
                     services.AddSingleton<Sekiban.Dcb.Runtime.IEventRuntime, Sekiban.Dcb.Runtime.Native.NativeEventRuntime>();
                     services.AddSingleton<Sekiban.Dcb.Runtime.IProjectionRuntime, Sekiban.Dcb.Runtime.Native.NativeProjectionRuntime>();
                     services.AddSingleton<Sekiban.Dcb.Runtime.ITagProjectionRuntime, Sekiban.Dcb.Runtime.Native.NativeTagProjectionRuntime>();
+                    services.AddSingleton<Sekiban.Dcb.Runtime.IProjectionActorHostFactory, Sekiban.Dcb.Runtime.Native.NativeProjectionActorHostFactory>();
                 })
                 .AddMemoryGrainStorageAsDefault()
                 .AddMemoryGrainStorage("OrleansStorage")


### PR DESCRIPTION
## 背景
Add Projection/Event Runtime Abstraction (Phase 1 + Phase 2 migration) #906 を進める中で、Grain に DcbDomainTypes / JsonSerializerOptions / IServiceProvider 等が漏れており、将来 WASM engine 差し替え時の障壁になっていました。

## 目的
Orleans Grain を orchestration のみにし、projection engine は差し替え可能にする（native C# now, WASM later）。

## 変更内容
- seam 導入: `IProjectionActorHost` / `IProjectionActorHostFactory` / `ProjectionStateMetadata`
- `NativeProjectionActorHost` は `GeneralMultiProjectionActor` を wrap して既存挙動を維持
- `MultiProjectionGrain` を seam 経由に移行
- DI 配線: internalUsages + Orleans tests に `IProjectionActorHostFactory` を追加

## DoD
- `MultiProjectionGrain` が `DcbDomainTypes` / `JsonSerializerOptions` / `IServiceProvider` を参照しない
- Grain 内の `JsonSerializer.Serialize/Deserialize(..., _domainTypes.JsonSerializerOptions)` を撤去
- Snapshot 永続化は Grain 側は `byte[]` のみ取り扱い
- Query 実行は `SerializableQueryParameter` を host に渡すだけ
- 既存 snapshot を restore できる（native host は legacy format を保持）

## 確認
- `dotnet build` / `dotnet test dcb/tests/Sekiban.Dcb.Orleans.Tests` pass

Refs: #913 #906
