### PR TITLE
Reduce transient memory spikes during large snapshot persistence

### DIFF
--- a/dcb/internalUsages/DcbOrleans.SnapshotPersistProbe/DcbOrleans.SnapshotPersistProbe.csproj
+++ b/dcb/internalUsages/DcbOrleans.SnapshotPersistProbe/DcbOrleans.SnapshotPersistProbe.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Sekiban.Dcb.Core.Model\Sekiban.Dcb.Core.Model.csproj" />
+    <ProjectReference Include="..\..\src\Sekiban.Dcb.Core\Sekiban.Dcb.Core.csproj" />
+    <ProjectReference Include="..\..\src\Sekiban.Dcb.Orleans.Core\Sekiban.Dcb.Orleans.Core.csproj" />
+    <ProjectReference Include="..\..\src\Sekiban.Dcb.Orleans.WithResult\Sekiban.Dcb.Orleans.WithResult.csproj" />
+  </ItemGroup>
+</Project>

--- a/dcb/internalUsages/DcbOrleans.SnapshotPersistProbe/Program.cs
+++ b/dcb/internalUsages/DcbOrleans.SnapshotPersistProbe/Program.cs
@@ -1,0 +1,403 @@
+using System.Diagnostics;
+using System.Reflection;
+using System.Text;
+using System.Text.Json;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using ResultBoxes;
+using Sekiban.Dcb;
+using Sekiban.Dcb.Actors;
+using Sekiban.Dcb.Common;
+using Sekiban.Dcb.Domains;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.MultiProjections;
+using Sekiban.Dcb.Queries;
+using Sekiban.Dcb.Runtime.Native;
+using Sekiban.Dcb.Snapshots;
+using Sekiban.Dcb.Tags;
+
+var options = ProbeOptions.Parse(args);
+using var workspace = new ProbeWorkspace();
+
+var runs = new List<ProbeRunResult>(capacity: options.Iterations);
+for (var i = 0; i < options.Iterations; i++)
+{
+    runs.Add(await ExecuteRunAsync(options, workspace, i).ConfigureAwait(false));
+}
+
+var summary = new ProbeSummary(
+    Mode: options.Mode,
+    EventCount: options.EventCount,
+    PayloadSizeBytes: options.PayloadSizeBytes,
+    OffloadThresholdBytes: options.OffloadThresholdBytes,
+    Iterations: options.Iterations,
+    Command: string.Join(" ", Environment.GetCommandLineArgs().Skip(1)),
+    PeakWorkingSetBytes: runs.Max(r => r.PeakWorkingSetBytes),
+    PeakManagedBytes: runs.Max(r => r.PeakManagedBytes),
+    SnapshotSizeBytes: runs.Max(r => r.SnapshotSizeBytes),
+    EnvelopeIsOffloaded: runs.Any(r => r.EnvelopeIsOffloaded),
+    OffloadedPayloadLengthBytes: runs.Max(r => r.OffloadedPayloadLengthBytes),
+    CompressedPayloadBytes: runs.Max(r => r.CompressedPayloadBytes),
+    OriginalPayloadBytes: runs.Max(r => r.OriginalPayloadBytes),
+    Runs: runs);
+
+Console.WriteLine(JsonSerializer.Serialize(summary, new JsonSerializerOptions
+{
+    WriteIndented = true
+}));
+return;
+
+static async Task<ProbeRunResult> ExecuteRunAsync(
+    ProbeOptions options,
+    ProbeWorkspace workspace,
+    int iteration)
+{
+    var domainTypes = BuildDomainTypes();
+    var primitive = new NativeMultiProjectionProjectionPrimitive(domainTypes);
+    var services = new ServiceCollection()
+        .AddSingleton<IBlobStorageSnapshotAccessor>(workspace.BlobAccessor)
+        .BuildServiceProvider();
+    var host = new NativeProjectionActorHost(
+        domainTypes,
+        services,
+        primitive,
+        LargePayloadProjector.MultiProjectorName,
+        new GeneralMultiProjectionActorOptions { SafeWindowMs = 1000 },
+        NullLogger.Instance);
+
+    var events = BuildEvents(options.EventCount, options.PayloadSizeBytes);
+    await host.AddSerializableEventsAsync(events, finishedCatchUp: true).ConfigureAwait(false);
+    host.ForcePromoteAllBufferedEvents();
+
+    GC.Collect();
+    GC.WaitForPendingFinalizers();
+    GC.Collect();
+
+    using var process = Process.GetCurrentProcess();
+    process.Refresh();
+
+    var baselineWorkingSet = process.WorkingSet64;
+    var baselineManaged = GC.GetTotalMemory(forceFullCollection: false);
+    var peakWorkingSet = baselineWorkingSet;
+    var peakManaged = baselineManaged;
+
+    using var cts = new CancellationTokenSource();
+    var samplingTask = Task.Run(async () =>
+    {
+        while (!cts.IsCancellationRequested)
+        {
+            process.Refresh();
+            peakWorkingSet = Math.Max(peakWorkingSet, process.WorkingSet64);
+            peakManaged = Math.Max(peakManaged, GC.GetTotalMemory(forceFullCollection: false));
+            try
+            {
+                await Task.Delay(5, cts.Token).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+        }
+    });
+
+    await using var snapshotStream = new MemoryStream();
+    var writeResult = options.Mode switch
+    {
+        ProbeMode.Legacy => await host.WriteSnapshotToStreamAsync(
+            snapshotStream,
+            canGetUnsafeState: false,
+            CancellationToken.None).ConfigureAwait(false),
+        ProbeMode.Offloaded => await WriteOffloadedSnapshotAsync(
+            host,
+            snapshotStream,
+            options.OffloadThresholdBytes).ConfigureAwait(false),
+        _ => throw new ArgumentOutOfRangeException()
+    };
+
+    cts.Cancel();
+    await samplingTask.ConfigureAwait(false);
+
+    if (!writeResult.IsSuccess)
+    {
+        throw writeResult.GetException();
+    }
+
+    snapshotStream.Position = 0;
+    var envelope = await JsonSerializer.DeserializeAsync<SerializableMultiProjectionStateEnvelope>(
+        snapshotStream,
+        domainTypes.JsonSerializerOptions).ConfigureAwait(false)
+        ?? throw new InvalidOperationException("Snapshot probe deserialized null envelope.");
+
+    return new ProbeRunResult(
+        Iteration: iteration + 1,
+        BaselineWorkingSetBytes: baselineWorkingSet,
+        BaselineManagedBytes: baselineManaged,
+        PeakWorkingSetBytes: peakWorkingSet,
+        PeakManagedBytes: peakManaged,
+        SnapshotSizeBytes: snapshotStream.Length,
+        EnvelopeIsOffloaded: envelope.IsOffloaded,
+        OffloadedPayloadLengthBytes: envelope.OffloadedState?.PayloadLength ?? 0,
+        CompressedPayloadBytes: GetOptionalLong(envelope.OffloadedState, "CompressedSizeBytes") ?? envelope.InlineState?.CompressedSizeBytes ?? 0,
+        OriginalPayloadBytes: GetOptionalLong(envelope.OffloadedState, "OriginalSizeBytes") ?? envelope.InlineState?.OriginalSizeBytes ?? 0);
+}
+
+static async Task<ResultBox<bool>> WriteOffloadedSnapshotAsync(
+    NativeProjectionActorHost host,
+    Stream target,
+    int offloadThresholdBytes)
+{
+    var method = typeof(NativeProjectionActorHost).GetMethod(
+        "WriteSnapshotForPersistenceToStreamAsync",
+        BindingFlags.Instance | BindingFlags.Public);
+    if (method is null)
+    {
+        return ResultBox.Error<bool>(
+            new NotSupportedException("Offloaded snapshot persistence is not available in this checkout."));
+    }
+
+    var task = method.Invoke(host, [target, false, offloadThresholdBytes, CancellationToken.None])
+        as Task<ResultBox<bool>>;
+    if (task is null)
+    {
+        return ResultBox.Error<bool>(
+            new InvalidOperationException("Unexpected WriteSnapshotForPersistenceToStreamAsync return type."));
+    }
+
+    return await task.ConfigureAwait(false);
+}
+
+static IReadOnlyList<SerializableEvent> BuildEvents(int eventCount, int payloadSizeBytes)
+{
+    var random = new Random(12345);
+    var baseTime = DateTime.UtcNow.AddMinutes(-10);
+    var events = new List<SerializableEvent>(capacity: eventCount);
+
+    for (var i = 0; i < eventCount; i++)
+    {
+        var payload = new LargePayloadCreated(GenerateRandomAsciiString(random, payloadSizeBytes));
+        var sortableUniqueId = SortableUniqueId.Generate(baseTime.AddSeconds(i), Guid.NewGuid());
+        events.Add(new SerializableEvent(
+            Encoding.UTF8.GetBytes(JsonSerializer.Serialize(payload, payload.GetType())),
+            sortableUniqueId,
+            Guid.NewGuid(),
+            new EventMetadata($"cmd-{i:D4}", $"causation-{i:D4}", "probe"),
+            [],
+            nameof(LargePayloadCreated)));
+    }
+
+    return events;
+}
+
+static DcbDomainTypes BuildDomainTypes()
+{
+    var eventTypes = new SimpleEventTypes();
+    eventTypes.RegisterEventType<LargePayloadCreated>(nameof(LargePayloadCreated));
+
+    var multiProjectorTypes = new SimpleMultiProjectorTypes();
+    multiProjectorTypes.RegisterProjector<LargePayloadProjector>();
+
+    return new DcbDomainTypes(
+        eventTypes,
+        new SimpleTagTypes(),
+        new SimpleTagProjectorTypes(),
+        new SimpleTagStatePayloadTypes(),
+        multiProjectorTypes,
+        new SimpleQueryTypes());
+}
+
+static string GenerateRandomAsciiString(Random random, int length)
+{
+    const string chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+    var buffer = new char[length];
+    for (var i = 0; i < buffer.Length; i++)
+    {
+        buffer[i] = chars[random.Next(chars.Length)];
+    }
+    return new string(buffer);
+}
+
+static long? GetOptionalLong(object? target, string propertyName)
+{
+    if (target is null)
+    {
+        return null;
+    }
+
+    var property = target.GetType().GetProperty(propertyName, BindingFlags.Instance | BindingFlags.Public);
+    if (property?.GetValue(target) is long longValue)
+    {
+        return longValue;
+    }
+
+    return null;
+}
+
+sealed class ProbeWorkspace : IDisposable
+{
+    private readonly string _rootDirectory = Path.Combine(
+        Path.GetTempPath(),
+        "sekiban-snapshot-persist-probe",
+        Guid.NewGuid().ToString("N"));
+
+    public ProbeWorkspace()
+    {
+        Directory.CreateDirectory(_rootDirectory);
+        BlobAccessor = new TempFileBlobStorageSnapshotAccessor(Path.Combine(_rootDirectory, "blob"));
+    }
+
+    public TempFileBlobStorageSnapshotAccessor BlobAccessor { get; }
+
+    public void Dispose()
+    {
+        BlobAccessor.Dispose();
+        if (Directory.Exists(_rootDirectory))
+        {
+            Directory.Delete(_rootDirectory, recursive: true);
+        }
+    }
+}
+
+sealed class TempFileBlobStorageSnapshotAccessor(string rootDirectory) : IBlobStorageSnapshotAccessor, IDisposable
+{
+    private readonly string _rootDirectory = rootDirectory;
+
+    public string ProviderName => "TempFileProbe";
+
+    public async Task<string> WriteAsync(
+        Stream data,
+        string projectorName,
+        CancellationToken cancellationToken = default)
+    {
+        Directory.CreateDirectory(_rootDirectory);
+        var key = $"{projectorName}-{Guid.NewGuid():N}.bin";
+        var path = Path.Combine(_rootDirectory, key);
+        await using var fileStream = File.Create(path);
+        await data.CopyToAsync(fileStream, cancellationToken).ConfigureAwait(false);
+        return key;
+    }
+
+    public Task<Stream> OpenReadAsync(string key, CancellationToken cancellationToken = default)
+    {
+        var path = Path.Combine(_rootDirectory, key);
+        Stream stream = File.OpenRead(path);
+        return Task.FromResult(stream);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_rootDirectory))
+        {
+            Directory.Delete(_rootDirectory, recursive: true);
+        }
+    }
+}
+
+sealed record ProbeOptions(
+    ProbeMode Mode,
+    int EventCount,
+    int PayloadSizeBytes,
+    int OffloadThresholdBytes,
+    int Iterations)
+{
+    public static ProbeOptions Parse(string[] args)
+    {
+        ProbeMode mode = ProbeMode.Legacy;
+        var eventCount = 24;
+        var payloadSizeBytes = 512 * 1024;
+        var offloadThresholdBytes = 1024 * 1024;
+        var iterations = 3;
+
+        for (var i = 0; i < args.Length; i++)
+        {
+            switch (args[i])
+            {
+                case "--mode":
+                    mode = ParseMode(args[++i]);
+                    break;
+                case "--event-count":
+                    eventCount = int.Parse(args[++i]);
+                    break;
+                case "--payload-size":
+                    payloadSizeBytes = int.Parse(args[++i]);
+                    break;
+                case "--offload-threshold-bytes":
+                    offloadThresholdBytes = int.Parse(args[++i]);
+                    break;
+                case "--iterations":
+                    iterations = int.Parse(args[++i]);
+                    break;
+                default:
+                    throw new ArgumentException($"Unknown argument: {args[i]}");
+            }
+        }
+
+        return new ProbeOptions(mode, eventCount, payloadSizeBytes, offloadThresholdBytes, iterations);
+    }
+
+    private static ProbeMode ParseMode(string value) =>
+        value.ToLowerInvariant() switch
+        {
+            "legacy" => ProbeMode.Legacy,
+            "offloaded" => ProbeMode.Offloaded,
+            _ => throw new ArgumentOutOfRangeException(nameof(value), value, "Mode must be legacy or offloaded.")
+        };
+}
+
+enum ProbeMode
+{
+    Legacy,
+    Offloaded
+}
+
+sealed record ProbeSummary(
+    ProbeMode Mode,
+    int EventCount,
+    int PayloadSizeBytes,
+    int OffloadThresholdBytes,
+    int Iterations,
+    string Command,
+    long PeakWorkingSetBytes,
+    long PeakManagedBytes,
+    long SnapshotSizeBytes,
+    bool EnvelopeIsOffloaded,
+    long OffloadedPayloadLengthBytes,
+    long CompressedPayloadBytes,
+    long OriginalPayloadBytes,
+    IReadOnlyList<ProbeRunResult> Runs);
+
+sealed record ProbeRunResult(
+    int Iteration,
+    long BaselineWorkingSetBytes,
+    long BaselineManagedBytes,
+    long PeakWorkingSetBytes,
+    long PeakManagedBytes,
+    long SnapshotSizeBytes,
+    bool EnvelopeIsOffloaded,
+    long OffloadedPayloadLengthBytes,
+    long CompressedPayloadBytes,
+    long OriginalPayloadBytes);
+
+sealed record LargePayloadCreated(string Text) : IEventPayload;
+
+sealed record LargePayloadProjector(List<string> Items) : IMultiProjector<LargePayloadProjector>
+{
+    public LargePayloadProjector() : this([])
+    {
+    }
+
+    public static string MultiProjectorVersion => "1.0";
+    public static string MultiProjectorName => "snapshot-persist-probe";
+    public static LargePayloadProjector GenerateInitialPayload() => new([]);
+
+    public static ResultBox<LargePayloadProjector> Project(
+        LargePayloadProjector payload,
+        Event ev,
+        List<ITag> tags,
+        DcbDomainTypes domainTypes,
+        SortableUniqueId safeWindowThreshold) => ev.Payload switch
+        {
+            LargePayloadCreated created => ResultBox.FromValue(
+                payload with { Items = payload.Items.Concat([created.Text]).ToList() }),
+            _ => ResultBox.FromValue(payload)
+        };
+}

--- a/dcb/internalUsages/DcbOrleans.SnapshotPersistProbe/Program.cs
+++ b/dcb/internalUsages/DcbOrleans.SnapshotPersistProbe/Program.cs
@@ -270,8 +270,8 @@ internal sealed class TempFileBlobStorageSnapshotAccessor(string rootDirectory) 
     private const string TempFileProbeProviderName = "TempFileProbe";
     private readonly string _rootDirectory = rootDirectory;
 
-    public static string StaticProviderName => TempFileProbeProviderName;
-    public string ProviderName => StaticProviderName;
+    public static string ProviderName => TempFileProbeProviderName;
+    string IBlobStorageSnapshotAccessor.ProviderName => ProviderName;
 
     public async Task<string> WriteAsync(
         Stream data,

--- a/dcb/internalUsages/DcbOrleans.SnapshotPersistProbe/Program.cs
+++ b/dcb/internalUsages/DcbOrleans.SnapshotPersistProbe/Program.cs
@@ -16,223 +16,231 @@ using Sekiban.Dcb.Runtime.Native;
 using Sekiban.Dcb.Snapshots;
 using Sekiban.Dcb.Tags;
 
-var options = ProbeOptions.Parse(args);
-using var workspace = new ProbeWorkspace();
+namespace DcbOrleans.SnapshotPersistProbe;
 
-var runs = new List<ProbeRunResult>(capacity: options.Iterations);
-for (var i = 0; i < options.Iterations; i++)
+internal static class Program
 {
-    runs.Add(await ExecuteRunAsync(options, workspace, i).ConfigureAwait(false));
-}
-
-var summary = new ProbeSummary(
-    Mode: options.Mode,
-    EventCount: options.EventCount,
-    PayloadSizeBytes: options.PayloadSizeBytes,
-    OffloadThresholdBytes: options.OffloadThresholdBytes,
-    Iterations: options.Iterations,
-    Command: string.Join(" ", Environment.GetCommandLineArgs().Skip(1)),
-    PeakWorkingSetBytes: runs.Max(r => r.PeakWorkingSetBytes),
-    PeakManagedBytes: runs.Max(r => r.PeakManagedBytes),
-    SnapshotSizeBytes: runs.Max(r => r.SnapshotSizeBytes),
-    EnvelopeIsOffloaded: runs.Any(r => r.EnvelopeIsOffloaded),
-    OffloadedPayloadLengthBytes: runs.Max(r => r.OffloadedPayloadLengthBytes),
-    CompressedPayloadBytes: runs.Max(r => r.CompressedPayloadBytes),
-    OriginalPayloadBytes: runs.Max(r => r.OriginalPayloadBytes),
-    Runs: runs);
-
-Console.WriteLine(JsonSerializer.Serialize(summary, new JsonSerializerOptions
-{
-    WriteIndented = true
-}));
-return;
-
-static async Task<ProbeRunResult> ExecuteRunAsync(
-    ProbeOptions options,
-    ProbeWorkspace workspace,
-    int iteration)
-{
-    var domainTypes = BuildDomainTypes();
-    var primitive = new NativeMultiProjectionProjectionPrimitive(domainTypes);
-    var services = new ServiceCollection()
-        .AddSingleton<IBlobStorageSnapshotAccessor>(workspace.BlobAccessor)
-        .BuildServiceProvider();
-    var host = new NativeProjectionActorHost(
-        domainTypes,
-        services,
-        primitive,
-        LargePayloadProjector.MultiProjectorName,
-        new GeneralMultiProjectionActorOptions { SafeWindowMs = 1000 },
-        NullLogger.Instance);
-
-    var events = BuildEvents(options.EventCount, options.PayloadSizeBytes);
-    await host.AddSerializableEventsAsync(events, finishedCatchUp: true).ConfigureAwait(false);
-    host.ForcePromoteAllBufferedEvents();
-
-    GC.Collect();
-    GC.WaitForPendingFinalizers();
-    GC.Collect();
-
-    using var process = Process.GetCurrentProcess();
-    process.Refresh();
-
-    var baselineWorkingSet = process.WorkingSet64;
-    var baselineManaged = GC.GetTotalMemory(forceFullCollection: false);
-    var peakWorkingSet = baselineWorkingSet;
-    var peakManaged = baselineManaged;
-
-    using var cts = new CancellationTokenSource();
-    var samplingTask = Task.Run(async () =>
+    public static async Task Main(string[] args)
     {
-        while (!cts.IsCancellationRequested)
+        var options = ProbeOptions.Parse(args);
+        using var workspace = new ProbeWorkspace();
+
+        var runs = new List<ProbeRunResult>(capacity: options.Iterations);
+        for (var iteration = 0; iteration < options.Iterations; iteration++)
         {
-            process.Refresh();
-            peakWorkingSet = Math.Max(peakWorkingSet, process.WorkingSet64);
-            peakManaged = Math.Max(peakManaged, GC.GetTotalMemory(forceFullCollection: false));
-            try
-            {
-                await Task.Delay(5, cts.Token).ConfigureAwait(false);
-            }
-            catch (OperationCanceledException)
-            {
-                break;
-            }
+            runs.Add(await ExecuteRunAsync(options, workspace, iteration).ConfigureAwait(false));
         }
-    });
 
-    await using var snapshotStream = new MemoryStream();
-    var writeResult = options.Mode switch
+        var summary = new ProbeSummary(
+            Mode: options.Mode,
+            EventCount: options.EventCount,
+            PayloadSizeBytes: options.PayloadSizeBytes,
+            OffloadThresholdBytes: options.OffloadThresholdBytes,
+            Iterations: options.Iterations,
+            Command: string.Join(" ", Environment.GetCommandLineArgs().Skip(1)),
+            PeakWorkingSetBytes: runs.Max(r => r.PeakWorkingSetBytes),
+            PeakManagedBytes: runs.Max(r => r.PeakManagedBytes),
+            SnapshotSizeBytes: runs.Max(r => r.SnapshotSizeBytes),
+            EnvelopeIsOffloaded: runs.Any(r => r.EnvelopeIsOffloaded),
+            OffloadedPayloadLengthBytes: runs.Max(r => r.OffloadedPayloadLengthBytes),
+            CompressedPayloadBytes: runs.Max(r => r.CompressedPayloadBytes),
+            OriginalPayloadBytes: runs.Max(r => r.OriginalPayloadBytes),
+            Runs: runs);
+
+        Console.WriteLine(JsonSerializer.Serialize(summary, new JsonSerializerOptions
+        {
+            WriteIndented = true
+        }));
+    }
+
+    private static async Task<ProbeRunResult> ExecuteRunAsync(
+        ProbeOptions options,
+        ProbeWorkspace workspace,
+        int iteration)
     {
-        ProbeMode.Legacy => await host.WriteSnapshotToStreamAsync(
+        var domainTypes = BuildDomainTypes();
+        var primitive = new NativeMultiProjectionProjectionPrimitive(domainTypes);
+        var services = new ServiceCollection()
+            .AddSingleton<IBlobStorageSnapshotAccessor>(workspace.BlobAccessor)
+            .BuildServiceProvider();
+        var host = new NativeProjectionActorHost(
+            domainTypes,
+            services,
+            primitive,
+            LargePayloadProjector.MultiProjectorName,
+            new GeneralMultiProjectionActorOptions { SafeWindowMs = 1000 },
+            NullLogger.Instance);
+
+        var events = BuildEvents(options.EventCount, options.PayloadSizeBytes);
+        await host.AddSerializableEventsAsync(events, finishedCatchUp: true).ConfigureAwait(false);
+        host.ForcePromoteAllBufferedEvents();
+
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+
+        using var process = Process.GetCurrentProcess();
+        process.Refresh();
+
+        var baselineWorkingSet = process.WorkingSet64;
+        var baselineManaged = GC.GetTotalMemory(forceFullCollection: false);
+        var peakWorkingSet = baselineWorkingSet;
+        var peakManaged = baselineManaged;
+
+        using var cts = new CancellationTokenSource();
+        var samplingTask = Task.Run(async () =>
+        {
+            while (!cts.IsCancellationRequested)
+            {
+                process.Refresh();
+                peakWorkingSet = Math.Max(peakWorkingSet, process.WorkingSet64);
+                peakManaged = Math.Max(peakManaged, GC.GetTotalMemory(forceFullCollection: false));
+                try
+                {
+                    await Task.Delay(5, cts.Token).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                    break;
+                }
+            }
+        });
+
+        await using var snapshotStream = new MemoryStream();
+        var writeResult = options.Mode switch
+        {
+            ProbeMode.Legacy => await host.WriteSnapshotToStreamAsync(
+                snapshotStream,
+                canGetUnsafeState: false,
+                CancellationToken.None).ConfigureAwait(false),
+            ProbeMode.Offloaded => await WriteOffloadedSnapshotAsync(
+                host,
+                snapshotStream,
+                options.OffloadThresholdBytes).ConfigureAwait(false),
+            _ => throw new ArgumentOutOfRangeException()
+        };
+
+        cts.Cancel();
+        await samplingTask.ConfigureAwait(false);
+
+        if (!writeResult.IsSuccess)
+        {
+            throw writeResult.GetException();
+        }
+
+        snapshotStream.Position = 0;
+        var envelope = await JsonSerializer.DeserializeAsync<SerializableMultiProjectionStateEnvelope>(
             snapshotStream,
-            canGetUnsafeState: false,
-            CancellationToken.None).ConfigureAwait(false),
-        ProbeMode.Offloaded => await WriteOffloadedSnapshotAsync(
-            host,
-            snapshotStream,
-            options.OffloadThresholdBytes).ConfigureAwait(false),
-        _ => throw new ArgumentOutOfRangeException()
-    };
+            domainTypes.JsonSerializerOptions).ConfigureAwait(false)
+            ?? throw new InvalidOperationException("Snapshot probe deserialized null envelope.");
 
-    cts.Cancel();
-    await samplingTask.ConfigureAwait(false);
-
-    if (!writeResult.IsSuccess)
-    {
-        throw writeResult.GetException();
+        return new ProbeRunResult(
+            Iteration: iteration + 1,
+            BaselineWorkingSetBytes: baselineWorkingSet,
+            BaselineManagedBytes: baselineManaged,
+            PeakWorkingSetBytes: peakWorkingSet,
+            PeakManagedBytes: peakManaged,
+            SnapshotSizeBytes: snapshotStream.Length,
+            EnvelopeIsOffloaded: envelope.IsOffloaded,
+            OffloadedPayloadLengthBytes: envelope.OffloadedState?.PayloadLength ?? 0,
+            CompressedPayloadBytes: GetOptionalLong(envelope.OffloadedState, "CompressedSizeBytes") ?? envelope.InlineState?.CompressedSizeBytes ?? 0,
+            OriginalPayloadBytes: GetOptionalLong(envelope.OffloadedState, "OriginalSizeBytes") ?? envelope.InlineState?.OriginalSizeBytes ?? 0);
     }
 
-    snapshotStream.Position = 0;
-    var envelope = await JsonSerializer.DeserializeAsync<SerializableMultiProjectionStateEnvelope>(
-        snapshotStream,
-        domainTypes.JsonSerializerOptions).ConfigureAwait(false)
-        ?? throw new InvalidOperationException("Snapshot probe deserialized null envelope.");
-
-    return new ProbeRunResult(
-        Iteration: iteration + 1,
-        BaselineWorkingSetBytes: baselineWorkingSet,
-        BaselineManagedBytes: baselineManaged,
-        PeakWorkingSetBytes: peakWorkingSet,
-        PeakManagedBytes: peakManaged,
-        SnapshotSizeBytes: snapshotStream.Length,
-        EnvelopeIsOffloaded: envelope.IsOffloaded,
-        OffloadedPayloadLengthBytes: envelope.OffloadedState?.PayloadLength ?? 0,
-        CompressedPayloadBytes: GetOptionalLong(envelope.OffloadedState, "CompressedSizeBytes") ?? envelope.InlineState?.CompressedSizeBytes ?? 0,
-        OriginalPayloadBytes: GetOptionalLong(envelope.OffloadedState, "OriginalSizeBytes") ?? envelope.InlineState?.OriginalSizeBytes ?? 0);
-}
-
-static async Task<ResultBox<bool>> WriteOffloadedSnapshotAsync(
-    NativeProjectionActorHost host,
-    Stream target,
-    int offloadThresholdBytes)
-{
-    var method = typeof(NativeProjectionActorHost).GetMethod(
-        "WriteSnapshotForPersistenceToStreamAsync",
-        BindingFlags.Instance | BindingFlags.Public);
-    if (method is null)
+    private static async Task<ResultBox<bool>> WriteOffloadedSnapshotAsync(
+        NativeProjectionActorHost host,
+        Stream target,
+        int offloadThresholdBytes)
     {
-        return ResultBox.Error<bool>(
-            new NotSupportedException("Offloaded snapshot persistence is not available in this checkout."));
+        var method = typeof(NativeProjectionActorHost).GetMethod(
+            "WriteSnapshotForPersistenceToStreamAsync",
+            BindingFlags.Instance | BindingFlags.Public);
+        if (method is null)
+        {
+            return ResultBox.Error<bool>(
+                new NotSupportedException("Offloaded snapshot persistence is not available in this checkout."));
+        }
+
+        var task = method.Invoke(host, [target, false, offloadThresholdBytes, CancellationToken.None])
+            as Task<ResultBox<bool>>;
+        if (task is null)
+        {
+            return ResultBox.Error<bool>(
+                new InvalidOperationException("Unexpected WriteSnapshotForPersistenceToStreamAsync return type."));
+        }
+
+        return await task.ConfigureAwait(false);
     }
 
-    var task = method.Invoke(host, [target, false, offloadThresholdBytes, CancellationToken.None])
-        as Task<ResultBox<bool>>;
-    if (task is null)
+    private static IReadOnlyList<SerializableEvent> BuildEvents(int eventCount, int payloadSizeBytes)
     {
-        return ResultBox.Error<bool>(
-            new InvalidOperationException("Unexpected WriteSnapshotForPersistenceToStreamAsync return type."));
+        var random = new Random(12345);
+        var baseTime = DateTime.UtcNow.AddMinutes(-10);
+        var events = new List<SerializableEvent>(capacity: eventCount);
+
+        for (var iteration = 0; iteration < eventCount; iteration++)
+        {
+            var payload = new LargePayloadCreated(GenerateRandomAsciiString(random, payloadSizeBytes));
+            var sortableUniqueId = SortableUniqueId.Generate(baseTime.AddSeconds(iteration), Guid.NewGuid());
+            events.Add(new SerializableEvent(
+                Encoding.UTF8.GetBytes(JsonSerializer.Serialize(payload, payload.GetType())),
+                sortableUniqueId,
+                Guid.NewGuid(),
+                new EventMetadata($"cmd-{iteration:D4}", $"causation-{iteration:D4}", "probe"),
+                [],
+                nameof(LargePayloadCreated)));
+        }
+
+        return events;
     }
 
-    return await task.ConfigureAwait(false);
-}
-
-static IReadOnlyList<SerializableEvent> BuildEvents(int eventCount, int payloadSizeBytes)
-{
-    var random = new Random(12345);
-    var baseTime = DateTime.UtcNow.AddMinutes(-10);
-    var events = new List<SerializableEvent>(capacity: eventCount);
-
-    for (var i = 0; i < eventCount; i++)
+    private static DcbDomainTypes BuildDomainTypes()
     {
-        var payload = new LargePayloadCreated(GenerateRandomAsciiString(random, payloadSizeBytes));
-        var sortableUniqueId = SortableUniqueId.Generate(baseTime.AddSeconds(i), Guid.NewGuid());
-        events.Add(new SerializableEvent(
-            Encoding.UTF8.GetBytes(JsonSerializer.Serialize(payload, payload.GetType())),
-            sortableUniqueId,
-            Guid.NewGuid(),
-            new EventMetadata($"cmd-{i:D4}", $"causation-{i:D4}", "probe"),
-            [],
-            nameof(LargePayloadCreated)));
+        var eventTypes = new SimpleEventTypes();
+        eventTypes.RegisterEventType<LargePayloadCreated>(nameof(LargePayloadCreated));
+
+        var multiProjectorTypes = new SimpleMultiProjectorTypes();
+        multiProjectorTypes.RegisterProjector<LargePayloadProjector>();
+
+        return new DcbDomainTypes(
+            eventTypes,
+            new SimpleTagTypes(),
+            new SimpleTagProjectorTypes(),
+            new SimpleTagStatePayloadTypes(),
+            multiProjectorTypes,
+            new SimpleQueryTypes());
     }
 
-    return events;
-}
-
-static DcbDomainTypes BuildDomainTypes()
-{
-    var eventTypes = new SimpleEventTypes();
-    eventTypes.RegisterEventType<LargePayloadCreated>(nameof(LargePayloadCreated));
-
-    var multiProjectorTypes = new SimpleMultiProjectorTypes();
-    multiProjectorTypes.RegisterProjector<LargePayloadProjector>();
-
-    return new DcbDomainTypes(
-        eventTypes,
-        new SimpleTagTypes(),
-        new SimpleTagProjectorTypes(),
-        new SimpleTagStatePayloadTypes(),
-        multiProjectorTypes,
-        new SimpleQueryTypes());
-}
-
-static string GenerateRandomAsciiString(Random random, int length)
-{
-    const string chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
-    var buffer = new char[length];
-    for (var i = 0; i < buffer.Length; i++)
+    private static string GenerateRandomAsciiString(Random random, int length)
     {
-        buffer[i] = chars[random.Next(chars.Length)];
+        const string chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+        var buffer = new char[length];
+        for (var index = 0; index < buffer.Length; index++)
+        {
+            buffer[index] = chars[random.Next(chars.Length)];
+        }
+
+        return new string(buffer);
     }
-    return new string(buffer);
-}
 
-static long? GetOptionalLong(object? target, string propertyName)
-{
-    if (target is null)
+    private static long? GetOptionalLong(object? target, string propertyName)
     {
+        if (target is null)
+        {
+            return null;
+        }
+
+        var property = target.GetType().GetProperty(propertyName, BindingFlags.Instance | BindingFlags.Public);
+        if (property?.GetValue(target) is long longValue)
+        {
+            return longValue;
+        }
+
         return null;
     }
-
-    var property = target.GetType().GetProperty(propertyName, BindingFlags.Instance | BindingFlags.Public);
-    if (property?.GetValue(target) is long longValue)
-    {
-        return longValue;
-    }
-
-    return null;
 }
 
-sealed class ProbeWorkspace : IDisposable
+internal sealed class ProbeWorkspace : IDisposable
 {
     private readonly string _rootDirectory = Path.Combine(
         Path.GetTempPath(),
@@ -257,11 +265,13 @@ sealed class ProbeWorkspace : IDisposable
     }
 }
 
-sealed class TempFileBlobStorageSnapshotAccessor(string rootDirectory) : IBlobStorageSnapshotAccessor, IDisposable
+internal sealed class TempFileBlobStorageSnapshotAccessor(string rootDirectory) : IBlobStorageSnapshotAccessor, IDisposable
 {
+    private const string TempFileProbeProviderName = "TempFileProbe";
     private readonly string _rootDirectory = rootDirectory;
 
-    public string ProviderName => "TempFileProbe";
+    public static string StaticProviderName => TempFileProbeProviderName;
+    public string ProviderName => StaticProviderName;
 
     public async Task<string> WriteAsync(
         Stream data,
@@ -292,7 +302,7 @@ sealed class TempFileBlobStorageSnapshotAccessor(string rootDirectory) : IBlobSt
     }
 }
 
-sealed record ProbeOptions(
+internal sealed record ProbeOptions(
     ProbeMode Mode,
     int EventCount,
     int PayloadSizeBytes,
@@ -307,27 +317,33 @@ sealed record ProbeOptions(
         var offloadThresholdBytes = 1024 * 1024;
         var iterations = 3;
 
-        for (var i = 0; i < args.Length; i++)
+        for (var index = 0; index < args.Length; index += 2)
         {
-            switch (args[i])
+            if (index + 1 >= args.Length)
+            {
+                throw new ArgumentException($"Missing value for argument: {args[index]}");
+            }
+
+            var value = args[index + 1];
+            switch (args[index])
             {
                 case "--mode":
-                    mode = ParseMode(args[++i]);
+                    mode = ParseMode(value);
                     break;
                 case "--event-count":
-                    eventCount = int.Parse(args[++i]);
+                    eventCount = int.Parse(value);
                     break;
                 case "--payload-size":
-                    payloadSizeBytes = int.Parse(args[++i]);
+                    payloadSizeBytes = int.Parse(value);
                     break;
                 case "--offload-threshold-bytes":
-                    offloadThresholdBytes = int.Parse(args[++i]);
+                    offloadThresholdBytes = int.Parse(value);
                     break;
                 case "--iterations":
-                    iterations = int.Parse(args[++i]);
+                    iterations = int.Parse(value);
                     break;
                 default:
-                    throw new ArgumentException($"Unknown argument: {args[i]}");
+                    throw new ArgumentException($"Unknown argument: {args[index]}");
             }
         }
 
@@ -343,13 +359,13 @@ sealed record ProbeOptions(
         };
 }
 
-enum ProbeMode
+internal enum ProbeMode
 {
     Legacy,
     Offloaded
 }
 
-sealed record ProbeSummary(
+internal sealed record ProbeSummary(
     ProbeMode Mode,
     int EventCount,
     int PayloadSizeBytes,
@@ -365,7 +381,7 @@ sealed record ProbeSummary(
     long OriginalPayloadBytes,
     IReadOnlyList<ProbeRunResult> Runs);
 
-sealed record ProbeRunResult(
+internal sealed record ProbeRunResult(
     int Iteration,
     long BaselineWorkingSetBytes,
     long BaselineManagedBytes,
@@ -377,9 +393,9 @@ sealed record ProbeRunResult(
     long CompressedPayloadBytes,
     long OriginalPayloadBytes);
 
-sealed record LargePayloadCreated(string Text) : IEventPayload;
+internal sealed record LargePayloadCreated(string Text) : IEventPayload;
 
-sealed record LargePayloadProjector(List<string> Items) : IMultiProjector<LargePayloadProjector>
+internal sealed record LargePayloadProjector(List<string> Items) : IMultiProjector<LargePayloadProjector>
 {
     public LargePayloadProjector() : this([])
     {

--- a/dcb/src/Sekiban.Dcb.Core/Actors/GeneralMultiProjectionActor.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Actors/GeneralMultiProjectionActor.cs
@@ -338,7 +338,14 @@ public class GeneralMultiProjectionActor
         await using var jsonStream = new MemoryStream();
         await JsonSerializer.SerializeAsync(jsonStream, envelope, _jsonOptions, cancellationToken)
             .ConfigureAwait(false);
-        var size = (int)jsonStream.Length;
+        var size = jsonStream.Length;
+
+        if (size > int.MaxValue)
+        {
+            return ResultBox.Error<SnapshotPersistenceData>(
+                new InvalidOperationException(
+                    $"Snapshot size {size} exceeds supported string conversion limit {int.MaxValue}."));
+        }
 
         if (_options.MaxSnapshotSerializedSizeBytes > 0 && size > _options.MaxSnapshotSerializedSizeBytes)
         {
@@ -349,8 +356,8 @@ public class GeneralMultiProjectionActor
 
         // Safe position for hosts to persist
         var safePosition = await GetSafeLastSortableUniqueIdAsync();
-        var json = Encoding.UTF8.GetString(jsonStream.GetBuffer(), 0, size);
-        return ResultBox.FromValue(new SnapshotPersistenceData(json, size, safePosition));
+        var json = Encoding.UTF8.GetString(jsonStream.GetBuffer(), 0, (int)size);
+        return ResultBox.FromValue(new SnapshotPersistenceData(json, (int)size, safePosition));
     }
 
     public async Task<bool> IsSortableUniqueIdReceived(string sortableUniqueId)

--- a/dcb/src/Sekiban.Dcb.Core/Actors/GeneralMultiProjectionActor.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Actors/GeneralMultiProjectionActor.cs
@@ -186,16 +186,16 @@ public class GeneralMultiProjectionActor
         _isCatchedUp = state.IsCatchedUp;
     }
 
-    private async Task<ResultBox<SerializableMultiProjectionState>> BuildSerializableStateAsync(bool canGetUnsafeState)
+    public async Task<ResultBox<SerializedMultiProjectionStatePayload>> BuildSerializedStatePayloadAsync(bool canGetUnsafeState)
     {
         InitializeProjectorsIfNeeded();
         var stateResult = await GetStateAsync(canGetUnsafeState);
-        if (!stateResult.IsSuccess) return ResultBox.Error<SerializableMultiProjectionState>(stateResult.GetException());
+        if (!stateResult.IsSuccess) return ResultBox.Error<SerializedMultiProjectionStatePayload>(stateResult.GetException());
 
         var multiProjectionState = stateResult.GetValue();
         var payload = multiProjectionState.Payload;
         var versionResult = _types.GetProjectorVersion(_projectorName);
-        if (!versionResult.IsSuccess) return ResultBox.Error<SerializableMultiProjectionState>(versionResult.GetException());
+        if (!versionResult.IsSuccess) return ResultBox.Error<SerializedMultiProjectionStatePayload>(versionResult.GetException());
         var projectorVersion = versionResult.GetValue();
 
         try
@@ -204,7 +204,7 @@ public class GeneralMultiProjectionActor
             var serializeResult = _types.Serialize(_projectorName, _domain, safeThreshold.Value, payload);
             if (!serializeResult.IsSuccess)
             {
-                return ResultBox.Error<SerializableMultiProjectionState>(serializeResult.GetException());
+                return ResultBox.Error<SerializedMultiProjectionStatePayload>(serializeResult.GetException());
             }
 
             var result = serializeResult.GetValue();
@@ -215,7 +215,7 @@ public class GeneralMultiProjectionActor
                 result.OriginalSizeBytes,
                 result.CompressionRatio);
             var payloadType = payload.GetType();
-            var state = SerializableMultiProjectionState.FromBytes(
+            return ResultBox.FromValue(new SerializedMultiProjectionStatePayload(
                 result.Data,
                 payloadType.FullName ?? payloadType.Name,
                 _projectorName,
@@ -226,26 +226,66 @@ public class GeneralMultiProjectionActor
                 _isCatchedUp,
                 multiProjectionState.IsSafeState,
                 result.OriginalSizeBytes,
-                result.CompressedSizeBytes);
-            return ResultBox.FromValue(state);
+                result.CompressedSizeBytes));
         }
         catch (Exception ex)
         {
-            return ResultBox.Error<SerializableMultiProjectionState>(ex);
+            return ResultBox.Error<SerializedMultiProjectionStatePayload>(ex);
         }
+    }
+
+    /// <summary>
+    ///     Returns a snapshot envelope, optionally offloading the payload when an accessor and threshold are provided.
+    /// </summary>
+    public async Task<ResultBox<SerializableMultiProjectionStateEnvelope>> BuildSnapshotEnvelopeAsync(
+        bool canGetUnsafeState = true,
+        IBlobStorageSnapshotAccessor? blobAccessor = null,
+        int offloadThresholdBytes = int.MaxValue,
+        CancellationToken cancellationToken = default)
+    {
+        var payloadResult = await BuildSerializedStatePayloadAsync(canGetUnsafeState);
+        if (!payloadResult.IsSuccess)
+        {
+            return ResultBox.Error<SerializableMultiProjectionStateEnvelope>(payloadResult.GetException());
+        }
+
+        var payload = payloadResult.GetValue();
+        if (blobAccessor is not null &&
+            offloadThresholdBytes > 0 &&
+            payload.PayloadBytes.LongLength > offloadThresholdBytes)
+        {
+            await using var uploadStream = new MemoryStream(payload.PayloadBytes, writable: false);
+            var offloadKey = await blobAccessor.WriteAsync(uploadStream, payload.ProjectorName, cancellationToken)
+                .ConfigureAwait(false);
+            return ResultBox.FromValue(new SerializableMultiProjectionStateEnvelope(
+                IsOffloaded: true,
+                InlineState: null,
+                OffloadedState: payload.ToOffloadedState(offloadKey, blobAccessor.ProviderName)));
+        }
+
+        return ResultBox.FromValue(new SerializableMultiProjectionStateEnvelope(
+            IsOffloaded: false,
+            InlineState: payload.ToInlineState(),
+            OffloadedState: null));
     }
 
     /// <summary>
     ///     Returns a snapshot envelope containing an inline payload.
     /// </summary>
-    public async Task<ResultBox<SerializableMultiProjectionStateEnvelope>> GetSnapshotAsync(
+    public Task<ResultBox<SerializableMultiProjectionStateEnvelope>> GetSnapshotAsync(
         bool canGetUnsafeState = true,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default) =>
+        BuildSnapshotEnvelopeAsync(canGetUnsafeState, null, int.MaxValue, cancellationToken);
+
+    private async Task<ResultBox<SerializableMultiProjectionState>> BuildSerializableStateAsync(bool canGetUnsafeState)
     {
-        var inline = await BuildSerializableStateAsync(canGetUnsafeState);
-        if (!inline.IsSuccess)
-            return ResultBox.Error<SerializableMultiProjectionStateEnvelope>(inline.GetException());
-        return ResultBox.FromValue(new SerializableMultiProjectionStateEnvelope(false, inline.GetValue(), null));
+        var payloadResult = await BuildSerializedStatePayloadAsync(canGetUnsafeState);
+        if (!payloadResult.IsSuccess)
+        {
+            return ResultBox.Error<SerializableMultiProjectionState>(payloadResult.GetException());
+        }
+
+        return ResultBox.FromValue(payloadResult.GetValue().ToInlineState());
     }
 
     /// <summary>
@@ -271,6 +311,8 @@ public class GeneralMultiProjectionActor
     /// </summary>
     public async Task<ResultBox<SnapshotPersistenceData>> BuildSnapshotForPersistenceAsync(
         bool canGetUnsafeState = false,
+        IBlobStorageSnapshotAccessor? blobAccessor = null,
+        int offloadThresholdBytes = int.MaxValue,
         CancellationToken cancellationToken = default)
     {
         // Promote buffered events before building a safe snapshot
@@ -282,15 +324,21 @@ public class GeneralMultiProjectionActor
         {
             // Ignore promotion errors to avoid blocking persistence
         }
-        var envelopeRb = await GetSnapshotAsync(canGetUnsafeState, cancellationToken);
+        var envelopeRb = await BuildSnapshotEnvelopeAsync(
+            canGetUnsafeState,
+            blobAccessor,
+            offloadThresholdBytes,
+            cancellationToken);
         if (!envelopeRb.IsSuccess)
         {
             return ResultBox.Error<SnapshotPersistenceData>(envelopeRb.GetException());
         }
 
         var envelope = envelopeRb.GetValue();
-        var json = JsonSerializer.Serialize(envelope, _jsonOptions);
-        var size = Encoding.UTF8.GetByteCount(json);
+        await using var jsonStream = new MemoryStream();
+        await JsonSerializer.SerializeAsync(jsonStream, envelope, _jsonOptions, cancellationToken)
+            .ConfigureAwait(false);
+        var size = (int)jsonStream.Length;
 
         if (_options.MaxSnapshotSerializedSizeBytes > 0 && size > _options.MaxSnapshotSerializedSizeBytes)
         {
@@ -301,6 +349,7 @@ public class GeneralMultiProjectionActor
 
         // Safe position for hosts to persist
         var safePosition = await GetSafeLastSortableUniqueIdAsync();
+        var json = Encoding.UTF8.GetString(jsonStream.GetBuffer(), 0, size);
         return ResultBox.FromValue(new SnapshotPersistenceData(json, size, safePosition));
     }
 

--- a/dcb/src/Sekiban.Dcb.Core/MultiProjections/MultiProjectionStateBuilder.cs
+++ b/dcb/src/Sekiban.Dcb.Core/MultiProjections/MultiProjectionStateBuilder.cs
@@ -20,6 +20,7 @@ public class MultiProjectionStateBuilder
     private readonly DcbDomainTypes _domainTypes;
     private readonly IEventStore _eventStore;
     private readonly IMultiProjectionStateStore _stateStore;
+    private readonly IBlobStorageSnapshotAccessor? _blobAccessor;
     private readonly ILogger<MultiProjectionStateBuilder> _logger;
 
     public MultiProjectionStateBuilder(
@@ -32,7 +33,7 @@ public class MultiProjectionStateBuilder
         _domainTypes = domainTypes;
         _eventStore = eventStore;
         _stateStore = stateStore;
-        _ = blobAccessor;
+        _blobAccessor = blobAccessor;
         _logger = logger ?? NullLogger<MultiProjectionStateBuilder>.Instance;
     }
 
@@ -132,7 +133,11 @@ public class MultiProjectionStateBuilder
                 actor, startPosition, options, ct);
 
             // Build snapshot
-            var snapshotResult = await actor.GetSnapshotAsync(canGetUnsafeState: false, ct);
+            var snapshotResult = await actor.BuildSnapshotEnvelopeAsync(
+                canGetUnsafeState: false,
+                blobAccessor: _blobAccessor,
+                offloadThresholdBytes: options.OffloadThresholdBytes,
+                cancellationToken: ct);
             if (!snapshotResult.IsSuccess)
             {
                 return new ProjectorBuildResult(
@@ -421,7 +426,7 @@ public class MultiProjectionStateBuilder
             throw new InvalidOperationException("Failed to deserialize Envelope JSON");
         }
 
-        return envelope;
+        return await SnapshotEnvelopeResolver.ResolveInlineAsync(envelope, _blobAccessor, ct);
     }
 
 }

--- a/dcb/src/Sekiban.Dcb.Core/MultiProjections/SerializableMultiProjectionState.cs
+++ b/dcb/src/Sekiban.Dcb.Core/MultiProjections/SerializableMultiProjectionState.cs
@@ -40,6 +40,13 @@ public record SerializableMultiProjectionState
     public long CompressedSizeBytes { get; init; }
 
     /// <summary>
+    ///     Runtime-only raw payload bytes used to avoid Base64 encode/decode churn
+    ///     when an offloaded snapshot is materialized back into an inline state.
+    /// </summary>
+    [JsonIgnore]
+    public byte[]? RuntimePayloadBytes { get; init; }
+
+    /// <summary>
     ///     JSON deserialization constructor - parameter names must match property names.
     /// </summary>
     [JsonConstructor]
@@ -108,11 +115,54 @@ public record SerializableMultiProjectionState
     }
 
     /// <summary>
+    ///     Creates a runtime-only inline state without Base64-encoding the payload.
+    ///     This is intended for transient restore flows and should not be serialized.
+    /// </summary>
+    public static SerializableMultiProjectionState FromRuntimeBytes(
+        byte[] payload,
+        string multiProjectionPayloadType,
+        string projectorName,
+        string projectorVersion,
+        string lastSortableUniqueId,
+        Guid lastEventId,
+        int version,
+        bool isCatchedUp = true,
+        bool isSafeState = true,
+        long originalSizeBytes = 0,
+        long compressedSizeBytes = 0)
+    {
+        if (originalSizeBytes == 0) originalSizeBytes = payload.LongLength;
+        if (compressedSizeBytes == 0) compressedSizeBytes = payload.LongLength;
+
+        return new SerializableMultiProjectionState(
+            payloadJson: null,
+            payloadBase64: null,
+            multiProjectionPayloadType,
+            projectorName,
+            projectorVersion,
+            lastSortableUniqueId,
+            lastEventId,
+            version,
+            isCatchedUp,
+            isSafeState,
+            originalSizeBytes,
+            compressedSizeBytes)
+        {
+            RuntimePayloadBytes = payload
+        };
+    }
+
+    /// <summary>
     ///     Gets the payload as bytes for deserialization.
     ///     Supports both v10 (Base64) and v9 (UTF-8 JSON) formats.
     /// </summary>
     public byte[] GetPayloadBytes()
     {
+        if (RuntimePayloadBytes is not null)
+        {
+            return RuntimePayloadBytes;
+        }
+
         // v10 format: Base64 encoded binary
         if (!string.IsNullOrEmpty(PayloadBase64))
         {

--- a/dcb/src/Sekiban.Dcb.Core/Snapshots/SerializableMultiProjectionStateOffloaded.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Snapshots/SerializableMultiProjectionStateOffloaded.cs
@@ -14,4 +14,6 @@ public sealed record SerializableMultiProjectionStateOffloaded(
     int Version,
     bool IsCatchedUp,
     bool IsSafeState,
-    long PayloadLength);
+    long PayloadLength,
+    long OriginalSizeBytes = 0,
+    long CompressedSizeBytes = 0);

--- a/dcb/src/Sekiban.Dcb.Core/Snapshots/SerializedMultiProjectionStatePayload.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Snapshots/SerializedMultiProjectionStatePayload.cs
@@ -1,0 +1,53 @@
+using Sekiban.Dcb.MultiProjections;
+
+namespace Sekiban.Dcb.Snapshots;
+
+/// <summary>
+///     Serialized multi-projection payload bytes plus the metadata needed to build
+///     either an inline snapshot state or an offloaded snapshot reference.
+/// </summary>
+public sealed record SerializedMultiProjectionStatePayload(
+    byte[] PayloadBytes,
+    string MultiProjectionPayloadType,
+    string ProjectorName,
+    string ProjectorVersion,
+    string LastSortableUniqueId,
+    Guid LastEventId,
+    int Version,
+    bool IsCatchedUp,
+    bool IsSafeState,
+    long OriginalSizeBytes,
+    long CompressedSizeBytes)
+{
+    public SerializableMultiProjectionState ToInlineState() =>
+        SerializableMultiProjectionState.FromBytes(
+            PayloadBytes,
+            MultiProjectionPayloadType,
+            ProjectorName,
+            ProjectorVersion,
+            LastSortableUniqueId,
+            LastEventId,
+            Version,
+            IsCatchedUp,
+            IsSafeState,
+            OriginalSizeBytes,
+            CompressedSizeBytes);
+
+    public SerializableMultiProjectionStateOffloaded ToOffloadedState(
+        string offloadKey,
+        string storageProvider) =>
+        new(
+            OffloadKey: offloadKey,
+            StorageProvider: storageProvider,
+            MultiProjectionPayloadType: MultiProjectionPayloadType,
+            ProjectorName: ProjectorName,
+            ProjectorVersion: ProjectorVersion,
+            LastSortableUniqueId: LastSortableUniqueId,
+            LastEventId: LastEventId,
+            Version: Version,
+            IsCatchedUp: IsCatchedUp,
+            IsSafeState: IsSafeState,
+            PayloadLength: PayloadBytes.LongLength,
+            OriginalSizeBytes: OriginalSizeBytes,
+            CompressedSizeBytes: CompressedSizeBytes);
+}

--- a/dcb/src/Sekiban.Dcb.Core/Snapshots/SnapshotEnvelopeResolver.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Snapshots/SnapshotEnvelopeResolver.cs
@@ -28,11 +28,11 @@ public static class SnapshotEnvelopeResolver
         var offloaded = envelope.OffloadedState;
         await using var stream = await blobAccessor.OpenReadAsync(offloaded.OffloadKey, cancellationToken)
             .ConfigureAwait(false);
-        using var buffer = new MemoryStream();
-        await stream.CopyToAsync(buffer, cancellationToken).ConfigureAwait(false);
+        var payloadBytes = await ReadPayloadBytesAsync(stream, offloaded.PayloadLength, cancellationToken)
+            .ConfigureAwait(false);
 
-        var inlineState = SerializableMultiProjectionState.FromBytes(
-            buffer.ToArray(),
+        var inlineState = SerializableMultiProjectionState.FromRuntimeBytes(
+            payloadBytes,
             offloaded.MultiProjectionPayloadType,
             offloaded.ProjectorName,
             offloaded.ProjectorVersion,
@@ -48,5 +48,45 @@ public static class SnapshotEnvelopeResolver
             IsOffloaded: false,
             InlineState: inlineState,
             OffloadedState: null);
+    }
+
+    private static async Task<byte[]> ReadPayloadBytesAsync(
+        Stream stream,
+        long payloadLength,
+        CancellationToken cancellationToken)
+    {
+        if (payloadLength <= 0 || payloadLength > int.MaxValue)
+        {
+            return await StreamReadHelper.ReadAllBytesAsync(stream, cancellationToken).ConfigureAwait(false);
+        }
+
+        var buffer = new byte[(int)payloadLength];
+        var offset = 0;
+        while (offset < buffer.Length)
+        {
+            var read = await stream.ReadAsync(
+                buffer.AsMemory(offset, buffer.Length - offset),
+                cancellationToken).ConfigureAwait(false);
+            if (read == 0)
+            {
+                break;
+            }
+
+            offset += read;
+        }
+
+        if (offset == buffer.Length)
+        {
+            return buffer;
+        }
+
+        if (offset == 0)
+        {
+            return [];
+        }
+
+        var trimmed = new byte[offset];
+        Buffer.BlockCopy(buffer, 0, trimmed, 0, offset);
+        return trimmed;
     }
 }

--- a/dcb/src/Sekiban.Dcb.Core/Snapshots/SnapshotEnvelopeResolver.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Snapshots/SnapshotEnvelopeResolver.cs
@@ -1,0 +1,52 @@
+using Sekiban.Dcb.MultiProjections;
+
+namespace Sekiban.Dcb.Snapshots;
+
+/// <summary>
+///     Resolves a snapshot envelope into a form that can be applied by the actor.
+///     Inline snapshots are returned as-is; offloaded payload snapshots are materialized
+///     back into an inline envelope using the provided blob accessor.
+/// </summary>
+public static class SnapshotEnvelopeResolver
+{
+    public static async Task<SerializableMultiProjectionStateEnvelope> ResolveInlineAsync(
+        SerializableMultiProjectionStateEnvelope envelope,
+        IBlobStorageSnapshotAccessor? blobAccessor,
+        CancellationToken cancellationToken = default)
+    {
+        if (!envelope.IsOffloaded || envelope.OffloadedState is null)
+        {
+            return envelope;
+        }
+
+        if (blobAccessor is null)
+        {
+            throw new InvalidOperationException(
+                "Offloaded snapshot payload cannot be restored without an IBlobStorageSnapshotAccessor.");
+        }
+
+        var offloaded = envelope.OffloadedState;
+        await using var stream = await blobAccessor.OpenReadAsync(offloaded.OffloadKey, cancellationToken)
+            .ConfigureAwait(false);
+        using var buffer = new MemoryStream();
+        await stream.CopyToAsync(buffer, cancellationToken).ConfigureAwait(false);
+
+        var inlineState = SerializableMultiProjectionState.FromBytes(
+            buffer.ToArray(),
+            offloaded.MultiProjectionPayloadType,
+            offloaded.ProjectorName,
+            offloaded.ProjectorVersion,
+            offloaded.LastSortableUniqueId,
+            offloaded.LastEventId,
+            offloaded.Version,
+            offloaded.IsCatchedUp,
+            offloaded.IsSafeState,
+            offloaded.OriginalSizeBytes,
+            offloaded.CompressedSizeBytes);
+
+        return new SerializableMultiProjectionStateEnvelope(
+            IsOffloaded: false,
+            InlineState: inlineState,
+            OffloadedState: null);
+    }
+}

--- a/dcb/src/Sekiban.Dcb.Orleans.Core/Grains/MultiProjectionGrain.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.Core/Grains/MultiProjectionGrain.cs
@@ -28,6 +28,10 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
 {
     private const int StreamingCatchUpApplyChunkSize = 4096;
     private const string EmptyLogValue = "empty";
+    private const int DefaultSnapshotEnvelopeSizeLimitBytes = 2 * 1024 * 1024;
+    private const int SnapshotEnvelopeBase64ExpansionNumerator = 3;
+    private const int SnapshotEnvelopeBase64ExpansionDenominator = 4;
+    private const int SnapshotEnvelopeReservedOverheadBytes = 16 * 1024;
     private readonly IProjectionActorHostFactory _actorHostFactory;
     private readonly IEventStore _eventStore;
     private readonly IPersistentState<MultiProjectionGrainState> _state;
@@ -833,7 +837,7 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
             var snapshotWriteResult = await _host.WriteSnapshotForPersistenceToStreamAsync(
                 snapshotStream,
                 canGetUnsafeState: false,
-                offloadThresholdBytes: _injectedActorOptions?.MaxSnapshotSerializedSizeBytes ?? 2 * 1024 * 1024,
+                offloadThresholdBytes: GetSnapshotPayloadOffloadThresholdBytes(),
                 CancellationToken.None);
             if (!snapshotWriteResult.IsSuccess)
             {
@@ -996,7 +1000,7 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
                 var writeResult = await _host!.WriteSnapshotForPersistenceToStreamAsync(
                     tempStream,
                     canGetUnsafeState: false,
-                    offloadThresholdBytes: _injectedActorOptions?.MaxSnapshotSerializedSizeBytes ?? 2 * 1024 * 1024,
+                    offloadThresholdBytes: GetSnapshotPayloadOffloadThresholdBytes(),
                     CancellationToken.None);
                 if (!writeResult.IsSuccess)
                 {
@@ -1142,6 +1146,21 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
                 await Task.Delay(50 * (retry + 1));
             }
         }
+    }
+
+    private int GetSnapshotPayloadOffloadThresholdBytes()
+    {
+        var envelopeLimit = _injectedActorOptions?.MaxSnapshotSerializedSizeBytes
+            ?? DefaultSnapshotEnvelopeSizeLimitBytes;
+        if (envelopeLimit <= 0)
+        {
+            return DefaultSnapshotEnvelopeSizeLimitBytes;
+        }
+
+        var adjustedLimit = Math.Max(1L, envelopeLimit - SnapshotEnvelopeReservedOverheadBytes);
+        var derivedThreshold = adjustedLimit * SnapshotEnvelopeBase64ExpansionNumerator
+            / SnapshotEnvelopeBase64ExpansionDenominator;
+        return (int)Math.Clamp(derivedThreshold, 1L, int.MaxValue);
     }
 
     // Debug: force promotion of ALL buffered events regardless of window

--- a/dcb/src/Sekiban.Dcb.Orleans.Core/Grains/MultiProjectionGrain.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.Core/Grains/MultiProjectionGrain.cs
@@ -830,9 +830,10 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
 
             // Get snapshot as opaque bytes from the host
             await using var snapshotStream = new MemoryStream();
-            var snapshotWriteResult = await _host.WriteSnapshotToStreamAsync(
+            var snapshotWriteResult = await _host.WriteSnapshotForPersistenceToStreamAsync(
                 snapshotStream,
                 canGetUnsafeState: false,
+                offloadThresholdBytes: _injectedActorOptions?.MaxSnapshotSerializedSizeBytes ?? 2 * 1024 * 1024,
                 CancellationToken.None);
             if (!snapshotWriteResult.IsSuccess)
             {
@@ -992,8 +993,11 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
 
             try
             {
-                var writeResult = await _host!.WriteSnapshotToStreamAsync(
-                    tempStream, canGetUnsafeState: false, CancellationToken.None);
+                var writeResult = await _host!.WriteSnapshotForPersistenceToStreamAsync(
+                    tempStream,
+                    canGetUnsafeState: false,
+                    offloadThresholdBytes: _injectedActorOptions?.MaxSnapshotSerializedSizeBytes ?? 2 * 1024 * 1024,
+                    CancellationToken.None);
                 if (!writeResult.IsSuccess)
                 {
                     _lastError = writeResult.GetException().Message;

--- a/dcb/src/Sekiban.Dcb.Orleans.Core/Runtimes/IProjectionActorHost.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.Core/Runtimes/IProjectionActorHost.cs
@@ -39,6 +39,16 @@ public interface IProjectionActorHost
         CancellationToken cancellationToken);
 
     /// <summary>
+    ///     Write a persistence-oriented snapshot to the provided stream, allowing the
+    ///     heavy payload to be offloaded before the envelope JSON is written.
+    /// </summary>
+    Task<ResultBox<bool>> WriteSnapshotForPersistenceToStreamAsync(
+        Stream target,
+        bool canGetUnsafeState,
+        int offloadThresholdBytes,
+        CancellationToken cancellationToken);
+
+    /// <summary>
     ///     Restore projection state from snapshot stream.
      /// </summary>
     Task<ResultBox<bool>> RestoreSnapshotFromStreamAsync(Stream source, CancellationToken cancellationToken);

--- a/dcb/src/Sekiban.Dcb.Orleans.Core/Runtimes/NativeProjectionActorHost.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.Core/Runtimes/NativeProjectionActorHost.cs
@@ -1,9 +1,11 @@
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.DependencyInjection;
 using ResultBoxes;
 using Sekiban.Dcb.Actors;
 using Sekiban.Dcb.Events;
 using Sekiban.Dcb.MultiProjections;
 using Sekiban.Dcb.Orleans.Serialization;
+using Sekiban.Dcb.Snapshots;
 
 namespace Sekiban.Dcb.Runtime.Native;
 
@@ -41,7 +43,11 @@ public class NativeProjectionActorHost : IProjectionActorHost
         _actor = accumulator.GetActor();
 
         _queryExecutor = new NativeProjectionQueryExecutor(domainTypes, jsonOptions, serviceProvider, _actor);
-        _snapshotHandler = new NativeProjectionSnapshotHandler(jsonOptions, _actor, resolvedLogger);
+        _snapshotHandler = new NativeProjectionSnapshotHandler(
+            jsonOptions,
+            _actor,
+            serviceProvider.GetService<IBlobStorageSnapshotAccessor>(),
+            resolvedLogger);
     }
 
     public Task AddSerializableEventsAsync(
@@ -99,6 +105,19 @@ public class NativeProjectionActorHost : IProjectionActorHost
         CancellationToken cancellationToken)
     {
         return _snapshotHandler.WriteSnapshotToStreamAsync(target, canGetUnsafeState, cancellationToken);
+    }
+
+    public Task<ResultBox<bool>> WriteSnapshotForPersistenceToStreamAsync(
+        Stream target,
+        bool canGetUnsafeState,
+        int offloadThresholdBytes,
+        CancellationToken cancellationToken)
+    {
+        return _snapshotHandler.WriteSnapshotForPersistenceToStreamAsync(
+            target,
+            canGetUnsafeState,
+            offloadThresholdBytes,
+            cancellationToken);
     }
 
     public Task<ResultBox<bool>> RestoreSnapshotFromStreamAsync(Stream source, CancellationToken cancellationToken)

--- a/dcb/src/Sekiban.Dcb.Orleans.Core/Runtimes/NativeProjectionSnapshotHandler.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.Core/Runtimes/NativeProjectionSnapshotHandler.cs
@@ -17,15 +17,18 @@ internal class NativeProjectionSnapshotHandler
 {
     private readonly JsonSerializerOptions _jsonOptions;
     private readonly GeneralMultiProjectionActor _actor;
+    private readonly IBlobStorageSnapshotAccessor? _blobAccessor;
     private readonly ILogger _logger;
 
     public NativeProjectionSnapshotHandler(
         JsonSerializerOptions jsonOptions,
         GeneralMultiProjectionActor actor,
+        IBlobStorageSnapshotAccessor? blobAccessor,
         ILogger logger)
     {
         _jsonOptions = jsonOptions;
         _actor = actor;
+        _blobAccessor = blobAccessor;
         _logger = logger;
     }
 
@@ -42,7 +45,12 @@ internal class NativeProjectionSnapshotHandler
                     new InvalidOperationException("Snapshot stream deserialized to null envelope."));
             }
 
-            await _actor.SetSnapshotAsync(envelope);
+            var resolvedEnvelope = await SnapshotEnvelopeResolver.ResolveInlineAsync(
+                envelope,
+                _blobAccessor,
+                cancellationToken);
+
+            await _actor.SetSnapshotAsync(resolvedEnvelope);
             return ResultBox.FromValue(true);
         }
         catch (Exception ex)
@@ -66,6 +74,45 @@ internal class NativeProjectionSnapshotHandler
 
             var envelope = snapshotResult.GetValue();
             await JsonSerializer.SerializeAsync(target, envelope, _jsonOptions, cancellationToken);
+            return ResultBox.FromValue(true);
+        }
+        catch (Exception ex)
+        {
+            return ResultBox.Error<bool>(ex);
+        }
+    }
+
+    public async Task<ResultBox<bool>> WriteSnapshotForPersistenceToStreamAsync(
+        Stream target,
+        bool canGetUnsafeState,
+        int offloadThresholdBytes,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            if (!canGetUnsafeState)
+            {
+                try
+                {
+                    _actor.ForcePromoteBufferedEvents();
+                }
+                catch
+                {
+                    // Best effort to align persistence snapshots with the current safe checkpoint.
+                }
+            }
+
+            var snapshotResult = await _actor.BuildSnapshotEnvelopeAsync(
+                canGetUnsafeState,
+                _blobAccessor,
+                offloadThresholdBytes,
+                cancellationToken);
+            if (!snapshotResult.IsSuccess)
+            {
+                return ResultBox.Error<bool>(snapshotResult.GetException());
+            }
+
+            await JsonSerializer.SerializeAsync(target, snapshotResult.GetValue(), _jsonOptions, cancellationToken);
             return ResultBox.FromValue(true);
         }
         catch (Exception ex)
@@ -140,7 +187,7 @@ internal class NativeProjectionSnapshotHandler
                     new SerializableMultiProjectionStateOffloaded(
                         o.OffloadKey, o.StorageProvider, o.MultiProjectionPayloadType, o.ProjectorName,
                         newVersion, o.LastSortableUniqueId, o.LastEventId, o.Version, o.IsCatchedUp, o.IsSafeState,
-                        o.PayloadLength));
+                        o.PayloadLength, o.OriginalSizeBytes, o.CompressedSizeBytes));
             }
             else
             {

--- a/dcb/tests/Sekiban.Dcb.Orleans.Tests/MockBlobStorageSnapshotAccessor.cs
+++ b/dcb/tests/Sekiban.Dcb.Orleans.Tests/MockBlobStorageSnapshotAccessor.cs
@@ -10,6 +10,8 @@ public class MockBlobStorageSnapshotAccessor : IBlobStorageSnapshotAccessor
     private readonly Dictionary<string, byte[]> _storage = new();
 
     public string ProviderName => "MockStorage";
+    public int StoredObjectCount => _storage.Count;
+    public void Clear() => _storage.Clear();
 
     public async Task<string> WriteAsync(Stream data, string projectorName, CancellationToken cancellationToken = default)
     {

--- a/dcb/tests/Sekiban.Dcb.Orleans.Tests/MultiProjectionGrainPersistPolicyTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Orleans.Tests/MultiProjectionGrainPersistPolicyTests.cs
@@ -244,6 +244,13 @@ public class MultiProjectionGrainPersistPolicyTests
         public Task<ResultBox<bool>> WriteSnapshotToStreamAsync(Stream target, bool canGetUnsafeState, CancellationToken cancellationToken) =>
             throw new NotSupportedException();
 
+        public Task<ResultBox<bool>> WriteSnapshotForPersistenceToStreamAsync(
+            Stream target,
+            bool canGetUnsafeState,
+            int offloadThresholdBytes,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
         public Task<ResultBox<bool>> RestoreSnapshotFromStreamAsync(Stream source, CancellationToken cancellationToken) =>
             throw new NotSupportedException();
 

--- a/dcb/tests/Sekiban.Dcb.Orleans.Tests/MultiProjectionGrainRetentionCompactionTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Orleans.Tests/MultiProjectionGrainRetentionCompactionTests.cs
@@ -180,6 +180,13 @@ public class MultiProjectionGrainRetentionCompactionTests
         public Task<ResultBox<bool>> WriteSnapshotToStreamAsync(Stream target, bool canGetUnsafeState, CancellationToken cancellationToken) =>
             throw new NotSupportedException();
 
+        public Task<ResultBox<bool>> WriteSnapshotForPersistenceToStreamAsync(
+            Stream target,
+            bool canGetUnsafeState,
+            int offloadThresholdBytes,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
         public Task<ResultBox<bool>> RestoreSnapshotFromStreamAsync(Stream source, CancellationToken cancellationToken) =>
             throw new NotSupportedException();
 

--- a/dcb/tests/Sekiban.Dcb.Orleans.Tests/NativeProjectionSnapshotPersistenceTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Orleans.Tests/NativeProjectionSnapshotPersistenceTests.cs
@@ -1,0 +1,142 @@
+using System.Text;
+using System.Text.Json;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using ResultBoxes;
+using Sekiban.Dcb.Actors;
+using Sekiban.Dcb.Common;
+using Sekiban.Dcb.Domains;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.MultiProjections;
+using Sekiban.Dcb.Queries;
+using Sekiban.Dcb.Runtime.Native;
+using Sekiban.Dcb.Snapshots;
+using Sekiban.Dcb.Tags;
+using Xunit;
+
+namespace Sekiban.Dcb.Orleans.Tests;
+
+public class NativeProjectionSnapshotPersistenceTests
+{
+    [Fact]
+    public async Task WriteSnapshotForPersistenceToStreamAsync_Should_Offload_Large_Payload_And_Restore()
+    {
+        var blobAccessor = new InMemoryBlobStorageSnapshotAccessor();
+        var services = new ServiceCollection()
+            .AddSingleton<IBlobStorageSnapshotAccessor>(blobAccessor)
+            .BuildServiceProvider();
+        var domainTypes = BuildDomainTypes();
+        var primitive = new NativeMultiProjectionProjectionPrimitive(domainTypes);
+
+        var host = new NativeProjectionActorHost(
+            domainTypes,
+            services,
+            primitive,
+            LargePayloadProjector.MultiProjectorName,
+            new GeneralMultiProjectionActorOptions { SafeWindowMs = 1000 },
+            NullLogger.Instance);
+
+        var events = Enumerable.Range(0, 6)
+            .Select(i => CreateSerializableEvent(new LargePayloadCreated(GenerateRandomString(2048)), DateTime.UtcNow.AddSeconds(-30 + i)))
+            .ToList();
+        await host.AddSerializableEventsAsync(events, finishedCatchUp: true);
+        host.ForcePromoteAllBufferedEvents();
+
+        await using var snapshotStream = new MemoryStream();
+        var writeResult = await host.WriteSnapshotForPersistenceToStreamAsync(
+            snapshotStream,
+            canGetUnsafeState: false,
+            offloadThresholdBytes: 16,
+            CancellationToken.None);
+
+        Assert.True(writeResult.IsSuccess);
+        snapshotStream.Position = 0;
+        var envelope = await JsonSerializer.DeserializeAsync<SerializableMultiProjectionStateEnvelope>(
+            snapshotStream,
+            domainTypes.JsonSerializerOptions);
+        Assert.NotNull(envelope);
+        Assert.True(envelope!.IsOffloaded);
+        Assert.NotNull(envelope.OffloadedState);
+
+        snapshotStream.Position = 0;
+        var restoredHost = new NativeProjectionActorHost(
+            domainTypes,
+            services,
+            primitive,
+            LargePayloadProjector.MultiProjectorName,
+            new GeneralMultiProjectionActorOptions { SafeWindowMs = 1000 },
+            NullLogger.Instance);
+        var restoreResult = await restoredHost.RestoreSnapshotFromStreamAsync(snapshotStream, CancellationToken.None);
+        Assert.True(restoreResult.IsSuccess);
+
+        var stateResult = await restoredHost.GetStateAsync(canGetUnsafeState: true);
+        Assert.True(stateResult.IsSuccess);
+        var payload = Assert.IsType<LargePayloadProjector>(stateResult.GetValue().Payload);
+        Assert.Equal(6, payload.Items.Count);
+    }
+
+    private static DcbDomainTypes BuildDomainTypes()
+    {
+        var eventTypes = new SimpleEventTypes();
+        eventTypes.RegisterEventType<LargePayloadCreated>("LargePayloadCreated");
+
+        var tagTypes = new SimpleTagTypes();
+        var tagProjectorTypes = new SimpleTagProjectorTypes();
+        var tagStatePayloadTypes = new SimpleTagStatePayloadTypes();
+        var multiProjectorTypes = new SimpleMultiProjectorTypes();
+        multiProjectorTypes.RegisterProjector<LargePayloadProjector>();
+
+        return new DcbDomainTypes(
+            eventTypes,
+            tagTypes,
+            tagProjectorTypes,
+            tagStatePayloadTypes,
+            multiProjectorTypes,
+            new SimpleQueryTypes());
+    }
+
+    private static SerializableEvent CreateSerializableEvent(IEventPayload payload, DateTime at)
+    {
+        var sortableUniqueId = SortableUniqueId.Generate(at, Guid.NewGuid());
+        return new SerializableEvent(
+            Encoding.UTF8.GetBytes(JsonSerializer.Serialize(payload, payload.GetType())),
+            sortableUniqueId,
+            Guid.NewGuid(),
+            new EventMetadata(Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), "tester"),
+            [],
+            payload.GetType().Name);
+    }
+
+    private static string GenerateRandomString(int size)
+    {
+        const string chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+        var buffer = new char[size];
+        for (var i = 0; i < size; i++)
+        {
+            buffer[i] = chars[Random.Shared.Next(chars.Length)];
+        }
+        return new string(buffer);
+    }
+
+    private record LargePayloadCreated(string Text) : IEventPayload;
+
+    private record LargePayloadProjector(List<string> Items) : IMultiProjector<LargePayloadProjector>
+    {
+        public LargePayloadProjector() : this(new List<string>()) { }
+        public static string MultiProjectorVersion => "1.0";
+        public static string MultiProjectorName => "native-large-payload";
+        public static LargePayloadProjector GenerateInitialPayload() => new(new List<string>());
+
+        public static ResultBox<LargePayloadProjector> Project(
+            LargePayloadProjector payload,
+            Event ev,
+            List<ITag> tags,
+            DcbDomainTypes domainTypes,
+            SortableUniqueId safeWindowThreshold) => ev.Payload switch
+            {
+                LargePayloadCreated created => ResultBox.FromValue(
+                    payload with { Items = payload.Items.Concat([created.Text]).ToList() }),
+                _ => ResultBox.FromValue(payload)
+            };
+    }
+}

--- a/dcb/tests/Sekiban.Dcb.Orleans.Tests/StreamingPersistIntegrationTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Orleans.Tests/StreamingPersistIntegrationTests.cs
@@ -7,11 +7,13 @@ using Sekiban.Dcb.Common;
 using Sekiban.Dcb.Domains;
 using Sekiban.Dcb.Events;
 using Sekiban.Dcb.InMemory;
+using Sekiban.Dcb.MultiProjections;
 using Sekiban.Dcb.Queries;
 using Sekiban.Dcb.Orleans.Grains;
 using Sekiban.Dcb.Orleans.Streams;
 using Sekiban.Dcb.Snapshots;
 using Sekiban.Dcb.Storage;
+using Sekiban.Dcb.Tags;
 using System.Text;
 using Xunit;
 
@@ -29,6 +31,7 @@ public class StreamingPersistIntegrationTests : IAsyncLifetime
 
     public async Task InitializeAsync()
     {
+        StreamingPersistSiloConfigurator.SharedBlobAccessor.Clear();
         var builder = new TestClusterBuilder();
         builder.Options.InitialSilosCount = 1;
         var uniqueId = Guid.NewGuid().ToString("N")[..8];
@@ -154,6 +157,39 @@ public class StreamingPersistIntegrationTests : IAsyncLifetime
         Assert.Equal(preName, postName);
     }
 
+    [Fact]
+    public async Task StreamingPersist_Should_Offload_Large_Payload_Before_Restore()
+    {
+        var grainId = LargePayloadProjector.MultiProjectorName;
+        var grain = _client.GetGrain<IMultiProjectionGrain>(grainId);
+        StreamingPersistSiloConfigurator.SharedBlobAccessor.Clear();
+
+        var events = Enumerable.Range(0, 6)
+            .Select(i => CreateEvent(new LargeStreamingTestEvt(GenerateRandomString(2048)), DateTime.UtcNow.AddSeconds(-30 + i)))
+            .ToList();
+        await grain.SeedEventsAsync(ToSerializableEvents(events));
+        await grain.RefreshAsync();
+
+        var persistResult = await grain.PersistStateAsync();
+        Assert.True(persistResult.IsSuccess);
+        Assert.True(persistResult.GetValue());
+
+        await grain.RequestDeactivationAsync();
+        await Task.Delay(1000);
+
+        var grain2 = _client.GetGrain<IMultiProjectionGrain>(grainId);
+        await Task.Delay(500);
+
+        var snapshotJson = await grain2.GetSnapshotJsonAsync(canGetUnsafeState: false);
+        Assert.True(snapshotJson.IsSuccess);
+
+        var env = JsonSerializer.Deserialize<SerializableMultiProjectionStateEnvelope>(snapshotJson.GetValue());
+        Assert.NotNull(env);
+        var version = env!.InlineState?.Version ?? env.OffloadedState?.Version ?? 0;
+        Assert.Equal(6, version);
+        Assert.True(StreamingPersistSiloConfigurator.SharedBlobAccessor.StoredObjectCount > 0);
+    }
+
     private static Event CreateEvent(IEventPayload payload, DateTime when)
     {
         var sortableId = SortableUniqueId.Generate(when, Guid.NewGuid());
@@ -178,12 +214,46 @@ public class StreamingPersistIntegrationTests : IAsyncLifetime
             .ToList();
 
     private record StreamingTestEvt(string Name) : IEventPayload;
+    private record LargeStreamingTestEvt(string Text) : IEventPayload;
+
+    private static string GenerateRandomString(int size)
+    {
+        const string chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+        var buffer = new char[size];
+        for (var i = 0; i < size; i++)
+        {
+            buffer[i] = chars[Random.Shared.Next(chars.Length)];
+        }
+        return new string(buffer);
+    }
+
+    private record LargePayloadProjector(List<string> Items) : IMultiProjector<LargePayloadProjector>
+    {
+        public LargePayloadProjector() : this(new List<string>()) { }
+        public static string MultiProjectorVersion => "1.0";
+        public static string MultiProjectorName => "large-streaming-payload";
+        public static LargePayloadProjector GenerateInitialPayload() => new(new List<string>());
+
+        public static ResultBox<LargePayloadProjector> Project(
+            LargePayloadProjector payload,
+            Event ev,
+            List<ITag> tags,
+            DcbDomainTypes domainTypes,
+            SortableUniqueId safeWindowThreshold) => ev.Payload switch
+            {
+                LargeStreamingTestEvt large => ResultBox.FromValue(
+                    payload with { Items = payload.Items.Concat([large.Text]).ToList() }),
+                _ => ResultBox.FromValue(payload)
+            };
+    }
 
     /// <summary>
     ///     Silo configurator that enables UseStreamingSnapshotIO = true.
     /// </summary>
     private class StreamingPersistSiloConfigurator : ISiloConfigurator
     {
+        internal static MockBlobStorageSnapshotAccessor SharedBlobAccessor { get; } = new();
+
         public void Configure(ISiloBuilder siloBuilder)
         {
             siloBuilder
@@ -193,6 +263,7 @@ public class StreamingPersistIntegrationTests : IAsyncLifetime
                     {
                         var eventTypes = new SimpleEventTypes();
                         eventTypes.RegisterEventType<StreamingTestEvt>();
+                        eventTypes.RegisterEventType<LargeStreamingTestEvt>();
                         var tagTypes = new SimpleTagTypes();
                         var tagProjectorTypes = new SimpleTagProjectorTypes();
                         var tagStatePayloadTypes = new SimpleTagStatePayloadTypes();
@@ -200,6 +271,7 @@ public class StreamingPersistIntegrationTests : IAsyncLifetime
                         var queryTypes = new SimpleQueryTypes();
 
                         multiProjectorTypes.RegisterProjectorWithCustomSerialization<CounterProjector>();
+                        multiProjectorTypes.RegisterProjector<LargePayloadProjector>();
 
                         return new DcbDomainTypes(
                             eventTypes,
@@ -215,7 +287,7 @@ public class StreamingPersistIntegrationTests : IAsyncLifetime
                     services.AddSingleton<IMultiProjectionStateStore, InMemoryMultiProjectionStateStore>();
                     services.AddSingleton<IEventSubscriptionResolver>(
                         new DefaultOrleansEventSubscriptionResolver("EventStreamProvider", "AllEvents", Guid.Empty));
-                    services.AddSingleton<IBlobStorageSnapshotAccessor, MockBlobStorageSnapshotAccessor>();
+                    services.AddSingleton<IBlobStorageSnapshotAccessor>(SharedBlobAccessor);
                     services.AddTransient<Sekiban.Dcb.MultiProjections.IMultiProjectionEventStatistics,
                         Sekiban.Dcb.MultiProjections.NoOpMultiProjectionEventStatistics>();
 
@@ -224,7 +296,8 @@ public class StreamingPersistIntegrationTests : IAsyncLifetime
                         new GeneralMultiProjectionActorOptions
                         {
                             SafeWindowMs = 20000,
-                            UseStreamingSnapshotIO = true
+                            UseStreamingSnapshotIO = true,
+                            MaxSnapshotSerializedSizeBytes = 512
                         });
 
                     services.AddSekibanDcbNativeRuntime();

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/ActorSnapshotOffloadTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/ActorSnapshotOffloadTests.cs
@@ -77,6 +77,48 @@ public class ActorSnapshotOffloadTests
     }
 
     [Fact]
+    public async Task BuildSnapshotEnvelopeAsync_Should_Offload_Large_Payload_And_Remain_Restorable()
+    {
+        var actor = new GeneralMultiProjectionActor(
+            _domainTypes,
+            BigPayloadProjector.MultiProjectorName,
+            new GeneralMultiProjectionActorOptions { SafeWindowMs = 1000 });
+        var blobAccessor = new InMemoryBlobStorageSnapshotAccessor();
+
+        foreach (var i in Enumerable.Range(0, 6))
+        {
+            var created = new Created(GenerateRandomString(2048));
+            await actor.AddEventsAsync(new[] { Ev(created) });
+        }
+
+        var envelopeResult = await actor.BuildSnapshotEnvelopeAsync(
+            canGetUnsafeState: true,
+            blobAccessor: blobAccessor,
+            offloadThresholdBytes: 512);
+
+        Assert.True(envelopeResult.IsSuccess);
+        var envelope = envelopeResult.GetValue();
+        Assert.True(envelope.IsOffloaded);
+        Assert.Null(envelope.InlineState);
+        Assert.NotNull(envelope.OffloadedState);
+
+        var resolved = await SnapshotEnvelopeResolver.ResolveInlineAsync(envelope, blobAccessor);
+        Assert.False(resolved.IsOffloaded);
+        Assert.NotNull(resolved.InlineState);
+
+        var restoredActor = new GeneralMultiProjectionActor(
+            _domainTypes,
+            BigPayloadProjector.MultiProjectorName,
+            new GeneralMultiProjectionActorOptions { SafeWindowMs = 1000 });
+        await restoredActor.SetSnapshotAsync(resolved);
+
+        var stateResult = await restoredActor.GetStateAsync(canGetUnsafeState: true);
+        Assert.True(stateResult.IsSuccess);
+        var restoredPayload = Assert.IsType<BigPayloadProjector>(stateResult.GetValue().Payload);
+        Assert.Equal(6, restoredPayload.Items.Count);
+    }
+
+    [Fact]
     public async Task SetSnapshot_Throws_When_Offloaded()
     {
         var actor = new GeneralMultiProjectionActor(


### PR DESCRIPTION
## Summary
- add an offloaded snapshot envelope path so large persistence writes avoid materializing payload bytes as Base64/JSON strings
- resolve offloaded envelopes back to inline payloads when loading from state stores or runtime snapshot streams
- add repeatable coverage and a dedicated probe executable for large snapshot persistence memory comparisons

## Verification
- `dotnet test dcb/tests/Sekiban.Dcb.WithResult.Tests/Sekiban.Dcb.WithResult.Tests.csproj --no-restore --filter ActorSnapshotOffloadTests`
- `dotnet test dcb/tests/Sekiban.Dcb.Orleans.Tests/Sekiban.Dcb.Orleans.Tests.csproj --no-restore --filter "NativeProjectionSnapshotPersistenceTests|StreamingPersistIntegrationTests"`
- `dotnet test dcb/tests/Sekiban.Dcb.WithResult.Tests/Sekiban.Dcb.WithResult.Tests.csproj --no-restore`
- `dotnet test dcb/tests/Sekiban.Dcb.Orleans.Tests/Sekiban.Dcb.Orleans.Tests.csproj --no-restore`
- `dotnet build dcb/internalUsages/DcbOrleans.SnapshotPersistProbe/DcbOrleans.SnapshotPersistProbe.csproj`

## Memory Comparison
Probe path:
- `dcb/internalUsages/DcbOrleans.SnapshotPersistProbe`

Commands:
- `dotnet run --project dcb/internalUsages/DcbOrleans.SnapshotPersistProbe/DcbOrleans.SnapshotPersistProbe.csproj -- --mode legacy --event-count 24 --payload-size 524288 --offload-threshold-bytes 1048576 --iterations 3`
- `dotnet run --project dcb/internalUsages/DcbOrleans.SnapshotPersistProbe/DcbOrleans.SnapshotPersistProbe.csproj -- --mode offloaded --event-count 24 --payload-size 524288 --offload-threshold-bytes 1048576 --iterations 3`

Runs were taken on the same machine. `origin/main` was measured from a detached worktree at `f096096bc23c40246d2aaab89fd664e26f900b2b` using the same probe source and the same legacy command.

| Scenario | Peak working set | Peak managed heap | Persisted snapshot size | Notes |
| --- | ---: | ---: | ---: | --- |
| `origin/main` legacy | 795,525,120 B | 1,401,472,848 B | 17,599,534 B | inline envelope |
| branch legacy control | 808,435,712 B | 1,521,444,920 B | 17,599,534 B | inline envelope |
| branch offloaded | 424,083,456 B | 242,235,624 B | 531 B | offloaded payload 12,560,781 B |

Compared with `origin/main`, the new offloaded path reduced peak working set by about 46.7% and peak managed heap by about 82.7% for this synthetic large snapshot.

Closes #1005
