### PR TITLE
[#946] github-issue-946-phase-1-multi

### DIFF
--- a/dcb/src/Sekiban.Dcb.Core/Actors/GeneralMultiProjectionActorOptions.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Actors/GeneralMultiProjectionActorOptions.cs
@@ -71,4 +71,10 @@ public class GeneralMultiProjectionActorOptions
     ///     Snapshot size threshold (bytes) that triggers the optional post-persist GC.
     /// </summary>
     public long LargeSnapshotGcThresholdBytes { get; set; } = 10_000_000;
+
+    /// <summary>
+    ///     When true, uses the stream-based snapshot I/O path for persistence.
+    ///     When false (default), uses the existing byte[] path for backward compatibility.
+    /// </summary>
+    public bool UseStreamingSnapshotIO { get; set; } = false;
 }

--- a/dcb/src/Sekiban.Dcb.Core/MultiProjections/MultiProjectionStateWriteRequest.cs
+++ b/dcb/src/Sekiban.Dcb.Core/MultiProjections/MultiProjectionStateWriteRequest.cs
@@ -1,0 +1,46 @@
+namespace Sekiban.Dcb.MultiProjections;
+
+/// <summary>
+///     Request type for stream-based upsert. StateData is nullable to support
+///     offloaded snapshots where data lives in blob storage.
+/// </summary>
+public sealed record MultiProjectionStateWriteRequest(
+    string ProjectorName,
+    string ProjectorVersion,
+    string PayloadType,
+    string LastSortableUniqueId,
+    long EventsProcessed,
+    byte[]? StateData,
+    bool IsOffloaded,
+    string? OffloadKey,
+    string? OffloadProvider,
+    long OriginalSizeBytes,
+    long CompressedSizeBytes,
+    string SafeWindowThreshold,
+    DateTime CreatedAt,
+    DateTime UpdatedAt,
+    string BuildSource,
+    string? BuildHost)
+{
+    /// <summary>
+    ///     Converts this write request to a <see cref="MultiProjectionStateRecord" />.
+    /// </summary>
+    public MultiProjectionStateRecord ToRecord() =>
+        new(
+            ProjectorName: ProjectorName,
+            ProjectorVersion: ProjectorVersion,
+            PayloadType: PayloadType,
+            LastSortableUniqueId: LastSortableUniqueId,
+            EventsProcessed: EventsProcessed,
+            StateData: StateData,
+            IsOffloaded: IsOffloaded,
+            OffloadKey: OffloadKey,
+            OffloadProvider: OffloadProvider,
+            OriginalSizeBytes: OriginalSizeBytes,
+            CompressedSizeBytes: CompressedSizeBytes,
+            SafeWindowThreshold: SafeWindowThreshold,
+            CreatedAt: CreatedAt,
+            UpdatedAt: UpdatedAt,
+            BuildSource: BuildSource,
+            BuildHost: BuildHost);
+}

--- a/dcb/src/Sekiban.Dcb.Core/Snapshots/IBlobStorageSnapshotAccessor.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Snapshots/IBlobStorageSnapshotAccessor.cs
@@ -21,5 +21,15 @@ public interface IBlobStorageSnapshotAccessor
     ///     Reads the snapshot payload bytes from storage using the provided key.
     /// </summary>
     Task<byte[]> ReadAsync(string key, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    ///     Writes the snapshot payload from a stream and returns a storage key.
+    /// </summary>
+    Task<string> WriteAsync(Stream data, string projectorName, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    ///     Opens a read stream for the snapshot payload identified by the given key.
+    /// </summary>
+    Task<Stream> OpenReadAsync(string key, CancellationToken cancellationToken = default);
 }
 

--- a/dcb/src/Sekiban.Dcb.Core/Snapshots/InMemoryBlobStorageSnapshotAccessor.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Snapshots/InMemoryBlobStorageSnapshotAccessor.cs
@@ -31,6 +31,22 @@ public sealed class InMemoryBlobStorageSnapshotAccessor : IBlobStorageSnapshotAc
         throw new FileNotFoundException($"Snapshot not found for key: {key}");
     }
 
+    public async Task<string> WriteAsync(Stream data, string projectorName, CancellationToken cancellationToken = default)
+    {
+        using var ms = new MemoryStream();
+        await data.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+        return await WriteAsync(ms.ToArray(), projectorName, cancellationToken).ConfigureAwait(false);
+    }
+
+    public Task<Stream> OpenReadAsync(string key, CancellationToken cancellationToken = default)
+    {
+        if (_store.TryGetValue(key, out var data))
+        {
+            return Task.FromResult<Stream>(new MemoryStream(data, writable: false));
+        }
+        throw new FileNotFoundException($"Snapshot not found for key: {key}");
+    }
+
     private static string Sanitize(string name)
     {
         var sb = new StringBuilder(name.Length);

--- a/dcb/src/Sekiban.Dcb.Core/Snapshots/OffloadResult.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Snapshots/OffloadResult.cs
@@ -1,0 +1,10 @@
+namespace Sekiban.Dcb.Snapshots;
+
+/// <summary>
+///     Result of the stream offload decision: either inlined data or offloaded metadata.
+/// </summary>
+public readonly record struct OffloadResult(
+    bool IsOffloaded,
+    byte[]? InlineData,
+    string? OffloadKey,
+    string? OffloadProvider);

--- a/dcb/src/Sekiban.Dcb.Core/Snapshots/StreamOffloadHelper.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Snapshots/StreamOffloadHelper.cs
@@ -1,0 +1,70 @@
+namespace Sekiban.Dcb.Snapshots;
+
+/// <summary>
+///     Shared helper that decides whether snapshot state data should be
+///     inlined (stored as byte[] in the DB row) or offloaded to blob storage.
+/// </summary>
+public static class StreamOffloadHelper
+{
+    /// <summary>
+    ///     Reads the stream, compares its length to the threshold, and either
+    ///     returns inline data or uploads to blob and returns offload metadata.
+    /// </summary>
+    public static async Task<OffloadResult> ProcessAsync(
+        Stream stream,
+        string projectorName,
+        int thresholdBytes,
+        IBlobStorageSnapshotAccessor? blobAccessor,
+        CancellationToken cancellationToken)
+    {
+        var buffer = await BufferStreamAsync(stream, cancellationToken).ConfigureAwait(false);
+        return await ProcessAsync(buffer, projectorName, thresholdBytes, blobAccessor, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    /// <summary>
+    ///     Compares byte[] length to the threshold, and either returns inline data
+    ///     or uploads to blob and returns offload metadata.
+    /// </summary>
+    public static async Task<OffloadResult> ProcessAsync(
+        byte[]? data,
+        string projectorName,
+        int thresholdBytes,
+        IBlobStorageSnapshotAccessor? blobAccessor,
+        CancellationToken cancellationToken)
+    {
+        if (data is not null && data.Length > thresholdBytes && blobAccessor is not null)
+        {
+            using var uploadStream = new MemoryStream(data, writable: false);
+            var key = await blobAccessor.WriteAsync(uploadStream, projectorName, cancellationToken)
+                .ConfigureAwait(false);
+            return new OffloadResult(
+                IsOffloaded: true,
+                InlineData: null,
+                OffloadKey: key,
+                OffloadProvider: blobAccessor.ProviderName);
+        }
+
+        return new OffloadResult(
+            IsOffloaded: false,
+            InlineData: data,
+            OffloadKey: null,
+            OffloadProvider: null);
+    }
+
+    private static async Task<byte[]> BufferStreamAsync(
+        Stream stream,
+        CancellationToken cancellationToken)
+    {
+        if (stream is MemoryStream ms && ms.TryGetBuffer(out var segment) && segment.Offset == 0 && segment.Count == (int)ms.Length)
+        {
+            return segment.Array!.Length == segment.Count
+                ? segment.Array
+                : segment.ToArray();
+        }
+
+        using var buffer = new MemoryStream();
+        await stream.CopyToAsync(buffer, cancellationToken).ConfigureAwait(false);
+        return buffer.ToArray();
+    }
+}

--- a/dcb/tests/Sekiban.Dcb.Orleans.Tests/MockBlobStorageSnapshotAccessor.cs
+++ b/dcb/tests/Sekiban.Dcb.Orleans.Tests/MockBlobStorageSnapshotAccessor.cs
@@ -23,4 +23,20 @@ public class MockBlobStorageSnapshotAccessor : IBlobStorageSnapshotAccessor
         _storage.TryGetValue(key, out var data);
         return Task.FromResult(data ?? Array.Empty<byte>());
     }
+
+    public async Task<string> WriteAsync(Stream data, string projectorName, CancellationToken cancellationToken = default)
+    {
+        using var ms = new MemoryStream();
+        await data.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+        return await WriteAsync(ms.ToArray(), projectorName, cancellationToken).ConfigureAwait(false);
+    }
+
+    public Task<Stream> OpenReadAsync(string key, CancellationToken cancellationToken = default)
+    {
+        if (_storage.TryGetValue(key, out var data))
+        {
+            return Task.FromResult<Stream>(new MemoryStream(data, writable: false));
+        }
+        throw new FileNotFoundException($"Snapshot not found for key: {key}");
+    }
 }

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/MultiProjectionStateWriteRequestTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/MultiProjectionStateWriteRequestTests.cs
@@ -1,0 +1,149 @@
+using Sekiban.Dcb.MultiProjections;
+
+namespace Sekiban.Dcb.Tests;
+
+/// <summary>
+///     Unit tests for MultiProjectionStateWriteRequest record type.
+///     Verifies construction and ToRecord() conversion to MultiProjectionStateRecord.
+/// </summary>
+public class MultiProjectionStateWriteRequestTests
+{
+    private static MultiProjectionStateWriteRequest CreateSampleRequest(
+        byte[]? stateData = null,
+        bool isOffloaded = false,
+        string? offloadKey = null,
+        string? offloadProvider = null) =>
+        new(
+            ProjectorName: "TestProjector",
+            ProjectorVersion: "1.0",
+            PayloadType: "TestPayloadType",
+            LastSortableUniqueId: "20260225T120000Z-00000000-0000-0000-0000-000000000001",
+            EventsProcessed: 42,
+            StateData: stateData,
+            IsOffloaded: isOffloaded,
+            OffloadKey: offloadKey,
+            OffloadProvider: offloadProvider,
+            OriginalSizeBytes: 1024,
+            CompressedSizeBytes: 512,
+            SafeWindowThreshold: "20260225T115940Z-00000000-0000-0000-0000-000000000000",
+            CreatedAt: new DateTime(2026, 2, 25, 12, 0, 0, DateTimeKind.Utc),
+            UpdatedAt: new DateTime(2026, 2, 25, 12, 0, 0, DateTimeKind.Utc),
+            BuildSource: "UnitTest",
+            BuildHost: "test-host");
+
+    [Fact]
+    public void Construction_Should_Preserve_All_Fields()
+    {
+        // Given/When
+        var request = CreateSampleRequest(
+            stateData: new byte[] { 1, 2, 3 },
+            isOffloaded: false);
+
+        // Then
+        Assert.Equal("TestProjector", request.ProjectorName);
+        Assert.Equal("1.0", request.ProjectorVersion);
+        Assert.Equal("TestPayloadType", request.PayloadType);
+        Assert.Equal(42, request.EventsProcessed);
+        Assert.NotNull(request.StateData);
+        Assert.Equal(new byte[] { 1, 2, 3 }, request.StateData);
+        Assert.False(request.IsOffloaded);
+        Assert.Null(request.OffloadKey);
+        Assert.Null(request.OffloadProvider);
+        Assert.Equal(1024, request.OriginalSizeBytes);
+        Assert.Equal(512, request.CompressedSizeBytes);
+        Assert.Equal("UnitTest", request.BuildSource);
+        Assert.Equal("test-host", request.BuildHost);
+    }
+
+    [Fact]
+    public void Construction_Should_Accept_Null_StateData_For_Offloaded_Case()
+    {
+        // Given/When
+        var request = CreateSampleRequest(
+            stateData: null,
+            isOffloaded: true,
+            offloadKey: "blob/key/abc",
+            offloadProvider: "AzureBlobStorage");
+
+        // Then
+        Assert.Null(request.StateData);
+        Assert.True(request.IsOffloaded);
+        Assert.Equal("blob/key/abc", request.OffloadKey);
+        Assert.Equal("AzureBlobStorage", request.OffloadProvider);
+    }
+
+    [Fact]
+    public void ToRecord_Should_Convert_Inline_Request_To_MultiProjectionStateRecord()
+    {
+        // Given
+        var inlineData = new byte[] { 10, 20, 30, 40 };
+        var request = CreateSampleRequest(stateData: inlineData);
+
+        // When
+        var record = request.ToRecord();
+
+        // Then: all metadata is preserved
+        Assert.Equal(request.ProjectorName, record.ProjectorName);
+        Assert.Equal(request.ProjectorVersion, record.ProjectorVersion);
+        Assert.Equal(request.PayloadType, record.PayloadType);
+        Assert.Equal(request.LastSortableUniqueId, record.LastSortableUniqueId);
+        Assert.Equal(request.EventsProcessed, record.EventsProcessed);
+        Assert.Equal(inlineData, record.StateData);
+        Assert.Equal(request.IsOffloaded, record.IsOffloaded);
+        Assert.Equal(request.OffloadKey, record.OffloadKey);
+        Assert.Equal(request.OffloadProvider, record.OffloadProvider);
+        Assert.Equal(request.OriginalSizeBytes, record.OriginalSizeBytes);
+        Assert.Equal(request.CompressedSizeBytes, record.CompressedSizeBytes);
+        Assert.Equal(request.SafeWindowThreshold, record.SafeWindowThreshold);
+        Assert.Equal(request.CreatedAt, record.CreatedAt);
+        Assert.Equal(request.UpdatedAt, record.UpdatedAt);
+        Assert.Equal(request.BuildSource, record.BuildSource);
+        Assert.Equal(request.BuildHost, record.BuildHost);
+    }
+
+    [Fact]
+    public void ToRecord_Should_Convert_Offloaded_Request_With_Null_StateData()
+    {
+        // Given
+        var request = CreateSampleRequest(
+            stateData: null,
+            isOffloaded: true,
+            offloadKey: "projector/v1/abc123",
+            offloadProvider: "InMemoryBlobStorage");
+
+        // When
+        var record = request.ToRecord();
+
+        // Then: offload metadata preserved, StateData is null
+        Assert.Null(record.StateData);
+        Assert.True(record.IsOffloaded);
+        Assert.Equal("projector/v1/abc123", record.OffloadKey);
+        Assert.Equal("InMemoryBlobStorage", record.OffloadProvider);
+    }
+
+    [Fact]
+    public void ToRecord_Should_Produce_Correct_PartitionKey()
+    {
+        // Given
+        var request = CreateSampleRequest();
+
+        // When
+        var record = request.ToRecord();
+
+        // Then
+        Assert.Equal("MultiProjectionState_TestProjector", record.GetPartitionKey());
+    }
+
+    [Fact]
+    public void ToRecord_Should_Produce_Correct_DocumentId()
+    {
+        // Given
+        var request = CreateSampleRequest();
+
+        // When
+        var record = request.ToRecord();
+
+        // Then
+        Assert.Equal("1.0", record.GetDocumentId());
+    }
+}

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/StreamOffloadHelperTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/StreamOffloadHelperTests.cs
@@ -1,0 +1,181 @@
+using Sekiban.Dcb.Snapshots;
+
+namespace Sekiban.Dcb.Tests;
+
+/// <summary>
+///     Unit tests for StreamOffloadHelper — the shared static helper
+///     that decides whether snapshot state data should be inlined or offloaded to blob storage.
+/// </summary>
+public class StreamOffloadHelperTests
+{
+    [Fact]
+    public async Task ProcessAsync_Should_Return_Inline_When_Stream_Size_Is_Below_Threshold()
+    {
+        // Given: a 500-byte stream and a 1000-byte threshold
+        var data = new byte[500];
+        Random.Shared.NextBytes(data);
+        using var stream = new MemoryStream(data);
+        var blobAccessor = new InMemoryBlobStorageSnapshotAccessor();
+        const int threshold = 1000;
+
+        // When
+        var result = await StreamOffloadHelper.ProcessAsync(
+            stream,
+            "test-projector/v1",
+            threshold,
+            blobAccessor,
+            CancellationToken.None);
+
+        // Then: data is inlined, not offloaded
+        Assert.False(result.IsOffloaded);
+        Assert.NotNull(result.InlineData);
+        Assert.Equal(data, result.InlineData);
+        Assert.Null(result.OffloadKey);
+        Assert.Null(result.OffloadProvider);
+    }
+
+    [Fact]
+    public async Task ProcessAsync_Should_Offload_When_Stream_Size_Exceeds_Threshold()
+    {
+        // Given: a 2000-byte stream and a 1000-byte threshold
+        var data = new byte[2000];
+        Random.Shared.NextBytes(data);
+        using var stream = new MemoryStream(data);
+        var blobAccessor = new InMemoryBlobStorageSnapshotAccessor();
+        const int threshold = 1000;
+
+        // When
+        var result = await StreamOffloadHelper.ProcessAsync(
+            stream,
+            "test-projector/v1",
+            threshold,
+            blobAccessor,
+            CancellationToken.None);
+
+        // Then: data is offloaded to blob
+        Assert.True(result.IsOffloaded);
+        Assert.Null(result.InlineData);
+        Assert.NotNull(result.OffloadKey);
+        Assert.Equal(blobAccessor.ProviderName, result.OffloadProvider);
+    }
+
+    [Fact]
+    public async Task ProcessAsync_Should_Inline_At_Exact_Threshold_Boundary()
+    {
+        // Given: stream size equals threshold exactly
+        const int threshold = 1000;
+        var data = new byte[threshold];
+        Random.Shared.NextBytes(data);
+        using var stream = new MemoryStream(data);
+        var blobAccessor = new InMemoryBlobStorageSnapshotAccessor();
+
+        // When
+        var result = await StreamOffloadHelper.ProcessAsync(
+            stream,
+            "test-projector/v1",
+            threshold,
+            blobAccessor,
+            CancellationToken.None);
+
+        // Then: exact threshold is not exceeded, so inline
+        Assert.False(result.IsOffloaded);
+        Assert.NotNull(result.InlineData);
+        Assert.Equal(data, result.InlineData);
+    }
+
+    [Fact]
+    public async Task ProcessAsync_Should_Offload_When_One_Byte_Over_Threshold()
+    {
+        // Given: stream size is threshold + 1
+        const int threshold = 1000;
+        var data = new byte[threshold + 1];
+        Random.Shared.NextBytes(data);
+        using var stream = new MemoryStream(data);
+        var blobAccessor = new InMemoryBlobStorageSnapshotAccessor();
+
+        // When
+        var result = await StreamOffloadHelper.ProcessAsync(
+            stream,
+            "test-projector/v1",
+            threshold,
+            blobAccessor,
+            CancellationToken.None);
+
+        // Then: exceeds threshold, offloaded
+        Assert.True(result.IsOffloaded);
+        Assert.Null(result.InlineData);
+        Assert.NotNull(result.OffloadKey);
+    }
+
+    [Fact]
+    public async Task ProcessAsync_Should_Inline_When_BlobAccessor_Is_Null_Even_If_Above_Threshold()
+    {
+        // Given: no blob accessor available, data exceeds threshold
+        var data = new byte[2000];
+        Random.Shared.NextBytes(data);
+        using var stream = new MemoryStream(data);
+        const int threshold = 1000;
+
+        // When
+        var result = await StreamOffloadHelper.ProcessAsync(
+            stream,
+            "test-projector/v1",
+            threshold,
+            blobAccessor: null,
+            CancellationToken.None);
+
+        // Then: forced to inline since no blob accessor
+        Assert.False(result.IsOffloaded);
+        Assert.NotNull(result.InlineData);
+        Assert.Equal(data, result.InlineData);
+        Assert.Null(result.OffloadKey);
+        Assert.Null(result.OffloadProvider);
+    }
+
+    [Fact]
+    public async Task ProcessAsync_Should_Handle_Empty_Stream()
+    {
+        // Given: an empty stream
+        using var stream = new MemoryStream(Array.Empty<byte>());
+        var blobAccessor = new InMemoryBlobStorageSnapshotAccessor();
+        const int threshold = 1000;
+
+        // When
+        var result = await StreamOffloadHelper.ProcessAsync(
+            stream,
+            "test-projector/v1",
+            threshold,
+            blobAccessor,
+            CancellationToken.None);
+
+        // Then: empty data is inlined
+        Assert.False(result.IsOffloaded);
+        Assert.NotNull(result.InlineData);
+        Assert.Empty(result.InlineData);
+    }
+
+    [Fact]
+    public async Task ProcessAsync_Offloaded_Data_Should_Be_Retrievable_From_Blob()
+    {
+        // Given: data that will be offloaded
+        var data = new byte[2000];
+        Random.Shared.NextBytes(data);
+        using var stream = new MemoryStream(data);
+        var blobAccessor = new InMemoryBlobStorageSnapshotAccessor();
+        const int threshold = 1000;
+
+        // When
+        var result = await StreamOffloadHelper.ProcessAsync(
+            stream,
+            "test-projector/v1",
+            threshold,
+            blobAccessor,
+            CancellationToken.None);
+
+        // Then: offloaded data can be read back from blob
+        Assert.True(result.IsOffloaded);
+        Assert.NotNull(result.OffloadKey);
+        var readBack = await blobAccessor.ReadAsync(result.OffloadKey);
+        Assert.Equal(data, readBack);
+    }
+}

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/StreamingSnapshotIOTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/StreamingSnapshotIOTests.cs
@@ -1,0 +1,275 @@
+using System.Text;
+using Sekiban.Dcb.Actors;
+using Sekiban.Dcb.InMemory;
+using Sekiban.Dcb.MultiProjections;
+using Sekiban.Dcb.Snapshots;
+using Sekiban.Dcb.Storage;
+
+namespace Sekiban.Dcb.Tests;
+
+/// <summary>
+///     Integration tests for the Streaming Snapshot I/O pipeline:
+///     - IBlobStorageSnapshotAccessor stream-based methods
+///     - IMultiProjectionStateStore.UpsertFromStreamAsync default implementation
+///     - UseStreamingSnapshotIO feature flag
+/// </summary>
+public class StreamingSnapshotIOTests
+{
+    // --- IBlobStorageSnapshotAccessor Stream API Tests ---
+
+    [Fact]
+    public async Task BlobAccessor_WriteAsync_Stream_Should_Return_Key()
+    {
+        // Given: a stream of data
+        var data = Encoding.UTF8.GetBytes("snapshot-payload-data");
+        using var stream = new MemoryStream(data);
+        var accessor = new InMemoryBlobStorageSnapshotAccessor();
+
+        // When: writing via stream overload
+        var key = await accessor.WriteAsync(stream, "test-projector", CancellationToken.None);
+
+        // Then: a non-empty key is returned
+        Assert.False(string.IsNullOrWhiteSpace(key));
+    }
+
+    [Fact]
+    public async Task BlobAccessor_Stream_Write_Then_Stream_Read_Should_RoundTrip()
+    {
+        // Given: data written via stream
+        var data = Encoding.UTF8.GetBytes("round-trip-stream-test");
+        using var writeStream = new MemoryStream(data);
+        var accessor = new InMemoryBlobStorageSnapshotAccessor();
+        var key = await accessor.WriteAsync(writeStream, "round-trip-projector", CancellationToken.None);
+
+        // When: reading via stream
+        using var readStream = await accessor.OpenReadAsync(key, CancellationToken.None);
+        using var ms = new MemoryStream();
+        await readStream.CopyToAsync(ms);
+        var readData = ms.ToArray();
+
+        // Then: data matches
+        Assert.Equal(data, readData);
+    }
+
+    [Fact]
+    public async Task BlobAccessor_Stream_Write_Then_ByteArray_Read_Should_Be_Compatible()
+    {
+        // Given: data written via stream
+        var data = Encoding.UTF8.GetBytes("cross-api-compat-test");
+        using var writeStream = new MemoryStream(data);
+        var accessor = new InMemoryBlobStorageSnapshotAccessor();
+        var key = await accessor.WriteAsync(writeStream, "compat-projector", CancellationToken.None);
+
+        // When: reading via existing byte[] API
+        var readData = await accessor.ReadAsync(key, CancellationToken.None);
+
+        // Then: data matches (backward compatibility)
+        Assert.Equal(data, readData);
+    }
+
+    [Fact]
+    public async Task BlobAccessor_ByteArray_Write_Then_Stream_Read_Should_Be_Compatible()
+    {
+        // Given: data written via existing byte[] API
+        var data = Encoding.UTF8.GetBytes("byte-to-stream-compat");
+        var accessor = new InMemoryBlobStorageSnapshotAccessor();
+        var key = await accessor.WriteAsync(data, "compat-projector", CancellationToken.None);
+
+        // When: reading via new stream API
+        using var readStream = await accessor.OpenReadAsync(key, CancellationToken.None);
+        using var ms = new MemoryStream();
+        await readStream.CopyToAsync(ms);
+        var readData = ms.ToArray();
+
+        // Then: data matches (backward compatibility)
+        Assert.Equal(data, readData);
+    }
+
+    [Fact]
+    public async Task BlobAccessor_OpenReadAsync_Should_Throw_For_NonExistent_Key()
+    {
+        // Given: an accessor with no stored data
+        var accessor = new InMemoryBlobStorageSnapshotAccessor();
+
+        // When/Then: reading a non-existent key throws
+        await Assert.ThrowsAsync<FileNotFoundException>(
+            () => accessor.OpenReadAsync("nonexistent-key", CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task BlobAccessor_WriteAsync_Stream_Should_Handle_Empty_Stream()
+    {
+        // Given: an empty stream
+        using var stream = new MemoryStream(Array.Empty<byte>());
+        var accessor = new InMemoryBlobStorageSnapshotAccessor();
+
+        // When: writing empty stream
+        var key = await accessor.WriteAsync(stream, "empty-projector", CancellationToken.None);
+
+        // Then: key is returned, data can be read back
+        Assert.False(string.IsNullOrWhiteSpace(key));
+        var readBack = await accessor.ReadAsync(key, CancellationToken.None);
+        Assert.Empty(readBack);
+    }
+
+    [Fact]
+    public async Task BlobAccessor_WriteAsync_Stream_Should_Handle_Large_Data()
+    {
+        // Given: a 2MB stream
+        var data = new byte[2 * 1024 * 1024];
+        Random.Shared.NextBytes(data);
+        using var stream = new MemoryStream(data);
+        var accessor = new InMemoryBlobStorageSnapshotAccessor();
+
+        // When
+        var key = await accessor.WriteAsync(stream, "large-projector", CancellationToken.None);
+
+        // Then: round-trip succeeds
+        var readBack = await accessor.ReadAsync(key, CancellationToken.None);
+        Assert.Equal(data, readBack);
+    }
+
+    // --- IMultiProjectionStateStore.UpsertFromStreamAsync Default Implementation Tests ---
+
+    [Fact]
+    public async Task UpsertFromStreamAsync_Default_Should_Store_Inline_Data()
+    {
+        // Given: InMemory store uses the default interface implementation
+        IMultiProjectionStateStore store = new InMemoryMultiProjectionStateStore();
+        var stateBytes = Encoding.UTF8.GetBytes("inline-state-data");
+        using var stream = new MemoryStream(stateBytes);
+        var request = new MultiProjectionStateWriteRequest(
+            ProjectorName: "TestProjector",
+            ProjectorVersion: "1.0",
+            PayloadType: "TestPayload",
+            LastSortableUniqueId: "20260225T120000Z-00000000-0000-0000-0000-000000000001",
+            EventsProcessed: 10,
+            StateData: null,
+            IsOffloaded: false,
+            OffloadKey: null,
+            OffloadProvider: null,
+            OriginalSizeBytes: stateBytes.Length,
+            CompressedSizeBytes: stateBytes.Length,
+            SafeWindowThreshold: "20260225T115940Z-00000000-0000-0000-0000-000000000000",
+            CreatedAt: DateTime.UtcNow,
+            UpdatedAt: DateTime.UtcNow,
+            BuildSource: "UnitTest",
+            BuildHost: "test-host");
+
+        // When: calling UpsertFromStreamAsync (default impl buffers to byte[] and calls UpsertAsync)
+        var result = await store.UpsertFromStreamAsync(request, stream, 1_000_000, CancellationToken.None);
+
+        // Then: record is stored and retrievable
+        Assert.True(result.IsSuccess);
+        var stored = await store.GetLatestForVersionAsync("TestProjector", "1.0", CancellationToken.None);
+        Assert.True(stored.IsSuccess);
+        var opt = stored.GetValue();
+        Assert.True(opt.HasValue);
+        var record = opt.GetValue();
+        Assert.Equal("TestProjector", record.ProjectorName);
+        Assert.Equal("1.0", record.ProjectorVersion);
+        Assert.Equal(10, record.EventsProcessed);
+        Assert.NotNull(record.StateData);
+        Assert.Equal(stateBytes, record.StateData);
+    }
+
+    [Fact]
+    public async Task UpsertFromStreamAsync_Default_Should_Handle_Empty_Stream()
+    {
+        // Given
+        IMultiProjectionStateStore store = new InMemoryMultiProjectionStateStore();
+        using var stream = new MemoryStream(Array.Empty<byte>());
+        var request = new MultiProjectionStateWriteRequest(
+            ProjectorName: "EmptyProjector",
+            ProjectorVersion: "1.0",
+            PayloadType: "TestPayload",
+            LastSortableUniqueId: "20260225T120000Z-00000000-0000-0000-0000-000000000001",
+            EventsProcessed: 0,
+            StateData: null,
+            IsOffloaded: false,
+            OffloadKey: null,
+            OffloadProvider: null,
+            OriginalSizeBytes: 0,
+            CompressedSizeBytes: 0,
+            SafeWindowThreshold: "20260225T115940Z-00000000-0000-0000-0000-000000000000",
+            CreatedAt: DateTime.UtcNow,
+            UpdatedAt: DateTime.UtcNow,
+            BuildSource: "UnitTest",
+            BuildHost: "test-host");
+
+        // When
+        var result = await store.UpsertFromStreamAsync(request, stream, 1_000_000, CancellationToken.None);
+
+        // Then
+        Assert.True(result.IsSuccess);
+        var stored = await store.GetLatestForVersionAsync("EmptyProjector", "1.0", CancellationToken.None);
+        Assert.True(stored.IsSuccess);
+        var opt = stored.GetValue();
+        Assert.True(opt.HasValue);
+        var record = opt.GetValue();
+        Assert.NotNull(record.StateData);
+        Assert.Empty(record.StateData);
+    }
+
+    [Fact]
+    public async Task UpsertFromStreamAsync_Default_Should_Preserve_Metadata()
+    {
+        // Given
+        IMultiProjectionStateStore store = new InMemoryMultiProjectionStateStore();
+        var stateBytes = new byte[] { 1, 2, 3 };
+        using var stream = new MemoryStream(stateBytes);
+        var createdAt = new DateTime(2026, 2, 25, 10, 0, 0, DateTimeKind.Utc);
+        var request = new MultiProjectionStateWriteRequest(
+            ProjectorName: "MetadataProjector",
+            ProjectorVersion: "2.0",
+            PayloadType: "MetadataPayload",
+            LastSortableUniqueId: "20260225T100000Z-00000000-0000-0000-0000-000000000002",
+            EventsProcessed: 100,
+            StateData: null,
+            IsOffloaded: false,
+            OffloadKey: null,
+            OffloadProvider: null,
+            OriginalSizeBytes: 3,
+            CompressedSizeBytes: 3,
+            SafeWindowThreshold: "20260225T095940Z-00000000-0000-0000-0000-000000000000",
+            CreatedAt: createdAt,
+            UpdatedAt: createdAt,
+            BuildSource: "MetadataTest",
+            BuildHost: "meta-host");
+
+        // When
+        await store.UpsertFromStreamAsync(request, stream, 1_000_000, CancellationToken.None);
+
+        // Then: all metadata fields are preserved
+        var stored = await store.GetLatestForVersionAsync("MetadataProjector", "2.0", CancellationToken.None);
+        var record = stored.GetValue().GetValue();
+        Assert.Equal("MetadataPayload", record.PayloadType);
+        Assert.Equal(100, record.EventsProcessed);
+        Assert.Equal(3, record.OriginalSizeBytes);
+        Assert.Equal(3, record.CompressedSizeBytes);
+        Assert.Equal("MetadataTest", record.BuildSource);
+        Assert.Equal("meta-host", record.BuildHost);
+    }
+
+    // --- Feature Flag Tests ---
+
+    [Fact]
+    public void UseStreamingSnapshotIO_Should_Default_To_False()
+    {
+        // Given/When
+        var options = new GeneralMultiProjectionActorOptions();
+
+        // Then
+        Assert.False(options.UseStreamingSnapshotIO);
+    }
+
+    [Fact]
+    public void UseStreamingSnapshotIO_Should_Be_Settable_To_True()
+    {
+        // Given/When
+        var options = new GeneralMultiProjectionActorOptions { UseStreamingSnapshotIO = true };
+
+        // Then
+        Assert.True(options.UseStreamingSnapshotIO);
+    }
+}


### PR DESCRIPTION
## Summary

## 背景
けんばいPROD（Azure Container Apps）で `MultiProjectionGrain` のキャッチアップ中にOOMが多発している。
現在はスナップショット永続化時に `byte[]` 全量をメモリに構築しており、状態サイズが大きいProjectionでピークメモリが急増する。

本Issueは以下設計をベースに、**実装可能な第1弾（Phase 1）** を実施する。
- https://github.com/J-Tech-Japan/Sekiban/blob/main/tasks/20260226_multiprojection_oom_streaming_design/design.md

## 目的（このIssueのスコープ）
- `byte[]` 前提のスナップショットI/O境界を段階的に外すための基盤を追加する。
- 既存挙動を壊さず、`Stream` ベース経路を導入する。
- 本番導入時に feature flag で切替できる状態を作る。

## 実装範囲（Phase 1）
1. `IBlobStorageSnapshotAccessor` の拡張
- 追加:
  - `Task<string> WriteAsync(Stream data, string projectorName, CancellationToken ct)`
  - `Task<Stream> OpenReadAsync(string key, CancellationToken ct)`
- 既存 `byte[]` API は互換維持し、内部でStream APIへ委譲。

2. `IMultiProjectionStateStore` の拡張
- 追加:
  - `UpsertFromStreamAsync(MultiProjectionStateWriteRequest request, ...)`
- 既存 `UpsertAsync(MultiProjectionStateRecord)` は残す。
- `MultiProjectionStateWriteRequest` は `StateData` 非必須（offloadメタ保存可能）。

3. StateStore実装への反映
- 対象:
  - CosmosMultiProjectionStateStore
  - PostgresMultiProjectionStateStore
  - DynamoMultiProjectionStateStore
- 要件:
  - しきい値超過時は Blob へ stream upload、DBには `IsOffloaded/OffloadKey/OffloadProvider` を保存
  - 既存の inline データ読み出し互換を維持

4. Feature flag
- 新経路の有効/無効を設定で切り替え可能にする（デフォルトは既存互換優先）。

## 非スコープ（別Issueで対応）
- `MultiProjectionGrain.PersistStateAsync` の `/tmp` 一時ファイル経由実装
- 完全な `byte[]` 経路撤廃
- 大規模ベンチマーク本番検証

## 受け入れ基準
- 既存の snapshot restore 互換（inline/offloaded 両方）が維持される。
- 新規Stream API経由で保存・復元するユニット/統合テストが追加される。
- `dcb` の主要テスト（少なくとも Orleans/Cosmos/Postgres/Dynamo 関連）がグリーン。
- feature flag OFF時は既存動作と同等。

## 実装チェックリスト
- [ ] Coreインターフェース拡張（Blob accessor / StateStore）
- [ ] 互換実装（既存 `byte[]` 経路を壊さない）
- [ ] Cosmos実装
- [ ] Postgres実装
- [ ] Dynamo実装
- [ ] Feature flag 導入
- [ ] テスト追加（Stream path + backward compatibility）
- [ ] ドキュメント更新（簡易）

## 補足
Phase 2（Grainのtemp-file persist切替）に進む前提として、このIssueは「ストリーム保存経路の土台」を目的とする。


## Execution Report

Piece `default` completed successfully.

Closes #946