### PR TITLE
docs: add self-contained Sekiban plan for serialized WASM command contract

### DIFF
--- a/tasks/0220_serialized_command_wasm_contract/design.md
+++ b/tasks/0220_serialized_command_wasm_contract/design.md
@@ -1,0 +1,138 @@
+# Serialized Command Contract for WASM (Sekiban-side Design)
+
+## Context
+Sekiban already has strong serialized boundaries for projection paths:
+- `SerializableEvent`
+- `SerializableTagState`
+- TagState primitive accumulator abstraction
+
+However, command execution is still typed-first (`ISekibanExecutor` + `ICommandContext`).
+That is correct for native C# usage, but it is not enough for a WASM-first command runtime where:
+- state is fetched as serialized payload,
+- command logic may run in WASM,
+- event payloads are returned serialized,
+- commit should not require typed event deserialization in Sekiban Core.
+
+This task defines the Sekiban-side contract needed before implementing full WASM local/remote command execution in SekibanWasmRuntime.
+
+## Goal
+Add a **serialized command boundary** in Sekiban Core that allows:
+1. local command path (client-side WASM execution + server-side serialized commit),
+2. remote command path (server-side WASM execution + in-proc serialized commit),
+while keeping existing `ISekibanExecutor` behavior unchanged.
+
+## Non-goals
+- Replacing existing `ISekibanExecutor`.
+- Changing existing public typed command/query APIs.
+- Implementing full WASM runtime in this repository.
+
+## Required Outcome
+A new executor contract dedicated to serialized command workflows, plus Orleans implementation and tests.
+
+## Proposed Contracts
+
+### 1) New core interface
+```csharp
+public interface ISerializedSekibanDcbExecutor
+{
+    Task<ResultBox<SerializableTagState>> GetTagStateAsync(
+        TagStateId tagStateId,
+        CancellationToken cancellationToken = default);
+
+    Task<ResultBox<SerializedCommitResult>> CommitSerializableEventsAsync(
+        SerializedCommitRequest request,
+        CancellationToken cancellationToken = default);
+}
+```
+
+### 2) New DTOs
+```csharp
+public sealed record SerializedCommitRequest(
+    IReadOnlyList<SerializableEventCandidate> Events,
+    IReadOnlyList<string> Tags,
+    IReadOnlyList<string>? ConsistencyTags,
+    IReadOnlyDictionary<string, string>? ExpectedLastSortableUniqueIds,
+    string CommandName,
+    string Producer);
+
+public sealed record SerializableEventCandidate(
+    string EventPayloadName,
+    byte[] PayloadUtf8Json);
+
+public sealed record SerializedCommitResult(
+    bool Success,
+    Guid? LastEventId,
+    string? LastSortableUniqueId,
+    IReadOnlyList<Guid> EventIds,
+    string? ErrorCode,
+    string? Message);
+```
+
+## Why this shape
+- `SerializableEvent` itself includes id/sortable-id/metadata. Those must be server-generated.
+- Request uses `SerializableEventCandidate` to prevent trust issues around externally supplied event metadata.
+- Concurrency should align with Sekiban reservation semantics, not version-only checks.
+
+## Concurrency model
+Use `ExpectedLastSortableUniqueIds` + `ITagConsistentActorCommon.MakeReservationAsync`.
+
+Behavior:
+- If expected sortable-id mismatches current consistency state for any required tag, fail fast with conflict.
+- On failure after partial reservation, cancel reservations.
+- On successful write, confirm reservations.
+
+## Command Context strategy (important)
+Do not expose existing typed `ICommandContext` directly to WASM.
+
+Introduce serialized-focused context for WASM command paths (contract name can vary):
+- state read as serialized tag state,
+- append event as serialized payload + tags,
+- no typed payload required at Sekiban boundary.
+
+This keeps domain code clean when paired with WASM-side shared pre-deserialization helpers.
+
+## WASM-side expectation (for compatibility)
+WASM runtime should follow this pattern:
+1. decode serialized state/event payload at command entry,
+2. keep typed state in WASM instance memory,
+3. apply multiple operations without repeated encode/decode,
+4. serialize only at output boundary.
+
+Sekiban must provide contract + commit semantics so this optimization remains possible.
+
+## Implementation slices
+
+### Slice 1: Core contracts
+- Add interface and DTOs in `Sekiban.Dcb.Core`.
+- Keep additive only.
+
+### Slice 2: Orleans implementation
+- Add `OrleansSerializedSekibanDcbExecutor` (name tentative).
+- Implement `GetTagStateAsync` via current tag state actor path.
+- Implement `CommitSerializableEventsAsync` with reservation + write + confirm/cancel.
+
+### Slice 3: DI wiring
+- Register default implementation in Orleans runtime extensions.
+- No replacement of existing executors.
+
+### Slice 4: Tests
+- happy path (single/multi event)
+- mismatch conflict
+- reservation cancellation on write failure
+- event ids/sortable id returned correctly
+
+## Acceptance criteria
+1. New serialized executor contract exists and is documented.
+2. Orleans implementation passes unit/integration tests.
+3. Existing typed APIs and tests remain green.
+4. Contract is sufficient for SekibanWasmRuntime local/remote command models without additional Sekiban API changes.
+
+## Risks
+- Divergence between typed and serialized command semantics.
+- Incorrect reservation rollback logic under partial failures.
+- Metadata inconsistency if producer/command naming policy is unclear.
+
+## Open decisions
+1. Final interface name: `ISerializedSekibanDcbExecutor` vs `ISekibanDcbSerializedExecutor`.
+2. Whether to accept both sortable-id and version hints for transition period.
+3. Whether `Producer` is client-provided or server-enforced.

--- a/tasks/0220_serialized_command_wasm_contract/implementation-plan.md
+++ b/tasks/0220_serialized_command_wasm_contract/implementation-plan.md
@@ -1,0 +1,76 @@
+# Implementation Plan (Self-contained)
+
+This plan is written so implementation can start without referencing any external design document.
+
+## Phase 0: Baseline lock
+- [ ] Record Sekiban SHA in issue comment.
+- [ ] Confirm current files:
+  - `dcb/src/Sekiban.Dcb.Core/Storage/IEventStore.cs`
+  - `dcb/src/Sekiban.Dcb.Core/Events/SerializableEvent.cs`
+  - `dcb/src/Sekiban.Dcb.Core/Tags/SerializableTagState.cs`
+  - `dcb/src/Sekiban.Dcb.Core/Actors/CoreGeneralSekibanExecutor.cs`
+
+## Phase 1: Core contract addition
+- [ ] Add new interface in Core runtime layer:
+  - `ISerializedSekibanDcbExecutor`
+- [ ] Add DTOs:
+  - `SerializedCommitRequest`
+  - `SerializableEventCandidate`
+  - `SerializedCommitResult`
+- [ ] Add XML docs including conflict and rollback semantics.
+
+Done when:
+- contract compiles,
+- no existing API removed/changed.
+
+## Phase 2: Orleans executor implementation
+- [ ] Add Orleans implementation class (example name: `OrleansSerializedSekibanDcbExecutor`).
+- [ ] `GetTagStateAsync`:
+  - resolve existing TagState actor path,
+  - return `SerializableTagState` directly.
+- [ ] `CommitSerializableEventsAsync`:
+  - generate event ids and sortable ids server-side,
+  - apply consistency reservation by expected sortable-id,
+  - call `IEventStore.WriteSerializableEventsAsync`,
+  - confirm reservations on success,
+  - cancel reservations on failure.
+
+Done when:
+- success and failure paths are deterministic and testable.
+
+## Phase 3: DI registration
+- [ ] Register serialized executor in Orleans runtime extension.
+- [ ] Keep existing `ISekibanExecutor` registration unchanged.
+
+Done when:
+- serialized executor is resolvable from DI,
+- existing applications continue working with no code change.
+
+## Phase 4: Tests
+- [ ] Add unit tests for executor behavior:
+  - commit success (single event)
+  - commit success (multi event)
+  - mismatch conflict
+  - rollback/cancel on write failure
+- [ ] Add integration-level test if needed for reservation semantics.
+
+Done when:
+- all new tests pass,
+- existing dcb tests pass.
+
+## Phase 5: Documentation
+- [ ] Add short README section in relevant dcb docs about serialized executor purpose.
+- [ ] Include usage snippet for WASM runtime integration (in-proc and HTTP adapter use cases).
+
+## Minimum command set before merge
+```bash
+dotnet build Sekiban.sln
+dotnet test Sekiban.sln
+```
+
+If full solution is too heavy, at minimum run targeted dcb test projects and attach exact commands/results in PR.
+
+## Definition of done
+- Contract + implementation + tests are merged.
+- No regression in existing typed command execution path.
+- SekibanWasmRuntime can start implementation against this contract without new Sekiban-side API changes.

--- a/tasks/0220_serialized_command_wasm_contract/issue.md
+++ b/tasks/0220_serialized_command_wasm_contract/issue.md
@@ -1,0 +1,54 @@
+## Goal
+Introduce a serialized command executor contract in Sekiban so WASM local/remote command models can use the same server-side commit semantics without relying on typed `ISekibanExecutor` paths.
+
+## Why this is needed
+Current Sekiban command execution is typed-first (`ISekibanExecutor`, `ICommandContext`).
+For WASM command execution, we need a boundary where:
+- tag state is fetched as `SerializableTagState`,
+- command output events are accepted as serialized payload candidates,
+- server generates event metadata and applies consistency reservation before write.
+
+Without this, SekibanWasmRuntime must duplicate commit semantics outside Sekiban.
+
+## Scope (Sekiban side only)
+- Add serialized command executor interface + DTOs in Core.
+- Add Orleans implementation with reservation/write/confirm/cancel flow.
+- Register via DI (additive).
+- Add tests and docs.
+
+## References
+- `tasks/0220_serialized_command_wasm_contract/design.md`
+- `tasks/0220_serialized_command_wasm_contract/implementation-plan.md`
+- `dcb/src/Sekiban.Dcb.Core/Storage/IEventStore.cs`
+- `dcb/src/Sekiban.Dcb.Core/Actors/CoreGeneralSekibanExecutor.cs`
+
+## Task Checklist
+### Phase 1: Contract
+- [ ] Add `ISerializedSekibanDcbExecutor`
+- [ ] Add `SerializedCommitRequest`, `SerializableEventCandidate`, `SerializedCommitResult`
+
+### Phase 2: Orleans implementation
+- [ ] Implement `GetTagStateAsync` (serialized return)
+- [ ] Implement `CommitSerializableEventsAsync` with consistency reservation flow
+
+### Phase 3: Wiring
+- [ ] Register implementation in Orleans DI extensions
+- [ ] Keep existing typed executor registrations untouched
+
+### Phase 4: Tests
+- [ ] success path (single event)
+- [ ] success path (multi event)
+- [ ] conflict path (mismatch)
+- [ ] rollback/cancel path
+
+### Phase 5: Docs
+- [ ] Add concise docs for purpose and intended WASM integration usage
+
+## Success Criteria
+- Serialized command executor works end-to-end in Orleans runtime.
+- Existing `ISekibanExecutor` behavior remains unchanged.
+- Contract is enough for SekibanWasmRuntime to implement both local and remote WASM command paths without additional Sekiban API changes.
+
+## Non-goals
+- Implement full WASM runtime in Sekiban.
+- Replace typed command APIs.

--- a/tasks/0220_serialized_command_wasm_contract/pr-summary.md
+++ b/tasks/0220_serialized_command_wasm_contract/pr-summary.md
@@ -1,0 +1,19 @@
+# PR Summary (Serialized Command Contract for WASM)
+
+## What this PR contains
+- Self-contained Sekiban-side design for serialized command contract.
+- Implementation plan that can be executed without external design references.
+- Issue body template with phased checklist and success criteria.
+
+## Deliverables
+- `tasks/0220_serialized_command_wasm_contract/design.md`
+- `tasks/0220_serialized_command_wasm_contract/implementation-plan.md`
+- `tasks/0220_serialized_command_wasm_contract/issue.md`
+- `tasks/0220_serialized_command_wasm_contract/pr-summary.md`
+
+## Why now
+This is a prerequisite for SekibanWasmRuntime to implement PoC-equivalent local/remote WASM command execution while keeping Sekiban typed APIs stable.
+
+## Next step
+- Open/track Sekiban implementation issue from `issue.md`.
+- Execute phased implementation in small PR slices.


### PR DESCRIPTION
# PR Summary (Serialized Command Contract for WASM)

## What this PR contains
- Self-contained Sekiban-side design for serialized command contract.
- Implementation plan that can be executed without external design references.
- Issue body template with phased checklist and success criteria.

## Deliverables
- `tasks/0220_serialized_command_wasm_contract/design.md`
- `tasks/0220_serialized_command_wasm_contract/implementation-plan.md`
- `tasks/0220_serialized_command_wasm_contract/issue.md`
- `tasks/0220_serialized_command_wasm_contract/pr-summary.md`

## Why now
This is a prerequisite for SekibanWasmRuntime to implement PoC-equivalent local/remote WASM command execution while keeping Sekiban typed APIs stable.

## Next step
- Open/track Sekiban implementation issue from `issue.md`.
- Execute phased implementation in small PR slices.
