### PR TITLE
Follow-up after #926: harden MultiProjection primitive snapshot contract

### DIFF
--- a/dcb/src/Sekiban.Dcb.Core/Runtime/IMultiProjectionProjectionPrimitive.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Runtime/IMultiProjectionProjectionPrimitive.cs
@@ -25,11 +25,31 @@ public interface IMultiProjectionProjectionPrimitive
 /// </summary>
 public interface IMultiProjectionProjectionAccumulator
 {
+    /// <summary>
+    ///     Applies a serialized snapshot envelope to the accumulator.
+    ///     Returns <c>false</c> when snapshot cannot be applied (for example:
+    ///     unsupported offloaded snapshot, projector identity/version mismatch, or deserialize failure).
+    /// </summary>
     bool ApplySnapshot(SerializableMultiProjectionStateEnvelope? snapshot);
+
+    /// <summary>
+    ///     Applies serialized events incrementally.
+    ///     Implementations must preserve deterministic ordering by <c>SortableUniqueId</c>,
+    ///     and must not apply events newer than <paramref name="latestSortableUniqueId"/>
+    ///     when it is provided.
+    /// </summary>
     bool ApplyEvents(
         IReadOnlyList<SerializableEvent> events,
         string? latestSortableUniqueId,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    ///     Gets the current serialized snapshot envelope.
+    /// </summary>
     ResultBox<SerializableMultiProjectionStateEnvelope> GetSnapshot();
+
+    /// <summary>
+    ///     Gets projection metadata (safe/unsafe versions and positions) from current state.
+    /// </summary>
     ResultBox<MultiProjectionStateMetadata> GetMetadata();
 }

--- a/dcb/src/Sekiban.Dcb.Orleans.Core/Runtimes/NativeMultiProjectionProjectionPrimitive.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.Core/Runtimes/NativeMultiProjectionProjectionPrimitive.cs
@@ -76,6 +76,27 @@ public sealed class NativeMultiProjectionProjectionPrimitive : IMultiProjectionP
                 return true;
             }
 
+            if (snapshot.IsOffloaded)
+            {
+                return false;
+            }
+
+            var inline = snapshot.InlineState;
+            if (inline is null)
+            {
+                return false;
+            }
+
+            if (!string.Equals(inline.ProjectorName, _projectorName, StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            if (!string.Equals(inline.ProjectorVersion, _projectorVersion, StringComparison.Ordinal))
+            {
+                return false;
+            }
+
             try
             {
                 _actor.SetSnapshotAsync(snapshot).GetAwaiter().GetResult();


### PR DESCRIPTION
## Summary
Follow-up PR after #926 merge to add the remaining contract hardening for MultiProjection primitive.

## Why this PR
#926 was already merged before these follow-up commits were included.
This PR carries only the missing post-merge changes.

## Changes
- clarify runtime contract behavior in `IMultiProjectionProjectionAccumulator` docs:
  - deterministic ordering by `SortableUniqueId`
  - respect `latestSortableUniqueId` boundary
  - expected failure semantics for snapshot apply
- add strict snapshot mismatch guards in native implementation (`ApplySnapshot` returns false on mismatch):
  - offloaded snapshot
  - missing inline snapshot
  - projector name mismatch
  - projector version mismatch
- add tests:
  - `ApplySnapshot_ShouldReturnFalse_WhenProjectorVersionMismatches`
  - `ApplySnapshot_ShouldReturnFalse_WhenProjectorNameMismatches`

## Files
- `dcb/src/Sekiban.Dcb.Core/Runtime/IMultiProjectionProjectionPrimitive.cs`
- `dcb/src/Sekiban.Dcb.Orleans.Core/Runtimes/NativeMultiProjectionProjectionPrimitive.cs`
- `dcb/tests/Sekiban.Dcb.Orleans.Tests/NativeMultiProjectionProjectionPrimitiveTests.cs`

## Verification
- `dotnet test dcb/tests/Sekiban.Dcb.Orleans.Tests/Sekiban.Dcb.Orleans.Tests.csproj --filter "FullyQualifiedName~NativeMultiProjectionProjectionPrimitiveTests"`
- passed on net9/net10.

## Related
- merged base PR: #926
- issue: #924
