### PR TITLE
[#940] github-issue-940-coldintaafyee

### DIFF
--- a/dcb/src/Sekiban.Dcb.Core/ColdEvents/ColdCatalogReader.cs
+++ b/dcb/src/Sekiban.Dcb.Core/ColdEvents/ColdCatalogReader.cs
@@ -1,0 +1,79 @@
+using System.Text.Json;
+using Microsoft.Extensions.Options;
+using ResultBoxes;
+namespace Sekiban.Dcb.ColdEvents;
+
+public sealed class ColdCatalogReader : IColdEventCatalogReader
+{
+    private readonly IColdObjectStorage _storage;
+    private readonly ColdEventStoreOptions _options;
+
+    public ColdCatalogReader(
+        IColdObjectStorage storage,
+        IOptions<ColdEventStoreOptions> options)
+    {
+        _storage = storage;
+        _options = options.Value;
+    }
+
+    public Task<ColdFeatureStatus> GetStatusAsync(CancellationToken ct)
+        => Task.FromResult(new ColdFeatureStatus(
+            IsSupported: true,
+            IsEnabled: _options.Enabled,
+            Reason: _options.Enabled ? "Cold event store is active" : "Cold event store is disabled"));
+
+    public async Task<ResultBox<ColdDataRangeSummary>> GetDataRangeSummaryAsync(
+        string serviceId,
+        CancellationToken ct)
+    {
+        ColdManifest? manifest;
+        try
+        {
+            manifest = await ColdControlFileHelper.LoadManifestAsync(_storage, serviceId, ct);
+        }
+        catch (JsonException ex)
+        {
+            return ResultBox.Error<ColdDataRangeSummary>(ex);
+        }
+
+        if (manifest is null)
+        {
+            return ResultBox.FromValue(new ColdDataRangeSummary(
+                ServiceId: serviceId,
+                OldestSortableUniqueId: null,
+                LatestSortableUniqueId: null,
+                TotalEventCount: 0,
+                SegmentCount: 0,
+                Segments: []));
+        }
+
+        return ResultBox.FromValue(BuildSummary(serviceId, manifest));
+    }
+
+    private static ColdDataRangeSummary BuildSummary(string serviceId, ColdManifest manifest)
+    {
+        var segments = manifest.Segments
+            .Select(s => new ColdSegmentSummary(
+                Path: s.Path,
+                FromSortableUniqueId: s.FromSortableUniqueId,
+                ToSortableUniqueId: s.ToSortableUniqueId,
+                EventCount: s.EventCount))
+            .ToList();
+
+        var oldest = manifest.Segments.Count > 0
+            ? manifest.Segments[0].FromSortableUniqueId
+            : null;
+        var latest = manifest.Segments.Count > 0
+            ? manifest.Segments[^1].ToSortableUniqueId
+            : null;
+        var totalEventCount = manifest.Segments.Sum(s => s.EventCount);
+
+        return new ColdDataRangeSummary(
+            ServiceId: serviceId,
+            OldestSortableUniqueId: oldest,
+            LatestSortableUniqueId: latest,
+            TotalEventCount: totalEventCount,
+            SegmentCount: manifest.Segments.Count,
+            Segments: segments);
+    }
+}

--- a/dcb/src/Sekiban.Dcb.Core/ColdEvents/ColdDataRangeSummary.cs
+++ b/dcb/src/Sekiban.Dcb.Core/ColdEvents/ColdDataRangeSummary.cs
@@ -1,0 +1,9 @@
+namespace Sekiban.Dcb.ColdEvents;
+
+public record ColdDataRangeSummary(
+    string ServiceId,
+    string? OldestSortableUniqueId,
+    string? LatestSortableUniqueId,
+    int TotalEventCount,
+    int SegmentCount,
+    IReadOnlyList<ColdSegmentSummary> Segments);

--- a/dcb/src/Sekiban.Dcb.Core/ColdEvents/ColdSegmentSummary.cs
+++ b/dcb/src/Sekiban.Dcb.Core/ColdEvents/ColdSegmentSummary.cs
@@ -1,0 +1,7 @@
+namespace Sekiban.Dcb.ColdEvents;
+
+public record ColdSegmentSummary(
+    string Path,
+    string FromSortableUniqueId,
+    string ToSortableUniqueId,
+    int EventCount);

--- a/dcb/src/Sekiban.Dcb.Core/ColdEvents/IColdEventCatalogReader.cs
+++ b/dcb/src/Sekiban.Dcb.Core/ColdEvents/IColdEventCatalogReader.cs
@@ -1,0 +1,9 @@
+using ResultBoxes;
+namespace Sekiban.Dcb.ColdEvents;
+
+public interface IColdEventCatalogReader : IColdEventStoreFeature
+{
+    Task<ResultBox<ColdDataRangeSummary>> GetDataRangeSummaryAsync(
+        string serviceId,
+        CancellationToken ct);
+}

--- a/dcb/src/Sekiban.Dcb.Core/ColdEvents/NotSupportedColdEventStore.cs
+++ b/dcb/src/Sekiban.Dcb.Core/ColdEvents/NotSupportedColdEventStore.cs
@@ -3,7 +3,8 @@ namespace Sekiban.Dcb.ColdEvents;
 
 public sealed class NotSupportedColdEventStore :
     IColdEventProgressReader,
-    IColdEventExporter
+    IColdEventExporter,
+    IColdEventCatalogReader
 {
     private static readonly ColdFeatureStatus NotConfiguredStatus = new(
         IsSupported: false,
@@ -21,4 +22,7 @@ public sealed class NotSupportedColdEventStore :
 
     public Task<ResultBox<ExportResult>> ExportIncrementalAsync(string serviceId, CancellationToken ct)
         => Task.FromResult(ResultBox.Error<ExportResult>(NotSupportedException));
+
+    public Task<ResultBox<ColdDataRangeSummary>> GetDataRangeSummaryAsync(string serviceId, CancellationToken ct)
+        => Task.FromResult(ResultBox.Error<ColdDataRangeSummary>(NotSupportedException));
 }

--- a/dcb/src/Sekiban.Dcb.Core/ColdEvents/SekibanDcbColdEventExtensions.cs
+++ b/dcb/src/Sekiban.Dcb.Core/ColdEvents/SekibanDcbColdEventExtensions.cs
@@ -14,6 +14,7 @@ public static class SekibanDcbColdEventExtensions
         services.TryAddSingleton<IColdEventStoreFeature>(notSupported);
         services.TryAddSingleton<IColdEventProgressReader>(notSupported);
         services.TryAddSingleton<IColdEventExporter>(notSupported);
+        services.TryAddSingleton<IColdEventCatalogReader>(notSupported);
         return services;
     }
 
@@ -26,6 +27,8 @@ public static class SekibanDcbColdEventExtensions
         services.AddSingleton<IColdEventExporter>(sp => sp.GetRequiredService<ColdExporter>());
         services.AddSingleton<IColdEventProgressReader>(sp => sp.GetRequiredService<ColdExporter>());
         services.AddSingleton<IColdEventStoreFeature>(sp => sp.GetRequiredService<ColdExporter>());
+        services.AddSingleton<ColdCatalogReader>();
+        services.AddSingleton<IColdEventCatalogReader>(sp => sp.GetRequiredService<ColdCatalogReader>());
         services.AddHostedService<ColdExportBackgroundService>();
         return services;
     }

--- a/dcb/tests/Sekiban.Dcb.ColdEvents.Tests/ColdCatalogReaderTests.cs
+++ b/dcb/tests/Sekiban.Dcb.ColdEvents.Tests/ColdCatalogReaderTests.cs
@@ -1,0 +1,233 @@
+using System.Text.Json;
+using Microsoft.Extensions.Options;
+using Sekiban.Dcb.ColdEvents;
+namespace Sekiban.Dcb.ColdEvents.Tests;
+
+public class ColdCatalogReaderTests
+{
+    private const string ServiceId = "test-service";
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
+
+    private static readonly ColdEventStoreOptions EnabledOptions = new()
+    {
+        Enabled = true,
+        PullInterval = TimeSpan.FromMinutes(30),
+        SafeWindow = TimeSpan.FromMinutes(2),
+        SegmentMaxEvents = 100_000,
+        SegmentMaxBytes = 512L * 1024 * 1024
+    };
+
+    private readonly InMemoryColdObjectStorage _storage = new();
+
+    private ColdCatalogReader CreateReader(ColdEventStoreOptions? options = null)
+    {
+        return new ColdCatalogReader(
+            _storage,
+            Options.Create(options ?? EnabledOptions));
+    }
+
+    [Fact]
+    public async Task GetStatusAsync_should_return_supported_and_enabled()
+    {
+        // Given
+        var reader = CreateReader();
+
+        // When
+        var status = await reader.GetStatusAsync(CancellationToken.None);
+
+        // Then
+        Assert.True(status.IsSupported);
+        Assert.True(status.IsEnabled);
+    }
+
+    [Fact]
+    public async Task GetStatusAsync_should_return_supported_but_disabled_when_not_enabled()
+    {
+        // Given
+        var options = new ColdEventStoreOptions { Enabled = false };
+        var reader = CreateReader(options);
+
+        // When
+        var status = await reader.GetStatusAsync(CancellationToken.None);
+
+        // Then
+        Assert.True(status.IsSupported);
+        Assert.False(status.IsEnabled);
+    }
+
+    [Fact]
+    public async Task GetDataRangeSummaryAsync_should_return_empty_when_no_manifest()
+    {
+        // Given
+        var reader = CreateReader();
+
+        // When
+        var result = await reader.GetDataRangeSummaryAsync(ServiceId, CancellationToken.None);
+
+        // Then
+        Assert.True(result.IsSuccess);
+        var summary = result.GetValue();
+        Assert.Equal(ServiceId, summary.ServiceId);
+        Assert.Null(summary.OldestSortableUniqueId);
+        Assert.Null(summary.LatestSortableUniqueId);
+        Assert.Equal(0, summary.TotalEventCount);
+        Assert.Equal(0, summary.SegmentCount);
+        Assert.Empty(summary.Segments);
+    }
+
+    [Fact]
+    public async Task GetDataRangeSummaryAsync_should_return_summary_for_single_segment()
+    {
+        // Given
+        var manifest = new ColdManifest(
+            ServiceId: ServiceId,
+            ManifestVersion: "v1",
+            LatestSafeSortableUniqueId: "id-200",
+            Segments:
+            [
+                new ColdSegmentInfo(
+                    Path: "segments/test-service/id-100_id-200.jsonl",
+                    FromSortableUniqueId: "id-100",
+                    ToSortableUniqueId: "id-200",
+                    EventCount: 50,
+                    SizeBytes: 1024,
+                    Sha256: "abc123",
+                    CreatedAtUtc: DateTimeOffset.UtcNow)
+            ],
+            UpdatedAtUtc: DateTimeOffset.UtcNow);
+        await WriteManifest(manifest);
+        var reader = CreateReader();
+
+        // When
+        var result = await reader.GetDataRangeSummaryAsync(ServiceId, CancellationToken.None);
+
+        // Then
+        Assert.True(result.IsSuccess);
+        var summary = result.GetValue();
+        Assert.Equal(ServiceId, summary.ServiceId);
+        Assert.Equal("id-100", summary.OldestSortableUniqueId);
+        Assert.Equal("id-200", summary.LatestSortableUniqueId);
+        Assert.Equal(50, summary.TotalEventCount);
+        Assert.Equal(1, summary.SegmentCount);
+        Assert.Single(summary.Segments);
+        var seg = summary.Segments[0];
+        Assert.Equal("segments/test-service/id-100_id-200.jsonl", seg.Path);
+        Assert.Equal("id-100", seg.FromSortableUniqueId);
+        Assert.Equal("id-200", seg.ToSortableUniqueId);
+        Assert.Equal(50, seg.EventCount);
+    }
+
+    [Fact]
+    public async Task GetDataRangeSummaryAsync_should_return_summary_for_multiple_segments()
+    {
+        // Given
+        var manifest = new ColdManifest(
+            ServiceId: ServiceId,
+            ManifestVersion: "v2",
+            LatestSafeSortableUniqueId: "id-400",
+            Segments:
+            [
+                new ColdSegmentInfo(
+                    Path: "segments/test-service/id-100_id-200.jsonl",
+                    FromSortableUniqueId: "id-100",
+                    ToSortableUniqueId: "id-200",
+                    EventCount: 50,
+                    SizeBytes: 1024,
+                    Sha256: "abc123",
+                    CreatedAtUtc: DateTimeOffset.UtcNow),
+                new ColdSegmentInfo(
+                    Path: "segments/test-service/id-201_id-300.jsonl",
+                    FromSortableUniqueId: "id-201",
+                    ToSortableUniqueId: "id-300",
+                    EventCount: 75,
+                    SizeBytes: 2048,
+                    Sha256: "def456",
+                    CreatedAtUtc: DateTimeOffset.UtcNow),
+                new ColdSegmentInfo(
+                    Path: "segments/test-service/id-301_id-400.jsonl",
+                    FromSortableUniqueId: "id-301",
+                    ToSortableUniqueId: "id-400",
+                    EventCount: 25,
+                    SizeBytes: 512,
+                    Sha256: "ghi789",
+                    CreatedAtUtc: DateTimeOffset.UtcNow)
+            ],
+            UpdatedAtUtc: DateTimeOffset.UtcNow);
+        await WriteManifest(manifest);
+        var reader = CreateReader();
+
+        // When
+        var result = await reader.GetDataRangeSummaryAsync(ServiceId, CancellationToken.None);
+
+        // Then
+        Assert.True(result.IsSuccess);
+        var summary = result.GetValue();
+        Assert.Equal("id-100", summary.OldestSortableUniqueId);
+        Assert.Equal("id-400", summary.LatestSortableUniqueId);
+        Assert.Equal(150, summary.TotalEventCount);
+        Assert.Equal(3, summary.SegmentCount);
+        Assert.Equal(3, summary.Segments.Count);
+    }
+
+    [Fact]
+    public async Task GetDataRangeSummaryAsync_should_return_error_when_manifest_is_corrupted()
+    {
+        // Given: write invalid JSON to the manifest path
+        var manifestPath = ColdStoragePaths.ManifestPath(ServiceId);
+        var corruptedData = "{ invalid json }"u8.ToArray();
+        await _storage.PutAsync(manifestPath, corruptedData, expectedETag: null, CancellationToken.None);
+        var reader = CreateReader();
+
+        // When
+        var result = await reader.GetDataRangeSummaryAsync(ServiceId, CancellationToken.None);
+
+        // Then
+        Assert.False(result.IsSuccess);
+        Assert.IsType<JsonException>(result.GetException());
+    }
+
+    [Fact]
+    public async Task GetDataRangeSummaryAsync_should_not_expose_internal_segment_details()
+    {
+        // Given
+        var manifest = new ColdManifest(
+            ServiceId: ServiceId,
+            ManifestVersion: "v1",
+            LatestSafeSortableUniqueId: "id-200",
+            Segments:
+            [
+                new ColdSegmentInfo(
+                    Path: "segments/test-service/id-100_id-200.jsonl",
+                    FromSortableUniqueId: "id-100",
+                    ToSortableUniqueId: "id-200",
+                    EventCount: 50,
+                    SizeBytes: 9999,
+                    Sha256: "secret-hash",
+                    CreatedAtUtc: DateTimeOffset.Parse("2026-01-01T00:00:00Z"))
+            ],
+            UpdatedAtUtc: DateTimeOffset.UtcNow);
+        await WriteManifest(manifest);
+        var reader = CreateReader();
+
+        // When
+        var result = await reader.GetDataRangeSummaryAsync(ServiceId, CancellationToken.None);
+
+        // Then: ColdSegmentSummary does not contain SizeBytes, Sha256, or CreatedAtUtc
+        Assert.True(result.IsSuccess);
+        var seg = result.GetValue().Segments[0];
+        Assert.Equal("id-100", seg.FromSortableUniqueId);
+        Assert.Equal("id-200", seg.ToSortableUniqueId);
+        Assert.Equal(50, seg.EventCount);
+    }
+
+    private async Task WriteManifest(ColdManifest manifest)
+    {
+        var manifestPath = ColdStoragePaths.ManifestPath(manifest.ServiceId);
+        var data = JsonSerializer.SerializeToUtf8Bytes(manifest, JsonOptions);
+        await _storage.PutAsync(manifestPath, data, expectedETag: null, CancellationToken.None);
+    }
+}

--- a/dcb/tests/Sekiban.Dcb.ColdEvents.Tests/NotSupportedColdEventStoreTests.cs
+++ b/dcb/tests/Sekiban.Dcb.ColdEvents.Tests/NotSupportedColdEventStoreTests.cs
@@ -32,4 +32,13 @@ public class NotSupportedColdEventStoreTests
         Assert.False(result.IsSuccess);
         Assert.IsType<NotSupportedException>(result.GetException());
     }
+
+    [Fact]
+    public async Task GetDataRangeSummaryAsync_should_return_error()
+    {
+        var result = await _sut.GetDataRangeSummaryAsync("test-service", CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.IsType<NotSupportedException>(result.GetException());
+    }
 }


### PR DESCRIPTION
## Summary

## 背景
現在の Cold Event の公開インターフェースでは、以下は取得できます。
- `GetStatusAsync()` で有効/無効
- `GetProgressAsync()` で `LatestSafeSortableUniqueId` / `LatestExportedSortableUniqueId`

一方で、運用時に必要な以下情報を **インターフェースとして直接取得**できません。
- 何件分のデータが保存されているか（総件数）
- 最古イベント位置（from）
- 最新イベント位置（to）
- セグメント単位の件数・範囲

## 目的
Cold Store の状態把握を、データ本体を読まずにインターフェース経由で取得できるようにする。

## 要求仕様

### 1. インターフェース追加
- `IColdEventProgressReader`（または新規 `IColdEventCatalogReader`）に、以下を取得できるAPIを追加する。
  - `OldestSortableUniqueId`
  - `LatestSortableUniqueId`
  - `TotalEventCount`
  - `SegmentCount`
  - `Segments[]`（from/to/eventCount/path など必要最小限）

### 2. 返却モデル追加
- 例: `ColdDataRangeSummary` / `ColdSegmentSummary`
- `GetProgressAsync()` 既存戻り値との責務を整理する。
  - 互換性重視なら `GetProgressAsync()` は維持
  - 新API（例: `GetDataRangeAsync`）追加で拡張

### 3. NotSupported 実装対応
- `NotSupportedColdEventStore` でも新APIに対して一貫した非対応結果を返す。
- `Enabled=false` のデフォルト挙動を崩さない。

### 4. Manifest 由来で計算
- データ本体ファイルは読まず、`manifest` から集計して返す。
- `manifest` が空/欠損時の戻り値方針を明確化する（空結果 or エラー）。

## 受け入れ条件 (DoD)
- [ ] 有効/無効状態と、最古/最新/総件数をAPIから取得できる
- [ ] セグメント一覧（範囲・件数）を取得できる
- [ ] `NotSupportedColdEventStore` 実装で非対応が一貫する
- [ ] 既存 `GetProgressAsync()` 利用コードを壊さない（後方互換）
- [ ] 単体テスト追加
  - [ ] 正常系（複数segment）
  - [ ] manifestなし
  - [ ] manifest破損
  - [ ] NotSupported実装

## 実装メモ（提案）
- まずは読み取り専用でよい（書き込み経路変更不要）
- `ColdControlFileHelper` で manifest 読み取り済みのため、集計ロジックを共通化可能
- API命名例
  - `GetDataRangeSummaryAsync(serviceId, ct)`
  - `GetSegmentCatalogAsync(serviceId, ct)`

## 参照
- PR #938
- PR #939
- `dcb/src/Sekiban.Dcb.Core/ColdEvents/*`


## Execution Report

Piece `default` completed successfully.

Closes #940