### PR TITLE
fix: resolve CA2007 and CA1062 warnings in DynamoMultiProjectionStateStore

### DIFF
--- a/dcb/src/Sekiban.Dcb.DynamoDB/DynamoMultiProjectionStateStore.cs
+++ b/dcb/src/Sekiban.Dcb.DynamoDB/DynamoMultiProjectionStateStore.cs
@@ -70,9 +70,12 @@ public class DynamoMultiProjectionStateStore : IMultiProjectionStateStore
             {
                 try
                 {
-                    await using var offloadStream = await _blobAccessor.OpenReadAsync(doc.OffloadKey, cancellationToken)
+                    var offloadStream = await _blobAccessor.OpenReadAsync(doc.OffloadKey, cancellationToken)
                         .ConfigureAwait(false);
-                    stateData = await ReadAllBytesAsync(offloadStream, cancellationToken).ConfigureAwait(false);
+                    await using (offloadStream.ConfigureAwait(false))
+                    {
+                        stateData = await ReadAllBytesAsync(offloadStream, cancellationToken).ConfigureAwait(false);
+                    }
                 }
                 catch (Exception ex)
                 {
@@ -115,9 +118,12 @@ public class DynamoMultiProjectionStateStore : IMultiProjectionStateStore
             {
                 try
                 {
-                    await using var offloadStream = await _blobAccessor.OpenReadAsync(latest.OffloadKey, cancellationToken)
+                    var offloadStream = await _blobAccessor.OpenReadAsync(latest.OffloadKey, cancellationToken)
                         .ConfigureAwait(false);
-                    stateData = await ReadAllBytesAsync(offloadStream, cancellationToken).ConfigureAwait(false);
+                    await using (offloadStream.ConfigureAwait(false))
+                    {
+                        stateData = await ReadAllBytesAsync(offloadStream, cancellationToken).ConfigureAwait(false);
+                    }
                 }
                 catch (Exception ex)
                 {
@@ -188,6 +194,7 @@ public class DynamoMultiProjectionStateStore : IMultiProjectionStateStore
         int offloadThresholdBytes,
         CancellationToken cancellationToken = default)
     {
+        ArgumentNullException.ThrowIfNull(request);
         try
         {
             await _context.EnsureTablesAsync(cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
## Summary
- Fix CA2007: apply `ConfigureAwait(false)` on `await using` disposal for offload streams (lines 73, 118)
- Fix CA1062: add `ArgumentNullException.ThrowIfNull(request)` for null parameter validation (line 199)

## Test plan
- [x] Project builds with zero CA warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)