### PR TITLE
Fix MultiProjection catch-up OOM by limiting ReadAllEventsAsync batches

### DIFF
--- a/dcb/src/Sekiban.Dcb.Core/InMemory/InMemoryEventStore.cs
+++ b/dcb/src/Sekiban.Dcb.Core/InMemory/InMemoryEventStore.cs
@@ -58,7 +58,7 @@ public class InMemoryEventStore : IEventStore
         }
     }
 
-    public Task<ResultBox<IEnumerable<Event>>> ReadAllEventsAsync(SortableUniqueId? since = null)
+    public Task<ResultBox<IEnumerable<Event>>> ReadAllEventsAsync(SortableUniqueId? since = null, int? maxCount = null)
     {
         var state = GetState();
         lock (state.Lock)
@@ -72,6 +72,11 @@ public class InMemoryEventStore : IEventStore
                         since.Value,
                         StringComparison.Ordinal) >
                     0);
+            }
+
+            if (maxCount.HasValue)
+            {
+                events = events.Take(maxCount.Value);
             }
 
             return Task.FromResult(ResultBox.FromValue(events));

--- a/dcb/src/Sekiban.Dcb.Core/Storage/IEventStore.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Storage/IEventStore.cs
@@ -15,7 +15,8 @@ public interface IEventStore
     ///     Reads all events from the event store
     /// </summary>
     /// <param name="since">Optional: Only return events after this ID</param>
-    Task<ResultBox<IEnumerable<Event>>> ReadAllEventsAsync(SortableUniqueId? since = null);
+    /// <param name="maxCount">Optional: Maximum number of events to return</param>
+    Task<ResultBox<IEnumerable<Event>>> ReadAllEventsAsync(SortableUniqueId? since = null, int? maxCount = null);
 
     /// <summary>
     ///     Reads events for a specific tag

--- a/dcb/src/Sekiban.Dcb.DynamoDB/DynamoDbEventStore.cs
+++ b/dcb/src/Sekiban.Dcb.DynamoDB/DynamoDbEventStore.cs
@@ -58,7 +58,7 @@ public class DynamoDbEventStore : IEventStore
     /// <summary>
     ///     Reads all events ordered by sortable unique ID.
     /// </summary>
-    public async Task<ResultBox<IEnumerable<Event>>> ReadAllEventsAsync(SortableUniqueId? since = null)
+    public async Task<ResultBox<IEnumerable<Event>>> ReadAllEventsAsync(SortableUniqueId? since = null, int? maxCount = null)
     {
         try
         {
@@ -82,6 +82,11 @@ public class DynamoDbEventStore : IEventStore
             var ordered = allEvents
                 .OrderBy(e => e.SortableUniqueIdValue, StringComparer.Ordinal)
                 .ToList();
+
+            if (maxCount.HasValue)
+            {
+                ordered = ordered.Take(maxCount.Value).ToList();
+            }
 
             return ResultBox.FromValue<IEnumerable<Event>>(ordered);
         }

--- a/dcb/src/Sekiban.Dcb.Sqlite/SqliteEventStore.cs
+++ b/dcb/src/Sekiban.Dcb.Sqlite/SqliteEventStore.cs
@@ -302,7 +302,7 @@ public class SqliteEventStore : IEventStore
         }
     }
 
-    public async Task<ResultBox<IEnumerable<Event>>> ReadAllEventsAsync(SortableUniqueId? since = null)
+    public async Task<ResultBox<IEnumerable<Event>>> ReadAllEventsAsync(SortableUniqueId? since = null, int? maxCount = null)
     {
         try
         {
@@ -331,6 +331,11 @@ public class SqliteEventStore : IEventStore
                     WHERE ServiceId = {ParamServiceId}
                     ORDER BY SortableUniqueId
                     """;
+            }
+            if (maxCount.HasValue)
+            {
+                cmd.CommandText += "\nLIMIT @maxCount";
+                cmd.Parameters.AddWithValue("@maxCount", maxCount.Value);
             }
             cmd.Parameters.AddWithValue(ParamServiceId, serviceId);
 

--- a/dcb/src/Sekiban.Dcb.WithResult/InMemory/InMemoryDcbExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.WithResult/InMemory/InMemoryDcbExecutor.cs
@@ -113,7 +113,7 @@ public class InMemoryDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecut
             EventMetadata EventMetadata,
             IReadOnlyList<string> Tags);
 
-        public Task<ResultBox<IEnumerable<Event>>> ReadAllEventsAsync(SortableUniqueId? since = null)
+        public Task<ResultBox<IEnumerable<Event>>> ReadAllEventsAsync(SortableUniqueId? since = null, int? maxCount = null)
         {
             var state = GetState();
             lock (state.Lock)
@@ -124,6 +124,10 @@ public class InMemoryDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecut
                     events = events.Where(e => string.Compare(e.SortableUniqueIdValue, since.Value, StringComparison.Ordinal) > 0);
                 }
                 events = events.OrderBy(e => e.SortableUniqueIdValue);
+                if (maxCount.HasValue)
+                {
+                    events = events.Take(maxCount.Value);
+                }
 
                 // Deserialize events
                 var result = new List<Event>();

--- a/dcb/src/Sekiban.Dcb.WithoutResult/InMemory/InMemoryDcbExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.WithoutResult/InMemory/InMemoryDcbExecutor.cs
@@ -117,7 +117,7 @@ public class InMemoryDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecut
             EventMetadata EventMetadata,
             IReadOnlyList<string> Tags);
 
-        public Task<ResultBox<IEnumerable<Event>>> ReadAllEventsAsync(SortableUniqueId? since = null)
+        public Task<ResultBox<IEnumerable<Event>>> ReadAllEventsAsync(SortableUniqueId? since = null, int? maxCount = null)
         {
             var state = GetState();
             lock (state.Lock)
@@ -128,6 +128,10 @@ public class InMemoryDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecut
                     events = events.Where(e => string.Compare(e.SortableUniqueIdValue, since.Value, StringComparison.Ordinal) > 0);
                 }
                 events = events.OrderBy(e => e.SortableUniqueIdValue);
+                if (maxCount.HasValue)
+                {
+                    events = events.Take(maxCount.Value);
+                }
 
                 // Deserialize events
                 var result = new List<Event>();

--- a/dcb/tests/Sekiban.Dcb.Orleans.Tests/OrleansTagStateGrainPersistenceTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Orleans.Tests/OrleansTagStateGrainPersistenceTests.cs
@@ -334,8 +334,8 @@ public class OrleansTagStateGrainPersistenceTests : IAsyncLifetime
 
         public void ClearCounts() => ReadEventsByTagCallCount = 0;
 
-        public Task<ResultBox<IEnumerable<Event>>> ReadAllEventsAsync(SortableUniqueId? since = null) =>
-            _inner.ReadAllEventsAsync(since);
+        public Task<ResultBox<IEnumerable<Event>>> ReadAllEventsAsync(SortableUniqueId? since = null, int? maxCount = null) =>
+            _inner.ReadAllEventsAsync(since, maxCount);
 
         public async Task<ResultBox<IEnumerable<Event>>> ReadEventsByTagAsync(ITag tag, SortableUniqueId? since = null)
         {

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/GeneralTagStateActorPersistenceTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/GeneralTagStateActorPersistenceTests.cs
@@ -342,8 +342,8 @@ public class GeneralTagStateActorPersistenceTests
         private readonly IEventStore _inner = inner;
         public int ReadEventsByTagCallCount { get; private set; }
 
-        public Task<ResultBox<IEnumerable<Event>>> ReadAllEventsAsync(SortableUniqueId? since = null) =>
-            _inner.ReadAllEventsAsync(since);
+        public Task<ResultBox<IEnumerable<Event>>> ReadAllEventsAsync(SortableUniqueId? since = null, int? maxCount = null) =>
+            _inner.ReadAllEventsAsync(since, maxCount);
 
         public Task<ResultBox<IEnumerable<Event>>> ReadEventsByTagAsync(ITag tag, SortableUniqueId? since = null)
         {

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/InMemoryEventStore.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/InMemoryEventStore.cs
@@ -13,7 +13,7 @@ public class InMemoryEventStore : IEventStore
     private readonly List<Event> _events = new();
     private readonly object _lock = new();
 
-    public Task<ResultBox<IEnumerable<Event>>> ReadAllEventsAsync(SortableUniqueId? since = null)
+    public Task<ResultBox<IEnumerable<Event>>> ReadAllEventsAsync(SortableUniqueId? since = null, int? maxCount = null)
     {
         lock (_lock)
         {
@@ -29,6 +29,10 @@ public class InMemoryEventStore : IEventStore
             }
 
             events = events.OrderBy(e => e.SortableUniqueIdValue);
+            if (maxCount.HasValue)
+            {
+                events = events.Take(maxCount.Value);
+            }
 
             return Task.FromResult(ResultBox.FromValue(events));
         }

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/InMemoryEventStoreTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/InMemoryEventStoreTests.cs
@@ -126,6 +126,29 @@ public class InMemoryEventStoreTests
     }
 
     [Fact]
+    public async Task ReadAllEventsAsync_With_MaxCount_Should_Return_Limited_Events()
+    {
+        // Arrange
+        var student1 = new StudentCreated(Guid.NewGuid(), "Student 1");
+        var student2 = new StudentCreated(Guid.NewGuid(), "Student 2");
+        var student3 = new StudentCreated(Guid.NewGuid(), "Student 3");
+
+        await _store.WriteEventAsync(EventTestHelper.CreateEvent(student1, new StudentTag(student1.StudentId)));
+        await _store.WriteEventAsync(EventTestHelper.CreateEvent(student2, new StudentTag(student2.StudentId)));
+        await _store.WriteEventAsync(EventTestHelper.CreateEvent(student3, new StudentTag(student3.StudentId)));
+
+        // Act
+        var result = await _store.ReadAllEventsAsync(maxCount: 2);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        var events = result.GetValue().ToList();
+        Assert.Equal(2, events.Count);
+        Assert.Equal("Student 1", ((StudentCreated)events[0].Payload).Name);
+        Assert.Equal("Student 2", ((StudentCreated)events[1].Payload).Name);
+    }
+
+    [Fact]
     public async Task ReadEventsByTagAsync_Should_Return_Events_For_Specific_Tag()
     {
         // Arrange


### PR DESCRIPTION
## Summary
- add optional `maxCount` to `IEventStore.ReadAllEventsAsync`
- update `MultiProjectionGrain` catch-up to read at most `CatchUpBatchSize` per batch (3000)
- implement `maxCount` handling across event store implementations (CosmosDB/Postgres/Sqlite/DynamoDB/InMemory)
- align test doubles with new signature
- add regression tests for:
  - catch-up passing `maxCount=3000` in Orleans
  - in-memory store enforcing `maxCount`

## Why
Previously catch-up called `ReadAllEventsAsync` without an upper bound and then applied `Take(3000)` in memory, which could expand to very large lists and trigger OOM in production.

## Validation
- `dotnet build Sekiban.slnx -v minimal`
- `dotnet test dcb/tests/Sekiban.Dcb.WithResult.Tests/Sekiban.Dcb.WithResult.Tests.csproj --no-build --filter "FullyQualifiedName~InMemoryEventStoreTests"`
- `dotnet test dcb/tests/Sekiban.Dcb.Orleans.Tests/Sekiban.Dcb.Orleans.Tests.csproj --no-build --filter "FullyQualifiedName=Sekiban.Dcb.Orleans.Tests.MinimalOrleansTests.Orleans_MultiProjectionCatchUp_Should_Read_With_BatchLimit"`
