### PR TITLE
Add cold event store design docs with phased implementation plan

### DIFF
--- a/tasks/cold-event-store/design.md
+++ b/tasks/cold-event-store/design.md
@@ -1,0 +1,259 @@
+# Cold Event Store 設計（実装ドラフト）
+
+## フェーズ別詳細
+
+- [Phase 1 設計](./phase1.md)
+- [Phase 2 設計](./phase2.md)
+- [Phase 3 設計](./phase3.md)
+
+## 目的
+
+- Hot Store（Cosmos DB / DynamoDB など）への連続読取負荷を下げつつ、キャッチアップを高速化する。
+- 既存経路に影響を与えないよう、機能をデフォルト無効で導入する。
+- JSONL / DuckDB / SQLite いずれの実装にも共通する最小インターフェースを先に固定する。
+
+## 要件整理（今回反映する内容）
+
+- 非対応を返せるインターフェースを用意する。
+- デフォルトは「使用不可（false）」とし、既定ではコールドストアを使わない。
+- 安全な更新方式として Pull 型（例: 30分ごと）を第一候補にする。
+- Change Feed / Stream 方式も可能だが、Safe Window（1-2分）未満のデータは取り込まない設計を含める。
+- データは 100,000 または 1,000,000 イベント単位で分割保存できるようにする。
+- データ本体ファイルとは別に「どこまで保存済みか」を示す管理ファイルを持つ。
+- 管理ファイルのみ取得して現状把握できるようにする。
+- Blob/S3 での同時書き込み制御（競合対策）を含める。
+
+## 全体構成
+
+```text
+[Hot Event Store]
+   -> (Pull Export Job: 30分周期推奨)
+[Cold Exporter]
+   -> segment files (jsonl/duckdb/sqlite)
+   -> control files (manifest/checkpoint/leases)
+[Blob or S3]
+
+[Cold Reader]
+   1) control fileだけ読む
+   2) 必要segmentを決定
+   3) segment本体を読む
+```
+
+## 管理ファイル分離
+
+### 1. segment 本体ファイル
+
+- 例:
+  - `segments/{serviceId}/{generation}/{segmentNo}.jsonl.zst`
+  - `segments/{serviceId}/{generation}/{segmentNo}.duckdb`
+  - `segments/{serviceId}/{generation}/{segmentNo}.sqlite`
+- 不変（immutable）運用。
+- 1セグメントの最大イベント数を設定可能。
+
+### 2. control ファイル
+
+- `control/{serviceId}/manifest.json`
+  - 保存済み範囲、セグメント一覧、最新安全位置を保持
+- `control/{serviceId}/checkpoint.json`
+  - エクスポータが次回開始する `nextSince` を保持
+- `control/{serviceId}/lease.json`（またはロック専用メカニズム）
+  - 同時書き込み回避に使用
+
+`manifest.json` だけを取得すれば、データ本体を読まずに現在位置を判定できる。
+
+## インターフェース案
+
+以下は DCB の実装向けドラフト。ポイントは「非対応」「デフォルト無効」を明示すること。
+
+```csharp
+namespace Sekiban.Dcb.ColdEvents;
+
+public record ColdEventStoreOptions
+{
+    // デフォルト無効
+    public bool Enabled { get; init; } = false;
+
+    // Pull 型エクスポート間隔（推奨: 30分）
+    public TimeSpan PullInterval { get; init; } = TimeSpan.FromMinutes(30);
+
+    // Safe Window: この時間以内のイベントは取り込まない
+    public TimeSpan SafeWindow { get; init; } = TimeSpan.FromMinutes(2);
+
+    // セグメント閾値（どちらか先に到達したらローテーション）
+    public int SegmentMaxEvents { get; init; } = 100_000; // 1_000_000に変更可能
+    public long SegmentMaxBytes { get; init; } = 512L * 1024 * 1024;
+}
+
+public record ColdFeatureStatus(
+    bool IsSupported,
+    bool IsEnabled,
+    string Reason);
+
+public record ColdStoreProgress(
+    string ServiceId,
+    string? LatestSafeSortableUniqueId,
+    string? LatestExportedSortableUniqueId,
+    string? NextSinceSortableUniqueId,
+    DateTimeOffset? LastExportedAtUtc,
+    string ManifestVersion);
+
+public interface IColdEventStoreFeature
+{
+    // 非対応を返せる（NotSupported実装で IsSupported=false）
+    Task<ColdFeatureStatus> GetStatusAsync(CancellationToken ct = default);
+}
+
+public interface IColdEventProgressReader : IColdEventStoreFeature
+{
+    // データ本体を読まずに状況把握
+    Task<ResultBox<ColdStoreProgress>> GetProgressAsync(
+        string serviceId,
+        CancellationToken ct = default);
+}
+
+public interface IColdEventExporter : IColdEventStoreFeature
+{
+    // Pullで増分取得しsegmentを追加
+    Task<ResultBox<ExportResult>> ExportIncrementalAsync(
+        string serviceId,
+        CancellationToken ct = default);
+}
+
+public interface IColdEventReader : IColdEventStoreFeature
+{
+    Task<ResultBox<IReadOnlyList<SerializableEvent>>> ReadAllSerializableEventsAsync(
+        string serviceId,
+        SortableUniqueId? since = null,
+        int? maxCount = null,
+        CancellationToken ct = default);
+}
+```
+
+### 非対応デフォルト実装
+
+```csharp
+public sealed class NotSupportedColdEventStore :
+    IColdEventProgressReader,
+    IColdEventExporter,
+    IColdEventReader
+{
+    public Task<ColdFeatureStatus> GetStatusAsync(CancellationToken ct = default)
+        => Task.FromResult(new ColdFeatureStatus(
+            IsSupported: false,
+            IsEnabled: false,
+            Reason: "Cold event store is not configured"));
+
+    public Task<ResultBox<ColdStoreProgress>> GetProgressAsync(string serviceId, CancellationToken ct = default)
+        => Task.FromResult(ResultBox.Error<ColdStoreProgress>(
+            new NotSupportedException("Cold event store is not supported")));
+
+    public Task<ResultBox<ExportResult>> ExportIncrementalAsync(string serviceId, CancellationToken ct = default)
+        => Task.FromResult(ResultBox.Error<ExportResult>(
+            new NotSupportedException("Cold event store is not supported")));
+
+    public Task<ResultBox<IReadOnlyList<SerializableEvent>>> ReadAllSerializableEventsAsync(
+        string serviceId,
+        SortableUniqueId? since = null,
+        int? maxCount = null,
+        CancellationToken ct = default)
+        => Task.FromResult(ResultBox.Error<IReadOnlyList<SerializableEvent>>(
+            new NotSupportedException("Cold event store is not supported")));
+}
+```
+
+## 更新方式設計
+
+## A. Pull 型（推奨・初期実装）
+
+- 実行トリガー: Function / Cron / Worker（30分ごと）
+- フロー:
+  1. lease取得
+  2. `checkpoint.nextSince` から Hot Store 増分取得
+  3. `now - SafeWindow` より新しいイベントを除外
+  4. segment閾値でファイルを切る
+  5. segmentアップロード
+  6. manifest/checkpointを条件付き更新
+  7. lease解放
+
+利点:
+
+- 実装が単純
+- 障害復旧しやすい
+- セーフウィンド制御を入れやすい
+
+## B. Stream/Change Feed 型（将来拡張）
+
+- 低遅延だが、再送/順序/重複制御が複雑。
+- Safe Window 内イベントの遅延確定が必要。
+- 初期は採用せず、Pull 実績後にオプション化する。
+
+## Safe Window の扱い
+
+- 基準時刻 `cutoff = UtcNow - SafeWindow`。
+- `SortableUniqueId.GetDateTime()` の時刻が `cutoff` 以前のイベントのみエクスポート対象。
+- 既定は 2分。環境により 1分に短縮可能。
+
+## セグメント分割方式
+
+- ローテーション条件（OR）
+  - `SegmentMaxEvents` 到達（100,000 または 1,000,000）
+  - `SegmentMaxBytes` 到達
+- セグメントは不変。
+- 再実行時の重複対策として、manifest 登録時に `sha256` と範囲（from/to）を検証する。
+
+## 同時書き込み制御（Blob/S3）
+
+## 課題
+
+- 管理ファイル（manifest/checkpoint）同時更新時のロストアップデート。
+
+## 対策
+
+- 単一ライター原則 + 条件付き更新。
+- `lease` と `manifest` 更新は以下で実施:
+  - Azure Blob: Lease + ETag (`If-Match`)
+  - S3: 条件付き書き込み（ETag比較）または DynamoDB ロック併用
+- 世代番号 `manifestVersion` を持ち、更新時に `expectedVersion` 一致を必須にする。
+- 不一致時は失敗させ、再取得してリトライ。
+
+## 運用時の取得手順（Reader）
+
+1. `manifest.json` のみ取得
+2. `LatestSafeSortableUniqueId` と segment index を確認
+3. 必要範囲の segment のみダウンロード
+4. 末尾不足分のみ Hot Store を読む（Hybrid構成時）
+
+## DI / 既定動作
+
+- 既定登録:
+  - `IColdEventProgressReader`, `IColdEventExporter`, `IColdEventReader` に `NotSupportedColdEventStore` を登録
+  - `ColdEventStoreOptions.Enabled = false`
+- 有効化時のみ実装を差し替える。
+
+これにより、未設定環境では必ず「非対応」または「無効」が返る。
+
+## 実装フェーズ
+
+### Phase 1
+
+- インターフェース + NotSupported 実装
+- JSONL segment + manifest/checkpoint + lease
+- 30分 Pull Export ジョブ
+
+### Phase 2
+
+- Hybrid Reader（Cold + Hot tail）
+- 監視メトリクス（latest safe lag / export duration / conflict retries）
+
+### Phase 3
+
+- DuckDB/SQLite 派生生成
+- Change Feed/Stream オプション実装
+
+## 検証項目
+
+- Enabled=false で既存機能に影響しないこと
+- 同時実行2ジョブで manifest 競合時に整合性が壊れないこと
+- Safe Window 内イベントが取り込まれないこと
+- 100,000 / 1,000,000 閾値で正しく segment 分割されること
+- manifest 単体取得で保存済み位置が取得できること

--- a/tasks/cold-event-store/phase1.md
+++ b/tasks/cold-event-store/phase1.md
@@ -1,0 +1,65 @@
+# Phase 1 設計（MVP: Pull + JSONL + Control Files）
+
+## スコープ
+
+- デフォルト無効の Cold Event Store インターフェース導入
+- NotSupported 実装導入
+- Pull Export（30分）で Hot Store から JSONL segment 生成
+- `manifest/checkpoint/lease` の control ファイル管理
+
+## 実装対象
+
+1. `Sekiban.Dcb.Core`（または新規 `Sekiban.Dcb.ColdEvents`）に以下追加
+- `ColdEventStoreOptions`
+- `IColdEventStoreFeature`
+- `IColdEventProgressReader`
+- `IColdEventExporter`
+- `IColdEventReader`
+- `NotSupportedColdEventStore`
+
+2. ストレージ抽象
+- `IColdObjectStorage`（Put/Get/List/Delete + conditional write）
+- `IColdLeaseManager`（Acquire/Renew/Release）
+
+3. データ契約
+- `ColdManifest`
+- `ColdCheckpoint`
+- `ColdSegmentInfo`
+- `ExportResult`
+
+4. エクスポートジョブ
+- `ColdExportHostedService` または Function 実装
+- 30分周期（設定可能）
+
+## エクスポートアルゴリズム
+
+1. `AcquireLease(serviceId)`
+2. `checkpoint.nextSince` 読み込み（なければ null）
+3. Hot Store から増分読取（`ReadAllSerializableEventsAsync`）
+4. `cutoff = now - SafeWindow` より新しいイベントを除外
+5. 100,000（既定）到達で segment ローテーション
+6. segment ファイルアップロード
+7. manifest + checkpoint を条件付き更新（ETag/version一致必須）
+8. lease 解放
+
+## 失敗時挙動
+
+- lease 取得失敗: 今回スキップ（多重実行防止）
+- manifest 更新競合: 再取得して最大3回リトライ
+- segment アップロード失敗: checkpoint を更新しない（再実行可能）
+
+## テスト
+
+- 単体
+  - NotSupported が `IsSupported=false, IsEnabled=false` を返す
+  - SafeWindow フィルタ境界テスト
+  - segment ローテーション（100,000 / byte上限）
+- 結合
+  - 同時2実行で manifest 整合性維持
+  - 再実行時に重複登録されない
+
+## 完了条件
+
+- Enabled=false 時に既存パスへ一切影響しない
+- manifest 単体取得で最新保存位置を取得可能
+- 30分 Pull で安定して増分エクスポート可能

--- a/tasks/cold-event-store/phase2.md
+++ b/tasks/cold-event-store/phase2.md
@@ -1,0 +1,53 @@
+# Phase 2 設計（Hybrid Reader + 運用監視）
+
+## スコープ
+
+- Cold + Hot tail の Hybrid 読み取り導入
+- MultiProjection catch-up で Cold 読み取りを利用
+- 監視指標と運用コマンド追加
+
+## 実装対象
+
+1. `HybridEventStore : IEventStore` 追加
+- 書き込みは既存 Hot Store に委譲
+- 読み取りは以下優先順
+  1) Cold (`IColdEventReader`)
+  2) 不足分のみ Hot Store tail
+
+2. Catch-up 統合
+- `MultiProjectionGrain.ProcessSingleCatchUpBatch()` で DI 経由 `IEventStore` を使用済みのため、登録差し替えで適用
+
+3. 監視・可視化
+- `latest_safe_lag_seconds`
+- `cold_export_duration_ms`
+- `cold_manifest_conflict_retries`
+- `cold_tail_hot_read_count`
+
+4. 運用 API（任意）
+- `GET /cold/progress/{serviceId}`
+- `POST /cold/export/{serviceId}`（手動実行）
+
+## 読み取りアルゴリズム（Hybrid）
+
+1. `manifest` から `LatestSafeSortableUniqueId` を確認
+2. `since` から `latestSafe` までを Cold から取得
+3. `latestSafe` より後を Hot Store から取得
+4. 連結後、`SortableUniqueId` で順序保証・重複除去
+
+## 失敗時挙動
+
+- Cold 読み取り失敗: Hot Store フルフォールバック（ログ警告）
+- manifest 未取得: Hot Store フルフォールバック
+- tail 読み取り失敗: エラー返却（既存挙動に合わせる）
+
+## テスト
+
+- Cold 正常 + tail ありで時系列順が崩れない
+- Cold 障害時に Hot フォールバックする
+- maxCount 指定時に Cold/Hot 合算でも件数上限を守る
+
+## 完了条件
+
+- 大部分が Cold 経由で読まれ、Hot 読み取りが tail のみに限定される
+- 監視指標から lag と競合状態を把握可能
+- 本番切替は feature flag で段階展開できる

--- a/tasks/cold-event-store/phase3.md
+++ b/tasks/cold-event-store/phase3.md
@@ -1,0 +1,44 @@
+# Phase 3 設計（マルチフォーマット + Stream/Change Feed 拡張）
+
+## スコープ
+
+- JSONL 正本 + DuckDB/SQLite 派生 artifact 生成
+- Stream/Change Feed 取り込みオプション
+- compaction・ライフサイクル管理
+
+## 実装対象
+
+1. 形式拡張
+- `IColdSegmentWriter` 実装
+  - `JsonlSegmentWriter`（正本）
+  - `DuckDbSegmentWriter`（派生）
+  - `SqliteSegmentWriter`（派生）
+
+2. 取り込み経路拡張
+- `IColdIngestionMode`:
+  - Pull
+  - ChangeFeed/Stream
+- ChangeFeed 時も SafeWindow 判定を共通化
+
+3. 保守機能
+- segment compaction（小segment統合）
+- retention（古世代削除）
+- manifest 世代管理（rollback 可能）
+
+## 同時更新戦略（強化）
+
+- manifest を append-only journal + head pointer 方式へ拡張可能にする
+- head 更新のみ CAS で制御
+- 失敗時は前世代 head にロールバック
+
+## テスト
+
+- JSONL から DuckDB/SQLite 派生生成の整合性
+- compaction 後も from/to 範囲が連続
+- ChangeFeed 再送があっても重複取り込みしない
+
+## 完了条件
+
+- JSONL/SQLite/DuckDB の選択または併用が可能
+- Pull と ChangeFeed どちらでも同じ整合性ルールを満たす
+- 長期運用で control file と segment の整合を維持できる


### PR DESCRIPTION
## Summary
- add cold event store design under `tasks/cold-event-store/`
- define interfaces that can return unsupported status
- set default behavior to disabled (`Enabled=false`)
- document safe pull-based ingestion (30 min), safe window, and segment split strategy
- add concrete Phase 1 / Phase 2 / Phase 3 implementation documents

## Files
- `tasks/cold-event-store/design.md`
- `tasks/cold-event-store/phase1.md`
- `tasks/cold-event-store/phase2.md`
- `tasks/cold-event-store/phase3.md`

## Notes
- no code behavior changes; documentation-only update
