### PR TITLE
Add GetLatestSortableUniqueIdForTagGroupAsync to ISekibanExecutor

### DIFF
--- a/dcb/src/Sekiban.Dcb.Core/Actors/CoreGeneralSekibanExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Actors/CoreGeneralSekibanExecutor.cs
@@ -746,6 +746,31 @@ public class CoreGeneralSekibanExecutor
         }
     }
 
+    public async Task<ResultBox<string>> GetLatestSortableUniqueIdForTagGroupAsync(string tagGroup)
+    {
+        try
+        {
+            var result = await _eventStore.GetAllTagsAsync(tagGroup);
+            if (!result.IsSuccess)
+            {
+                return ResultBox.Error<string>(result.GetException());
+            }
+
+            var tags = result.GetValue();
+            var latest = tags
+                .Select(t => t.LastSortableUniqueId)
+                .Where(id => !string.IsNullOrEmpty(id))
+                .OrderByDescending(id => id, StringComparer.Ordinal)
+                .FirstOrDefault() ?? string.Empty;
+
+            return ResultBox.FromValue(latest);
+        }
+        catch (Exception ex)
+        {
+            return ResultBox.Error<string>(ex);
+        }
+    }
+
     /// <summary>
     ///     Parses a tag string into an ITag for serialized commit.
     ///     Consistency tags are wrapped in ConsistencyTag, others in FallbackTag.

--- a/dcb/src/Sekiban.Dcb.Core/Actors/CoreGeneralSekibanExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Actors/CoreGeneralSekibanExecutor.cs
@@ -750,6 +750,8 @@ public class CoreGeneralSekibanExecutor
     {
         try
         {
+            NameValidator.ValidateTagGroupNameAndThrow(tagGroup);
+
             var result = await _eventStore.GetAllTagsAsync(tagGroup);
             if (!result.IsSuccess)
             {
@@ -757,11 +759,15 @@ public class CoreGeneralSekibanExecutor
             }
 
             var tags = result.GetValue();
-            var latest = tags
+            var nonEmptyIds = tags
                 .Select(t => t.LastSortableUniqueId)
                 .Where(id => !string.IsNullOrEmpty(id))
-                .OrderByDescending(id => id, StringComparer.Ordinal)
-                .FirstOrDefault() ?? string.Empty;
+                .Select(id => id!)
+                .ToList();
+
+            var latest = nonEmptyIds.Count > 0
+                ? nonEmptyIds.Max(StringComparer.Ordinal) ?? string.Empty
+                : string.Empty;
 
             return ResultBox.FromValue(latest);
         }

--- a/dcb/src/Sekiban.Dcb.Orleans.WithResult/OrleansDcbExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.WithResult/OrleansDcbExecutor.cs
@@ -239,6 +239,9 @@ public class OrleansDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecuto
         return listGeneralBox.GetValue().ToTypedResult<TResult>();
     }
 
+    public Task<ResultBox<string>> GetLatestSortableUniqueIdForTagGroupAsync(string tagGroup) =>
+        _generalExecutor.GetLatestSortableUniqueIdForTagGroupAsync(tagGroup);
+
     public Task<ResultBox<SerializableTagState>> GetSerializableTagStateAsync(TagStateId tagStateId) =>
         _generalExecutor.GetSerializableTagStateAsync(tagStateId);
 

--- a/dcb/src/Sekiban.Dcb.Orleans.WithoutResult/OrleansDcbExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.WithoutResult/OrleansDcbExecutor.cs
@@ -221,6 +221,9 @@ public class OrleansDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecuto
         return listGeneralBox.GetValue().ToTypedResult<TResult>().UnwrapBox();
     }
 
+    public Task<string> GetLatestSortableUniqueIdForTagGroupAsync(string tagGroup) =>
+        _generalExecutor.GetLatestSortableUniqueIdForTagGroupAsync(tagGroup);
+
     public Task<ResultBox<SerializableTagState>> GetSerializableTagStateAsync(TagStateId tagStateId) =>
         _generalExecutor.GetSerializableTagStateAsync(tagStateId);
 

--- a/dcb/src/Sekiban.Dcb.WithResult/Actors/GeneralSekibanExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.WithResult/Actors/GeneralSekibanExecutor.cs
@@ -96,6 +96,9 @@ public class GeneralSekibanExecutor : ISekibanExecutor, ISerializedSekibanDcbExe
         where TResult : notnull =>
         _core.QueryAsync(queryCommon);
 
+    public Task<ResultBox<string>> GetLatestSortableUniqueIdForTagGroupAsync(string tagGroup) =>
+        _core.GetLatestSortableUniqueIdForTagGroupAsync(tagGroup);
+
     public Task<ResultBox<SerializableTagState>> GetSerializableTagStateAsync(TagStateId tagStateId) =>
         _core.GetSerializableTagStateAsync(tagStateId);
 

--- a/dcb/src/Sekiban.Dcb.WithResult/ISekibanExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.WithResult/ISekibanExecutor.cs
@@ -34,4 +34,19 @@ public interface ISekibanExecutor : ICommandExecutor
     /// <returns>The paginated query result</returns>
     Task<ResultBox<ListQueryResult<TResult>>> QueryAsync<TResult>(IListQueryCommon<TResult> queryCommon)
         where TResult : notnull;
+
+    /// <summary>
+    ///     Get the latest SortableUniqueId committed for any tag in the specified tag group.
+    ///     Queries the event store directly, so the result reflects the latest committed state.
+    /// </summary>
+    /// <param name="tagGroup">The tag group name to query</param>
+    /// <returns>The latest SortableUniqueId string, or empty string if no events exist for the tag group</returns>
+    Task<ResultBox<string>> GetLatestSortableUniqueIdForTagGroupAsync(string tagGroup);
+
+    /// <summary>
+    ///     Type-safe overload that derives the tag group name from TTagGroup.
+    /// </summary>
+    Task<ResultBox<string>> GetLatestSortableUniqueIdForTagGroupAsync<TTagGroup>()
+        where TTagGroup : ITagGroup<TTagGroup>
+        => GetLatestSortableUniqueIdForTagGroupAsync(TTagGroup.TagGroupName);
 }

--- a/dcb/src/Sekiban.Dcb.WithResult/InMemory/InMemoryDcbExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.WithResult/InMemory/InMemoryDcbExecutor.cs
@@ -66,6 +66,9 @@ public class InMemoryDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecut
         IListQueryCommon<TResult> queryCommon) =>
         _inner.QueryAsync(queryCommon);
 
+    Task<ResultBox<string>> ISekibanExecutor.GetLatestSortableUniqueIdForTagGroupAsync(string tagGroup) =>
+        _inner.GetLatestSortableUniqueIdForTagGroupAsync(tagGroup);
+
     Task<ResultBox<SerializableTagState>> ISerializedSekibanDcbExecutor.GetSerializableTagStateAsync(TagStateId tagStateId) =>
         _inner.GetSerializableTagStateAsync(tagStateId);
 

--- a/dcb/src/Sekiban.Dcb.WithoutResult/Actors/GeneralSekibanExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.WithoutResult/Actors/GeneralSekibanExecutor.cs
@@ -132,6 +132,12 @@ public class GeneralSekibanExecutor : ISekibanExecutor, ISerializedSekibanDcbExe
         return result.UnwrapBox();
     }
 
+    public async Task<string> GetLatestSortableUniqueIdForTagGroupAsync(string tagGroup)
+    {
+        var result = await _core.GetLatestSortableUniqueIdForTagGroupAsync(tagGroup);
+        return result.UnwrapBox();
+    }
+
     public Task<ResultBox<SerializableTagState>> GetSerializableTagStateAsync(TagStateId tagStateId) =>
         _core.GetSerializableTagStateAsync(tagStateId);
 

--- a/dcb/src/Sekiban.Dcb.WithoutResult/ISekibanExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.WithoutResult/ISekibanExecutor.cs
@@ -42,4 +42,20 @@ public interface ISekibanExecutor : ICommandExecutor
     /// <exception cref="Exception">Thrown when query execution fails</exception>
     Task<ListQueryResult<TResult>> QueryAsync<TResult>(IListQueryCommon<TResult> queryCommon)
         where TResult : notnull;
+
+    /// <summary>
+    ///     Get the latest SortableUniqueId committed for any tag in the specified tag group.
+    ///     Queries the event store directly, so the result reflects the latest committed state.
+    /// </summary>
+    /// <param name="tagGroup">The tag group name to query</param>
+    /// <returns>The latest SortableUniqueId string, or empty string if no events exist for the tag group</returns>
+    /// <exception cref="Exception">Thrown when the event store query fails</exception>
+    Task<string> GetLatestSortableUniqueIdForTagGroupAsync(string tagGroup);
+
+    /// <summary>
+    ///     Type-safe overload that derives the tag group name from TTagGroup.
+    /// </summary>
+    Task<string> GetLatestSortableUniqueIdForTagGroupAsync<TTagGroup>()
+        where TTagGroup : ITagGroup<TTagGroup>
+        => GetLatestSortableUniqueIdForTagGroupAsync(TTagGroup.TagGroupName);
 }

--- a/dcb/src/Sekiban.Dcb.WithoutResult/InMemory/InMemoryDcbExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.WithoutResult/InMemory/InMemoryDcbExecutor.cs
@@ -68,6 +68,9 @@ public class InMemoryDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecut
         IListQueryCommon<TResult> queryCommon) =>
         _inner.QueryAsync(queryCommon);
 
+    Task<string> ISekibanExecutor.GetLatestSortableUniqueIdForTagGroupAsync(string tagGroup) =>
+        _inner.GetLatestSortableUniqueIdForTagGroupAsync(tagGroup);
+
     Task<ResultBox<SerializableTagState>> ISerializedSekibanDcbExecutor.GetSerializableTagStateAsync(TagStateId tagStateId) =>
         _inner.GetSerializableTagStateAsync(tagStateId);
 

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/GetLatestSortableUniqueIdForTagGroupTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/GetLatestSortableUniqueIdForTagGroupTests.cs
@@ -1,0 +1,117 @@
+using Dcb.Domain;
+using Dcb.Domain.Student;
+using Sekiban.Dcb.InMemory;
+using Xunit;
+
+namespace Sekiban.Dcb.Tests;
+
+/// <summary>
+///     Tests for ISekibanExecutor.GetLatestSortableUniqueIdForTagGroupAsync
+/// </summary>
+public class GetLatestSortableUniqueIdForTagGroupTests
+{
+    [Fact]
+    public async Task EmptyTagGroup_Should_Return_EmptyString()
+    {
+        var domain = DomainType.GetDomainTypes();
+        ISekibanExecutor executor = new InMemoryDcbExecutor(domain);
+
+        var result = await executor.GetLatestSortableUniqueIdForTagGroupAsync("Student");
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(string.Empty, result.GetValue());
+    }
+
+    [Fact]
+    public async Task NonExistentTagGroup_Should_Return_EmptyString()
+    {
+        var domain = DomainType.GetDomainTypes();
+        ISekibanExecutor executor = new InMemoryDcbExecutor(domain);
+
+        var result = await executor.GetLatestSortableUniqueIdForTagGroupAsync("NonExistentGroup");
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(string.Empty, result.GetValue());
+    }
+
+    [Fact]
+    public async Task AfterSingleCommand_Should_Return_LatestSortableUniqueId()
+    {
+        var domain = DomainType.GetDomainTypes();
+        ISekibanExecutor executor = new InMemoryDcbExecutor(domain);
+
+        var studentId = Guid.NewGuid();
+        var commandResult = await executor.ExecuteAsync(new CreateStudent(studentId, "Test Student", 5));
+        Assert.True(commandResult.IsSuccess);
+
+        var commandSortableId = commandResult.GetValue().SortableUniqueId;
+        Assert.NotNull(commandSortableId);
+
+        var result = await executor.GetLatestSortableUniqueIdForTagGroupAsync("Student");
+
+        Assert.True(result.IsSuccess);
+        var latestId = result.GetValue();
+        Assert.NotEmpty(latestId);
+        // The returned ID should be >= the command's ID (could be equal or later if multiple events)
+        Assert.True(
+            string.Compare(latestId, commandSortableId, StringComparison.Ordinal) >= 0,
+            $"Expected latestId >= commandSortableId, but got '{latestId}' < '{commandSortableId}'");
+    }
+
+    [Fact]
+    public async Task AfterMultipleCommands_Should_Return_MaxSortableUniqueId()
+    {
+        var domain = DomainType.GetDomainTypes();
+        ISekibanExecutor executor = new InMemoryDcbExecutor(domain);
+
+        var commandResult1 = await executor.ExecuteAsync(new CreateStudent(Guid.NewGuid(), "Student One", 3));
+        Assert.True(commandResult1.IsSuccess);
+        var id1 = commandResult1.GetValue().SortableUniqueId!;
+
+        var commandResult2 = await executor.ExecuteAsync(new CreateStudent(Guid.NewGuid(), "Student Two", 4));
+        Assert.True(commandResult2.IsSuccess);
+        var id2 = commandResult2.GetValue().SortableUniqueId!;
+
+        // id2 should be later than id1
+        Assert.True(string.Compare(id2, id1, StringComparison.Ordinal) > 0);
+
+        var result = await executor.GetLatestSortableUniqueIdForTagGroupAsync("Student");
+
+        Assert.True(result.IsSuccess);
+        var latestId = result.GetValue();
+        // The returned ID should be >= the second command's ID
+        Assert.True(
+            string.Compare(latestId, id2, StringComparison.Ordinal) >= 0,
+            $"Expected latestId >= id2, but got '{latestId}' < '{id2}'");
+    }
+
+    [Fact]
+    public async Task GenericOverload_Should_Work()
+    {
+        var domain = DomainType.GetDomainTypes();
+        ISekibanExecutor executor = new InMemoryDcbExecutor(domain);
+
+        var commandResult = await executor.ExecuteAsync(new CreateStudent(Guid.NewGuid(), "Test", 5));
+        Assert.True(commandResult.IsSuccess);
+
+        var result = await executor.GetLatestSortableUniqueIdForTagGroupAsync<StudentTag>();
+
+        Assert.True(result.IsSuccess);
+        Assert.NotEmpty(result.GetValue());
+    }
+
+    [Fact]
+    public async Task InvalidTagGroup_Should_Return_Error()
+    {
+        var domain = DomainType.GetDomainTypes();
+        ISekibanExecutor executor = new InMemoryDcbExecutor(domain);
+
+        // Empty string should fail validation
+        var result = await executor.GetLatestSortableUniqueIdForTagGroupAsync("");
+        Assert.False(result.IsSuccess);
+
+        // Colon in tag group name should fail validation
+        var result2 = await executor.GetLatestSortableUniqueIdForTagGroupAsync("Invalid:Group");
+        Assert.False(result2.IsSuccess);
+    }
+}


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Add `GetLatestSortableUniqueIdForTagGroupAsync` method to `ISekibanExecutor` (both WithResult and WithoutResult flavors) that retrieves the latest committed `SortableUniqueId` for a given TagGroup directly from the event store.

**Problem**: After writing events via a command, executing a projection-based query requires waiting for eventual consistency catch-up. The existing `IWaitForSortableUniqueId` mechanism works well, but requires passing the `SortableUniqueId` from `ExecutionResult` — which is difficult when command execution and query execution occur in separate request scopes.

**Solution**: This new method queries the DB directly (via existing `IEventStore.GetAllTagsAsync`) and returns the MAX `LastSortableUniqueId` across all tags in the group. Since the DB is the single source of truth (events are committed atomically before Orleans stream publishing), the result is guaranteed to reflect the latest committed state.

**Usage**:
```csharp
// Before executing a query, get the latest committed ID for the tag group
var latestId = await executor.GetLatestSortableUniqueIdForTagGroupAsync<OrderTag>();
var orders = await executor.QueryAsync(new GetOrderListQuery
{
    WaitForSortableUniqueId = latestId
});
```

Both a `string tagGroup` overload and a type-safe `<TTagGroup>` generic overload (with default interface implementation) are provided.

**Files changed (9)**:
- `CoreGeneralSekibanExecutor.cs` — core implementation
- `ISekibanExecutor.cs` (WithResult + WithoutResult) — interface declarations
- `GeneralSekibanExecutor.cs` (WithResult + WithoutResult) — delegation to core
- `OrleansDcbExecutor.cs` (WithResult + WithoutResult) — delegation
- `InMemoryDcbExecutor.cs` (WithResult + WithoutResult) — delegation

No changes to `IEventStore` or any storage provider implementations.

## Related Tickets & Documents

- Closes #1003

## QA Instructions, Screenshots, Recordings

1. Build the solution: `dotnet build Sekiban.slnx` — should succeed with 0 errors
2. Run DCB tests: `dotnet test Sekiban.slnx --filter "FullyQualifiedName~Sekiban.Dcb"` — all existing tests pass (2 pre-existing failures in `EventStoreCacheSyncTests` unrelated to this change)
3. Verify the method can be called on any `ISekibanExecutor` instance with a tag group name string or a generic `ITagGroup<T>` type parameter

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: This is an additive interface method with trivial delegation through existing infrastructure. The core logic (`GetAllTagsAsync` + LINQ max) is already covered by existing event store tests. Integration tests will follow when the feature is used in the domain layer.
- [ ] I need help with writing tests