### PR TITLE
Mitigate MultiProjectionGrain OOM during catch-up

### DIFF
--- a/dcb/src/Sekiban.Dcb.Core/Actors/GeneralMultiProjectionActorOptions.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Actors/GeneralMultiProjectionActorOptions.cs
@@ -55,4 +55,20 @@ public class GeneralMultiProjectionActorOptions
     ///     Enable this for stricter error handling in production environments.
     /// </summary>
     public bool FailOnUnhealthyActivation { get; set; } = false;
+
+    /// <summary>
+    ///     Maximum number of processed event IDs to keep for duplicate suppression.
+    ///     Lower values reduce memory usage; too low may allow rare duplicate re-processing.
+    /// </summary>
+    public int ProcessedEventIdCacheSize { get; set; } = 200000;
+
+    /// <summary>
+    ///     Whether to force a Gen2 GC with LOH compaction after persisting a large snapshot.
+    /// </summary>
+    public bool ForceGcAfterLargeSnapshotPersist { get; set; } = true;
+
+    /// <summary>
+    ///     Snapshot size threshold (bytes) that triggers the optional post-persist GC.
+    /// </summary>
+    public long LargeSnapshotGcThresholdBytes { get; set; } = 10_000_000;
 }


### PR DESCRIPTION
## Summary
- bound the duplicate-event tracking cache in MultiProjectionGrain so processed IDs cannot grow unbounded
- switch duplicate tracking from HashSet<string> to HashSet<Guid> to reduce per-entry memory and string allocations
- apply configured pending-stream queue limit consistently during catch-up buffering
- add optional post-persist GC compaction for very large snapshots
- add new actor options for cache size and large-snapshot GC behavior

## Why
MultiProjectionGrain kept all processed event IDs forever, which can grow very large in long catch-up runs and cause memory pressure/OOM.

## Validation
- dotnet build dcb/src/Sekiban.Dcb.Core/Sekiban.Dcb.Core.csproj -v minimal
- dotnet build dcb/src/Sekiban.Dcb.Orleans.Core/Sekiban.Dcb.Orleans.Core.csproj -v minimal
- dotnet test dcb/tests/Sekiban.Dcb.Orleans.Tests/Sekiban.Dcb.Orleans.Tests.csproj --filter "FullyQualifiedName~MinimalOrleansTests" -v minimal
