### PR TITLE
[#937] github-issue-937-implement-col

### DIFF
--- a/dcb/Sekiban.Dcb.slnx
+++ b/dcb/Sekiban.Dcb.slnx
@@ -48,5 +48,6 @@
     <Project Path="tests/Sekiban.Dcb.Postgres.Tests/Sekiban.Dcb.Postgres.Tests.csproj" />
     <Project Path="tests/Sekiban.Dcb.WithResult.Tests/Sekiban.Dcb.WithResult.Tests.csproj" />
     <Project Path="tests/Sekiban.Dcb.WithoutResult.Tests/Sekiban.Dcb.WithoutResult.Tests.csproj" />
+    <Project Path="tests/Sekiban.Dcb.ColdEvents.Tests/Sekiban.Dcb.ColdEvents.Tests.csproj" />
   </Folder>
 </Solution>

--- a/dcb/src/Sekiban.Dcb.Core/ColdEvents/ColdCheckpoint.cs
+++ b/dcb/src/Sekiban.Dcb.Core/ColdEvents/ColdCheckpoint.cs
@@ -1,0 +1,6 @@
+namespace Sekiban.Dcb.ColdEvents;
+
+public record ColdCheckpoint(
+    string ServiceId,
+    string? NextSinceSortableUniqueId,
+    DateTimeOffset UpdatedAtUtc);

--- a/dcb/src/Sekiban.Dcb.Core/ColdEvents/ColdControlFileHelper.cs
+++ b/dcb/src/Sekiban.Dcb.Core/ColdEvents/ColdControlFileHelper.cs
@@ -1,0 +1,53 @@
+using System.Text.Json;
+namespace Sekiban.Dcb.ColdEvents;
+
+/// Shared logic for loading manifest and checkpoint control files from cold storage.
+public static class ColdControlFileHelper
+{
+    public static async Task<ColdManifest?> LoadManifestAsync(
+        IColdObjectStorage storage,
+        string serviceId,
+        CancellationToken ct)
+    {
+        var result = await LoadManifestWithETagAsync(storage, serviceId, ct);
+        return result?.Manifest;
+    }
+
+    public static async Task<ManifestWithETag?> LoadManifestWithETagAsync(
+        IColdObjectStorage storage,
+        string serviceId,
+        CancellationToken ct)
+    {
+        var path = ColdStoragePaths.ManifestPath(serviceId);
+        var getResult = await storage.GetAsync(path, ct);
+        if (!getResult.IsSuccess)
+        {
+            return null;
+        }
+
+        var obj = getResult.GetValue();
+        var manifest = JsonSerializer.Deserialize<ColdManifest>(obj.Data, ColdEventJsonOptions.Default);
+        if (manifest is null)
+        {
+            return null;
+        }
+        return new ManifestWithETag(manifest, obj.ETag);
+    }
+
+    public static async Task<ColdCheckpoint?> LoadCheckpointAsync(
+        IColdObjectStorage storage,
+        string serviceId,
+        CancellationToken ct)
+    {
+        var path = ColdStoragePaths.CheckpointPath(serviceId);
+        var getResult = await storage.GetAsync(path, ct);
+        if (!getResult.IsSuccess)
+        {
+            return null;
+        }
+
+        return JsonSerializer.Deserialize<ColdCheckpoint>(getResult.GetValue().Data, ColdEventJsonOptions.Default);
+    }
+
+    public sealed record ManifestWithETag(ColdManifest Manifest, string ETag);
+}

--- a/dcb/src/Sekiban.Dcb.Core/ColdEvents/ColdEventJsonOptions.cs
+++ b/dcb/src/Sekiban.Dcb.Core/ColdEvents/ColdEventJsonOptions.cs
@@ -1,0 +1,10 @@
+using System.Text.Json;
+namespace Sekiban.Dcb.ColdEvents;
+
+internal static class ColdEventJsonOptions
+{
+    internal static readonly JsonSerializerOptions Default = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
+}

--- a/dcb/src/Sekiban.Dcb.Core/ColdEvents/ColdEventStoreOptions.cs
+++ b/dcb/src/Sekiban.Dcb.Core/ColdEvents/ColdEventStoreOptions.cs
@@ -1,0 +1,10 @@
+namespace Sekiban.Dcb.ColdEvents;
+
+public record ColdEventStoreOptions
+{
+    public bool Enabled { get; init; }
+    public TimeSpan PullInterval { get; init; } = TimeSpan.FromMinutes(30);
+    public TimeSpan SafeWindow { get; init; } = TimeSpan.FromMinutes(2);
+    public int SegmentMaxEvents { get; init; } = 100_000;
+    public long SegmentMaxBytes { get; init; } = 512L * 1024 * 1024;
+}

--- a/dcb/src/Sekiban.Dcb.Core/ColdEvents/ColdExportBackgroundService.cs
+++ b/dcb/src/Sekiban.Dcb.Core/ColdEvents/ColdExportBackgroundService.cs
@@ -1,0 +1,75 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Sekiban.Dcb.ServiceId;
+namespace Sekiban.Dcb.ColdEvents;
+
+public sealed class ColdExportBackgroundService : BackgroundService
+{
+    private readonly IColdEventExporter _exporter;
+    private readonly ColdEventStoreOptions _options;
+    private readonly IServiceIdProvider _serviceIdProvider;
+    private readonly ILogger<ColdExportBackgroundService> _logger;
+
+    public ColdExportBackgroundService(
+        IColdEventExporter exporter,
+        IOptions<ColdEventStoreOptions> options,
+        IServiceIdProvider serviceIdProvider,
+        ILogger<ColdExportBackgroundService> logger)
+    {
+        _exporter = exporter;
+        _options = options.Value;
+        _serviceIdProvider = serviceIdProvider;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        if (!_options.Enabled)
+        {
+            _logger.LogInformation("Cold event export is disabled, background service will not run");
+            return;
+        }
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await RunExportCycleAsync(stoppingToken);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Unexpected error in cold event export cycle");
+            }
+
+            await Task.Delay(_options.PullInterval, stoppingToken);
+        }
+    }
+
+    private async Task RunExportCycleAsync(CancellationToken ct)
+    {
+        var serviceId = _serviceIdProvider.GetCurrentServiceId();
+        _logger.LogInformation("Starting cold event export cycle for {ServiceId}", serviceId);
+
+        var result = await _exporter.ExportIncrementalAsync(serviceId, ct);
+
+        if (result.IsSuccess)
+        {
+            var value = result.GetValue();
+            _logger.LogInformation(
+                "Cold event export completed for {ServiceId}: exported {Count} events, {SegmentCount} new segments",
+                serviceId, value.ExportedEventCount, value.NewSegments.Count);
+        }
+        else
+        {
+            _logger.LogError(
+                result.GetException(),
+                "Cold event export failed for {ServiceId}",
+                serviceId);
+        }
+    }
+}

--- a/dcb/src/Sekiban.Dcb.Core/ColdEvents/ColdExporter.cs
+++ b/dcb/src/Sekiban.Dcb.Core/ColdEvents/ColdExporter.cs
@@ -1,0 +1,220 @@
+using System.Security.Cryptography;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using ResultBoxes;
+using Sekiban.Dcb.Common;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.Storage;
+namespace Sekiban.Dcb.ColdEvents;
+
+public sealed class ColdExporter : IColdEventExporter, IColdEventProgressReader
+{
+    private const int MaxManifestRetries = 3;
+    private const string InitialManifestVersion = "0";
+
+    private readonly IEventStore _hotStore;
+    private readonly IColdObjectStorage _storage;
+    private readonly IColdLeaseManager _leaseManager;
+    private readonly ColdEventStoreOptions _options;
+    private readonly ILogger<ColdExporter> _logger;
+
+    public ColdExporter(
+        IEventStore hotStore,
+        IColdObjectStorage storage,
+        IColdLeaseManager leaseManager,
+        IOptions<ColdEventStoreOptions> options,
+        ILogger<ColdExporter> logger)
+    {
+        _hotStore = hotStore;
+        _storage = storage;
+        _leaseManager = leaseManager;
+        _options = options.Value;
+        _logger = logger;
+    }
+
+    public Task<ColdFeatureStatus> GetStatusAsync(CancellationToken ct)
+        => Task.FromResult(new ColdFeatureStatus(
+            IsSupported: true,
+            IsEnabled: _options.Enabled,
+            Reason: _options.Enabled ? "Cold event store is active" : "Cold event store is disabled"));
+
+    public async Task<ResultBox<ColdStoreProgress>> GetProgressAsync(string serviceId, CancellationToken ct)
+    {
+        var manifest = await ColdControlFileHelper.LoadManifestAsync(_storage, serviceId, ct);
+        var checkpoint = await ColdControlFileHelper.LoadCheckpointAsync(_storage, serviceId, ct);
+
+        return ResultBox.FromValue(new ColdStoreProgress(
+            ServiceId: serviceId,
+            LatestSafeSortableUniqueId: manifest?.LatestSafeSortableUniqueId,
+            LatestExportedSortableUniqueId: GetLatestExportedId(manifest),
+            NextSinceSortableUniqueId: checkpoint?.NextSinceSortableUniqueId,
+            LastExportedAtUtc: manifest?.UpdatedAtUtc,
+            ManifestVersion: manifest?.ManifestVersion ?? InitialManifestVersion));
+    }
+
+    public async Task<ResultBox<ExportResult>> ExportIncrementalAsync(string serviceId, CancellationToken ct)
+    {
+        var leaseResult = await _leaseManager.AcquireAsync(
+            $"cold-export-{serviceId}", _options.PullInterval, ct);
+        if (!leaseResult.IsSuccess)
+        {
+            _logger.LogInformation("Skipping export for {ServiceId}: lease not acquired", serviceId);
+            return ResultBox.FromValue(new ExportResult(0, [], InitialManifestVersion));
+        }
+
+        var lease = leaseResult.GetValue();
+
+        try
+        {
+            return await ExecuteExportAsync(serviceId, lease, ct);
+        }
+        finally
+        {
+            await _leaseManager.ReleaseAsync(lease, ct);
+        }
+    }
+
+    private async Task<ResultBox<ExportResult>> ExecuteExportAsync(
+        string serviceId,
+        ColdLease lease,
+        CancellationToken ct)
+    {
+        var checkpoint = await ColdControlFileHelper.LoadCheckpointAsync(_storage, serviceId, ct);
+        var since = checkpoint?.NextSinceSortableUniqueId is not null
+            ? new SortableUniqueId(checkpoint.NextSinceSortableUniqueId)
+            : (SortableUniqueId?)null;
+
+        var readResult = await _hotStore.ReadAllSerializableEventsAsync(since);
+        if (!readResult.IsSuccess)
+        {
+            return ResultBox.Error<ExportResult>(readResult.GetException());
+        }
+
+        var allEvents = readResult.GetValue().ToList();
+        if (allEvents.Count == 0)
+        {
+            return ResultBox.FromValue(new ExportResult(0, [], InitialManifestVersion));
+        }
+
+        var cutoff = DateTime.UtcNow - _options.SafeWindow;
+        var safeEvents = SafeWindowFilter.Apply(allEvents, cutoff);
+        if (safeEvents.Count == 0)
+        {
+            return ResultBox.FromValue(new ExportResult(0, [], InitialManifestVersion));
+        }
+
+        var segments = ColdSegmentSplitter.Split(
+            safeEvents, _options.SegmentMaxEvents, _options.SegmentMaxBytes);
+
+        return await UploadAndUpdateManifestAsync(serviceId, segments, safeEvents, ct);
+    }
+
+    private async Task<ResultBox<ExportResult>> UploadAndUpdateManifestAsync(
+        string serviceId,
+        IReadOnlyList<IReadOnlyList<SerializableEvent>> segments,
+        IReadOnlyList<SerializableEvent> allSafeEvents,
+        CancellationToken ct)
+    {
+        var newSegmentInfos = new List<ColdSegmentInfo>();
+
+        foreach (var segment in segments)
+        {
+            var segmentData = JsonlSegmentWriter.Write(segment);
+            var sha256 = ComputeSha256(segmentData);
+            var segmentPath = ColdStoragePaths.SegmentPath(
+                serviceId, segment[0].SortableUniqueIdValue, segment[^1].SortableUniqueIdValue);
+
+            var putResult = await _storage.PutAsync(segmentPath, segmentData, expectedETag: null, ct);
+            if (!putResult.IsSuccess)
+            {
+                return ResultBox.Error<ExportResult>(putResult.GetException());
+            }
+
+            newSegmentInfos.Add(new ColdSegmentInfo(
+                Path: segmentPath,
+                FromSortableUniqueId: segment[0].SortableUniqueIdValue,
+                ToSortableUniqueId: segment[^1].SortableUniqueIdValue,
+                EventCount: segment.Count,
+                SizeBytes: segmentData.Length,
+                Sha256: sha256,
+                CreatedAtUtc: DateTimeOffset.UtcNow));
+        }
+
+        for (var attempt = 0; attempt < MaxManifestRetries; attempt++)
+        {
+            var updateResult = await TryUpdateManifestAndCheckpointAsync(
+                serviceId, newSegmentInfos, allSafeEvents, ct);
+
+            if (updateResult.IsSuccess)
+            {
+                return updateResult;
+            }
+
+            _logger.LogWarning(
+                "Manifest update conflict for {ServiceId}, attempt {Attempt}/{Max}",
+                serviceId, attempt + 1, MaxManifestRetries);
+        }
+
+        return ResultBox.Error<ExportResult>(
+            new InvalidOperationException($"Manifest update failed after {MaxManifestRetries} retries"));
+    }
+
+    private async Task<ResultBox<ExportResult>> TryUpdateManifestAndCheckpointAsync(
+        string serviceId,
+        List<ColdSegmentInfo> newSegmentInfos,
+        IReadOnlyList<SerializableEvent> allSafeEvents,
+        CancellationToken ct)
+    {
+        var existingManifest = await ColdControlFileHelper.LoadManifestWithETagAsync(_storage, serviceId, ct);
+        var existingSegments = existingManifest?.Manifest?.Segments ?? [];
+        var allSegments = existingSegments.Concat(newSegmentInfos).ToList();
+
+        var lastSafe = allSafeEvents[^1].SortableUniqueIdValue;
+        var newVersion = Guid.NewGuid().ToString();
+        var manifest = new ColdManifest(
+            ServiceId: serviceId,
+            ManifestVersion: newVersion,
+            LatestSafeSortableUniqueId: lastSafe,
+            Segments: allSegments,
+            UpdatedAtUtc: DateTimeOffset.UtcNow);
+
+        var manifestData = JsonSerializer.SerializeToUtf8Bytes(manifest, ColdEventJsonOptions.Default);
+        var manifestPath = ColdStoragePaths.ManifestPath(serviceId);
+        var manifestResult = await _storage.PutAsync(
+            manifestPath, manifestData, existingManifest?.ETag, ct);
+
+        if (!manifestResult.IsSuccess)
+        {
+            return ResultBox.Error<ExportResult>(manifestResult.GetException());
+        }
+
+        var checkpointObj = new ColdCheckpoint(
+            ServiceId: serviceId,
+            NextSinceSortableUniqueId: lastSafe,
+            UpdatedAtUtc: DateTimeOffset.UtcNow);
+        var checkpointData = JsonSerializer.SerializeToUtf8Bytes(checkpointObj, ColdEventJsonOptions.Default);
+        var checkpointPath = ColdStoragePaths.CheckpointPath(serviceId);
+        await _storage.PutAsync(checkpointPath, checkpointData, expectedETag: null, ct);
+
+        return ResultBox.FromValue(new ExportResult(
+            ExportedEventCount: allSafeEvents.Count,
+            NewSegments: newSegmentInfos,
+            UpdatedManifestVersion: newVersion));
+    }
+
+    private static string? GetLatestExportedId(ColdManifest? manifest)
+    {
+        if (manifest is null || manifest.Segments.Count == 0)
+        {
+            return null;
+        }
+        return manifest.Segments[^1].ToSortableUniqueId;
+    }
+
+    private static string ComputeSha256(byte[] data)
+    {
+        var hash = SHA256.HashData(data);
+        return Convert.ToHexStringLower(hash);
+    }
+}

--- a/dcb/src/Sekiban.Dcb.Core/ColdEvents/ColdFeatureStatus.cs
+++ b/dcb/src/Sekiban.Dcb.Core/ColdEvents/ColdFeatureStatus.cs
@@ -1,0 +1,6 @@
+namespace Sekiban.Dcb.ColdEvents;
+
+public record ColdFeatureStatus(
+    bool IsSupported,
+    bool IsEnabled,
+    string Reason);

--- a/dcb/src/Sekiban.Dcb.Core/ColdEvents/ColdLease.cs
+++ b/dcb/src/Sekiban.Dcb.Core/ColdEvents/ColdLease.cs
@@ -1,0 +1,6 @@
+namespace Sekiban.Dcb.ColdEvents;
+
+public record ColdLease(
+    string LeaseId,
+    string Token,
+    DateTimeOffset ExpiresAt);

--- a/dcb/src/Sekiban.Dcb.Core/ColdEvents/ColdManifest.cs
+++ b/dcb/src/Sekiban.Dcb.Core/ColdEvents/ColdManifest.cs
@@ -1,0 +1,8 @@
+namespace Sekiban.Dcb.ColdEvents;
+
+public record ColdManifest(
+    string ServiceId,
+    string ManifestVersion,
+    string? LatestSafeSortableUniqueId,
+    IReadOnlyList<ColdSegmentInfo> Segments,
+    DateTimeOffset UpdatedAtUtc);

--- a/dcb/src/Sekiban.Dcb.Core/ColdEvents/ColdSegmentInfo.cs
+++ b/dcb/src/Sekiban.Dcb.Core/ColdEvents/ColdSegmentInfo.cs
@@ -1,0 +1,10 @@
+namespace Sekiban.Dcb.ColdEvents;
+
+public record ColdSegmentInfo(
+    string Path,
+    string FromSortableUniqueId,
+    string ToSortableUniqueId,
+    int EventCount,
+    long SizeBytes,
+    string Sha256,
+    DateTimeOffset CreatedAtUtc);

--- a/dcb/src/Sekiban.Dcb.Core/ColdEvents/ColdSegmentSplitter.cs
+++ b/dcb/src/Sekiban.Dcb.Core/ColdEvents/ColdSegmentSplitter.cs
@@ -1,0 +1,53 @@
+using Sekiban.Dcb.Events;
+namespace Sekiban.Dcb.ColdEvents;
+
+public static class ColdSegmentSplitter
+{
+    public static IReadOnlyList<IReadOnlyList<SerializableEvent>> Split(
+        IReadOnlyList<SerializableEvent> events,
+        int maxEvents,
+        long maxBytes)
+    {
+        if (events.Count == 0)
+        {
+            return [];
+        }
+
+        var segments = new List<IReadOnlyList<SerializableEvent>>();
+        var currentSegment = new List<SerializableEvent>();
+        long currentBytes = 0;
+
+        foreach (var e in events)
+        {
+            long eventSize = e.Payload.Length;
+
+            if (currentSegment.Count > 0 && ShouldRotate(currentSegment.Count, currentBytes, eventSize, maxEvents, maxBytes))
+            {
+                segments.Add(currentSegment);
+                currentSegment = new List<SerializableEvent>();
+                currentBytes = 0;
+            }
+
+            currentSegment.Add(e);
+            currentBytes += eventSize;
+        }
+
+        if (currentSegment.Count > 0)
+        {
+            segments.Add(currentSegment);
+        }
+
+        return segments;
+    }
+
+    private static bool ShouldRotate(
+        int currentCount,
+        long currentBytes,
+        long nextEventSize,
+        int maxEvents,
+        long maxBytes)
+    {
+        return currentCount >= maxEvents
+               || currentBytes + nextEventSize > maxBytes;
+    }
+}

--- a/dcb/src/Sekiban.Dcb.Core/ColdEvents/ColdStorageObject.cs
+++ b/dcb/src/Sekiban.Dcb.Core/ColdEvents/ColdStorageObject.cs
@@ -1,0 +1,5 @@
+namespace Sekiban.Dcb.ColdEvents;
+
+public record ColdStorageObject(
+    byte[] Data,
+    string ETag);

--- a/dcb/src/Sekiban.Dcb.Core/ColdEvents/ColdStoragePaths.cs
+++ b/dcb/src/Sekiban.Dcb.Core/ColdEvents/ColdStoragePaths.cs
@@ -1,0 +1,14 @@
+namespace Sekiban.Dcb.ColdEvents;
+
+/// Centralized path construction for cold storage control and segment files.
+public static class ColdStoragePaths
+{
+    public static string ManifestPath(string serviceId) =>
+        $"control/{serviceId}/manifest.json";
+
+    public static string CheckpointPath(string serviceId) =>
+        $"control/{serviceId}/checkpoint.json";
+
+    public static string SegmentPath(string serviceId, string from, string to) =>
+        $"segments/{serviceId}/{from}_{to}.jsonl";
+}

--- a/dcb/src/Sekiban.Dcb.Core/ColdEvents/ColdStoreProgress.cs
+++ b/dcb/src/Sekiban.Dcb.Core/ColdEvents/ColdStoreProgress.cs
@@ -1,0 +1,9 @@
+namespace Sekiban.Dcb.ColdEvents;
+
+public record ColdStoreProgress(
+    string ServiceId,
+    string? LatestSafeSortableUniqueId,
+    string? LatestExportedSortableUniqueId,
+    string? NextSinceSortableUniqueId,
+    DateTimeOffset? LastExportedAtUtc,
+    string ManifestVersion);

--- a/dcb/src/Sekiban.Dcb.Core/ColdEvents/ExportResult.cs
+++ b/dcb/src/Sekiban.Dcb.Core/ColdEvents/ExportResult.cs
@@ -1,0 +1,6 @@
+namespace Sekiban.Dcb.ColdEvents;
+
+public record ExportResult(
+    int ExportedEventCount,
+    IReadOnlyList<ColdSegmentInfo> NewSegments,
+    string UpdatedManifestVersion);

--- a/dcb/src/Sekiban.Dcb.Core/ColdEvents/HybridEventStore.cs
+++ b/dcb/src/Sekiban.Dcb.Core/ColdEvents/HybridEventStore.cs
@@ -1,0 +1,193 @@
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using ResultBoxes;
+using Sekiban.Dcb.Common;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.ServiceId;
+using Sekiban.Dcb.Storage;
+using Sekiban.Dcb.Tags;
+namespace Sekiban.Dcb.ColdEvents;
+
+public sealed class HybridEventStore : IEventStore
+{
+    private readonly IEventStore _hotStore;
+    private readonly IColdObjectStorage _coldStorage;
+    private readonly IServiceIdProvider _serviceIdProvider;
+    private readonly ColdEventStoreOptions _options;
+    private readonly ILogger<HybridEventStore> _logger;
+
+    public HybridEventStore(
+        IEventStore hotStore,
+        IColdObjectStorage coldStorage,
+        IServiceIdProvider serviceIdProvider,
+        IOptions<ColdEventStoreOptions> options,
+        ILogger<HybridEventStore> logger)
+    {
+        _hotStore = hotStore;
+        _coldStorage = coldStorage;
+        _serviceIdProvider = serviceIdProvider;
+        _options = options.Value;
+        _logger = logger;
+    }
+
+    public Task<ResultBox<(IReadOnlyList<Event> Events, IReadOnlyList<TagWriteResult> TagWrites)>> WriteEventsAsync(
+        IEnumerable<Event> events)
+        => _hotStore.WriteEventsAsync(events);
+
+    public Task<ResultBox<IEnumerable<TagStream>>> ReadTagsAsync(ITag tag)
+        => _hotStore.ReadTagsAsync(tag);
+
+    public Task<ResultBox<TagState>> GetLatestTagAsync(ITag tag)
+        => _hotStore.GetLatestTagAsync(tag);
+
+    public Task<ResultBox<bool>> TagExistsAsync(ITag tag)
+        => _hotStore.TagExistsAsync(tag);
+
+    public Task<ResultBox<long>> GetEventCountAsync(SortableUniqueId? since = null)
+        => _hotStore.GetEventCountAsync(since);
+
+    public Task<ResultBox<IEnumerable<TagInfo>>> GetAllTagsAsync(string? tagGroup = null)
+        => _hotStore.GetAllTagsAsync(tagGroup);
+
+    public Task<ResultBox<IEnumerable<Event>>> ReadEventsByTagAsync(ITag tag, SortableUniqueId? since = null)
+        => _hotStore.ReadEventsByTagAsync(tag, since);
+
+    public Task<ResultBox<Event>> ReadEventAsync(Guid eventId)
+        => _hotStore.ReadEventAsync(eventId);
+
+    public Task<ResultBox<IEnumerable<SerializableEvent>>> ReadSerializableEventsByTagAsync(
+        ITag tag, SortableUniqueId? since = null)
+        => _hotStore.ReadSerializableEventsByTagAsync(tag, since);
+
+    public Task<ResultBox<(IReadOnlyList<SerializableEvent> Events, IReadOnlyList<TagWriteResult> TagWrites)>>
+        WriteSerializableEventsAsync(IEnumerable<SerializableEvent> events)
+        => _hotStore.WriteSerializableEventsAsync(events);
+
+    public async Task<ResultBox<IEnumerable<Event>>> ReadAllEventsAsync(
+        SortableUniqueId? since = null, int? maxCount = null)
+        => await _hotStore.ReadAllEventsAsync(since, maxCount);
+
+    public async Task<ResultBox<IEnumerable<SerializableEvent>>> ReadAllSerializableEventsAsync(
+        SortableUniqueId? since = null)
+        => await ReadAllSerializableEventsAsync(since, maxCount: null);
+
+    public async Task<ResultBox<IEnumerable<SerializableEvent>>> ReadAllSerializableEventsAsync(
+        SortableUniqueId? since,
+        int? maxCount)
+    {
+        if (!_options.Enabled)
+        {
+            return await _hotStore.ReadAllSerializableEventsAsync(since, maxCount);
+        }
+
+        return await ReadHybridSerializableEventsAsync(since, maxCount);
+    }
+
+    private async Task<ResultBox<IEnumerable<SerializableEvent>>> ReadHybridSerializableEventsAsync(
+        SortableUniqueId? since,
+        int? maxCount)
+    {
+        var serviceId = _serviceIdProvider.GetCurrentServiceId();
+        var manifest = await ColdControlFileHelper.LoadManifestAsync(_coldStorage, serviceId, CancellationToken.None);
+
+        if (manifest is null || manifest.LatestSafeSortableUniqueId is null)
+        {
+            _logger.LogDebug("No cold manifest found for {ServiceId}, falling back to hot store", serviceId);
+            return await _hotStore.ReadAllSerializableEventsAsync(since, maxCount);
+        }
+
+        var coldBoundary = new SortableUniqueId(manifest.LatestSafeSortableUniqueId);
+
+        if (since is not null && since.IsLaterThan(coldBoundary))
+        {
+            return await _hotStore.ReadAllSerializableEventsAsync(since, maxCount);
+        }
+
+        var coldEvents = await ReadFromColdSegmentsAsync(manifest, since);
+        if (coldEvents is null)
+        {
+            _logger.LogWarning("Cold read failed for {ServiceId}, falling back to hot store", serviceId);
+            return await _hotStore.ReadAllSerializableEventsAsync(since, maxCount);
+        }
+
+        var hotResult = await _hotStore.ReadAllSerializableEventsAsync(coldBoundary, maxCount: null);
+        if (!hotResult.IsSuccess)
+        {
+            return hotResult;
+        }
+
+        var merged = coldEvents
+            .Concat(hotResult.GetValue())
+            .DistinctBy(e => e.SortableUniqueIdValue)
+            .OrderBy(e => e.SortableUniqueIdValue, StringComparer.Ordinal);
+
+        IEnumerable<SerializableEvent> result = maxCount.HasValue
+            ? merged.Take(maxCount.Value)
+            : merged;
+
+        return ResultBox.FromValue(result);
+    }
+
+    private async Task<List<SerializableEvent>?> ReadFromColdSegmentsAsync(
+        ColdManifest manifest,
+        SortableUniqueId? since)
+    {
+        var events = new List<SerializableEvent>();
+
+        foreach (var segment in manifest.Segments)
+        {
+            if (since is not null
+                && string.Compare(segment.ToSortableUniqueId, since.Value, StringComparison.Ordinal) <= 0)
+            {
+                continue;
+            }
+
+            var getResult = await _coldStorage.GetAsync(segment.Path, CancellationToken.None);
+            if (!getResult.IsSuccess)
+            {
+                _logger.LogWarning("Failed to read cold segment {Path}", segment.Path);
+                return null;
+            }
+
+            var segmentEvents = ParseJsonlSegment(getResult.GetValue().Data);
+            if (segmentEvents is null)
+            {
+                _logger.LogWarning("Failed to parse cold segment {Path}", segment.Path);
+                return null;
+            }
+
+            foreach (var e in segmentEvents)
+            {
+                if (since is not null
+                    && string.Compare(e.SortableUniqueIdValue, since.Value, StringComparison.Ordinal) <= 0)
+                {
+                    continue;
+                }
+                events.Add(e);
+            }
+        }
+
+        return events;
+    }
+
+    private static List<SerializableEvent>? ParseJsonlSegment(byte[] data)
+    {
+        var text = System.Text.Encoding.UTF8.GetString(data);
+        var lines = text.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+        var events = new List<SerializableEvent>(lines.Length);
+
+        foreach (var line in lines)
+        {
+            var evt = JsonSerializer.Deserialize<SerializableEvent>(line, ColdEventJsonOptions.Default);
+            if (evt is null)
+            {
+                return null;
+            }
+            events.Add(evt);
+        }
+
+        return events;
+    }
+
+}

--- a/dcb/src/Sekiban.Dcb.Core/ColdEvents/IColdEventExporter.cs
+++ b/dcb/src/Sekiban.Dcb.Core/ColdEvents/IColdEventExporter.cs
@@ -1,0 +1,9 @@
+using ResultBoxes;
+namespace Sekiban.Dcb.ColdEvents;
+
+public interface IColdEventExporter : IColdEventStoreFeature
+{
+    Task<ResultBox<ExportResult>> ExportIncrementalAsync(
+        string serviceId,
+        CancellationToken ct);
+}

--- a/dcb/src/Sekiban.Dcb.Core/ColdEvents/IColdEventProgressReader.cs
+++ b/dcb/src/Sekiban.Dcb.Core/ColdEvents/IColdEventProgressReader.cs
@@ -1,0 +1,9 @@
+using ResultBoxes;
+namespace Sekiban.Dcb.ColdEvents;
+
+public interface IColdEventProgressReader : IColdEventStoreFeature
+{
+    Task<ResultBox<ColdStoreProgress>> GetProgressAsync(
+        string serviceId,
+        CancellationToken ct);
+}

--- a/dcb/src/Sekiban.Dcb.Core/ColdEvents/IColdEventStoreFeature.cs
+++ b/dcb/src/Sekiban.Dcb.Core/ColdEvents/IColdEventStoreFeature.cs
@@ -1,0 +1,6 @@
+namespace Sekiban.Dcb.ColdEvents;
+
+public interface IColdEventStoreFeature
+{
+    Task<ColdFeatureStatus> GetStatusAsync(CancellationToken ct);
+}

--- a/dcb/src/Sekiban.Dcb.Core/ColdEvents/IColdLeaseManager.cs
+++ b/dcb/src/Sekiban.Dcb.Core/ColdEvents/IColdLeaseManager.cs
@@ -1,0 +1,11 @@
+using ResultBoxes;
+namespace Sekiban.Dcb.ColdEvents;
+
+public interface IColdLeaseManager
+{
+    Task<ResultBox<ColdLease>> AcquireAsync(string leaseId, TimeSpan duration, CancellationToken ct);
+
+    Task<ResultBox<ColdLease>> RenewAsync(ColdLease lease, TimeSpan duration, CancellationToken ct);
+
+    Task<ResultBox<bool>> ReleaseAsync(ColdLease lease, CancellationToken ct);
+}

--- a/dcb/src/Sekiban.Dcb.Core/ColdEvents/IColdObjectStorage.cs
+++ b/dcb/src/Sekiban.Dcb.Core/ColdEvents/IColdObjectStorage.cs
@@ -1,0 +1,17 @@
+using ResultBoxes;
+namespace Sekiban.Dcb.ColdEvents;
+
+public interface IColdObjectStorage
+{
+    Task<ResultBox<ColdStorageObject>> GetAsync(string path, CancellationToken ct);
+
+    Task<ResultBox<bool>> PutAsync(
+        string path,
+        byte[] data,
+        string? expectedETag,
+        CancellationToken ct);
+
+    Task<ResultBox<IReadOnlyList<string>>> ListAsync(string prefix, CancellationToken ct);
+
+    Task<ResultBox<bool>> DeleteAsync(string path, CancellationToken ct);
+}

--- a/dcb/src/Sekiban.Dcb.Core/ColdEvents/JsonlSegmentWriter.cs
+++ b/dcb/src/Sekiban.Dcb.Core/ColdEvents/JsonlSegmentWriter.cs
@@ -1,0 +1,26 @@
+using System.Text;
+using System.Text.Json;
+using Sekiban.Dcb.Events;
+namespace Sekiban.Dcb.ColdEvents;
+
+public static class JsonlSegmentWriter
+{
+    private static readonly Encoding Utf8NoBom = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+
+    public static byte[] Write(IReadOnlyList<SerializableEvent> events)
+    {
+        using var stream = new MemoryStream();
+        WriteToStream(events, stream);
+        return stream.ToArray();
+    }
+
+    private static void WriteToStream(IReadOnlyList<SerializableEvent> events, Stream stream)
+    {
+        using var writer = new StreamWriter(stream, Utf8NoBom, leaveOpen: true);
+        foreach (var e in events)
+        {
+            var line = JsonSerializer.Serialize(e, ColdEventJsonOptions.Default);
+            writer.WriteLine(line);
+        }
+    }
+}

--- a/dcb/src/Sekiban.Dcb.Core/ColdEvents/NotSupportedColdEventStore.cs
+++ b/dcb/src/Sekiban.Dcb.Core/ColdEvents/NotSupportedColdEventStore.cs
@@ -1,0 +1,24 @@
+using ResultBoxes;
+namespace Sekiban.Dcb.ColdEvents;
+
+public sealed class NotSupportedColdEventStore :
+    IColdEventProgressReader,
+    IColdEventExporter
+{
+    private static readonly ColdFeatureStatus NotConfiguredStatus = new(
+        IsSupported: false,
+        IsEnabled: false,
+        Reason: "Cold event store is not configured");
+
+    private static readonly NotSupportedException NotSupportedException = new(
+        "Cold event store is not supported");
+
+    public Task<ColdFeatureStatus> GetStatusAsync(CancellationToken ct)
+        => Task.FromResult(NotConfiguredStatus);
+
+    public Task<ResultBox<ColdStoreProgress>> GetProgressAsync(string serviceId, CancellationToken ct)
+        => Task.FromResult(ResultBox.Error<ColdStoreProgress>(NotSupportedException));
+
+    public Task<ResultBox<ExportResult>> ExportIncrementalAsync(string serviceId, CancellationToken ct)
+        => Task.FromResult(ResultBox.Error<ExportResult>(NotSupportedException));
+}

--- a/dcb/src/Sekiban.Dcb.Core/ColdEvents/SafeWindowFilter.cs
+++ b/dcb/src/Sekiban.Dcb.Core/ColdEvents/SafeWindowFilter.cs
@@ -1,0 +1,21 @@
+using Sekiban.Dcb.Common;
+using Sekiban.Dcb.Events;
+namespace Sekiban.Dcb.ColdEvents;
+
+public static class SafeWindowFilter
+{
+    public static IReadOnlyList<SerializableEvent> Apply(
+        IEnumerable<SerializableEvent> events,
+        DateTime cutoffUtc)
+    {
+        return events
+            .Where(e => IsSafe(e, cutoffUtc))
+            .ToList();
+    }
+
+    private static bool IsSafe(SerializableEvent e, DateTime cutoffUtc)
+    {
+        var eventTime = new SortableUniqueId(e.SortableUniqueIdValue).GetDateTime();
+        return eventTime <= cutoffUtc;
+    }
+}

--- a/dcb/src/Sekiban.Dcb.Core/ColdEvents/SekibanDcbColdEventExtensions.cs
+++ b/dcb/src/Sekiban.Dcb.Core/ColdEvents/SekibanDcbColdEventExtensions.cs
@@ -1,0 +1,73 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Sekiban.Dcb.ServiceId;
+using Sekiban.Dcb.Storage;
+namespace Sekiban.Dcb.ColdEvents;
+
+public static class SekibanDcbColdEventExtensions
+{
+    public static IServiceCollection AddSekibanDcbColdEventDefaults(this IServiceCollection services)
+    {
+        var notSupported = new NotSupportedColdEventStore();
+        services.TryAddSingleton<IColdEventStoreFeature>(notSupported);
+        services.TryAddSingleton<IColdEventProgressReader>(notSupported);
+        services.TryAddSingleton<IColdEventExporter>(notSupported);
+        return services;
+    }
+
+    public static IServiceCollection AddSekibanDcbColdEvents(
+        this IServiceCollection services,
+        Action<ColdEventStoreOptions> configureOptions)
+    {
+        services.Configure(configureOptions);
+        services.AddSingleton<ColdExporter>();
+        services.AddSingleton<IColdEventExporter>(sp => sp.GetRequiredService<ColdExporter>());
+        services.AddSingleton<IColdEventProgressReader>(sp => sp.GetRequiredService<ColdExporter>());
+        services.AddSingleton<IColdEventStoreFeature>(sp => sp.GetRequiredService<ColdExporter>());
+        services.AddHostedService<ColdExportBackgroundService>();
+        return services;
+    }
+
+    public static IServiceCollection AddSekibanDcbColdEventHybridRead(
+        this IServiceCollection services)
+    {
+        var existingDescriptor = services.FirstOrDefault(d => d.ServiceType == typeof(IEventStore));
+        if (existingDescriptor is null)
+        {
+            throw new InvalidOperationException(
+                "IEventStore must be registered before adding hybrid read support");
+        }
+
+        services.Replace(ServiceDescriptor.Singleton<IEventStore>(sp =>
+        {
+            var hotStore = ResolveFromDescriptor(sp, existingDescriptor);
+            return new HybridEventStore(
+                hotStore,
+                sp.GetRequiredService<IColdObjectStorage>(),
+                sp.GetRequiredService<IServiceIdProvider>(),
+                sp.GetRequiredService<IOptions<ColdEventStoreOptions>>(),
+                sp.GetRequiredService<ILogger<HybridEventStore>>());
+        }));
+
+        return services;
+    }
+
+    private static IEventStore ResolveFromDescriptor(IServiceProvider sp, ServiceDescriptor descriptor)
+    {
+        if (descriptor.ImplementationInstance is IEventStore instance)
+        {
+            return instance;
+        }
+        if (descriptor.ImplementationFactory is not null)
+        {
+            return (IEventStore)descriptor.ImplementationFactory(sp);
+        }
+        if (descriptor.ImplementationType is not null)
+        {
+            return (IEventStore)ActivatorUtilities.CreateInstance(sp, descriptor.ImplementationType);
+        }
+        throw new InvalidOperationException("Cannot resolve inner IEventStore from existing registration");
+    }
+}

--- a/dcb/src/Sekiban.Dcb.Core/Sekiban.Dcb.Core.csproj
+++ b/dcb/src/Sekiban.Dcb.Core/Sekiban.Dcb.Core.csproj
@@ -32,6 +32,7 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.9" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.2" />
+        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.2" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.2" />
         <PackageReference Include="ResultBoxes" Version="0.4.0"/>
         <PackageReference Include="Sekiban.Dcb.Core.Model" Version="10.0.2-preview05" />

--- a/dcb/tests/Sekiban.Dcb.ColdEvents.Tests/ColdExporterTests.cs
+++ b/dcb/tests/Sekiban.Dcb.ColdEvents.Tests/ColdExporterTests.cs
@@ -1,0 +1,213 @@
+using System.Text.Json;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using ResultBoxes;
+using Sekiban.Dcb.ColdEvents;
+using Sekiban.Dcb.Common;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.Storage;
+using Sekiban.Dcb.Tags;
+namespace Sekiban.Dcb.ColdEvents.Tests;
+
+public class ColdExporterTests
+{
+    private const string ServiceId = "test-service";
+
+    private static readonly ColdEventStoreOptions EnabledOptions = new()
+    {
+        Enabled = true,
+        PullInterval = TimeSpan.FromMinutes(30),
+        SafeWindow = TimeSpan.FromMinutes(2),
+        SegmentMaxEvents = 100_000,
+        SegmentMaxBytes = 512L * 1024 * 1024
+    };
+
+    private readonly InMemoryColdObjectStorage _storage = new();
+    private readonly InMemoryColdLeaseManager _leaseManager = new();
+
+    private static SerializableEvent CreateEvent(DateTime timestamp, string name)
+    {
+        var sortableId = SortableUniqueId.Generate(timestamp, Guid.NewGuid());
+        return new SerializableEvent(
+            Payload: [1, 2, 3],
+            SortableUniqueIdValue: sortableId,
+            Id: Guid.NewGuid(),
+            EventMetadata: new EventMetadata("cause", "corr", "user"),
+            Tags: ["tag1"],
+            EventPayloadName: name);
+    }
+
+    private ColdExporter CreateExporter(IEventStore hotStore, ColdEventStoreOptions? options = null)
+    {
+        return new ColdExporter(
+            hotStore,
+            _storage,
+            _leaseManager,
+            Options.Create(options ?? EnabledOptions),
+            NullLogger<ColdExporter>.Instance);
+    }
+
+    [Fact]
+    public async Task GetStatusAsync_should_return_supported_and_enabled()
+    {
+        // Given
+        var exporter = CreateExporter(new StubEventStore([]));
+
+        // When
+        var status = await exporter.GetStatusAsync(CancellationToken.None);
+
+        // Then
+        Assert.True(status.IsSupported);
+        Assert.True(status.IsEnabled);
+    }
+
+    [Fact]
+    public async Task GetStatusAsync_should_return_supported_but_disabled_when_not_enabled()
+    {
+        // Given
+        var options = new ColdEventStoreOptions { Enabled = false };
+        var exporter = CreateExporter(new StubEventStore([]), options);
+
+        // When
+        var status = await exporter.GetStatusAsync(CancellationToken.None);
+
+        // Then
+        Assert.True(status.IsSupported);
+        Assert.False(status.IsEnabled);
+    }
+
+    [Fact]
+    public async Task ExportIncrementalAsync_should_return_zero_when_no_events()
+    {
+        // Given
+        var exporter = CreateExporter(new StubEventStore([]));
+
+        // When
+        var result = await exporter.ExportIncrementalAsync(ServiceId, CancellationToken.None);
+
+        // Then
+        Assert.True(result.IsSuccess);
+        Assert.Equal(0, result.GetValue().ExportedEventCount);
+    }
+
+    [Fact]
+    public async Task ExportIncrementalAsync_should_export_safe_events_only()
+    {
+        // Given: 2 safe events (old) + 1 unsafe event (now)
+        var safeTime = DateTime.UtcNow.AddMinutes(-10);
+        var unsafeTime = DateTime.UtcNow;
+        var events = new[]
+        {
+            CreateEvent(safeTime, "Event1"),
+            CreateEvent(safeTime.AddSeconds(1), "Event2"),
+            CreateEvent(unsafeTime, "Event3")
+        };
+        var exporter = CreateExporter(new StubEventStore(events));
+
+        // When
+        var result = await exporter.ExportIncrementalAsync(ServiceId, CancellationToken.None);
+
+        // Then
+        Assert.True(result.IsSuccess);
+        Assert.Equal(2, result.GetValue().ExportedEventCount);
+        Assert.Single(result.GetValue().NewSegments);
+    }
+
+    [Fact]
+    public async Task ExportIncrementalAsync_should_skip_when_lease_held()
+    {
+        // Given: lease already held
+        await _leaseManager.AcquireAsync($"cold-export-{ServiceId}", TimeSpan.FromHours(1), CancellationToken.None);
+        var events = new[] { CreateEvent(DateTime.UtcNow.AddMinutes(-10), "Event1") };
+        var exporter = CreateExporter(new StubEventStore(events));
+
+        // When
+        var result = await exporter.ExportIncrementalAsync(ServiceId, CancellationToken.None);
+
+        // Then: should return 0 exported (skipped)
+        Assert.True(result.IsSuccess);
+        Assert.Equal(0, result.GetValue().ExportedEventCount);
+    }
+
+    [Fact]
+    public async Task ExportIncrementalAsync_should_create_manifest_and_checkpoint()
+    {
+        // Given
+        var safeTime = DateTime.UtcNow.AddMinutes(-10);
+        var events = new[] { CreateEvent(safeTime, "Event1") };
+        var exporter = CreateExporter(new StubEventStore(events));
+
+        // When
+        await exporter.ExportIncrementalAsync(ServiceId, CancellationToken.None);
+
+        // Then: manifest should be readable
+        var progressResult = await exporter.GetProgressAsync(ServiceId, CancellationToken.None);
+        Assert.True(progressResult.IsSuccess);
+        var progress = progressResult.GetValue();
+        Assert.NotNull(progress.LatestSafeSortableUniqueId);
+        Assert.NotNull(progress.NextSinceSortableUniqueId);
+    }
+
+    [Fact]
+    public async Task GetProgressAsync_should_return_default_when_no_manifest()
+    {
+        // Given
+        var exporter = CreateExporter(new StubEventStore([]));
+
+        // When
+        var result = await exporter.GetProgressAsync(ServiceId, CancellationToken.None);
+
+        // Then
+        Assert.True(result.IsSuccess);
+        var progress = result.GetValue();
+        Assert.Equal(ServiceId, progress.ServiceId);
+        Assert.Null(progress.LatestSafeSortableUniqueId);
+        Assert.Equal("0", progress.ManifestVersion);
+    }
+
+    private sealed class StubEventStore : IEventStore
+    {
+        private readonly IReadOnlyList<SerializableEvent> _events;
+
+        public StubEventStore(IReadOnlyList<SerializableEvent> events)
+        {
+            _events = events;
+        }
+
+        public Task<ResultBox<IEnumerable<Event>>> ReadAllEventsAsync(SortableUniqueId? since = null, int? maxCount = null)
+            => throw new NotSupportedException();
+
+        public Task<ResultBox<IEnumerable<Event>>> ReadEventsByTagAsync(ITag tag, SortableUniqueId? since = null)
+            => throw new NotSupportedException();
+
+        public Task<ResultBox<Event>> ReadEventAsync(Guid eventId)
+            => throw new NotSupportedException();
+
+        public Task<ResultBox<(IReadOnlyList<Event> Events, IReadOnlyList<TagWriteResult> TagWrites)>> WriteEventsAsync(IEnumerable<Event> events)
+            => throw new NotSupportedException();
+
+        public Task<ResultBox<IEnumerable<TagStream>>> ReadTagsAsync(ITag tag)
+            => throw new NotSupportedException();
+
+        public Task<ResultBox<TagState>> GetLatestTagAsync(ITag tag)
+            => throw new NotSupportedException();
+
+        public Task<ResultBox<bool>> TagExistsAsync(ITag tag)
+            => throw new NotSupportedException();
+
+        public Task<ResultBox<long>> GetEventCountAsync(SortableUniqueId? since = null)
+            => throw new NotSupportedException();
+
+        public Task<ResultBox<IEnumerable<TagInfo>>> GetAllTagsAsync(string? tagGroup = null)
+            => throw new NotSupportedException();
+
+        public Task<ResultBox<IEnumerable<SerializableEvent>>> ReadAllSerializableEventsAsync(SortableUniqueId? since = null)
+        {
+            IEnumerable<SerializableEvent> result = since is null
+                ? _events
+                : _events.Where(e =>
+                    string.Compare(e.SortableUniqueIdValue, since.Value, StringComparison.Ordinal) > 0);
+            return Task.FromResult(ResultBox.FromValue(result));
+        }
+    }
+}

--- a/dcb/tests/Sekiban.Dcb.ColdEvents.Tests/ColdManifestTests.cs
+++ b/dcb/tests/Sekiban.Dcb.ColdEvents.Tests/ColdManifestTests.cs
@@ -1,0 +1,86 @@
+using System.Text.Json;
+using Sekiban.Dcb.ColdEvents;
+namespace Sekiban.Dcb.ColdEvents.Tests;
+
+public class ColdManifestTests
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
+
+    [Fact]
+    public void Should_round_trip_serialize_and_deserialize()
+    {
+        // Given
+        var manifest = new ColdManifest(
+            ServiceId: "svc-1",
+            ManifestVersion: "v1",
+            LatestSafeSortableUniqueId: "063923136000000000000000000000",
+            Segments:
+            [
+                new ColdSegmentInfo(
+                    Path: "segments/svc-1/seg1.jsonl",
+                    FromSortableUniqueId: "063923136000000000000000000000",
+                    ToSortableUniqueId: "063923136000000000099999999999",
+                    EventCount: 100,
+                    SizeBytes: 4096,
+                    Sha256: "abc123",
+                    CreatedAtUtc: DateTimeOffset.UtcNow)
+            ],
+            UpdatedAtUtc: DateTimeOffset.UtcNow);
+
+        // When
+        var json = JsonSerializer.Serialize(manifest, JsonOptions);
+        var deserialized = JsonSerializer.Deserialize<ColdManifest>(json, JsonOptions);
+
+        // Then
+        Assert.NotNull(deserialized);
+        Assert.Equal("svc-1", deserialized.ServiceId);
+        Assert.Equal("v1", deserialized.ManifestVersion);
+        Assert.Equal("063923136000000000000000000000", deserialized.LatestSafeSortableUniqueId);
+        Assert.Single(deserialized.Segments);
+        Assert.Equal(100, deserialized.Segments[0].EventCount);
+    }
+
+    [Fact]
+    public void Should_deserialize_manifest_to_get_stored_position()
+    {
+        // Given: stored manifest JSON
+        var manifest = new ColdManifest(
+            ServiceId: "svc-1",
+            ManifestVersion: "v2",
+            LatestSafeSortableUniqueId: "063923136000000000050000000000",
+            Segments:
+            [
+                new ColdSegmentInfo(
+                    Path: "segments/svc-1/seg1.jsonl",
+                    FromSortableUniqueId: "063923136000000000000000000000",
+                    ToSortableUniqueId: "063923136000000000025000000000",
+                    EventCount: 50_000,
+                    SizeBytes: 2048,
+                    Sha256: "hash1",
+                    CreatedAtUtc: DateTimeOffset.UtcNow),
+                new ColdSegmentInfo(
+                    Path: "segments/svc-1/seg2.jsonl",
+                    FromSortableUniqueId: "063923136000000000025000000001",
+                    ToSortableUniqueId: "063923136000000000050000000000",
+                    EventCount: 50_000,
+                    SizeBytes: 2048,
+                    Sha256: "hash2",
+                    CreatedAtUtc: DateTimeOffset.UtcNow)
+            ],
+            UpdatedAtUtc: DateTimeOffset.UtcNow);
+
+        var json = JsonSerializer.SerializeToUtf8Bytes(manifest, JsonOptions);
+
+        // When
+        var restored = JsonSerializer.Deserialize<ColdManifest>(json, JsonOptions);
+
+        // Then: can determine stored position from manifest alone
+        Assert.NotNull(restored);
+        Assert.Equal("063923136000000000050000000000", restored.LatestSafeSortableUniqueId);
+        Assert.Equal(2, restored.Segments.Count);
+        Assert.Equal(100_000, restored.Segments.Sum(s => s.EventCount));
+    }
+}

--- a/dcb/tests/Sekiban.Dcb.ColdEvents.Tests/ColdSegmentSplitterTests.cs
+++ b/dcb/tests/Sekiban.Dcb.ColdEvents.Tests/ColdSegmentSplitterTests.cs
@@ -1,0 +1,92 @@
+using Sekiban.Dcb.ColdEvents;
+using Sekiban.Dcb.Common;
+using Sekiban.Dcb.Events;
+namespace Sekiban.Dcb.ColdEvents.Tests;
+
+public class ColdSegmentSplitterTests
+{
+    private static SerializableEvent CreateEvent(int payloadSize)
+    {
+        var sortableId = SortableUniqueId.Generate(DateTime.UtcNow, Guid.NewGuid());
+        return new SerializableEvent(
+            Payload: new byte[payloadSize],
+            SortableUniqueIdValue: sortableId,
+            Id: Guid.NewGuid(),
+            EventMetadata: new EventMetadata("cause", "corr", "user"),
+            Tags: ["tag1"],
+            EventPayloadName: "TestEvent");
+    }
+
+    [Fact]
+    public void Should_return_empty_when_no_events()
+    {
+        // When
+        var result = ColdSegmentSplitter.Split([], maxEvents: 100, maxBytes: 1000);
+
+        // Then
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void Should_not_split_when_under_limits()
+    {
+        // Given
+        var events = Enumerable.Range(0, 5).Select(_ => CreateEvent(10)).ToList();
+
+        // When
+        var result = ColdSegmentSplitter.Split(events, maxEvents: 100, maxBytes: 10_000);
+
+        // Then
+        Assert.Single(result);
+        Assert.Equal(5, result[0].Count);
+    }
+
+    [Fact]
+    public void Should_split_by_event_count()
+    {
+        // Given
+        var events = Enumerable.Range(0, 250).Select(_ => CreateEvent(10)).ToList();
+
+        // When
+        var result = ColdSegmentSplitter.Split(events, maxEvents: 100, maxBytes: long.MaxValue);
+
+        // Then
+        Assert.Equal(3, result.Count);
+        Assert.Equal(100, result[0].Count);
+        Assert.Equal(100, result[1].Count);
+        Assert.Equal(50, result[2].Count);
+    }
+
+    [Fact]
+    public void Should_split_by_byte_size()
+    {
+        // Given: 5 events of 100 bytes each, max 250 bytes
+        var events = Enumerable.Range(0, 5).Select(_ => CreateEvent(100)).ToList();
+
+        // When
+        var result = ColdSegmentSplitter.Split(events, maxEvents: int.MaxValue, maxBytes: 250);
+
+        // Then: first 2 fit (200 bytes), 3rd would exceed so new segment, etc.
+        Assert.Equal(3, result.Count);
+        Assert.Equal(2, result[0].Count);
+        Assert.Equal(2, result[1].Count);
+        Assert.Single(result[2]);
+    }
+
+    [Fact]
+    public void Should_split_by_whichever_limit_is_reached_first()
+    {
+        // Given: 10 events of 50 bytes each; maxEvents=3, maxBytes=500
+        var events = Enumerable.Range(0, 10).Select(_ => CreateEvent(50)).ToList();
+
+        // When
+        var result = ColdSegmentSplitter.Split(events, maxEvents: 3, maxBytes: 500);
+
+        // Then: splits at 3 events each (count limit reached first)
+        Assert.Equal(4, result.Count);
+        Assert.Equal(3, result[0].Count);
+        Assert.Equal(3, result[1].Count);
+        Assert.Equal(3, result[2].Count);
+        Assert.Single(result[3]);
+    }
+}

--- a/dcb/tests/Sekiban.Dcb.ColdEvents.Tests/HybridEventStoreTests.cs
+++ b/dcb/tests/Sekiban.Dcb.ColdEvents.Tests/HybridEventStoreTests.cs
@@ -1,0 +1,268 @@
+using System.Text;
+using System.Text.Json;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using ResultBoxes;
+using Sekiban.Dcb.ColdEvents;
+using Sekiban.Dcb.Common;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.ServiceId;
+using Sekiban.Dcb.Storage;
+using Sekiban.Dcb.Tags;
+namespace Sekiban.Dcb.ColdEvents.Tests;
+
+public class HybridEventStoreTests
+{
+    private const string TestServiceId = "default";
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
+
+    private static readonly ColdEventStoreOptions EnabledOptions = new()
+    {
+        Enabled = true,
+        PullInterval = TimeSpan.FromMinutes(30),
+        SafeWindow = TimeSpan.FromMinutes(2),
+        SegmentMaxEvents = 100_000,
+        SegmentMaxBytes = 512L * 1024 * 1024
+    };
+
+    private static readonly ColdEventStoreOptions DisabledOptions = new()
+    {
+        Enabled = false
+    };
+
+    private readonly InMemoryColdObjectStorage _coldStorage = new();
+
+    private static SerializableEvent CreateEvent(DateTime timestamp, string name)
+    {
+        var sortableId = SortableUniqueId.Generate(timestamp, Guid.NewGuid());
+        return new SerializableEvent(
+            Payload: Encoding.UTF8.GetBytes("{\"name\":\"" + name + "\"}"),
+            SortableUniqueIdValue: sortableId,
+            Id: Guid.NewGuid(),
+            EventMetadata: new EventMetadata("cause", "corr", "user"),
+            Tags: ["tag1"],
+            EventPayloadName: name);
+    }
+
+    private HybridEventStore CreateHybrid(IEventStore hotStore, ColdEventStoreOptions? options = null)
+    {
+        return new HybridEventStore(
+            hotStore,
+            _coldStorage,
+            new DefaultServiceIdProvider(),
+            Options.Create(options ?? EnabledOptions),
+            NullLogger<HybridEventStore>.Instance);
+    }
+
+    private async Task StoreColdManifestAndSegmentsAsync(
+        IReadOnlyList<SerializableEvent> coldEvents,
+        string latestSafe)
+    {
+        var segmentData = JsonlSegmentWriter.Write(coldEvents);
+        var segmentPath = $"segments/{TestServiceId}/cold_segment.jsonl";
+        await _coldStorage.PutAsync(segmentPath, segmentData, expectedETag: null, CancellationToken.None);
+
+        var manifest = new ColdManifest(
+            ServiceId: TestServiceId,
+            ManifestVersion: "v1",
+            LatestSafeSortableUniqueId: latestSafe,
+            Segments:
+            [
+                new ColdSegmentInfo(
+                    Path: segmentPath,
+                    FromSortableUniqueId: coldEvents[0].SortableUniqueIdValue,
+                    ToSortableUniqueId: coldEvents[^1].SortableUniqueIdValue,
+                    EventCount: coldEvents.Count,
+                    SizeBytes: segmentData.Length,
+                    Sha256: "test",
+                    CreatedAtUtc: DateTimeOffset.UtcNow)
+            ],
+            UpdatedAtUtc: DateTimeOffset.UtcNow);
+
+        var manifestData = JsonSerializer.SerializeToUtf8Bytes(manifest, JsonOptions);
+        var manifestPath = $"control/{TestServiceId}/manifest.json";
+        await _coldStorage.PutAsync(manifestPath, manifestData, expectedETag: null, CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task Should_delegate_to_hot_store_when_disabled()
+    {
+        // Given
+        var hotEvent = CreateEvent(DateTime.UtcNow.AddMinutes(-5), "HotEvent");
+        var hotStore = new StubSerializableEventStore([hotEvent]);
+        var hybrid = CreateHybrid(hotStore, DisabledOptions);
+
+        // When
+        var result = await hybrid.ReadAllSerializableEventsAsync();
+
+        // Then
+        Assert.True(result.IsSuccess);
+        Assert.Single(result.GetValue());
+    }
+
+    [Fact]
+    public async Task Should_delegate_to_hot_store_when_no_manifest()
+    {
+        // Given: no manifest in cold storage
+        var hotEvent = CreateEvent(DateTime.UtcNow.AddMinutes(-5), "HotEvent");
+        var hotStore = new StubSerializableEventStore([hotEvent]);
+        var hybrid = CreateHybrid(hotStore);
+
+        // When
+        var result = await hybrid.ReadAllSerializableEventsAsync();
+
+        // Then
+        Assert.True(result.IsSuccess);
+        Assert.Single(result.GetValue());
+    }
+
+    [Fact]
+    public async Task Should_merge_cold_and_hot_events_in_order()
+    {
+        // Given: 2 cold events + 1 hot tail event
+        var coldTime = new DateTime(2025, 1, 1, 10, 0, 0, DateTimeKind.Utc);
+        var coldEvent1 = CreateEvent(coldTime, "ColdEvent1");
+        var coldEvent2 = CreateEvent(coldTime.AddMinutes(1), "ColdEvent2");
+        var latestSafe = coldEvent2.SortableUniqueIdValue;
+
+        await StoreColdManifestAndSegmentsAsync([coldEvent1, coldEvent2], latestSafe);
+
+        var hotTime = coldTime.AddMinutes(5);
+        var hotEvent = CreateEvent(hotTime, "HotEvent");
+        var hotStore = new StubSerializableEventStore([hotEvent], latestSafe);
+        var hybrid = CreateHybrid(hotStore);
+
+        // When
+        var result = await hybrid.ReadAllSerializableEventsAsync();
+
+        // Then
+        Assert.True(result.IsSuccess);
+        var events = result.GetValue().ToList();
+        Assert.Equal(3, events.Count);
+        Assert.Equal("ColdEvent1", events[0].EventPayloadName);
+        Assert.Equal("ColdEvent2", events[1].EventPayloadName);
+        Assert.Equal("HotEvent", events[2].EventPayloadName);
+    }
+
+    [Fact]
+    public async Task Should_respect_maxCount()
+    {
+        // Given: 2 cold events + 1 hot event
+        var coldTime = new DateTime(2025, 1, 1, 10, 0, 0, DateTimeKind.Utc);
+        var coldEvent1 = CreateEvent(coldTime, "Cold1");
+        var coldEvent2 = CreateEvent(coldTime.AddMinutes(1), "Cold2");
+        var latestSafe = coldEvent2.SortableUniqueIdValue;
+
+        await StoreColdManifestAndSegmentsAsync([coldEvent1, coldEvent2], latestSafe);
+
+        var hotEvent = CreateEvent(coldTime.AddMinutes(5), "Hot1");
+        var hotStore = new StubSerializableEventStore([hotEvent], latestSafe);
+        var hybrid = CreateHybrid(hotStore);
+
+        // When
+        var result = await hybrid.ReadAllSerializableEventsAsync(since: null, maxCount: 2);
+
+        // Then
+        Assert.True(result.IsSuccess);
+        Assert.Equal(2, result.GetValue().Count());
+    }
+
+    [Fact]
+    public async Task Should_fall_back_to_hot_when_cold_segment_missing()
+    {
+        // Given: manifest exists but segment file is missing
+        var manifest = new ColdManifest(
+            ServiceId: TestServiceId,
+            ManifestVersion: "v1",
+            LatestSafeSortableUniqueId: "063923136000000000000000000000",
+            Segments:
+            [
+                new ColdSegmentInfo(
+                    Path: "segments/default/missing.jsonl",
+                    FromSortableUniqueId: "063923136000000000000000000000",
+                    ToSortableUniqueId: "063923136000000000000000000000",
+                    EventCount: 1,
+                    SizeBytes: 100,
+                    Sha256: "abc",
+                    CreatedAtUtc: DateTimeOffset.UtcNow)
+            ],
+            UpdatedAtUtc: DateTimeOffset.UtcNow);
+        var manifestData = JsonSerializer.SerializeToUtf8Bytes(manifest, JsonOptions);
+        await _coldStorage.PutAsync($"control/{TestServiceId}/manifest.json", manifestData, null, CancellationToken.None);
+
+        var hotEvent = CreateEvent(DateTime.UtcNow.AddMinutes(-5), "HotFallback");
+        var hotStore = new StubSerializableEventStore([hotEvent]);
+        var hybrid = CreateHybrid(hotStore);
+
+        // When
+        var result = await hybrid.ReadAllSerializableEventsAsync();
+
+        // Then: should fall back to hot store
+        Assert.True(result.IsSuccess);
+        Assert.Single(result.GetValue());
+        Assert.Equal("HotFallback", result.GetValue().First().EventPayloadName);
+    }
+
+    private sealed class StubSerializableEventStore : IEventStore
+    {
+        private readonly IReadOnlyList<SerializableEvent> _events;
+        private readonly string? _sinceFilter;
+
+        public StubSerializableEventStore(IReadOnlyList<SerializableEvent> events, string? sinceFilter = null)
+        {
+            _events = events;
+            _sinceFilter = sinceFilter;
+        }
+
+        public Task<ResultBox<IEnumerable<Event>>> ReadAllEventsAsync(SortableUniqueId? since = null, int? maxCount = null)
+            => throw new NotSupportedException();
+
+        public Task<ResultBox<IEnumerable<Event>>> ReadEventsByTagAsync(ITag tag, SortableUniqueId? since = null)
+            => throw new NotSupportedException();
+
+        public Task<ResultBox<Event>> ReadEventAsync(Guid eventId)
+            => throw new NotSupportedException();
+
+        public Task<ResultBox<(IReadOnlyList<Event> Events, IReadOnlyList<TagWriteResult> TagWrites)>> WriteEventsAsync(IEnumerable<Event> events)
+            => throw new NotSupportedException();
+
+        public Task<ResultBox<IEnumerable<TagStream>>> ReadTagsAsync(ITag tag)
+            => throw new NotSupportedException();
+
+        public Task<ResultBox<TagState>> GetLatestTagAsync(ITag tag)
+            => throw new NotSupportedException();
+
+        public Task<ResultBox<bool>> TagExistsAsync(ITag tag)
+            => throw new NotSupportedException();
+
+        public Task<ResultBox<long>> GetEventCountAsync(SortableUniqueId? since = null)
+            => throw new NotSupportedException();
+
+        public Task<ResultBox<IEnumerable<TagInfo>>> GetAllTagsAsync(string? tagGroup = null)
+            => throw new NotSupportedException();
+
+        public Task<ResultBox<IEnumerable<SerializableEvent>>> ReadAllSerializableEventsAsync(SortableUniqueId? since = null)
+        {
+            IEnumerable<SerializableEvent> filtered = since is null
+                ? _events
+                : _events.Where(e => string.Compare(e.SortableUniqueIdValue, since.Value, StringComparison.Ordinal) > 0);
+            return Task.FromResult(ResultBox.FromValue(filtered));
+        }
+
+        public Task<ResultBox<IEnumerable<SerializableEvent>>> ReadAllSerializableEventsAsync(SortableUniqueId? since, int? maxCount)
+        {
+            IEnumerable<SerializableEvent> filtered = since is null
+                ? _events
+                : _events.Where(e => string.Compare(e.SortableUniqueIdValue, since.Value, StringComparison.Ordinal) > 0);
+            if (maxCount.HasValue)
+            {
+                filtered = filtered.Take(maxCount.Value);
+            }
+            return Task.FromResult(ResultBox.FromValue(filtered));
+        }
+    }
+}

--- a/dcb/tests/Sekiban.Dcb.ColdEvents.Tests/InMemoryColdLeaseManager.cs
+++ b/dcb/tests/Sekiban.Dcb.ColdEvents.Tests/InMemoryColdLeaseManager.cs
@@ -1,0 +1,52 @@
+using System.Collections.Concurrent;
+using ResultBoxes;
+using Sekiban.Dcb.ColdEvents;
+namespace Sekiban.Dcb.ColdEvents.Tests;
+
+public sealed class InMemoryColdLeaseManager : IColdLeaseManager
+{
+    private readonly ConcurrentDictionary<string, ColdLease> _leases = new();
+
+    public Task<ResultBox<ColdLease>> AcquireAsync(string leaseId, TimeSpan duration, CancellationToken ct)
+    {
+        var now = DateTimeOffset.UtcNow;
+
+        if (_leases.TryGetValue(leaseId, out var existing) && existing.ExpiresAt > now)
+        {
+            return Task.FromResult(
+                ResultBox.Error<ColdLease>(new InvalidOperationException(
+                    $"Lease {leaseId} is already held until {existing.ExpiresAt}")));
+        }
+
+        var lease = new ColdLease(leaseId, Guid.NewGuid().ToString(), now.Add(duration));
+        _leases[leaseId] = lease;
+        return Task.FromResult(ResultBox.FromValue(lease));
+    }
+
+    public Task<ResultBox<ColdLease>> RenewAsync(ColdLease lease, TimeSpan duration, CancellationToken ct)
+    {
+        if (!_leases.TryGetValue(lease.LeaseId, out var current) || current.Token != lease.Token)
+        {
+            return Task.FromResult(
+                ResultBox.Error<ColdLease>(new InvalidOperationException(
+                    $"Lease {lease.LeaseId} is not held by this token")));
+        }
+
+        var renewed = lease with { ExpiresAt = DateTimeOffset.UtcNow.Add(duration) };
+        _leases[lease.LeaseId] = renewed;
+        return Task.FromResult(ResultBox.FromValue(renewed));
+    }
+
+    public Task<ResultBox<bool>> ReleaseAsync(ColdLease lease, CancellationToken ct)
+    {
+        if (!_leases.TryGetValue(lease.LeaseId, out var current) || current.Token != lease.Token)
+        {
+            return Task.FromResult(
+                ResultBox.Error<bool>(new InvalidOperationException(
+                    $"Lease {lease.LeaseId} is not held by this token")));
+        }
+
+        _leases.TryRemove(lease.LeaseId, out _);
+        return Task.FromResult(ResultBox.FromValue(true));
+    }
+}

--- a/dcb/tests/Sekiban.Dcb.ColdEvents.Tests/InMemoryColdObjectStorage.cs
+++ b/dcb/tests/Sekiban.Dcb.ColdEvents.Tests/InMemoryColdObjectStorage.cs
@@ -1,0 +1,72 @@
+using System.Collections.Concurrent;
+using System.Security.Cryptography;
+using ResultBoxes;
+using Sekiban.Dcb.ColdEvents;
+namespace Sekiban.Dcb.ColdEvents.Tests;
+
+public sealed class InMemoryColdObjectStorage : IColdObjectStorage
+{
+    private readonly ConcurrentDictionary<string, StoredBlob> _blobs = new();
+
+    private sealed record StoredBlob(byte[] Data, string ETag);
+
+    public Task<ResultBox<ColdStorageObject>> GetAsync(string path, CancellationToken ct)
+    {
+        if (!_blobs.TryGetValue(path, out var blob))
+        {
+            return Task.FromResult(
+                ResultBox.Error<ColdStorageObject>(new KeyNotFoundException($"Object not found: {path}")));
+        }
+        return Task.FromResult(
+            ResultBox.FromValue(new ColdStorageObject(blob.Data, blob.ETag)));
+    }
+
+    public Task<ResultBox<bool>> PutAsync(
+        string path,
+        byte[] data,
+        string? expectedETag,
+        CancellationToken ct)
+    {
+        if (expectedETag is not null)
+        {
+            if (!_blobs.TryGetValue(path, out var existing))
+            {
+                return Task.FromResult(
+                    ResultBox.Error<bool>(new InvalidOperationException(
+                        $"Conditional write failed: object does not exist at {path}")));
+            }
+            if (existing.ETag != expectedETag)
+            {
+                return Task.FromResult(
+                    ResultBox.Error<bool>(new InvalidOperationException(
+                        $"ETag mismatch at {path}: expected={expectedETag}, actual={existing.ETag}")));
+            }
+        }
+
+        var newETag = ComputeETag(data);
+        _blobs[path] = new StoredBlob(data, newETag);
+        return Task.FromResult(ResultBox.FromValue(true));
+    }
+
+    public Task<ResultBox<IReadOnlyList<string>>> ListAsync(string prefix, CancellationToken ct)
+    {
+        var keys = _blobs.Keys
+            .Where(k => k.StartsWith(prefix, StringComparison.Ordinal))
+            .Order()
+            .ToList();
+        return Task.FromResult(
+            ResultBox.FromValue<IReadOnlyList<string>>(keys));
+    }
+
+    public Task<ResultBox<bool>> DeleteAsync(string path, CancellationToken ct)
+    {
+        var removed = _blobs.TryRemove(path, out _);
+        return Task.FromResult(ResultBox.FromValue(removed));
+    }
+
+    private static string ComputeETag(byte[] data)
+    {
+        var hash = SHA256.HashData(data);
+        return Convert.ToHexStringLower(hash);
+    }
+}

--- a/dcb/tests/Sekiban.Dcb.ColdEvents.Tests/JsonlSegmentWriterTests.cs
+++ b/dcb/tests/Sekiban.Dcb.ColdEvents.Tests/JsonlSegmentWriterTests.cs
@@ -1,0 +1,80 @@
+using System.Text;
+using System.Text.Json;
+using Sekiban.Dcb.ColdEvents;
+using Sekiban.Dcb.Common;
+using Sekiban.Dcb.Events;
+namespace Sekiban.Dcb.ColdEvents.Tests;
+
+public class JsonlSegmentWriterTests
+{
+    private static SerializableEvent CreateEvent(string payloadName)
+    {
+        var sortableId = SortableUniqueId.Generate(
+            new DateTime(2025, 1, 1, 12, 0, 0, DateTimeKind.Utc), Guid.NewGuid());
+        return new SerializableEvent(
+            Payload: Encoding.UTF8.GetBytes("{\"key\":\"value\"}"),
+            SortableUniqueIdValue: sortableId,
+            Id: Guid.NewGuid(),
+            EventMetadata: new EventMetadata("cause", "corr", "user"),
+            Tags: ["tag1"],
+            EventPayloadName: payloadName);
+    }
+
+    [Fact]
+    public void Should_write_one_json_line_per_event()
+    {
+        // Given
+        var events = new[] { CreateEvent("Event1"), CreateEvent("Event2"), CreateEvent("Event3") };
+
+        // When
+        var bytes = JsonlSegmentWriter.Write(events);
+        var text = Encoding.UTF8.GetString(bytes);
+        var lines = text.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+
+        // Then
+        Assert.Equal(3, lines.Length);
+    }
+
+    [Fact]
+    public void Should_produce_valid_json_per_line()
+    {
+        // Given
+        var events = new[] { CreateEvent("TestEvent") };
+
+        // When
+        var bytes = JsonlSegmentWriter.Write(events);
+        var text = Encoding.UTF8.GetString(bytes);
+        var lines = text.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+
+        // Then
+        var doc = JsonDocument.Parse(lines[0]);
+        Assert.NotNull(doc.RootElement.GetProperty("eventPayloadName").GetString());
+    }
+
+    [Fact]
+    public void Should_return_empty_bytes_for_empty_input()
+    {
+        // When
+        var bytes = JsonlSegmentWriter.Write([]);
+        var text = Encoding.UTF8.GetString(bytes);
+
+        // Then
+        Assert.Equal(string.Empty, text.Trim());
+    }
+
+    [Fact]
+    public void Should_preserve_event_payload_name_in_output()
+    {
+        // Given
+        var events = new[] { CreateEvent("OrderCreated") };
+
+        // When
+        var bytes = JsonlSegmentWriter.Write(events);
+        var text = Encoding.UTF8.GetString(bytes);
+        var line = text.Split('\n', StringSplitOptions.RemoveEmptyEntries)[0];
+        var doc = JsonDocument.Parse(line);
+
+        // Then
+        Assert.Equal("OrderCreated", doc.RootElement.GetProperty("eventPayloadName").GetString());
+    }
+}

--- a/dcb/tests/Sekiban.Dcb.ColdEvents.Tests/NotSupportedColdEventStoreTests.cs
+++ b/dcb/tests/Sekiban.Dcb.ColdEvents.Tests/NotSupportedColdEventStoreTests.cs
@@ -1,0 +1,35 @@
+using Sekiban.Dcb.ColdEvents;
+namespace Sekiban.Dcb.ColdEvents.Tests;
+
+public class NotSupportedColdEventStoreTests
+{
+    private readonly NotSupportedColdEventStore _sut = new();
+
+    [Fact]
+    public async Task GetStatusAsync_should_return_not_supported_and_not_enabled()
+    {
+        var status = await _sut.GetStatusAsync(CancellationToken.None);
+
+        Assert.False(status.IsSupported);
+        Assert.False(status.IsEnabled);
+        Assert.Equal("Cold event store is not configured", status.Reason);
+    }
+
+    [Fact]
+    public async Task GetProgressAsync_should_return_error()
+    {
+        var result = await _sut.GetProgressAsync("test-service", CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.IsType<NotSupportedException>(result.GetException());
+    }
+
+    [Fact]
+    public async Task ExportIncrementalAsync_should_return_error()
+    {
+        var result = await _sut.ExportIncrementalAsync("test-service", CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.IsType<NotSupportedException>(result.GetException());
+    }
+}

--- a/dcb/tests/Sekiban.Dcb.ColdEvents.Tests/SafeWindowFilterTests.cs
+++ b/dcb/tests/Sekiban.Dcb.ColdEvents.Tests/SafeWindowFilterTests.cs
@@ -1,0 +1,78 @@
+using Sekiban.Dcb.ColdEvents;
+using Sekiban.Dcb.Common;
+using Sekiban.Dcb.Events;
+namespace Sekiban.Dcb.ColdEvents.Tests;
+
+public class SafeWindowFilterTests
+{
+    private static SerializableEvent CreateEvent(DateTime timestamp)
+    {
+        var sortableId = SortableUniqueId.Generate(timestamp, Guid.NewGuid());
+        return new SerializableEvent(
+            Payload: [1, 2, 3],
+            SortableUniqueIdValue: sortableId,
+            Id: Guid.NewGuid(),
+            EventMetadata: new EventMetadata("cause", "corr", "user"),
+            Tags: ["tag1"],
+            EventPayloadName: "TestEvent");
+    }
+
+    [Fact]
+    public void Should_include_events_at_cutoff_boundary()
+    {
+        // Given
+        var cutoff = new DateTime(2025, 1, 1, 12, 0, 0, DateTimeKind.Utc);
+        var events = new[] { CreateEvent(cutoff) };
+
+        // When
+        var result = SafeWindowFilter.Apply(events, cutoff);
+
+        // Then
+        Assert.Single(result);
+    }
+
+    [Fact]
+    public void Should_include_events_before_cutoff()
+    {
+        // Given
+        var cutoff = new DateTime(2025, 1, 1, 12, 0, 0, DateTimeKind.Utc);
+        var events = new[] { CreateEvent(cutoff.AddMilliseconds(-1)) };
+
+        // When
+        var result = SafeWindowFilter.Apply(events, cutoff);
+
+        // Then
+        Assert.Single(result);
+    }
+
+    [Fact]
+    public void Should_exclude_events_after_cutoff()
+    {
+        // Given
+        var cutoff = new DateTime(2025, 1, 1, 12, 0, 0, DateTimeKind.Utc);
+        var events = new[] { CreateEvent(cutoff.AddMilliseconds(1)) };
+
+        // When
+        var result = SafeWindowFilter.Apply(events, cutoff);
+
+        // Then
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void Should_filter_mixed_events_correctly()
+    {
+        // Given
+        var cutoff = new DateTime(2025, 1, 1, 12, 0, 0, DateTimeKind.Utc);
+        var safe1 = CreateEvent(cutoff.AddMinutes(-5));
+        var safe2 = CreateEvent(cutoff);
+        var unsafe1 = CreateEvent(cutoff.AddSeconds(1));
+        var unsafe2 = CreateEvent(cutoff.AddMinutes(10));
+
+        // When
+        var result = SafeWindowFilter.Apply([safe1, safe2, unsafe1, unsafe2], cutoff);
+
+        // Then
+        Assert.Equal(2, result.Count);
+    }
+}

--- a/dcb/tests/Sekiban.Dcb.ColdEvents.Tests/Sekiban.Dcb.ColdEvents.Tests.csproj
+++ b/dcb/tests/Sekiban.Dcb.ColdEvents.Tests/Sekiban.Dcb.ColdEvents.Tests.csproj
@@ -1,0 +1,33 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+        <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="coverlet.collector" Version="6.0.4">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+        <PackageReference Include="xunit" Version="2.9.3" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="ResultBoxes" Version="0.4.0"/>
+        <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.102" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <Using Include="Xunit"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\src\Sekiban.Dcb.Core\Sekiban.Dcb.Core.csproj"/>
+    </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary

## Background
This issue tracks implementation work to execute after PR #936 is merged.

Reference docs:
- `tasks/cold-event-store/design.md`
- `tasks/cold-event-store/phase1.md`
- `tasks/cold-event-store/phase2.md`
- `tasks/cold-event-store/phase3.md`

## Goal
Implement Cold Event Store incrementally with safe defaults (`Enabled=false`) and clear operational control via control files.

## Phase 1 (MVP)
- [ ] Add interfaces/options for cold event store feature status
- [ ] Add `NotSupportedColdEventStore` default implementation (`IsSupported=false`, `IsEnabled=false`)
- [ ] Add JSONL segment export (pull mode, every 30 minutes configurable)
- [ ] Add control files (`manifest`, `checkpoint`, `lease`)
- [ ] Add safe window filter (default 2 minutes)
- [ ] Add segment split by event count/size (100,000 default, configurable to 1,000,000)
- [ ] Add conditional write + lease based concurrency control for Blob/S3

## Phase 2 (Hybrid Read)
- [ ] Add Hybrid reader (`Cold + Hot tail`) integration via `IEventStore`
- [ ] Integrate with multi-projection catch-up path
- [ ] Add fallback behavior when cold read fails
- [ ] Add operational metrics (lag, export duration, manifest conflict retries)

## Phase 3 (Extensions)
- [ ] Add DuckDB/SQLite derived segment generation
- [ ] Add stream/change-feed ingestion option with same safe window rules
- [ ] Add compaction/retention lifecycle process
- [ ] Add manifest generation/version management hardening

## Definition of Done
- [ ] Existing behavior unchanged when `Enabled=false`
- [ ] Cold progress can be observed by reading control file only
- [ ] Concurrency conflicts do not corrupt manifest/checkpoint


## Execution Report

Piece `default` completed successfully.

Closes #937