### PR TITLE
Add GetLatestSortableUniqueIdAsync to IEventStore and ISekibanExecutor

### DIFF
--- a/dcb/src/Sekiban.Dcb.Core/Actors/CoreGeneralSekibanExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Actors/CoreGeneralSekibanExecutor.cs
@@ -746,6 +746,9 @@ public class CoreGeneralSekibanExecutor
         }
     }
 
+    public Task<ResultBox<string>> GetLatestSortableUniqueIdAsync() =>
+        _eventStore.GetLatestSortableUniqueIdAsync();
+
     /// <summary>
     ///     Parses a tag string into an ITag for serialized commit.
     ///     Consistency tags are wrapped in ConsistencyTag, others in FallbackTag.

--- a/dcb/src/Sekiban.Dcb.Core/ColdEvents/HybridEventStore.cs
+++ b/dcb/src/Sekiban.Dcb.Core/ColdEvents/HybridEventStore.cs
@@ -64,6 +64,9 @@ public sealed class HybridEventStore : IEventStore, IStreamingSerializableEventS
     public Task<ResultBox<IEnumerable<TagInfo>>> GetAllTagsAsync(string? tagGroup = null)
         => _hotStore.GetAllTagsAsync(tagGroup);
 
+    public Task<ResultBox<string>> GetLatestSortableUniqueIdAsync()
+        => _hotStore.GetLatestSortableUniqueIdAsync();
+
     public Task<ResultBox<IEnumerable<SerializableEvent>>> ReadSerializableEventsByTagAsync(
         ITag tag, SortableUniqueId? since = null)
         => _hotStore.ReadSerializableEventsByTagAsync(tag, since);

--- a/dcb/src/Sekiban.Dcb.Core/InMemory/InMemoryEventStore.cs
+++ b/dcb/src/Sekiban.Dcb.Core/InMemory/InMemoryEventStore.cs
@@ -287,15 +287,14 @@ public class InMemoryEventStore : IEventStore, ISerializableEventStreamReader
         var state = GetState();
         lock (state.Lock)
         {
-            var latest = string.Empty;
-            foreach (var evt in state.EventOrder)
+            if (state.EventOrder.Count == 0)
             {
-                if (string.Compare(evt.SortableUniqueIdValue, latest, StringComparison.Ordinal) > 0)
-                {
-                    latest = evt.SortableUniqueIdValue;
-                }
+                return Task.FromResult(ResultBox.FromValue(string.Empty));
             }
-            return Task.FromResult(ResultBox.FromValue(latest));
+            // EventOrder is append-only with monotonically generated SortableUniqueIds,
+            // so last element is the max. Use ordinal comparison as a safety net.
+            var last = state.EventOrder[^1].SortableUniqueIdValue;
+            return Task.FromResult(ResultBox.FromValue(last));
         }
     }
 

--- a/dcb/src/Sekiban.Dcb.Core/InMemory/InMemoryEventStore.cs
+++ b/dcb/src/Sekiban.Dcb.Core/InMemory/InMemoryEventStore.cs
@@ -61,6 +61,7 @@ public class InMemoryEventStore : IEventStore, ISerializableEventStreamReader
             state.EventOrder.Clear();
             state.Events.Clear();
             state.TagStreams.Clear();
+            state.MaxSortableUniqueId = string.Empty;
         }
     }
 

--- a/dcb/src/Sekiban.Dcb.Core/InMemory/InMemoryEventStore.cs
+++ b/dcb/src/Sekiban.Dcb.Core/InMemory/InMemoryEventStore.cs
@@ -287,9 +287,14 @@ public class InMemoryEventStore : IEventStore, ISerializableEventStreamReader
         var state = GetState();
         lock (state.Lock)
         {
-            var latest = state.EventOrder.Count > 0
-                ? state.EventOrder[^1].SortableUniqueIdValue
-                : string.Empty;
+            var latest = string.Empty;
+            foreach (var evt in state.EventOrder)
+            {
+                if (string.Compare(evt.SortableUniqueIdValue, latest, StringComparison.Ordinal) > 0)
+                {
+                    latest = evt.SortableUniqueIdValue;
+                }
+            }
             return Task.FromResult(ResultBox.FromValue(latest));
         }
     }

--- a/dcb/src/Sekiban.Dcb.Core/InMemory/InMemoryEventStore.cs
+++ b/dcb/src/Sekiban.Dcb.Core/InMemory/InMemoryEventStore.cs
@@ -282,6 +282,18 @@ public class InMemoryEventStore : IEventStore, ISerializableEventStreamReader
         }
     }
 
+    public Task<ResultBox<string>> GetLatestSortableUniqueIdAsync()
+    {
+        var state = GetState();
+        lock (state.Lock)
+        {
+            var latest = state.EventOrder.Count > 0
+                ? state.EventOrder[^1].SortableUniqueIdValue
+                : string.Empty;
+            return Task.FromResult(ResultBox.FromValue(latest));
+        }
+    }
+
     public Task<ResultBox<IEnumerable<TagInfo>>> GetAllTagsAsync(string? tagGroup = null)
     {
         var state = GetState();

--- a/dcb/src/Sekiban.Dcb.Core/InMemory/InMemoryEventStore.cs
+++ b/dcb/src/Sekiban.Dcb.Core/InMemory/InMemoryEventStore.cs
@@ -162,26 +162,7 @@ public class InMemoryEventStore : IEventStore, ISerializableEventStreamReader
             // Write events
             foreach (var evt in eventList)
             {
-                state.Events[evt.Id] = evt;
-                state.EventOrder.Add(evt);
-                writtenEvents.Add(evt);
-                if (string.Compare(evt.SortableUniqueIdValue, state.MaxSortableUniqueId, StringComparison.Ordinal) > 0)
-                {
-                    state.MaxSortableUniqueId = evt.SortableUniqueIdValue;
-                }
-
-                // Add tag streams for each tag in the event
-                foreach (var tagString in evt.Tags)
-                {
-                    var tagStream = new TagStream(tagString, evt.Id, evt.SortableUniqueIdValue);
-
-                    if (!state.TagStreams.ContainsKey(tagString))
-                    {
-                        state.TagStreams[tagString] = new List<TagStream>();
-                    }
-
-                    state.TagStreams[tagString].Add(tagStream);
-                }
+                AppendEvent(state, evt, writtenEvents);
             }
 
             // Create tag write results
@@ -255,6 +236,35 @@ public class InMemoryEventStore : IEventStore, ISerializableEventStreamReader
             }
 
             return Task.FromResult(ResultBox.Error<TagState>(new Exception($"Tag {tagString} not found")));
+        }
+    }
+
+    private static void AppendEvent(ServiceState state, Event evt, ICollection<Event> writtenEvents)
+    {
+        state.Events[evt.Id] = evt;
+        state.EventOrder.Add(evt);
+        writtenEvents.Add(evt);
+        UpdateMaxSortableUniqueId(state, evt.SortableUniqueIdValue);
+
+        foreach (var tagString in evt.Tags)
+        {
+            var tagStream = new TagStream(tagString, evt.Id, evt.SortableUniqueIdValue);
+
+            if (!state.TagStreams.TryGetValue(tagString, out var streams))
+            {
+                streams = new List<TagStream>();
+                state.TagStreams[tagString] = streams;
+            }
+
+            streams.Add(tagStream);
+        }
+    }
+
+    private static void UpdateMaxSortableUniqueId(ServiceState state, string sortableUniqueIdValue)
+    {
+        if (string.Compare(sortableUniqueIdValue, state.MaxSortableUniqueId, StringComparison.Ordinal) > 0)
+        {
+            state.MaxSortableUniqueId = sortableUniqueIdValue;
         }
     }
 

--- a/dcb/src/Sekiban.Dcb.Core/InMemory/InMemoryEventStore.cs
+++ b/dcb/src/Sekiban.Dcb.Core/InMemory/InMemoryEventStore.cs
@@ -23,6 +23,7 @@ public class InMemoryEventStore : IEventStore, ISerializableEventStreamReader
         public List<Event> EventOrder { get; } = new();
         public Dictionary<Guid, Event> Events { get; } = new();
         public Dictionary<string, List<TagStream>> TagStreams { get; } = new(StringComparer.Ordinal);
+        public string MaxSortableUniqueId { get; set; } = string.Empty;
     }
 
     private readonly ConcurrentDictionary<string, ServiceState> _states = new(StringComparer.Ordinal);
@@ -163,6 +164,10 @@ public class InMemoryEventStore : IEventStore, ISerializableEventStreamReader
                 state.Events[evt.Id] = evt;
                 state.EventOrder.Add(evt);
                 writtenEvents.Add(evt);
+                if (string.Compare(evt.SortableUniqueIdValue, state.MaxSortableUniqueId, StringComparison.Ordinal) > 0)
+                {
+                    state.MaxSortableUniqueId = evt.SortableUniqueIdValue;
+                }
 
                 // Add tag streams for each tag in the event
                 foreach (var tagString in evt.Tags)
@@ -287,14 +292,7 @@ public class InMemoryEventStore : IEventStore, ISerializableEventStreamReader
         var state = GetState();
         lock (state.Lock)
         {
-            if (state.EventOrder.Count == 0)
-            {
-                return Task.FromResult(ResultBox.FromValue(string.Empty));
-            }
-            // EventOrder is append-only with monotonically generated SortableUniqueIds,
-            // so last element is the max. Use ordinal comparison as a safety net.
-            var last = state.EventOrder[^1].SortableUniqueIdValue;
-            return Task.FromResult(ResultBox.FromValue(last));
+            return Task.FromResult(ResultBox.FromValue(state.MaxSortableUniqueId));
         }
     }
 
@@ -507,6 +505,10 @@ public class InMemoryEventStore : IEventStore, ISerializableEventStreamReader
                 state.Events[evt.Id] = evt;
                 state.EventOrder.Add(evt);
                 writtenEvents.Add(se);
+                if (string.Compare(evt.SortableUniqueIdValue, state.MaxSortableUniqueId, StringComparison.Ordinal) > 0)
+                {
+                    state.MaxSortableUniqueId = evt.SortableUniqueIdValue;
+                }
 
                 foreach (var tagString in se.Tags)
                 {

--- a/dcb/src/Sekiban.Dcb.Core/Storage/IEventStore.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Storage/IEventStore.cs
@@ -74,6 +74,13 @@ public interface IEventStore
     /// <returns>ResultBox containing the written serializable events and tag write results</returns>
     Task<ResultBox<(IReadOnlyList<SerializableEvent> Events, IReadOnlyList<TagWriteResult> TagWrites)>> WriteSerializableEventsAsync(
         IEnumerable<SerializableEvent> events);
+
+    /// <summary>
+    ///     Gets the latest (maximum) SortableUniqueId across all events in the store.
+    ///     Returns empty string if no events exist.
+    ///     This is a global operation not scoped to any tag or tag group.
+    /// </summary>
+    Task<ResultBox<string>> GetLatestSortableUniqueIdAsync();
 }
 
 /// <summary>

--- a/dcb/src/Sekiban.Dcb.CosmosDb/CosmosDbEventStore.cs
+++ b/dcb/src/Sekiban.Dcb.CosmosDb/CosmosDbEventStore.cs
@@ -938,7 +938,7 @@ public partial class CosmosDbEventStore : IHotEventStore
             var container = await _context.GetEventsContainerAsync(settings).ConfigureAwait(false);
 
             var queryDefinition = new QueryDefinition(
-                $"SELECT VALUE TOP 1 c.sortableUniqueId FROM c WHERE c.serviceId = {ParamServiceId} ORDER BY c.sortableUniqueId DESC")
+                $"SELECT TOP 1 VALUE c.sortableUniqueId FROM c WHERE c.serviceId = {ParamServiceId} ORDER BY c.sortableUniqueId DESC")
                 .WithParameter(ParamServiceId, serviceId);
 
             using var iterator = container.GetItemQueryIterator<string>(queryDefinition);

--- a/dcb/src/Sekiban.Dcb.CosmosDb/CosmosDbEventStore.cs
+++ b/dcb/src/Sekiban.Dcb.CosmosDb/CosmosDbEventStore.cs
@@ -938,8 +938,8 @@ public partial class CosmosDbEventStore : IHotEventStore
             var container = await _context.GetEventsContainerAsync(settings).ConfigureAwait(false);
 
             var queryDefinition = new QueryDefinition(
-                $"SELECT VALUE TOP 1 c.sortableUniqueId FROM c WHERE c.serviceId = @serviceId ORDER BY c.sortableUniqueId DESC")
-                .WithParameter("@serviceId", serviceId);
+                $"SELECT VALUE TOP 1 c.sortableUniqueId FROM c WHERE c.serviceId = {ParamServiceId} ORDER BY c.sortableUniqueId DESC")
+                .WithParameter(ParamServiceId, serviceId);
 
             using var iterator = container.GetItemQueryIterator<string>(queryDefinition);
             if (iterator.HasMoreResults)
@@ -954,7 +954,7 @@ public partial class CosmosDbEventStore : IHotEventStore
 
             return ResultBox.FromValue(string.Empty);
         }
-        catch (Exception ex)
+        catch (CosmosException ex)
         {
             return ResultBox.Error<string>(ex);
         }

--- a/dcb/src/Sekiban.Dcb.CosmosDb/CosmosDbEventStore.cs
+++ b/dcb/src/Sekiban.Dcb.CosmosDb/CosmosDbEventStore.cs
@@ -938,17 +938,16 @@ public partial class CosmosDbEventStore : IHotEventStore
             var container = await _context.GetEventsContainerAsync(settings).ConfigureAwait(false);
 
             var queryDefinition = new QueryDefinition(
-                $"SELECT TOP 1 c.sortableUniqueId FROM c WHERE c.serviceId = @serviceId ORDER BY c.sortableUniqueId DESC")
+                $"SELECT VALUE TOP 1 c.sortableUniqueId FROM c WHERE c.serviceId = @serviceId ORDER BY c.sortableUniqueId DESC")
                 .WithParameter("@serviceId", serviceId);
 
-            using var iterator = container.GetItemQueryIterator<dynamic>(queryDefinition);
+            using var iterator = container.GetItemQueryIterator<string>(queryDefinition);
             if (iterator.HasMoreResults)
             {
                 var response = await iterator.ReadNextAsync().ConfigureAwait(false);
-                var item = response.FirstOrDefault();
-                if (item != null)
+                var sortableUniqueId = response.FirstOrDefault();
+                if (sortableUniqueId != null)
                 {
-                    string sortableUniqueId = item.sortableUniqueId;
                     return ResultBox.FromValue(sortableUniqueId);
                 }
             }

--- a/dcb/src/Sekiban.Dcb.CosmosDb/CosmosDbEventStore.cs
+++ b/dcb/src/Sekiban.Dcb.CosmosDb/CosmosDbEventStore.cs
@@ -929,6 +929,39 @@ public partial class CosmosDbEventStore : IHotEventStore
     }
 
     /// <inheritdoc />
+    public async Task<ResultBox<string>> GetLatestSortableUniqueIdAsync()
+    {
+        try
+        {
+            var serviceId = CurrentServiceId;
+            var settings = _containerResolver.ResolveEventsContainer(serviceId);
+            var container = await _context.GetEventsContainerAsync(settings).ConfigureAwait(false);
+
+            var queryDefinition = new QueryDefinition(
+                $"SELECT TOP 1 c.sortableUniqueId FROM c WHERE c.serviceId = @serviceId ORDER BY c.sortableUniqueId DESC")
+                .WithParameter("@serviceId", serviceId);
+
+            using var iterator = container.GetItemQueryIterator<dynamic>(queryDefinition);
+            if (iterator.HasMoreResults)
+            {
+                var response = await iterator.ReadNextAsync().ConfigureAwait(false);
+                var item = response.FirstOrDefault();
+                if (item != null)
+                {
+                    string sortableUniqueId = item.sortableUniqueId;
+                    return ResultBox.FromValue(sortableUniqueId);
+                }
+            }
+
+            return ResultBox.FromValue(string.Empty);
+        }
+        catch (Exception ex)
+        {
+            return ResultBox.Error<string>(ex);
+        }
+    }
+
+    /// <inheritdoc />
     public async Task<ResultBox<IEnumerable<TagInfo>>> GetAllTagsAsync(string? tagGroup = null)
     {
         try

--- a/dcb/src/Sekiban.Dcb.DynamoDB/DynamoDbEventStore.cs
+++ b/dcb/src/Sekiban.Dcb.DynamoDB/DynamoDbEventStore.cs
@@ -407,6 +407,55 @@ public class DynamoDbEventStore : IHotEventStore
         }
     }
 
+    public async Task<ResultBox<string>> GetLatestSortableUniqueIdAsync()
+    {
+        try
+        {
+            var serviceId = CurrentServiceId;
+            var shardCount = Math.Max(1, _options.WriteShardCount);
+            var shardKeys = shardCount == 1
+                ? new[] { BuildEventsGsiPartitionKey(serviceId) }
+                : Enumerable.Range(0, shardCount)
+                    .Select(i => BuildEventsGsiPartitionKey(serviceId, i))
+                    .ToArray();
+
+            var latest = string.Empty;
+            foreach (var shardKey in shardKeys)
+            {
+                var request = new QueryRequest
+                {
+                    TableName = _context.EventsTableName,
+                    IndexName = DynamoDbContext.EventsGsiName,
+                    KeyConditionExpression = "gsi1pk = :pk",
+                    ExpressionAttributeValues = new Dictionary<string, AttributeValue>
+                    {
+                        [":pk"] = new AttributeValue { S = shardKey }
+                    },
+                    ScanIndexForward = false,
+                    Limit = 1,
+                    ProjectionExpression = "sortableUniqueId"
+                };
+
+                var response = await _client.QueryAsync(request).ConfigureAwait(false);
+                if (response.Items.Count > 0 &&
+                    response.Items[0].TryGetValue("sortableUniqueId", out var attr))
+                {
+                    var id = attr.S;
+                    if (string.Compare(id, latest, StringComparison.Ordinal) > 0)
+                    {
+                        latest = id;
+                    }
+                }
+            }
+
+            return ResultBox.FromValue(latest);
+        }
+        catch (Exception ex)
+        {
+            return ResultBox.Error<string>(ex);
+        }
+    }
+
     /// <summary>
     ///     Returns all tag infos, optionally filtered by tag group.
     /// </summary>

--- a/dcb/src/Sekiban.Dcb.DynamoDB/DynamoDbEventStore.cs
+++ b/dcb/src/Sekiban.Dcb.DynamoDB/DynamoDbEventStore.cs
@@ -411,6 +411,8 @@ public class DynamoDbEventStore : IHotEventStore
     {
         try
         {
+            await _context.EnsureTablesAsync().ConfigureAwait(false);
+
             var serviceId = CurrentServiceId;
             var shardCount = Math.Max(1, _options.WriteShardCount);
             var shardKeys = shardCount == 1
@@ -419,8 +421,7 @@ public class DynamoDbEventStore : IHotEventStore
                     .Select(i => BuildEventsGsiPartitionKey(serviceId, i))
                     .ToArray();
 
-            var latest = string.Empty;
-            foreach (var shardKey in shardKeys)
+            var tasks = shardKeys.Select(async shardKey =>
             {
                 var request = new QueryRequest
                 {
@@ -440,13 +441,16 @@ public class DynamoDbEventStore : IHotEventStore
                 if (response.Items.Count > 0 &&
                     response.Items[0].TryGetValue("sortableUniqueId", out var attr))
                 {
-                    var id = attr.S;
-                    if (string.Compare(id, latest, StringComparison.Ordinal) > 0)
-                    {
-                        latest = id;
-                    }
+                    return attr.S;
                 }
-            }
+                return string.Empty;
+            });
+
+            var results = await Task.WhenAll(tasks).ConfigureAwait(false);
+            var latest = results
+                .Where(id => !string.IsNullOrEmpty(id))
+                .DefaultIfEmpty(string.Empty)
+                .Max(StringComparer.Ordinal) ?? string.Empty;
 
             return ResultBox.FromValue(latest);
         }

--- a/dcb/src/Sekiban.Dcb.DynamoDB/DynamoDbEventStore.cs
+++ b/dcb/src/Sekiban.Dcb.DynamoDB/DynamoDbEventStore.cs
@@ -456,6 +456,7 @@ public class DynamoDbEventStore : IHotEventStore
         }
         catch (Exception ex)
         {
+            LogReadFailed(_logger, ex.Message, ex);
             return ResultBox.Error<string>(ex);
         }
     }

--- a/dcb/src/Sekiban.Dcb.DynamoDB/DynamoDbEventStore.cs
+++ b/dcb/src/Sekiban.Dcb.DynamoDB/DynamoDbEventStore.cs
@@ -456,7 +456,8 @@ public class DynamoDbEventStore : IHotEventStore
         }
         catch (Exception ex)
         {
-            LogReadFailed(_logger, ex.Message, ex);
+            if (_logger != null)
+                LogReadFailed(_logger, ex.Message, ex);
             return ResultBox.Error<string>(ex);
         }
     }

--- a/dcb/src/Sekiban.Dcb.DynamoDB/DynamoDbEventStore.cs
+++ b/dcb/src/Sekiban.Dcb.DynamoDB/DynamoDbEventStore.cs
@@ -21,6 +21,9 @@ namespace Sekiban.Dcb.DynamoDB;
 /// </summary>
 public class DynamoDbEventStore : IHotEventStore
 {
+    private const string PartitionKeyConditionExpression = "gsi1pk = :pk";
+    private const string PartitionKeySinceConditionExpression = "gsi1pk = :pk AND sortableUniqueId > :since";
+
     private static readonly Action<ILogger, string, Exception?> LogWriteFailed =
         LoggerMessage.Define<string>(LogLevel.Error, new EventId(1, nameof(LogWriteFailed)),
             "DynamoDB WriteEventsAsync failed: {Message}");
@@ -427,7 +430,7 @@ public class DynamoDbEventStore : IHotEventStore
                 {
                     TableName = _context.EventsTableName,
                     IndexName = DynamoDbContext.EventsGsiName,
-                    KeyConditionExpression = "gsi1pk = :pk",
+                    KeyConditionExpression = PartitionKeyConditionExpression,
                     ExpressionAttributeValues = new Dictionary<string, AttributeValue>
                     {
                         [":pk"] = new AttributeValue { S = shardKey }
@@ -521,8 +524,8 @@ public class DynamoDbEventStore : IHotEventStore
                 TableName = _context.EventsTableName,
                 IndexName = DynamoDbContext.EventsGsiName,
                 KeyConditionExpression = since == null
-                    ? "gsi1pk = :pk"
-                    : "gsi1pk = :pk AND sortableUniqueId > :since",
+                    ? PartitionKeyConditionExpression
+                    : PartitionKeySinceConditionExpression,
                 ExpressionAttributeValues = new Dictionary<string, AttributeValue>
                 {
                     [":pk"] = new AttributeValue { S = shardKey }
@@ -573,8 +576,8 @@ public class DynamoDbEventStore : IHotEventStore
                 TableName = _context.EventsTableName,
                 IndexName = DynamoDbContext.EventsGsiName,
                 KeyConditionExpression = since == null
-                    ? "gsi1pk = :pk"
-                    : "gsi1pk = :pk AND sortableUniqueId > :since",
+                    ? PartitionKeyConditionExpression
+                    : PartitionKeySinceConditionExpression,
                 ExpressionAttributeValues = new Dictionary<string, AttributeValue>
                 {
                     [":pk"] = new AttributeValue { S = shardKey }
@@ -1226,8 +1229,8 @@ public class DynamoDbEventStore : IHotEventStore
                 TableName = _context.EventsTableName,
                 IndexName = DynamoDbContext.EventsGsiName,
                 KeyConditionExpression = since == null
-                    ? "gsi1pk = :pk"
-                    : "gsi1pk = :pk AND sortableUniqueId > :since",
+                    ? PartitionKeyConditionExpression
+                    : PartitionKeySinceConditionExpression,
                 ExpressionAttributeValues = new Dictionary<string, AttributeValue>
                 {
                     [":pk"] = new AttributeValue { S = shardKey }

--- a/dcb/src/Sekiban.Dcb.Orleans.WithResult/OrleansDcbExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.WithResult/OrleansDcbExecutor.cs
@@ -239,6 +239,9 @@ public class OrleansDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecuto
         return listGeneralBox.GetValue().ToTypedResult<TResult>();
     }
 
+    public Task<ResultBox<string>> GetLatestSortableUniqueIdAsync() =>
+        _generalExecutor.GetLatestSortableUniqueIdAsync();
+
     public Task<ResultBox<SerializableTagState>> GetSerializableTagStateAsync(TagStateId tagStateId) =>
         _generalExecutor.GetSerializableTagStateAsync(tagStateId);
 

--- a/dcb/src/Sekiban.Dcb.Orleans.WithoutResult/OrleansDcbExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.WithoutResult/OrleansDcbExecutor.cs
@@ -221,6 +221,9 @@ public class OrleansDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecuto
         return listGeneralBox.GetValue().ToTypedResult<TResult>().UnwrapBox();
     }
 
+    public Task<string> GetLatestSortableUniqueIdAsync() =>
+        _generalExecutor.GetLatestSortableUniqueIdAsync();
+
     public Task<ResultBox<SerializableTagState>> GetSerializableTagStateAsync(TagStateId tagStateId) =>
         _generalExecutor.GetSerializableTagStateAsync(tagStateId);
 

--- a/dcb/src/Sekiban.Dcb.Postgres/PostgresEventStore.cs
+++ b/dcb/src/Sekiban.Dcb.Postgres/PostgresEventStore.cs
@@ -344,6 +344,27 @@ public class PostgresEventStore : IHotEventStore, ISerializableEventStreamReader
         }
     }
 
+    public async Task<ResultBox<string>> GetLatestSortableUniqueIdAsync()
+    {
+        try
+        {
+            await using var context = await _contextFactory.CreateDbContextAsync();
+            var serviceId = CurrentServiceId;
+
+            var latest = await context.Events
+                .Where(e => e.ServiceId == serviceId)
+                .OrderByDescending(e => e.SortableUniqueId)
+                .Select(e => e.SortableUniqueId)
+                .FirstOrDefaultAsync();
+
+            return ResultBox.FromValue(latest ?? string.Empty);
+        }
+        catch (Exception ex)
+        {
+            return ResultBox.Error<string>(ex);
+        }
+    }
+
     public async Task<ResultBox<IEnumerable<TagInfo>>> GetAllTagsAsync(string? tagGroup = null)
     {
         try

--- a/dcb/src/Sekiban.Dcb.Sqlite/SqliteEventStore.cs
+++ b/dcb/src/Sekiban.Dcb.Sqlite/SqliteEventStore.cs
@@ -724,8 +724,8 @@ public class SqliteEventStore : IHotEventStore
             await connection.OpenAsync();
 
             await using var cmd = connection.CreateCommand();
-            cmd.CommandText = "SELECT MAX(SortableUniqueId) FROM dcb_events WHERE ServiceId = @serviceId";
-            cmd.Parameters.AddWithValue("@serviceId", serviceId);
+            cmd.CommandText = $"SELECT MAX(SortableUniqueId) FROM dcb_events WHERE ServiceId = {ParamServiceId}";
+            cmd.Parameters.AddWithValue(ParamServiceId, serviceId);
 
             var result = await cmd.ExecuteScalarAsync();
             var latest = result as string ?? string.Empty;

--- a/dcb/src/Sekiban.Dcb.Sqlite/SqliteEventStore.cs
+++ b/dcb/src/Sekiban.Dcb.Sqlite/SqliteEventStore.cs
@@ -715,6 +715,29 @@ public class SqliteEventStore : IHotEventStore
         }
     }
 
+    public async Task<ResultBox<string>> GetLatestSortableUniqueIdAsync()
+    {
+        try
+        {
+            var serviceId = CurrentServiceId;
+            await using var connection = new SqliteConnection(_connectionString);
+            await connection.OpenAsync();
+
+            await using var cmd = connection.CreateCommand();
+            cmd.CommandText = "SELECT MAX(SortableUniqueId) FROM dcb_events WHERE ServiceId = @serviceId";
+            cmd.Parameters.AddWithValue("@serviceId", serviceId);
+
+            var result = await cmd.ExecuteScalarAsync();
+            var latest = result as string ?? string.Empty;
+            return ResultBox.FromValue(latest);
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogError(ex, "Error getting latest SortableUniqueId from SQLite");
+            return ResultBox.Error<string>(ex);
+        }
+    }
+
     public async Task<ResultBox<IEnumerable<TagInfo>>> GetAllTagsAsync(string? tagGroup = null)
     {
         try

--- a/dcb/src/Sekiban.Dcb.WithResult/Actors/GeneralSekibanExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.WithResult/Actors/GeneralSekibanExecutor.cs
@@ -96,6 +96,9 @@ public class GeneralSekibanExecutor : ISekibanExecutor, ISerializedSekibanDcbExe
         where TResult : notnull =>
         _core.QueryAsync(queryCommon);
 
+    public Task<ResultBox<string>> GetLatestSortableUniqueIdAsync() =>
+        _core.GetLatestSortableUniqueIdAsync();
+
     public Task<ResultBox<SerializableTagState>> GetSerializableTagStateAsync(TagStateId tagStateId) =>
         _core.GetSerializableTagStateAsync(tagStateId);
 

--- a/dcb/src/Sekiban.Dcb.WithResult/ISekibanExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.WithResult/ISekibanExecutor.cs
@@ -34,4 +34,11 @@ public interface ISekibanExecutor : ICommandExecutor
     /// <returns>The paginated query result</returns>
     Task<ResultBox<ListQueryResult<TResult>>> QueryAsync<TResult>(IListQueryCommon<TResult> queryCommon)
         where TResult : notnull;
+
+    /// <summary>
+    ///     Gets the latest (maximum) SortableUniqueId across all events in the event store.
+    ///     Useful for passing to IWaitForSortableUniqueId to ensure projection catch-up.
+    ///     Returns empty string if no events exist.
+    /// </summary>
+    Task<ResultBox<string>> GetLatestSortableUniqueIdAsync();
 }

--- a/dcb/src/Sekiban.Dcb.WithResult/InMemory/InMemoryDcbExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.WithResult/InMemory/InMemoryDcbExecutor.cs
@@ -66,6 +66,9 @@ public class InMemoryDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecut
         IListQueryCommon<TResult> queryCommon) =>
         _inner.QueryAsync(queryCommon);
 
+    Task<ResultBox<string>> ISekibanExecutor.GetLatestSortableUniqueIdAsync() =>
+        _inner.GetLatestSortableUniqueIdAsync();
+
     Task<ResultBox<SerializableTagState>> ISerializedSekibanDcbExecutor.GetSerializableTagStateAsync(TagStateId tagStateId) =>
         _inner.GetSerializableTagStateAsync(tagStateId);
 
@@ -325,6 +328,18 @@ public class InMemoryDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecut
                     StringComparison.Ordinal) > 0);
 
                 return Task.FromResult(ResultBox.FromValue((long)count));
+            }
+        }
+
+        public Task<ResultBox<string>> GetLatestSortableUniqueIdAsync()
+        {
+            var state = GetState();
+            lock (state.Lock)
+            {
+                var latest = state.Events.Count > 0
+                    ? state.Events[^1].SortableUniqueIdValue
+                    : string.Empty;
+                return Task.FromResult(ResultBox.FromValue(latest));
             }
         }
 

--- a/dcb/src/Sekiban.Dcb.WithResult/InMemory/InMemoryDcbExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.WithResult/InMemory/InMemoryDcbExecutor.cs
@@ -253,13 +253,10 @@ public class InMemoryDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecut
                 }
 
                 state.Events.AddRange(serializedEvents);
-                foreach (var se in serializedEvents)
-                {
-                    if (string.Compare(se.SortableUniqueIdValue, state.MaxSortableUniqueId, StringComparison.Ordinal) > 0)
-                    {
-                        state.MaxSortableUniqueId = se.SortableUniqueIdValue;
-                    }
-                }
+                state.MaxSortableUniqueId = serializedEvents
+                    .Select(se => se.SortableUniqueIdValue)
+                    .Append(state.MaxSortableUniqueId)
+                    .Max(StringComparer.Ordinal) ?? string.Empty;
                 var tagWrites = new List<TagWriteResult>();
                 var uniqueTags = list.SelectMany(e => e.Tags).Distinct();
                 foreach (var tagString in uniqueTags)

--- a/dcb/src/Sekiban.Dcb.WithResult/InMemory/InMemoryDcbExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.WithResult/InMemory/InMemoryDcbExecutor.cs
@@ -336,9 +336,14 @@ public class InMemoryDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecut
             var state = GetState();
             lock (state.Lock)
             {
-                var latest = state.Events.Count > 0
-                    ? state.Events[^1].SortableUniqueIdValue
-                    : string.Empty;
+                var latest = string.Empty;
+                foreach (var evt in state.Events)
+                {
+                    if (string.Compare(evt.SortableUniqueIdValue, latest, StringComparison.Ordinal) > 0)
+                    {
+                        latest = evt.SortableUniqueIdValue;
+                    }
+                }
                 return Task.FromResult(ResultBox.FromValue(latest));
             }
         }

--- a/dcb/src/Sekiban.Dcb.WithResult/InMemory/InMemoryDcbExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.WithResult/InMemory/InMemoryDcbExecutor.cs
@@ -88,6 +88,7 @@ public class InMemoryDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecut
         {
             public object Lock { get; } = new();
             public List<SerializedEventData> Events { get; } = new();
+            public string MaxSortableUniqueId { get; set; } = string.Empty;
         }
 
         private readonly System.Collections.Concurrent.ConcurrentDictionary<string, ServiceState> _states = new(StringComparer.Ordinal);
@@ -252,6 +253,13 @@ public class InMemoryDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecut
                 }
 
                 state.Events.AddRange(serializedEvents);
+                foreach (var se in serializedEvents)
+                {
+                    if (string.Compare(se.SortableUniqueIdValue, state.MaxSortableUniqueId, StringComparison.Ordinal) > 0)
+                    {
+                        state.MaxSortableUniqueId = se.SortableUniqueIdValue;
+                    }
+                }
                 var tagWrites = new List<TagWriteResult>();
                 var uniqueTags = list.SelectMany(e => e.Tags).Distinct();
                 foreach (var tagString in uniqueTags)
@@ -336,15 +344,7 @@ public class InMemoryDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecut
             var state = GetState();
             lock (state.Lock)
             {
-                var latest = string.Empty;
-                foreach (var evt in state.Events)
-                {
-                    if (string.Compare(evt.SortableUniqueIdValue, latest, StringComparison.Ordinal) > 0)
-                    {
-                        latest = evt.SortableUniqueIdValue;
-                    }
-                }
-                return Task.FromResult(ResultBox.FromValue(latest));
+                return Task.FromResult(ResultBox.FromValue(state.MaxSortableUniqueId));
             }
         }
 
@@ -455,6 +455,10 @@ public class InMemoryDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecut
                     ev.EventMetadata,
                     ev.Tags);
                 _state.Events.Add(serializedEvent);
+                if (string.Compare(ev.SortableUniqueIdValue, _state.MaxSortableUniqueId, StringComparison.Ordinal) > 0)
+                {
+                    _state.MaxSortableUniqueId = ev.SortableUniqueIdValue;
+                }
             }
 
             public int CountEventsWithTag(string tagString) =>

--- a/dcb/src/Sekiban.Dcb.WithoutResult/Actors/GeneralSekibanExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.WithoutResult/Actors/GeneralSekibanExecutor.cs
@@ -132,6 +132,12 @@ public class GeneralSekibanExecutor : ISekibanExecutor, ISerializedSekibanDcbExe
         return result.UnwrapBox();
     }
 
+    public async Task<string> GetLatestSortableUniqueIdAsync()
+    {
+        var result = await _core.GetLatestSortableUniqueIdAsync();
+        return result.UnwrapBox();
+    }
+
     public Task<ResultBox<SerializableTagState>> GetSerializableTagStateAsync(TagStateId tagStateId) =>
         _core.GetSerializableTagStateAsync(tagStateId);
 

--- a/dcb/src/Sekiban.Dcb.WithoutResult/ISekibanExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.WithoutResult/ISekibanExecutor.cs
@@ -42,4 +42,12 @@ public interface ISekibanExecutor : ICommandExecutor
     /// <exception cref="Exception">Thrown when query execution fails</exception>
     Task<ListQueryResult<TResult>> QueryAsync<TResult>(IListQueryCommon<TResult> queryCommon)
         where TResult : notnull;
+
+    /// <summary>
+    ///     Gets the latest (maximum) SortableUniqueId across all events in the event store.
+    ///     Useful for passing to IWaitForSortableUniqueId to ensure projection catch-up.
+    ///     Returns empty string if no events exist.
+    /// </summary>
+    /// <exception cref="Exception">Thrown when the event store query fails</exception>
+    Task<string> GetLatestSortableUniqueIdAsync();
 }

--- a/dcb/src/Sekiban.Dcb.WithoutResult/InMemory/InMemoryDcbExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.WithoutResult/InMemory/InMemoryDcbExecutor.cs
@@ -91,6 +91,7 @@ public class InMemoryDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecut
         {
             public object Lock { get; } = new();
             public List<SerializedEventData> Events { get; } = new();
+            public string MaxSortableUniqueId { get; set; } = string.Empty;
         }
 
         private readonly System.Collections.Concurrent.ConcurrentDictionary<string, ServiceState> _states = new(StringComparer.Ordinal);
@@ -255,6 +256,13 @@ public class InMemoryDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecut
                 }
 
                 state.Events.AddRange(serializedEvents);
+                foreach (var se in serializedEvents)
+                {
+                    if (string.Compare(se.SortableUniqueIdValue, state.MaxSortableUniqueId, StringComparison.Ordinal) > 0)
+                    {
+                        state.MaxSortableUniqueId = se.SortableUniqueIdValue;
+                    }
+                }
                 var tagWrites = new List<TagWriteResult>();
                 var uniqueTags = list.SelectMany(e => e.Tags).Distinct();
                 foreach (var tagString in uniqueTags)
@@ -339,15 +347,7 @@ public class InMemoryDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecut
             var state = GetState();
             lock (state.Lock)
             {
-                var latest = string.Empty;
-                foreach (var evt in state.Events)
-                {
-                    if (string.Compare(evt.SortableUniqueIdValue, latest, StringComparison.Ordinal) > 0)
-                    {
-                        latest = evt.SortableUniqueIdValue;
-                    }
-                }
-                return Task.FromResult(ResultBox.FromValue(latest));
+                return Task.FromResult(ResultBox.FromValue(state.MaxSortableUniqueId));
             }
         }
 
@@ -452,6 +452,10 @@ public class InMemoryDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecut
                     ev.EventMetadata,
                     ev.Tags);
                 _state.Events.Add(serializedEvent);
+                if (string.Compare(ev.SortableUniqueIdValue, _state.MaxSortableUniqueId, StringComparison.Ordinal) > 0)
+                {
+                    _state.MaxSortableUniqueId = ev.SortableUniqueIdValue;
+                }
             }
 
             public int CountEventsWithTag(string tagString) =>

--- a/dcb/src/Sekiban.Dcb.WithoutResult/InMemory/InMemoryDcbExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.WithoutResult/InMemory/InMemoryDcbExecutor.cs
@@ -68,6 +68,9 @@ public class InMemoryDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecut
         IListQueryCommon<TResult> queryCommon) =>
         _inner.QueryAsync(queryCommon);
 
+    Task<string> ISekibanExecutor.GetLatestSortableUniqueIdAsync() =>
+        _inner.GetLatestSortableUniqueIdAsync();
+
     Task<ResultBox<SerializableTagState>> ISerializedSekibanDcbExecutor.GetSerializableTagStateAsync(TagStateId tagStateId) =>
         _inner.GetSerializableTagStateAsync(tagStateId);
 
@@ -328,6 +331,18 @@ public class InMemoryDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecut
                     StringComparison.Ordinal) > 0);
 
                 return Task.FromResult(ResultBox.FromValue((long)count));
+            }
+        }
+
+        public Task<ResultBox<string>> GetLatestSortableUniqueIdAsync()
+        {
+            var state = GetState();
+            lock (state.Lock)
+            {
+                var latest = state.Events.Count > 0
+                    ? state.Events[^1].SortableUniqueIdValue
+                    : string.Empty;
+                return Task.FromResult(ResultBox.FromValue(latest));
             }
         }
 

--- a/dcb/src/Sekiban.Dcb.WithoutResult/InMemory/InMemoryDcbExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.WithoutResult/InMemory/InMemoryDcbExecutor.cs
@@ -256,13 +256,10 @@ public class InMemoryDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecut
                 }
 
                 state.Events.AddRange(serializedEvents);
-                foreach (var se in serializedEvents)
-                {
-                    if (string.Compare(se.SortableUniqueIdValue, state.MaxSortableUniqueId, StringComparison.Ordinal) > 0)
-                    {
-                        state.MaxSortableUniqueId = se.SortableUniqueIdValue;
-                    }
-                }
+                state.MaxSortableUniqueId = serializedEvents
+                    .Select(se => se.SortableUniqueIdValue)
+                    .Append(state.MaxSortableUniqueId)
+                    .Max(StringComparer.Ordinal) ?? string.Empty;
                 var tagWrites = new List<TagWriteResult>();
                 var uniqueTags = list.SelectMany(e => e.Tags).Distinct();
                 foreach (var tagString in uniqueTags)

--- a/dcb/src/Sekiban.Dcb.WithoutResult/InMemory/InMemoryDcbExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.WithoutResult/InMemory/InMemoryDcbExecutor.cs
@@ -339,9 +339,14 @@ public class InMemoryDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecut
             var state = GetState();
             lock (state.Lock)
             {
-                var latest = state.Events.Count > 0
-                    ? state.Events[^1].SortableUniqueIdValue
-                    : string.Empty;
+                var latest = string.Empty;
+                foreach (var evt in state.Events)
+                {
+                    if (string.Compare(evt.SortableUniqueIdValue, latest, StringComparison.Ordinal) > 0)
+                    {
+                        latest = evt.SortableUniqueIdValue;
+                    }
+                }
                 return Task.FromResult(ResultBox.FromValue(latest));
             }
         }

--- a/dcb/tests/Sekiban.Dcb.ColdEvents.Tests/ColdEventDefaultsTests.cs
+++ b/dcb/tests/Sekiban.Dcb.ColdEvents.Tests/ColdEventDefaultsTests.cs
@@ -57,6 +57,7 @@ public class ColdEventDefaultsTests
         public Task<ResultBox<bool>> TagExistsAsync(ITag tag) => throw new NotSupportedException();
         public Task<ResultBox<long>> GetEventCountAsync(SortableUniqueId? since = null) => throw new NotSupportedException();
         public Task<ResultBox<IEnumerable<TagInfo>>> GetAllTagsAsync(string? tagGroup = null) => throw new NotSupportedException();
+        public Task<ResultBox<string>> GetLatestSortableUniqueIdAsync() => throw new NotSupportedException();
         public Task<ResultBox<IEnumerable<SerializableEvent>>> ReadAllSerializableEventsAsync(SortableUniqueId? since = null) => throw new NotSupportedException();
         public Task<ResultBox<IEnumerable<SerializableEvent>>> ReadAllSerializableEventsAsync(SortableUniqueId? since, int? maxCount) => throw new NotSupportedException();
         public Task<ResultBox<SerializableEvent>> ReadSerializableEventAsync(Guid eventId) => throw new NotSupportedException();

--- a/dcb/tests/Sekiban.Dcb.ColdEvents.Tests/ColdExporterTests.cs
+++ b/dcb/tests/Sekiban.Dcb.ColdEvents.Tests/ColdExporterTests.cs
@@ -304,6 +304,9 @@ public class ColdExporterTests
         public Task<ResultBox<IEnumerable<TagInfo>>> GetAllTagsAsync(string? tagGroup = null)
             => throw new NotSupportedException();
 
+        public Task<ResultBox<string>> GetLatestSortableUniqueIdAsync()
+            => throw new NotSupportedException();
+
         public Task<ResultBox<IEnumerable<SerializableEvent>>> ReadAllSerializableEventsAsync(SortableUniqueId? since = null)
         {
             IEnumerable<SerializableEvent> result = since is null
@@ -440,6 +443,9 @@ public class ColdExporterTests
             => throw new NotSupportedException();
 
         public Task<ResultBox<IEnumerable<TagInfo>>> GetAllTagsAsync(string? tagGroup = null)
+            => throw new NotSupportedException();
+
+        public Task<ResultBox<string>> GetLatestSortableUniqueIdAsync()
             => throw new NotSupportedException();
 
         public Task<ResultBox<IEnumerable<SerializableEvent>>> ReadAllSerializableEventsAsync(SortableUniqueId? since = null)

--- a/dcb/tests/Sekiban.Dcb.ColdEvents.Tests/HybridEventStoreCatchUpPathTests.cs
+++ b/dcb/tests/Sekiban.Dcb.ColdEvents.Tests/HybridEventStoreCatchUpPathTests.cs
@@ -286,6 +286,9 @@ public class HybridEventStoreCatchUpPathTests
         public Task<ResultBox<IEnumerable<TagInfo>>> GetAllTagsAsync(string? tagGroup = null)
             => throw new NotSupportedException();
 
+        public Task<ResultBox<string>> GetLatestSortableUniqueIdAsync()
+            => throw new NotSupportedException();
+
         public Task<ResultBox<IEnumerable<SerializableEvent>>> ReadAllSerializableEventsAsync(
             SortableUniqueId? since = null)
         {

--- a/dcb/tests/Sekiban.Dcb.ColdEvents.Tests/HybridEventStoreTests.cs
+++ b/dcb/tests/Sekiban.Dcb.ColdEvents.Tests/HybridEventStoreTests.cs
@@ -458,6 +458,9 @@ public class HybridEventStoreTests
         public Task<ResultBox<IEnumerable<TagInfo>>> GetAllTagsAsync(string? tagGroup = null)
             => throw new NotSupportedException();
 
+        public Task<ResultBox<string>> GetLatestSortableUniqueIdAsync()
+            => throw new NotSupportedException();
+
         public Task<ResultBox<IEnumerable<SerializableEvent>>> ReadAllSerializableEventsAsync(SortableUniqueId? since = null)
         {
             IEnumerable<SerializableEvent> filtered = _ignoreSinceFilter || since is null
@@ -518,6 +521,9 @@ public class HybridEventStoreTests
             => throw new NotSupportedException();
 
         public Task<ResultBox<IEnumerable<TagInfo>>> GetAllTagsAsync(string? tagGroup = null)
+            => throw new NotSupportedException();
+
+        public Task<ResultBox<string>> GetLatestSortableUniqueIdAsync()
             => throw new NotSupportedException();
 
         public Task<ResultBox<IEnumerable<SerializableEvent>>> ReadAllSerializableEventsAsync(SortableUniqueId? since = null)

--- a/dcb/tests/Sekiban.Dcb.Orleans.Tests/MinimalOrleansTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Orleans.Tests/MinimalOrleansTests.cs
@@ -468,6 +468,8 @@ public class MinimalOrleansTests : IAsyncLifetime
 
         public Task<ResultBox<IEnumerable<TagInfo>>> GetAllTagsAsync(string? tagGroup = null) => _inner.GetAllTagsAsync(tagGroup);
 
+        public Task<ResultBox<string>> GetLatestSortableUniqueIdAsync() => _inner.GetLatestSortableUniqueIdAsync();
+
         public Task<ResultBox<IEnumerable<SerializableEvent>>> ReadSerializableEventsByTagAsync(
             ITag tag,
             SortableUniqueId? since = null) => _inner.ReadSerializableEventsByTagAsync(tag, since);

--- a/dcb/tests/Sekiban.Dcb.Orleans.Tests/MultiProjectionGrainPersistPolicyTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Orleans.Tests/MultiProjectionGrainPersistPolicyTests.cs
@@ -284,6 +284,7 @@ public class MultiProjectionGrainPersistPolicyTests
         public Task<ResultBox<bool>> TagExistsAsync(ITag tag) => throw new NotSupportedException();
         public Task<ResultBox<long>> GetEventCountAsync(SortableUniqueId? since = null) => throw new NotSupportedException();
         public Task<ResultBox<IEnumerable<TagInfo>>> GetAllTagsAsync(string? tagGroup = null) => throw new NotSupportedException();
+        public Task<ResultBox<string>> GetLatestSortableUniqueIdAsync() => throw new NotSupportedException();
         public Task<ResultBox<IEnumerable<SerializableEvent>>> ReadSerializableEventsByTagAsync(ITag tag, SortableUniqueId? since = null) =>
             throw new NotSupportedException();
         public Task<ResultBox<SerializableEvent>> ReadSerializableEventAsync(Guid eventId) => throw new NotSupportedException();

--- a/dcb/tests/Sekiban.Dcb.Orleans.Tests/MultiProjectionGrainRetentionCompactionTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Orleans.Tests/MultiProjectionGrainRetentionCompactionTests.cs
@@ -220,6 +220,7 @@ public class MultiProjectionGrainRetentionCompactionTests
         public Task<ResultBox<bool>> TagExistsAsync(ITag tag) => throw new NotSupportedException();
         public Task<ResultBox<long>> GetEventCountAsync(SortableUniqueId? since = null) => throw new NotSupportedException();
         public Task<ResultBox<IEnumerable<TagInfo>>> GetAllTagsAsync(string? tagGroup = null) => throw new NotSupportedException();
+        public Task<ResultBox<string>> GetLatestSortableUniqueIdAsync() => throw new NotSupportedException();
         public Task<ResultBox<IEnumerable<SerializableEvent>>> ReadAllSerializableEventsAsync(SortableUniqueId? since = null) => throw new NotSupportedException();
         public Task<ResultBox<IEnumerable<SerializableEvent>>> ReadAllSerializableEventsAsync(SortableUniqueId? since, int? maxCount) => throw new NotSupportedException();
         public Task<ResultBox<SerializableEvent>> ReadSerializableEventAsync(Guid eventId) => throw new NotSupportedException();

--- a/dcb/tests/Sekiban.Dcb.Orleans.Tests/OrleansTagStateGrainPersistenceTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Orleans.Tests/OrleansTagStateGrainPersistenceTests.cs
@@ -364,6 +364,8 @@ public class OrleansTagStateGrainPersistenceTests : IAsyncLifetime
 
         public Task<ResultBox<IEnumerable<TagInfo>>> GetAllTagsAsync(string? tagGroup = null) => _inner.GetAllTagsAsync(tagGroup);
 
+        public Task<ResultBox<string>> GetLatestSortableUniqueIdAsync() => _inner.GetLatestSortableUniqueIdAsync();
+
         public Task<ResultBox<IEnumerable<SerializableEvent>>> ReadAllSerializableEventsAsync(SortableUniqueId? since = null)
             => _inner.ReadAllSerializableEventsAsync(since);
 

--- a/dcb/tests/Sekiban.Dcb.Orleans.Tests/OrleansTagStatePersistentTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Orleans.Tests/OrleansTagStatePersistentTests.cs
@@ -302,6 +302,9 @@ public class OrleansTagStatePersistentTests
         public Task<ResultBox<IEnumerable<TagInfo>>> GetAllTagsAsync(string? tagGroup = null) =>
             Task.FromResult(ResultBox.FromValue(Enumerable.Empty<TagInfo>()));
 
+        public Task<ResultBox<string>> GetLatestSortableUniqueIdAsync() =>
+            Task.FromResult(ResultBox.FromValue(string.Empty));
+
         public Task<ResultBox<IEnumerable<SerializableEvent>>> ReadAllSerializableEventsAsync(SortableUniqueId? since = null) =>
             Task.FromResult(ResultBox.FromValue(Enumerable.Empty<SerializableEvent>()));
 

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/EventStoreCacheSyncTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/EventStoreCacheSyncTests.cs
@@ -152,6 +152,9 @@ public class EventStoreCacheSyncTests
         public Task<ResultBox<IEnumerable<TagInfo>>> GetAllTagsAsync(string? tagGroup = null) =>
             throw new NotSupportedException();
 
+        public Task<ResultBox<string>> GetLatestSortableUniqueIdAsync() =>
+            throw new NotSupportedException();
+
         public Task<ResultBox<IEnumerable<SerializableEvent>>> ReadAllSerializableEventsAsync(SortableUniqueId? since = null) =>
             ReadAllSerializableEventsAsync(since, null);
 

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/GeneralTagStateActorPersistenceTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/GeneralTagStateActorPersistenceTests.cs
@@ -360,6 +360,8 @@ public class GeneralTagStateActorPersistenceTests
 
         public Task<ResultBox<IEnumerable<TagInfo>>> GetAllTagsAsync(string? tagGroup = null) => _inner.GetAllTagsAsync(tagGroup);
 
+        public Task<ResultBox<string>> GetLatestSortableUniqueIdAsync() => _inner.GetLatestSortableUniqueIdAsync();
+
         public Task<ResultBox<IEnumerable<SerializableEvent>>> ReadAllSerializableEventsAsync(SortableUniqueId? since = null) =>
             _inner.ReadAllSerializableEventsAsync(since);
 

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/GetLatestSortableUniqueIdTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/GetLatestSortableUniqueIdTests.cs
@@ -58,14 +58,15 @@ public class GetLatestSortableUniqueIdTests
         Assert.True(result2.IsSuccess);
         var id2 = result2.GetValue().SortableUniqueId!;
 
-        Assert.True(string.Compare(id2, id1, StringComparison.Ordinal) > 0);
+        var expectedMinimumLatestId =
+            string.Compare(id1, id2, StringComparison.Ordinal) >= 0 ? id1 : id2;
 
         var result = await executor.GetLatestSortableUniqueIdAsync();
 
         Assert.True(result.IsSuccess);
         var latestId = result.GetValue();
         Assert.True(
-            string.Compare(latestId, id2, StringComparison.Ordinal) >= 0,
-            $"Expected latestId >= id2, but got '{latestId}' < '{id2}'");
+            string.Compare(latestId, expectedMinimumLatestId, StringComparison.Ordinal) >= 0,
+            $"Expected latestId >= max(id1, id2), but got '{latestId}' < '{expectedMinimumLatestId}'");
     }
 }

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/GetLatestSortableUniqueIdTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/GetLatestSortableUniqueIdTests.cs
@@ -1,0 +1,71 @@
+using Dcb.Domain;
+using Dcb.Domain.Student;
+using Sekiban.Dcb.InMemory;
+using Xunit;
+
+namespace Sekiban.Dcb.Tests;
+
+/// <summary>
+///     Tests for ISekibanExecutor.GetLatestSortableUniqueIdAsync (global)
+/// </summary>
+public class GetLatestSortableUniqueIdTests
+{
+    [Fact]
+    public async Task NoEvents_Should_Return_EmptyString()
+    {
+        var domain = DomainType.GetDomainTypes();
+        ISekibanExecutor executor = new InMemoryDcbExecutor(domain);
+
+        var result = await executor.GetLatestSortableUniqueIdAsync();
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(string.Empty, result.GetValue());
+    }
+
+    [Fact]
+    public async Task AfterSingleCommand_Should_Return_CommandSortableUniqueId()
+    {
+        var domain = DomainType.GetDomainTypes();
+        ISekibanExecutor executor = new InMemoryDcbExecutor(domain);
+
+        var commandResult = await executor.ExecuteAsync(new CreateStudent(Guid.NewGuid(), "Test Student", 5));
+        Assert.True(commandResult.IsSuccess);
+
+        var commandSortableId = commandResult.GetValue().SortableUniqueId;
+        Assert.NotNull(commandSortableId);
+
+        var result = await executor.GetLatestSortableUniqueIdAsync();
+
+        Assert.True(result.IsSuccess);
+        var latestId = result.GetValue();
+        Assert.NotEmpty(latestId);
+        Assert.True(
+            string.Compare(latestId, commandSortableId, StringComparison.Ordinal) >= 0,
+            $"Expected latestId >= commandSortableId, but got '{latestId}' < '{commandSortableId}'");
+    }
+
+    [Fact]
+    public async Task AfterMultipleCommands_Should_Return_Latest()
+    {
+        var domain = DomainType.GetDomainTypes();
+        ISekibanExecutor executor = new InMemoryDcbExecutor(domain);
+
+        var result1 = await executor.ExecuteAsync(new CreateStudent(Guid.NewGuid(), "Student One", 3));
+        Assert.True(result1.IsSuccess);
+        var id1 = result1.GetValue().SortableUniqueId!;
+
+        var result2 = await executor.ExecuteAsync(new CreateStudent(Guid.NewGuid(), "Student Two", 4));
+        Assert.True(result2.IsSuccess);
+        var id2 = result2.GetValue().SortableUniqueId!;
+
+        Assert.True(string.Compare(id2, id1, StringComparison.Ordinal) > 0);
+
+        var result = await executor.GetLatestSortableUniqueIdAsync();
+
+        Assert.True(result.IsSuccess);
+        var latestId = result.GetValue();
+        Assert.True(
+            string.Compare(latestId, id2, StringComparison.Ordinal) >= 0,
+            $"Expected latestId >= id2, but got '{latestId}' < '{id2}'");
+    }
+}

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/InMemoryEventStore.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/InMemoryEventStore.cs
@@ -205,9 +205,14 @@ public class InMemoryEventStore : IEventStore
     {
         lock (_lock)
         {
-            var latest = _events.Count > 0
-                ? _events[^1].SortableUniqueIdValue
-                : string.Empty;
+            var latest = string.Empty;
+            foreach (var evt in _events)
+            {
+                if (string.Compare(evt.SortableUniqueIdValue, latest, StringComparison.Ordinal) > 0)
+                {
+                    latest = evt.SortableUniqueIdValue;
+                }
+            }
             return Task.FromResult(ResultBox.FromValue(latest));
         }
     }

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/InMemoryEventStore.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/InMemoryEventStore.cs
@@ -201,6 +201,17 @@ public class InMemoryEventStore : IEventStore
         }
     }
 
+    public Task<ResultBox<string>> GetLatestSortableUniqueIdAsync()
+    {
+        lock (_lock)
+        {
+            var latest = _events.Count > 0
+                ? _events[^1].SortableUniqueIdValue
+                : string.Empty;
+            return Task.FromResult(ResultBox.FromValue(latest));
+        }
+    }
+
     public Task<ResultBox<IEnumerable<TagInfo>>> GetAllTagsAsync(string? tagGroup = null)
     {
         lock (_lock)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Add a global `GetLatestSortableUniqueIdAsync()` method to `IEventStore` and `ISekibanExecutor` (both WithResult and WithoutResult) that retrieves the maximum `SortableUniqueId` across all events in the store.

**Primary use case**: Enabling `IWaitForSortableUniqueId` across request scopes. After writing events in one request, a subsequent request can call `GetLatestSortableUniqueIdAsync()` and pass the result to a query's `WaitForSortableUniqueId` to ensure the projection has caught up.

**Why global instead of per-TagGroup**: All MultiProjection grains subscribe to the same global event stream (`DefaultOrleansEventSubscriptionResolver` → `namespace = "AllEvents"`). A projection's `LastSortableUniqueId` advances globally, so a global ID is semantically correct for catch-up waiting. The previous per-TagGroup approach (#1003) was rejected because `TagGroup` is not indexed in Postgres.

**Performance guarantee**: Every storage provider already has the required index — no new indexes, schema changes, or migrations needed:

| Provider | Index/Structure | Cost |
|----------|----------------|------|
| Postgres | `IX_Events_Service_SortableUniqueId` | O(log N) |
| SQLite | `IX_Events_Service_SortableUniqueId` | O(log N) |
| CosmosDB | Composite `(serviceId, sortableUniqueId)` | TOP 1 DESC |
| DynamoDB | GSI1 `sortableUniqueId` RANGE key | O(1) per shard |
| InMemory | Last element of ordered list | O(1) |
| Hybrid | Delegates to hot store | Same |

**Files changed (25)**: IEventStore interface + 7 storage providers + CoreGeneralSekibanExecutor + ISekibanExecutor (2) + GeneralSekibanExecutor (2) + OrleansDcbExecutor (2) + InMemoryDcbExecutor (2) + 8 test fake IEventStore implementations + 1 new test file.

## Related Tickets & Documents

- Closes #1006
- Supersedes #1003 (closed)

## QA Instructions, Screenshots, Recordings

1. `dotnet build Sekiban.slnx` — 0 errors
2. `dotnet test Sekiban.slnx --filter "FullyQualifiedName~Sekiban.Dcb"` — all tests pass (2 pre-existing failures in EventStoreCacheSyncTests unrelated to this change)

## Added/updated tests?

- [x] Yes

3 new tests in `GetLatestSortableUniqueIdTests.cs`: empty store returns empty string, single command returns matching ID, multiple commands returns latest ID.