### PR TITLE
Follow-up: reduce catch-up memory pressure in preview04

### DIFF
--- a/dcb/src/Sekiban.Dcb.Core/Actors/GeneralMultiProjectionActorOptions.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Actors/GeneralMultiProjectionActorOptions.cs
@@ -25,6 +25,12 @@ public class GeneralMultiProjectionActorOptions
     /// </summary>
     public int MaxPendingStreamEvents { get; set; } = 50000;
 
+    /// <summary>
+    ///     Number of events read per catch-up batch from the event store.
+    ///     Lower values reduce peak memory usage during catch-up.
+    /// </summary>
+    public int CatchUpBatchSize { get; set; } = 500;
+
     // Dynamic SafeWindow controls (optional; default OFF)
     public bool EnableDynamicSafeWindow { get; set; } = false;
 

--- a/dcb/src/Sekiban.Dcb.CosmosDb/CosmosDbEventStore.cs
+++ b/dcb/src/Sekiban.Dcb.CosmosDb/CosmosDbEventStore.cs
@@ -88,7 +88,13 @@ public partial class CosmosDbEventStore : IEventStore
                         .WithParameter(ParamServiceId, serviceId);
             }
             var queryRequestOptions = options.CreateOptimizedQueryRequestOptions();
-            if (maxCount.HasValue)
+            if (options.MaxItemCountPerReadAllPage > 0)
+            {
+                queryRequestOptions.MaxItemCount = maxCount.HasValue
+                    ? Math.Min(maxCount.Value, options.MaxItemCountPerReadAllPage)
+                    : options.MaxItemCountPerReadAllPage;
+            }
+            else if (maxCount.HasValue)
             {
                 queryRequestOptions.MaxItemCount = maxCount.Value;
             }

--- a/dcb/src/Sekiban.Dcb.CosmosDb/CosmosDbEventStoreOptions.cs
+++ b/dcb/src/Sekiban.Dcb.CosmosDb/CosmosDbEventStoreOptions.cs
@@ -97,6 +97,13 @@ public class CosmosDbEventStoreOptions
     public int MaxItemCountPerPage { get; set; } = 1000;
 
     /// <summary>
+    ///     Maximum items per page specifically for ReadAllEventsAsync.
+    ///     This is separate from maxCount (total events requested by caller).
+    ///     Default: 500 to keep per-page memory usage low in constrained environments.
+    /// </summary>
+    public int MaxItemCountPerReadAllPage { get; set; } = 500;
+
+    /// <summary>
     ///     Maximum degree of parallelism for cross-partition queries.
     ///     Default: -1 (unlimited, let Cosmos DB SDK decide)
     /// </summary>
@@ -157,6 +164,7 @@ public class CosmosDbEventStoreOptions
         new()
         {
             MaxItemCountPerPage = -1, // Use SDK default (~100)
+            MaxItemCountPerReadAllPage = 100, // Keep pages small in compatibility mode
             MaxConcurrencyForQueries = -1,
             MaxBufferedItemCount = -1, // Use SDK default
             UseDirectConnectionMode = false, // Gateway mode (HTTPS)

--- a/dcb/tests/Sekiban.Dcb.Orleans.Tests/MinimalOrleansTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Orleans.Tests/MinimalOrleansTests.cs
@@ -101,7 +101,7 @@ public class MinimalOrleansTests : IAsyncLifetime
         }
 
         Assert.True(SharedEventStore.ReadAllEventsCallCount > 0);
-        Assert.All(SharedEventStore.ReadAllEventsMaxCounts, maxCount => Assert.Equal(3000, maxCount));
+        Assert.All(SharedEventStore.ReadAllEventsMaxCounts, maxCount => Assert.Equal(500, maxCount));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- add  to  and set default to 500
- use configurable catch-up batch size in  instead of hard-coded 3000
- add a silo-wide catch-up semaphore to avoid concurrent catch-up batch reads across projections
- separate Cosmos  page size from total  with new  option (default 500)
- update Orleans regression test to assert new batch size default

## Why
Preview04 fixed full-scan reads, but production still showed OOM when multiple projections caught up concurrently with large per-batch reads. This change reduces peak memory usage per batch and reduces concurrent read pressure.

## Validation
-   Determining projects to restore...
  All projects are up-to-date for restore.
  Sekiban.Dcb.Core.Model -> /Users/tomohisa/dev/GitHub/Sekiban-dcb/dcb/src/Sekiban.Dcb.Core.Model/bin/Debug/net10.0/Sekiban.Dcb.Core.Model.dll
  Sekiban.Dcb.Core.Model -> /Users/tomohisa/dev/GitHub/Sekiban-dcb/dcb/src/Sekiban.Dcb.Core.Model/bin/Debug/net9.0/Sekiban.Dcb.Core.Model.dll
  Sekiban.Dcb.Core -> /Users/tomohisa/dev/GitHub/Sekiban-dcb/dcb/src/Sekiban.Dcb.Core/bin/Debug/net9.0/Sekiban.Dcb.Core.dll
  Sekiban.Dcb.Core -> /Users/tomohisa/dev/GitHub/Sekiban-dcb/dcb/src/Sekiban.Dcb.Core/bin/Debug/net10.0/Sekiban.Dcb.Core.dll
  Sekiban.Dcb.Orleans.Core -> /Users/tomohisa/dev/GitHub/Sekiban-dcb/dcb/src/Sekiban.Dcb.Orleans.Core/bin/Debug/net9.0/Sekiban.Dcb.Orleans.Core.dll
  Sekiban.Dcb.Orleans.Core -> /Users/tomohisa/dev/GitHub/Sekiban-dcb/dcb/src/Sekiban.Dcb.Orleans.Core/bin/Debug/net10.0/Sekiban.Dcb.Orleans.Core.dll
  Successfully created package '/Users/tomohisa/dev/GitHub/Sekiban-dcb/dcb/src/Sekiban.Dcb.Orleans.Core/bin/Debug/Sekiban.Dcb.Orleans.Core.10.0.2-preview03.nupkg'.
  Successfully created package '/Users/tomohisa/dev/GitHub/Sekiban-dcb/dcb/src/Sekiban.Dcb.Orleans.Core/bin/Debug/Sekiban.Dcb.Orleans.Core.10.0.2-preview03.snupkg'.
##[information]Finding components...
##[information]No instructions received to scan docker images.
##[information]Starting enumeration of "/Users/tomohisa/dev/GitHub/Sekiban-dcb/dcb/src/Sekiban.Dcb.Orleans.Core"
##[information]Enumerated 126 files and 21 directories in 00:00:00.0097887
##[information]PipReport: No valid pip version found on system. "22.2.0" or greater is required. Pip installation report detection will not run.
                               Detection Summary                                
┌───────────────────┬───────────────────┬───────────────────┬──────────────────┐
│ Component         │ Detection Time    │ # Components      │ # Explicitly     │
│ Detector Id       │                   │ Found             │ Referenced       │
├───────────────────┼───────────────────┼───────────────────┼──────────────────┤
│ CocoaPods         │ 0.063 seconds     │ 0                 │ 0                │
│ ConanLock         │ 0.062 seconds     │ 0                 │ 0                │
│ DotNet            │ 0.31 seconds      │ 2                 │ 0                │
│ Go                │ 0.063 seconds     │ 0                 │ 0                │
│ Gradle            │ 0.063 seconds     │ 0                 │ 0                │
│ Ivy (Beta)        │ 0.063 seconds     │ 0                 │ 0                │
│ Linux             │ 0.0026 seconds    │ 0                 │ 0                │
│ MvnCli            │ 0.061 seconds     │ 0                 │ 0                │
│ Npm               │ 0.062 seconds     │ 0                 │ 0                │
│ NpmLockfile3      │ 0.062 seconds     │ 0                 │ 0                │
│ NpmWithRoots      │ 0.062 seconds     │ 0                 │ 0                │
│ NuGet             │ 0.062 seconds     │ 1                 │ 0                │
│ NuGetPackagesConf │ 0.062 seconds     │ 0                 │ 0                │
│ ig                │                   │                   │                  │
│ NuGetProjectCentr │ 0.13 seconds      │ 100               │ 6                │
│ ic                │                   │                   │                  │
│ PipReport         │ 0.4 seconds       │ 0                 │ 0                │
│ Pnpm              │ 0.061 seconds     │ 0                 │ 0                │
│ Poetry (Beta)     │ 0.061 seconds     │ 0                 │ 0                │
│ Ruby              │ 0.062 seconds     │ 0                 │ 0                │
│ RustCli           │ 0.062 seconds     │ 0                 │ 0                │
│ RustCrateDetector │ 0.061 seconds     │ 0                 │ 0                │
│ RustSbom (Beta)   │ 0.062 seconds     │ 0                 │ 0                │
│ SPDX22SBOM        │ 0.061 seconds     │ 0                 │ 0                │
│ Vcpkg             │ 0.061 seconds     │ 0                 │ 0                │
│ Yarn              │ 0.062 seconds     │ 0                 │ 0                │
│ ───────────────── │ ───────────────── │ ───────────────── │ ──────────────── │
│ Total             │ 0.41 seconds      │ 103               │ 6                │
└───────────────────┴───────────────────┴───────────────────┴──────────────────┘
##[information]""
##[information]""
##[information]Detection time: 0.4101774 seconds.
##[information]Scan Manifest file: "/var/folders/bs/1qh88g953fx8dccvxc9p5rhr0000gn/T/ScanManifest_20260217190630451.json"
##[information]Finished execution of the Generate workflow SbomTelemetry {Result=Success, Errors=ErrorContainer`1 {Count=0, Errors=[]}, Parameters=Configuration {BuildDropPath=ConfigurationSetting`1 {Value="/Users/tomohisa/dev/GitHub/Sekiban-dcb/dcb/src/Sekiban.Dcb.Orleans.Core/bin/Debug/Sekiban.Dcb.Orleans.Core.10.0.2-preview03.810eefa6.temp", Source=SbomApi, IsDefaultSource=False}, BuildComponentPath=ConfigurationSetting`1 {Value="/Users/tomohisa/dev/GitHub/Sekiban-dcb/dcb/src/Sekiban.Dcb.Orleans.Core", Source=SbomApi, IsDefaultSource=False}, BuildListFile=null, ManifestPath=null, ManifestDirPath=ConfigurationSetting`1 {Value="/Users/tomohisa/dev/GitHub/Sekiban-dcb/dcb/src/Sekiban.Dcb.Orleans.Core/bin/Debug/Sekiban.Dcb.Orleans.Core.10.0.2-preview03.810eefa6.temp/_manifest", Source=Default, IsDefaultSource=True}, OutputPath=null, Parallelism=ConfigurationSetting`1 {Value=8, Source=SbomApi, IsDefaultSource=False}, Verbosity=ConfigurationSetting`1 {Value=Information, Source=SbomApi, IsDefaultSource=False}, ConfigFilePath=null, ManifestInfo=ConfigurationSetting`1 {Value=[ManifestInfo {Name="SPDX", Version="2.2"}], Source=SbomApi, IsDefaultSource=False}, HashAlgorithm=null, RootPathFilter=null, CatalogFilePath=null, ValidateSignature=null, IgnoreMissing=null, ManifestToolAction=Generate, PackageName=ConfigurationSetting`1 {Value="Sekiban.Dcb.Orleans.Core", Source=SbomApi, IsDefaultSource=False}, PackageVersion=ConfigurationSetting`1 {Value="0.0.0-local", Source=SbomApi, IsDefaultSource=False}, PackageSupplier=ConfigurationSetting`1 {Value="J-Tech Group", Source=SbomApi, IsDefaultSource=False}, FilesList=null, PackagesList=null, TelemetryFilePath=null, DockerImagesToScan=null, ExternalDocumentReferenceListFile=null, AdditionalComponentDetectorArgs=ConfigurationSetting`1 {Value=null, Source=SbomApi, IsDefaultSource=False}, NamespaceUriUniquePart=ConfigurationSetting`1 {Value=null, Source=SbomApi, IsDefaultSource=False}, NamespaceUriBase=ConfigurationSetting`1 {Value="http://spdx.org/spdxdocs/Sekiban.Dcb.Orleans.Core", Source=SbomApi, IsDefaultSource=False}, GenerationTimestamp=ConfigurationSetting`1 {Value=null, Source=SbomApi, IsDefaultSource=False}, FollowSymlinks=ConfigurationSetting`1 {Value=True, Source=SbomApi, IsDefaultSource=False}, DeleteManifestDirIfPresent=ConfigurationSetting`1 {Value=True, Source=SbomApi, IsDefaultSource=False}, FailIfNoPackages=null, FetchLicenseInformation=null, LicenseInformationTimeoutInSeconds=ConfigurationSetting`1 {Value=30, Source=Default, IsDefaultSource=True}, EnablePackageMetadataParsing=null, SbomPath=null, SbomDir=null, Conformance=ConfigurationSetting`1 {Value=ConformanceType {Name="None"}, Source=Default, IsDefaultSource=True}, ArtifactInfoMap=null}, SbomFormatsUsed=[SbomFile {SbomFormatName=ManifestInfo {Name="SPDX", Version="2.2"}, SbomFilePath="/Users/tomohisa/dev/GitHub/Sekiban-dcb/dcb/src/Sekiban.Dcb.Orleans.Core/bin/Debug/Sekiban.Dcb.Orleans.Core.10.0.2-preview03.810eefa6.temp/_manifest/spdx_2.2/manifest.spdx.json", FileSizeInBytes=159560, TotalNumberOfPackages=102}], Timings=[Timing {EventName="Metadata build time for SPDX:2.2 format", TimeSpan="00:00:00.0037981"}, Timing {EventName="Relationships generation time", TimeSpan="00:00:00.0029213"}, Timing {EventName="External document reference generation time", TimeSpan="00:00:00.0012792"}, Timing {EventName="Packages generation time", TimeSpan="00:00:00.0227463"}, Timing {EventName="Files generation time", TimeSpan="00:00:00.5331452"}, Timing {EventName="Total generation time", TimeSpan="00:00:00.5765274"}], Switches={}, Exceptions={}, APIExceptions={}, MetadataExceptions={}, TotalLicensesDetected=0, PackageDetailsEntries=0, AdditionalResults={["NumberOfRelationships"]="328", ["NumberOfDependsOnRelationships"]="327"}, AggregationSourceTelemetry={}}
  Zipping directory "/Users/tomohisa/dev/GitHub/Sekiban-dcb/dcb/src/Sekiban.Dcb.Orleans.Core/bin/Debug/Sekiban.Dcb.Orleans.Core.10.0.2-preview03.810eefa6.temp" to "/Users/tomohisa/dev/GitHub/Sekiban-dcb/dcb/src/Sekiban.Dcb.Orleans.Core/bin/Debug/Sekiban.Dcb.Orleans.Core.10.0.2-preview03.nupkg".

Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:00:04.70
-   Determining projects to restore...
  All projects are up-to-date for restore.
  Sekiban.Dcb.Core.Model -> /Users/tomohisa/dev/GitHub/Sekiban-dcb/dcb/src/Sekiban.Dcb.Core.Model/bin/Debug/net10.0/Sekiban.Dcb.Core.Model.dll
  Sekiban.Dcb.Core.Model -> /Users/tomohisa/dev/GitHub/Sekiban-dcb/dcb/src/Sekiban.Dcb.Core.Model/bin/Debug/net9.0/Sekiban.Dcb.Core.Model.dll
  Sekiban.Dcb.Core -> /Users/tomohisa/dev/GitHub/Sekiban-dcb/dcb/src/Sekiban.Dcb.Core/bin/Debug/net9.0/Sekiban.Dcb.Core.dll
  Sekiban.Dcb.Core -> /Users/tomohisa/dev/GitHub/Sekiban-dcb/dcb/src/Sekiban.Dcb.Core/bin/Debug/net10.0/Sekiban.Dcb.Core.dll
  Sekiban.Dcb.CosmosDb -> /Users/tomohisa/dev/GitHub/Sekiban-dcb/dcb/src/Sekiban.Dcb.CosmosDb/bin/Debug/net9.0/Sekiban.Dcb.CosmosDb.dll
  Sekiban.Dcb.CosmosDb -> /Users/tomohisa/dev/GitHub/Sekiban-dcb/dcb/src/Sekiban.Dcb.CosmosDb/bin/Debug/net10.0/Sekiban.Dcb.CosmosDb.dll
  Successfully created package '/Users/tomohisa/dev/GitHub/Sekiban-dcb/dcb/src/Sekiban.Dcb.CosmosDb/bin/Debug/Sekiban.Dcb.CosmosDb.10.0.2-preview03.nupkg'.
  Successfully created package '/Users/tomohisa/dev/GitHub/Sekiban-dcb/dcb/src/Sekiban.Dcb.CosmosDb/bin/Debug/Sekiban.Dcb.CosmosDb.10.0.2-preview03.snupkg'.
##[information]Finding components...
##[information]Starting enumeration of "/Users/tomohisa/dev/GitHub/Sekiban-dcb/dcb/src/Sekiban.Dcb.CosmosDb"
##[information]No instructions received to scan container images.
##[information]No instructions received to scan container images.
##[information]Preparing Rust component detection
##[information]Enumerated 92 files and 21 directories in 00:00:00.0300400
##[information]Detection mode: FALLBACK
##[information]No Cargo.toml files found; ownership and metadata cache unavailable
##[information]FALLBACK mode: Processing 0 Cargo.toml/Cargo.lock files
##[information]PipReport: No valid pip version found on system. "22.2.0" or greater is required. Pip installation report detection will not run.
                               Detection Summary                                
┌───────────────────┬───────────────────┬───────────────────┬──────────────────┐
│ Component         │ Detection Time    │ # Components      │ # Explicitly     │
│ Detector Id       │                   │ Found             │ Referenced       │
├───────────────────┼───────────────────┼───────────────────┼──────────────────┤
│ CocoaPods         │ 0.044 seconds     │ 0                 │ 0                │
│ ConanLock         │ 0.028 seconds     │ 0                 │ 0                │
│ DotNet            │ 0.26 seconds      │ 2                 │ 0                │
│ Go                │ 0.044 seconds     │ 0                 │ 0                │
│ Gradle            │ 0.043 seconds     │ 0                 │ 0                │
│ Ivy (Beta)        │ 0.016 seconds     │ 0                 │ 0                │
│ Linux             │ 0.0011 seconds    │ 0                 │ 0                │
│ LinuxApplicationL │ 0.0011 seconds    │ 0                 │ 0                │
│ ayer (Beta)       │                   │                   │                  │
│ MvnCli            │ 0.0013 seconds    │ 0                 │ 0                │
│ Npm               │ 0.028 seconds     │ 0                 │ 0                │
│ NpmLockfile3      │ 0.028 seconds     │ 0                 │ 0                │
│ NpmWithRoots      │ 0.028 seconds     │ 0                 │ 0                │
│ NuGet             │ 0.03 seconds      │ 1                 │ 0                │
│ NuGetPackagesConf │ 0.028 seconds     │ 0                 │ 0                │
│ ig                │                   │                   │                  │
│ NuGetProjectCentr │ 0.09 seconds      │ 32                │ 12               │
│ ic                │                   │                   │                  │
│ PipReport         │ 0.32 seconds      │ 0                 │ 0                │
│ Pnpm              │ 0.028 seconds     │ 0                 │ 0                │
│ Poetry (Beta)     │ 0.028 seconds     │ 0                 │ 0                │
│ Ruby              │ 0.028 seconds     │ 0                 │ 0                │
│ RustSbom          │ 0.028 seconds     │ 0                 │ 0                │
│ SPDX22SBOM        │ 0.028 seconds     │ 0                 │ 0                │
│ UvLock (Beta)     │ 0.028 seconds     │ 0                 │ 0                │
│ Vcpkg             │ 0.028 seconds     │ 0                 │ 0                │
│ Yarn              │ 0.028 seconds     │ 0                 │ 0                │
│ ───────────────── │ ───────────────── │ ───────────────── │ ──────────────── │
│ Total             │ 0.35 seconds      │ 35                │ 12               │
└───────────────────┴───────────────────┴───────────────────┴──────────────────┘
##[information]""
##[information]""
##[information]Detection time: 0.3450107 seconds.
##[information]Scan Manifest file: "/var/folders/bs/1qh88g953fx8dccvxc9p5rhr0000gn/T/ScanManifest_20260217190633370.json"
##[information]Finished execution of the Generate workflow SbomTelemetry {Result=Success, Errors=ErrorContainer`1 {Count=0, Errors=[]}, Parameters=Configuration {BuildDropPath=ConfigurationSetting`1 {Value="/Users/tomohisa/dev/GitHub/Sekiban-dcb/dcb/src/Sekiban.Dcb.CosmosDb/bin/Debug/Sekiban.Dcb.CosmosDb.10.0.2-preview03.26a1349f.temp", Source=SbomApi, IsDefaultSource=False}, BuildComponentPath=ConfigurationSetting`1 {Value="/Users/tomohisa/dev/GitHub/Sekiban-dcb/dcb/src/Sekiban.Dcb.CosmosDb", Source=SbomApi, IsDefaultSource=False}, BuildListFile=null, ManifestPath=null, ManifestDirPath=ConfigurationSetting`1 {Value="/Users/tomohisa/dev/GitHub/Sekiban-dcb/dcb/src/Sekiban.Dcb.CosmosDb/bin/Debug/Sekiban.Dcb.CosmosDb.10.0.2-preview03.26a1349f.temp/_manifest", Source=Default, IsDefaultSource=True}, OutputPath=null, Parallelism=ConfigurationSetting`1 {Value=8, Source=SbomApi, IsDefaultSource=False}, Verbosity=ConfigurationSetting`1 {Value=Information, Source=SbomApi, IsDefaultSource=False}, ConfigFilePath=null, ManifestInfo=ConfigurationSetting`1 {Value=[ManifestInfo {Name="SPDX", Version="2.2"}], Source=SbomApi, IsDefaultSource=False}, HashAlgorithm=null, RootPathFilter=null, CatalogFilePath=null, ValidateSignature=null, IgnoreMissing=null, ManifestToolAction=Generate, PackageName=ConfigurationSetting`1 {Value="Sekiban.Dcb.CosmosDb", Source=SbomApi, IsDefaultSource=False}, PackageVersion=ConfigurationSetting`1 {Value="0.0.0-local", Source=SbomApi, IsDefaultSource=False}, PackageSupplier=ConfigurationSetting`1 {Value="J-Tech Group", Source=SbomApi, IsDefaultSource=False}, FilesList=null, PackagesList=null, TelemetryFilePath=null, DockerImagesToScan=null, ExternalDocumentReferenceListFile=null, AdditionalComponentDetectorArgs=ConfigurationSetting`1 {Value=null, Source=SbomApi, IsDefaultSource=False}, NamespaceUriUniquePart=ConfigurationSetting`1 {Value=null, Source=SbomApi, IsDefaultSource=False}, NamespaceUriBase=ConfigurationSetting`1 {Value="http://spdx.org/spdxdocs/Sekiban.Dcb.CosmosDb", Source=SbomApi, IsDefaultSource=False}, GenerationTimestamp=ConfigurationSetting`1 {Value=null, Source=SbomApi, IsDefaultSource=False}, FollowSymlinks=ConfigurationSetting`1 {Value=True, Source=SbomApi, IsDefaultSource=False}, DeleteManifestDirIfPresent=ConfigurationSetting`1 {Value=True, Source=SbomApi, IsDefaultSource=False}, FailIfNoPackages=null, FetchLicenseInformation=null, LicenseInformationTimeoutInSeconds=ConfigurationSetting`1 {Value=30, Source=Default, IsDefaultSource=True}, EnablePackageMetadataParsing=null, SbomPath=null, SbomDir=null, Conformance=ConfigurationSetting`1 {Value=ConformanceType {Name="None"}, Source=Default, IsDefaultSource=True}, ArtifactInfoMap=null}, SbomFormatsUsed=[SbomFile {SbomFormatName=ManifestInfo {Name="SPDX", Version="2.2"}, SbomFilePath="/Users/tomohisa/dev/GitHub/Sekiban-dcb/dcb/src/Sekiban.Dcb.CosmosDb/bin/Debug/Sekiban.Dcb.CosmosDb.10.0.2-preview03.26a1349f.temp/_manifest/spdx_2.2/manifest.spdx.json", FileSizeInBytes=45420, TotalNumberOfPackages=34}], Timings=[Timing {EventName="Metadata build time for SPDX:2.2 format", TimeSpan="00:00:00.0029534"}, Timing {EventName="Relationships generation time", TimeSpan="00:00:00.0014899"}, Timing {EventName="External document reference generation time", TimeSpan="00:00:00.0012038"}, Timing {EventName="Packages generation time", TimeSpan="00:00:00.0113291"}, Timing {EventName="Files generation time", TimeSpan="00:00:00.4624035"}, Timing {EventName="Total generation time", TimeSpan="00:00:00.4912465"}], Switches={}, Exceptions={}, APIExceptions={}, MetadataExceptions={}, TotalLicensesDetected=0, PackageDetailsEntries=0, AdditionalResults={["NumberOfRelationships"]="64", ["NumberOfDependsOnRelationships"]="63"}, AggregationSourceTelemetry={}}
  Zipping directory "/Users/tomohisa/dev/GitHub/Sekiban-dcb/dcb/src/Sekiban.Dcb.CosmosDb/bin/Debug/Sekiban.Dcb.CosmosDb.10.0.2-preview03.26a1349f.temp" to "/Users/tomohisa/dev/GitHub/Sekiban-dcb/dcb/src/Sekiban.Dcb.CosmosDb/bin/Debug/Sekiban.Dcb.CosmosDb.10.0.2-preview03.nupkg".

Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:00:02.70
- Test run for /Users/tomohisa/dev/GitHub/Sekiban-dcb/dcb/tests/Sekiban.Dcb.WithResult.Tests/bin/Debug/net9.0/Sekiban.Dcb.WithResult.Tests.dll (.NETCoreApp,Version=v9.0)
VSTest version 18.0.1 (arm64)

Starting test execution, please wait...
A total of 1 test files matched the specified pattern.
Test run for /Users/tomohisa/dev/GitHub/Sekiban-dcb/dcb/tests/Sekiban.Dcb.WithResult.Tests/bin/Debug/net10.0/Sekiban.Dcb.WithResult.Tests.dll (.NETCoreApp,Version=v10.0)
VSTest version 18.0.1 (arm64)

Starting test execution, please wait...
A total of 1 test files matched the specified pattern.

Passed!  - Failed:     0, Passed:    15, Skipped:     0, Total:    15, Duration: 217 ms - Sekiban.Dcb.WithResult.Tests.dll (net9.0)

Passed!  - Failed:     0, Passed:    15, Skipped:     0, Total:    15, Duration: 218 ms - Sekiban.Dcb.WithResult.Tests.dll (net10.0)
- Test run for /Users/tomohisa/dev/GitHub/Sekiban-dcb/dcb/tests/Sekiban.Dcb.Orleans.Tests/bin/Debug/net9.0/Sekiban.Dcb.Orleans.Tests.dll (.NETCoreApp,Version=v9.0)
VSTest version 18.0.1 (arm64)

Starting test execution, please wait...
A total of 1 test files matched the specified pattern.
Test run for /Users/tomohisa/dev/GitHub/Sekiban-dcb/dcb/tests/Sekiban.Dcb.Orleans.Tests/bin/Debug/net10.0/Sekiban.Dcb.Orleans.Tests.dll (.NETCoreApp,Version=v10.0)
VSTest version 18.0.1 (arm64)

Starting test execution, please wait...
A total of 1 test files matched the specified pattern.

Passed!  - Failed:     0, Passed:     1, Skipped:     0, Total:     1, Duration: 598 ms - Sekiban.Dcb.Orleans.Tests.dll (net9.0)

Passed!  - Failed:     0, Passed:     1, Skipped:     0, Total:     1, Duration: 660 ms - Sekiban.Dcb.Orleans.Tests.dll (net10.0)
