### PR TITLE
Add catch-up awareness to query execution in Orleans grains

### DIFF
--- a/dcb/src/Sekiban.Dcb.Core.Model/Queries/IListQueryResult.cs
+++ b/dcb/src/Sekiban.Dcb.Core.Model/Queries/IListQueryResult.cs
@@ -9,4 +9,10 @@ public interface IListQueryResult
     int? TotalPages { get; }
     int? CurrentPage { get; }
     int? PageSize { get; }
+
+    /// <summary>
+    ///     Indicates whether the projection is still catching up from the event store.
+    ///     When true, the results may be incomplete or stale.
+    /// </summary>
+    bool IsCatchUpInProgress => false;
 }

--- a/dcb/src/Sekiban.Dcb.Core.Model/Queries/ListQueryResult.cs
+++ b/dcb/src/Sekiban.Dcb.Core.Model/Queries/ListQueryResult.cs
@@ -9,7 +9,8 @@ public record ListQueryResult<T>(
     int? TotalPages,
     int? CurrentPage,
     int? PageSize,
-    IEnumerable<T> Items) where T : notnull
+    IEnumerable<T> Items,
+    bool IsCatchUpInProgress = false) where T : notnull
 {
     /// <summary>
     ///     Empty result

--- a/dcb/src/Sekiban.Dcb.Core.Model/Queries/ListQueryResultGeneral.cs
+++ b/dcb/src/Sekiban.Dcb.Core.Model/Queries/ListQueryResultGeneral.cs
@@ -11,7 +11,8 @@ public record ListQueryResultGeneral(
     int? PageSize,
     IEnumerable<object> Items,
     string RecordType,
-    IListQueryCommon Query) : IListQueryResult
+    IListQueryCommon Query,
+    bool IsCatchUpInProgress = false) : IListQueryResult
 {
     public static ListQueryResultGeneral Empty =>
         new(0, 0, 0, 0, Array.Empty<object>(), string.Empty, new EmptyListQueryCommon());
@@ -42,7 +43,7 @@ public record ListQueryResultGeneral(
         try
         {
             var typedItems = Items.Cast<T>().ToList();
-            var result = new ListQueryResult<T>(TotalCount, TotalPages, CurrentPage, PageSize, typedItems);
+            var result = new ListQueryResult<T>(TotalCount, TotalPages, CurrentPage, PageSize, typedItems, IsCatchUpInProgress);
             return ResultBox.FromValue(result);
         }
         catch (InvalidCastException ex)

--- a/dcb/src/Sekiban.Dcb.Orleans.Core/Grains/IMultiProjectionGrain.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.Core/Grains/IMultiProjectionGrain.cs
@@ -65,11 +65,29 @@ public interface IMultiProjectionGrain : IGrainWithStringKey
     Task<SerializableQueryResult> ExecuteQueryAsync(SerializableQueryParameter query);
 
     /// <summary>
+    ///     Execute a single-result query against the projection
+    /// </summary>
+    /// <param name="query">The query to execute</param>
+    /// <param name="waitForCatchUp">Whether to wait for catch-up completion before executing the query.
+    /// If true, waits up to 30 seconds for catch-up to complete.</param>
+    /// <returns>The query result with IsCatchUpInProgress indicating whether catch-up is still active</returns>
+    Task<SerializableQueryResult> ExecuteQueryAsync(SerializableQueryParameter query, bool waitForCatchUp);
+
+    /// <summary>
     ///     Execute a list query against the projection
     /// </summary>
     /// <param name="query">The list query to execute</param>
     /// <returns>The paginated query result wrapped in ListQueryResultGeneral for serialization</returns>
     Task<SerializableListQueryResult> ExecuteListQueryAsync(SerializableQueryParameter query);
+
+    /// <summary>
+    ///     Execute a list query against the projection
+    /// </summary>
+    /// <param name="query">The list query to execute</param>
+    /// <param name="waitForCatchUp">Whether to wait for catch-up completion before executing the query.
+    /// If true, waits up to 30 seconds for catch-up to complete.</param>
+    /// <returns>The paginated query result with IsCatchUpInProgress indicating whether catch-up is still active</returns>
+    Task<SerializableListQueryResult> ExecuteListQueryAsync(SerializableQueryParameter query, bool waitForCatchUp);
 
     /// <summary>
     ///     Check if a specific sortable unique ID has been received and processed.

--- a/dcb/src/Sekiban.Dcb.Orleans.Core/Grains/MultiProjectionGrain.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.Core/Grains/MultiProjectionGrain.cs
@@ -1262,6 +1262,13 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
     public Task<SerializableListQueryResult> ExecuteListQueryAsync(SerializableQueryParameter queryParameter, bool waitForCatchUp) =>
         ExecuteListQueryInternalAsync(queryParameter, waitForCatchUp);
 
+    private sealed record QueryExecutionMetadata(
+        int? SafeVersion,
+        string? SafeThreshold,
+        DateTime? SafeThresholdTime,
+        int? UnsafeVersion,
+        bool IsCatchUpInProgress);
+
     private async Task<SerializableQueryResult> ExecuteQueryInternalAsync(
         SerializableQueryParameter queryParameter, bool waitForCatchUp)
     {
@@ -1284,51 +1291,14 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
 
         try
         {
-            await StartSubscriptionAsync();
-
-            if (_orleansStreamHandle == null)
-            {
-                await CatchUpFromEventStoreAsync();
-            }
-
-            // Wait for catch-up if requested
-            if (waitForCatchUp && _catchUpProgress.IsActive)
-            {
-                await WaitForCatchUpWithTimeoutAsync(TimeSpan.FromSeconds(30));
-            }
-
-            // Get safe/unsafe metadata for query context
-            int? safeVersion = null;
-            string? safeThreshold = null;
-            DateTime? safeThresholdTime = null;
-            int? unsafeVersion = null;
-
-            var safeStateResult = await _host.GetStateAsync(canGetUnsafeState: false);
-            if (safeStateResult.IsSuccess)
-            {
-                safeVersion = safeStateResult.GetValue().Version;
-            }
-
-            safeThreshold = _host.PeekCurrentSafeWindowThreshold();
-            try
-            {
-                var safeThresholdId = new SortableUniqueId(safeThreshold);
-                safeThresholdTime = safeThresholdId.GetDateTime();
-            }
-            catch { }
-
-            var unsafeStateResult = await _host.GetStateAsync(canGetUnsafeState: true);
-            if (unsafeStateResult.IsSuccess)
-            {
-                unsafeVersion = unsafeStateResult.GetValue().Version;
-            }
+            var queryMetadata = await GetQueryExecutionMetadataAsync(waitForCatchUp);
 
             var result = await _host.ExecuteQueryAsync(
                 queryParameter,
-                safeVersion,
-                safeThreshold,
-                safeThresholdTime,
-                unsafeVersion);
+                queryMetadata.SafeVersion,
+                queryMetadata.SafeThreshold,
+                queryMetadata.SafeThresholdTime,
+                queryMetadata.UnsafeVersion);
 
             if (!result.IsSuccess)
             {
@@ -1337,8 +1307,7 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
 
             var resultValue = result.GetValue();
 
-            // Enrich result with catch-up progress information
-            if (_catchUpProgress.IsActive)
+            if (queryMetadata.IsCatchUpInProgress)
             {
                 resultValue = resultValue with { IsCatchUpInProgress = true };
             }
@@ -1374,51 +1343,14 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
 
         try
         {
-            await StartSubscriptionAsync();
-
-            if (_orleansStreamHandle == null)
-            {
-                await CatchUpFromEventStoreAsync();
-            }
-
-            // Wait for catch-up if requested
-            if (waitForCatchUp && _catchUpProgress.IsActive)
-            {
-                await WaitForCatchUpWithTimeoutAsync(TimeSpan.FromSeconds(30));
-            }
-
-            // Get safe/unsafe metadata for query context
-            int? safeVersion = null;
-            string? safeThreshold = null;
-            DateTime? safeThresholdTime = null;
-            int? unsafeVersion = null;
-
-            var safeStateResult = await _host.GetStateAsync(canGetUnsafeState: false);
-            if (safeStateResult.IsSuccess)
-            {
-                safeVersion = safeStateResult.GetValue().Version;
-            }
-
-            safeThreshold = _host.PeekCurrentSafeWindowThreshold();
-            try
-            {
-                var safeThresholdId = new SortableUniqueId(safeThreshold);
-                safeThresholdTime = safeThresholdId.GetDateTime();
-            }
-            catch { }
-
-            var unsafeStateResult = await _host.GetStateAsync(canGetUnsafeState: true);
-            if (unsafeStateResult.IsSuccess)
-            {
-                unsafeVersion = unsafeStateResult.GetValue().Version;
-            }
+            var queryMetadata = await GetQueryExecutionMetadataAsync(waitForCatchUp);
 
             var result = await _host.ExecuteListQueryAsync(
                 queryParameter,
-                safeVersion,
-                safeThreshold,
-                safeThresholdTime,
-                unsafeVersion);
+                queryMetadata.SafeVersion,
+                queryMetadata.SafeThreshold,
+                queryMetadata.SafeThresholdTime,
+                queryMetadata.UnsafeVersion);
 
             if (!result.IsSuccess)
             {
@@ -1427,8 +1359,7 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
 
             var resultValue = result.GetValue();
 
-            // Enrich result with catch-up progress information
-            if (_catchUpProgress.IsActive)
+            if (queryMetadata.IsCatchUpInProgress)
             {
                 resultValue = resultValue with { IsCatchUpInProgress = true };
             }
@@ -1440,6 +1371,62 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
             _lastError = $"List query failed: {ex.Message}";
             throw;
         }
+    }
+
+    private async Task<QueryExecutionMetadata> GetQueryExecutionMetadataAsync(bool waitForCatchUp)
+    {
+        var isCatchUpInProgress = await PrepareForQueryExecutionAsync(waitForCatchUp);
+
+        int? safeVersion = null;
+        string? safeThreshold = null;
+        DateTime? safeThresholdTime = null;
+        int? unsafeVersion = null;
+
+        var safeStateResult = await _host!.GetStateAsync(canGetUnsafeState: false);
+        if (safeStateResult.IsSuccess)
+        {
+            safeVersion = safeStateResult.GetValue().Version;
+        }
+
+        safeThreshold = _host.PeekCurrentSafeWindowThreshold();
+        try
+        {
+            var safeThresholdId = new SortableUniqueId(safeThreshold);
+            safeThresholdTime = safeThresholdId.GetDateTime();
+        }
+        catch { }
+
+        var unsafeStateResult = await _host.GetStateAsync(canGetUnsafeState: true);
+        if (unsafeStateResult.IsSuccess)
+        {
+            unsafeVersion = unsafeStateResult.GetValue().Version;
+        }
+
+        return new QueryExecutionMetadata(
+            safeVersion,
+            safeThreshold,
+            safeThresholdTime,
+            unsafeVersion,
+            isCatchUpInProgress);
+    }
+
+    private async Task<bool> PrepareForQueryExecutionAsync(bool waitForCatchUp)
+    {
+        await StartSubscriptionAsync();
+
+        if (_orleansStreamHandle == null || waitForCatchUp)
+        {
+            await CatchUpFromEventStoreAsync();
+        }
+
+        var isCatchUpInProgress = _catchUpProgress.IsActive;
+        if (waitForCatchUp && isCatchUpInProgress)
+        {
+            await WaitForCatchUpWithTimeoutAsync(TimeSpan.FromSeconds(30));
+            return _catchUpProgress.IsActive;
+        }
+
+        return isCatchUpInProgress;
     }
 
     public async Task<bool> IsSortableUniqueIdReceived(string sortableUniqueId)

--- a/dcb/src/Sekiban.Dcb.Orleans.Core/Grains/MultiProjectionGrain.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.Core/Grains/MultiProjectionGrain.cs
@@ -1250,7 +1250,20 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
         // Do not auto-catch-up here; catch-up will be triggered by state/query access
     }
 
-    public async Task<SerializableQueryResult> ExecuteQueryAsync(SerializableQueryParameter queryParameter)
+    public Task<SerializableQueryResult> ExecuteQueryAsync(SerializableQueryParameter queryParameter) =>
+        ExecuteQueryInternalAsync(queryParameter, waitForCatchUp: false);
+
+    public Task<SerializableQueryResult> ExecuteQueryAsync(SerializableQueryParameter queryParameter, bool waitForCatchUp) =>
+        ExecuteQueryInternalAsync(queryParameter, waitForCatchUp);
+
+    public Task<SerializableListQueryResult> ExecuteListQueryAsync(SerializableQueryParameter queryParameter) =>
+        ExecuteListQueryInternalAsync(queryParameter, waitForCatchUp: false);
+
+    public Task<SerializableListQueryResult> ExecuteListQueryAsync(SerializableQueryParameter queryParameter, bool waitForCatchUp) =>
+        ExecuteListQueryInternalAsync(queryParameter, waitForCatchUp);
+
+    private async Task<SerializableQueryResult> ExecuteQueryInternalAsync(
+        SerializableQueryParameter queryParameter, bool waitForCatchUp)
     {
         // Check health if FailOnUnhealthyActivation is enabled
         if (_injectedActorOptions?.FailOnUnhealthyActivation == true && !_activationHealthy)
@@ -1273,6 +1286,17 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
         {
             await StartSubscriptionAsync();
 
+            if (_orleansStreamHandle == null)
+            {
+                await CatchUpFromEventStoreAsync();
+            }
+
+            // Wait for catch-up if requested
+            if (waitForCatchUp && _catchUpProgress.IsActive)
+            {
+                await WaitForCatchUpWithTimeoutAsync(TimeSpan.FromSeconds(30));
+            }
+
             // Get safe/unsafe metadata for query context
             int? safeVersion = null;
             string? safeThreshold = null;
@@ -1299,11 +1323,6 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
                 unsafeVersion = unsafeStateResult.GetValue().Version;
             }
 
-            if (_orleansStreamHandle == null)
-            {
-                await CatchUpFromEventStoreAsync();
-            }
-
             var result = await _host.ExecuteQueryAsync(
                 queryParameter,
                 safeVersion,
@@ -1316,7 +1335,15 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
                 throw result.GetException();
             }
 
-            return result.GetValue();
+            var resultValue = result.GetValue();
+
+            // Enrich result with catch-up progress information
+            if (_catchUpProgress.IsActive)
+            {
+                resultValue = resultValue with { IsCatchUpInProgress = true };
+            }
+
+            return resultValue;
         }
         catch (Exception ex)
         {
@@ -1325,7 +1352,8 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
         }
     }
 
-    public async Task<SerializableListQueryResult> ExecuteListQueryAsync(SerializableQueryParameter queryParameter)
+    private async Task<SerializableListQueryResult> ExecuteListQueryInternalAsync(
+        SerializableQueryParameter queryParameter, bool waitForCatchUp)
     {
         // Check health if FailOnUnhealthyActivation is enabled
         if (_injectedActorOptions?.FailOnUnhealthyActivation == true && !_activationHealthy)
@@ -1348,6 +1376,17 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
         {
             await StartSubscriptionAsync();
 
+            if (_orleansStreamHandle == null)
+            {
+                await CatchUpFromEventStoreAsync();
+            }
+
+            // Wait for catch-up if requested
+            if (waitForCatchUp && _catchUpProgress.IsActive)
+            {
+                await WaitForCatchUpWithTimeoutAsync(TimeSpan.FromSeconds(30));
+            }
+
             // Get safe/unsafe metadata for query context
             int? safeVersion = null;
             string? safeThreshold = null;
@@ -1374,11 +1413,6 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
                 unsafeVersion = unsafeStateResult.GetValue().Version;
             }
 
-            if (_orleansStreamHandle == null)
-            {
-                await CatchUpFromEventStoreAsync();
-            }
-
             var result = await _host.ExecuteListQueryAsync(
                 queryParameter,
                 safeVersion,
@@ -1391,7 +1425,15 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
                 throw result.GetException();
             }
 
-            return result.GetValue();
+            var resultValue = result.GetValue();
+
+            // Enrich result with catch-up progress information
+            if (_catchUpProgress.IsActive)
+            {
+                resultValue = resultValue with { IsCatchUpInProgress = true };
+            }
+
+            return resultValue;
         }
         catch (Exception ex)
         {

--- a/dcb/src/Sekiban.Dcb.Orleans.Core/Serialization/SerializableListQueryResult.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.Core/Serialization/SerializableListQueryResult.cs
@@ -156,7 +156,8 @@ public sealed record SerializableListQueryResult
             listQueryResult.PageSize,
             items,
             recordTypeName,
-            originalQuery);
+            originalQuery,
+            listQueryResult.IsCatchUpInProgress);
 
         var serializable = await CreateFromAsync(listResultGeneral, options);
 

--- a/dcb/src/Sekiban.Dcb.Orleans.Core/Serialization/SerializableListQueryResult.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.Core/Serialization/SerializableListQueryResult.cs
@@ -40,6 +40,13 @@ public sealed record SerializableListQueryResult
     [Id(8)]
     public string ItemsAssemblyVersion { get; init; } = string.Empty;
 
+    /// <summary>
+    ///     Indicates whether the projection is still catching up from the event store.
+    ///     When true, the results may be incomplete or stale.
+    /// </summary>
+    [Id(9)]
+    public bool IsCatchUpInProgress { get; init; }
+
     public SerializableListQueryResult() { }
 
     private SerializableListQueryResult(
@@ -103,16 +110,19 @@ public sealed record SerializableListQueryResult
         var compressedItemsJson = await CompressAsync(itemsJson);
         var compressedQueryJson = await CompressAsync(queryJson);
 
-        return new SerializableListQueryResult(
-            result.TotalCount,
-            result.TotalPages,
-            result.CurrentPage,
-            result.PageSize,
-            recordTypeName,
-            queryType.AssemblyQualifiedName ?? queryType.FullName ?? queryType.Name,
-            compressedItemsJson,
-            compressedQueryJson,
-            itemsAssemblyVersion);
+        return new SerializableListQueryResult
+        {
+            TotalCount = result.TotalCount,
+            TotalPages = result.TotalPages,
+            CurrentPage = result.CurrentPage,
+            PageSize = result.PageSize,
+            RecordTypeName = recordTypeName,
+            QueryTypeName = queryType.AssemblyQualifiedName ?? queryType.FullName ?? queryType.Name,
+            CompressedItemsJson = compressedItemsJson,
+            CompressedQueryJson = compressedQueryJson,
+            ItemsAssemblyVersion = itemsAssemblyVersion,
+            IsCatchUpInProgress = result.IsCatchUpInProgress
+        };
     }
 
     public static async Task<ResultBox<SerializableListQueryResult>> CreateFromResultBoxAsync(
@@ -222,7 +232,8 @@ public sealed record SerializableListQueryResult
                 PageSize,
                 items,
                 RecordTypeName,
-                query);
+                query,
+                IsCatchUpInProgress);
 
             return ResultBox<ListQueryResultGeneral>.FromValue(listQueryResult);
         }

--- a/dcb/src/Sekiban.Dcb.Orleans.Core/Serialization/SerializableQueryResult.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.Core/Serialization/SerializableQueryResult.cs
@@ -28,6 +28,13 @@ public sealed record SerializableQueryResult
     [Id(4)]
     public string ResultAssemblyVersion { get; init; } = string.Empty;
 
+    /// <summary>
+    ///     Indicates whether the projection is still catching up from the event store.
+    ///     When true, the result may be incomplete or stale.
+    /// </summary>
+    [Id(5)]
+    public bool IsCatchUpInProgress { get; init; }
+
     public SerializableQueryResult() { }
 
     private SerializableQueryResult(

--- a/dcb/src/Sekiban.Dcb.Orleans.Core/Surrogates/ListQueryResultGeneralSurrogate.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.Core/Surrogates/ListQueryResultGeneralSurrogate.cs
@@ -19,4 +19,6 @@ public record struct ListQueryResultGeneralSurrogate(
     [property: Id(5)]
     string RecordType,
     [property: Id(6)]
-    IListQueryCommon Query);
+    IListQueryCommon Query,
+    [property: Id(7)]
+    bool IsCatchUpInProgress);

--- a/dcb/src/Sekiban.Dcb.Orleans.Core/Surrogates/ListQueryResultGeneralSurrogateConverter.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.Core/Surrogates/ListQueryResultGeneralSurrogateConverter.cs
@@ -16,7 +16,8 @@ public sealed class
             surrogate.PageSize,
             surrogate.Items,
             surrogate.RecordType,
-            surrogate.Query);
+            surrogate.Query,
+            surrogate.IsCatchUpInProgress);
 
     public ListQueryResultGeneralSurrogate ConvertToSurrogate(in ListQueryResultGeneral value) =>
         new(
@@ -26,5 +27,6 @@ public sealed class
             value.PageSize,
             value.Items,
             value.RecordType,
-            value.Query);
+            value.Query,
+            value.IsCatchUpInProgress);
 }

--- a/dcb/tests/Sekiban.Dcb.Orleans.Tests/CatchUpQueryAwarenessTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Orleans.Tests/CatchUpQueryAwarenessTests.cs
@@ -102,6 +102,9 @@ public class CatchUpQueryAwarenessTests : IAsyncLifetime
             await Task.Delay(200);
         }
 
+        var finalStatus = await grain.GetCatchUpStatusAsync();
+        Assert.False(finalStatus.IsActive, "Catch-up should complete within the polling timeout");
+
         // Execute list query — should return all items with IsCatchUpInProgress=false
         var domainTypes = CreateDomainTypes();
         var query = new CountingListQuery();

--- a/dcb/tests/Sekiban.Dcb.Orleans.Tests/CatchUpQueryAwarenessTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Orleans.Tests/CatchUpQueryAwarenessTests.cs
@@ -1,0 +1,294 @@
+using Microsoft.Extensions.DependencyInjection;
+using Orleans.TestingHost;
+using ResultBoxes;
+using Sekiban.Dcb;
+using Sekiban.Dcb.Actors;
+using Sekiban.Dcb.Common;
+using Sekiban.Dcb.Domains;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.InMemory;
+using Sekiban.Dcb.MultiProjections;
+using Sekiban.Dcb.Orleans;
+using Sekiban.Dcb.Orleans.Grains;
+using Sekiban.Dcb.Orleans.Serialization;
+using Sekiban.Dcb.Orleans.Streams;
+using Sekiban.Dcb.Queries;
+using Sekiban.Dcb.Storage;
+using Sekiban.Dcb.Tags;
+using System.Text;
+using System.Text.Json;
+using Xunit;
+
+namespace Sekiban.Dcb.Orleans.Tests;
+
+/// <summary>
+///     Tests verifying that query results include IsCatchUpInProgress flag
+///     and that the waitForCatchUp parameter works correctly.
+/// </summary>
+public class CatchUpQueryAwarenessTests : IAsyncLifetime
+{
+    private static readonly InMemoryEventStore SharedEventStore = new();
+    private TestCluster _cluster = null!;
+    private IClusterClient _client => _cluster.Client;
+
+    public async Task InitializeAsync()
+    {
+        SharedEventStore.Clear();
+
+        var builder = new TestClusterBuilder();
+        builder.Options.InitialSilosCount = 1;
+        var uniqueId = Guid.NewGuid().ToString("N")[..8];
+        builder.Options.ClusterId = $"CatchUpTest-{uniqueId}";
+        builder.Options.ServiceId = $"CatchUpTestSvc-{uniqueId}";
+        builder.AddSiloBuilderConfigurator<CatchUpTestSiloConfigurator>();
+
+        _cluster = builder.Build();
+        await _cluster.DeployAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _cluster.StopAllSilosAsync();
+        _cluster.Dispose();
+    }
+
+    [Fact]
+    public async Task ListQuery_WithWaitForCatchUp_ReturnsAllResults()
+    {
+        const int eventCount = 200;
+        var grain = _client.GetGrain<IMultiProjectionGrain>("catchup-counter");
+
+        // Seed events into the event store
+        var events = CreateTestEvents(eventCount);
+        await grain.SeedEventsAsync(ToSerializableEvents(events));
+
+        // Request deactivation to simulate restart
+        await grain.RequestDeactivationAsync();
+        await Task.Delay(2000); // Allow deactivation to complete
+
+        // Execute list query WITH waitForCatchUp — should return all items
+        var domainTypes = CreateDomainTypes();
+        var query = new CountingListQuery();
+        var serializableQuery = await SerializableQueryParameter.CreateFromAsync(
+            query, domainTypes.JsonSerializerOptions);
+
+        var result = await grain.ExecuteListQueryAsync(serializableQuery, waitForCatchUp: true);
+
+        // Verify we got all results and catch-up is complete
+        Assert.NotNull(result);
+        Assert.False(result.IsCatchUpInProgress, "IsCatchUpInProgress should be false after waitForCatchUp");
+        Assert.Equal(eventCount, result.TotalCount);
+    }
+
+    [Fact]
+    public async Task ListQuery_AfterNaturalCatchUp_ReturnsIsCatchUpInProgressFalse()
+    {
+        const int eventCount = 50;
+        var grain = _client.GetGrain<IMultiProjectionGrain>("catchup-counter");
+
+        // Seed events and let catch-up complete
+        var events = CreateTestEvents(eventCount);
+        await grain.SeedEventsAsync(ToSerializableEvents(events));
+
+        // Wait for catch-up to complete via RefreshAsync and polling
+        await grain.RefreshAsync();
+
+        // Poll until catch-up completes or timeout
+        var deadline = DateTime.UtcNow.AddSeconds(15);
+        while (DateTime.UtcNow < deadline)
+        {
+            var status = await grain.GetCatchUpStatusAsync();
+            if (!status.IsActive) break;
+            await Task.Delay(200);
+        }
+
+        // Execute list query — should return all items with IsCatchUpInProgress=false
+        var domainTypes = CreateDomainTypes();
+        var query = new CountingListQuery();
+        var serializableQuery = await SerializableQueryParameter.CreateFromAsync(
+            query, domainTypes.JsonSerializerOptions);
+
+        var result = await grain.ExecuteListQueryAsync(serializableQuery);
+
+        Assert.NotNull(result);
+        Assert.False(result.IsCatchUpInProgress, "IsCatchUpInProgress should be false after catch-up completes");
+        Assert.Equal(eventCount, result.TotalCount);
+    }
+
+    [Fact]
+    public async Task ListQuery_DefaultBehavior_DoesNotBlock()
+    {
+        const int eventCount = 200;
+        var grain = _client.GetGrain<IMultiProjectionGrain>("catchup-counter");
+
+        // Seed events
+        var events = CreateTestEvents(eventCount);
+        await grain.SeedEventsAsync(ToSerializableEvents(events));
+
+        // Request deactivation to simulate restart
+        await grain.RequestDeactivationAsync();
+        await Task.Delay(2000);
+
+        // Execute the original single-parameter overload — should return immediately (not block)
+        var domainTypes = CreateDomainTypes();
+        var query = new CountingListQuery();
+        var serializableQuery = await SerializableQueryParameter.CreateFromAsync(
+            query, domainTypes.JsonSerializerOptions);
+
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        var result = await grain.ExecuteListQueryAsync(serializableQuery);
+        sw.Stop();
+
+        // The call should return quickly (not wait 30 seconds)
+        Assert.NotNull(result);
+        // We accept any result — the key is that it doesn't block for 30 seconds
+        Assert.True(sw.ElapsedMilliseconds < 25000, "Default behavior should not block for catch-up");
+    }
+
+    // --- Test domain types ---
+
+    private static List<Event> CreateTestEvents(int count)
+    {
+        var baseTick = DateTime.UtcNow.Ticks;
+        return Enumerable.Range(0, count)
+            .Select(i => new Event(
+                new CounterIncrementedEvent(i),
+                new SortableUniqueId(
+                    SortableUniqueId.GetTickString(baseTick + i) +
+                    SortableUniqueId.GetIdString(Guid.Empty)),
+                nameof(CounterIncrementedEvent),
+                Guid.CreateVersion7(),
+                new EventMetadata(
+                    Guid.NewGuid().ToString(),
+                    Guid.NewGuid().ToString(),
+                    "test"),
+                new List<string>()))
+            .ToList();
+    }
+
+    private static IReadOnlyList<SerializableEvent> ToSerializableEvents(IEnumerable<Event> events) =>
+        events
+            .Select(e => new SerializableEvent(
+                Encoding.UTF8.GetBytes(JsonSerializer.Serialize(e.Payload, e.Payload.GetType())),
+                e.SortableUniqueIdValue,
+                e.Id,
+                e.EventMetadata,
+                e.Tags.ToList(),
+                e.EventType))
+            .ToList();
+
+    internal static DcbDomainTypes CreateDomainTypes()
+    {
+        var eventTypes = new SimpleEventTypes();
+        eventTypes.RegisterEventType<CounterIncrementedEvent>();
+
+        var tagTypes = new SimpleTagTypes();
+        var tagProjectorTypes = new SimpleTagProjectorTypes();
+        var tagStatePayloadTypes = new SimpleTagStatePayloadTypes();
+
+        var multiProjectorTypes = new SimpleMultiProjectorTypes();
+        multiProjectorTypes.RegisterProjector<CatchUpCountingProjector>();
+
+        var queryTypes = new SimpleQueryTypes();
+        queryTypes.RegisterListQuery<CatchUpCountingProjector, CountingListQuery, CountItem>();
+
+        return new DcbDomainTypes(
+            eventTypes,
+            tagTypes,
+            tagProjectorTypes,
+            tagStatePayloadTypes,
+            multiProjectorTypes,
+            queryTypes,
+            new JsonSerializerOptions
+            {
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+                WriteIndented = false
+            });
+    }
+
+    // --- Event ---
+    public record CounterIncrementedEvent(int Value) : IEventPayload;
+
+    // --- Multi-projector that counts events ---
+    public record CatchUpCountingProjector : IMultiProjector<CatchUpCountingProjector>
+    {
+        public int Count { get; init; }
+        public CatchUpCountingProjector() => Count = 0;
+
+        public static string MultiProjectorVersion => "1.0";
+        public static string MultiProjectorName => "catchup-counter";
+
+        public static CatchUpCountingProjector GenerateInitialPayload() => new();
+
+        public static ResultBox<CatchUpCountingProjector> Project(
+            CatchUpCountingProjector payload,
+            Event ev,
+            List<ITag> tags,
+            DcbDomainTypes domainTypes,
+            SortableUniqueId safeWindowThreshold) =>
+            ResultBox.FromValue(new CatchUpCountingProjector { Count = payload.Count + 1 });
+    }
+
+    // --- Query result item ---
+    public record CountItem(int Value);
+
+    // --- List query ---
+    public sealed record CountingListQuery(
+        int? PageNumber = null,
+        int? PageSize = null
+    ) : ICoreMultiProjectionListQuery<CatchUpCountingProjector, CountingListQuery, CountItem>,
+        IQueryPagingParameter,
+        IEquatable<CountingListQuery>
+    {
+        public static ResultBox<IEnumerable<CountItem>> HandleFilter(
+            CatchUpCountingProjector projector,
+            CountingListQuery query,
+            IQueryContext context)
+        {
+            // Return one item per counted event
+            var items = Enumerable.Range(0, projector.Count)
+                .Select(i => new CountItem(i));
+            return ResultBox.FromValue(items);
+        }
+
+        public static ResultBox<IEnumerable<CountItem>> HandleSort(
+            IEnumerable<CountItem> filteredList,
+            CountingListQuery query,
+            IQueryContext context) =>
+            ResultBox.FromValue(filteredList.OrderBy(item => item.Value).AsEnumerable());
+    }
+
+    // --- Silo configurator ---
+    private class CatchUpTestSiloConfigurator : ISiloConfigurator
+    {
+        public void Configure(ISiloBuilder siloBuilder)
+        {
+            siloBuilder
+                .ConfigureServices(services =>
+                {
+                    services.AddSingleton<DcbDomainTypes>(_ => CreateDomainTypes());
+                    services.AddSingleton<IEventStore>(SharedEventStore);
+                    services.AddSingleton<IMultiProjectionStateStore, InMemoryMultiProjectionStateStore>();
+                    services.AddSingleton<IEventSubscriptionResolver>(
+                        new DefaultOrleansEventSubscriptionResolver(
+                            "EventStreamProvider", "AllEvents", Guid.Empty));
+                    services.AddSingleton<IActorObjectAccessor, OrleansActorObjectAccessor>();
+                    services.AddSingleton<Sekiban.Dcb.Snapshots.IBlobStorageSnapshotAccessor,
+                        MockBlobStorageSnapshotAccessor>();
+                    services.AddTransient<IMultiProjectionEventStatistics,
+                        NoOpMultiProjectionEventStatistics>();
+                    services.AddTransient<GeneralMultiProjectionActorOptions>(_ =>
+                        new GeneralMultiProjectionActorOptions
+                        {
+                            SafeWindowMs = 20000
+                        });
+                    services.AddSekibanDcbNativeRuntime();
+                })
+                .AddMemoryGrainStorageAsDefault()
+                .AddMemoryGrainStorage("OrleansStorage")
+                .AddMemoryGrainStorage("PubSubStore")
+                .AddMemoryStreams("EventStreamProvider")
+                .AddMemoryGrainStorage("EventStreamProvider");
+        }
+    }
+}

--- a/dcb/tests/Sekiban.Dcb.Orleans.Tests/SerializableQuerySerializationTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Orleans.Tests/SerializableQuerySerializationTests.cs
@@ -67,7 +67,8 @@ public class SerializableQuerySerializationTests
             10,
             items,
             typeof(TestRecord).AssemblyQualifiedName ?? typeof(TestRecord).FullName ?? nameof(TestRecord),
-            query);
+            query,
+            true);
 
         var serialized = await SerializableListQueryResult.CreateFromAsync(
             general,
@@ -78,6 +79,36 @@ public class SerializableQuerySerializationTests
         var typedBox = roundTripBox.GetValue().ToTypedResult<TestRecord>();
         Assert.True(typedBox.IsSuccess);
         Assert.Equal(items.Cast<TestRecord>(), typedBox.GetValue().Items);
+        Assert.True(typedBox.GetValue().IsCatchUpInProgress);
+    }
+
+    [Fact]
+    public async Task SerializableListQueryResult_CreateFromResultBox_PreservesCatchUpFlag()
+    {
+        var query = new TestListQuery(PageNumber: 1, PageSize: 10);
+        IListQueryResult result = new ListQueryResultGeneral(
+            2,
+            1,
+            1,
+            10,
+            [new TestRecord("alpha"), new TestRecord("beta")],
+            typeof(TestRecord).AssemblyQualifiedName ?? typeof(TestRecord).FullName ?? nameof(TestRecord),
+            query,
+            true);
+
+        var serializedBox = await SerializableListQueryResult.CreateFromResultBoxAsync(
+            ResultBox<IListQueryResult>.FromValue(result),
+            query,
+            _domainTypes.JsonSerializerOptions);
+
+        Assert.True(serializedBox.IsSuccess);
+
+        var roundTripBox = await serializedBox.GetValue().ToListQueryResultAsync(_domainTypes);
+        Assert.True(roundTripBox.IsSuccess);
+
+        var typedBox = roundTripBox.GetValue().ToTypedResult<TestRecord>();
+        Assert.True(typedBox.IsSuccess);
+        Assert.True(typedBox.GetValue().IsCatchUpInProgress);
     }
 
     private static DcbDomainTypes CreateDomainTypes() =>


### PR DESCRIPTION
## Summary
- After grain restart, `ExecuteListQueryAsync` and `ExecuteQueryAsync` returned partial results during catch-up with **no indication** to the caller
- `GetStateAsync` already had `waitForCatchUp` support, but query methods did not — this was a design gap
- Adds `IsCatchUpInProgress` flag to all query result types so callers can detect incomplete data
- Adds `waitForCatchUp` overloads to `ExecuteQueryAsync` and `ExecuteListQueryAsync` on `IMultiProjectionGrain`
- Default behavior is unchanged (no waiting, fully backward compatible)

## Changes
| File | Change |
|------|--------|
| `IListQueryResult.cs` | Add `IsCatchUpInProgress` default property |
| `ListQueryResult<T>.cs` | Add `IsCatchUpInProgress` parameter |
| `ListQueryResultGeneral.cs` | Add `IsCatchUpInProgress` parameter, propagate in `ToTypedResult<T>()` |
| `SerializableListQueryResult.cs` | Add `[Id(9)] IsCatchUpInProgress`, propagate in serialization/deserialization |
| `SerializableQueryResult.cs` | Add `[Id(5)] IsCatchUpInProgress` for single-query symmetry |
| `IMultiProjectionGrain.cs` | Add `waitForCatchUp` overloads for `ExecuteQueryAsync` and `ExecuteListQueryAsync` |
| `MultiProjectionGrain.cs` | Implement `waitForCatchUp` using existing `WaitForCatchUpWithTimeoutAsync`, enrich results with `IsCatchUpInProgress` |
| `CatchUpQueryAwarenessTests.cs` | 3 test cases verifying catch-up awareness behavior |

## Test plan
- [x] `ListQuery_WithWaitForCatchUp_ReturnsAllResults` — verifies waitForCatchUp blocks and returns complete results
- [x] `ListQuery_AfterNaturalCatchUp_ReturnsIsCatchUpInProgressFalse` — verifies flag is false after natural completion
- [x] `ListQuery_DefaultBehavior_DoesNotBlock` — verifies backward compatibility (no blocking)
- [x] All 67 existing Orleans tests pass
- [x] All 484 WithResult tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)