### PR TITLE
Add GetMaxTagInTagGroupAsync to IEventStore, ICommandContext, and ISekibanExecutor

### DIFF
--- a/dcb/src/Sekiban.Dcb.Core.Model/Commands/ICoreCommandContext.cs
+++ b/dcb/src/Sekiban.Dcb.Core.Model/Commands/ICoreCommandContext.cs
@@ -46,6 +46,13 @@ public interface ICoreCommandContext
     Task<ResultBox<string>> GetTagLatestSortableUniqueIdAsync(ITag tag);
 
     /// <summary>
+    ///     Gets the lexicographically maximum tag string within a tag group.
+    /// </summary>
+    /// <param name="tagGroup">The tag group name (e.g. "Student")</param>
+    /// <returns>ResultBox containing the full tag string (e.g. "Student:01HX999") or empty string if none exist</returns>
+    Task<ResultBox<string>> GetMaxTagInTagGroupAsync(string tagGroup);
+
+    /// <summary>
     ///     Appends an event with tags to the context
     /// </summary>
     /// <param name="ev">The event with tags to append</param>

--- a/dcb/src/Sekiban.Dcb.Core/Actors/CoreGeneralSekibanExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Actors/CoreGeneralSekibanExecutor.cs
@@ -54,7 +54,7 @@ public class CoreGeneralSekibanExecutor
             }
 
             // Step 1: Create command context
-            var commandContext = new CoreCommandContext(_actorAccessor, _domainTypes);
+            var commandContext = new CoreCommandContext(_actorAccessor, _domainTypes, _eventStore);
 
             // Step 2: Execute handler function with context
             var handlerResult = await handlerFunc(command, commandContext);
@@ -743,6 +743,19 @@ public class CoreGeneralSekibanExecutor
         catch (Exception ex)
         {
             return ResultBox.Error<ListQueryResult<TResult>>(ex);
+        }
+    }
+
+    public async Task<ResultBox<string>> GetMaxTagInTagGroupAsync(string tagGroup)
+    {
+        try
+        {
+            NameValidator.ValidateTagGroupNameAndThrow(tagGroup);
+            return await _eventStore.GetMaxTagInTagGroupAsync(tagGroup);
+        }
+        catch (Exception ex)
+        {
+            return ResultBox.Error<string>(ex);
         }
     }
 

--- a/dcb/src/Sekiban.Dcb.Core/ColdEvents/HybridEventStore.cs
+++ b/dcb/src/Sekiban.Dcb.Core/ColdEvents/HybridEventStore.cs
@@ -64,6 +64,9 @@ public sealed class HybridEventStore : IEventStore, IStreamingSerializableEventS
     public Task<ResultBox<IEnumerable<TagInfo>>> GetAllTagsAsync(string? tagGroup = null)
         => _hotStore.GetAllTagsAsync(tagGroup);
 
+    public Task<ResultBox<string>> GetMaxTagInTagGroupAsync(string tagGroup)
+        => _hotStore.GetMaxTagInTagGroupAsync(tagGroup);
+
     public Task<ResultBox<IEnumerable<SerializableEvent>>> ReadSerializableEventsByTagAsync(
         ITag tag, SortableUniqueId? since = null)
         => _hotStore.ReadSerializableEventsByTagAsync(tag, since);

--- a/dcb/src/Sekiban.Dcb.Core/Commands/CoreGeneralCommandContext.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Commands/CoreGeneralCommandContext.cs
@@ -1,6 +1,7 @@
 using ResultBoxes;
 using Sekiban.Dcb.Actors;
 using Sekiban.Dcb.Events;
+using Sekiban.Dcb.Storage;
 using Sekiban.Dcb.Tags;
 namespace Sekiban.Dcb.Commands;
 
@@ -16,11 +17,13 @@ public class CoreGeneralCommandContext : ICoreCommandContext, ICommandContextRes
     private readonly IActorObjectAccessor _actorAccessor;
     private readonly List<EventPayloadWithTags> _appendedEvents = new();
     private readonly DcbDomainTypes _domainTypes;
+    private readonly IEventStore _eventStore;
 
-    public CoreGeneralCommandContext(IActorObjectAccessor actorAccessor, DcbDomainTypes domainTypes)
+    public CoreGeneralCommandContext(IActorObjectAccessor actorAccessor, DcbDomainTypes domainTypes, IEventStore eventStore)
     {
         _actorAccessor = actorAccessor ?? throw new ArgumentNullException(nameof(actorAccessor));
         _domainTypes = domainTypes ?? throw new ArgumentNullException(nameof(domainTypes));
+        _eventStore = eventStore ?? throw new ArgumentNullException(nameof(eventStore));
     }
 
     public async Task<ResultBox<TagStateTyped<TState>>> GetStateAsync<TState, TProjector>(ITag tag)
@@ -261,6 +264,11 @@ public class CoreGeneralCommandContext : ICoreCommandContext, ICommandContextRes
             return ResultBox.Error<string>(ex);
         }
     }
+    public Task<ResultBox<string>> GetMaxTagInTagGroupAsync(string tagGroup)
+    {
+        return _eventStore.GetMaxTagInTagGroupAsync(tagGroup);
+    }
+
     public Task<ResultBox<EventOrNone>> AppendEvent(IEventPayload ev, params ITag[] tags)
     {
         if (ev is null)

--- a/dcb/src/Sekiban.Dcb.Core/Commands/CoreGeneralCommandContext.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Commands/CoreGeneralCommandContext.cs
@@ -3,6 +3,7 @@ using Sekiban.Dcb.Actors;
 using Sekiban.Dcb.Events;
 using Sekiban.Dcb.Storage;
 using Sekiban.Dcb.Tags;
+using Sekiban.Dcb.Validation;
 namespace Sekiban.Dcb.Commands;
 
 /// <summary>
@@ -264,9 +265,17 @@ public class CoreGeneralCommandContext : ICoreCommandContext, ICommandContextRes
             return ResultBox.Error<string>(ex);
         }
     }
-    public Task<ResultBox<string>> GetMaxTagInTagGroupAsync(string tagGroup)
+    public async Task<ResultBox<string>> GetMaxTagInTagGroupAsync(string tagGroup)
     {
-        return _eventStore.GetMaxTagInTagGroupAsync(tagGroup);
+        try
+        {
+            NameValidator.ValidateTagGroupNameAndThrow(tagGroup);
+            return await _eventStore.GetMaxTagInTagGroupAsync(tagGroup);
+        }
+        catch (Exception ex)
+        {
+            return ResultBox.Error<string>(ex);
+        }
     }
 
     public Task<ResultBox<EventOrNone>> AppendEvent(IEventPayload ev, params ITag[] tags)

--- a/dcb/src/Sekiban.Dcb.Core/InMemory/InMemoryEventStore.cs
+++ b/dcb/src/Sekiban.Dcb.Core/InMemory/InMemoryEventStore.cs
@@ -312,6 +312,20 @@ public class InMemoryEventStore : IEventStore, ISerializableEventStreamReader
         }
     }
 
+    public Task<ResultBox<string>> GetMaxTagInTagGroupAsync(string tagGroup)
+    {
+        var state = GetState();
+        lock (state.Lock)
+        {
+            var prefix = tagGroup + ":";
+            var maxTag = state.TagStreams.Keys
+                .Where(k => k.StartsWith(prefix))
+                .OrderByDescending(k => k, StringComparer.Ordinal)
+                .FirstOrDefault() ?? string.Empty;
+            return Task.FromResult(ResultBox.FromValue(maxTag));
+        }
+    }
+
     public Task<ResultBox<IEnumerable<SerializableEvent>>> ReadAllSerializableEventsAsync(SortableUniqueId? since = null)
         => ReadAllSerializableEventsAsync(since, maxCount: null);
 

--- a/dcb/src/Sekiban.Dcb.Core/InMemory/InMemoryEventStore.cs
+++ b/dcb/src/Sekiban.Dcb.Core/InMemory/InMemoryEventStore.cs
@@ -319,9 +319,13 @@ public class InMemoryEventStore : IEventStore, ISerializableEventStreamReader
         {
             var prefix = tagGroup + ":";
             var maxTag = state.TagStreams.Keys
-                .Where(k => k.StartsWith(prefix))
-                .OrderByDescending(k => k, StringComparer.Ordinal)
-                .FirstOrDefault() ?? string.Empty;
+                .Where(k => k.StartsWith(prefix, StringComparison.Ordinal))
+                .Aggregate(
+                    string.Empty,
+                    (current, candidate) => string.IsNullOrEmpty(current) ||
+                                            StringComparer.Ordinal.Compare(candidate, current) > 0
+                        ? candidate
+                        : current);
             return Task.FromResult(ResultBox.FromValue(maxTag));
         }
     }

--- a/dcb/src/Sekiban.Dcb.Core/Storage/IEventStore.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Storage/IEventStore.cs
@@ -38,6 +38,13 @@ public interface IEventStore
     /// <returns>List of unique tag information</returns>
     Task<ResultBox<IEnumerable<TagInfo>>> GetAllTagsAsync(string? tagGroup = null);
 
+    /// <summary>
+    ///     Gets the lexicographically maximum tag string within a tag group.
+    /// </summary>
+    /// <param name="tagGroup">The tag group name (e.g. "Student")</param>
+    /// <returns>ResultBox containing the full tag string (e.g. "Student:01HX999") or empty string if none exist</returns>
+    Task<ResultBox<string>> GetMaxTagInTagGroupAsync(string tagGroup);
+
     // SerializableEvent operations (payload stays serialized until an explicit caller-side conversion)
 
     /// <summary>

--- a/dcb/src/Sekiban.Dcb.CosmosDb/CosmosDbEventStore.cs
+++ b/dcb/src/Sekiban.Dcb.CosmosDb/CosmosDbEventStore.cs
@@ -997,22 +997,21 @@ public partial class CosmosDbEventStore : IHotEventStore
             var upperBound = tagGroup + ";";
 
             var queryDef = new QueryDefinition(
-                "SELECT TOP 1 c.tag FROM c WHERE c.serviceId = @serviceId AND c.tag >= @prefix AND c.tag < @upperBound ORDER BY c.tag DESC")
-                .WithParameter("@serviceId", serviceId)
+                $"SELECT VALUE TOP 1 c.tag FROM c WHERE c.serviceId = {ParamServiceId} AND c.tag >= @prefix AND c.tag < @upperBound ORDER BY c.tag DESC")
+                .WithParameter(ParamServiceId, serviceId)
                 .WithParameter("@prefix", prefix)
                 .WithParameter("@upperBound", upperBound);
 
-            using var iterator = tagsContainer.GetItemQueryIterator<dynamic>(
+            using var iterator = tagsContainer.GetItemQueryIterator<string>(
                 queryDef,
                 requestOptions: new QueryRequestOptions { MaxItemCount = 1 });
 
-            if (iterator.HasMoreResults)
+            while (iterator.HasMoreResults)
             {
                 var response = await iterator.ReadNextAsync().ConfigureAwait(false);
-                var item = response.FirstOrDefault();
-                if (item != null)
+                var tag = response.FirstOrDefault();
+                if (tag != null)
                 {
-                    string tag = item.tag;
                     return ResultBox.FromValue(tag);
                 }
             }

--- a/dcb/src/Sekiban.Dcb.CosmosDb/CosmosDbEventStore.cs
+++ b/dcb/src/Sekiban.Dcb.CosmosDb/CosmosDbEventStore.cs
@@ -997,7 +997,7 @@ public partial class CosmosDbEventStore : IHotEventStore
             var upperBound = tagGroup + ";";
 
             var queryDef = new QueryDefinition(
-                $"SELECT VALUE TOP 1 c.tag FROM c WHERE c.serviceId = {ParamServiceId} AND c.tag >= @prefix AND c.tag < @upperBound ORDER BY c.tag DESC")
+                $"SELECT TOP 1 VALUE c.tag FROM c WHERE c.serviceId = {ParamServiceId} AND c.tag >= @prefix AND c.tag < @upperBound ORDER BY c.tag DESC")
                 .WithParameter(ParamServiceId, serviceId)
                 .WithParameter("@prefix", prefix)
                 .WithParameter("@upperBound", upperBound);

--- a/dcb/src/Sekiban.Dcb.CosmosDb/CosmosDbEventStore.cs
+++ b/dcb/src/Sekiban.Dcb.CosmosDb/CosmosDbEventStore.cs
@@ -984,6 +984,51 @@ public partial class CosmosDbEventStore : IHotEventStore
         }
     }
 
+    /// <inheritdoc />
+    public async Task<ResultBox<string>> GetMaxTagInTagGroupAsync(string tagGroup)
+    {
+        try
+        {
+            var serviceId = CurrentServiceId;
+            var settings = _containerResolver.ResolveTagsContainer(serviceId);
+            var tagsContainer = await _context.GetTagsContainerAsync(settings).ConfigureAwait(false);
+
+            var prefix = tagGroup + ":";
+            var upperBound = tagGroup + ";";
+
+            var queryDef = new QueryDefinition(
+                "SELECT TOP 1 c.tag FROM c WHERE c.serviceId = @serviceId AND c.tag >= @prefix AND c.tag < @upperBound ORDER BY c.tag DESC")
+                .WithParameter("@serviceId", serviceId)
+                .WithParameter("@prefix", prefix)
+                .WithParameter("@upperBound", upperBound);
+
+            using var iterator = tagsContainer.GetItemQueryIterator<dynamic>(
+                queryDef,
+                requestOptions: new QueryRequestOptions { MaxItemCount = 1 });
+
+            if (iterator.HasMoreResults)
+            {
+                var response = await iterator.ReadNextAsync().ConfigureAwait(false);
+                var item = response.FirstOrDefault();
+                if (item != null)
+                {
+                    string tag = item.tag;
+                    return ResultBox.FromValue(tag);
+                }
+            }
+
+            return ResultBox.FromValue(string.Empty);
+        }
+        catch (CosmosException ex)
+        {
+            return ResultBox.Error<string>(ex);
+        }
+        catch (Exception ex)
+        {
+            return ResultBox.Error<string>(ex);
+        }
+    }
+
     /// <summary>
     ///     Reads all events as SerializableEvent (no payload deserialization).
     /// </summary>

--- a/dcb/src/Sekiban.Dcb.DynamoDB/DynamoDbEventStore.cs
+++ b/dcb/src/Sekiban.Dcb.DynamoDB/DynamoDbEventStore.cs
@@ -452,6 +452,33 @@ public class DynamoDbEventStore : IHotEventStore
         }
     }
 
+    /// <inheritdoc />
+    public async Task<ResultBox<string>> GetMaxTagInTagGroupAsync(string tagGroup)
+    {
+        try
+        {
+            // Reuse GetAllTagsAsync to get all tags in this group, then find the max
+            var allTagsResult = await GetAllTagsAsync(tagGroup).ConfigureAwait(false);
+            if (!allTagsResult.IsSuccess)
+            {
+                return ResultBox.Error<string>(allTagsResult.GetException());
+            }
+
+            var maxTag = allTagsResult.GetValue()
+                .Select(t => t.Tag)
+                .OrderByDescending(t => t, StringComparer.Ordinal)
+                .FirstOrDefault() ?? string.Empty;
+
+            return ResultBox.FromValue(maxTag);
+        }
+        catch (Exception ex)
+        {
+            if (_logger != null)
+                LogReadFailed(_logger, ex.Message, ex);
+            return ResultBox.Error<string>(ex);
+        }
+    }
+
     private async Task<List<Event>> QueryEventsByShardAsync(string shardKey, SortableUniqueId? since)
     {
         var events = new List<Event>();

--- a/dcb/src/Sekiban.Dcb.DynamoDB/DynamoDbEventStore.cs
+++ b/dcb/src/Sekiban.Dcb.DynamoDB/DynamoDbEventStore.cs
@@ -466,8 +466,11 @@ public class DynamoDbEventStore : IHotEventStore
 
             var maxTag = allTagsResult.GetValue()
                 .Select(t => t.Tag)
-                .OrderByDescending(t => t, StringComparer.Ordinal)
-                .FirstOrDefault() ?? string.Empty;
+                .Aggregate(
+                    string.Empty,
+                    (current, candidate) => StringComparer.Ordinal.Compare(candidate, current) > 0
+                        ? candidate
+                        : current);
 
             return ResultBox.FromValue(maxTag);
         }

--- a/dcb/src/Sekiban.Dcb.Orleans.WithResult/OrleansDcbExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.WithResult/OrleansDcbExecutor.cs
@@ -73,6 +73,12 @@ public class OrleansDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecuto
         _generalExecutor.GetTagStateAsync(tagStateId);
 
     /// <summary>
+    ///     Gets the lexicographically maximum tag string within a tag group.
+    /// </summary>
+    public Task<ResultBox<string>> GetMaxTagInTagGroupAsync(string tagGroup) =>
+        _generalExecutor.GetMaxTagInTagGroupAsync(tagGroup);
+
+    /// <summary>
     ///     Execute a single-result query using Orleans grains
     /// </summary>
     public async Task<ResultBox<TResult>> QueryAsync<TResult>(IQueryCommon<TResult> queryCommon) where TResult : notnull

--- a/dcb/src/Sekiban.Dcb.Orleans.WithoutResult/OrleansDcbExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.WithoutResult/OrleansDcbExecutor.cs
@@ -73,6 +73,12 @@ public class OrleansDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecuto
         _generalExecutor.GetTagStateAsync(tagStateId);
 
     /// <summary>
+    ///     Gets the lexicographically maximum tag string within a tag group.
+    /// </summary>
+    public Task<string> GetMaxTagInTagGroupAsync(string tagGroup) =>
+        _generalExecutor.GetMaxTagInTagGroupAsync(tagGroup);
+
+    /// <summary>
     ///     Execute a single-result query using Orleans grains
     /// </summary>
     public async Task<TResult> QueryAsync<TResult>(IQueryCommon<TResult> queryCommon) where TResult : notnull

--- a/dcb/src/Sekiban.Dcb.Postgres/PostgresEventStore.cs
+++ b/dcb/src/Sekiban.Dcb.Postgres/PostgresEventStore.cs
@@ -401,7 +401,7 @@ public class PostgresEventStore : IHotEventStore, ISerializableEventStreamReader
             var upperBound = tagGroup + ";";
 
             var latest = await context.Tags
-                .Where(t => t.ServiceId == serviceId && t.Tag.CompareTo(prefix) >= 0 && t.Tag.CompareTo(upperBound) < 0)
+                .Where(t => t.ServiceId == serviceId && string.Compare(t.Tag, prefix) >= 0 && string.Compare(t.Tag, upperBound) < 0)
                 .OrderByDescending(t => t.Tag)
                 .Select(t => t.Tag)
                 .FirstOrDefaultAsync();

--- a/dcb/src/Sekiban.Dcb.Postgres/PostgresEventStore.cs
+++ b/dcb/src/Sekiban.Dcb.Postgres/PostgresEventStore.cs
@@ -391,6 +391,29 @@ public class PostgresEventStore : IHotEventStore, ISerializableEventStreamReader
         }
     }
 
+    public async Task<ResultBox<string>> GetMaxTagInTagGroupAsync(string tagGroup)
+    {
+        try
+        {
+            await using var context = await _contextFactory.CreateDbContextAsync();
+            var serviceId = CurrentServiceId;
+            var prefix = tagGroup + ":";
+            var upperBound = tagGroup + ";";
+
+            var latest = await context.Tags
+                .Where(t => t.ServiceId == serviceId && t.Tag.CompareTo(prefix) >= 0 && t.Tag.CompareTo(upperBound) < 0)
+                .OrderByDescending(t => t.Tag)
+                .Select(t => t.Tag)
+                .FirstOrDefaultAsync();
+
+            return ResultBox.FromValue(latest ?? string.Empty);
+        }
+        catch (Exception ex)
+        {
+            return ResultBox.Error<string>(ex);
+        }
+    }
+
     public Task<ResultBox<IEnumerable<SerializableEvent>>> ReadAllSerializableEventsAsync(SortableUniqueId? since = null)
         => ReadAllSerializableEventsAsync(since, maxCount: null);
 

--- a/dcb/src/Sekiban.Dcb.Sqlite/SqliteEventStore.cs
+++ b/dcb/src/Sekiban.Dcb.Sqlite/SqliteEventStore.cs
@@ -785,6 +785,38 @@ public class SqliteEventStore : IHotEventStore
         }
     }
 
+    public async Task<ResultBox<string>> GetMaxTagInTagGroupAsync(string tagGroup)
+    {
+        try
+        {
+            var serviceId = CurrentServiceId;
+            var prefix = tagGroup + ":";
+            var upperBound = tagGroup + ";";
+
+            await using var connection = new SqliteConnection(_connectionString);
+            await connection.OpenAsync();
+
+            await using var cmd = connection.CreateCommand();
+            cmd.CommandText = $"""
+                SELECT MAX(Tag) FROM dcb_tags
+                WHERE ServiceId = {ParamServiceId} AND Tag >= @prefix AND Tag < @upperBound
+                """;
+            cmd.Parameters.AddWithValue(ParamServiceId, serviceId);
+            cmd.Parameters.AddWithValue("@prefix", prefix);
+            cmd.Parameters.AddWithValue("@upperBound", upperBound);
+
+            var result = await cmd.ExecuteScalarAsync();
+            var maxTag = result is DBNull || result == null ? string.Empty : (string)result;
+
+            return ResultBox.FromValue(maxTag);
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogError(ex, "Error getting max tag in tag group from SQLite");
+            return ResultBox.Error<string>(ex);
+        }
+    }
+
     // Cache-specific methods
 
     /// <summary>

--- a/dcb/src/Sekiban.Dcb.WithResult/Actors/GeneralCommandContext.cs
+++ b/dcb/src/Sekiban.Dcb.WithResult/Actors/GeneralCommandContext.cs
@@ -3,6 +3,7 @@ using Sekiban.Dcb.Commands;
 using Sekiban.Dcb.Events;
 using Sekiban.Dcb.Storage;
 using Sekiban.Dcb.Tags;
+using Sekiban.Dcb.Validation;
 namespace Sekiban.Dcb.Actors;
 
 /// <summary>
@@ -269,13 +270,23 @@ public class GeneralCommandContext : ICommandContext, ICommandContextResultAcces
             return ResultBox.Error<string>(ex);
         }
     }
-    public Task<ResultBox<string>> GetMaxTagInTagGroupAsync(string tagGroup)
+    public async Task<ResultBox<string>> GetMaxTagInTagGroupAsync(string tagGroup)
     {
-        if (_eventStore == null)
+        try
         {
-            return Task.FromResult(ResultBox.Error<string>(new NotSupportedException("IEventStore is not available in this context")));
+            if (_eventStore == null)
+            {
+                return ResultBox.Error<string>(new NotSupportedException("IEventStore is not available in this context"));
+            }
+
+            NameValidator.ValidateTagGroupNameAndThrow(tagGroup);
+
+            return await _eventStore.GetMaxTagInTagGroupAsync(tagGroup);
         }
-        return _eventStore.GetMaxTagInTagGroupAsync(tagGroup);
+        catch (Exception ex)
+        {
+            return ResultBox.Error<string>(ex);
+        }
     }
 
     public Task<ResultBox<EventOrNone>> AppendEvent(IEventPayload ev, params ITag[] tags)

--- a/dcb/src/Sekiban.Dcb.WithResult/Actors/GeneralCommandContext.cs
+++ b/dcb/src/Sekiban.Dcb.WithResult/Actors/GeneralCommandContext.cs
@@ -19,6 +19,10 @@ public class GeneralCommandContext : ICommandContext, ICommandContextResultAcces
     private readonly DcbDomainTypes _domainTypes;
     private readonly IEventStore? _eventStore;
 
+    /// <summary>
+    ///     Creates a context without IEventStore. GetMaxTagInTagGroupAsync will return NotSupportedException.
+    ///     Prefer the constructor that accepts IEventStore for full functionality.
+    /// </summary>
     public GeneralCommandContext(IActorObjectAccessor actorAccessor, DcbDomainTypes domainTypes)
     {
         _actorAccessor = actorAccessor ?? throw new ArgumentNullException(nameof(actorAccessor));

--- a/dcb/src/Sekiban.Dcb.WithResult/Actors/GeneralCommandContext.cs
+++ b/dcb/src/Sekiban.Dcb.WithResult/Actors/GeneralCommandContext.cs
@@ -1,6 +1,7 @@
 using ResultBoxes;
 using Sekiban.Dcb.Commands;
 using Sekiban.Dcb.Events;
+using Sekiban.Dcb.Storage;
 using Sekiban.Dcb.Tags;
 namespace Sekiban.Dcb.Actors;
 
@@ -15,11 +16,19 @@ public class GeneralCommandContext : ICommandContext, ICommandContextResultAcces
     private readonly IActorObjectAccessor _actorAccessor;
     private readonly List<EventPayloadWithTags> _appendedEvents = new();
     private readonly DcbDomainTypes _domainTypes;
+    private readonly IEventStore? _eventStore;
 
     public GeneralCommandContext(IActorObjectAccessor actorAccessor, DcbDomainTypes domainTypes)
     {
         _actorAccessor = actorAccessor ?? throw new ArgumentNullException(nameof(actorAccessor));
         _domainTypes = domainTypes ?? throw new ArgumentNullException(nameof(domainTypes));
+    }
+
+    public GeneralCommandContext(IActorObjectAccessor actorAccessor, DcbDomainTypes domainTypes, IEventStore eventStore)
+    {
+        _actorAccessor = actorAccessor ?? throw new ArgumentNullException(nameof(actorAccessor));
+        _domainTypes = domainTypes ?? throw new ArgumentNullException(nameof(domainTypes));
+        _eventStore = eventStore ?? throw new ArgumentNullException(nameof(eventStore));
     }
 
     public async Task<ResultBox<TagStateTyped<TState>>> GetStateAsync<TState, TProjector>(ITag tag)
@@ -260,6 +269,15 @@ public class GeneralCommandContext : ICommandContext, ICommandContextResultAcces
             return ResultBox.Error<string>(ex);
         }
     }
+    public Task<ResultBox<string>> GetMaxTagInTagGroupAsync(string tagGroup)
+    {
+        if (_eventStore == null)
+        {
+            return Task.FromResult(ResultBox.Error<string>(new NotSupportedException("IEventStore is not available in this context")));
+        }
+        return _eventStore.GetMaxTagInTagGroupAsync(tagGroup);
+    }
+
     public Task<ResultBox<EventOrNone>> AppendEvent(IEventPayload ev, params ITag[] tags)
     {
         if (ev is null)

--- a/dcb/src/Sekiban.Dcb.WithResult/Actors/GeneralSekibanExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.WithResult/Actors/GeneralSekibanExecutor.cs
@@ -84,6 +84,12 @@ public class GeneralSekibanExecutor : ISekibanExecutor, ISerializedSekibanDcbExe
         _core.GetTagStateAsync(tagStateId);
 
     /// <summary>
+    ///     Gets the lexicographically maximum tag string within a tag group.
+    /// </summary>
+    public Task<ResultBox<string>> GetMaxTagInTagGroupAsync(string tagGroup) =>
+        _core.GetMaxTagInTagGroupAsync(tagGroup);
+
+    /// <summary>
     ///     Execute a single-result query
     /// </summary>
     public Task<ResultBox<TResult>> QueryAsync<TResult>(IQueryCommon<TResult> queryCommon) where TResult : notnull =>

--- a/dcb/src/Sekiban.Dcb.WithResult/Commands/CommandContextAdapter.cs
+++ b/dcb/src/Sekiban.Dcb.WithResult/Commands/CommandContextAdapter.cs
@@ -31,6 +31,9 @@ internal class CommandContextAdapter : ICommandContext
     public Task<ResultBox<string>> GetTagLatestSortableUniqueIdAsync(ITag tag) =>
         _core.GetTagLatestSortableUniqueIdAsync(tag);
 
+    public Task<ResultBox<string>> GetMaxTagInTagGroupAsync(string tagGroup) =>
+        _core.GetMaxTagInTagGroupAsync(tagGroup);
+
     public Task<ResultBox<EventOrNone>> AppendEvent(IEventPayload ev, params ITag[] tags) =>
         _core.AppendEvent(ev, tags);
 

--- a/dcb/src/Sekiban.Dcb.WithResult/ISekibanExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.WithResult/ISekibanExecutor.cs
@@ -19,6 +19,13 @@ public interface ISekibanExecutor : ICommandExecutor
     Task<ResultBox<TagState>> GetTagStateAsync<TProjector>(ITag tag) where TProjector : ITagProjector<TProjector> => GetTagStateAsync(TagStateId.FromProjector<TProjector>(tag));
 
     /// <summary>
+    ///     Gets the lexicographically maximum tag string within a tag group.
+    /// </summary>
+    /// <param name="tagGroup">The tag group name (e.g. "Student")</param>
+    /// <returns>ResultBox containing the full tag string (e.g. "Student:01HX999") or empty string if none exist</returns>
+    Task<ResultBox<string>> GetMaxTagInTagGroupAsync(string tagGroup);
+
+    /// <summary>
     ///     Execute a single-result query
     /// </summary>
     /// <typeparam name="TResult">The result type</typeparam>

--- a/dcb/src/Sekiban.Dcb.WithResult/InMemory/InMemoryDcbExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.WithResult/InMemory/InMemoryDcbExecutor.cs
@@ -59,6 +59,9 @@ public class InMemoryDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecut
     Task<ResultBox<TagState>> ISekibanExecutor.GetTagStateAsync(TagStateId tagStateId) =>
         _inner.GetTagStateAsync(tagStateId);
 
+    Task<ResultBox<string>> ISekibanExecutor.GetMaxTagInTagGroupAsync(string tagGroup) =>
+        _inner.GetMaxTagInTagGroupAsync(tagGroup);
+
     Task<ResultBox<TResult>> ISekibanExecutor.QueryAsync<TResult>(IQueryCommon<TResult> queryCommon) =>
         _inner.QueryAsync(queryCommon);
 
@@ -358,6 +361,22 @@ public class InMemoryDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecut
                 .ToList();
 
                 return Task.FromResult(ResultBox.FromValue(tagInfos.AsEnumerable()));
+            }
+        }
+
+        public Task<ResultBox<string>> GetMaxTagInTagGroupAsync(string tagGroup)
+        {
+            var state = GetState();
+            lock (state.Lock)
+            {
+                var prefix = tagGroup + ":";
+                var maxTag = state.Events
+                    .SelectMany(e => e.Tags)
+                    .Where(t => t.StartsWith(prefix))
+                    .Distinct()
+                    .OrderByDescending(t => t, StringComparer.Ordinal)
+                    .FirstOrDefault() ?? string.Empty;
+                return Task.FromResult(ResultBox.FromValue(maxTag));
             }
         }
 

--- a/dcb/src/Sekiban.Dcb.WithResult/InMemory/InMemoryDcbExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.WithResult/InMemory/InMemoryDcbExecutor.cs
@@ -372,10 +372,13 @@ public class InMemoryDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecut
                 var prefix = tagGroup + ":";
                 var maxTag = state.Events
                     .SelectMany(e => e.Tags)
-                    .Where(t => t.StartsWith(prefix))
+                    .Where(t => t.StartsWith(prefix, StringComparison.Ordinal))
                     .Distinct()
-                    .OrderByDescending(t => t, StringComparer.Ordinal)
-                    .FirstOrDefault() ?? string.Empty;
+                    .Aggregate(
+                        string.Empty,
+                        (current, candidate) => StringComparer.Ordinal.Compare(candidate, current) > 0
+                            ? candidate
+                            : current);
                 return Task.FromResult(ResultBox.FromValue(maxTag));
             }
         }

--- a/dcb/src/Sekiban.Dcb.WithResult/InMemory/InMemoryDcbExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.WithResult/InMemory/InMemoryDcbExecutor.cs
@@ -373,7 +373,6 @@ public class InMemoryDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecut
                 var maxTag = state.Events
                     .SelectMany(e => e.Tags)
                     .Where(t => t.StartsWith(prefix, StringComparison.Ordinal))
-                    .Distinct()
                     .Aggregate(
                         string.Empty,
                         (current, candidate) => StringComparer.Ordinal.Compare(candidate, current) > 0

--- a/dcb/src/Sekiban.Dcb.WithoutResult.Model/Commands/ICommandContext.cs
+++ b/dcb/src/Sekiban.Dcb.WithoutResult.Model/Commands/ICommandContext.cs
@@ -46,6 +46,14 @@ public interface ICommandContext
     Task<string> GetTagLatestSortableUniqueIdAsync(ITag tag);
 
     /// <summary>
+    ///     Gets the lexicographically maximum tag string within a tag group.
+    /// </summary>
+    /// <param name="tagGroup">The tag group name (e.g. "Student")</param>
+    /// <returns>The full tag string (e.g. "Student:01HX999") or empty string if none exist</returns>
+    /// <exception cref="Exception">Thrown when retrieval fails</exception>
+    Task<string> GetMaxTagInTagGroupAsync(string tagGroup);
+
+    /// <summary>
     ///     Appends an event with tags to the context
     /// </summary>
     /// <param name="ev">The event with tags to append</param>

--- a/dcb/src/Sekiban.Dcb.WithoutResult/Actors/GeneralSekibanExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.WithoutResult/Actors/GeneralSekibanExecutor.cs
@@ -114,6 +114,15 @@ public class GeneralSekibanExecutor : ISekibanExecutor, ISerializedSekibanDcbExe
     }
 
     /// <summary>
+    ///     Gets the lexicographically maximum tag string within a tag group.
+    /// </summary>
+    public async Task<string> GetMaxTagInTagGroupAsync(string tagGroup)
+    {
+        var result = await _core.GetMaxTagInTagGroupAsync(tagGroup);
+        return result.UnwrapBox();
+    }
+
+    /// <summary>
     ///     Execute a single-result query
     /// </summary>
     public async Task<TResult> QueryAsync<TResult>(IQueryCommon<TResult> queryCommon) where TResult : notnull

--- a/dcb/src/Sekiban.Dcb.WithoutResult/Commands/CommandContextAdapter.cs
+++ b/dcb/src/Sekiban.Dcb.WithoutResult/Commands/CommandContextAdapter.cs
@@ -43,6 +43,12 @@ internal class CommandContextAdapter : ICommandContext
         return result.UnwrapBox();
     }
 
+    public async Task<string> GetMaxTagInTagGroupAsync(string tagGroup)
+    {
+        var result = await _core.GetMaxTagInTagGroupAsync(tagGroup);
+        return result.UnwrapBox();
+    }
+
     public async Task<EventOrNone> AppendEvent(IEventPayload ev, params ITag[] tags)
     {
         var result = await _core.AppendEvent(ev, tags);

--- a/dcb/src/Sekiban.Dcb.WithoutResult/ISekibanExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.WithoutResult/ISekibanExecutor.cs
@@ -24,6 +24,14 @@ public interface ISekibanExecutor : ICommandExecutor
         GetTagStateAsync(TagStateId.FromProjector<TProjector>(tag));
 
     /// <summary>
+    ///     Gets the lexicographically maximum tag string within a tag group.
+    /// </summary>
+    /// <param name="tagGroup">The tag group name (e.g. "Student")</param>
+    /// <returns>The full tag string (e.g. "Student:01HX999") or empty string if none exist</returns>
+    /// <exception cref="Exception">Thrown when retrieval fails</exception>
+    Task<string> GetMaxTagInTagGroupAsync(string tagGroup);
+
+    /// <summary>
     ///     Execute a single-result query
     /// </summary>
     /// <typeparam name="TResult">The result type</typeparam>

--- a/dcb/src/Sekiban.Dcb.WithoutResult/InMemory/InMemoryDcbExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.WithoutResult/InMemory/InMemoryDcbExecutor.cs
@@ -375,10 +375,13 @@ public class InMemoryDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecut
                 var prefix = tagGroup + ":";
                 var maxTag = state.Events
                     .SelectMany(e => e.Tags)
-                    .Where(t => t.StartsWith(prefix))
+                    .Where(t => t.StartsWith(prefix, StringComparison.Ordinal))
                     .Distinct()
-                    .OrderByDescending(t => t, StringComparer.Ordinal)
-                    .FirstOrDefault() ?? string.Empty;
+                    .Aggregate(
+                        string.Empty,
+                        (current, candidate) => StringComparer.Ordinal.Compare(candidate, current) > 0
+                            ? candidate
+                            : current);
                 return Task.FromResult(ResultBox.FromValue(maxTag));
             }
         }

--- a/dcb/src/Sekiban.Dcb.WithoutResult/InMemory/InMemoryDcbExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.WithoutResult/InMemory/InMemoryDcbExecutor.cs
@@ -376,7 +376,6 @@ public class InMemoryDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecut
                 var maxTag = state.Events
                     .SelectMany(e => e.Tags)
                     .Where(t => t.StartsWith(prefix, StringComparison.Ordinal))
-                    .Distinct()
                     .Aggregate(
                         string.Empty,
                         (current, candidate) => StringComparer.Ordinal.Compare(candidate, current) > 0

--- a/dcb/src/Sekiban.Dcb.WithoutResult/InMemory/InMemoryDcbExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.WithoutResult/InMemory/InMemoryDcbExecutor.cs
@@ -61,6 +61,9 @@ public class InMemoryDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecut
     Task<TagState> ISekibanExecutor.GetTagStateAsync(TagStateId tagStateId) =>
         _inner.GetTagStateAsync(tagStateId);
 
+    Task<string> ISekibanExecutor.GetMaxTagInTagGroupAsync(string tagGroup) =>
+        _inner.GetMaxTagInTagGroupAsync(tagGroup);
+
     Task<TResult> ISekibanExecutor.QueryAsync<TResult>(IQueryCommon<TResult> queryCommon) =>
         _inner.QueryAsync(queryCommon);
 
@@ -361,6 +364,22 @@ public class InMemoryDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecut
                 .ToList();
 
                 return Task.FromResult(ResultBox.FromValue(tagInfos.AsEnumerable()));
+            }
+        }
+
+        public Task<ResultBox<string>> GetMaxTagInTagGroupAsync(string tagGroup)
+        {
+            var state = GetState();
+            lock (state.Lock)
+            {
+                var prefix = tagGroup + ":";
+                var maxTag = state.Events
+                    .SelectMany(e => e.Tags)
+                    .Where(t => t.StartsWith(prefix))
+                    .Distinct()
+                    .OrderByDescending(t => t, StringComparer.Ordinal)
+                    .FirstOrDefault() ?? string.Empty;
+                return Task.FromResult(ResultBox.FromValue(maxTag));
             }
         }
 

--- a/dcb/tests/Sekiban.Dcb.ColdEvents.Tests/ColdEventDefaultsTests.cs
+++ b/dcb/tests/Sekiban.Dcb.ColdEvents.Tests/ColdEventDefaultsTests.cs
@@ -62,5 +62,6 @@ public class ColdEventDefaultsTests
         public Task<ResultBox<SerializableEvent>> ReadSerializableEventAsync(Guid eventId) => throw new NotSupportedException();
         public Task<ResultBox<IEnumerable<SerializableEvent>>> ReadSerializableEventsByTagAsync(ITag tag, SortableUniqueId? since = null) => throw new NotSupportedException();
         public Task<ResultBox<(IReadOnlyList<SerializableEvent> Events, IReadOnlyList<TagWriteResult> TagWrites)>> WriteSerializableEventsAsync(IEnumerable<SerializableEvent> events) => throw new NotSupportedException();
+        public Task<ResultBox<string>> GetMaxTagInTagGroupAsync(string tagGroup) => throw new NotSupportedException();
     }
 }

--- a/dcb/tests/Sekiban.Dcb.ColdEvents.Tests/ColdExporterTests.cs
+++ b/dcb/tests/Sekiban.Dcb.ColdEvents.Tests/ColdExporterTests.cs
@@ -345,6 +345,9 @@ public class ColdExporterTests
         public Task<ResultBox<(IReadOnlyList<SerializableEvent> Events, IReadOnlyList<TagWriteResult> TagWrites)>>
             WriteSerializableEventsAsync(IEnumerable<SerializableEvent> events)
             => throw new NotSupportedException();
+
+        public Task<ResultBox<string>> GetMaxTagInTagGroupAsync(string tagGroup)
+            => throw new NotSupportedException();
     }
 
     private sealed class FailingCheckpointStorage : IColdObjectStorage
@@ -465,6 +468,9 @@ public class ColdExporterTests
 
         public Task<ResultBox<(IReadOnlyList<SerializableEvent> Events, IReadOnlyList<TagWriteResult> TagWrites)>>
             WriteSerializableEventsAsync(IEnumerable<SerializableEvent> events)
+            => throw new NotSupportedException();
+
+        public Task<ResultBox<string>> GetMaxTagInTagGroupAsync(string tagGroup)
             => throw new NotSupportedException();
     }
 }

--- a/dcb/tests/Sekiban.Dcb.ColdEvents.Tests/HybridEventStoreCatchUpPathTests.cs
+++ b/dcb/tests/Sekiban.Dcb.ColdEvents.Tests/HybridEventStoreCatchUpPathTests.cs
@@ -286,6 +286,9 @@ public class HybridEventStoreCatchUpPathTests
         public Task<ResultBox<IEnumerable<TagInfo>>> GetAllTagsAsync(string? tagGroup = null)
             => throw new NotSupportedException();
 
+        public Task<ResultBox<string>> GetMaxTagInTagGroupAsync(string tagGroup)
+            => throw new NotSupportedException();
+
         public Task<ResultBox<IEnumerable<SerializableEvent>>> ReadAllSerializableEventsAsync(
             SortableUniqueId? since = null)
         {

--- a/dcb/tests/Sekiban.Dcb.ColdEvents.Tests/HybridEventStoreTests.cs
+++ b/dcb/tests/Sekiban.Dcb.ColdEvents.Tests/HybridEventStoreTests.cs
@@ -458,6 +458,9 @@ public class HybridEventStoreTests
         public Task<ResultBox<IEnumerable<TagInfo>>> GetAllTagsAsync(string? tagGroup = null)
             => throw new NotSupportedException();
 
+        public Task<ResultBox<string>> GetMaxTagInTagGroupAsync(string tagGroup)
+            => throw new NotSupportedException();
+
         public Task<ResultBox<IEnumerable<SerializableEvent>>> ReadAllSerializableEventsAsync(SortableUniqueId? since = null)
         {
             IEnumerable<SerializableEvent> filtered = _ignoreSinceFilter || since is null
@@ -518,6 +521,9 @@ public class HybridEventStoreTests
             => throw new NotSupportedException();
 
         public Task<ResultBox<IEnumerable<TagInfo>>> GetAllTagsAsync(string? tagGroup = null)
+            => throw new NotSupportedException();
+
+        public Task<ResultBox<string>> GetMaxTagInTagGroupAsync(string tagGroup)
             => throw new NotSupportedException();
 
         public Task<ResultBox<IEnumerable<SerializableEvent>>> ReadAllSerializableEventsAsync(SortableUniqueId? since = null)

--- a/dcb/tests/Sekiban.Dcb.Orleans.Tests/MinimalOrleansTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Orleans.Tests/MinimalOrleansTests.cs
@@ -468,6 +468,8 @@ public class MinimalOrleansTests : IAsyncLifetime
 
         public Task<ResultBox<IEnumerable<TagInfo>>> GetAllTagsAsync(string? tagGroup = null) => _inner.GetAllTagsAsync(tagGroup);
 
+        public Task<ResultBox<string>> GetMaxTagInTagGroupAsync(string tagGroup) => _inner.GetMaxTagInTagGroupAsync(tagGroup);
+
         public Task<ResultBox<IEnumerable<SerializableEvent>>> ReadSerializableEventsByTagAsync(
             ITag tag,
             SortableUniqueId? since = null) => _inner.ReadSerializableEventsByTagAsync(tag, since);

--- a/dcb/tests/Sekiban.Dcb.Orleans.Tests/MultiProjectionGrainPersistPolicyTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Orleans.Tests/MultiProjectionGrainPersistPolicyTests.cs
@@ -284,6 +284,7 @@ public class MultiProjectionGrainPersistPolicyTests
         public Task<ResultBox<bool>> TagExistsAsync(ITag tag) => throw new NotSupportedException();
         public Task<ResultBox<long>> GetEventCountAsync(SortableUniqueId? since = null) => throw new NotSupportedException();
         public Task<ResultBox<IEnumerable<TagInfo>>> GetAllTagsAsync(string? tagGroup = null) => throw new NotSupportedException();
+        public Task<ResultBox<string>> GetMaxTagInTagGroupAsync(string tagGroup) => throw new NotSupportedException();
         public Task<ResultBox<IEnumerable<SerializableEvent>>> ReadSerializableEventsByTagAsync(ITag tag, SortableUniqueId? since = null) =>
             throw new NotSupportedException();
         public Task<ResultBox<SerializableEvent>> ReadSerializableEventAsync(Guid eventId) => throw new NotSupportedException();

--- a/dcb/tests/Sekiban.Dcb.Orleans.Tests/MultiProjectionGrainRetentionCompactionTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Orleans.Tests/MultiProjectionGrainRetentionCompactionTests.cs
@@ -220,6 +220,7 @@ public class MultiProjectionGrainRetentionCompactionTests
         public Task<ResultBox<bool>> TagExistsAsync(ITag tag) => throw new NotSupportedException();
         public Task<ResultBox<long>> GetEventCountAsync(SortableUniqueId? since = null) => throw new NotSupportedException();
         public Task<ResultBox<IEnumerable<TagInfo>>> GetAllTagsAsync(string? tagGroup = null) => throw new NotSupportedException();
+        public Task<ResultBox<string>> GetMaxTagInTagGroupAsync(string tagGroup) => throw new NotSupportedException();
         public Task<ResultBox<IEnumerable<SerializableEvent>>> ReadAllSerializableEventsAsync(SortableUniqueId? since = null) => throw new NotSupportedException();
         public Task<ResultBox<IEnumerable<SerializableEvent>>> ReadAllSerializableEventsAsync(SortableUniqueId? since, int? maxCount) => throw new NotSupportedException();
         public Task<ResultBox<SerializableEvent>> ReadSerializableEventAsync(Guid eventId) => throw new NotSupportedException();

--- a/dcb/tests/Sekiban.Dcb.Orleans.Tests/OrleansTagStateGrainPersistenceTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Orleans.Tests/OrleansTagStateGrainPersistenceTests.cs
@@ -364,6 +364,8 @@ public class OrleansTagStateGrainPersistenceTests : IAsyncLifetime
 
         public Task<ResultBox<IEnumerable<TagInfo>>> GetAllTagsAsync(string? tagGroup = null) => _inner.GetAllTagsAsync(tagGroup);
 
+        public Task<ResultBox<string>> GetMaxTagInTagGroupAsync(string tagGroup) => _inner.GetMaxTagInTagGroupAsync(tagGroup);
+
         public Task<ResultBox<IEnumerable<SerializableEvent>>> ReadAllSerializableEventsAsync(SortableUniqueId? since = null)
             => _inner.ReadAllSerializableEventsAsync(since);
 

--- a/dcb/tests/Sekiban.Dcb.Orleans.Tests/OrleansTagStatePersistentTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Orleans.Tests/OrleansTagStatePersistentTests.cs
@@ -302,6 +302,9 @@ public class OrleansTagStatePersistentTests
         public Task<ResultBox<IEnumerable<TagInfo>>> GetAllTagsAsync(string? tagGroup = null) =>
             Task.FromResult(ResultBox.FromValue(Enumerable.Empty<TagInfo>()));
 
+        public Task<ResultBox<string>> GetMaxTagInTagGroupAsync(string tagGroup) =>
+            Task.FromResult(ResultBox.FromValue(string.Empty));
+
         public Task<ResultBox<IEnumerable<SerializableEvent>>> ReadAllSerializableEventsAsync(SortableUniqueId? since = null) =>
             Task.FromResult(ResultBox.FromValue(Enumerable.Empty<SerializableEvent>()));
 

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/EventStoreCacheSyncTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/EventStoreCacheSyncTests.cs
@@ -152,6 +152,9 @@ public class EventStoreCacheSyncTests
         public Task<ResultBox<IEnumerable<TagInfo>>> GetAllTagsAsync(string? tagGroup = null) =>
             throw new NotSupportedException();
 
+        public Task<ResultBox<string>> GetMaxTagInTagGroupAsync(string tagGroup) =>
+            throw new NotSupportedException();
+
         public Task<ResultBox<IEnumerable<SerializableEvent>>> ReadAllSerializableEventsAsync(SortableUniqueId? since = null) =>
             ReadAllSerializableEventsAsync(since, null);
 

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/GeneralTagStateActorPersistenceTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/GeneralTagStateActorPersistenceTests.cs
@@ -360,6 +360,8 @@ public class GeneralTagStateActorPersistenceTests
 
         public Task<ResultBox<IEnumerable<TagInfo>>> GetAllTagsAsync(string? tagGroup = null) => _inner.GetAllTagsAsync(tagGroup);
 
+        public Task<ResultBox<string>> GetMaxTagInTagGroupAsync(string tagGroup) => _inner.GetMaxTagInTagGroupAsync(tagGroup);
+
         public Task<ResultBox<IEnumerable<SerializableEvent>>> ReadAllSerializableEventsAsync(SortableUniqueId? since = null) =>
             _inner.ReadAllSerializableEventsAsync(since);
 

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/GetMaxTagInTagGroupTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/GetMaxTagInTagGroupTests.cs
@@ -1,0 +1,80 @@
+using Dcb.Domain;
+using Dcb.Domain.Student;
+using ResultBoxes;
+using Sekiban.Dcb;
+using Sekiban.Dcb.InMemory;
+using Xunit;
+
+namespace Sekiban.Dcb.Tests;
+
+/// <summary>
+///     Tests for GetMaxTagInTagGroupAsync functionality.
+/// </summary>
+public class GetMaxTagInTagGroupTests
+{
+    [Fact]
+    public async Task Empty_TagGroup_Returns_Empty_String()
+    {
+        var domain = DomainType.GetDomainTypes();
+        ISekibanExecutor executor = new InMemoryDcbExecutor(domain);
+
+        var result = await executor.GetMaxTagInTagGroupAsync("Student");
+        Assert.True(result.IsSuccess);
+        Assert.Equal(string.Empty, result.GetValue());
+    }
+
+    [Fact]
+    public async Task After_Creating_Students_Returns_Max_Tag()
+    {
+        var domain = DomainType.GetDomainTypes();
+        ISekibanExecutor executor = new InMemoryDcbExecutor(domain);
+
+        // Create multiple students with known GUIDs that have clear lexicographic ordering
+        var id1 = Guid.Parse("00000000-0000-0000-0000-000000000001");
+        var id2 = Guid.Parse("00000000-0000-0000-0000-000000000002");
+        var id3 = Guid.Parse("00000000-0000-0000-0000-000000000003");
+
+        var r1 = await executor.ExecuteAsync(new CreateStudent(id1, "Alice", 5));
+        Assert.True(r1.IsSuccess);
+        var r2 = await executor.ExecuteAsync(new CreateStudent(id2, "Bob", 5));
+        Assert.True(r2.IsSuccess);
+        var r3 = await executor.ExecuteAsync(new CreateStudent(id3, "Charlie", 5));
+        Assert.True(r3.IsSuccess);
+
+        var result = await executor.GetMaxTagInTagGroupAsync("Student");
+        Assert.True(result.IsSuccess);
+
+        var maxTag = result.GetValue();
+        Assert.NotEmpty(maxTag);
+        Assert.StartsWith("Student:", maxTag);
+
+        // The max should be the lexicographically largest tag among the three
+        var expectedTag1 = $"Student:{id1}";
+        var expectedTag2 = $"Student:{id2}";
+        var expectedTag3 = $"Student:{id3}";
+
+        // Verify the max tag is one of the created tags
+        Assert.Contains(maxTag, new[] { expectedTag1, expectedTag2, expectedTag3 });
+
+        // Verify it's actually the max
+        Assert.True(string.Compare(maxTag, expectedTag1, StringComparison.Ordinal) >= 0);
+        Assert.True(string.Compare(maxTag, expectedTag2, StringComparison.Ordinal) >= 0);
+        Assert.True(string.Compare(maxTag, expectedTag3, StringComparison.Ordinal) >= 0);
+    }
+
+    [Fact]
+    public async Task NonExistent_TagGroup_Returns_Empty_String()
+    {
+        var domain = DomainType.GetDomainTypes();
+        ISekibanExecutor executor = new InMemoryDcbExecutor(domain);
+
+        // Create a student so the store isn't empty
+        var r = await executor.ExecuteAsync(new CreateStudent(Guid.NewGuid(), "Alice", 5));
+        Assert.True(r.IsSuccess);
+
+        // Query a different tag group that doesn't exist
+        var result = await executor.GetMaxTagInTagGroupAsync("NonExistentGroup");
+        Assert.True(result.IsSuccess);
+        Assert.Equal(string.Empty, result.GetValue());
+    }
+}

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/InMemoryEventStore.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/InMemoryEventStore.cs
@@ -233,6 +233,21 @@ public class InMemoryEventStore : IEventStore
         }
     }
 
+    public Task<ResultBox<string>> GetMaxTagInTagGroupAsync(string tagGroup)
+    {
+        lock (_lock)
+        {
+            var prefix = tagGroup + ":";
+            var maxTag = _events
+                .SelectMany(e => e.Tags)
+                .Where(t => t.StartsWith(prefix))
+                .Distinct()
+                .OrderByDescending(t => t, StringComparer.Ordinal)
+                .FirstOrDefault() ?? string.Empty;
+            return Task.FromResult(ResultBox.FromValue(maxTag));
+        }
+    }
+
     public Task<ResultBox<IEnumerable<SerializableEvent>>> ReadAllSerializableEventsAsync(SortableUniqueId? since = null) =>
         ReadAllSerializableEventsAsync(since, null);
 

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/InMemoryEventStore.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/InMemoryEventStore.cs
@@ -241,7 +241,6 @@ public class InMemoryEventStore : IEventStore
             var maxTag = _events
                 .SelectMany(e => e.Tags)
                 .Where(t => t.StartsWith(prefix, StringComparison.Ordinal))
-                .Distinct()
                 .Aggregate(
                     string.Empty,
                     (current, candidate) => StringComparer.Ordinal.Compare(candidate, current) > 0

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/InMemoryEventStore.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/InMemoryEventStore.cs
@@ -240,10 +240,13 @@ public class InMemoryEventStore : IEventStore
             var prefix = tagGroup + ":";
             var maxTag = _events
                 .SelectMany(e => e.Tags)
-                .Where(t => t.StartsWith(prefix))
+                .Where(t => t.StartsWith(prefix, StringComparison.Ordinal))
                 .Distinct()
-                .OrderByDescending(t => t, StringComparer.Ordinal)
-                .FirstOrDefault() ?? string.Empty;
+                .Aggregate(
+                    string.Empty,
+                    (current, candidate) => StringComparer.Ordinal.Compare(candidate, current) > 0
+                        ? candidate
+                        : current);
             return Task.FromResult(ResultBox.FromValue(maxTag));
         }
     }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Add `GetMaxTagInTagGroupAsync(string tagGroup)` that returns the lexicographically maximum Tag string within a TagGroup (e.g., `"Student:01HX999"` for TagGroup `"Student"`). Returns empty string if no tags exist.

**Use cases**:
- Incremental ID generation: get the current max, compute next value, create entity
- Determining the most recently created entity (when using ULID/v7 GUID tags)

**Exposed on three layers**:
- `IEventStore`: per-provider efficient implementation
- `ICoreCommandContext` / `ICommandContext`: for use inside command handlers (typical incremental ID pattern)
- `ISekibanExecutor`: for use outside command handlers

**Performance guarantee**: Uses existing `IX_Tags_Service_Tag` B-tree index with prefix range scan (`Tag >= 'Group:' AND Tag < 'Group;'`). No new indexes or schema changes needed:

| Provider | Approach | Cost |
|----------|---------|------|
| Postgres | EF Core `OrderByDescending(Tag).FirstOrDefault()` with prefix range | O(log N) — B-tree reverse seek |
| SQLite | `SELECT MAX(Tag)` with prefix range | O(log N) |
| CosmosDB | Cross-partition `TOP 1 ... ORDER BY tag DESC` with prefix range | Efficient |
| DynamoDB | Reuses `GetAllTagsAsync` + in-memory max | Same as existing GetAllTagsAsync |
| InMemory (Core) | `TagStreams.Keys` prefix filter + max | O(T) — dictionary key scan |
| InMemory (Executor) | Events scan + prefix filter + max | O(E) — acceptable for test use |
| Hybrid | Delegates to hot store | Same as underlying |

**Lexicographic ordering limitation**: String comparison means ULID and zero-padded INT work correctly, but non-padded INT does not (`"9" > "42"`). This is documented in the Issue.

## Related Tickets & Documents

- Closes #1007

## QA Instructions, Screenshots, Recordings

1. `dotnet build Sekiban.slnx` — 0 errors
2. `dotnet test Sekiban.slnx --filter "FullyQualifiedName~Sekiban.Dcb"` — all tests pass (2 pre-existing failures in EventStoreCacheSyncTests unrelated)

## Added/updated tests?

- [x] Yes

3 new tests in `GetMaxTagInTagGroupTests.cs`: empty group, max after multiple creates, non-existent group.