### PR TITLE
[codex] Fix restored generic tag wrapper state

### DIFF
--- a/dcb/src/Sekiban.Dcb.Core/Actors/GeneralMultiProjectionActor.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Actors/GeneralMultiProjectionActor.cs
@@ -163,12 +163,11 @@ public class GeneralMultiProjectionActor
         }
         else
         {
-            _singleStateAccessor = DualStateProjectionWrapperFactory.Create(
+            _singleStateAccessor = DualStateProjectionWrapperFactory.CreateFromRestoredSnapshot(
                 loadedPayload,
                 _projectorName,
                 _types,
                 _jsonOptions,
-                isRestoredFromSnapshot: true,
                 initialVersion: state.Version,
                 initialLastEventId: state.LastEventId,
                 initialLastSortableUniqueId: state.LastSortableUniqueId);

--- a/dcb/src/Sekiban.Dcb.Core/Actors/GeneralMultiProjectionActor.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Actors/GeneralMultiProjectionActor.cs
@@ -167,7 +167,8 @@ public class GeneralMultiProjectionActor
                 loadedPayload,
                 _projectorName,
                 _types,
-                _jsonOptions,
+                _domain,
+                safeThreshold.Value,
                 initialVersion: state.Version,
                 initialLastEventId: state.LastEventId,
                 initialLastSortableUniqueId: state.LastSortableUniqueId);

--- a/dcb/src/Sekiban.Dcb.Core/MultiProjections/DualStateProjectionWrapper.cs
+++ b/dcb/src/Sekiban.Dcb.Core/MultiProjections/DualStateProjectionWrapper.cs
@@ -74,7 +74,12 @@ public class DualStateProjectionWrapper<T> : ISafeAndUnsafeStateAccessor<T>, IMu
     {
         _jsonOptions = jsonOptions;
         _safeProjector = initialProjector;
-        _unsafeProjector = CloneProjector(initialProjector, jsonOptions);
+        // Snapshot restore already provides a fully materialized safe projection.
+        // Re-cloning through generic JSON serialization can silently drop state for
+        // custom-serialized projectors such as GenericTagMultiProjector.
+        _unsafeProjector = isRestoredFromSnapshot
+            ? initialProjector
+            : CloneProjector(initialProjector, jsonOptions);
         _projectorName = projectorName;
         _types = types;
         _useIncrementalSafePromotion = isRestoredFromSnapshot;

--- a/dcb/src/Sekiban.Dcb.Core/MultiProjections/DualStateProjectionWrapper.cs
+++ b/dcb/src/Sekiban.Dcb.Core/MultiProjections/DualStateProjectionWrapper.cs
@@ -50,41 +50,40 @@ public class DualStateProjectionWrapper<T> : ISafeAndUnsafeStateAccessor<T>, IMu
         int initialVersion = 0,
         Guid initialLastEventId = default,
         string? initialLastSortableUniqueId = null)
-        : this(
-            initialProjector,
-            projectorName,
-            types,
-            jsonOptions,
-            initialVersion,
-            initialLastEventId,
-            initialLastSortableUniqueId,
-            false)
     {
+        _jsonOptions = jsonOptions;
+        _safeProjector = initialProjector;
+        _projectorName = projectorName;
+        _types = types;
+        _unsafeProjector = CloneProjector(initialProjector, jsonOptions);
+        _useIncrementalSafePromotion = false;
+
+        // Initialize version tracking
+        _safeVersion = initialVersion;
+        _unsafeVersion = initialVersion;
+        _safeLastEventId = initialLastEventId;
+        _unsafeLastEventId = initialLastEventId;
+        _safeLastSortableUniqueId = initialLastSortableUniqueId ?? string.Empty;
+        _unsafeLastSortableUniqueId = initialLastSortableUniqueId ?? string.Empty;
     }
 
     internal DualStateProjectionWrapper(
-        T initialProjector,
+        T safeProjector,
+        T unsafeProjector,
         string projectorName,
         ICoreMultiProjectorTypes types,
         JsonSerializerOptions jsonOptions,
         int initialVersion,
         Guid initialLastEventId,
-        string? initialLastSortableUniqueId,
-        bool isRestoredFromSnapshot)
+        string? initialLastSortableUniqueId)
     {
         _jsonOptions = jsonOptions;
-        _safeProjector = initialProjector;
-        // Snapshot restore already provides a fully materialized safe projection.
-        // Re-cloning through generic JSON serialization can silently drop state for
-        // custom-serialized projectors such as GenericTagMultiProjector.
-        _unsafeProjector = isRestoredFromSnapshot
-            ? initialProjector
-            : CloneProjector(initialProjector, jsonOptions);
+        _safeProjector = safeProjector;
+        _unsafeProjector = unsafeProjector;
         _projectorName = projectorName;
         _types = types;
-        _useIncrementalSafePromotion = isRestoredFromSnapshot;
+        _useIncrementalSafePromotion = true;
 
-        // Initialize version tracking
         _safeVersion = initialVersion;
         _unsafeVersion = initialVersion;
         _safeLastEventId = initialLastEventId;

--- a/dcb/src/Sekiban.Dcb.Core/MultiProjections/DualStateProjectionWrapper.cs
+++ b/dcb/src/Sekiban.Dcb.Core/MultiProjections/DualStateProjectionWrapper.cs
@@ -62,7 +62,7 @@ public class DualStateProjectionWrapper<T> : ISafeAndUnsafeStateAccessor<T>, IMu
     {
     }
 
-    public DualStateProjectionWrapper(
+    internal DualStateProjectionWrapper(
         T initialProjector,
         string projectorName,
         ICoreMultiProjectorTypes types,

--- a/dcb/src/Sekiban.Dcb.Core/MultiProjections/DualStateProjectionWrapperFactory.cs
+++ b/dcb/src/Sekiban.Dcb.Core/MultiProjections/DualStateProjectionWrapperFactory.cs
@@ -1,4 +1,5 @@
 using Sekiban.Dcb.Domains;
+using System.Reflection;
 using System.Text.Json;
 
 namespace Sekiban.Dcb.MultiProjections;
@@ -15,10 +16,46 @@ public static class DualStateProjectionWrapperFactory
         string projectorName,
         ICoreMultiProjectorTypes multiProjectorTypes,
         JsonSerializerOptions jsonOptions,
-        bool isRestoredFromSnapshot = false,
         int initialVersion = 0,
         Guid initialLastEventId = default,
         string? initialLastSortableUniqueId = null)
+        => CreateCore(
+            payload,
+            projectorName,
+            multiProjectorTypes,
+            jsonOptions,
+            initialVersion,
+            initialLastEventId,
+            initialLastSortableUniqueId,
+            false);
+
+    public static IMultiProjectionPayload? CreateFromRestoredSnapshot(
+        IMultiProjectionPayload payload,
+        string projectorName,
+        ICoreMultiProjectorTypes multiProjectorTypes,
+        JsonSerializerOptions jsonOptions,
+        int initialVersion = 0,
+        Guid initialLastEventId = default,
+        string? initialLastSortableUniqueId = null)
+        => CreateCore(
+            payload,
+            projectorName,
+            multiProjectorTypes,
+            jsonOptions,
+            initialVersion,
+            initialLastEventId,
+            initialLastSortableUniqueId,
+            true);
+
+    private static IMultiProjectionPayload? CreateCore(
+        IMultiProjectionPayload payload,
+        string projectorName,
+        ICoreMultiProjectorTypes multiProjectorTypes,
+        JsonSerializerOptions jsonOptions,
+        int initialVersion,
+        Guid initialLastEventId,
+        string? initialLastSortableUniqueId,
+        bool isRestoredFromSnapshot)
     {
         var wrapperType = typeof(DualStateProjectionWrapper<>).MakeGenericType(payload.GetType());
 
@@ -26,14 +63,20 @@ public static class DualStateProjectionWrapperFactory
         {
             return Activator.CreateInstance(
                 wrapperType,
-                payload,
-                projectorName,
-                multiProjectorTypes,
-                jsonOptions,
-                initialVersion,
-                initialLastEventId,
-                initialLastSortableUniqueId,
-                true) as IMultiProjectionPayload;
+                BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
+                binder: null,
+                args:
+                [
+                    payload,
+                    projectorName,
+                    multiProjectorTypes,
+                    jsonOptions,
+                    initialVersion,
+                    initialLastEventId,
+                    initialLastSortableUniqueId,
+                    true
+                ],
+                culture: null) as IMultiProjectionPayload;
         }
 
         return Activator.CreateInstance(

--- a/dcb/src/Sekiban.Dcb.Core/MultiProjections/DualStateProjectionWrapperFactory.cs
+++ b/dcb/src/Sekiban.Dcb.Core/MultiProjections/DualStateProjectionWrapperFactory.cs
@@ -26,26 +26,43 @@ public static class DualStateProjectionWrapperFactory
             jsonOptions,
             initialVersion,
             initialLastEventId,
-            initialLastSortableUniqueId,
-            false);
+            initialLastSortableUniqueId);
 
     public static IMultiProjectionPayload? CreateFromRestoredSnapshot(
         IMultiProjectionPayload payload,
         string projectorName,
         ICoreMultiProjectorTypes multiProjectorTypes,
-        JsonSerializerOptions jsonOptions,
+        DcbDomainTypes domainTypes,
+        string safeWindowThreshold,
         int initialVersion = 0,
         Guid initialLastEventId = default,
         string? initialLastSortableUniqueId = null)
-        => CreateCore(
+    {
+        var clonedPayload = CloneRestoredPayload(
             payload,
             projectorName,
             multiProjectorTypes,
-            jsonOptions,
-            initialVersion,
-            initialLastEventId,
-            initialLastSortableUniqueId,
-            true);
+            domainTypes,
+            safeWindowThreshold);
+
+        var wrapperType = typeof(DualStateProjectionWrapper<>).MakeGenericType(payload.GetType());
+        return Activator.CreateInstance(
+            wrapperType,
+            BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
+            binder: null,
+            args:
+            [
+                payload,
+                clonedPayload,
+                projectorName,
+                multiProjectorTypes,
+                domainTypes.JsonSerializerOptions,
+                initialVersion,
+                initialLastEventId,
+                initialLastSortableUniqueId
+            ],
+            culture: null) as IMultiProjectionPayload;
+    }
 
     private static IMultiProjectionPayload? CreateCore(
         IMultiProjectionPayload payload,
@@ -54,30 +71,9 @@ public static class DualStateProjectionWrapperFactory
         JsonSerializerOptions jsonOptions,
         int initialVersion,
         Guid initialLastEventId,
-        string? initialLastSortableUniqueId,
-        bool isRestoredFromSnapshot)
+        string? initialLastSortableUniqueId)
     {
         var wrapperType = typeof(DualStateProjectionWrapper<>).MakeGenericType(payload.GetType());
-
-        if (isRestoredFromSnapshot)
-        {
-            return Activator.CreateInstance(
-                wrapperType,
-                BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
-                binder: null,
-                args:
-                [
-                    payload,
-                    projectorName,
-                    multiProjectorTypes,
-                    jsonOptions,
-                    initialVersion,
-                    initialLastEventId,
-                    initialLastSortableUniqueId,
-                    true
-                ],
-                culture: null) as IMultiProjectionPayload;
-        }
 
         return Activator.CreateInstance(
             wrapperType,
@@ -88,5 +84,35 @@ public static class DualStateProjectionWrapperFactory
             initialVersion,
             initialLastEventId,
             initialLastSortableUniqueId) as IMultiProjectionPayload;
+    }
+
+    private static IMultiProjectionPayload CloneRestoredPayload(
+        IMultiProjectionPayload payload,
+        string projectorName,
+        ICoreMultiProjectorTypes multiProjectorTypes,
+        DcbDomainTypes domainTypes,
+        string safeWindowThreshold)
+    {
+        var serializeResult = multiProjectorTypes.Serialize(
+            projectorName,
+            domainTypes,
+            safeWindowThreshold,
+            payload);
+        if (!serializeResult.IsSuccess)
+        {
+            throw serializeResult.GetException();
+        }
+
+        var deserializeResult = multiProjectorTypes.Deserialize(
+            projectorName,
+            domainTypes,
+            safeWindowThreshold,
+            serializeResult.GetValue().Data);
+        if (!deserializeResult.IsSuccess)
+        {
+            throw deserializeResult.GetException();
+        }
+
+        return deserializeResult.GetValue();
     }
 }

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/DualStateProjectionWrapperCloneTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/DualStateProjectionWrapperCloneTests.cs
@@ -104,7 +104,8 @@ public class DualStateProjectionWrapperCloneTests
             restoredProjector,
             CamelCaseProjector.MultiProjectorName,
             _multiProjectorTypes,
-            _camelCaseOptions,
+            _domainTypes,
+            "000000000000000000000000000000000000000000000000",
             initialVersion: 5,
             initialLastEventId: Guid.NewGuid(),
             initialLastSortableUniqueId: null));

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/DualStateProjectionWrapperCloneTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/DualStateProjectionWrapperCloneTests.cs
@@ -90,7 +90,7 @@ public class DualStateProjectionWrapperCloneTests
     }
 
     [Fact]
-    public void Constructor_ShouldCloneWithSnapshotRestore_WhenRestoredFromSnapshot()
+    public void Factory_ShouldPreservePayload_WhenRestoredFromSnapshot()
     {
         // Given: a projector with nested data, simulating snapshot restore
         var restoredProjector = new CamelCaseProjector
@@ -98,16 +98,16 @@ public class DualStateProjectionWrapperCloneTests
             Detail = new NestedDetail("Restored", 999)
         };
 
-        // When: constructing the wrapper as if restored from snapshot
-        var wrapper = new DualStateProjectionWrapper<CamelCaseProjector>(
+        // When: wrapping the restored payload through the snapshot-specific factory
+        var wrapper = Assert.IsType<DualStateProjectionWrapper<CamelCaseProjector>>(
+            DualStateProjectionWrapperFactory.CreateFromRestoredSnapshot(
             restoredProjector,
             CamelCaseProjector.MultiProjectorName,
             _multiProjectorTypes,
             _camelCaseOptions,
             initialVersion: 5,
             initialLastEventId: Guid.NewGuid(),
-            initialLastSortableUniqueId: null,
-            isRestoredFromSnapshot: true);
+            initialLastSortableUniqueId: null));
 
         // Then: construction succeeds and data is preserved
         var unsafeProjection = wrapper.GetUnsafeProjection(_domainTypes);

--- a/dcb/tests/Sekiban.Dcb.WithoutResult.Tests/GenericTagMultiProjectorSerializationTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithoutResult.Tests/GenericTagMultiProjectorSerializationTests.cs
@@ -130,6 +130,56 @@ public class GenericTagMultiProjectorSerializationTests
         Assert.Equal(deleted.SortableUniqueIdValue, unsafeProjectionAfter.LastSortableUniqueId);
     }
 
+    [Fact]
+    public void RestoredSnapshot_WrapperPreservesUnsafeState_ForGenericTagMultiProjector()
+    {
+        var forecastId = Guid.NewGuid();
+        var eventTime = new DateTime(2024, 1, 1, 12, 0, 0, DateTimeKind.Utc);
+        var safeThreshold = SortableUniqueId.Generate(eventTime.AddSeconds(20), Guid.Empty);
+        var weatherEvent = CreateEvent(
+            new WeatherForecastCreated(
+                forecastId,
+                "Tokyo",
+                DateOnly.FromDateTime(eventTime),
+                20,
+                "Sunny"),
+            eventTime,
+            forecastId) with { Tags = new List<string>() };
+
+        var projected = GenericTagMultiProjector<WeatherForecastProjector, WeatherForecastTag>.Project(
+            GenericTagMultiProjector<WeatherForecastProjector, WeatherForecastTag>.GenerateInitialPayload(),
+            weatherEvent,
+            new List<ITag> { new WeatherForecastTag(forecastId) },
+            _domainTypes,
+            safeThreshold);
+
+        var serialized = GenericTagMultiProjector<WeatherForecastProjector, WeatherForecastTag>.Serialize(
+            _domainTypes,
+            safeThreshold,
+            projected);
+        var deserialized = GenericTagMultiProjector<WeatherForecastProjector, WeatherForecastTag>.Deserialize(
+            _domainTypes,
+            safeThreshold,
+            serialized.Data);
+
+        var wrapper = new DualStateProjectionWrapper<GenericTagMultiProjector<WeatherForecastProjector, WeatherForecastTag>>(
+            deserialized,
+            GenericTagMultiProjector<WeatherForecastProjector, WeatherForecastTag>.MultiProjectorName,
+            (ICoreMultiProjectorTypes)_domainTypes.MultiProjectorTypes,
+            _domainTypes.JsonSerializerOptions,
+            initialVersion: 1,
+            initialLastEventId: weatherEvent.Id,
+            initialLastSortableUniqueId: weatherEvent.SortableUniqueIdValue,
+            isRestoredFromSnapshot: true);
+
+        var unsafeProjection = wrapper.GetUnsafeProjection(_domainTypes);
+        var restoredStates = unsafeProjection.State.GetCurrentTagStates();
+
+        Assert.Single(restoredStates);
+        Assert.Contains(forecastId, restoredStates.Keys);
+        Assert.Equal(20, Assert.IsType<WeatherForecastState>(restoredStates[forecastId].Payload).TemperatureC);
+    }
+
     private static Event CreateEvent(IEventPayload payload, DateTime timestamp, Guid forecastId)
     {
         var eventId = Guid.NewGuid();

--- a/dcb/tests/Sekiban.Dcb.WithoutResult.Tests/GenericTagMultiProjectorSerializationTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithoutResult.Tests/GenericTagMultiProjectorSerializationTests.cs
@@ -131,7 +131,7 @@ public class GenericTagMultiProjectorSerializationTests
     }
 
     [Fact]
-    public void RestoredSnapshot_WrapperPreservesUnsafeState_ForGenericTagMultiProjector()
+    public void RestoredSnapshot_WrapperPreservesTagStates_ForGenericTagMultiProjector()
     {
         var forecastId = Guid.NewGuid();
         var eventTime = new DateTime(2024, 1, 1, 12, 0, 0, DateTimeKind.Utc);
@@ -167,7 +167,8 @@ public class GenericTagMultiProjectorSerializationTests
             deserialized,
             GenericTagMultiProjector<WeatherForecastProjector, WeatherForecastTag>.MultiProjectorName,
             (ICoreMultiProjectorTypes)_domainTypes.MultiProjectorTypes,
-            _domainTypes.JsonSerializerOptions,
+            _domainTypes,
+            safeThreshold,
             initialVersion: 1,
             initialLastEventId: weatherEvent.Id,
             initialLastSortableUniqueId: weatherEvent.SortableUniqueIdValue));
@@ -236,7 +237,8 @@ public class GenericTagMultiProjectorSerializationTests
             deserialized,
             GenericTagMultiProjector<WeatherForecastProjector, WeatherForecastTag>.MultiProjectorName,
             (ICoreMultiProjectorTypes)_domainTypes.MultiProjectorTypes,
-            _domainTypes.JsonSerializerOptions,
+            _domainTypes,
+            safeThreshold,
             initialVersion: 3,
             initialLastEventId: lastEvent.Id,
             initialLastSortableUniqueId: lastEvent.SortableUniqueIdValue));

--- a/dcb/tests/Sekiban.Dcb.WithoutResult.Tests/GenericTagMultiProjectorSerializationTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithoutResult.Tests/GenericTagMultiProjectorSerializationTests.cs
@@ -162,15 +162,15 @@ public class GenericTagMultiProjectorSerializationTests
             safeThreshold,
             serialized.Data);
 
-        var wrapper = new DualStateProjectionWrapper<GenericTagMultiProjector<WeatherForecastProjector, WeatherForecastTag>>(
+        var wrapper = Assert.IsType<DualStateProjectionWrapper<GenericTagMultiProjector<WeatherForecastProjector, WeatherForecastTag>>>(
+            DualStateProjectionWrapperFactory.CreateFromRestoredSnapshot(
             deserialized,
             GenericTagMultiProjector<WeatherForecastProjector, WeatherForecastTag>.MultiProjectorName,
             (ICoreMultiProjectorTypes)_domainTypes.MultiProjectorTypes,
             _domainTypes.JsonSerializerOptions,
             initialVersion: 1,
             initialLastEventId: weatherEvent.Id,
-            initialLastSortableUniqueId: weatherEvent.SortableUniqueIdValue,
-            isRestoredFromSnapshot: true);
+            initialLastSortableUniqueId: weatherEvent.SortableUniqueIdValue));
 
         var unsafeProjection = wrapper.GetUnsafeProjection(_domainTypes);
         var restoredStates = unsafeProjection.State.GetCurrentTagStates();
@@ -231,15 +231,15 @@ public class GenericTagMultiProjectorSerializationTests
             lastForecast.Time,
             lastForecast.Id);
 
-        var wrapper = new DualStateProjectionWrapper<GenericTagMultiProjector<WeatherForecastProjector, WeatherForecastTag>>(
+        var wrapper = Assert.IsType<DualStateProjectionWrapper<GenericTagMultiProjector<WeatherForecastProjector, WeatherForecastTag>>>(
+            DualStateProjectionWrapperFactory.CreateFromRestoredSnapshot(
             deserialized,
             GenericTagMultiProjector<WeatherForecastProjector, WeatherForecastTag>.MultiProjectorName,
             (ICoreMultiProjectorTypes)_domainTypes.MultiProjectorTypes,
             _domainTypes.JsonSerializerOptions,
             initialVersion: 3,
             initialLastEventId: lastEvent.Id,
-            initialLastSortableUniqueId: lastEvent.SortableUniqueIdValue,
-            isRestoredFromSnapshot: true);
+            initialLastSortableUniqueId: lastEvent.SortableUniqueIdValue));
 
         // Verify ALL 3 items are preserved in the unsafe projection
         var unsafeProjection = wrapper.GetUnsafeProjection(_domainTypes);

--- a/dcb/tests/Sekiban.Dcb.WithoutResult.Tests/GenericTagMultiProjectorSerializationTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithoutResult.Tests/GenericTagMultiProjectorSerializationTests.cs
@@ -180,6 +180,86 @@ public class GenericTagMultiProjectorSerializationTests
         Assert.Equal(20, Assert.IsType<WeatherForecastState>(restoredStates[forecastId].Payload).TemperatureC);
     }
 
+    [Fact]
+    public void RestoredSnapshot_WrapperPreservesAllItems_ForMultipleTagStates()
+    {
+        var eventTime = new DateTime(2024, 1, 1, 12, 0, 0, DateTimeKind.Utc);
+        var safeThreshold = SortableUniqueId.Generate(eventTime.AddSeconds(60), Guid.Empty);
+
+        // Create 3 forecasts with different data
+        var forecasts = new[]
+        {
+            (Id: Guid.NewGuid(), City: "Tokyo", Temp: 20, Time: eventTime),
+            (Id: Guid.NewGuid(), City: "Osaka", Temp: 28, Time: eventTime.AddSeconds(1)),
+            (Id: Guid.NewGuid(), City: "Sapporo", Temp: 5, Time: eventTime.AddSeconds(2)),
+        };
+
+        var projector = GenericTagMultiProjector<WeatherForecastProjector, WeatherForecastTag>.GenerateInitialPayload();
+
+        foreach (var f in forecasts)
+        {
+            var ev = CreateEvent(
+                new WeatherForecastCreated(f.Id, f.City, DateOnly.FromDateTime(f.Time), f.Temp, "Sunny"),
+                f.Time,
+                f.Id) with { Tags = new List<string>() };
+
+            projector = GenericTagMultiProjector<WeatherForecastProjector, WeatherForecastTag>.Project(
+                projector,
+                ev,
+                new List<ITag> { new WeatherForecastTag(f.Id) },
+                _domainTypes,
+                safeThreshold);
+        }
+
+        // Verify projector has 3 items before serialization
+        Assert.Equal(3, projector.GetCurrentTagStates().Count);
+
+        // Serialize → Deserialize (snapshot round-trip)
+        var serialized = GenericTagMultiProjector<WeatherForecastProjector, WeatherForecastTag>.Serialize(
+            _domainTypes,
+            safeThreshold,
+            projector);
+        var deserialized = GenericTagMultiProjector<WeatherForecastProjector, WeatherForecastTag>.Deserialize(
+            _domainTypes,
+            safeThreshold,
+            serialized.Data);
+
+        // Wrap in DualStateProjectionWrapper as if restored from snapshot
+        var lastForecast = forecasts[^1];
+        var lastEvent = CreateEvent(
+            new WeatherForecastCreated(lastForecast.Id, lastForecast.City, DateOnly.FromDateTime(lastForecast.Time), lastForecast.Temp, "Sunny"),
+            lastForecast.Time,
+            lastForecast.Id);
+
+        var wrapper = new DualStateProjectionWrapper<GenericTagMultiProjector<WeatherForecastProjector, WeatherForecastTag>>(
+            deserialized,
+            GenericTagMultiProjector<WeatherForecastProjector, WeatherForecastTag>.MultiProjectorName,
+            (ICoreMultiProjectorTypes)_domainTypes.MultiProjectorTypes,
+            _domainTypes.JsonSerializerOptions,
+            initialVersion: 3,
+            initialLastEventId: lastEvent.Id,
+            initialLastSortableUniqueId: lastEvent.SortableUniqueIdValue,
+            isRestoredFromSnapshot: true);
+
+        // Verify ALL 3 items are preserved in the unsafe projection
+        var unsafeProjection = wrapper.GetUnsafeProjection(_domainTypes);
+        var restoredStates = unsafeProjection.State.GetCurrentTagStates();
+
+        Assert.Equal(3, restoredStates.Count);
+
+        foreach (var f in forecasts)
+        {
+            Assert.Contains(f.Id, restoredStates.Keys);
+            var state = Assert.IsType<WeatherForecastState>(restoredStates[f.Id].Payload);
+            Assert.Equal(f.City, state.Location);
+            Assert.Equal(f.Temp, state.TemperatureC);
+        }
+
+        // Also verify GetStatePayloads (the method used by list queries) returns all 3
+        var payloads = unsafeProjection.State.GetStatePayloads().ToList();
+        Assert.Equal(3, payloads.Count);
+    }
+
     private static Event CreateEvent(IEventPayload payload, DateTime timestamp, Guid forecastId)
     {
         var eventId = Guid.NewGuid();


### PR DESCRIPTION
## What changed
- add a regression test covering `DualStateProjectionWrapper` created from a restored `GenericTagMultiProjector` snapshot
- stop JSON-cloning the restored projector when `isRestoredFromSnapshot` is true

## Why
`GenericTagMultiProjector` uses custom binary snapshot serialization. After restore, `DualStateProjectionWrapper` rebuilt the unsafe projector by round-tripping the restored payload through generic `System.Text.Json` cloning. That clone silently dropped the `SafeUnsafeProjectionState` contents, so list queries that read unsafe state could return empty results after restart even though the persisted snapshot was correct.

## Impact
Restored multi-projection snapshots now preserve the unsafe state for custom-serialized projectors such as `GenericTagMultiProjector`, so post-restart list queries see the restored items instead of an empty in-memory unsafe projection.

## Validation
- `dotnet test dcb/tests/Sekiban.Dcb.WithoutResult.Tests/Sekiban.Dcb.WithoutResult.Tests.csproj`
- `dotnet test dcb/tests/Sekiban.Dcb.WithResult.Tests/Sekiban.Dcb.WithResult.Tests.csproj`
