### PR TITLE
Stream-first snapshot persistence for large multi-projections

### DIFF
--- a/dcb/internalUsages/DcbOrleans.SnapshotPersistProbe/Program.cs
+++ b/dcb/internalUsages/DcbOrleans.SnapshotPersistProbe/Program.cs
@@ -60,9 +60,23 @@ internal static class Program
     {
         var domainTypes = BuildDomainTypes();
         var primitive = new NativeMultiProjectionProjectionPrimitive(domainTypes);
-        var services = new ServiceCollection()
-            .AddSingleton<IBlobStorageSnapshotAccessor>(workspace.BlobAccessor)
-            .BuildServiceProvider();
+        var servicesBuilder = new ServiceCollection()
+            .AddSingleton<IBlobStorageSnapshotAccessor>(workspace.BlobAccessor);
+
+        // Stream-first mode registers a spillable payload buffer so the handler picks
+        // the new zero-materialization persist path internally.
+        if (options.Mode == ProbeMode.StreamFirst)
+        {
+            servicesBuilder.AddSingleton<ISnapshotPayloadBufferProvider>(
+                new SpillableSnapshotPayloadBufferProvider(
+                    new SpillableSnapshotPayloadOptions
+                    {
+                        InMemoryThresholdBytes = options.SpillThresholdBytes,
+                        TempDirectory = workspace.SpillDirectory
+                    }));
+        }
+
+        var services = servicesBuilder.BuildServiceProvider();
         var host = new NativeProjectionActorHost(
             domainTypes,
             services,
@@ -117,6 +131,11 @@ internal static class Program
                 host,
                 snapshotStream,
                 options.OffloadThresholdBytes).ConfigureAwait(false),
+            ProbeMode.StreamFirst => await host.WriteSnapshotForPersistenceToStreamAsync(
+                snapshotStream,
+                canGetUnsafeState: false,
+                offloadThresholdBytes: options.OffloadThresholdBytes,
+                CancellationToken.None).ConfigureAwait(false),
             _ => throw new ArgumentOutOfRangeException()
         };
 
@@ -251,9 +270,13 @@ internal sealed class ProbeWorkspace : IDisposable
     {
         Directory.CreateDirectory(_rootDirectory);
         BlobAccessor = new TempFileBlobStorageSnapshotAccessor(Path.Combine(_rootDirectory, "blob"));
+        SpillDirectory = Path.Combine(_rootDirectory, "spill");
+        Directory.CreateDirectory(SpillDirectory);
     }
 
     public TempFileBlobStorageSnapshotAccessor BlobAccessor { get; }
+
+    public string SpillDirectory { get; }
 
     public void Dispose()
     {
@@ -307,6 +330,7 @@ internal sealed record ProbeOptions(
     int EventCount,
     int PayloadSizeBytes,
     int OffloadThresholdBytes,
+    int SpillThresholdBytes,
     int Iterations)
 {
     public static ProbeOptions Parse(string[] args)
@@ -315,6 +339,7 @@ internal sealed record ProbeOptions(
         var eventCount = 24;
         var payloadSizeBytes = 512 * 1024;
         var offloadThresholdBytes = 1024 * 1024;
+        var spillThresholdBytes = 64 * 1024;
         var iterations = 3;
 
         for (var index = 0; index < args.Length; index += 2)
@@ -339,6 +364,9 @@ internal sealed record ProbeOptions(
                 case "--offload-threshold-bytes":
                     offloadThresholdBytes = int.Parse(value);
                     break;
+                case "--spill-threshold-bytes":
+                    spillThresholdBytes = int.Parse(value);
+                    break;
                 case "--iterations":
                     iterations = int.Parse(value);
                     break;
@@ -347,7 +375,7 @@ internal sealed record ProbeOptions(
             }
         }
 
-        return new ProbeOptions(mode, eventCount, payloadSizeBytes, offloadThresholdBytes, iterations);
+        return new ProbeOptions(mode, eventCount, payloadSizeBytes, offloadThresholdBytes, spillThresholdBytes, iterations);
     }
 
     private static ProbeMode ParseMode(string value) =>
@@ -355,14 +383,16 @@ internal sealed record ProbeOptions(
         {
             "legacy" => ProbeMode.Legacy,
             "offloaded" => ProbeMode.Offloaded,
-            _ => throw new ArgumentOutOfRangeException(nameof(value), value, "Mode must be legacy or offloaded.")
+            "streamfirst" or "stream-first" => ProbeMode.StreamFirst,
+            _ => throw new ArgumentOutOfRangeException(nameof(value), value, "Mode must be legacy, offloaded, or streamfirst.")
         };
 }
 
 internal enum ProbeMode
 {
     Legacy,
-    Offloaded
+    Offloaded,
+    StreamFirst
 }
 
 internal sealed record ProbeSummary(

--- a/dcb/src/Sekiban.Dcb.Core.Model/Domains/AotMultiProjectorTypes.cs
+++ b/dcb/src/Sekiban.Dcb.Core.Model/Domains/AotMultiProjectorTypes.cs
@@ -26,6 +26,7 @@ public sealed class AotMultiProjectorTypes : ICoreMultiProjectorTypes
         Func<IMultiProjectionPayload> GenerateInitial,
         string Version,
         Func<DcbDomainTypes, string, IMultiProjectionPayload, SerializationResult> Serialize,
+        Func<Stream, DcbDomainTypes, string, IMultiProjectionPayload, SerializationSizeInfo> SerializeToStream,
         Func<DcbDomainTypes, string, byte[], IMultiProjectionPayload> Deserialize);
 
     /// <summary>
@@ -59,6 +60,18 @@ public sealed class AotMultiProjectorTypes : ICoreMultiProjectorTypes
             {
                 var (compressed, originalSize) = GzipCompression.CompressJson((TProjector)payload, typeInfo);
                 return new SerializationResult(compressed, originalSize, compressed.LongLength);
+            },
+            SerializeToStream: (destination, domainTypes, safeWindowThreshold, payload) =>
+            {
+                var startPosition = destination.CanSeek ? destination.Position : 0L;
+                var originalSize = GzipCompression.CompressJsonToStream(
+                    destination,
+                    (TProjector)payload,
+                    typeInfo);
+                var compressedSize = destination.CanSeek
+                    ? Math.Max(0, destination.Position - startPosition)
+                    : originalSize;
+                return new SerializationSizeInfo(originalSize, compressedSize);
             },
             Deserialize: (domainTypes, safeWindowThreshold, data) =>
             {
@@ -124,6 +137,33 @@ public sealed class AotMultiProjectorTypes : ICoreMultiProjectorTypes
         if (_projectors.TryGetValue(projectorName, out var reg))
             return ResultBox.FromValue(reg.Serialize(domainTypes, safeWindowThreshold, payload));
         return ResultBox.Error<SerializationResult>(new Exception($"Projector not found: {projectorName}"));
+    }
+
+    /// <inheritdoc />
+    public ResultBox<SerializationSizeInfo> SerializeToStream(
+        string projectorName,
+        DcbDomainTypes domainTypes,
+        string safeWindowThreshold,
+        IMultiProjectionPayload payload,
+        Stream destination)
+    {
+        if (destination is null)
+        {
+            return ResultBox.Error<SerializationSizeInfo>(new ArgumentNullException(nameof(destination)));
+        }
+
+        if (_projectors.TryGetValue(projectorName, out var reg))
+        {
+            try
+            {
+                return ResultBox.FromValue(reg.SerializeToStream(destination, domainTypes, safeWindowThreshold, payload));
+            }
+            catch (Exception ex)
+            {
+                return ResultBox.Error<SerializationSizeInfo>(ex);
+            }
+        }
+        return ResultBox.Error<SerializationSizeInfo>(new Exception($"Projector not found: {projectorName}"));
     }
 
     /// <inheritdoc />

--- a/dcb/src/Sekiban.Dcb.Core.Model/Domains/AotMultiProjectorTypes.cs
+++ b/dcb/src/Sekiban.Dcb.Core.Model/Domains/AotMultiProjectorTypes.cs
@@ -63,15 +63,15 @@ public sealed class AotMultiProjectorTypes : ICoreMultiProjectorTypes
             },
             SerializeToStream: (destination, domainTypes, safeWindowThreshold, payload) =>
             {
-                var startPosition = destination.CanSeek ? destination.Position : 0L;
-                var originalSize = GzipCompression.CompressJsonToStream(
+                var result = MultiProjectorStreamSerializationHelper.WriteGzipJsonToStream(
                     destination,
                     (TProjector)payload,
                     typeInfo);
-                var compressedSize = destination.CanSeek
-                    ? Math.Max(0, destination.Position - startPosition)
-                    : originalSize;
-                return new SerializationSizeInfo(originalSize, compressedSize);
+                if (!result.IsSuccess)
+                {
+                    throw result.GetException();
+                }
+                return result.GetValue();
             },
             Deserialize: (domainTypes, safeWindowThreshold, data) =>
             {

--- a/dcb/src/Sekiban.Dcb.Core.Model/Domains/IMultiProjectorTypes.cs
+++ b/dcb/src/Sekiban.Dcb.Core.Model/Domains/IMultiProjectorTypes.cs
@@ -54,6 +54,48 @@ public interface ICoreMultiProjectorTypes
         IMultiProjectionPayload payload);
 
     /// <summary>
+    ///     Stream-oriented variant of <see cref="Serialize" />. Writes the serialized
+    ///     (and optionally compressed) payload bytes directly to <paramref name="destination" />
+    ///     without materializing a <see cref="byte" />[] in managed memory.
+    ///     The default implementation delegates to <see cref="Serialize" /> and copies the
+    ///     resulting bytes to the destination stream for backward compatibility; registries
+    ///     that own their serialization pipeline (such as
+    ///     <see cref="Sekiban.Dcb.MultiProjections.GzipCompression" />-based JSON serializers)
+    ///     should override this method with a fully streaming implementation.
+    /// </summary>
+    /// <param name="projectorName">Name of the projector</param>
+    /// <param name="domainTypes">Domain types containing serialization options</param>
+    /// <param name="safeWindowThreshold">Safe window threshold (SortableUniqueId string)</param>
+    /// <param name="payload">The payload to serialize</param>
+    /// <param name="destination">Writable stream that will receive the serialized payload</param>
+    /// <returns>
+    ///     <see cref="SerializationSizeInfo" /> describing the original and compressed byte
+    ///     counts written to <paramref name="destination" />.
+    /// </returns>
+    ResultBox<SerializationSizeInfo> SerializeToStream(
+        string projectorName,
+        DcbDomainTypes domainTypes,
+        string safeWindowThreshold,
+        IMultiProjectionPayload payload,
+        Stream destination)
+    {
+        var result = Serialize(projectorName, domainTypes, safeWindowThreshold, payload);
+        if (!result.IsSuccess)
+        {
+            return ResultBox.Error<SerializationSizeInfo>(result.GetException());
+        }
+
+        var value = result.GetValue();
+        if (value.Data is { Length: > 0 })
+        {
+            destination.Write(value.Data, 0, value.Data.Length);
+        }
+
+        return ResultBox.FromValue(
+            new SerializationSizeInfo(value.OriginalSizeBytes, value.CompressedSizeBytes));
+    }
+
+    /// <summary>
     ///     Deserializes a JSON string to a multi-projection payload.
     ///     Uses custom deserialization if registered, otherwise falls back to standard JSON deserialization.
     ///     Caller MUST always supply safeWindowThreshold; passing empty or null is treated as error.

--- a/dcb/src/Sekiban.Dcb.Core.Model/Domains/MultiProjectorStreamSerializationHelper.cs
+++ b/dcb/src/Sekiban.Dcb.Core.Model/Domains/MultiProjectorStreamSerializationHelper.cs
@@ -1,0 +1,113 @@
+using System.IO;
+using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
+using ResultBoxes;
+using Sekiban.Dcb.MultiProjections;
+
+namespace Sekiban.Dcb.Domains;
+
+/// <summary>
+///     Shared helper used by <see cref="ICoreMultiProjectorTypes" /> implementations to
+///     emit a serialized multi-projection payload to a destination stream without
+///     duplicating boilerplate (argument validation, custom-serializer fallback, seek-based
+///     size measurement) across every registry.
+///     Centralizing this logic keeps the stream-first persistence path uniform across
+///     <c>SimpleMultiProjectorTypes</c>, AOT registries, and custom implementations.
+/// </summary>
+public static class MultiProjectorStreamSerializationHelper
+{
+    /// <summary>
+    ///     Validate common arguments for the stream-first serialize path.
+    /// </summary>
+    public static ResultBox<SerializationSizeInfo>? ValidateCommonArguments(
+        string safeWindowThreshold,
+        Stream destination)
+    {
+        if (string.IsNullOrWhiteSpace(safeWindowThreshold))
+        {
+            return ResultBox.Error<SerializationSizeInfo>(
+                new ArgumentException("safeWindowThreshold must be supplied"));
+        }
+        if (destination is null)
+        {
+            return ResultBox.Error<SerializationSizeInfo>(new ArgumentNullException(nameof(destination)));
+        }
+        return null;
+    }
+
+    /// <summary>
+    ///     Copy a pre-materialized <see cref="SerializationResult" /> (produced by a custom
+    ///     serializer registration) to the destination stream and return the size info.
+    /// </summary>
+    public static ResultBox<SerializationSizeInfo> CopyCustomResultToStream(
+        Stream destination,
+        SerializationResult customResult)
+    {
+        try
+        {
+            if (customResult.Data is { Length: > 0 } data)
+            {
+                destination.Write(data, 0, data.Length);
+            }
+            return ResultBox.FromValue(new SerializationSizeInfo(
+                customResult.OriginalSizeBytes,
+                customResult.CompressedSizeBytes));
+        }
+        catch (Exception ex)
+        {
+            return ResultBox.Error<SerializationSizeInfo>(ex);
+        }
+    }
+
+    /// <summary>
+    ///     Streams the payload as gzipped JSON directly into the destination stream and
+    ///     returns the original (pre-compression) and compressed byte counts.
+    /// </summary>
+    public static ResultBox<SerializationSizeInfo> WriteGzipJsonToStream(
+        Stream destination,
+        IMultiProjectionPayload payload,
+        JsonSerializerOptions jsonOptions)
+    {
+        try
+        {
+            var startPosition = destination.CanSeek ? destination.Position : 0L;
+            var originalSize = GzipCompression.CompressJsonToStream(
+                destination,
+                payload,
+                payload.GetType(),
+                jsonOptions);
+            var compressedSize = destination.CanSeek
+                ? Math.Max(0, destination.Position - startPosition)
+                : originalSize;
+            return ResultBox.FromValue(new SerializationSizeInfo(originalSize, compressedSize));
+        }
+        catch (Exception ex)
+        {
+            return ResultBox.Error<SerializationSizeInfo>(ex);
+        }
+    }
+
+    /// <summary>
+    ///     AOT-friendly overload that streams gzipped JSON via a strongly-typed
+    ///     <see cref="JsonTypeInfo{T}" />.
+    /// </summary>
+    public static ResultBox<SerializationSizeInfo> WriteGzipJsonToStream<T>(
+        Stream destination,
+        T payload,
+        JsonTypeInfo<T> typeInfo)
+    {
+        try
+        {
+            var startPosition = destination.CanSeek ? destination.Position : 0L;
+            var originalSize = GzipCompression.CompressJsonToStream(destination, payload, typeInfo);
+            var compressedSize = destination.CanSeek
+                ? Math.Max(0, destination.Position - startPosition)
+                : originalSize;
+            return ResultBox.FromValue(new SerializationSizeInfo(originalSize, compressedSize));
+        }
+        catch (Exception ex)
+        {
+            return ResultBox.Error<SerializationSizeInfo>(ex);
+        }
+    }
+}

--- a/dcb/src/Sekiban.Dcb.Core.Model/Domains/SerializationResult.cs
+++ b/dcb/src/Sekiban.Dcb.Core.Model/Domains/SerializationResult.cs
@@ -19,3 +19,18 @@ public record SerializationResult(
         ? (double)CompressedSizeBytes / OriginalSizeBytes
         : 1.0;
 }
+
+/// <summary>
+///     Size information produced by a stream-oriented serialization pass.
+///     Used by the stream-first multi-projection persistence path so callers can
+///     report both uncompressed and compressed sizes without holding the serialized
+///     <see cref="byte"/>[] in managed memory.
+/// </summary>
+/// <param name="OriginalSizeBytes">Size before compression (number of bytes written to the counting writer)</param>
+/// <param name="CompressedSizeBytes">Size after compression (number of bytes written to the destination stream)</param>
+public record SerializationSizeInfo(long OriginalSizeBytes, long CompressedSizeBytes)
+{
+    public double CompressionRatio => OriginalSizeBytes > 0
+        ? (double)CompressedSizeBytes / OriginalSizeBytes
+        : 1.0;
+}

--- a/dcb/src/Sekiban.Dcb.Core.Model/MultiProjections/GzipCompression.cs
+++ b/dcb/src/Sekiban.Dcb.Core.Model/MultiProjections/GzipCompression.cs
@@ -66,6 +66,68 @@ public static class GzipCompression
     }
 
     /// <summary>
+    ///     Serialize JSON directly into a GZip stream wrapping <paramref name="destination"/>.
+    ///     Returns the uncompressed byte count. The compressed bytes are written straight to the
+    ///     provided destination, avoiding a large intermediate byte[] for the final payload.
+    /// </summary>
+    public static long CompressJsonToStream(
+        Stream destination,
+        object value,
+        Type inputType,
+        JsonSerializerOptions options)
+    {
+        if (destination is null)
+        {
+            throw new ArgumentNullException(nameof(destination));
+        }
+
+        long originalSizeBytes;
+        using (var gzip = new GZipStream(destination, CompressionLevel.Fastest, leaveOpen: true))
+        using (var counting = new CountingWriteStream(gzip))
+        {
+            JsonSerializer.Serialize(counting, value, inputType, options);
+            counting.Flush();
+            gzip.Flush();
+            originalSizeBytes = counting.BytesWritten;
+        }
+
+        return originalSizeBytes;
+    }
+
+    /// <summary>
+    ///     Async overload of <see cref="CompressJsonToStream(Stream, object, Type, JsonSerializerOptions)"/>.
+    /// </summary>
+    public static async Task<long> CompressJsonToStreamAsync(
+        Stream destination,
+        object value,
+        Type inputType,
+        JsonSerializerOptions options,
+        CancellationToken cancellationToken = default)
+    {
+        if (destination is null)
+        {
+            throw new ArgumentNullException(nameof(destination));
+        }
+
+        long originalSizeBytes;
+        var gzip = new GZipStream(destination, CompressionLevel.Fastest, leaveOpen: true);
+        await using (gzip.ConfigureAwait(false))
+        {
+            var counting = new CountingWriteStream(gzip);
+            await using (counting.ConfigureAwait(false))
+            {
+                await JsonSerializer.SerializeAsync(counting, value, inputType, options, cancellationToken)
+                    .ConfigureAwait(false);
+                await counting.FlushAsync(cancellationToken).ConfigureAwait(false);
+                await gzip.FlushAsync(cancellationToken).ConfigureAwait(false);
+                originalSizeBytes = counting.BytesWritten;
+            }
+        }
+
+        return originalSizeBytes;
+    }
+
+    /// <summary>
     ///     AOT-friendly overload of CompressJson using JsonTypeInfo.
     /// </summary>
     public static (byte[] CompressedBytes, long OriginalSizeBytes) CompressJson<T>(
@@ -83,6 +145,31 @@ public static class GzipCompression
             originalSizeBytes = counting.BytesWritten;
         }
         return (output.ToArray(), originalSizeBytes);
+    }
+
+    /// <summary>
+    ///     AOT-friendly overload that writes the compressed JSON directly to a destination stream.
+    /// </summary>
+    public static long CompressJsonToStream<T>(
+        Stream destination,
+        T value,
+        JsonTypeInfo<T> typeInfo)
+    {
+        if (destination is null)
+        {
+            throw new ArgumentNullException(nameof(destination));
+        }
+
+        long originalSizeBytes;
+        using (var gzip = new GZipStream(destination, CompressionLevel.Fastest, leaveOpen: true))
+        using (var counting = new CountingWriteStream(gzip))
+        {
+            JsonSerializer.Serialize(counting, value, typeInfo);
+            counting.Flush();
+            gzip.Flush();
+            originalSizeBytes = counting.BytesWritten;
+        }
+        return originalSizeBytes;
     }
 
     /// <summary>

--- a/dcb/src/Sekiban.Dcb.Core/Actors/GeneralMultiProjectionActor.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Actors/GeneralMultiProjectionActor.cs
@@ -326,11 +326,11 @@ public class GeneralMultiProjectionActor
             .ConfigureAwait(false);
 
         var bufferStream = buffer.Stream;
-        if (!bufferStream.CanWrite || !bufferStream.CanSeek)
+        if (!bufferStream.CanRead || !bufferStream.CanWrite || !bufferStream.CanSeek)
         {
             return ResultBox.Error<SerializableMultiProjectionStateEnvelope>(
                 new InvalidOperationException(
-                    "ISnapshotPayloadBufferProvider must return a writable, seekable stream."));
+                    "ISnapshotPayloadBufferProvider must return a readable, writable, seekable stream."));
         }
 
         // Reset in case the provider reused a stream.
@@ -411,19 +411,25 @@ public class GeneralMultiProjectionActor
         // Base64 field in the envelope. Since inline payloads are below the offload threshold
         // by construction, this does not cause the large-memory spike the stream-first path
         // is designed to avoid.
-        bufferStream.Position = 0;
-        var payloadBytes = new byte[compressedLength];
-        var offset = 0;
-        while (offset < payloadBytes.Length)
+        if (compressedLength > int.MaxValue)
         {
-            var read = await bufferStream
-                .ReadAsync(payloadBytes.AsMemory(offset, payloadBytes.Length - offset), cancellationToken)
-                .ConfigureAwait(false);
-            if (read == 0)
-            {
-                break;
-            }
-            offset += read;
+            return ResultBox.Error<SerializableMultiProjectionStateEnvelope>(
+                new InvalidOperationException(
+                    $"Inline snapshot payload size {compressedLength} exceeds int.MaxValue; the payload must be offloaded via IBlobStorageSnapshotAccessor."));
+        }
+
+        bufferStream.Position = 0;
+        var payloadBytes = new byte[(int)compressedLength];
+        try
+        {
+            await bufferStream.ReadExactlyAsync(payloadBytes, cancellationToken).ConfigureAwait(false);
+        }
+        catch (EndOfStreamException ex)
+        {
+            return ResultBox.Error<SerializableMultiProjectionStateEnvelope>(
+                new InvalidOperationException(
+                    $"Snapshot payload buffer returned fewer bytes than the declared length {compressedLength} for projector {_projectorName}.",
+                    ex));
         }
 
         var inlineState = SerializableMultiProjectionState.FromBytes(

--- a/dcb/src/Sekiban.Dcb.Core/Actors/GeneralMultiProjectionActor.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Actors/GeneralMultiProjectionActor.cs
@@ -270,6 +270,182 @@ public class GeneralMultiProjectionActor
     }
 
     /// <summary>
+    ///     Stream-first variant of <see cref="BuildSnapshotEnvelopeAsync" />.
+    ///     Serializes the snapshot payload directly into a spillable buffer (supplied by
+    ///     <paramref name="payloadBufferProvider" />) so that a very large multi-projection
+    ///     snapshot never has to materialize a full compressed <see cref="byte" />[] in managed
+    ///     memory before the offload decision is made.
+    ///     When the buffered payload exceeds <paramref name="offloadThresholdBytes" /> and a
+    ///     <paramref name="blobAccessor" /> is provided, the buffer stream is uploaded directly
+    ///     to blob storage and an offloaded envelope (metadata only) is returned. Otherwise,
+    ///     the buffered bytes are materialized for the inline envelope — which is safe because
+    ///     inline payloads are, by definition, below the offload threshold.
+    ///     If no buffer provider is supplied the method falls back to <see cref="BuildSnapshotEnvelopeAsync" />.
+    /// </summary>
+    public async Task<ResultBox<SerializableMultiProjectionStateEnvelope>> BuildSnapshotEnvelopeStreamFirstAsync(
+        ISnapshotPayloadBufferProvider? payloadBufferProvider,
+        bool canGetUnsafeState = true,
+        IBlobStorageSnapshotAccessor? blobAccessor = null,
+        int offloadThresholdBytes = int.MaxValue,
+        CancellationToken cancellationToken = default)
+    {
+        // Without a spill buffer we cannot stream-first; fall back to the legacy path.
+        if (payloadBufferProvider is null)
+        {
+            return await BuildSnapshotEnvelopeAsync(
+                canGetUnsafeState,
+                blobAccessor,
+                offloadThresholdBytes,
+                cancellationToken).ConfigureAwait(false);
+        }
+
+        InitializeProjectorsIfNeeded();
+
+        var stateResult = await GetStateAsync(canGetUnsafeState);
+        if (!stateResult.IsSuccess)
+        {
+            return ResultBox.Error<SerializableMultiProjectionStateEnvelope>(stateResult.GetException());
+        }
+
+        var multiProjectionState = stateResult.GetValue();
+        var payload = multiProjectionState.Payload;
+        var payloadType = payload.GetType();
+        var payloadTypeName = payloadType.FullName ?? payloadType.Name;
+
+        var versionResult = _types.GetProjectorVersion(_projectorName);
+        if (!versionResult.IsSuccess)
+        {
+            return ResultBox.Error<SerializableMultiProjectionStateEnvelope>(versionResult.GetException());
+        }
+        var projectorVersion = versionResult.GetValue();
+
+        var safeThreshold = GetSafeWindowThreshold();
+
+        await using var buffer = await payloadBufferProvider
+            .CreateBufferAsync(_projectorName, cancellationToken)
+            .ConfigureAwait(false);
+
+        var bufferStream = buffer.Stream;
+        if (!bufferStream.CanWrite || !bufferStream.CanSeek)
+        {
+            return ResultBox.Error<SerializableMultiProjectionStateEnvelope>(
+                new InvalidOperationException(
+                    "ISnapshotPayloadBufferProvider must return a writable, seekable stream."));
+        }
+
+        // Reset in case the provider reused a stream.
+        if (bufferStream.Length > 0)
+        {
+            bufferStream.SetLength(0);
+        }
+        bufferStream.Position = 0;
+
+        SerializationSizeInfo sizeInfo;
+        try
+        {
+            var serializeResult = _types.SerializeToStream(
+                _projectorName,
+                _domain,
+                safeThreshold.Value,
+                payload,
+                bufferStream);
+            if (!serializeResult.IsSuccess)
+            {
+                return ResultBox.Error<SerializableMultiProjectionStateEnvelope>(serializeResult.GetException());
+            }
+
+            sizeInfo = serializeResult.GetValue();
+        }
+        catch (Exception ex)
+        {
+            return ResultBox.Error<SerializableMultiProjectionStateEnvelope>(ex);
+        }
+
+        await bufferStream.FlushAsync(cancellationToken).ConfigureAwait(false);
+        var compressedLength = bufferStream.Length;
+        // Reconcile compressed size reported by the serializer with the actual stream length
+        // (SerializeToStream may return originalSize when the destination is not seekable).
+        var originalSize = sizeInfo.OriginalSizeBytes;
+        var compressedSize = Math.Max(sizeInfo.CompressedSizeBytes, compressedLength);
+
+        _logger.LogDebug(
+            "[{ProjectorName}] StreamFirstSerialize: location={Location} original={OriginalBytes} compressed={CompressedBytes}",
+            _projectorName,
+            buffer.Location,
+            originalSize,
+            compressedSize);
+
+        var shouldOffload = blobAccessor is not null
+            && offloadThresholdBytes > 0
+            && compressedLength > offloadThresholdBytes;
+
+        if (shouldOffload)
+        {
+            bufferStream.Position = 0;
+            var offloadKey = await blobAccessor!
+                .WriteAsync(bufferStream, _projectorName, cancellationToken)
+                .ConfigureAwait(false);
+
+            var offloadedState = new SerializableMultiProjectionStateOffloaded(
+                OffloadKey: offloadKey,
+                StorageProvider: blobAccessor.ProviderName,
+                MultiProjectionPayloadType: payloadTypeName,
+                ProjectorName: _projectorName,
+                ProjectorVersion: projectorVersion,
+                LastSortableUniqueId: multiProjectionState.LastSortableUniqueId,
+                LastEventId: multiProjectionState.LastEventId,
+                Version: multiProjectionState.Version,
+                IsCatchedUp: _isCatchedUp,
+                IsSafeState: multiProjectionState.IsSafeState,
+                PayloadLength: compressedLength,
+                OriginalSizeBytes: originalSize,
+                CompressedSizeBytes: compressedSize);
+
+            return ResultBox.FromValue(new SerializableMultiProjectionStateEnvelope(
+                IsOffloaded: true,
+                InlineState: null,
+                OffloadedState: offloadedState));
+        }
+
+        // Inline path: rewind and rematerialize the (sub-threshold) payload bytes for the
+        // Base64 field in the envelope. Since inline payloads are below the offload threshold
+        // by construction, this does not cause the large-memory spike the stream-first path
+        // is designed to avoid.
+        bufferStream.Position = 0;
+        var payloadBytes = new byte[compressedLength];
+        var offset = 0;
+        while (offset < payloadBytes.Length)
+        {
+            var read = await bufferStream
+                .ReadAsync(payloadBytes.AsMemory(offset, payloadBytes.Length - offset), cancellationToken)
+                .ConfigureAwait(false);
+            if (read == 0)
+            {
+                break;
+            }
+            offset += read;
+        }
+
+        var inlineState = SerializableMultiProjectionState.FromBytes(
+            payloadBytes,
+            payloadTypeName,
+            _projectorName,
+            projectorVersion,
+            multiProjectionState.LastSortableUniqueId,
+            multiProjectionState.LastEventId,
+            multiProjectionState.Version,
+            _isCatchedUp,
+            multiProjectionState.IsSafeState,
+            originalSize,
+            compressedSize);
+
+        return ResultBox.FromValue(new SerializableMultiProjectionStateEnvelope(
+            IsOffloaded: false,
+            InlineState: inlineState,
+            OffloadedState: null));
+    }
+
+    /// <summary>
     ///     Returns a snapshot envelope containing an inline payload.
     /// </summary>
     public Task<ResultBox<SerializableMultiProjectionStateEnvelope>> GetSnapshotAsync(

--- a/dcb/src/Sekiban.Dcb.Core/Domains/SimpleMultiProjectorTypes.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Domains/SimpleMultiProjectorTypes.cs
@@ -276,9 +276,8 @@ internal class SimpleMultiProjectorTypes : ICoreMultiProjectorTypes
     ///     Stream-oriented fallback. For the default JSON+Gzip serializer, the compressed
     ///     bytes are piped straight into the destination stream, so a large multi-projection
     ///     snapshot never needs the full compressed payload in managed memory. Custom
-    ///     serializers still fall back to the base implementation (materializing via
-    ///     <see cref="Serialize" />), which is acceptable because they typically emit
-    ///     compact binary forms already.
+    ///     serializers still fall back to materialized bytes — copied through the destination
+    ///     stream — because they typically emit compact binary forms already.
     /// </summary>
     public ResultBox<SerializationSizeInfo> SerializeToStream(
         string projectorName,
@@ -287,58 +286,24 @@ internal class SimpleMultiProjectorTypes : ICoreMultiProjectorTypes
         IMultiProjectionPayload payload,
         Stream destination)
     {
-        try
+        var validationError = MultiProjectorStreamSerializationHelper.ValidateCommonArguments(
+            safeWindowThreshold,
+            destination);
+        if (validationError is { } error)
         {
-            if (string.IsNullOrWhiteSpace(safeWindowThreshold))
-            {
-                return ResultBox.Error<SerializationSizeInfo>(
-                    new ArgumentException("safeWindowThreshold must be supplied"));
-            }
-            if (destination is null)
-            {
-                return ResultBox.Error<SerializationSizeInfo>(new ArgumentNullException(nameof(destination)));
-            }
-
-            if (_customSerializers.TryGetValue(projectorName, out var serializers))
-            {
-                // Custom serializers still return materialized bytes — copy them through.
-                var serializeResult = serializers.serialize(domainTypes, safeWindowThreshold, payload);
-                if (serializeResult.Data is { Length: > 0 })
-                {
-                    destination.Write(serializeResult.Data, 0, serializeResult.Data.Length);
-                }
-                return ResultBox.FromValue(new SerializationSizeInfo(
-                    serializeResult.OriginalSizeBytes,
-                    serializeResult.CompressedSizeBytes));
-            }
-
-            // Measure the post-gzip byte count by wrapping destination in a counting stream.
-            var initialPosition = destination.CanSeek ? destination.Position : 0L;
-            var initialLength = destination.CanSeek ? destination.Length : 0L;
-
-            var originalSize = GzipCompression.CompressJsonToStream(
-                destination,
-                payload,
-                payload.GetType(),
-                domainTypes.JsonSerializerOptions);
-
-            long compressedSize;
-            if (destination.CanSeek)
-            {
-                compressedSize = Math.Max(0, destination.Position - initialPosition);
-            }
-            else
-            {
-                compressedSize = originalSize; // Cannot measure post-gzip length on non-seekable destination
-            }
-
-            _ = initialLength; // reserved to keep API stable with counting destinations
-            return ResultBox.FromValue(new SerializationSizeInfo(originalSize, compressedSize));
+            return error;
         }
-        catch (Exception ex)
+
+        if (_customSerializers.TryGetValue(projectorName, out var serializers))
         {
-            return ResultBox.Error<SerializationSizeInfo>(ex);
+            var customResult = serializers.serialize(domainTypes, safeWindowThreshold, payload);
+            return MultiProjectorStreamSerializationHelper.CopyCustomResultToStream(destination, customResult);
         }
+
+        return MultiProjectorStreamSerializationHelper.WriteGzipJsonToStream(
+            destination,
+            payload,
+            domainTypes.JsonSerializerOptions);
     }
 
     /// <summary>

--- a/dcb/src/Sekiban.Dcb.Core/Domains/SimpleMultiProjectorTypes.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Domains/SimpleMultiProjectorTypes.cs
@@ -273,6 +273,75 @@ internal class SimpleMultiProjectorTypes : ICoreMultiProjectorTypes
     }
 
     /// <summary>
+    ///     Stream-oriented fallback. For the default JSON+Gzip serializer, the compressed
+    ///     bytes are piped straight into the destination stream, so a large multi-projection
+    ///     snapshot never needs the full compressed payload in managed memory. Custom
+    ///     serializers still fall back to the base implementation (materializing via
+    ///     <see cref="Serialize" />), which is acceptable because they typically emit
+    ///     compact binary forms already.
+    /// </summary>
+    public ResultBox<SerializationSizeInfo> SerializeToStream(
+        string projectorName,
+        DcbDomainTypes domainTypes,
+        string safeWindowThreshold,
+        IMultiProjectionPayload payload,
+        Stream destination)
+    {
+        try
+        {
+            if (string.IsNullOrWhiteSpace(safeWindowThreshold))
+            {
+                return ResultBox.Error<SerializationSizeInfo>(
+                    new ArgumentException("safeWindowThreshold must be supplied"));
+            }
+            if (destination is null)
+            {
+                return ResultBox.Error<SerializationSizeInfo>(new ArgumentNullException(nameof(destination)));
+            }
+
+            if (_customSerializers.TryGetValue(projectorName, out var serializers))
+            {
+                // Custom serializers still return materialized bytes — copy them through.
+                var serializeResult = serializers.serialize(domainTypes, safeWindowThreshold, payload);
+                if (serializeResult.Data is { Length: > 0 })
+                {
+                    destination.Write(serializeResult.Data, 0, serializeResult.Data.Length);
+                }
+                return ResultBox.FromValue(new SerializationSizeInfo(
+                    serializeResult.OriginalSizeBytes,
+                    serializeResult.CompressedSizeBytes));
+            }
+
+            // Measure the post-gzip byte count by wrapping destination in a counting stream.
+            var initialPosition = destination.CanSeek ? destination.Position : 0L;
+            var initialLength = destination.CanSeek ? destination.Length : 0L;
+
+            var originalSize = GzipCompression.CompressJsonToStream(
+                destination,
+                payload,
+                payload.GetType(),
+                domainTypes.JsonSerializerOptions);
+
+            long compressedSize;
+            if (destination.CanSeek)
+            {
+                compressedSize = Math.Max(0, destination.Position - initialPosition);
+            }
+            else
+            {
+                compressedSize = originalSize; // Cannot measure post-gzip length on non-seekable destination
+            }
+
+            _ = initialLength; // reserved to keep API stable with counting destinations
+            return ResultBox.FromValue(new SerializationSizeInfo(originalSize, compressedSize));
+        }
+        catch (Exception ex)
+        {
+            return ResultBox.Error<SerializationSizeInfo>(ex);
+        }
+    }
+
+    /// <summary>
     ///     Deserializes a JSON string to a multi-projection payload.
     ///     Uses custom deserialization if registered, otherwise falls back to standard JSON deserialization.
     /// </summary>

--- a/dcb/src/Sekiban.Dcb.Core/Snapshots/ISnapshotPayloadBufferProvider.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Snapshots/ISnapshotPayloadBufferProvider.cs
@@ -1,0 +1,41 @@
+namespace Sekiban.Dcb.Snapshots;
+
+/// <summary>
+///     Provides a writable, seekable stream used by the stream-first multi-projection
+///     snapshot persistence path to buffer the serialized payload before the
+///     inline/offload decision is made.
+///     Implementations must return a stream that supports <see cref="Stream.Length" /> and
+///     <see cref="Stream.Position" /> after write completion, so the caller can either
+///     rewind and upload the payload to blob storage or rewind and materialize it for
+///     inline envelope JSON emission.
+/// </summary>
+public interface ISnapshotPayloadBufferProvider
+{
+    /// <summary>
+    ///     Create a new empty buffer that will receive the serialized snapshot payload.
+    ///     The returned buffer must be disposed by the caller once it is no longer needed.
+    /// </summary>
+    /// <param name="projectorName">Logical projector name (used for diagnostics / naming).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<ISnapshotPayloadBuffer> CreateBufferAsync(string projectorName, CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+///     A transient buffer used by the stream-first snapshot persistence path.
+///     The underlying <see cref="Stream" /> must be seekable and writable; reading and
+///     rewinding is done by the consumer after the serialized payload has been written.
+///     Disposing the buffer is expected to clean up any backing resources (e.g. temp file).
+/// </summary>
+public interface ISnapshotPayloadBuffer : IAsyncDisposable, IDisposable
+{
+    /// <summary>
+    ///     The writable/seekable stream receiving the serialized snapshot payload.
+    /// </summary>
+    Stream Stream { get; }
+
+    /// <summary>
+    ///     A short, human-readable description of where the buffer is stored (e.g. "memory", "tempfile:/tmp/...").
+    ///     Intended for diagnostics and tests; not used for routing decisions.
+    /// </summary>
+    string Location { get; }
+}

--- a/dcb/src/Sekiban.Dcb.Core/Snapshots/ISnapshotPayloadBufferProvider.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Snapshots/ISnapshotPayloadBufferProvider.cs
@@ -1,13 +1,16 @@
 namespace Sekiban.Dcb.Snapshots;
 
 /// <summary>
-///     Provides a writable, seekable stream used by the stream-first multi-projection
-///     snapshot persistence path to buffer the serialized payload before the
-///     inline/offload decision is made.
+///     Provides a readable, writable, seekable stream used by the stream-first
+///     multi-projection snapshot persistence path to buffer the serialized payload
+///     before the inline/offload decision is made.
 ///     Implementations must return a stream that supports <see cref="Stream.Length" /> and
 ///     <see cref="Stream.Position" /> after write completion, so the caller can either
 ///     rewind and upload the payload to blob storage or rewind and materialize it for
-///     inline envelope JSON emission.
+///     inline envelope JSON emission. Because both of those follow-up operations need to
+///     re-read the serialized payload, the underlying stream MUST report
+///     <see cref="Stream.CanRead" /> == true in addition to <see cref="Stream.CanWrite" />
+///     and <see cref="Stream.CanSeek" />.
 /// </summary>
 public interface ISnapshotPayloadBufferProvider
 {
@@ -22,14 +25,16 @@ public interface ISnapshotPayloadBufferProvider
 
 /// <summary>
 ///     A transient buffer used by the stream-first snapshot persistence path.
-///     The underlying <see cref="Stream" /> must be seekable and writable; reading and
-///     rewinding is done by the consumer after the serialized payload has been written.
+///     The underlying <see cref="Stream" /> must be readable, writable, and seekable:
+///     the consumer writes the serialized payload, rewinds the stream, and then either
+///     reads it back for inline envelope emission or uploads it to blob storage for an
+///     offloaded envelope.
 ///     Disposing the buffer is expected to clean up any backing resources (e.g. temp file).
 /// </summary>
 public interface ISnapshotPayloadBuffer : IAsyncDisposable, IDisposable
 {
     /// <summary>
-    ///     The writable/seekable stream receiving the serialized snapshot payload.
+    ///     The readable/writable/seekable stream receiving the serialized snapshot payload.
     /// </summary>
     Stream Stream { get; }
 

--- a/dcb/src/Sekiban.Dcb.Core/Snapshots/SpillableSnapshotPayloadBufferProvider.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Snapshots/SpillableSnapshotPayloadBufferProvider.cs
@@ -1,0 +1,106 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Sekiban.Dcb.Snapshots;
+
+/// <summary>
+///     Default <see cref="ISnapshotPayloadBufferProvider" /> used by the stream-first
+///     multi-projection snapshot persistence path.
+///     Returns a buffer backed by a <see cref="SpillableSnapshotPayloadStream" />, which
+///     holds the serialized payload in a small in-memory buffer and transparently spills to
+///     a temp file once the configured threshold is exceeded. This guarantees that a very
+///     large snapshot payload never has to materialize as a contiguous managed
+///     <see cref="byte" />[] on the persistence hot path.
+/// </summary>
+public sealed class SpillableSnapshotPayloadBufferProvider : ISnapshotPayloadBufferProvider
+{
+    private readonly SpillableSnapshotPayloadOptions _options;
+    private readonly ILogger<SpillableSnapshotPayloadBufferProvider> _logger;
+
+    public SpillableSnapshotPayloadBufferProvider(
+        SpillableSnapshotPayloadOptions? options = null,
+        ILogger<SpillableSnapshotPayloadBufferProvider>? logger = null)
+    {
+        _options = options ?? new SpillableSnapshotPayloadOptions();
+        _logger = logger ?? NullLogger<SpillableSnapshotPayloadBufferProvider>.Instance;
+    }
+
+    public Task<ISnapshotPayloadBuffer> CreateBufferAsync(
+        string projectorName,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var directory = string.IsNullOrWhiteSpace(_options.TempDirectory)
+            ? Path.Combine(Path.GetTempPath(), "sekiban-snapshot-payload")
+            : _options.TempDirectory;
+
+        var stream = new SpillableSnapshotPayloadStream(
+            _options.InMemoryThresholdBytes,
+            directory,
+            projectorName);
+
+        _logger.LogTrace(
+            "Created spillable snapshot payload buffer for {Projector} (threshold={ThresholdBytes} bytes, tempDir={Dir})",
+            projectorName,
+            _options.InMemoryThresholdBytes,
+            directory);
+
+        return Task.FromResult<ISnapshotPayloadBuffer>(new SpillableSnapshotPayloadBuffer(stream));
+    }
+
+    private sealed class SpillableSnapshotPayloadBuffer : ISnapshotPayloadBuffer
+    {
+        private readonly SpillableSnapshotPayloadStream _stream;
+        private bool _disposed;
+
+        public SpillableSnapshotPayloadBuffer(SpillableSnapshotPayloadStream stream)
+        {
+            _stream = stream;
+        }
+
+        public Stream Stream => _stream;
+
+        public string Location =>
+            _stream.IsSpilled
+                ? $"tempfile:{_stream.TempFilePath}"
+                : "memory";
+
+        public void Dispose()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+            _disposed = true;
+            _stream.Dispose();
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            Dispose();
+            return ValueTask.CompletedTask;
+        }
+    }
+}
+
+/// <summary>
+///     Options controlling the spillable snapshot payload buffer.
+/// </summary>
+public sealed class SpillableSnapshotPayloadOptions
+{
+    /// <summary>
+    ///     Size in bytes of the in-memory buffer used for small snapshot payloads. Once a
+    ///     write would push the total buffered size past this threshold, the buffer is
+    ///     flushed to a temp file and all subsequent writes go directly to disk.
+    ///     Default: 256 KB, which is large enough to keep small projections in memory while
+    ///     preventing large projections from holding tens of megabytes of managed byte[].
+    /// </summary>
+    public int InMemoryThresholdBytes { get; set; } = 256 * 1024;
+
+    /// <summary>
+    ///     Directory used for the temp spill file. Defaults to a Sekiban-specific subdirectory
+    ///     under <see cref="Path.GetTempPath" /> when left unset.
+    /// </summary>
+    public string? TempDirectory { get; set; }
+}

--- a/dcb/src/Sekiban.Dcb.Core/Snapshots/SpillableSnapshotPayloadStream.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Snapshots/SpillableSnapshotPayloadStream.cs
@@ -140,7 +140,7 @@ internal sealed class SpillableSnapshotPayloadStream : Stream
             return;
         }
 
-        EnsureBacking(_length + count);
+        EnsureBacking(Math.Max(_length, _position + count));
 
         if (_file is not null)
         {
@@ -167,7 +167,7 @@ internal sealed class SpillableSnapshotPayloadStream : Stream
             return;
         }
 
-        EnsureBacking(_length + buffer.Length);
+        EnsureBacking(Math.Max(_length, _position + buffer.Length));
 
         if (_file is not null)
         {
@@ -197,7 +197,7 @@ internal sealed class SpillableSnapshotPayloadStream : Stream
             return;
         }
 
-        EnsureBacking(_length + buffer.Length);
+        EnsureBacking(Math.Max(_length, _position + buffer.Length));
 
         if (_file is not null)
         {
@@ -219,7 +219,7 @@ internal sealed class SpillableSnapshotPayloadStream : Stream
 
     public override void WriteByte(byte value)
     {
-        EnsureBacking(_length + 1);
+        EnsureBacking(Math.Max(_length, _position + 1));
         if (_file is not null)
         {
             _file.Position = _position;

--- a/dcb/src/Sekiban.Dcb.Core/Snapshots/SpillableSnapshotPayloadStream.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Snapshots/SpillableSnapshotPayloadStream.cs
@@ -1,0 +1,376 @@
+using System.Buffers;
+
+namespace Sekiban.Dcb.Snapshots;
+
+/// <summary>
+///     A seekable, writable stream that starts buffered in a small <see cref="MemoryStream" /> and
+///     transparently spills over to a temp file once the in-memory buffer exceeds a configurable
+///     threshold. Used by the stream-first multi-projection snapshot persistence path so that a
+///     very large serialized payload never needs to live as a contiguous managed
+///     <see cref="byte" />[] on the hot path.
+///     The stream mirrors each write into whichever backing store is active, switching backing
+///     stores exactly once (memory -> disk). Dispose guarantees the temp file is deleted.
+/// </summary>
+internal sealed class SpillableSnapshotPayloadStream : Stream
+{
+    private const int CopyChunkSize = 81920;
+
+    private readonly int _spillThresholdBytes;
+    private readonly string _tempFileDirectory;
+    private readonly string _projectorName;
+
+    private MemoryStream? _memory;
+    private FileStream? _file;
+    private string? _filePath;
+    private long _length;
+    private long _position;
+    private bool _disposed;
+
+    /// <summary>
+    ///     Creates a new spillable stream.
+    /// </summary>
+    /// <param name="spillThresholdBytes">
+    ///     Once the buffered byte count exceeds this threshold, the buffer is flushed to a
+    ///     temp file and all subsequent writes go directly to the file. Must be &gt;= 0.
+    ///     A value of 0 effectively forces immediate spill on first write.
+    /// </param>
+    /// <param name="tempFileDirectory">Directory used for the spill file. Created if missing.</param>
+    /// <param name="projectorName">Logical projector name embedded in the temp file name for diagnostics.</param>
+    public SpillableSnapshotPayloadStream(
+        int spillThresholdBytes,
+        string tempFileDirectory,
+        string projectorName)
+    {
+        if (spillThresholdBytes < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(spillThresholdBytes));
+        }
+
+        _spillThresholdBytes = spillThresholdBytes;
+        _tempFileDirectory = tempFileDirectory ?? throw new ArgumentNullException(nameof(tempFileDirectory));
+        _projectorName = string.IsNullOrWhiteSpace(projectorName) ? "unknown" : projectorName;
+
+        _memory = new MemoryStream();
+    }
+
+    /// <summary>
+    ///     True after the backing store has been switched from memory to a temp file.
+    /// </summary>
+    public bool IsSpilled => _file is not null;
+
+    /// <summary>
+    ///     Path of the temp file used for spillover, or <c>null</c> when still in memory.
+    /// </summary>
+    public string? TempFilePath => _filePath;
+
+    public override bool CanRead => true;
+    public override bool CanSeek => true;
+    public override bool CanWrite => true;
+    public override long Length => _length;
+
+    public override long Position
+    {
+        get => _position;
+        set => Seek(value, SeekOrigin.Begin);
+    }
+
+    public override void Flush() => _file?.Flush();
+
+    public override Task FlushAsync(CancellationToken cancellationToken) =>
+        _file is not null ? _file.FlushAsync(cancellationToken) : Task.CompletedTask;
+
+    public override int Read(byte[] buffer, int offset, int count)
+    {
+        if (_file is not null)
+        {
+            _file.Position = _position;
+            var read = _file.Read(buffer, offset, count);
+            _position += read;
+            return read;
+        }
+
+        _memory!.Position = _position;
+        var memRead = _memory.Read(buffer, offset, count);
+        _position += memRead;
+        return memRead;
+    }
+
+    public override long Seek(long offset, SeekOrigin origin)
+    {
+        var newPosition = origin switch
+        {
+            SeekOrigin.Begin => offset,
+            SeekOrigin.Current => _position + offset,
+            SeekOrigin.End => _length + offset,
+            _ => throw new ArgumentOutOfRangeException(nameof(origin))
+        };
+
+        if (newPosition < 0)
+        {
+            throw new IOException("Cannot seek before stream start");
+        }
+
+        _position = newPosition;
+        return _position;
+    }
+
+    public override void SetLength(long value)
+    {
+        EnsureBacking(value);
+        if (_file is not null)
+        {
+            _file.SetLength(value);
+        }
+        else
+        {
+            _memory!.SetLength(value);
+        }
+
+        _length = value;
+        if (_position > value)
+        {
+            _position = value;
+        }
+    }
+
+    public override void Write(byte[] buffer, int offset, int count)
+    {
+        if (count == 0)
+        {
+            return;
+        }
+
+        EnsureBacking(_length + count);
+
+        if (_file is not null)
+        {
+            _file.Position = _position;
+            _file.Write(buffer, offset, count);
+        }
+        else
+        {
+            _memory!.Position = _position;
+            _memory.Write(buffer, offset, count);
+        }
+
+        _position += count;
+        if (_position > _length)
+        {
+            _length = _position;
+        }
+    }
+
+    public override void Write(ReadOnlySpan<byte> buffer)
+    {
+        if (buffer.IsEmpty)
+        {
+            return;
+        }
+
+        EnsureBacking(_length + buffer.Length);
+
+        if (_file is not null)
+        {
+            _file.Position = _position;
+            _file.Write(buffer);
+        }
+        else
+        {
+            _memory!.Position = _position;
+            _memory.Write(buffer);
+        }
+
+        _position += buffer.Length;
+        if (_position > _length)
+        {
+            _length = _position;
+        }
+    }
+
+    public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) =>
+        WriteAsync(buffer.AsMemory(offset, count), cancellationToken).AsTask();
+
+    public override async ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+    {
+        if (buffer.IsEmpty)
+        {
+            return;
+        }
+
+        EnsureBacking(_length + buffer.Length);
+
+        if (_file is not null)
+        {
+            _file.Position = _position;
+            await _file.WriteAsync(buffer, cancellationToken).ConfigureAwait(false);
+        }
+        else
+        {
+            _memory!.Position = _position;
+            await _memory.WriteAsync(buffer, cancellationToken).ConfigureAwait(false);
+        }
+
+        _position += buffer.Length;
+        if (_position > _length)
+        {
+            _length = _position;
+        }
+    }
+
+    public override void WriteByte(byte value)
+    {
+        EnsureBacking(_length + 1);
+        if (_file is not null)
+        {
+            _file.Position = _position;
+            _file.WriteByte(value);
+        }
+        else
+        {
+            _memory!.Position = _position;
+            _memory.WriteByte(value);
+        }
+
+        _position++;
+        if (_position > _length)
+        {
+            _length = _position;
+        }
+    }
+
+    /// <summary>
+    ///     Ensures the backing store can hold the requested total length. If the new total
+    ///     exceeds the spill threshold and we are still in memory, the buffered content is
+    ///     flushed to a temp file and the file takes over as the backing store.
+    /// </summary>
+    private void EnsureBacking(long requiredTotalLength)
+    {
+        if (_file is not null)
+        {
+            return;
+        }
+
+        if (requiredTotalLength <= _spillThresholdBytes)
+        {
+            return;
+        }
+
+        SpillToTempFile();
+    }
+
+    private void SpillToTempFile()
+    {
+        if (_file is not null)
+        {
+            return;
+        }
+
+        Directory.CreateDirectory(_tempFileDirectory);
+        var fileName = BuildTempFileName();
+        var filePath = Path.Combine(_tempFileDirectory, fileName);
+        var file = new FileStream(
+            filePath,
+            FileMode.CreateNew,
+            FileAccess.ReadWrite,
+            FileShare.None,
+            bufferSize: CopyChunkSize,
+            FileOptions.Asynchronous | FileOptions.DeleteOnClose);
+
+        _filePath = filePath;
+        _file = file;
+
+        if (_memory is not null)
+        {
+            if (_memory.TryGetBuffer(out var segment) && segment.Count > 0)
+            {
+                _file.Write(segment.Array!, segment.Offset, segment.Count);
+            }
+            else
+            {
+                _memory.Position = 0;
+                CopyMemoryToFile();
+            }
+
+            _memory.Dispose();
+            _memory = null;
+        }
+    }
+
+    private void CopyMemoryToFile()
+    {
+        // Fallback copy path for memory streams that do not expose TryGetBuffer.
+        var rented = ArrayPool<byte>.Shared.Rent(CopyChunkSize);
+        try
+        {
+            int read;
+            while ((read = _memory!.Read(rented, 0, rented.Length)) > 0)
+            {
+                _file!.Write(rented, 0, read);
+            }
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(rented);
+        }
+    }
+
+    private string BuildTempFileName()
+    {
+        var safe = new System.Text.StringBuilder(_projectorName.Length);
+        foreach (var ch in _projectorName)
+        {
+            safe.Append(char.IsLetterOrDigit(ch) || ch == '-' || ch == '_' ? ch : '_');
+        }
+        return $"sekiban-snapshot-spill-{safe}-{Guid.NewGuid():N}.bin";
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        if (disposing)
+        {
+            if (_memory is not null)
+            {
+                _memory.Dispose();
+                _memory = null;
+            }
+            if (_file is not null)
+            {
+                // DeleteOnClose takes care of the temp file itself.
+                try
+                {
+                    _file.Dispose();
+                }
+                catch
+                {
+                    // Best-effort cleanup.
+                }
+                _file = null;
+            }
+            // Defensive cleanup in case DeleteOnClose didn't remove the file
+            // (for example, if the stream was never successfully written to).
+            if (_filePath is not null)
+            {
+                try
+                {
+                    if (File.Exists(_filePath))
+                    {
+                        File.Delete(_filePath);
+                    }
+                }
+                catch
+                {
+                    // Best-effort cleanup.
+                }
+                _filePath = null;
+            }
+        }
+
+        _disposed = true;
+        base.Dispose(disposing);
+    }
+}

--- a/dcb/src/Sekiban.Dcb.Orleans.Core/Runtimes/NativeProjectionActorHost.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.Core/Runtimes/NativeProjectionActorHost.cs
@@ -47,7 +47,8 @@ public class NativeProjectionActorHost : IProjectionActorHost
             jsonOptions,
             _actor,
             serviceProvider.GetService<IBlobStorageSnapshotAccessor>(),
-            resolvedLogger);
+            resolvedLogger,
+            serviceProvider.GetService<ISnapshotPayloadBufferProvider>());
     }
 
     public Task AddSerializableEventsAsync(

--- a/dcb/src/Sekiban.Dcb.Orleans.Core/Runtimes/NativeProjectionSnapshotHandler.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.Core/Runtimes/NativeProjectionSnapshotHandler.cs
@@ -18,17 +18,20 @@ internal class NativeProjectionSnapshotHandler
     private readonly JsonSerializerOptions _jsonOptions;
     private readonly GeneralMultiProjectionActor _actor;
     private readonly IBlobStorageSnapshotAccessor? _blobAccessor;
+    private readonly ISnapshotPayloadBufferProvider? _payloadBufferProvider;
     private readonly ILogger _logger;
 
     public NativeProjectionSnapshotHandler(
         JsonSerializerOptions jsonOptions,
         GeneralMultiProjectionActor actor,
         IBlobStorageSnapshotAccessor? blobAccessor,
-        ILogger logger)
+        ILogger logger,
+        ISnapshotPayloadBufferProvider? payloadBufferProvider = null)
     {
         _jsonOptions = jsonOptions;
         _actor = actor;
         _blobAccessor = blobAccessor;
+        _payloadBufferProvider = payloadBufferProvider;
         _logger = logger;
     }
 
@@ -102,11 +105,21 @@ internal class NativeProjectionSnapshotHandler
                 }
             }
 
-            var snapshotResult = await _actor.BuildSnapshotEnvelopeAsync(
-                canGetUnsafeState,
-                _blobAccessor,
-                offloadThresholdBytes,
-                cancellationToken);
+            // Prefer the stream-first persistence path when a spillable buffer is available.
+            // It keeps the serialized payload off the managed heap for large snapshots and
+            // streams directly to blob storage when the payload crosses the offload threshold.
+            var snapshotResult = _payloadBufferProvider is not null
+                ? await _actor.BuildSnapshotEnvelopeStreamFirstAsync(
+                    _payloadBufferProvider,
+                    canGetUnsafeState,
+                    _blobAccessor,
+                    offloadThresholdBytes,
+                    cancellationToken)
+                : await _actor.BuildSnapshotEnvelopeAsync(
+                    canGetUnsafeState,
+                    _blobAccessor,
+                    offloadThresholdBytes,
+                    cancellationToken);
             if (!snapshotResult.IsSuccess)
             {
                 return ResultBox.Error<bool>(snapshotResult.GetException());

--- a/dcb/src/Sekiban.Dcb.Orleans.Core/Runtimes/NativeProjectionSnapshotHandler.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.Core/Runtimes/NativeProjectionSnapshotHandler.cs
@@ -105,10 +105,17 @@ internal class NativeProjectionSnapshotHandler
                 }
             }
 
-            // Prefer the stream-first persistence path when a spillable buffer is available.
-            // It keeps the serialized payload off the managed heap for large snapshots and
-            // streams directly to blob storage when the payload crosses the offload threshold.
-            var snapshotResult = _payloadBufferProvider is not null
+            // Prefer the stream-first persistence path only when offload is actually possible:
+            // both a blob accessor and a positive offload threshold must be configured, and a
+            // spillable payload buffer provider must be registered. For inline-only
+            // configurations (no blob accessor) the legacy byte[] path is still the fastest
+            // because it avoids the buffer allocation + rehydrate copy that stream-first does
+            // for sub-threshold payloads.
+            var canStreamFirst = _payloadBufferProvider is not null
+                && _blobAccessor is not null
+                && offloadThresholdBytes > 0;
+
+            var snapshotResult = canStreamFirst
                 ? await _actor.BuildSnapshotEnvelopeStreamFirstAsync(
                     _payloadBufferProvider,
                     canGetUnsafeState,

--- a/dcb/src/Sekiban.Dcb.Orleans.Core/SekibanDcbNativeRuntimeExtensions.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.Core/SekibanDcbNativeRuntimeExtensions.cs
@@ -31,6 +31,12 @@ public static class SekibanDcbNativeRuntimeExtensions
         services.TryAddSingleton<SnapshotTempFileOptions>();
         services.TryAddSingleton<TempFileSnapshotManager>();
 
+        // Stream-first snapshot persistence: the spillable payload buffer keeps the
+        // serialized multi-projection payload off the managed heap once it exceeds the
+        // in-memory threshold, removing the large transient byte[] spike during persist.
+        services.TryAddSingleton<SpillableSnapshotPayloadOptions>();
+        services.TryAddSingleton<ISnapshotPayloadBufferProvider, SpillableSnapshotPayloadBufferProvider>();
+
         return services;
     }
 }

--- a/dcb/src/Sekiban.Dcb.WithResult/Domains/SimpleMultiProjectorTypes.cs
+++ b/dcb/src/Sekiban.Dcb.WithResult/Domains/SimpleMultiProjectorTypes.cs
@@ -276,7 +276,8 @@ public class SimpleMultiProjectorTypes : IMultiProjectorTypes
     ///     Stream-oriented fallback. For the default JSON+Gzip serializer, the compressed
     ///     bytes are piped straight into the destination stream, so a large multi-projection
     ///     snapshot never needs the full compressed payload in managed memory. Custom
-    ///     serializers still fall back to materializing via <see cref="Serialize" />.
+    ///     serializers still fall back to materialized bytes — copied through the destination
+    ///     stream — because they typically emit compact binary forms already.
     /// </summary>
     public ResultBox<SerializationSizeInfo> SerializeToStream(
         string projectorName,
@@ -285,46 +286,24 @@ public class SimpleMultiProjectorTypes : IMultiProjectorTypes
         IMultiProjectionPayload payload,
         Stream destination)
     {
-        try
+        var validationError = MultiProjectorStreamSerializationHelper.ValidateCommonArguments(
+            safeWindowThreshold,
+            destination);
+        if (validationError is { } error)
         {
-            if (string.IsNullOrWhiteSpace(safeWindowThreshold))
-            {
-                return ResultBox.Error<SerializationSizeInfo>(
-                    new ArgumentException("safeWindowThreshold must be supplied"));
-            }
-            if (destination is null)
-            {
-                return ResultBox.Error<SerializationSizeInfo>(new ArgumentNullException(nameof(destination)));
-            }
-
-            if (_customSerializers.TryGetValue(projectorName, out var serializers))
-            {
-                var serializeResult = serializers.serialize(domainTypes, safeWindowThreshold, payload);
-                if (serializeResult.Data is { Length: > 0 })
-                {
-                    destination.Write(serializeResult.Data, 0, serializeResult.Data.Length);
-                }
-                return ResultBox.FromValue(new SerializationSizeInfo(
-                    serializeResult.OriginalSizeBytes,
-                    serializeResult.CompressedSizeBytes));
-            }
-
-            var startPosition = destination.CanSeek ? destination.Position : 0L;
-            var originalSize = GzipCompression.CompressJsonToStream(
-                destination,
-                payload,
-                payload.GetType(),
-                domainTypes.JsonSerializerOptions);
-            var compressedSize = destination.CanSeek
-                ? Math.Max(0, destination.Position - startPosition)
-                : originalSize;
-
-            return ResultBox.FromValue(new SerializationSizeInfo(originalSize, compressedSize));
+            return error;
         }
-        catch (Exception ex)
+
+        if (_customSerializers.TryGetValue(projectorName, out var serializers))
         {
-            return ResultBox.Error<SerializationSizeInfo>(ex);
+            var customResult = serializers.serialize(domainTypes, safeWindowThreshold, payload);
+            return MultiProjectorStreamSerializationHelper.CopyCustomResultToStream(destination, customResult);
         }
+
+        return MultiProjectorStreamSerializationHelper.WriteGzipJsonToStream(
+            destination,
+            payload,
+            domainTypes.JsonSerializerOptions);
     }
 
     /// <summary>

--- a/dcb/src/Sekiban.Dcb.WithResult/Domains/SimpleMultiProjectorTypes.cs
+++ b/dcb/src/Sekiban.Dcb.WithResult/Domains/SimpleMultiProjectorTypes.cs
@@ -254,11 +254,11 @@ public class SimpleMultiProjectorTypes : IMultiProjectorTypes
                 return ResultBox.FromValue(serializers.serialize(domainTypes, safeWindowThreshold, payload));
             }
 
-            // Fallback: JSON serialize + Gzip compression
-            var json = JsonSerializer.Serialize(payload, payload.GetType(), domainTypes.JsonSerializerOptions);
-            var rawBytes = Encoding.UTF8.GetBytes(json);
-            var originalSize = rawBytes.LongLength;
-            var compressed = GzipCompression.Compress(rawBytes);
+            // Fallback: stream JSON directly into GZip to avoid holding json string + raw bytes + gzip bytes at once.
+            var (compressed, originalSize) = GzipCompression.CompressJson(
+                payload,
+                payload.GetType(),
+                domainTypes.JsonSerializerOptions);
             var compressedSize = compressed.LongLength;
 
             return ResultBox.FromValue(new SerializationResult(
@@ -269,6 +269,61 @@ public class SimpleMultiProjectorTypes : IMultiProjectorTypes
         catch (Exception ex)
         {
             return ResultBox.Error<SerializationResult>(ex);
+        }
+    }
+
+    /// <summary>
+    ///     Stream-oriented fallback. For the default JSON+Gzip serializer, the compressed
+    ///     bytes are piped straight into the destination stream, so a large multi-projection
+    ///     snapshot never needs the full compressed payload in managed memory. Custom
+    ///     serializers still fall back to materializing via <see cref="Serialize" />.
+    /// </summary>
+    public ResultBox<SerializationSizeInfo> SerializeToStream(
+        string projectorName,
+        DcbDomainTypes domainTypes,
+        string safeWindowThreshold,
+        IMultiProjectionPayload payload,
+        Stream destination)
+    {
+        try
+        {
+            if (string.IsNullOrWhiteSpace(safeWindowThreshold))
+            {
+                return ResultBox.Error<SerializationSizeInfo>(
+                    new ArgumentException("safeWindowThreshold must be supplied"));
+            }
+            if (destination is null)
+            {
+                return ResultBox.Error<SerializationSizeInfo>(new ArgumentNullException(nameof(destination)));
+            }
+
+            if (_customSerializers.TryGetValue(projectorName, out var serializers))
+            {
+                var serializeResult = serializers.serialize(domainTypes, safeWindowThreshold, payload);
+                if (serializeResult.Data is { Length: > 0 })
+                {
+                    destination.Write(serializeResult.Data, 0, serializeResult.Data.Length);
+                }
+                return ResultBox.FromValue(new SerializationSizeInfo(
+                    serializeResult.OriginalSizeBytes,
+                    serializeResult.CompressedSizeBytes));
+            }
+
+            var startPosition = destination.CanSeek ? destination.Position : 0L;
+            var originalSize = GzipCompression.CompressJsonToStream(
+                destination,
+                payload,
+                payload.GetType(),
+                domainTypes.JsonSerializerOptions);
+            var compressedSize = destination.CanSeek
+                ? Math.Max(0, destination.Position - startPosition)
+                : originalSize;
+
+            return ResultBox.FromValue(new SerializationSizeInfo(originalSize, compressedSize));
+        }
+        catch (Exception ex)
+        {
+            return ResultBox.Error<SerializationSizeInfo>(ex);
         }
     }
 

--- a/dcb/src/Sekiban.Dcb.WithoutResult.Model/Domains/AotWithoutResultMultiProjectorTypes.cs
+++ b/dcb/src/Sekiban.Dcb.WithoutResult.Model/Domains/AotWithoutResultMultiProjectorTypes.cs
@@ -1,3 +1,4 @@
+using System.IO;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization.Metadata;
@@ -24,6 +25,7 @@ public sealed class AotWithoutResultMultiProjectorTypes : ICoreMultiProjectorTyp
         Func<IMultiProjectionPayload> GenerateInitial,
         string Version,
         Func<DcbDomainTypes, string, IMultiProjectionPayload, SerializationResult> Serialize,
+        Func<Stream, DcbDomainTypes, string, IMultiProjectionPayload, SerializationSizeInfo> SerializeToStream,
         Func<DcbDomainTypes, string, byte[], IMultiProjectionPayload> Deserialize);
 
     public void RegisterProjector<TProjector>(JsonTypeInfo<TProjector> typeInfo)
@@ -48,6 +50,16 @@ public sealed class AotWithoutResultMultiProjectorTypes : ICoreMultiProjectorTyp
                 var typed = (TProjector)payload;
                 var (compressed, uncompressedLength) = GzipCompression.CompressJson(typed, typeInfo);
                 return new SerializationResult(compressed, uncompressedLength, compressed.LongLength);
+            },
+            SerializeToStream: (destination, _, _, payload) =>
+            {
+                var typed = (TProjector)payload;
+                var startPosition = destination.CanSeek ? destination.Position : 0L;
+                var originalSize = GzipCompression.CompressJsonToStream(destination, typed, typeInfo);
+                var compressedSize = destination.CanSeek
+                    ? Math.Max(0, destination.Position - startPosition)
+                    : originalSize;
+                return new SerializationSizeInfo(originalSize, compressedSize);
             },
             Deserialize: (_, _, data) =>
             {
@@ -178,6 +190,34 @@ public sealed class AotWithoutResultMultiProjectorTypes : ICoreMultiProjectorTyp
         }
 
         return ResultBox.Error<SerializationResult>(new Exception($"Projector not found: {projectorName}"));
+    }
+
+    public ResultBox<SerializationSizeInfo> SerializeToStream(
+        string projectorName,
+        DcbDomainTypes domainTypes,
+        string safeWindowThreshold,
+        IMultiProjectionPayload payload,
+        Stream destination)
+    {
+        if (destination is null)
+        {
+            return ResultBox.Error<SerializationSizeInfo>(new ArgumentNullException(nameof(destination)));
+        }
+
+        if (_projectors.TryGetValue(projectorName, out ProjectorRegistration? reg))
+        {
+            try
+            {
+                return ResultBox.FromValue(
+                    reg.SerializeToStream(destination, domainTypes, safeWindowThreshold, payload));
+            }
+            catch (Exception ex)
+            {
+                return ResultBox.Error<SerializationSizeInfo>(ex);
+            }
+        }
+
+        return ResultBox.Error<SerializationSizeInfo>(new Exception($"Projector not found: {projectorName}"));
     }
 
     public ResultBox<bool> RegisterProjectorWithCustomSerialization<T>()

--- a/dcb/src/Sekiban.Dcb.WithoutResult.Model/Domains/AotWithoutResultMultiProjectorTypes.cs
+++ b/dcb/src/Sekiban.Dcb.WithoutResult.Model/Domains/AotWithoutResultMultiProjectorTypes.cs
@@ -54,12 +54,15 @@ public sealed class AotWithoutResultMultiProjectorTypes : ICoreMultiProjectorTyp
             SerializeToStream: (destination, _, _, payload) =>
             {
                 var typed = (TProjector)payload;
-                var startPosition = destination.CanSeek ? destination.Position : 0L;
-                var originalSize = GzipCompression.CompressJsonToStream(destination, typed, typeInfo);
-                var compressedSize = destination.CanSeek
-                    ? Math.Max(0, destination.Position - startPosition)
-                    : originalSize;
-                return new SerializationSizeInfo(originalSize, compressedSize);
+                var result = MultiProjectorStreamSerializationHelper.WriteGzipJsonToStream(
+                    destination,
+                    typed,
+                    typeInfo);
+                if (!result.IsSuccess)
+                {
+                    throw result.GetException();
+                }
+                return result.GetValue();
             },
             Deserialize: (_, _, data) =>
             {

--- a/dcb/src/Sekiban.Dcb.WithoutResult/Domains/SimpleMultiProjectorTypes.cs
+++ b/dcb/src/Sekiban.Dcb.WithoutResult/Domains/SimpleMultiProjectorTypes.cs
@@ -220,7 +220,8 @@ public class SimpleMultiProjectorTypes : IMultiProjectorTypes
     ///     Stream-oriented fallback. For the default JSON+Gzip serializer, the compressed
     ///     bytes are piped straight into the destination stream, so a large multi-projection
     ///     snapshot never needs the full compressed payload in managed memory. Custom
-    ///     serializers still fall back to materializing via <see cref="Serialize" />.
+    ///     serializers still fall back to materialized bytes — copied through the destination
+    ///     stream — because they typically emit compact binary forms already.
     /// </summary>
     public ResultBox<SerializationSizeInfo> SerializeToStream(
         string projectorName,
@@ -229,46 +230,24 @@ public class SimpleMultiProjectorTypes : IMultiProjectorTypes
         IMultiProjectionPayload payload,
         Stream destination)
     {
-        try
+        var validationError = MultiProjectorStreamSerializationHelper.ValidateCommonArguments(
+            safeWindowThreshold,
+            destination);
+        if (validationError is { } error)
         {
-            if (string.IsNullOrWhiteSpace(safeWindowThreshold))
-            {
-                return ResultBox.Error<SerializationSizeInfo>(
-                    new ArgumentException("safeWindowThreshold must be supplied"));
-            }
-            if (destination is null)
-            {
-                return ResultBox.Error<SerializationSizeInfo>(new ArgumentNullException(nameof(destination)));
-            }
-
-            if (_customSerializers.TryGetValue(projectorName, out var serializers))
-            {
-                var serializeResult = serializers.serialize(domainTypes, safeWindowThreshold, payload);
-                if (serializeResult.Data is { Length: > 0 })
-                {
-                    destination.Write(serializeResult.Data, 0, serializeResult.Data.Length);
-                }
-                return ResultBox.FromValue(new SerializationSizeInfo(
-                    serializeResult.OriginalSizeBytes,
-                    serializeResult.CompressedSizeBytes));
-            }
-
-            var startPosition = destination.CanSeek ? destination.Position : 0L;
-            var originalSize = GzipCompression.CompressJsonToStream(
-                destination,
-                payload,
-                payload.GetType(),
-                domainTypes.JsonSerializerOptions);
-            var compressedSize = destination.CanSeek
-                ? Math.Max(0, destination.Position - startPosition)
-                : originalSize;
-
-            return ResultBox.FromValue(new SerializationSizeInfo(originalSize, compressedSize));
+            return error;
         }
-        catch (Exception ex)
+
+        if (_customSerializers.TryGetValue(projectorName, out var serializers))
         {
-            return ResultBox.Error<SerializationSizeInfo>(ex);
+            var customResult = serializers.serialize(domainTypes, safeWindowThreshold, payload);
+            return MultiProjectorStreamSerializationHelper.CopyCustomResultToStream(destination, customResult);
         }
+
+        return MultiProjectorStreamSerializationHelper.WriteGzipJsonToStream(
+            destination,
+            payload,
+            domainTypes.JsonSerializerOptions);
     }
 
     /// <summary>

--- a/dcb/src/Sekiban.Dcb.WithoutResult/Domains/SimpleMultiProjectorTypes.cs
+++ b/dcb/src/Sekiban.Dcb.WithoutResult/Domains/SimpleMultiProjectorTypes.cs
@@ -198,11 +198,11 @@ public class SimpleMultiProjectorTypes : IMultiProjectorTypes
                 return ResultBox.FromValue(serializers.serialize(domainTypes, safeWindowThreshold, payload));
             }
 
-            // Fallback: JSON serialize + Gzip compression
-            var json = JsonSerializer.Serialize(payload, payload.GetType(), domainTypes.JsonSerializerOptions);
-            var rawBytes = Encoding.UTF8.GetBytes(json);
-            var originalSize = rawBytes.LongLength;
-            var compressed = GzipCompression.Compress(rawBytes);
+            // Fallback: stream JSON directly into GZip to avoid holding json string + raw bytes + gzip bytes at once.
+            var (compressed, originalSize) = GzipCompression.CompressJson(
+                payload,
+                payload.GetType(),
+                domainTypes.JsonSerializerOptions);
             var compressedSize = compressed.LongLength;
 
             return ResultBox.FromValue(new SerializationResult(
@@ -213,6 +213,61 @@ public class SimpleMultiProjectorTypes : IMultiProjectorTypes
         catch (Exception ex)
         {
             return ResultBox.Error<SerializationResult>(ex);
+        }
+    }
+
+    /// <summary>
+    ///     Stream-oriented fallback. For the default JSON+Gzip serializer, the compressed
+    ///     bytes are piped straight into the destination stream, so a large multi-projection
+    ///     snapshot never needs the full compressed payload in managed memory. Custom
+    ///     serializers still fall back to materializing via <see cref="Serialize" />.
+    /// </summary>
+    public ResultBox<SerializationSizeInfo> SerializeToStream(
+        string projectorName,
+        DcbDomainTypes domainTypes,
+        string safeWindowThreshold,
+        IMultiProjectionPayload payload,
+        Stream destination)
+    {
+        try
+        {
+            if (string.IsNullOrWhiteSpace(safeWindowThreshold))
+            {
+                return ResultBox.Error<SerializationSizeInfo>(
+                    new ArgumentException("safeWindowThreshold must be supplied"));
+            }
+            if (destination is null)
+            {
+                return ResultBox.Error<SerializationSizeInfo>(new ArgumentNullException(nameof(destination)));
+            }
+
+            if (_customSerializers.TryGetValue(projectorName, out var serializers))
+            {
+                var serializeResult = serializers.serialize(domainTypes, safeWindowThreshold, payload);
+                if (serializeResult.Data is { Length: > 0 })
+                {
+                    destination.Write(serializeResult.Data, 0, serializeResult.Data.Length);
+                }
+                return ResultBox.FromValue(new SerializationSizeInfo(
+                    serializeResult.OriginalSizeBytes,
+                    serializeResult.CompressedSizeBytes));
+            }
+
+            var startPosition = destination.CanSeek ? destination.Position : 0L;
+            var originalSize = GzipCompression.CompressJsonToStream(
+                destination,
+                payload,
+                payload.GetType(),
+                domainTypes.JsonSerializerOptions);
+            var compressedSize = destination.CanSeek
+                ? Math.Max(0, destination.Position - startPosition)
+                : originalSize;
+
+            return ResultBox.FromValue(new SerializationSizeInfo(originalSize, compressedSize));
+        }
+        catch (Exception ex)
+        {
+            return ResultBox.Error<SerializationSizeInfo>(ex);
         }
     }
 

--- a/dcb/tests/Sekiban.Dcb.Orleans.Tests/NativeProjectionSnapshotPersistenceTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Orleans.Tests/NativeProjectionSnapshotPersistenceTests.cs
@@ -19,6 +19,85 @@ namespace Sekiban.Dcb.Orleans.Tests;
 public class NativeProjectionSnapshotPersistenceTests
 {
     [Fact]
+    public async Task WriteSnapshotForPersistenceToStreamAsync_StreamFirst_Should_Offload_Large_Payload()
+    {
+        // Stream-first persist path: register ISnapshotPayloadBufferProvider so the
+        // NativeProjectionSnapshotHandler picks the spillable buffer path internally.
+        var blobAccessor = new InMemoryBlobStorageSnapshotAccessor();
+        var tempDir = Path.Combine(Path.GetTempPath(), $"sekiban-native-streamfirst-{Guid.NewGuid():N}");
+        var bufferProvider = new SpillableSnapshotPayloadBufferProvider(
+            new SpillableSnapshotPayloadOptions
+            {
+                InMemoryThresholdBytes = 64,
+                TempDirectory = tempDir
+            });
+        var services = new ServiceCollection()
+            .AddSingleton<IBlobStorageSnapshotAccessor>(blobAccessor)
+            .AddSingleton<ISnapshotPayloadBufferProvider>(bufferProvider)
+            .BuildServiceProvider();
+        var domainTypes = BuildDomainTypes();
+        var primitive = new NativeMultiProjectionProjectionPrimitive(domainTypes);
+
+        var host = new NativeProjectionActorHost(
+            domainTypes,
+            services,
+            primitive,
+            LargePayloadProjector.MultiProjectorName,
+            new GeneralMultiProjectionActorOptions { SafeWindowMs = 1000 },
+            NullLogger.Instance);
+
+        try
+        {
+            var events = Enumerable.Range(0, 6)
+                .Select(i => CreateSerializableEvent(new LargePayloadCreated(GenerateRandomString(2048)), DateTime.UtcNow.AddSeconds(-30 + i)))
+                .ToList();
+            await host.AddSerializableEventsAsync(events, finishedCatchUp: true);
+            host.ForcePromoteAllBufferedEvents();
+
+            await using var snapshotStream = new MemoryStream();
+            var writeResult = await host.WriteSnapshotForPersistenceToStreamAsync(
+                snapshotStream,
+                canGetUnsafeState: false,
+                offloadThresholdBytes: 16,
+                CancellationToken.None);
+
+            Assert.True(writeResult.IsSuccess);
+            snapshotStream.Position = 0;
+            var envelope = await JsonSerializer.DeserializeAsync<SerializableMultiProjectionStateEnvelope>(
+                snapshotStream,
+                domainTypes.JsonSerializerOptions);
+            Assert.NotNull(envelope);
+            Assert.True(envelope!.IsOffloaded);
+            Assert.NotNull(envelope.OffloadedState);
+            Assert.True(envelope.OffloadedState!.PayloadLength > 0);
+
+            // Restore via the stream-first path and verify contents are intact.
+            snapshotStream.Position = 0;
+            var restoredHost = new NativeProjectionActorHost(
+                domainTypes,
+                services,
+                primitive,
+                LargePayloadProjector.MultiProjectorName,
+                new GeneralMultiProjectionActorOptions { SafeWindowMs = 1000 },
+                NullLogger.Instance);
+            var restoreResult = await restoredHost.RestoreSnapshotFromStreamAsync(snapshotStream, CancellationToken.None);
+            Assert.True(restoreResult.IsSuccess);
+
+            var stateResult = await restoredHost.GetStateAsync(canGetUnsafeState: true);
+            Assert.True(stateResult.IsSuccess);
+            var payload = Assert.IsType<LargePayloadProjector>(stateResult.GetValue().Payload);
+            Assert.Equal(6, payload.Items.Count);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+            {
+                try { Directory.Delete(tempDir, recursive: true); } catch { }
+            }
+        }
+    }
+
+    [Fact]
     public async Task WriteSnapshotForPersistenceToStreamAsync_Should_Offload_Large_Payload_And_Restore()
     {
         var blobAccessor = new InMemoryBlobStorageSnapshotAccessor();

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/ActorSnapshotOffloadTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/ActorSnapshotOffloadTests.cs
@@ -119,6 +119,142 @@ public class ActorSnapshotOffloadTests
     }
 
     [Fact]
+    public async Task BuildSnapshotEnvelopeStreamFirstAsync_Should_Offload_Large_Payload()
+    {
+        var actor = new GeneralMultiProjectionActor(
+            _domainTypes,
+            BigPayloadProjector.MultiProjectorName,
+            new GeneralMultiProjectionActorOptions { SafeWindowMs = 1000 });
+        var blobAccessor = new InMemoryBlobStorageSnapshotAccessor();
+        var bufferProvider = new SpillableSnapshotPayloadBufferProvider(
+            new SpillableSnapshotPayloadOptions { InMemoryThresholdBytes = 256 });
+
+        foreach (var i in Enumerable.Range(0, 6))
+        {
+            var created = new Created(GenerateRandomString(2048));
+            await actor.AddEventsAsync(new[] { Ev(created) });
+        }
+
+        var envelopeResult = await actor.BuildSnapshotEnvelopeStreamFirstAsync(
+            bufferProvider,
+            canGetUnsafeState: true,
+            blobAccessor: blobAccessor,
+            offloadThresholdBytes: 512);
+
+        Assert.True(envelopeResult.IsSuccess);
+        var envelope = envelopeResult.GetValue();
+        Assert.True(envelope.IsOffloaded);
+        Assert.Null(envelope.InlineState);
+        Assert.NotNull(envelope.OffloadedState);
+        Assert.True(envelope.OffloadedState!.PayloadLength > 0);
+        Assert.True(envelope.OffloadedState.CompressedSizeBytes > 0);
+
+        // Restore the state from the offloaded snapshot and verify it matches the original.
+        var resolved = await SnapshotEnvelopeResolver.ResolveInlineAsync(envelope, blobAccessor);
+        Assert.False(resolved.IsOffloaded);
+        Assert.NotNull(resolved.InlineState);
+
+        var restoredActor = new GeneralMultiProjectionActor(
+            _domainTypes,
+            BigPayloadProjector.MultiProjectorName,
+            new GeneralMultiProjectionActorOptions { SafeWindowMs = 1000 });
+        await restoredActor.SetSnapshotAsync(resolved);
+
+        var stateResult = await restoredActor.GetStateAsync(canGetUnsafeState: true);
+        Assert.True(stateResult.IsSuccess);
+        var restoredPayload = Assert.IsType<BigPayloadProjector>(stateResult.GetValue().Payload);
+        Assert.Equal(6, restoredPayload.Items.Count);
+    }
+
+    [Fact]
+    public async Task BuildSnapshotEnvelopeStreamFirstAsync_Should_Inline_Small_Payload()
+    {
+        var actor = new GeneralMultiProjectionActor(
+            _domainTypes,
+            BigPayloadProjector.MultiProjectorName,
+            new GeneralMultiProjectionActorOptions { SafeWindowMs = 1000 });
+        var blobAccessor = new InMemoryBlobStorageSnapshotAccessor();
+        var bufferProvider = new SpillableSnapshotPayloadBufferProvider(
+            new SpillableSnapshotPayloadOptions { InMemoryThresholdBytes = 1024 * 1024 });
+
+        // Small payload, well under the offload threshold.
+        await actor.AddEventsAsync(new[] { Ev(new Created("tiny")) });
+
+        var envelopeResult = await actor.BuildSnapshotEnvelopeStreamFirstAsync(
+            bufferProvider,
+            canGetUnsafeState: true,
+            blobAccessor: blobAccessor,
+            offloadThresholdBytes: 1024 * 1024);
+
+        Assert.True(envelopeResult.IsSuccess);
+        var envelope = envelopeResult.GetValue();
+        Assert.False(envelope.IsOffloaded);
+        Assert.NotNull(envelope.InlineState);
+        Assert.True(envelope.InlineState!.CompressedSizeBytes > 0);
+        Assert.True(envelope.InlineState.OriginalSizeBytes > 0);
+
+        // Restore and verify contents.
+        var restoredActor = new GeneralMultiProjectionActor(
+            _domainTypes,
+            BigPayloadProjector.MultiProjectorName,
+            new GeneralMultiProjectionActorOptions { SafeWindowMs = 1000 });
+        await restoredActor.SetSnapshotAsync(envelope);
+
+        var stateResult = await restoredActor.GetStateAsync(canGetUnsafeState: true);
+        Assert.True(stateResult.IsSuccess);
+        var restoredPayload = Assert.IsType<BigPayloadProjector>(stateResult.GetValue().Payload);
+        Assert.Single(restoredPayload.Items);
+        Assert.Equal("tiny", restoredPayload.Items[0]);
+    }
+
+    [Fact]
+    public async Task BuildSnapshotEnvelopeStreamFirstAsync_Should_Spill_Large_Payload_To_TempFile()
+    {
+        var actor = new GeneralMultiProjectionActor(
+            _domainTypes,
+            BigPayloadProjector.MultiProjectorName,
+            new GeneralMultiProjectionActorOptions { SafeWindowMs = 1000 });
+        var blobAccessor = new InMemoryBlobStorageSnapshotAccessor();
+
+        // InMemoryThresholdBytes deliberately tiny so the stream has to spill to disk
+        // for any non-trivial projection — this is the behavior under test.
+        var tempDir = Path.Combine(Path.GetTempPath(), $"sekiban-spill-test-{Guid.NewGuid():N}");
+        var bufferProvider = new SpillableSnapshotPayloadBufferProvider(
+            new SpillableSnapshotPayloadOptions
+            {
+                InMemoryThresholdBytes = 16,
+                TempDirectory = tempDir
+            });
+
+        try
+        {
+            foreach (var i in Enumerable.Range(0, 6))
+            {
+                var created = new Created(GenerateRandomString(2048));
+                await actor.AddEventsAsync(new[] { Ev(created) });
+            }
+
+            var envelopeResult = await actor.BuildSnapshotEnvelopeStreamFirstAsync(
+                bufferProvider,
+                canGetUnsafeState: true,
+                blobAccessor: blobAccessor,
+                offloadThresholdBytes: 512);
+
+            Assert.True(envelopeResult.IsSuccess);
+            var envelope = envelopeResult.GetValue();
+            Assert.True(envelope.IsOffloaded);
+            Assert.NotNull(envelope.OffloadedState);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+            {
+                try { Directory.Delete(tempDir, recursive: true); } catch { }
+            }
+        }
+    }
+
+    [Fact]
     public async Task SetSnapshot_Throws_When_Offloaded()
     {
         var actor = new GeneralMultiProjectionActor(


### PR DESCRIPTION
## Summary
- add a stream-first snapshot persistence path so large multi-projection payloads never need to be held as a full compressed `byte[]` before the inline/offload decision is made
- introduce `SpillableSnapshotPayloadStream` / `SpillableSnapshotPayloadBufferProvider`: small snapshots stay in memory, larger ones transparently spill to a `DeleteOnClose` temp file once a configurable threshold is exceeded
- extend `ICoreMultiProjectorTypes` with `SerializeToStream` (new `SerializationSizeInfo`) so the default JSON+Gzip path pipes serialized bytes straight into the spill stream via `GzipCompression.CompressJsonToStream(Async)`
- add `GeneralMultiProjectionActor.BuildSnapshotEnvelopeStreamFirstAsync`: serializes into the spill buffer, then either uploads the buffer stream directly to blob storage (offloaded envelope with accurate `PayloadLength` / original / compressed sizes) or rehydrates the sub-threshold bytes for an inline envelope — restore behavior is unchanged
- wire `NativeProjectionSnapshotHandler` to automatically pick the stream-first path whenever an `ISnapshotPayloadBufferProvider` is available in DI; `AddSekibanDcbNativeRuntime` now registers the spillable provider by default
- extend the `DcbOrleans.SnapshotPersistProbe` with a `streamfirst` mode and `--spill-threshold-bytes` flag so the new path can be measured against the existing `legacy` and `offloaded` modes

Closes #1011

## Verification
- `dotnet build Sekiban.slnx`
- `dotnet test dcb/tests/Sekiban.Dcb.WithResult.Tests/Sekiban.Dcb.WithResult.Tests.csproj` — 491 passed (includes 3 new stream-first `ActorSnapshotOffloadTests`)
- `dotnet test dcb/tests/Sekiban.Dcb.Orleans.Tests/Sekiban.Dcb.Orleans.Tests.csproj` — 71 passed (includes new `WriteSnapshotForPersistenceToStreamAsync_StreamFirst_Should_Offload_Large_Payload`)
- `dotnet test dcb/tests/Sekiban.Dcb.WithoutResult.Tests/Sekiban.Dcb.WithoutResult.Tests.csproj` — 29 passed
- `dotnet build dcb/internalUsages/DcbOrleans.SnapshotPersistProbe/DcbOrleans.SnapshotPersistProbe.csproj -c Release`

## Memory Comparison

Reproducible via `dcb/internalUsages/DcbOrleans.SnapshotPersistProbe`. All three commands share the same synthetic projection built from random 512 KiB payloads and were run on the same machine (`darwin 25.4.0`) from this branch in release configuration.

Commands:

```
dotnet run --project dcb/internalUsages/DcbOrleans.SnapshotPersistProbe -c Release -- \
  --mode legacy --event-count 24 --payload-size 524288 \
  --offload-threshold-bytes 1048576 --iterations 3

dotnet run --project dcb/internalUsages/DcbOrleans.SnapshotPersistProbe -c Release -- \
  --mode offloaded --event-count 24 --payload-size 524288 \
  --offload-threshold-bytes 1048576 --iterations 3

dotnet run --project dcb/internalUsages/DcbOrleans.SnapshotPersistProbe -c Release -- \
  --mode streamfirst --event-count 24 --payload-size 524288 \
  --offload-threshold-bytes 1048576 --spill-threshold-bytes 65536 --iterations 3
```

For each run the probe samples `Process.WorkingSet64` and `GC.GetTotalMemory` at ~5 ms intervals while the snapshot is persisted, and reports the peak across all iterations plus the uncompressed / compressed payload sizes.

### 24 events × 512 KiB payload (~12.5 MB compressed snapshot)

| Scenario | Peak working set | Peak managed heap | Persisted envelope | Offloaded payload |
| --- | ---: | ---: | ---: | ---: |
| `legacy` (inline envelope, `byte[]`) | 786,022,400 B | 1,418,320,240 B | 17,599,589 B | — |
| `offloaded` (today, after #1009) | 363,724,800 B | 173,008,376 B | 563 B | 12,560,786 B |
| `streamfirst` (this PR) | **338,362,368 B** | **158,882,352 B** | 563 B | 12,560,786 B |

- vs `offloaded`: **−7.0 % peak working set**, **−8.2 % peak managed heap** — the spillable buffer removes the remaining transient compressed `byte[]` from the persist hot path.
- vs `legacy`: **−57.0 % peak working set**, **−88.8 % peak managed heap** — cumulative gain with #1009 already included in the comparison baseline.

### 48 events × 512 KiB payload (~25 MB compressed snapshot)

Same commands with `--event-count 48`:

| Scenario | Peak working set | Peak managed heap |
| --- | ---: | ---: |
| `legacy` | 1,425,113,088 B | 2,943,333,408 B |
| `offloaded` | 669,958,144 B | 349,267,808 B |
| `streamfirst` | **588,906,496 B** | **257,549,504 B** |

The stream-first win grows with snapshot size: **−12.1 %** working set and **−26.3 %** managed heap vs `offloaded` at ~25 MB compressed, because the full `byte[]` that `offloaded` still materializes before upload is now serialized straight into the spillable buffer and streamed from disk.

## Test plan
- [x] Build all `Sekiban.Dcb.*` projects
- [x] Stream-first inline + offload envelope restore in `ActorSnapshotOffloadTests`
- [x] `NativeProjectionSnapshotPersistenceTests` verifies offload + full restore through the native host when the buffer provider is registered in DI
- [x] Existing `WithResult.Tests` (491) / `Orleans.Tests` (71) / `WithoutResult.Tests` (29) suites green
- [x] `DcbOrleans.SnapshotPersistProbe` runs all three modes without materializing a large `byte[]` in `streamfirst`

🤖 Generated with [Claude Code](https://claude.com/claude-code)