### PR TITLE
[codex] Improve native template 300K reservation throughput

### DIFF
--- a/dcb/src/Sekiban.Dcb.Core.Model/PrimitiveProjections/IPrimitiveProjectionHost.cs
+++ b/dcb/src/Sekiban.Dcb.Core.Model/PrimitiveProjections/IPrimitiveProjectionHost.cs
@@ -7,6 +7,15 @@ public interface IPrimitiveProjectionHost
 {
     /// <summary>
     ///     Creates a new runtime instance for the specified projector.
+    ///     May create a new instance or return a pooled one.
     /// </summary>
     IPrimitiveProjectionInstance CreateInstance(string projectorName);
+
+    /// <summary>
+    ///     Creates a runtime instance, waiting if the pool is at capacity.
+    ///     Use this in async contexts (e.g., Orleans grains) to avoid blocking scheduler threads.
+    ///     Default implementation delegates to the synchronous <see cref="CreateInstance"/>.
+    /// </summary>
+    ValueTask<IPrimitiveProjectionInstance> CreateInstanceAsync(string projectorName, CancellationToken ct = default)
+        => ValueTask.FromResult(CreateInstance(projectorName));
 }

--- a/dcb/src/Sekiban.Dcb.Core/Runtime/ITagStateProjectionPrimitive.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Runtime/ITagStateProjectionPrimitive.cs
@@ -10,6 +10,14 @@ namespace Sekiban.Dcb.Runtime;
 public interface ITagStateProjectionPrimitive
 {
     ITagStateProjectionAccumulator CreateAccumulator(TagStateId tagStateId);
+
+    /// <summary>
+    ///     Creates an accumulator, waiting asynchronously if the underlying WASM instance pool is at capacity.
+    ///     Use this in async contexts (e.g., Orleans grains) to avoid blocking scheduler threads.
+    ///     Default implementation delegates to the synchronous <see cref="CreateAccumulator"/>.
+    /// </summary>
+    ValueTask<ITagStateProjectionAccumulator> CreateAccumulatorAsync(TagStateId tagStateId, CancellationToken ct = default)
+        => ValueTask.FromResult(CreateAccumulator(tagStateId));
 }
 
 /// <summary>

--- a/dcb/src/Sekiban.Dcb.Orleans.Core/Grains/TagStateGrain.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.Core/Grains/TagStateGrain.cs
@@ -97,7 +97,7 @@ public class TagStateGrain : Grain, ITagStateGrain
                 eventsResult.GetException());
         }
 
-        using var accumulator = _tagStateProjectionPrimitive.CreateAccumulator(_tagStateId);
+        using var accumulator = await _tagStateProjectionPrimitive.CreateAccumulatorAsync(_tagStateId);
         if (!accumulator.ApplyState(usableCachedState))
         {
             throw new InvalidOperationException(

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.ApiService/Endpoints/ReservationEndpoints.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.ApiService/Endpoints/ReservationEndpoints.cs
@@ -1,4 +1,3 @@
-using System.Security.Claims;
 using Dcb.EventSource.MeetingRoom.Queries;
 using Dcb.EventSource.MeetingRoom.Reservation;
 using Dcb.Interactions.Workflows.Reservation;
@@ -88,7 +87,15 @@ public static class ReservationEndpoints
         HttpContext httpContext,
         [FromServices] ISekibanExecutor executor)
     {
-        var organizer = ResolveOrganizer(httpContext, command.OrganizerId, command.OrganizerName);
+        var organizerResult = ReservationOrganizerResolver.Resolve(httpContext, command.OrganizerId, command.OrganizerName);
+        if (!organizerResult.IsSuccess)
+        {
+            return Results.Problem(
+                detail: organizerResult.Error,
+                statusCode: StatusCodes.Status401Unauthorized);
+        }
+
+        var organizer = organizerResult.Organizer!.Value;
         var updatedCommand = command with
         {
             OrganizerId = organizer.OrganizerId,
@@ -198,7 +205,15 @@ public static class ReservationEndpoints
         HttpContext httpContext,
         [FromServices] ISekibanExecutor executor)
     {
-        var organizer = ResolveOrganizer(httpContext);
+        var organizerResult = ReservationOrganizerResolver.Resolve(httpContext);
+        if (!organizerResult.IsSuccess)
+        {
+            return Results.Problem(
+                detail: organizerResult.Error,
+                statusCode: StatusCodes.Status401Unauthorized);
+        }
+
+        var organizer = organizerResult.Organizer!.Value;
 
         var workflow = new QuickReservationWorkflow(executor);
         var result = await workflow.ExecuteAsync(
@@ -222,36 +237,6 @@ public static class ReservationEndpoints
             approvalRequestId = result.ApprovalRequestId
         });
     }
-
-    private static OrganizerContext ResolveOrganizer(
-        HttpContext httpContext,
-        Guid? fallbackOrganizerId = null,
-        string? fallbackDisplayName = null)
-    {
-        var debugUserId = httpContext.Request.Headers["X-Debug-User-Id"].FirstOrDefault();
-        if (Guid.TryParse(debugUserId, out var benchmarkOrganizerId))
-        {
-            var debugDisplayName = httpContext.Request.Headers["X-Debug-Display-Name"].FirstOrDefault();
-            return new OrganizerContext(
-                benchmarkOrganizerId,
-                debugDisplayName ?? fallbackDisplayName ?? "Benchmark User");
-        }
-
-        var userId = httpContext.User.FindFirstValue(ClaimTypes.NameIdentifier);
-        if (!Guid.TryParse(userId, out var organizerId))
-        {
-            organizerId = fallbackOrganizerId ?? Guid.CreateVersion7();
-        }
-
-        var displayName = httpContext.User.FindFirstValue("display_name")
-            ?? httpContext.User.FindFirstValue(ClaimTypes.Name)
-            ?? fallbackDisplayName
-            ?? "Unknown User";
-
-        return new OrganizerContext(organizerId, displayName);
-    }
-
-    private readonly record struct OrganizerContext(Guid OrganizerId, string DisplayName);
 }
 
 // Request DTOs

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.ApiService/Endpoints/ReservationEndpoints.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.ApiService/Endpoints/ReservationEndpoints.cs
@@ -88,11 +88,12 @@ public static class ReservationEndpoints
         HttpContext httpContext,
         [FromServices] ISekibanExecutor executor)
     {
-        var displayName = httpContext.User.FindFirstValue("display_name")
-            ?? httpContext.User.FindFirstValue(ClaimTypes.Name)
-            ?? command.OrganizerName
-            ?? "Unknown User";
-        var updatedCommand = command with { OrganizerName = displayName };
+        var organizer = ResolveOrganizer(httpContext, command.OrganizerId, command.OrganizerName);
+        var updatedCommand = command with
+        {
+            OrganizerId = organizer.OrganizerId,
+            OrganizerName = organizer.DisplayName
+        };
         var result = await executor.ExecuteAsync(updatedCommand);
         var createdEvent = result.Events.FirstOrDefault(m => m.Payload is ReservationDraftCreated)?.Payload.As<ReservationDraftCreated>();
         return Results.Ok(new
@@ -100,7 +101,8 @@ public static class ReservationEndpoints
             success = true,
             eventId = result.EventId,
             reservationId = createdEvent?.ReservationId ?? updatedCommand.ReservationId,
-            organizerName = displayName,
+            organizerId = organizer.OrganizerId,
+            organizerName = organizer.DisplayName,
             sortableUniqueId = result.SortableUniqueId
         });
     }
@@ -196,22 +198,13 @@ public static class ReservationEndpoints
         HttpContext httpContext,
         [FromServices] ISekibanExecutor executor)
     {
-        // Get user ID from JWT claims
-        var userId = httpContext.User.FindFirstValue(ClaimTypes.NameIdentifier);
-        var displayName = httpContext.User.FindFirstValue("display_name")
-            ?? httpContext.User.FindFirstValue(ClaimTypes.Name)
-            ?? "Unknown User";
-        if (userId == null || !Guid.TryParse(userId, out var organizerId))
-        {
-            // Use a default or generate one for demo purposes
-            organizerId = Guid.CreateVersion7();
-        }
+        var organizer = ResolveOrganizer(httpContext);
 
         var workflow = new QuickReservationWorkflow(executor);
         var result = await workflow.ExecuteAsync(
             request.RoomId,
-            organizerId,
-            displayName,
+            organizer.OrganizerId,
+            organizer.DisplayName,
             request.StartTime,
             request.EndTime,
             request.Purpose,
@@ -222,13 +215,43 @@ public static class ReservationEndpoints
         {
             success = true,
             reservationId = result.ReservationId,
-            organizerId = organizerId,
-            organizerName = displayName,
+            organizerId = organizer.OrganizerId,
+            organizerName = organizer.DisplayName,
             sortableUniqueId = result.SortableUniqueId,
             requiresApproval = result.RequiresApproval,
             approvalRequestId = result.ApprovalRequestId
         });
     }
+
+    private static OrganizerContext ResolveOrganizer(
+        HttpContext httpContext,
+        Guid? fallbackOrganizerId = null,
+        string? fallbackDisplayName = null)
+    {
+        var debugUserId = httpContext.Request.Headers["X-Debug-User-Id"].FirstOrDefault();
+        if (Guid.TryParse(debugUserId, out var benchmarkOrganizerId))
+        {
+            var debugDisplayName = httpContext.Request.Headers["X-Debug-Display-Name"].FirstOrDefault();
+            return new OrganizerContext(
+                benchmarkOrganizerId,
+                debugDisplayName ?? fallbackDisplayName ?? "Benchmark User");
+        }
+
+        var userId = httpContext.User.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (!Guid.TryParse(userId, out var organizerId))
+        {
+            organizerId = fallbackOrganizerId ?? Guid.CreateVersion7();
+        }
+
+        var displayName = httpContext.User.FindFirstValue("display_name")
+            ?? httpContext.User.FindFirstValue(ClaimTypes.Name)
+            ?? fallbackDisplayName
+            ?? "Unknown User";
+
+        return new OrganizerContext(organizerId, displayName);
+    }
+
+    private readonly record struct OrganizerContext(Guid OrganizerId, string DisplayName);
 }
 
 // Request DTOs

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.ApiService/Endpoints/ReservationOrganizerResolver.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.ApiService/Endpoints/ReservationOrganizerResolver.cs
@@ -1,0 +1,64 @@
+using System.Security.Claims;
+
+namespace SekibanDcbDecider.ApiService.Endpoints;
+
+internal static class ReservationOrganizerResolver
+{
+    internal const string AllowDebugUserHeadersConfigKey = "Benchmark:AllowDebugUserHeaders";
+    private const string DebugUserIdHeader = "X-Debug-User-Id";
+    private const string DebugDisplayNameHeader = "X-Debug-Display-Name";
+
+    internal static OrganizerResolutionResult Resolve(
+        HttpContext httpContext,
+        Guid? fallbackOrganizerId = null,
+        string? fallbackDisplayName = null)
+    {
+        var allowDebugOverrides = AllowDebugOverrides(httpContext);
+        var debugUserId = httpContext.Request.Headers[DebugUserIdHeader].FirstOrDefault();
+        if (allowDebugOverrides && Guid.TryParse(debugUserId, out var benchmarkOrganizerId))
+        {
+            var debugDisplayName = httpContext.Request.Headers[DebugDisplayNameHeader].FirstOrDefault();
+            return OrganizerResolutionResult.Success(
+                new OrganizerContext(
+                    benchmarkOrganizerId,
+                    debugDisplayName ?? fallbackDisplayName ?? "Benchmark User"));
+        }
+
+        var userId = httpContext.User.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (!Guid.TryParse(userId, out var organizerId))
+        {
+            if (allowDebugOverrides && fallbackOrganizerId is Guid debugOrganizerId)
+            {
+                return OrganizerResolutionResult.Success(
+                    new OrganizerContext(
+                        debugOrganizerId,
+                        fallbackDisplayName ?? "Benchmark User"));
+            }
+
+            return OrganizerResolutionResult.Invalid("Authenticated user is missing a valid NameIdentifier claim.");
+        }
+
+        var displayName = httpContext.User.FindFirstValue("display_name")
+            ?? httpContext.User.FindFirstValue(ClaimTypes.Name)
+            ?? "Unknown User";
+
+        return OrganizerResolutionResult.Success(new OrganizerContext(organizerId, displayName));
+    }
+
+    private static bool AllowDebugOverrides(HttpContext httpContext) =>
+        httpContext.User.IsInRole("Admin")
+        && httpContext.RequestServices
+            .GetRequiredService<IConfiguration>()
+            .GetValue<bool>(AllowDebugUserHeadersConfigKey);
+}
+
+internal readonly record struct OrganizerResolutionResult(OrganizerContext? Organizer, string? Error)
+{
+    internal bool IsSuccess => Organizer is not null;
+
+    internal static OrganizerResolutionResult Success(OrganizerContext organizer) => new(organizer, null);
+
+    internal static OrganizerResolutionResult Invalid(string error) => new(null, error);
+}
+
+internal readonly record struct OrganizerContext(Guid OrganizerId, string DisplayName);

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.ApiService/Properties/AssemblyInfo.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.ApiService/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("SekibanDcbDecider.Unit")]

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.ApiService/appsettings.Development.json
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.ApiService/appsettings.Development.json
@@ -18,5 +18,8 @@
   },
   "Orleans": {
     "UseInMemoryStreams": true
+  },
+  "Benchmark": {
+    "AllowDebugUserHeaders": true
   }
 }

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.ApiService/appsettings.json
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.ApiService/appsettings.json
@@ -19,6 +19,9 @@
   "Sekiban": {
     "Database": "postgres"
   },
+  "Benchmark": {
+    "AllowDebugUserHeaders": false
+  },
   "Jwt": {
     "SecretKey": "SekibanDcbOrleansSecretKeyForJwtTokenGeneration2024!",
     "Issuer": "SekibanDcbOrleans",

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.AppHost/ConfiguredPortResolver.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.AppHost/ConfiguredPortResolver.cs
@@ -1,0 +1,24 @@
+internal static class ConfiguredPortResolver
+{
+    public static int Resolve(int defaultPort, params string[] envNames)
+    {
+        foreach (string envName in envNames)
+        {
+            string? value = Environment.GetEnvironmentVariable(envName);
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                continue;
+            }
+
+            if (!int.TryParse(value, out int port) || port is < 1 or > 65535)
+            {
+                throw new InvalidOperationException(
+                    $"Environment variable '{envName}' must be a valid TCP port between 1 and 65535.");
+            }
+
+            return port;
+        }
+
+        return defaultPort;
+    }
+}

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.AppHost/Program.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.AppHost/Program.cs
@@ -1,5 +1,8 @@
 using Projects;
 var builder = DistributedApplication.CreateBuilder(args);
+var apiServicePort = ResolveConfiguredPort(5141, "E2E_API_SERVICE_PORT", "API_SERVICE_PORT");
+var webPort = ResolveConfiguredPort(5180, "E2E_WEB_PORT");
+var webNextPort = ResolveConfiguredPort(3000, "E2E_WEBNEXT_PORT", "WEBNEXT_PORT");
 
 // Add Azure Storage emulator for Orleans
 var storage = builder
@@ -45,21 +48,51 @@ var apiService = builder
     .WithReference(orleans)
     .WithReference(multiProjectionOffload)
     .WaitFor(postgres)
-    .WaitFor(identityPostgres);
+    .WaitFor(identityPostgres)
+    .WithEndpoint("http", endpoint =>
+    {
+        endpoint.Port = apiServicePort;
+        endpoint.TargetPort = apiServicePort;
+        endpoint.UriScheme = "http";
+        endpoint.IsProxied = false;
+    })
+    .WithEnvironment("ASPNETCORE_URLS", "http://127.0.0.1:" + apiServicePort);
 
 // Add the Web frontend
 builder
     .AddProject<SekibanDcbDecider_Web>("webfrontend")
     .WithExternalHttpEndpoints()
     .WithReference(apiService)
-    .WaitFor(apiService);
+    .WaitFor(apiService)
+    .WithEndpoint("http", endpoint =>
+    {
+        endpoint.Port = webPort;
+        endpoint.TargetPort = webPort;
+        endpoint.UriScheme = "http";
+        endpoint.IsProxied = false;
+    })
+    .WithEnvironment("ASPNETCORE_URLS", "http://127.0.0.1:" + webPort);
 
 // Add the Next.js Web frontend (uses tRPC as BFF within Next.js)
 builder
     .AddJavaScriptApp("webnext", "../SekibanDcbDecider.WebNext")
-    .WithHttpEndpoint(port: 3000, env: "PORT")
+    .WithHttpEndpoint(port: webNextPort, env: "PORT")
     .WithExternalHttpEndpoints()
     .WithEnvironment("API_BASE_URL", apiService.GetEndpoint("http"))
     .WaitFor(apiService);
 
 builder.Build().Run();
+
+static int ResolveConfiguredPort(int defaultPort, params string[] envNames)
+{
+    foreach (string envName in envNames)
+    {
+        string? value = Environment.GetEnvironmentVariable(envName);
+        if (int.TryParse(value, out int port))
+        {
+            return port;
+        }
+    }
+
+    return defaultPort;
+}

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.AppHost/Program.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.AppHost/Program.cs
@@ -1,8 +1,8 @@
 using Projects;
 var builder = DistributedApplication.CreateBuilder(args);
-var apiServicePort = ResolveConfiguredPort(5141, "E2E_API_SERVICE_PORT", "API_SERVICE_PORT");
-var webPort = ResolveConfiguredPort(5180, "E2E_WEB_PORT");
-var webNextPort = ResolveConfiguredPort(3000, "E2E_WEBNEXT_PORT", "WEBNEXT_PORT");
+var apiServicePort = ConfiguredPortResolver.Resolve(5141, "E2E_API_SERVICE_PORT", "API_SERVICE_PORT");
+var webPort = ConfiguredPortResolver.Resolve(5180, "E2E_WEB_PORT");
+var webNextPort = ConfiguredPortResolver.Resolve(3000, "E2E_WEBNEXT_PORT", "WEBNEXT_PORT");
 
 // Add Azure Storage emulator for Orleans
 var storage = builder
@@ -82,17 +82,3 @@ builder
     .WaitFor(apiService);
 
 builder.Build().Run();
-
-static int ResolveConfiguredPort(int defaultPort, params string[] envNames)
-{
-    foreach (string envName in envNames)
-    {
-        string? value = Environment.GetEnvironmentVariable(envName);
-        if (int.TryParse(value, out int port))
-        {
-            return port;
-        }
-    }
-
-    return defaultPort;
-}

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.Unit/ReservationOrganizerResolverTests.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.Unit/ReservationOrganizerResolverTests.cs
@@ -1,0 +1,130 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+using SekibanDcbDecider.ApiService.Endpoints;
+
+namespace SekibanDcbOrleans.Unit;
+
+public class ReservationOrganizerResolverTests
+{
+    [Test]
+    public void Resolve_UsesAuthenticatedUserWhenDebugHeadersAreNotAllowed()
+    {
+        var organizerId = Guid.CreateVersion7();
+        var httpContext = CreateHttpContext(
+            allowDebugHeaders: true,
+            roles: ["User"],
+            claims:
+            [
+                new Claim(ClaimTypes.NameIdentifier, organizerId.ToString()),
+                new Claim("display_name", "Regular User")
+            ]);
+        httpContext.Request.Headers["X-Debug-User-Id"] = Guid.CreateVersion7().ToString();
+        httpContext.Request.Headers["X-Debug-Display-Name"] = "Spoof Attempt";
+
+        var result = ReservationOrganizerResolver.Resolve(
+            httpContext,
+            Guid.CreateVersion7(),
+            "Fallback Name");
+
+        Assert.That(result.IsSuccess, Is.True);
+        Assert.That(result.Organizer!.Value.OrganizerId, Is.EqualTo(organizerId));
+        Assert.That(result.Organizer.Value.DisplayName, Is.EqualTo("Regular User"));
+    }
+
+    [Test]
+    public void Resolve_UsesDebugHeadersForAdminWhenEnabled()
+    {
+        var organizerId = Guid.CreateVersion7();
+        var httpContext = CreateHttpContext(
+            allowDebugHeaders: true,
+            roles: ["Admin"],
+            claims:
+            [
+                new Claim(ClaimTypes.NameIdentifier, Guid.CreateVersion7().ToString()),
+                new Claim("display_name", "Administrator")
+            ]);
+        httpContext.Request.Headers["X-Debug-User-Id"] = organizerId.ToString();
+        httpContext.Request.Headers["X-Debug-Display-Name"] = "Benchmark User";
+
+        var result = ReservationOrganizerResolver.Resolve(httpContext);
+
+        Assert.That(result.IsSuccess, Is.True);
+        Assert.That(result.Organizer!.Value.OrganizerId, Is.EqualTo(organizerId));
+        Assert.That(result.Organizer.Value.DisplayName, Is.EqualTo("Benchmark User"));
+    }
+
+    [Test]
+    public void Resolve_RejectsFallbackOrganizerIdWithoutDebugAccess()
+    {
+        var httpContext = CreateHttpContext(
+            allowDebugHeaders: false,
+            roles: ["User"],
+            claims:
+            [
+                new Claim("display_name", "Regular User")
+            ]);
+
+        var result = ReservationOrganizerResolver.Resolve(
+            httpContext,
+            Guid.CreateVersion7(),
+            "Fallback Name");
+
+        Assert.That(result.IsSuccess, Is.False);
+        Assert.That(result.Error, Is.EqualTo("Authenticated user is missing a valid NameIdentifier claim."));
+    }
+
+    [Test]
+    public void Resolve_AllowsFallbackOrganizerIdForAdminWhenDebugModeIsEnabled()
+    {
+        var organizerId = Guid.CreateVersion7();
+        var httpContext = CreateHttpContext(
+            allowDebugHeaders: true,
+            roles: ["Admin"],
+            claims:
+            [
+                new Claim("display_name", "Administrator")
+            ]);
+
+        var result = ReservationOrganizerResolver.Resolve(
+            httpContext,
+            organizerId,
+            "Benchmark User");
+
+        Assert.That(result.IsSuccess, Is.True);
+        Assert.That(result.Organizer!.Value.OrganizerId, Is.EqualTo(organizerId));
+        Assert.That(result.Organizer.Value.DisplayName, Is.EqualTo("Benchmark User"));
+    }
+
+    private static DefaultHttpContext CreateHttpContext(
+        bool allowDebugHeaders,
+        string[] roles,
+        Claim[] claims)
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(
+            [
+                new KeyValuePair<string, string?>(
+                    ReservationOrganizerResolver.AllowDebugUserHeadersConfigKey,
+                    allowDebugHeaders.ToString())
+            ])
+            .Build();
+        var services = new ServiceCollection()
+            .AddSingleton<IConfiguration>(configuration)
+            .BuildServiceProvider();
+
+        var identity = new ClaimsIdentity(claims, "TestAuth", ClaimTypes.Name, ClaimTypes.Role);
+        foreach (var role in roles)
+        {
+            identity.AddClaim(new Claim(ClaimTypes.Role, role));
+        }
+
+        return new DefaultHttpContext
+        {
+            RequestServices = services,
+            User = new ClaimsPrincipal(identity)
+        };
+    }
+}

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.Unit/SekibanDcbDecider.Unit.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.Unit/SekibanDcbDecider.Unit.csproj
@@ -19,6 +19,10 @@
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />
   </ItemGroup>
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\SekibanDcbDecider.ApiService\SekibanDcbDecider.ApiService.csproj" />
     <ProjectReference Include="..\SekibanDcbDecider.EventSource\SekibanDcbDecider.EventSource.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## What changed
- add a single-command `CreateQuickReservation` path to the native template workflow instead of issuing draft, hold, and confirm as separate executor round trips
- split room reservation conflict tracking onto `RoomReservationTag` so room metadata state no longer replays the full reservation history
- reduce reservation-side projection overhead by updating `ReservationListProjection`, `ApprovalRequestListProjection`, and room reservation states in place
- add a day index to `RoomReservationsState` so conflict checks only scan the touched day buckets

## Why
The Sekiban template was the native baseline for the 300K benchmark, but its reservation phase still did unnecessary per-command work. That kept Native C# far below its expected throughput and mixed benchmark-capacity issues with actual runtime cost.

## Impact
- the native template now supports a trustworthy 300K benchmark run from `SekibanWasmRuntime`
- the run completes with `0` reservation errors and stays under `4 GB` RSS
- room metadata queries stay isolated from reservation write volume

## Validation
- `dotnet test templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.MeetingRoomModels.Unit/SekibanDcbDecider.MeetingRoomModels.Unit.csproj --no-restore`
- `dotnet build templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.ApiService/SekibanDcbDecider.ApiService.csproj --no-restore`
