### PR TITLE
Fix cold event exporter guards and hybrid dedupe issues

### DIFF
--- a/dcb/src/Sekiban.Dcb.Core/ColdEvents/HybridEventStore.cs
+++ b/dcb/src/Sekiban.Dcb.Core/ColdEvents/HybridEventStore.cs
@@ -119,7 +119,7 @@ public sealed class HybridEventStore : IEventStore
 
         var merged = coldEvents
             .Concat(hotResult.GetValue())
-            .DistinctBy(e => e.SortableUniqueIdValue)
+            .DistinctBy(e => e.Id)
             .OrderBy(e => e.SortableUniqueIdValue, StringComparer.Ordinal);
 
         IEnumerable<SerializableEvent> result = maxCount.HasValue


### PR DESCRIPTION
## Summary
Fix follow-up issues found in the review of PR #938.

### Changes
1. Guard export when cold store is disabled
- `ColdExporter.ExportIncrementalAsync` now returns an error when `Enabled=false`.

2. Validate checkpoint write and use checkpoint ETag
- Added checkpoint-with-ETag load helper.
- Checkpoint write result is now validated.
- Checkpoint update now uses conditional write with expected ETag.

3. Fix hybrid deduplication key
- `HybridEventStore` now deduplicates by event `Id` instead of `SortableUniqueIdValue`.

### Tests
- Added test: exporter returns error when disabled.
- Added test: exporter fails when checkpoint write fails.
- Added test: hybrid read does not drop distinct events sharing same sortable unique id.

## Validation
- `dotnet test dcb/tests/Sekiban.Dcb.ColdEvents.Tests/Sekiban.Dcb.ColdEvents.Tests.csproj -v minimal`
- Passed on net9.0 and net10.0.
