### PR TITLE
Add maxCount support for serializable reads and batch cache sync

### DIFF
--- a/dcb/src/Sekiban.Dcb.Core/Storage/IEventStore.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Storage/IEventStore.cs
@@ -77,6 +77,16 @@ public interface IEventStore
         => throw new NotSupportedException("SerializableEvent read not implemented");
 
     /// <summary>
+    ///     Reads all events as SerializableEvent (no payload deserialization).
+    /// </summary>
+    /// <param name="since">Optional: Only return events after this ID</param>
+    /// <param name="maxCount">Optional: Maximum number of events to return</param>
+    Task<ResultBox<IEnumerable<SerializableEvent>>> ReadAllSerializableEventsAsync(
+        SortableUniqueId? since,
+        int? maxCount)
+        => ReadAllSerializableEventsAsync(since);
+
+    /// <summary>
     ///     Reads events for a specific tag as SerializableEvent (no payload deserialization).
     /// </summary>
     /// <param name="tag">The tag to filter events by</param>

--- a/dcb/src/Sekiban.Dcb.Sqlite/CacheSyncOptions.cs
+++ b/dcb/src/Sekiban.Dcb.Sqlite/CacheSyncOptions.cs
@@ -6,6 +6,11 @@ namespace Sekiban.Dcb.Sqlite;
 public class CacheSyncOptions
 {
     /// <summary>
+    ///     Number of events to fetch per remote read during cache sync.
+    /// </summary>
+    public int BatchSize { get; set; } = 3000;
+
+    /// <summary>
     ///     Time window to exclude from caching.
     ///     Events within this window are considered "unsafe" and will be fetched from remote.
     /// </summary>

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/EventStoreCacheSyncTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/EventStoreCacheSyncTests.cs
@@ -1,0 +1,191 @@
+using System.Text;
+using Dcb.Domain;
+using ResultBoxes;
+using Sekiban.Dcb.Common;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.Sqlite;
+using Sekiban.Dcb.Storage;
+using Sekiban.Dcb.Tags;
+
+namespace Sekiban.Dcb.Tests;
+
+public class EventStoreCacheSyncTests
+{
+    [Fact]
+    public async Task SyncAsync_UsesBatchSize_WhenReadingSerializableEvents()
+    {
+        var dbPath = Path.Combine(Path.GetTempPath(), $"cache-sync-{Guid.NewGuid():N}.db");
+        try
+        {
+            var events = CreateSerializableEvents(7);
+            var remoteStore = new FakeSerializableRemoteStore(events);
+            var localStore = new SqliteEventStore(dbPath, DomainType.GetDomainTypes().EventTypes);
+            var sync = new EventStoreCacheSync(
+                localStore,
+                remoteStore,
+                new CacheSyncOptions { BatchSize = 3, SafeWindow = TimeSpan.Zero });
+
+            var result = await sync.SyncAsync();
+
+            Assert.True(result.IsSuccess);
+            Assert.Equal(7, result.EventsSynced);
+            Assert.Equal(7, result.TotalEventsInCache);
+            Assert.Equal(new int?[] { 3, 3, 3 }, remoteStore.ReadAllSerializableMaxCounts.ToArray());
+            Assert.Equal(7L, (await localStore.GetEventCountAsync()).GetValue());
+        }
+        finally
+        {
+            if (File.Exists(dbPath))
+            {
+                File.Delete(dbPath);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task SyncAsync_PersistsProgress_PerBatch_WhenRemoteFailsMidway()
+    {
+        var dbPath = Path.Combine(Path.GetTempPath(), $"cache-sync-{Guid.NewGuid():N}.db");
+        try
+        {
+            var events = CreateSerializableEvents(5);
+            var failingRemote = new FakeSerializableRemoteStore(events, failAtReadCall: 2);
+            var localStore = new SqliteEventStore(dbPath, DomainType.GetDomainTypes().EventTypes);
+            var options = new CacheSyncOptions
+            {
+                BatchSize = 2,
+                SafeWindow = TimeSpan.Zero,
+                RemoteEndpoint = "test-remote",
+                DatabaseName = "test-db"
+            };
+            var failingSync = new EventStoreCacheSync(localStore, failingRemote, options);
+
+            var firstResult = await failingSync.SyncAsync();
+            Assert.False(firstResult.IsSuccess);
+            Assert.Equal(2L, (await localStore.GetEventCountAsync()).GetValue());
+
+            var metadataAfterFailure = await localStore.GetMetadataAsync();
+            Assert.NotNull(metadataAfterFailure);
+            Assert.Equal(events[1].SortableUniqueIdValue, metadataAfterFailure!.LastCachedSortableUniqueId);
+
+            var succeedingRemote = new FakeSerializableRemoteStore(events);
+            var succeedingSync = new EventStoreCacheSync(localStore, succeedingRemote, options);
+            var secondResult = await succeedingSync.SyncAsync();
+
+            Assert.True(secondResult.IsSuccess);
+            Assert.Equal(3, secondResult.EventsSynced);
+            Assert.Equal(5, secondResult.TotalEventsInCache);
+        }
+        finally
+        {
+            if (File.Exists(dbPath))
+            {
+                File.Delete(dbPath);
+            }
+        }
+    }
+
+    private static List<SerializableEvent> CreateSerializableEvents(int count)
+    {
+        var baseTime = DateTime.UtcNow.AddHours(-1);
+        var result = new List<SerializableEvent>(count);
+        for (var i = 0; i < count; i++)
+        {
+            var id = Guid.NewGuid();
+            var sortableUniqueId = SortableUniqueId.Generate(baseTime.AddSeconds(i), id);
+            result.Add(new SerializableEvent(
+                Encoding.UTF8.GetBytes($"{{\"index\":{i}}}"),
+                sortableUniqueId,
+                id,
+                new EventMetadata("causation", "correlation", "tester"),
+                new List<string> { $"test:{i}" },
+                "StudentCreated"));
+        }
+
+        return result.OrderBy(e => e.SortableUniqueIdValue, StringComparer.Ordinal).ToList();
+    }
+
+    private sealed class FakeSerializableRemoteStore : IEventStore
+    {
+        private readonly List<SerializableEvent> _events;
+        private readonly int? _failAtReadCall;
+        private int _readCallCount;
+        private readonly List<int?> _maxCounts = new();
+
+        public FakeSerializableRemoteStore(IEnumerable<SerializableEvent> events, int? failAtReadCall = null)
+        {
+            _events = events.OrderBy(e => e.SortableUniqueIdValue, StringComparer.Ordinal).ToList();
+            _failAtReadCall = failAtReadCall;
+        }
+
+        public IReadOnlyList<int?> ReadAllSerializableMaxCounts => _maxCounts;
+
+        public Task<ResultBox<IEnumerable<Event>>> ReadAllEventsAsync(SortableUniqueId? since = null, int? maxCount = null) =>
+            throw new NotSupportedException();
+
+        public Task<ResultBox<IEnumerable<Event>>> ReadEventsByTagAsync(ITag tag, SortableUniqueId? since = null) =>
+            throw new NotSupportedException();
+
+        public Task<ResultBox<Event>> ReadEventAsync(Guid eventId) =>
+            throw new NotSupportedException();
+
+        public Task<ResultBox<(IReadOnlyList<Event> Events, IReadOnlyList<TagWriteResult> TagWrites)>> WriteEventsAsync(
+            IEnumerable<Event> events) => throw new NotSupportedException();
+
+        public Task<ResultBox<IEnumerable<TagStream>>> ReadTagsAsync(ITag tag) =>
+            throw new NotSupportedException();
+
+        public Task<ResultBox<TagState>> GetLatestTagAsync(ITag tag) =>
+            throw new NotSupportedException();
+
+        public Task<ResultBox<bool>> TagExistsAsync(ITag tag) =>
+            throw new NotSupportedException();
+
+        public Task<ResultBox<long>> GetEventCountAsync(SortableUniqueId? since = null)
+        {
+            var count = since == null
+                ? _events.Count
+                : _events.Count(e => string.Compare(e.SortableUniqueIdValue, since.Value, StringComparison.Ordinal) > 0);
+            return Task.FromResult(ResultBox.FromValue((long)count));
+        }
+
+        public Task<ResultBox<IEnumerable<TagInfo>>> GetAllTagsAsync(string? tagGroup = null) =>
+            throw new NotSupportedException();
+
+        public Task<ResultBox<IEnumerable<SerializableEvent>>> ReadAllSerializableEventsAsync(SortableUniqueId? since = null) =>
+            ReadAllSerializableEventsAsync(since, null);
+
+        public Task<ResultBox<IEnumerable<SerializableEvent>>> ReadAllSerializableEventsAsync(
+            SortableUniqueId? since,
+            int? maxCount)
+        {
+            _readCallCount++;
+            _maxCounts.Add(maxCount);
+
+            if (_failAtReadCall.HasValue && _readCallCount == _failAtReadCall.Value)
+            {
+                return Task.FromResult(ResultBox.Error<IEnumerable<SerializableEvent>>(
+                    new InvalidOperationException("Simulated remote failure")));
+            }
+
+            IEnumerable<SerializableEvent> query = _events;
+            if (since != null)
+            {
+                query = query.Where(e => string.Compare(e.SortableUniqueIdValue, since.Value, StringComparison.Ordinal) > 0);
+            }
+
+            if (maxCount.HasValue)
+            {
+                query = query.Take(maxCount.Value);
+            }
+
+            return Task.FromResult(ResultBox.FromValue(query));
+        }
+
+        public Task<ResultBox<IEnumerable<SerializableEvent>>> ReadSerializableEventsByTagAsync(ITag tag, SortableUniqueId? since = null) =>
+            throw new NotSupportedException();
+
+        public Task<ResultBox<(IReadOnlyList<SerializableEvent> Events, IReadOnlyList<TagWriteResult> TagWrites)>> WriteSerializableEventsAsync(
+            IEnumerable<SerializableEvent> events) => throw new NotSupportedException();
+    }
+}

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/Sekiban.Dcb.WithResult.Tests.csproj
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/Sekiban.Dcb.WithResult.Tests.csproj
@@ -29,6 +29,7 @@
 
     <ItemGroup>
         <ProjectReference Include="..\..\src\Sekiban.Dcb.WithResult\Sekiban.Dcb.WithResult.csproj"/>
+        <ProjectReference Include="..\..\src\Sekiban.Dcb.Sqlite\Sekiban.Dcb.Sqlite.csproj"/>
         <ProjectReference Include="..\..\internalUsages\Dcb.Domain\Dcb.Domain.csproj"/>
     </ItemGroup>
 


### PR DESCRIPTION
## Summary
- add `IEventStore.ReadAllSerializableEventsAsync(since, maxCount)` default overload to keep existing implementations compatible
- implement `maxCount` support in Cosmos `ReadAllSerializableEventsAsync` and add per-page `ReadProgressCallback` invocation with RU/event counters
- update SQLite `EventStoreCacheSync` to read remote serializable events in batches (`CacheSyncOptions.BatchSize`, default 3000) and persist metadata per batch for resumable sync
- add cache sync tests for batch-size usage and mid-sync failure/restart behavior

## Validation
- `dotnet build dcb/src/Sekiban.Dcb.CosmosDb/Sekiban.Dcb.CosmosDb.csproj -v minimal`
- `dotnet build dcb/src/Sekiban.Dcb.Sqlite/Sekiban.Dcb.Sqlite.csproj -v minimal`
- `dotnet test dcb/tests/Sekiban.Dcb.WithResult.Tests/Sekiban.Dcb.WithResult.Tests.csproj --filter "FullyQualifiedName~EventStoreCacheSyncTests" -v minimal`
