### PR TITLE
feat(dcb): remove DcbDomainTypes from Tag grains

### DIFF
--- a/dcb/internalUsages/DcbOrleans.ApiService/Program.cs
+++ b/dcb/internalUsages/DcbOrleans.ApiService/Program.cs
@@ -390,6 +390,9 @@ builder.Services.AddSingleton<Sekiban.Dcb.Runtime.IEventRuntime, Sekiban.Dcb.Run
 builder.Services.AddSingleton<Sekiban.Dcb.Runtime.IProjectionRuntime, Sekiban.Dcb.Runtime.Native.NativeProjectionRuntime>();
 builder.Services.AddSingleton<Sekiban.Dcb.Runtime.ITagProjectionRuntime, Sekiban.Dcb.Runtime.Native.NativeTagProjectionRuntime>();
 builder.Services.AddSingleton<Sekiban.Dcb.Runtime.IProjectionActorHostFactory, Sekiban.Dcb.Runtime.Native.NativeProjectionActorHostFactory>();
+builder.Services.AddSingleton<Sekiban.Dcb.Domains.ITagProjectorTypes>(sp => sp.GetRequiredService<DcbDomainTypes>().TagProjectorTypes);
+builder.Services.AddSingleton<Sekiban.Dcb.Domains.ITagTypes>(sp => sp.GetRequiredService<DcbDomainTypes>().TagTypes);
+builder.Services.AddSingleton<Sekiban.Dcb.Domains.ITagStatePayloadTypes>(sp => sp.GetRequiredService<DcbDomainTypes>().TagStatePayloadTypes);
 
 // Configure database storage based on configuration
 if (databaseType == "cosmos")

--- a/dcb/internalUsages/DcbOrleans.WithoutResult.ApiService/Program.cs
+++ b/dcb/internalUsages/DcbOrleans.WithoutResult.ApiService/Program.cs
@@ -394,6 +394,9 @@ builder.Services.AddSingleton<Sekiban.Dcb.Runtime.IEventRuntime, Sekiban.Dcb.Run
 builder.Services.AddSingleton<Sekiban.Dcb.Runtime.IProjectionRuntime, Sekiban.Dcb.Runtime.Native.NativeProjectionRuntime>();
 builder.Services.AddSingleton<Sekiban.Dcb.Runtime.ITagProjectionRuntime, Sekiban.Dcb.Runtime.Native.NativeTagProjectionRuntime>();
 builder.Services.AddSingleton<Sekiban.Dcb.Runtime.IProjectionActorHostFactory, Sekiban.Dcb.Runtime.Native.NativeProjectionActorHostFactory>();
+builder.Services.AddSingleton<Sekiban.Dcb.Domains.ITagProjectorTypes>(sp => sp.GetRequiredService<DcbDomainTypes>().TagProjectorTypes);
+builder.Services.AddSingleton<Sekiban.Dcb.Domains.ITagTypes>(sp => sp.GetRequiredService<DcbDomainTypes>().TagTypes);
+builder.Services.AddSingleton<Sekiban.Dcb.Domains.ITagStatePayloadTypes>(sp => sp.GetRequiredService<DcbDomainTypes>().TagStatePayloadTypes);
 
 // Configure database storage based on configuration
 if (databaseType == "cosmos")

--- a/dcb/internalUsages/DcbOrleansDynamoDB.WithoutResult.ApiService/Program.cs
+++ b/dcb/internalUsages/DcbOrleansDynamoDB.WithoutResult.ApiService/Program.cs
@@ -228,6 +228,9 @@ builder.Services.AddSingleton<Sekiban.Dcb.Runtime.IEventRuntime, Sekiban.Dcb.Run
 builder.Services.AddSingleton<Sekiban.Dcb.Runtime.IProjectionRuntime, Sekiban.Dcb.Runtime.Native.NativeProjectionRuntime>();
 builder.Services.AddSingleton<Sekiban.Dcb.Runtime.ITagProjectionRuntime, Sekiban.Dcb.Runtime.Native.NativeTagProjectionRuntime>();
 builder.Services.AddSingleton<Sekiban.Dcb.Runtime.IProjectionActorHostFactory, Sekiban.Dcb.Runtime.Native.NativeProjectionActorHostFactory>();
+builder.Services.AddSingleton<Sekiban.Dcb.Domains.ITagProjectorTypes>(sp => sp.GetRequiredService<DcbDomainTypes>().TagProjectorTypes);
+builder.Services.AddSingleton<Sekiban.Dcb.Domains.ITagTypes>(sp => sp.GetRequiredService<DcbDomainTypes>().TagTypes);
+builder.Services.AddSingleton<Sekiban.Dcb.Domains.ITagStatePayloadTypes>(sp => sp.GetRequiredService<DcbDomainTypes>().TagStatePayloadTypes);
 
 // Configure database storage based on configuration
 if (databaseType != "dynamodb")

--- a/dcb/src/Sekiban.Dcb.Core/InMemory/InMemoryObjectAccessor.cs
+++ b/dcb/src/Sekiban.Dcb.Core/InMemory/InMemoryObjectAccessor.cs
@@ -115,14 +115,20 @@ public class InMemoryObjectAccessor : IActorObjectAccessor, IServiceProvider
                 tagName,
                 _eventStore,
                 new TagConsistentActorOptions(),
-                _domainTypes) as T;
+                _domainTypes.TagTypes) as T;
         }
 
         // Create TagStateActor
         if (typeof(T) == typeof(ITagStateActorCommon) && parts.Length >= 3)
         {
             // Format: "TagGroup:TagContent:TagProjectorName"
-            return new GeneralTagStateActor(actorId, _eventStore, _domainTypes, this) as T;
+            return new GeneralTagStateActor(
+                actorId,
+                _eventStore,
+                _domainTypes.TagProjectorTypes,
+                _domainTypes.TagTypes,
+                _domainTypes.TagStatePayloadTypes,
+                this) as T;
         }
 
         // Create MultiProjectionActor (projectorName passed as actorId)

--- a/dcb/src/Sekiban.Dcb.Orleans.Core/Grains/TagConsistentGrain.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.Core/Grains/TagConsistentGrain.cs
@@ -1,5 +1,6 @@
 using ResultBoxes;
 using Sekiban.Dcb.Actors;
+using Sekiban.Dcb.Domains;
 using Sekiban.Dcb.Orleans.ServiceId;
 using Sekiban.Dcb.Storage;
 using Sekiban.Dcb.Tags;
@@ -11,18 +12,18 @@ namespace Sekiban.Dcb.Orleans.Grains;
 /// </summary>
 public class TagConsistentGrain : Grain, ITagConsistentGrain
 {
-    private readonly DcbDomainTypes _domainTypes;
+    private readonly ITagTypes _tagTypes;
     private readonly IEventStore _eventStore;
     private readonly TagConsistentActorOptions _options;
     private GeneralTagConsistentActor? _actor;
 
     public TagConsistentGrain(
         IEventStore eventStore,
-        DcbDomainTypes domainTypes,
+        ITagTypes tagTypes,
         TagConsistentActorOptions? options = null)
     {
         _eventStore = eventStore;
-        _domainTypes = domainTypes ?? throw new ArgumentNullException(nameof(domainTypes));
+        _tagTypes = tagTypes ?? throw new ArgumentNullException(nameof(tagTypes));
         _options = options ?? new TagConsistentActorOptions();
     }
 
@@ -92,7 +93,7 @@ public class TagConsistentGrain : Grain, ITagConsistentGrain
         var tagName = ServiceIdGrainKey.Strip(this.GetPrimaryKeyString());
 
         // Create the actor instance
-        _actor = new GeneralTagConsistentActor(tagName, _eventStore, _options, _domainTypes);
+        _actor = new GeneralTagConsistentActor(tagName, _eventStore, _options, _tagTypes);
 
         return base.OnActivateAsync(cancellationToken);
     }

--- a/dcb/src/Sekiban.Dcb.Orleans.Core/Grains/TagStateGrain.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.Core/Grains/TagStateGrain.cs
@@ -1,4 +1,5 @@
 using Sekiban.Dcb.Actors;
+using Sekiban.Dcb.Domains;
 using Sekiban.Dcb.Orleans.ServiceId;
 using Sekiban.Dcb.Runtime;
 using Sekiban.Dcb.Storage;
@@ -13,20 +14,26 @@ public class TagStateGrain : Grain, ITagStateGrain
 {
     private readonly IActorObjectAccessor _actorAccessor;
     private readonly IPersistentState<TagStateCacheState> _cache;
-    private readonly DcbDomainTypes _domainTypes;
+    private readonly ITagProjectorTypes _tagProjectorTypes;
+    private readonly ITagTypes _tagTypes;
+    private readonly ITagStatePayloadTypes _tagStatePayloadTypes;
     private readonly IEventStore _eventStore;
     private readonly ITagProjectionRuntime _tagProjectionRuntime;
     private GeneralTagStateActor? _actor;
 
     public TagStateGrain(
         IEventStore eventStore,
-        DcbDomainTypes domainTypes,
+        ITagProjectorTypes tagProjectorTypes,
+        ITagTypes tagTypes,
+        ITagStatePayloadTypes tagStatePayloadTypes,
         ITagProjectionRuntime tagProjectionRuntime,
         IActorObjectAccessor actorAccessor,
         [PersistentState("tagStateCache", "OrleansStorage")] IPersistentState<TagStateCacheState> cache)
     {
         _eventStore = eventStore;
-        _domainTypes = domainTypes;
+        _tagProjectorTypes = tagProjectorTypes;
+        _tagTypes = tagTypes;
+        _tagStatePayloadTypes = tagStatePayloadTypes;
         _tagProjectionRuntime = tagProjectionRuntime;
         _actorAccessor = actorAccessor;
         _cache = cache;
@@ -111,7 +118,9 @@ public class TagStateGrain : Grain, ITagStateGrain
         _actor = new GeneralTagStateActor(
             tagStateId,
             _eventStore,
-            _domainTypes,
+            _tagProjectorTypes,
+            _tagTypes,
+            _tagStatePayloadTypes,
             new TagStateOptions(),
             _actorAccessor,
             tagStatePersistent);

--- a/dcb/src/Sekiban.Dcb.Orleans.Core/Runtimes/NativeProjectionActorHost.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.Core/Runtimes/NativeProjectionActorHost.cs
@@ -1,13 +1,9 @@
-using System.Text;
-using System.Text.Json;
 using Microsoft.Extensions.Logging;
 using ResultBoxes;
 using Sekiban.Dcb.Actors;
 using Sekiban.Dcb.Events;
 using Sekiban.Dcb.MultiProjections;
 using Sekiban.Dcb.Orleans.Serialization;
-using Sekiban.Dcb.Queries;
-using Sekiban.Dcb.Snapshots;
 
 namespace Sekiban.Dcb.Runtime.Native;
 
@@ -15,15 +11,15 @@ namespace Sekiban.Dcb.Runtime.Native;
 ///     Native C# implementation of IProjectionActorHost.
 ///     Wraps GeneralMultiProjectionActor and hides all domain-specific dependencies
 ///     (DcbDomainTypes, JsonSerializerOptions, IServiceProvider) from the Grain.
+///     Query execution and snapshot handling are delegated to focused helper classes.
 /// </summary>
 public class NativeProjectionActorHost : IProjectionActorHost
 {
     private readonly DcbDomainTypes _domainTypes;
-    private readonly JsonSerializerOptions _jsonOptions;
-    private readonly IServiceProvider _serviceProvider;
     private readonly GeneralMultiProjectionActor _actor;
     private readonly string _projectorName;
-    private readonly ILogger _logger;
+    private readonly NativeProjectionQueryExecutor _queryExecutor;
+    private readonly NativeProjectionSnapshotHandler _snapshotHandler;
 
     public NativeProjectionActorHost(
         DcbDomainTypes domainTypes,
@@ -33,12 +29,13 @@ public class NativeProjectionActorHost : IProjectionActorHost
         ILogger? logger)
     {
         _domainTypes = domainTypes;
-        _jsonOptions = domainTypes.JsonSerializerOptions;
-        _serviceProvider = serviceProvider;
         _projectorName = projectorName;
-        _logger = logger ?? Microsoft.Extensions.Logging.Abstractions.NullLogger.Instance;
+        var resolvedLogger = logger ?? Microsoft.Extensions.Logging.Abstractions.NullLogger.Instance;
+        var jsonOptions = domainTypes.JsonSerializerOptions;
 
         _actor = new GeneralMultiProjectionActor(domainTypes, projectorName, options, logger);
+        _queryExecutor = new NativeProjectionQueryExecutor(domainTypes, jsonOptions, serviceProvider, _actor);
+        _snapshotHandler = new NativeProjectionSnapshotHandler(jsonOptions, _actor, resolvedLogger);
     }
 
     public Task AddSerializableEventsAsync(
@@ -97,167 +94,34 @@ public class NativeProjectionActorHost : IProjectionActorHost
         return _actor.GetStateAsync(canGetUnsafeState);
     }
 
-    public async Task<ResultBox<byte[]>> GetSnapshotBytesAsync(bool canGetUnsafeState = true)
+    public Task<ResultBox<byte[]>> GetSnapshotBytesAsync(bool canGetUnsafeState = true)
     {
-        var snapshotResult = await _actor.GetSnapshotAsync(canGetUnsafeState);
-        if (!snapshotResult.IsSuccess)
-        {
-            return ResultBox.Error<byte[]>(snapshotResult.GetException());
-        }
-
-        var envelope = snapshotResult.GetValue();
-        using var memoryStream = new MemoryStream();
-        await JsonSerializer.SerializeAsync(memoryStream, envelope, _jsonOptions);
-        return ResultBox.FromValue(memoryStream.ToArray());
+        return _snapshotHandler.GetSnapshotBytesAsync(canGetUnsafeState);
     }
 
-    public async Task<ResultBox<bool>> RestoreSnapshotAsync(byte[] snapshotData)
+    public Task<ResultBox<bool>> RestoreSnapshotAsync(byte[] snapshotData)
     {
-        try
-        {
-            // Auto-detect format: v9 (Gzip) or v10 (plain JSON)
-            string envelopeJson;
-            if (snapshotData.Length >= 2 && snapshotData[0] == 0x1f && snapshotData[1] == 0x8b)
-            {
-                envelopeJson = GzipCompression.DecompressToString(snapshotData);
-            }
-            else
-            {
-                envelopeJson = Encoding.UTF8.GetString(snapshotData);
-            }
-
-            var envelope = JsonSerializer.Deserialize<SerializableMultiProjectionStateEnvelope>(
-                envelopeJson, _jsonOptions)!;
-
-            await _actor.SetSnapshotAsync(envelope);
-            return ResultBox.FromValue(true);
-        }
-        catch (Exception ex)
-        {
-            return ResultBox.Error<bool>(ex);
-        }
+        return _snapshotHandler.RestoreSnapshotAsync(snapshotData);
     }
 
-    public async Task<ResultBox<SerializableQueryResult>> ExecuteQueryAsync(
+    public Task<ResultBox<SerializableQueryResult>> ExecuteQueryAsync(
         SerializableQueryParameter query,
         int? safeVersion,
         string? safeThreshold,
         DateTime? safeThresholdTime,
         int? unsafeVersion)
     {
-        try
-        {
-            var queryBox = await query.ToQueryAsync(_domainTypes);
-            if (!queryBox.IsSuccess)
-            {
-                return ResultBox.Error<SerializableQueryResult>(queryBox.GetException());
-            }
-
-            if (queryBox.GetValue() is not IQueryCommon typedQuery)
-            {
-                return ResultBox.Error<SerializableQueryResult>(
-                    new InvalidOperationException(
-                        $"Deserialized query does not implement IQueryCommon: {queryBox.GetValue().GetType().FullName}"));
-            }
-
-            var stateResult = await _actor.GetStateAsync();
-            if (!stateResult.IsSuccess)
-            {
-                var emptyResult = await SerializableQueryResult.CreateFromAsync(
-                    new QueryResultGeneral(null!, string.Empty, typedQuery),
-                    _jsonOptions);
-                return ResultBox.FromValue(emptyResult);
-            }
-
-            var state = stateResult.GetValue();
-            var projectorProvider = () => Task.FromResult(ResultBox.FromValue(state.Payload!));
-
-            var result = await _domainTypes.QueryTypes.ExecuteQueryAsync(
-                typedQuery,
-                projectorProvider,
-                _serviceProvider,
-                safeVersion,
-                safeThreshold,
-                safeThresholdTime,
-                unsafeVersion);
-
-            object? value = null;
-            string resultType = string.Empty;
-
-            if (result.IsSuccess)
-            {
-                value = result.GetValue();
-                resultType = value?.GetType().FullName ?? string.Empty;
-            }
-
-            var serialized = await SerializableQueryResult.CreateFromAsync(
-                new QueryResultGeneral(value ?? null!, resultType, typedQuery),
-                _jsonOptions);
-            return ResultBox.FromValue(serialized);
-        }
-        catch (Exception ex)
-        {
-            return ResultBox.Error<SerializableQueryResult>(ex);
-        }
+        return _queryExecutor.ExecuteQueryAsync(query, safeVersion, safeThreshold, safeThresholdTime, unsafeVersion);
     }
 
-    public async Task<ResultBox<SerializableListQueryResult>> ExecuteListQueryAsync(
+    public Task<ResultBox<SerializableListQueryResult>> ExecuteListQueryAsync(
         SerializableQueryParameter query,
         int? safeVersion,
         string? safeThreshold,
         DateTime? safeThresholdTime,
         int? unsafeVersion)
     {
-        try
-        {
-            var queryBox = await query.ToQueryAsync(_domainTypes);
-            if (!queryBox.IsSuccess)
-            {
-                return ResultBox.Error<SerializableListQueryResult>(queryBox.GetException());
-            }
-
-            if (queryBox.GetValue() is not IListQueryCommon listQuery)
-            {
-                return ResultBox.Error<SerializableListQueryResult>(
-                    new InvalidOperationException(
-                        $"Deserialized query does not implement IListQueryCommon: {queryBox.GetValue().GetType().FullName}"));
-            }
-
-            var stateResult = await _actor.GetStateAsync();
-            if (!stateResult.IsSuccess)
-            {
-                var emptyGeneral = new ListQueryResultGeneral(
-                    0, 0, 0, 0, Array.Empty<object>(), string.Empty, listQuery);
-                var emptyResult = await SerializableListQueryResult.CreateFromAsync(
-                    emptyGeneral, _jsonOptions);
-                return ResultBox.FromValue(emptyResult);
-            }
-
-            var state = stateResult.GetValue();
-            var projectorProvider = () => Task.FromResult(ResultBox.FromValue(state.Payload!));
-
-            var result = await _domainTypes.QueryTypes.ExecuteListQueryAsGeneralAsync(
-                listQuery,
-                projectorProvider,
-                _serviceProvider,
-                safeVersion,
-                safeThreshold,
-                safeThresholdTime,
-                unsafeVersion);
-
-            var general = result.IsSuccess
-                ? result.GetValue()
-                : new ListQueryResultGeneral(
-                    0, 0, 0, 0, Array.Empty<object>(), string.Empty, listQuery);
-
-            var serialized = await SerializableListQueryResult.CreateFromAsync(
-                general, _jsonOptions);
-            return ResultBox.FromValue(serialized);
-        }
-        catch (Exception ex)
-        {
-            return ResultBox.Error<SerializableListQueryResult>(ex);
-        }
+        return _queryExecutor.ExecuteListQueryAsync(query, safeVersion, safeThreshold, safeThresholdTime, unsafeVersion);
     }
 
     public void ForcePromoteBufferedEvents()
@@ -282,66 +146,7 @@ public class NativeProjectionActorHost : IProjectionActorHost
 
     public long EstimateStateSizeBytes(bool includeUnsafeDetails)
     {
-        try
-        {
-            var stateResult = _actor.GetStateAsync(canGetUnsafeState: includeUnsafeDetails).GetAwaiter().GetResult();
-            if (!stateResult.IsSuccess) return 0;
-
-            var payload = stateResult.GetValue().Payload;
-
-            // Special handling for TagState-based projectors
-            var payloadType = payload.GetType();
-            var stateProp = payloadType.GetProperty("State");
-            if (stateProp != null)
-            {
-                var stateObj = stateProp.GetValue(payload);
-                if (stateObj != null && stateObj.GetType().Name.StartsWith("SafeUnsafeProjectionState"))
-                {
-                    var stateType = stateObj.GetType();
-                    var currentDataField = stateType.GetField("_currentData",
-                        System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
-                    var safeBackupField = stateType.GetField("_safeBackup",
-                        System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
-
-                    var currentData = currentDataField?.GetValue(stateObj) as System.Collections.IDictionary;
-                    var safeBackup = safeBackupField?.GetValue(stateObj) as System.Collections.IDictionary;
-
-                    var safeKeys = new List<string>();
-                    var unsafeKeys = new List<string>();
-
-                    if (currentData != null)
-                    {
-                        foreach (System.Collections.DictionaryEntry de in currentData)
-                        {
-                            safeKeys.Add(de.Key?.ToString() ?? string.Empty);
-                        }
-                    }
-                    if (safeBackup != null)
-                    {
-                        var backupKeys = new HashSet<string>();
-                        foreach (System.Collections.DictionaryEntry de in safeBackup)
-                        {
-                            backupKeys.Add(de.Key?.ToString() ?? string.Empty);
-                        }
-                        unsafeKeys.AddRange(backupKeys);
-                        safeKeys = safeKeys.Where(k => !backupKeys.Contains(k)).ToList();
-                    }
-
-                    object dto = includeUnsafeDetails
-                        ? new { safeKeys, unsafeKeys }
-                        : new { safeKeys };
-                    var json = JsonSerializer.Serialize(dto, _jsonOptions);
-                    return Encoding.UTF8.GetByteCount(json);
-                }
-            }
-
-            var defJson = JsonSerializer.Serialize(payload, payload.GetType(), _jsonOptions);
-            return Encoding.UTF8.GetByteCount(defJson);
-        }
-        catch
-        {
-            return 0;
-        }
+        return _snapshotHandler.EstimateStateSizeBytes(includeUnsafeDetails);
     }
 
     public string PeekCurrentSafeWindowThreshold()
@@ -357,49 +162,6 @@ public class NativeProjectionActorHost : IProjectionActorHost
 
     public byte[] RewriteSnapshotVersion(byte[] snapshotData, string newVersion)
     {
-        // Auto-detect format: v9 (Gzip) or v10 (plain JSON)
-        string envelopeJson;
-        if (snapshotData.Length >= 2 && snapshotData[0] == 0x1f && snapshotData[1] == 0x8b)
-        {
-            envelopeJson = GzipCompression.DecompressToString(snapshotData);
-        }
-        else
-        {
-            envelopeJson = Encoding.UTF8.GetString(snapshotData);
-        }
-
-        var envelope = JsonSerializer.Deserialize<SerializableMultiProjectionStateEnvelope>(
-            envelopeJson, _jsonOptions)!;
-
-        SerializableMultiProjectionStateEnvelope modified;
-        if (!envelope.IsOffloaded && envelope.InlineState != null)
-        {
-            var s = envelope.InlineState;
-            modified = new SerializableMultiProjectionStateEnvelope(
-                false,
-                SerializableMultiProjectionState.FromBytes(
-                    s.GetPayloadBytes(), s.MultiProjectionPayloadType, s.ProjectorName, newVersion,
-                    s.LastSortableUniqueId, s.LastEventId, s.Version, s.IsCatchedUp, s.IsSafeState,
-                    s.OriginalSizeBytes, s.CompressedSizeBytes),
-                null);
-        }
-        else if (envelope.OffloadedState != null)
-        {
-            var o = envelope.OffloadedState;
-            modified = new SerializableMultiProjectionStateEnvelope(
-                true,
-                null,
-                new SerializableMultiProjectionStateOffloaded(
-                    o.OffloadKey, o.StorageProvider, o.MultiProjectionPayloadType, o.ProjectorName,
-                    newVersion, o.LastSortableUniqueId, o.LastEventId, o.Version, o.IsCatchedUp, o.IsSafeState,
-                    o.PayloadLength));
-        }
-        else
-        {
-            throw new InvalidOperationException("Cannot rewrite version: envelope has no inline or offloaded state");
-        }
-
-        var modifiedJson = JsonSerializer.Serialize(modified, _jsonOptions);
-        return Encoding.UTF8.GetBytes(modifiedJson);
+        return _snapshotHandler.RewriteSnapshotVersion(snapshotData, newVersion);
     }
 }

--- a/dcb/src/Sekiban.Dcb.Orleans.Core/Runtimes/NativeProjectionQueryExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.Core/Runtimes/NativeProjectionQueryExecutor.cs
@@ -1,0 +1,154 @@
+using System.Text.Json;
+using ResultBoxes;
+using Sekiban.Dcb.Actors;
+using Sekiban.Dcb.MultiProjections;
+using Sekiban.Dcb.Orleans.Serialization;
+using Sekiban.Dcb.Queries;
+
+namespace Sekiban.Dcb.Runtime.Native;
+
+/// <summary>
+///     Handles query execution for NativeProjectionActorHost.
+///     Encapsulates the domain-specific query deserialization and execution logic.
+/// </summary>
+internal class NativeProjectionQueryExecutor
+{
+    private readonly DcbDomainTypes _domainTypes;
+    private readonly JsonSerializerOptions _jsonOptions;
+    private readonly IServiceProvider _serviceProvider;
+    private readonly GeneralMultiProjectionActor _actor;
+
+    public NativeProjectionQueryExecutor(
+        DcbDomainTypes domainTypes,
+        JsonSerializerOptions jsonOptions,
+        IServiceProvider serviceProvider,
+        GeneralMultiProjectionActor actor)
+    {
+        _domainTypes = domainTypes;
+        _jsonOptions = jsonOptions;
+        _serviceProvider = serviceProvider;
+        _actor = actor;
+    }
+
+    public async Task<ResultBox<SerializableQueryResult>> ExecuteQueryAsync(
+        SerializableQueryParameter query,
+        int? safeVersion,
+        string? safeThreshold,
+        DateTime? safeThresholdTime,
+        int? unsafeVersion)
+    {
+        try
+        {
+            var queryBox = await query.ToQueryAsync(_domainTypes);
+            if (!queryBox.IsSuccess)
+            {
+                return ResultBox.Error<SerializableQueryResult>(queryBox.GetException());
+            }
+
+            if (queryBox.GetValue() is not IQueryCommon typedQuery)
+            {
+                return ResultBox.Error<SerializableQueryResult>(
+                    new InvalidOperationException(
+                        $"Deserialized query does not implement IQueryCommon: {queryBox.GetValue().GetType().FullName}"));
+            }
+
+            var stateResult = await _actor.GetStateAsync();
+            if (!stateResult.IsSuccess)
+            {
+                var emptyResult = await SerializableQueryResult.CreateFromAsync(
+                    new QueryResultGeneral(null!, string.Empty, typedQuery),
+                    _jsonOptions);
+                return ResultBox.FromValue(emptyResult);
+            }
+
+            var state = stateResult.GetValue();
+            var projectorProvider = () => Task.FromResult(ResultBox.FromValue(state.Payload!));
+
+            var result = await _domainTypes.QueryTypes.ExecuteQueryAsync(
+                typedQuery,
+                projectorProvider,
+                _serviceProvider,
+                safeVersion,
+                safeThreshold,
+                safeThresholdTime,
+                unsafeVersion);
+
+            object? value = null;
+            string resultType = string.Empty;
+
+            if (result.IsSuccess)
+            {
+                value = result.GetValue();
+                resultType = value?.GetType().FullName ?? string.Empty;
+            }
+
+            var serialized = await SerializableQueryResult.CreateFromAsync(
+                new QueryResultGeneral(value ?? null!, resultType, typedQuery),
+                _jsonOptions);
+            return ResultBox.FromValue(serialized);
+        }
+        catch (Exception ex)
+        {
+            return ResultBox.Error<SerializableQueryResult>(ex);
+        }
+    }
+
+    public async Task<ResultBox<SerializableListQueryResult>> ExecuteListQueryAsync(
+        SerializableQueryParameter query,
+        int? safeVersion,
+        string? safeThreshold,
+        DateTime? safeThresholdTime,
+        int? unsafeVersion)
+    {
+        try
+        {
+            var queryBox = await query.ToQueryAsync(_domainTypes);
+            if (!queryBox.IsSuccess)
+            {
+                return ResultBox.Error<SerializableListQueryResult>(queryBox.GetException());
+            }
+
+            if (queryBox.GetValue() is not IListQueryCommon listQuery)
+            {
+                return ResultBox.Error<SerializableListQueryResult>(
+                    new InvalidOperationException(
+                        $"Deserialized query does not implement IListQueryCommon: {queryBox.GetValue().GetType().FullName}"));
+            }
+
+            var stateResult = await _actor.GetStateAsync();
+            if (!stateResult.IsSuccess)
+            {
+                var emptyGeneral = new ListQueryResultGeneral(
+                    0, 0, 0, 0, Array.Empty<object>(), string.Empty, listQuery);
+                var emptyResult = await SerializableListQueryResult.CreateFromAsync(
+                    emptyGeneral, _jsonOptions);
+                return ResultBox.FromValue(emptyResult);
+            }
+
+            var state = stateResult.GetValue();
+            var projectorProvider = () => Task.FromResult(ResultBox.FromValue(state.Payload!));
+
+            var result = await _domainTypes.QueryTypes.ExecuteListQueryAsGeneralAsync(
+                listQuery,
+                projectorProvider,
+                _serviceProvider,
+                safeVersion,
+                safeThreshold,
+                safeThresholdTime,
+                unsafeVersion);
+
+            var general = result.IsSuccess
+                ? result.GetValue()
+                : new ListQueryResultGeneral(
+                    0, 0, 0, 0, Array.Empty<object>(), string.Empty, listQuery);
+
+            var serialized = await SerializableListQueryResult.CreateFromAsync(
+                general, _jsonOptions);
+            return ResultBox.FromValue(serialized);
+        }
+        catch (Exception ex)
+        {
+            return ResultBox.Error<SerializableListQueryResult>(ex);
+        }
+    }
+}

--- a/dcb/src/Sekiban.Dcb.Orleans.Core/Runtimes/NativeProjectionSnapshotHandler.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.Core/Runtimes/NativeProjectionSnapshotHandler.cs
@@ -1,0 +1,183 @@
+using System.Text;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using ResultBoxes;
+using Sekiban.Dcb.Actors;
+using Sekiban.Dcb.MultiProjections;
+using Sekiban.Dcb.Orleans.Serialization;
+using Sekiban.Dcb.Snapshots;
+
+namespace Sekiban.Dcb.Runtime.Native;
+
+/// <summary>
+///     Handles snapshot serialization, restoration, rewriting, and size estimation
+///     for NativeProjectionActorHost.
+/// </summary>
+internal class NativeProjectionSnapshotHandler
+{
+    private readonly JsonSerializerOptions _jsonOptions;
+    private readonly GeneralMultiProjectionActor _actor;
+    private readonly ILogger _logger;
+
+    public NativeProjectionSnapshotHandler(
+        JsonSerializerOptions jsonOptions,
+        GeneralMultiProjectionActor actor,
+        ILogger logger)
+    {
+        _jsonOptions = jsonOptions;
+        _actor = actor;
+        _logger = logger;
+    }
+
+    public async Task<ResultBox<byte[]>> GetSnapshotBytesAsync(bool canGetUnsafeState = true)
+    {
+        var snapshotResult = await _actor.GetSnapshotAsync(canGetUnsafeState);
+        if (!snapshotResult.IsSuccess)
+        {
+            return ResultBox.Error<byte[]>(snapshotResult.GetException());
+        }
+
+        var envelope = snapshotResult.GetValue();
+        using var memoryStream = new MemoryStream();
+        await JsonSerializer.SerializeAsync(memoryStream, envelope, _jsonOptions);
+        return ResultBox.FromValue(memoryStream.ToArray());
+    }
+
+    public async Task<ResultBox<bool>> RestoreSnapshotAsync(byte[] snapshotData)
+    {
+        try
+        {
+            var envelopeJson = DecompressSnapshotData(snapshotData);
+
+            var envelope = JsonSerializer.Deserialize<SerializableMultiProjectionStateEnvelope>(
+                envelopeJson, _jsonOptions)!;
+
+            await _actor.SetSnapshotAsync(envelope);
+            return ResultBox.FromValue(true);
+        }
+        catch (Exception ex)
+        {
+            return ResultBox.Error<bool>(ex);
+        }
+    }
+
+    public long EstimateStateSizeBytes(bool includeUnsafeDetails)
+    {
+        try
+        {
+            var stateResult = _actor.GetStateAsync(canGetUnsafeState: includeUnsafeDetails).GetAwaiter().GetResult();
+            if (!stateResult.IsSuccess) return 0;
+
+            var payload = stateResult.GetValue().Payload;
+
+            var payloadType = payload.GetType();
+            var stateProp = payloadType.GetProperty("State");
+            if (stateProp != null)
+            {
+                var stateObj = stateProp.GetValue(payload);
+                if (stateObj != null && stateObj.GetType().Name.StartsWith("SafeUnsafeProjectionState"))
+                {
+                    return EstimateSafeUnsafeProjectionStateSize(stateObj, includeUnsafeDetails);
+                }
+            }
+
+            var defJson = JsonSerializer.Serialize(payload, payload.GetType(), _jsonOptions);
+            return Encoding.UTF8.GetByteCount(defJson);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "[NativeProjectionSnapshotHandler] Error estimating state size");
+            return 0;
+        }
+    }
+
+    public byte[] RewriteSnapshotVersion(byte[] snapshotData, string newVersion)
+    {
+        var envelopeJson = DecompressSnapshotData(snapshotData);
+
+        var envelope = JsonSerializer.Deserialize<SerializableMultiProjectionStateEnvelope>(
+            envelopeJson, _jsonOptions)!;
+
+        SerializableMultiProjectionStateEnvelope modified;
+        if (!envelope.IsOffloaded && envelope.InlineState != null)
+        {
+            var s = envelope.InlineState;
+            modified = new SerializableMultiProjectionStateEnvelope(
+                false,
+                SerializableMultiProjectionState.FromBytes(
+                    s.GetPayloadBytes(), s.MultiProjectionPayloadType, s.ProjectorName, newVersion,
+                    s.LastSortableUniqueId, s.LastEventId, s.Version, s.IsCatchedUp, s.IsSafeState,
+                    s.OriginalSizeBytes, s.CompressedSizeBytes),
+                null);
+        }
+        else if (envelope.OffloadedState != null)
+        {
+            var o = envelope.OffloadedState;
+            modified = new SerializableMultiProjectionStateEnvelope(
+                true,
+                null,
+                new SerializableMultiProjectionStateOffloaded(
+                    o.OffloadKey, o.StorageProvider, o.MultiProjectionPayloadType, o.ProjectorName,
+                    newVersion, o.LastSortableUniqueId, o.LastEventId, o.Version, o.IsCatchedUp, o.IsSafeState,
+                    o.PayloadLength));
+        }
+        else
+        {
+            throw new InvalidOperationException("Cannot rewrite version: envelope has no inline or offloaded state");
+        }
+
+        var modifiedJson = JsonSerializer.Serialize(modified, _jsonOptions);
+        return Encoding.UTF8.GetBytes(modifiedJson);
+    }
+
+    /// <summary>
+    ///     Auto-detect snapshot format: v9 (Gzip) or v10 (plain JSON)
+    /// </summary>
+    private static string DecompressSnapshotData(byte[] snapshotData)
+    {
+        if (snapshotData.Length >= 2 && snapshotData[0] == 0x1f && snapshotData[1] == 0x8b)
+        {
+            return GzipCompression.DecompressToString(snapshotData);
+        }
+        return Encoding.UTF8.GetString(snapshotData);
+    }
+
+    private long EstimateSafeUnsafeProjectionStateSize(object stateObj, bool includeUnsafeDetails)
+    {
+        var stateType = stateObj.GetType();
+        var currentDataField = stateType.GetField("_currentData",
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+        var safeBackupField = stateType.GetField("_safeBackup",
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+
+        var currentData = currentDataField?.GetValue(stateObj) as System.Collections.IDictionary;
+        var safeBackup = safeBackupField?.GetValue(stateObj) as System.Collections.IDictionary;
+
+        var safeKeys = new List<string>();
+        var unsafeKeys = new List<string>();
+
+        if (currentData != null)
+        {
+            foreach (System.Collections.DictionaryEntry de in currentData)
+            {
+                safeKeys.Add(de.Key?.ToString() ?? string.Empty);
+            }
+        }
+        if (safeBackup != null)
+        {
+            var backupKeys = new HashSet<string>();
+            foreach (System.Collections.DictionaryEntry de in safeBackup)
+            {
+                backupKeys.Add(de.Key?.ToString() ?? string.Empty);
+            }
+            unsafeKeys.AddRange(backupKeys);
+            safeKeys = safeKeys.Where(k => !backupKeys.Contains(k)).ToList();
+        }
+
+        object dto = includeUnsafeDetails
+            ? new { safeKeys, unsafeKeys }
+            : new { safeKeys };
+        var json = JsonSerializer.Serialize(dto, _jsonOptions);
+        return Encoding.UTF8.GetByteCount(json);
+    }
+}

--- a/dcb/tests/Sekiban.Dcb.Orleans.Tests/ListQueryOptionalValueOrleansTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Orleans.Tests/ListQueryOptionalValueOrleansTests.cs
@@ -140,6 +140,9 @@ public class ListQueryOptionalValueOrleansTests : IAsyncLifetime
                     services.AddSingleton<Sekiban.Dcb.Runtime.IProjectionRuntime, Sekiban.Dcb.Runtime.Native.NativeProjectionRuntime>();
                     services.AddSingleton<Sekiban.Dcb.Runtime.ITagProjectionRuntime, Sekiban.Dcb.Runtime.Native.NativeTagProjectionRuntime>();
                     services.AddSingleton<Sekiban.Dcb.Runtime.IProjectionActorHostFactory, Sekiban.Dcb.Runtime.Native.NativeProjectionActorHostFactory>();
+                    services.AddSingleton<Sekiban.Dcb.Domains.ITagProjectorTypes>(sp => sp.GetRequiredService<DcbDomainTypes>().TagProjectorTypes);
+                    services.AddSingleton<Sekiban.Dcb.Domains.ITagTypes>(sp => sp.GetRequiredService<DcbDomainTypes>().TagTypes);
+                    services.AddSingleton<Sekiban.Dcb.Domains.ITagStatePayloadTypes>(sp => sp.GetRequiredService<DcbDomainTypes>().TagStatePayloadTypes);
                 })
                 .AddMemoryGrainStorageAsDefault()
                 .AddMemoryGrainStorage("OrleansStorage")

--- a/dcb/tests/Sekiban.Dcb.Orleans.Tests/MinimalOrleansTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Orleans.Tests/MinimalOrleansTests.cs
@@ -251,6 +251,9 @@ public class MinimalOrleansTests : IAsyncLifetime
                     services.AddSingleton<Sekiban.Dcb.Runtime.IProjectionRuntime, Sekiban.Dcb.Runtime.Native.NativeProjectionRuntime>();
                     services.AddSingleton<Sekiban.Dcb.Runtime.ITagProjectionRuntime, Sekiban.Dcb.Runtime.Native.NativeTagProjectionRuntime>();
                     services.AddSingleton<Sekiban.Dcb.Runtime.IProjectionActorHostFactory, Sekiban.Dcb.Runtime.Native.NativeProjectionActorHostFactory>();
+                    services.AddSingleton<Sekiban.Dcb.Domains.ITagProjectorTypes>(sp => sp.GetRequiredService<DcbDomainTypes>().TagProjectorTypes);
+                    services.AddSingleton<Sekiban.Dcb.Domains.ITagTypes>(sp => sp.GetRequiredService<DcbDomainTypes>().TagTypes);
+                    services.AddSingleton<Sekiban.Dcb.Domains.ITagStatePayloadTypes>(sp => sp.GetRequiredService<DcbDomainTypes>().TagStatePayloadTypes);
                 })
                 .AddMemoryGrainStorageAsDefault()
                 .AddMemoryGrainStorage("OrleansStorage")

--- a/dcb/tests/Sekiban.Dcb.Orleans.Tests/SimpleOrleansCommandQueryTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Orleans.Tests/SimpleOrleansCommandQueryTests.cs
@@ -546,6 +546,9 @@ public class SimpleOrleansCommandQueryTests : IAsyncLifetime
                     services.AddSingleton<Sekiban.Dcb.Runtime.IProjectionRuntime, Sekiban.Dcb.Runtime.Native.NativeProjectionRuntime>();
                     services.AddSingleton<Sekiban.Dcb.Runtime.ITagProjectionRuntime, Sekiban.Dcb.Runtime.Native.NativeTagProjectionRuntime>();
                     services.AddSingleton<Sekiban.Dcb.Runtime.IProjectionActorHostFactory, Sekiban.Dcb.Runtime.Native.NativeProjectionActorHostFactory>();
+                    services.AddSingleton<Sekiban.Dcb.Domains.ITagProjectorTypes>(sp => sp.GetRequiredService<DcbDomainTypes>().TagProjectorTypes);
+                    services.AddSingleton<Sekiban.Dcb.Domains.ITagTypes>(sp => sp.GetRequiredService<DcbDomainTypes>().TagTypes);
+                    services.AddSingleton<Sekiban.Dcb.Domains.ITagStatePayloadTypes>(sp => sp.GetRequiredService<DcbDomainTypes>().TagStatePayloadTypes);
                 })
                 .AddMemoryGrainStorageAsDefault()
                 .AddMemoryGrainStorage("OrleansStorage")

--- a/dcb/tests/Sekiban.Dcb.Orleans.Tests/SnapshotVersioningTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Orleans.Tests/SnapshotVersioningTests.cs
@@ -196,6 +196,9 @@ public class SnapshotVersioningTests : IAsyncLifetime
                     services.AddSingleton<Sekiban.Dcb.Runtime.IProjectionRuntime, Sekiban.Dcb.Runtime.Native.NativeProjectionRuntime>();
                     services.AddSingleton<Sekiban.Dcb.Runtime.ITagProjectionRuntime, Sekiban.Dcb.Runtime.Native.NativeTagProjectionRuntime>();
                     services.AddSingleton<Sekiban.Dcb.Runtime.IProjectionActorHostFactory, Sekiban.Dcb.Runtime.Native.NativeProjectionActorHostFactory>();
+                    services.AddSingleton<Sekiban.Dcb.Domains.ITagProjectorTypes>(sp => sp.GetRequiredService<DcbDomainTypes>().TagProjectorTypes);
+                    services.AddSingleton<Sekiban.Dcb.Domains.ITagTypes>(sp => sp.GetRequiredService<DcbDomainTypes>().TagTypes);
+                    services.AddSingleton<Sekiban.Dcb.Domains.ITagStatePayloadTypes>(sp => sp.GetRequiredService<DcbDomainTypes>().TagStatePayloadTypes);
                 })
                 .AddMemoryGrainStorageAsDefault()
                 .AddMemoryGrainStorage("OrleansStorage")

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/GeneralTagConsistentActorTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/GeneralTagConsistentActorTests.cs
@@ -37,7 +37,7 @@ public class GeneralTagConsistentActorTests
         await _eventStore.WriteEventAsync(event2);
 
         // Create actor (it should catch up lazily)
-        var actor = new GeneralTagConsistentActor(tagName, _eventStore, new TagConsistentActorOptions(), _domainTypes);
+        var actor = new GeneralTagConsistentActor(tagName, _eventStore, new TagConsistentActorOptions(), _domainTypes.TagTypes);
 
         // Act - Get latest sortable unique ID (should trigger catch-up)
         var latestSortableUniqueIdResult = await actor.GetLatestSortableUniqueIdAsync();
@@ -56,7 +56,7 @@ public class GeneralTagConsistentActorTests
         var tagName = studentTag.GetTag();
 
         // Create actor without any existing state
-        var actor = new GeneralTagConsistentActor(tagName, _eventStore, new TagConsistentActorOptions(), _domainTypes);
+        var actor = new GeneralTagConsistentActor(tagName, _eventStore, new TagConsistentActorOptions(), _domainTypes.TagTypes);
 
         // Act
         var latestSortableUniqueIdResult = await actor.GetLatestSortableUniqueIdAsync();
@@ -73,7 +73,7 @@ public class GeneralTagConsistentActorTests
         var studentId = Guid.NewGuid();
         var studentTag = new StudentTag(studentId);
         var tagName = studentTag.GetTag();
-        var actor = new GeneralTagConsistentActor(tagName, _eventStore, new TagConsistentActorOptions(), _domainTypes);
+        var actor = new GeneralTagConsistentActor(tagName, _eventStore, new TagConsistentActorOptions(), _domainTypes.TagTypes);
 
         // Act
         var newSortableUniqueId = SortableUniqueId.GenerateNew();
@@ -91,7 +91,7 @@ public class GeneralTagConsistentActorTests
     {
         // Arrange
         var tagName = "Student:12345";
-        var actor = new GeneralTagConsistentActor(tagName, null, new TagConsistentActorOptions(), _domainTypes);
+        var actor = new GeneralTagConsistentActor(tagName, null, new TagConsistentActorOptions(), _domainTypes.TagTypes);
 
         // Act
         var latestSortableUniqueIdResult = await actor.GetLatestSortableUniqueIdAsync();
@@ -116,7 +116,7 @@ public class GeneralTagConsistentActorTests
         await _eventStore.WriteEventAsync(event1);
 
         // Create actor and trigger catch-up
-        var actor = new GeneralTagConsistentActor(tagName, _eventStore, new TagConsistentActorOptions(), _domainTypes);
+        var actor = new GeneralTagConsistentActor(tagName, _eventStore, new TagConsistentActorOptions(), _domainTypes.TagTypes);
         var firstIdResult = await actor.GetLatestSortableUniqueIdAsync();
 
         // Write another event after actor creation
@@ -146,7 +146,7 @@ public class GeneralTagConsistentActorTests
         await _eventStore.WriteEventAsync(event1);
 
         // Create actor - it will catch up from event store
-        var actor = new GeneralTagConsistentActor(tagName, _eventStore, new TagConsistentActorOptions(), _domainTypes);
+        var actor = new GeneralTagConsistentActor(tagName, _eventStore, new TagConsistentActorOptions(), _domainTypes.TagTypes);
 
         // Act - Get the latest ID after catch up
         var latestIdResult = await actor.GetLatestSortableUniqueIdAsync();
@@ -171,13 +171,13 @@ public class GeneralTagConsistentActorTests
         // Test each method triggers catch-up
 
         // Test GetLatestSortableUniqueId
-        var actor1 = new GeneralTagConsistentActor(tagName, _eventStore, new TagConsistentActorOptions(), _domainTypes);
+        var actor1 = new GeneralTagConsistentActor(tagName, _eventStore, new TagConsistentActorOptions(), _domainTypes.TagTypes);
         var result1 = await actor1.GetLatestSortableUniqueIdAsync();
         Assert.True(result1.IsSuccess);
         Assert.Equal(event1.SortableUniqueIdValue, result1.GetValue());
 
         // Test MakeReservation
-        var actor2 = new GeneralTagConsistentActor(tagName, _eventStore, new TagConsistentActorOptions(), _domainTypes);
+        var actor2 = new GeneralTagConsistentActor(tagName, _eventStore, new TagConsistentActorOptions(), _domainTypes.TagTypes);
         var reservation = await actor2.MakeReservationAsync("");
         Assert.True(reservation.IsSuccess);
         var result2 = await actor2.GetLatestSortableUniqueIdAsync();
@@ -185,21 +185,21 @@ public class GeneralTagConsistentActorTests
         Assert.Equal(event1.SortableUniqueIdValue, result2.GetValue());
 
         // Test ConfirmReservation
-        var actor3 = new GeneralTagConsistentActor(tagName, _eventStore, new TagConsistentActorOptions(), _domainTypes);
+        var actor3 = new GeneralTagConsistentActor(tagName, _eventStore, new TagConsistentActorOptions(), _domainTypes.TagTypes);
         await actor3.ConfirmReservationAsync(null!);
         var result3 = await actor3.GetLatestSortableUniqueIdAsync();
         Assert.True(result3.IsSuccess);
         Assert.Equal(event1.SortableUniqueIdValue, result3.GetValue());
 
         // Test CancelReservation
-        var actor4 = new GeneralTagConsistentActor(tagName, _eventStore, new TagConsistentActorOptions(), _domainTypes);
+        var actor4 = new GeneralTagConsistentActor(tagName, _eventStore, new TagConsistentActorOptions(), _domainTypes.TagTypes);
         await actor4.CancelReservationAsync(null!);
         var result4 = await actor4.GetLatestSortableUniqueIdAsync();
         Assert.True(result4.IsSuccess);
         Assert.Equal(event1.SortableUniqueIdValue, result4.GetValue());
 
         // Test GetActiveReservations
-        var actor5 = new GeneralTagConsistentActor(tagName, _eventStore, new TagConsistentActorOptions(), _domainTypes);
+        var actor5 = new GeneralTagConsistentActor(tagName, _eventStore, new TagConsistentActorOptions(), _domainTypes.TagTypes);
         await actor5.GetActiveReservationsAsync();
         var result5 = await actor5.GetLatestSortableUniqueIdAsync();
         Assert.True(result5.IsSuccess);

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/GeneralTagStateActorIncrementalTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/GeneralTagStateActorIncrementalTests.cs
@@ -61,7 +61,9 @@ public class GeneralTagStateActorIncrementalTests
         var actor = new GeneralTagStateActor(
             tagStateId,
             _eventStore,
-            _domainTypes,
+            _domainTypes.TagProjectorTypes,
+            _domainTypes.TagTypes,
+            _domainTypes.TagStatePayloadTypes,
             new TagStateOptions(),
             _actorAccessor,
             _statePersistent);
@@ -109,7 +111,9 @@ public class GeneralTagStateActorIncrementalTests
         var actor = new GeneralTagStateActor(
             tagStateId,
             _eventStore,
-            _domainTypes,
+            _domainTypes.TagProjectorTypes,
+            _domainTypes.TagTypes,
+            _domainTypes.TagStatePayloadTypes,
             new TagStateOptions(),
             _actorAccessor,
             _statePersistent);
@@ -131,7 +135,9 @@ public class GeneralTagStateActorIncrementalTests
         var newActor = new GeneralTagStateActor(
             newTagStateId,
             _eventStore,
-            _domainTypes,
+            _domainTypes.TagProjectorTypes,
+            _domainTypes.TagTypes,
+            _domainTypes.TagStatePayloadTypes,
             new TagStateOptions(),
             _actorAccessor,
             new InMemoryTagStatePersistent()); // New cache
@@ -154,7 +160,9 @@ public class GeneralTagStateActorIncrementalTests
         var actor = new GeneralTagStateActor(
             tagStateId,
             _eventStore,
-            _domainTypes,
+            _domainTypes.TagProjectorTypes,
+            _domainTypes.TagTypes,
+            _domainTypes.TagStatePayloadTypes,
             new TagStateOptions(),
             _actorAccessor,
             _statePersistent);
@@ -188,7 +196,9 @@ public class GeneralTagStateActorIncrementalTests
         var actor = new GeneralTagStateActor(
             tagStateId,
             _eventStore,
-            _domainTypes,
+            _domainTypes.TagProjectorTypes,
+            _domainTypes.TagTypes,
+            _domainTypes.TagStatePayloadTypes,
             new TagStateOptions(),
             _actorAccessor,
             _statePersistent);

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/GeneralTagStateActorTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/GeneralTagStateActorTests.cs
@@ -38,7 +38,7 @@ public class GeneralTagStateActorTests
         await _eventStore.WriteEventAsync(EventTestHelper.CreateEvent(studentCreatedEvent, studentTag));
 
         // Act
-        var actor = new GeneralTagStateActor(tagStateId.GetTagStateId(), _eventStore, _domainTypes, _accessor);
+        var actor = new GeneralTagStateActor(tagStateId.GetTagStateId(), _eventStore, _domainTypes.TagProjectorTypes, _domainTypes.TagTypes, _domainTypes.TagStatePayloadTypes, _accessor);
         var state = await actor.GetTagStateAsync();
 
         // Assert
@@ -78,7 +78,7 @@ public class GeneralTagStateActorTests
             EventTestHelper.CreateEvent(new StudentEnrolledInClassRoom(studentId, classRoomId2), studentTag));
 
         // Act
-        var actor = new GeneralTagStateActor(tagStateId.GetTagStateId(), _eventStore, _domainTypes, _accessor);
+        var actor = new GeneralTagStateActor(tagStateId.GetTagStateId(), _eventStore, _domainTypes.TagProjectorTypes, _domainTypes.TagTypes, _domainTypes.TagStatePayloadTypes, _accessor);
         var state = await actor.GetTagStateAsync();
 
         // Assert
@@ -112,7 +112,7 @@ public class GeneralTagStateActorTests
             EventTestHelper.CreateEvent(new StudentEnrolledInClassRoom(studentId2, classRoomId), classRoomTag));
 
         // Act
-        var actor = new GeneralTagStateActor(tagStateId.GetTagStateId(), _eventStore, _domainTypes, _accessor);
+        var actor = new GeneralTagStateActor(tagStateId.GetTagStateId(), _eventStore, _domainTypes.TagProjectorTypes, _domainTypes.TagTypes, _domainTypes.TagStatePayloadTypes, _accessor);
         var state = await actor.GetTagStateAsync();
 
         // Assert
@@ -148,7 +148,7 @@ public class GeneralTagStateActorTests
             EventTestHelper.CreateEvent(new StudentDroppedFromClassRoom(studentId, classRoomId), studentTag));
 
         // Act
-        var actor = new GeneralTagStateActor(tagStateId.GetTagStateId(), _eventStore, _domainTypes, _accessor);
+        var actor = new GeneralTagStateActor(tagStateId.GetTagStateId(), _eventStore, _domainTypes.TagProjectorTypes, _domainTypes.TagTypes, _domainTypes.TagStatePayloadTypes, _accessor);
         var state = await actor.GetTagStateAsync();
 
         // Assert
@@ -167,7 +167,7 @@ public class GeneralTagStateActorTests
         var tagStateId = TagStateId.FromProjector<StudentProjector>(studentTag);
 
         // Act
-        var actor = new GeneralTagStateActor(tagStateId.GetTagStateId(), _eventStore, _domainTypes, _accessor);
+        var actor = new GeneralTagStateActor(tagStateId.GetTagStateId(), _eventStore, _domainTypes.TagProjectorTypes, _domainTypes.TagTypes, _domainTypes.TagStatePayloadTypes, _accessor);
         var state = await actor.GetTagStateAsync();
 
         // Assert
@@ -191,7 +191,7 @@ public class GeneralTagStateActorTests
         await _eventStore.WriteEventAsync(
             EventTestHelper.CreateEvent(new StudentCreated(studentId, "Carol Davis", 2), studentTag));
 
-        var actor = new GeneralTagStateActor(tagStateId.GetTagStateId(), _eventStore, _domainTypes, _accessor);
+        var actor = new GeneralTagStateActor(tagStateId.GetTagStateId(), _eventStore, _domainTypes.TagProjectorTypes, _domainTypes.TagTypes, _domainTypes.TagStatePayloadTypes, _accessor);
 
         // Act
         var serializableState = await actor.GetStateAsync();
@@ -218,13 +218,17 @@ public class GeneralTagStateActorTests
         Assert.Throws<ArgumentException>(() => new GeneralTagStateActor(
             "InvalidFormat",
             _eventStore,
-            _domainTypes,
+            _domainTypes.TagProjectorTypes,
+            _domainTypes.TagTypes,
+            _domainTypes.TagStatePayloadTypes,
             _accessor));
 
         Assert.Throws<ArgumentException>(() => new GeneralTagStateActor(
             "Only:Two",
             _eventStore,
-            _domainTypes,
+            _domainTypes.TagProjectorTypes,
+            _domainTypes.TagTypes,
+            _domainTypes.TagStatePayloadTypes,
             _accessor));
     }
 
@@ -239,7 +243,7 @@ public class GeneralTagStateActorTests
         var studentTag = new StudentTag(studentId);
         var tagStateId = TagStateId.FromProjector<StudentProjector>(studentTag);
 
-        var actor = new GeneralTagStateActor(tagStateId.GetTagStateId(), _eventStore, _domainTypes, _accessor);
+        var actor = new GeneralTagStateActor(tagStateId.GetTagStateId(), _eventStore, _domainTypes.TagProjectorTypes, _domainTypes.TagTypes, _domainTypes.TagStatePayloadTypes, _accessor);
 
         var differentState = new TagState(
             null!,

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/InMemoryActorTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/InMemoryActorTests.cs
@@ -20,7 +20,7 @@ public class InMemoryActorTests
             "Student:student-123",
             null,
             new TagConsistentActorOptions(),
-            _domainTypes);
+            _domainTypes.TagTypes);
 
         // Act
         var actorId = await actor.GetTagActorIdAsync();
@@ -35,7 +35,7 @@ public class InMemoryActorTests
         // Arrange
         var studentId = Guid.NewGuid();
         var tagName = $"Student:{studentId}";
-        var actor = new GeneralTagConsistentActor(tagName, null, new TagConsistentActorOptions(), _domainTypes);
+        var actor = new GeneralTagConsistentActor(tagName, null, new TagConsistentActorOptions(), _domainTypes.TagTypes);
         var lastSortableId = SortableUniqueId.GenerateNew();
 
         // Act
@@ -60,7 +60,7 @@ public class InMemoryActorTests
         // Arrange
         var studentId = Guid.NewGuid();
         var tagName = $"Student:{studentId}";
-        var actor = new GeneralTagConsistentActor(tagName, null, new TagConsistentActorOptions(), _domainTypes);
+        var actor = new GeneralTagConsistentActor(tagName, null, new TagConsistentActorOptions(), _domainTypes.TagTypes);
         var lastSortableId = SortableUniqueId.GenerateNew();
 
         // Make first reservation
@@ -82,7 +82,7 @@ public class InMemoryActorTests
             "Student:student-123",
             null,
             new TagConsistentActorOptions(),
-            _domainTypes);
+            _domainTypes.TagTypes);
         var reservation = (await actor.MakeReservationAsync("")).GetValue();
 
         // Act
@@ -105,7 +105,7 @@ public class InMemoryActorTests
             "Student:student-123",
             null,
             new TagConsistentActorOptions(),
-            _domainTypes);
+            _domainTypes.TagTypes);
         var fakeReservation = new TagWriteReservation(
             Guid.NewGuid().ToString(),
             DateTime.UtcNow.AddSeconds(30).ToString("O"),
@@ -126,7 +126,7 @@ public class InMemoryActorTests
             "Student:student-123",
             null,
             new TagConsistentActorOptions(),
-            _domainTypes);
+            _domainTypes.TagTypes);
         var reservation = (await actor.MakeReservationAsync("")).GetValue();
 
         // Act
@@ -147,7 +147,7 @@ public class InMemoryActorTests
         // Arrange
         var studentId = Guid.NewGuid();
         var tagName = $"Student:{studentId}";
-        var actor = new GeneralTagConsistentActor(tagName, null, new TagConsistentActorOptions(), _domainTypes);
+        var actor = new GeneralTagConsistentActor(tagName, null, new TagConsistentActorOptions(), _domainTypes.TagTypes);
 
         // Create reservation
         var reservationResult = await actor.MakeReservationAsync("");
@@ -324,7 +324,7 @@ public class InMemoryActorTests
 
         // Create actors
         var tagName = $"{tagGroup}:{tagContent}";
-    var consistentActor = new GeneralTagConsistentActor(tagName, null, new TagConsistentActorOptions(), _domainTypes);
+    var consistentActor = new GeneralTagConsistentActor(tagName, null, new TagConsistentActorOptions(), _domainTypes.TagTypes);
         var studentState = new StudentState(studentId, "John", 5, new List<Guid>());
         var tagState = new TagState(
             studentState,

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/TagConsistentActorCatchupTest.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/TagConsistentActorCatchupTest.cs
@@ -47,7 +47,7 @@ public class TagConsistentActorCatchupTest
             tagConsistentId,
             null,
             new TagConsistentActorOptions(),
-            _domainTypes);
+            _domainTypes.TagTypes);
         var latestIdResult = await tagConsistentActor.GetLatestSortableUniqueIdAsync();
         Assert.True(latestIdResult.IsSuccess);
         Assert.Equal("", latestIdResult.GetValue()); // Verify it's empty
@@ -56,7 +56,7 @@ public class TagConsistentActorCatchupTest
         var accessor = new TestActorAccessor(tagConsistentActor);
 
         // Create TagStateActor
-        var tagStateActor = new GeneralTagStateActor(tagStateId, _eventStore, _domainTypes, accessor);
+        var tagStateActor = new GeneralTagStateActor(tagStateId, _eventStore, _domainTypes.TagProjectorTypes, _domainTypes.TagTypes, _domainTypes.TagStatePayloadTypes, accessor);
 
         // Act
         var state = await tagStateActor.GetStateAsync();
@@ -117,7 +117,7 @@ public class TagConsistentActorCatchupTest
         var accessor = new InMemoryObjectAccessor(_eventStore, _domainTypes);
 
         // First access - TagConsistentActor doesn't exist yet, should create and catchup
-        var tagStateActor = new GeneralTagStateActor(tagStateId, _eventStore, _domainTypes, accessor);
+        var tagStateActor = new GeneralTagStateActor(tagStateId, _eventStore, _domainTypes.TagProjectorTypes, _domainTypes.TagTypes, _domainTypes.TagStatePayloadTypes, accessor);
         var state1 = await tagStateActor.GetStateAsync();
 
         // Should see events after TagConsistentActor catches up

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/TagConsistentActorOptionsTest.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/TagConsistentActorOptionsTest.cs
@@ -29,7 +29,7 @@ public class TagConsistentActorOptionsTest
         };
 
         var domainTypes = DomainType.GetDomainTypes();
-        var actor = new GeneralTagConsistentActor(tagName, null, customOptions, domainTypes);
+        var actor = new GeneralTagConsistentActor(tagName, null, customOptions, domainTypes.TagTypes);
 
         // Act
         var reservationResult = await actor.MakeReservationAsync("test-sortable-id");
@@ -64,7 +64,7 @@ public class TagConsistentActorOptionsTest
             tagName,
             null,
             new TagConsistentActorOptions(),
-            domainTypes); // Using default options
+            domainTypes.TagTypes); // Using default options
 
         // Act
         var reservationResult = await actor.MakeReservationAsync("test-sortable-id");

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/TagConsistentActorReservationWindowTest.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/TagConsistentActorReservationWindowTest.cs
@@ -17,7 +17,7 @@ public class TagConsistentActorReservationWindowTest
         {
             CancellationWindowSeconds = 2.0 // Short window for testing
         };
-        var actor = new GeneralTagConsistentActor(tagName, null, options, _domainTypes);
+        var actor = new GeneralTagConsistentActor(tagName, null, options, _domainTypes.TagTypes);
 
         // Act & Assert
 
@@ -52,7 +52,7 @@ public class TagConsistentActorReservationWindowTest
     {
         // Arrange
         var tagName = "TestTag:456";
-        var actor = new GeneralTagConsistentActor(tagName, null, new TagConsistentActorOptions(), _domainTypes);
+        var actor = new GeneralTagConsistentActor(tagName, null, new TagConsistentActorOptions(), _domainTypes.TagTypes);
 
         // Act & Assert
 
@@ -74,7 +74,7 @@ public class TagConsistentActorReservationWindowTest
     {
         // Arrange
         var tagName = "TestTag:789";
-        var actor = new GeneralTagConsistentActor(tagName, null, new TagConsistentActorOptions(), _domainTypes);
+        var actor = new GeneralTagConsistentActor(tagName, null, new TagConsistentActorOptions(), _domainTypes.TagTypes);
 
         // Act & Assert
 
@@ -100,7 +100,7 @@ public class TagConsistentActorReservationWindowTest
         {
             CancellationWindowSeconds = 1.0 // Very short window
         };
-        var actor = new GeneralTagConsistentActor(tagName, null, options, _domainTypes);
+        var actor = new GeneralTagConsistentActor(tagName, null, options, _domainTypes.TagTypes);
 
         // Make reservation
         var reservationResult = await actor.MakeReservationAsync("");

--- a/tasks/0209_remove_domainTypesFromGrain/plan.md
+++ b/tasks/0209_remove_domainTypesFromGrain/plan.md
@@ -1,0 +1,113 @@
+# 実装方針: Tag Grains から DcbDomainTypes を除去
+
+## 現状
+
+PR #914 (merged) で MultiProjectionGrain の DcbDomainTypes 除去は **全て完了**。Issue #913 の DoD は MultiProjectionGrain について全て達成済み。
+
+Grain フォルダ内で `DcbDomainTypes` が残っているのは **TagStateGrain.cs** と **TagConsistentGrain.cs** の 2 ファイル（各4箇所、計8箇所）のみ。
+
+## 方針
+
+Actor のコンストラクタを `DcbDomainTypes` → Core.Model に定義済みの個別インターフェースに分解する。
+
+**理由:**
+- `ITagProjectionRuntime` は Orleans.Core に定義されており、Core の Actor からは参照不可（依存方向: Core → Core.Model のみ）
+- `ITagProjectorTypes`, `ITagTypes`, `ITagStatePayloadTypes` は全て Core.Model (`Sekiban.Dcb.Domains` 名前空間) に定義済み → Actor から直接参照可能
+- IProjectionActorHost のようなホストパターンは Tag grain の規模では不要（設計ドキュメント: "Keep tag grains native-only"）
+
+## 変更ファイル一覧
+
+### Actor 層 (Sekiban.Dcb.Core)
+
+#### 1. `Actors/GeneralTagConsistentActor.cs`
+
+`DcbDomainTypes` の使用は 1 箇所のみ: `_domainTypes.TagTypes.GetTag(_tagName)` (L215)
+
+- コンストラクタ: `DcbDomainTypes domainTypes` → `ITagTypes tagTypes`
+- フィールド: `_domainTypes` (DcbDomainTypes) → `_tagTypes` (ITagTypes)
+- L215: `_domainTypes.TagTypes.GetTag(_tagName)` → `_tagTypes.GetTag(_tagName)`
+- using 追加: `using Sekiban.Dcb.Domains;`
+
+#### 2. `Actors/GeneralTagStateActor.cs`
+
+`DcbDomainTypes` の使用は 4 箇所:
+
+| 行 | Before | After |
+|----|--------|-------|
+| L100 | `_domainTypes.TagStatePayloadTypes.SerializePayload(...)` | `_tagStatePayloadTypes.SerializePayload(...)` |
+| L172 | `_domainTypes.TagProjectorTypes.GetProjectorFunction(...)` | `_tagProjectorTypes.GetProjectorFunction(...)` |
+| L182 | `_domainTypes.TagProjectorTypes.GetProjectorVersion(...)` | `_tagProjectorTypes.GetProjectorVersion(...)` |
+| L312 | `_domainTypes.TagTypes.GetTag(...)` | `_tagTypes.GetTag(...)` |
+
+- 3 つのコンストラクタオーバーロード全てで `DcbDomainTypes domainTypes` → `ITagProjectorTypes tagProjectorTypes, ITagTypes tagTypes, ITagStatePayloadTypes tagStatePayloadTypes`
+- フィールド: `_domainTypes` → `_tagProjectorTypes`, `_tagTypes`, `_tagStatePayloadTypes`
+- using 追加: `using Sekiban.Dcb.Domains;`
+
+#### 3. `InMemory/InMemoryObjectAccessor.cs`
+
+`_domainTypes` フィールド自体は `GeneralMultiProjectionActor` 生成で使うので残す。Actor 生成箇所のみ変更:
+
+- L114-118: `..., _domainTypes)` → `..., _domainTypes.TagTypes)`
+- L125: `..., _domainTypes, this)` → `..., _domainTypes.TagProjectorTypes, _domainTypes.TagTypes, _domainTypes.TagStatePayloadTypes, this)`
+
+### Grain 層 (Sekiban.Dcb.Orleans.Core)
+
+#### 4. `Grains/TagConsistentGrain.cs`
+
+- コンストラクタ: `DcbDomainTypes domainTypes` → `ITagTypes tagTypes`（DI 注入）
+- フィールド: `_domainTypes` → `_tagTypes`
+- L95: `..., _domainTypes)` → `..., _tagTypes)`
+- using 追加: `using Sekiban.Dcb.Domains;`
+
+#### 5. `Grains/TagStateGrain.cs`
+
+- コンストラクタ: `DcbDomainTypes domainTypes` を削除し、`ITagProjectorTypes tagProjectorTypes, ITagTypes tagTypes, ITagStatePayloadTypes tagStatePayloadTypes` を追加
+- `_domainTypes` フィールドを 3 フィールドに分解
+- Actor 生成時に個別インターフェースを渡す
+- using 追加: `using Sekiban.Dcb.Domains;`
+
+### DI 登録
+
+#### 6-8. `internalUsages/*/Program.cs` (3 ファイル)
+
+既存の Runtime 登録ブロックの直後に追加:
+
+```csharp
+builder.Services.AddSingleton<ITagProjectorTypes>(sp => sp.GetRequiredService<DcbDomainTypes>().TagProjectorTypes);
+builder.Services.AddSingleton<ITagTypes>(sp => sp.GetRequiredService<DcbDomainTypes>().TagTypes);
+builder.Services.AddSingleton<ITagStatePayloadTypes>(sp => sp.GetRequiredService<DcbDomainTypes>().TagStatePayloadTypes);
+```
+
+対象:
+- `DcbOrleans.ApiService/Program.cs`
+- `DcbOrleans.WithoutResult.ApiService/Program.cs`
+- `DcbOrleansDynamoDB.WithoutResult.ApiService/Program.cs`
+
+### テスト
+
+#### 9. `tests/Sekiban.Dcb.Orleans.Tests/MinimalOrleansTests.cs`
+
+DI 登録を Program.cs と同様に追加。
+
+#### 10-16. `tests/Sekiban.Dcb.WithResult.Tests/` 内テストファイル (7 ファイル)
+
+コンストラクタ引数を `_domainTypes` → `_domainTypes.TagTypes` (TagConsistent) / `_domainTypes.TagProjectorTypes, _domainTypes.TagTypes, _domainTypes.TagStatePayloadTypes` (TagState) に変更。
+
+- `GeneralTagStateActorTests.cs`
+- `GeneralTagConsistentActorTests.cs`
+- `GeneralTagStateActorIncrementalTests.cs`
+- `TagConsistentActorCatchupTest.cs`
+- `TagConsistentActorReservationWindowTest.cs`
+- `TagConsistentActorOptionsTest.cs`
+- `InMemoryActorTests.cs`
+
+## 実装順序
+
+1. `GeneralTagConsistentActor.cs` — `DcbDomainTypes` → `ITagTypes`
+2. `GeneralTagStateActor.cs` — `DcbDomainTypes` → 3 個別インターフェース
+3. `InMemoryObjectAccessor.cs` — Actor 生成箇所を更新
+4. `TagConsistentGrain.cs` — `DcbDomainTypes` → `ITagTypes`
+5. `TagStateGrain.cs` — `DcbDomainTypes` → 3 個別インターフェース
+6. DI 登録 — 3 つの Program.cs + テスト DI
+7. テスト更新 — 7 テストファイルのコンストラクタ引数修正
+8. ビルド・テスト確認


### PR DESCRIPTION
## Summary
- Remove `DcbDomainTypes` references from `TagConsistentGrain` and `TagStateGrain`, completing the WASM-friendly grain boundary started in PR #914
- Decompose `DcbDomainTypes` into `ITagTypes`, `ITagProjectorTypes`, and `ITagStatePayloadTypes` interfaces at the grain/actor level
- Extract `NativeProjectionQueryExecutor` and `NativeProjectionSnapshotHandler` to encapsulate domain/serializer concerns inside the `IProjectionActorHost` boundary

## Verification
- All Grain files (`MultiProjectionGrain`, `TagConsistentGrain`, `TagStateGrain`) now have **zero** references to:
  - `DcbDomainTypes`
  - `JsonSerializerOptions`
  - `IServiceProvider`
  - `IQueryCommon` / `IListQueryCommon`
  - `IMultiProjectionPayload`
  - `JsonSerializer.Serialize/Deserialize`
- Solution builds with 0 errors (39 pre-existing warnings)

## Test plan
- [ ] Verify full solution build passes
- [ ] Run `Sekiban.Dcb.WithResult.Tests` (actor tests updated)
- [ ] Run `Sekiban.Dcb.Orleans.Tests` (Orleans integration tests updated)
- [ ] Verify snapshot restore still works with existing data

Closes #913

🤖 Generated with [Claude Code](https://claude.com/claude-code)