### PR TITLE
docs: Add DCB Materialized View design & task breakdown

### DIFF
--- a/tasks/db-projection-read-model/README.md
+++ b/tasks/db-projection-read-model/README.md
@@ -25,8 +25,8 @@ Every publicly exposed new type uses the full word `MaterializedView` or the sho
 
 | File | Purpose |
 |---|---|
-| `design.md` | Full design document (lifecycle, object model, context APIs, cross-view reads, WASM marshaling, ORM layers, name-collision audit) |
-| `tasks.md` | Task breakdown into phases (Phase 1 → Phase 11) and the scope of the first PoC sprint |
+| `design.md` | Full design document (lifecycle, object model, context APIs, dependency-pinned reads, runtime protocol/WASM notes, ORM layers, name-collision audit) |
+| `tasks.md` | Task breakdown into phases (Phase 1 → Phase 13) and the scope of the first PoC sprint |
 | `poc-scope.md` | Minimum viable PoC and acceptance criteria |
 | `open-questions.md` | Open questions captured during design, grouped by category |
 | `integration-notes.md` | Notes on how this fits into existing DCB architecture (relationship to `ICoreMultiProjector`, `IMultiProjectionStateStore`, `GeneralMultiProjectionActor`, safe/unsafe state) |
@@ -40,7 +40,7 @@ DCB projections currently materialize a single in-memory state that is snapshott
 - No schema evolution story for projection internals
 - Not ideal as a read model for application queries that need `WHERE` / `JOIN` / index access
 
-The DCB Materialized View subsystem provides a parallel option: projection logic still consumes events, but writes are emitted as a list of `MvSqlStatement`s that the framework executes against real tables in one transaction per event. The table shape, indexes, and queries become normal database artifacts.
+The DCB Materialized View subsystem provides a parallel option: projection logic still consumes events, but writes are emitted as a list of `MvSqlStatement`s that the framework executes against real tables in one transaction per event. Reads performed by `ApplyToViewAsync` are part of that same transaction/snapshot. The table shape, indexes, and queries become normal database artifacts.
 
 ## Relationship to existing `ICoreMultiProjector<T>`
 
@@ -55,11 +55,11 @@ The same `IEventStore`, `SortableUniqueId`, safe/unsafe window semantics, and sh
 
 1. **Two-phase lifecycle**: `InitializeAsync` (once) + `ApplyToViewAsync` (per event)
 2. **Developer writes SQL**: No SQL dialect abstraction in the framework
-3. **Writes are returned, not executed**: `ApplyToViewAsync` returns `IReadOnlyList<MvSqlStatement>`, framework executes them in one transaction
+3. **Writes are returned, not executed**: `ApplyToViewAsync` returns `IReadOnlyList<MvSqlStatement>`, framework executes them in the same transaction/snapshot used for reads
 4. **Row metadata for idempotency**: `_last_sortable_unique_id` column enables safe replay
-5. **Cross-view reads**: Read from another MV's active-version tables via a context helper
+5. **Cross-view reads**: Deferred for PoC; future support resolves dependency-pinned tables, not live active pointers
 6. **ORM via layered `IMvRow`**: Framework core exposes `IMvRow`/`IMvRowSet`, mappers sit on top, Dapper is an internal implementation detail
-7. **WASM-friendly**: All boundary data is JSON/MessagePack-friendly, SQL strings pass freely
+7. **Runtime-protocol-ready**: .NET authoring APIs stay idiomatic; future Wasm/remote execution uses a separate JSON/MessagePack-friendly protocol
 8. **Name-clash-free**: Every new public type uses `MaterializedView` or `Mv*` prefix
 
 ## This PR contains ONLY

--- a/tasks/db-projection-read-model/README.md
+++ b/tasks/db-projection-read-model/README.md
@@ -1,0 +1,76 @@
+# DCB Materialized View (MV)
+
+This folder contains the design and task breakdown for adding **DCB Materialized View** — a new, parallel projection mechanism that writes typed rows to real SQL tables — to Sekiban DCB.
+
+Today, `IMultiProjectionStateStore` implementations (Postgres/Cosmos/DynamoDB/SQLite) persist a single serialized snapshot per projector. This proposal adds a **separate, parallel subsystem** that materializes projection output to actual tables so that read models can be queried with normal SQL / BI tooling.
+
+**No implementation is included in this PR** — only design and task documents.
+
+## Why a new name ("Materialized View" / `Mv*`)
+
+This feature is intentionally named to avoid collision with existing DCB concepts:
+
+| Existing in DCB | New (this proposal) |
+|---|---|
+| `ICoreMultiProjector<T>` | `IMaterializedViewProjector` |
+| `MultiProjectionStateBuilder` | `MvCatchUpWorker` |
+| `dcb_multi_projection_states` | `sekiban_mv_registry` + `sekiban_mv_active` |
+| `IMultiProjectionStateStore` | `IMvRegistryStore` + `IMvExecutor` |
+
+Every publicly exposed new type uses the full word `MaterializedView` or the short prefix `Mv*`, so code search and IntelliSense stay unambiguous. Shared primitives (`IEvent`, `SortableUniqueId`, `IEventStore`, `ServiceId`) are reused intentionally.
+
+> **Note**: "Materialized view" here is used in the general database sense ("a query result stored as a real table"). It does NOT mean PostgreSQL's built-in `MATERIALIZED VIEW` SQL object — we use normal CREATE TABLE statements written by the developer.
+
+## Contents
+
+| File | Purpose |
+|---|---|
+| `design.md` | Full design document (lifecycle, object model, context APIs, cross-view reads, WASM marshaling, ORM layers, name-collision audit) |
+| `tasks.md` | Task breakdown into phases (Phase 1 → Phase 11) and the scope of the first PoC sprint |
+| `poc-scope.md` | Minimum viable PoC and acceptance criteria |
+| `open-questions.md` | Open questions captured during design, grouped by category |
+| `integration-notes.md` | Notes on how this fits into existing DCB architecture (relationship to `ICoreMultiProjector`, `IMultiProjectionStateStore`, `GeneralMultiProjectionActor`, safe/unsafe state) |
+
+## Motivation (one paragraph)
+
+DCB projections currently materialize a single in-memory state that is snapshotted to storage as a gzipped JSON blob. This works well for small/medium projections but has limitations:
+
+- Cannot be queried directly with SQL / BI tools
+- Memory pressure scales with projection size
+- No schema evolution story for projection internals
+- Not ideal as a read model for application queries that need `WHERE` / `JOIN` / index access
+
+The DCB Materialized View subsystem provides a parallel option: projection logic still consumes events, but writes are emitted as a list of `MvSqlStatement`s that the framework executes against real tables in one transaction per event. The table shape, indexes, and queries become normal database artifacts.
+
+## Relationship to existing `ICoreMultiProjector<T>`
+
+This proposal does **not** replace the existing multi-projector model. Both coexist:
+
+- `ICoreMultiProjector<T>` — in-memory state, snapshotted as blob (existing, unchanged)
+- `IMaterializedViewProjector` (new) — row-level state, writes to real tables
+
+The same `IEventStore`, `SortableUniqueId`, safe/unsafe window semantics, and shared DCB primitives are used by both.
+
+## Core design principles
+
+1. **Two-phase lifecycle**: `InitializeAsync` (once) + `ApplyToViewAsync` (per event)
+2. **Developer writes SQL**: No SQL dialect abstraction in the framework
+3. **Writes are returned, not executed**: `ApplyToViewAsync` returns `IReadOnlyList<MvSqlStatement>`, framework executes them in one transaction
+4. **Row metadata for idempotency**: `_last_sortable_unique_id` column enables safe replay
+5. **Cross-view reads**: Read from another MV's active-version tables via a context helper
+6. **ORM via layered `IMvRow`**: Framework core exposes `IMvRow`/`IMvRowSet`, mappers sit on top, Dapper is an internal implementation detail
+7. **WASM-friendly**: All boundary data is JSON/MessagePack-friendly, SQL strings pass freely
+8. **Name-clash-free**: Every new public type uses `MaterializedView` or `Mv*` prefix
+
+## This PR contains ONLY
+
+- Design documents (`design.md`, `tasks.md`, `poc-scope.md`, `open-questions.md`, `integration-notes.md`)
+
+## This PR does NOT contain
+
+- Any `.cs` files
+- Any changes to existing DCB source code
+- Any project file changes (`.csproj`, `.slnx`)
+- Any test projects
+
+Implementation is a follow-up effort, tracked via the task breakdown in `tasks.md`.

--- a/tasks/db-projection-read-model/design.md
+++ b/tasks/db-projection-read-model/design.md
@@ -1,0 +1,834 @@
+# DCB Materialized View — Design Document
+
+**Status**: Proposal (design-only, no implementation in this PR)
+**Scope**: New public API in `Sekiban.Dcb.Core` (new interfaces), new packages `Sekiban.Dcb.MaterializedView` + `Sekiban.Dcb.MaterializedView.Postgres`, integration with existing event store
+**Working name**: **"DCB Materialized View"** (DCB MV / `Mv*`). The feature is distinct from the existing multi-projection model and uses a separate name to avoid confusion.
+
+---
+
+## 1. Background
+
+### 1.1 Current multi-projection persistence
+
+Sekiban DCB today has exactly one way to persist a multi-projection:
+
+- `ICoreMultiProjector<T>` (in `Sekiban.Dcb.Core.Model/MultiProjections/IMultiProjector.cs`) defines a **static abstract** `Project(payload, ev, tags, domainTypes, safeWindowThreshold)` method.
+- A projector produces an in-memory state `T` (typically a record tree or `SafeUnsafeProjectionState<TKey, TState>`).
+- `MultiProjectionStateBuilder` rebuilds the state from the event store and hands it to `IMultiProjectionStateStore` implementations (`PostgresMultiProjectionStateStore`, `CosmosMultiProjectionStateStore`, etc.).
+- The state is serialized to JSON, gzip-compressed, and stored as a blob in `dcb_multi_projection_states` (`DbMultiProjectionState.StateData`). Large payloads can be offloaded to blob storage.
+- `SortableUniqueId` (30-char string: 19 ticks + 11 random) provides global ordering, and safe/unsafe state is managed via `SafeUnsafeProjectionState`.
+
+This is excellent for correctness and replay semantics but cannot be queried directly via SQL.
+
+### 1.2 What is missing
+
+Nothing in the current code writes projection output to actual database tables with typed columns. The `Sekiban.Dcb.Postgres` package stores the projector snapshot blob — not the projected data itself. There is no row-level materialization, no table schema per projector, no `UPDATE / SELECT` based projector authoring.
+
+### 1.3 What this proposal adds
+
+**A brand-new, parallel mechanism** called a **DCB Materialized View** (written `MaterializedView`, shortened `Mv`). It coexists with `ICoreMultiProjector<T>`, sharing `IEventStore`, `SortableUniqueId`, and orchestration, but writes **row-level state to real database tables**.
+
+Both can be used in the same application:
+- Use `ICoreMultiProjector<T>` when state is small, accessed purely in-memory, or needs actor-hosted queries
+- Use `IMaterializedViewProjector` when you want SQL-queryable read models, BI tool integration, or large datasets that don't fit well in a single blob
+
+### 1.4 Naming rationale
+
+The term **Materialized View** was chosen deliberately because:
+
+1. It is the standard database community term for "a query result stored as a real table"
+2. It does NOT collide with DCB's existing `MultiProjection`, `MultiProjector`, `MultiProjectionState*` types
+3. "Materialized" immediately conveys that data lives in real tables, not in memory
+4. The `Mv*` prefix gives a short, consistent, searchable abbreviation in code and SQL
+5. In this document and in code:
+   - `MaterializedView` refers to **the projection mechanism as a whole** (one logical read model, possibly with multiple tables)
+   - `MvTable` refers to **a single physical table** inside a materialized view
+   - `MvSqlStatement` is a parameter + SQL pair returned from an apply method
+   - `Mv*Context` names the framework-supplied apply/init contexts
+
+> **Important**: "Materialized view" in this document does NOT mean PostgreSQL's built-in `MATERIALIZED VIEW` SQL object. We use the term conceptually. The implementation uses normal CREATE TABLE statements written by the developer; PostgreSQL's `MATERIALIZED VIEW` feature is unrelated and not used here.
+
+---
+
+## 2. Goals and Non-goals
+
+### Goals
+
+1. Let developers define a materialized view whose output is **rows in typed SQL tables**
+2. Support **multiple versions** of the same materialized view coexisting (v1 active, v2 catching up)
+3. Support **1 materialized view → multiple tables** (e.g., `OrderSummaryMv` → `orders` + `items`)
+4. Make the developer experience familiar to users of `ICoreMultiProjector<T>` — "same mental model, different target"
+5. Keep **SQL authorship in the developer's hands** — no SQL dialect abstraction leaks
+6. Provide **row metadata** for idempotency and debugging (`_last_sortable_unique_id`)
+7. Allow **cross-view reads** during apply, via a context helper that resolves the active version of another materialized view
+8. Be **WASM-friendly**: all boundary data is JSON or string-shaped
+9. Keep all names distinct from existing DCB types so code search and IntelliSense stay unambiguous
+
+### Non-goals
+
+1. Replacing `ICoreMultiProjector<T>` — it continues to exist and is unchanged
+2. Providing a cross-database ORM — each DB has its own SQL dialect and that's fine
+3. Providing query abstractions on the read side in this iteration (read-side API is planned future work)
+4. Migration tooling for schema evolution (covered at a high level, but detailed migration DSL is out of scope)
+5. Multi-tenant isolation beyond simple name prefix override (out of scope for v1)
+
+---
+
+## 3. Core concepts
+
+### 3.1 Two-phase lifecycle
+
+A DCB materialized view has exactly two phases:
+
+```
+┌────────────────────────────┐   ┌─────────────────────────────────────┐
+│ Phase 1: InitializeAsync   │──▶│ Phase 2: ApplyToViewAsync (per event)│
+│ (once per view + version)  │   │  - read (immediate)                  │
+│                            │   │  - build MvSqlStatement list          │
+│  - RegisterTable           │   │  - return list to framework           │
+│  - CREATE TABLE/INDEX      │   │  - framework runs in 1 transaction    │
+└────────────────────────────┘   └─────────────────────────────────────┘
+```
+
+**Phase 1 (Initialize)** runs once when the view version is first registered in the MV registry. It creates the physical tables, indexes, and any preparatory structures.
+
+**Phase 2 (Apply)** runs for every event during catch-up and steady-state. It consumes an event, optionally reads existing rows, and returns a list of `MvSqlStatement`s describing the writes. The framework executes the list inside a single transaction and advances `current_position`.
+
+The apply method is named `ApplyToViewAsync` (not `ApplyAsync` or `ProjectAsync`) to make its purpose unmistakable and avoid visual confusion with `ICoreMultiProjector.Project` when both types appear in the same file.
+
+### 3.2 Writes are returned, not executed
+
+The key design choice: `ApplyToViewAsync` does **not** execute writes. It returns `IReadOnlyList<MvSqlStatement>`.
+
+```csharp
+public readonly record struct MvSqlStatement(string Sql, object? Parameters = null);
+```
+
+This has several benefits:
+
+- **Atomicity is explicit** — the returned list is one transaction
+- **Order is explicit** — list order = execution order
+- **Testing is pure** — the returned list is the output, assertable without a database
+- **Dry-run / logging is trivial** — you have all the SQL as data
+- **Pipeline optimization** — framework can log/audit/transform before executing
+
+Reads **are** executed immediately through the context, since apply logic often needs to read existing rows and branch on them. Separating "reads happen now, writes happen at the end" is conceptually clean.
+
+### 3.3 Developer writes SQL; framework abstracts nothing
+
+The framework does **not** provide `Upsert(row)`, `Insert(row)`, `Update(row)` helpers that generate SQL. Instead the developer writes SQL strings directly. Rationale:
+
+- SQL dialects diverge deeply (JSONB, UPSERT, interval types, partitioning). Any abstraction leaks.
+- Dapper already gives a great minimal API surface; we don't need another layer
+- Debugging and performance tuning are far easier when you see the actual SQL in your code
+- When a view needs to target two DBs, the developer `switch`es on `ctx.DbType` once — no framework-wide dialect system needed
+
+The framework provides:
+- **Physical table name resolution** (via `MvTable.PhysicalName`)
+- **A Dapper-free `IMvRow` row abstraction** for read results
+- **Context-level helpers** for executing reads and resolving cross-view tables
+- **A row mapper** (`IMvRow → T`) with convention-based defaults
+
+Everything else — the `CREATE TABLE`, the `INSERT ... ON CONFLICT DO UPDATE`, the `SELECT ... WHERE ... JOIN ...` — is written by the developer in plain SQL.
+
+### 3.4 Row metadata for idempotency and tracking
+
+Every MV table is expected (or recommended) to include two standard columns:
+
+```sql
+_last_sortable_unique_id TEXT NOT NULL,
+_last_applied_at         TIMESTAMPTZ NOT NULL DEFAULT NOW()
+```
+
+This enables:
+
+- **Idempotent replays**: `WHERE _last_sortable_unique_id < @sid` prevents older events from overwriting newer state
+- **Catch-up progress tracking at the row level** (complements registry-level `current_position`)
+- **Cross-view integrity checks**: a reader view can verify another view has reached a given `SortableUniqueId`
+
+The `IMvApplyContext` exposes `CurrentSortableUniqueId` so user code can embed it trivially in writes.
+
+### 3.5 Cross-view reads
+
+Apply logic sometimes needs to read from **another** materialized view to compute its writes (e.g., `OrderSummaryMv.ApplyToViewAsync(OrderItemAdded)` reads a discount tier from `CustomerSummaryMv`). This is supported through:
+
+```csharp
+MvTable GetActiveViewTable(string viewName, string logicalTable);
+MvTable GetActiveViewTable<TView>(string logicalTable)
+    where TView : IMaterializedViewProjector;
+```
+
+The resolution uses the **MV registry + MV active** tables (see §5) to locate the currently-active version's physical table name. Writes are forbidden across views — you can only read from another view. Your own view's writes are the only thing returned from `ApplyToViewAsync`.
+
+**Consistency caveat**: during catch-up, the "other view" may be at an earlier `current_position` than your view. This is an eventually-consistent system; document it clearly.
+
+---
+
+## 4. Object model
+
+```
+IMaterializedViewProjector                 (user implements)
+ ├── MvTable Orders                        (holds logical & physical names)
+ ├── MvTable Items                         (holds logical & physical names)
+ ├── InitializeAsync(IMvInitContext)
+ └── ApplyToViewAsync(IEvent, IMvApplyContext) → IReadOnlyList<MvSqlStatement>
+
+MvSqlStatement (record struct)             (value type, framework-executed)
+
+IMvInitContext                             (framework provides)
+ ├── DbType, Connection
+ ├── RegisterTable(logicalName): MvTable
+ └── ExecuteAsync(sql, params)              ← used for CREATE TABLE/INDEX
+
+IMvApplyContext                            (framework provides)
+ ├── DbType, Connection
+ ├── CurrentEvent, CurrentSortableUniqueId
+ ├── QuerySingleOrDefaultAsync<T>(sql, params)
+ ├── QueryAsync<T>(sql, params)
+ ├── QuerySingleOrDefaultRowAsync(sql, params): IMvRow?
+ ├── QueryRowsAsync(sql, params): IMvRowSet
+ └── GetActiveViewTable(viewName, logicalTable): MvTable
+```
+
+### 4.1 `IMaterializedViewProjector`
+
+```csharp
+public interface IMaterializedViewProjector
+{
+    string ViewName { get; }
+    int ViewVersion { get; }
+
+    Task InitializeAsync(IMvInitContext ctx);
+
+    Task<IReadOnlyList<MvSqlStatement>> ApplyToViewAsync(
+        IEvent ev,
+        IMvApplyContext ctx);
+}
+```
+
+This has a purposely different shape from `ICoreMultiProjector<T>`:
+
+| Aspect | `ICoreMultiProjector<T>` | `IMaterializedViewProjector` |
+|---|---|---|
+| Member style | `static abstract` | instance |
+| State | In-memory `T` payload | No in-memory state; row data in DB |
+| Write path | `return new T with {...}` | `return [new MvSqlStatement(...)]` |
+| Key identifier | `MultiProjectorName` | `ViewName` |
+| Version | `MultiProjectorVersion` (string) | `ViewVersion` (int) |
+| Persistence | blob snapshot | real tables |
+
+The name differences (`ViewName` vs `MultiProjectorName`, `ApplyToViewAsync` vs `Project`) are intentional — code search for either term returns only its own ecosystem.
+
+### 4.2 `MvTable`
+
+```csharp
+public sealed class MvTable
+{
+    public string LogicalName { get; }
+    public string PhysicalName { get; }    // resolved during Initialize
+    public string ViewName { get; }        // owner view name
+    public int    ViewVersion { get; }     // owner view version
+}
+```
+
+A thin value holder. It does not carry SQL generation methods. The developer reads `PhysicalName` and embeds it in SQL strings. The `ViewName`/`ViewVersion` are kept for debugging and to support cross-view sanity checks.
+
+### 4.3 `MvSqlStatement`
+
+```csharp
+public readonly record struct MvSqlStatement(string Sql, object? Parameters = null);
+```
+
+A value type. `Sql` is a raw SQL string (parameterized via `@name` placeholders). `Parameters` is an anonymous object or POCO compatible with Dapper's parameter model.
+
+The name `MvSqlStatement` was chosen over plain `SqlStatement` to avoid ambiguity with any general-purpose "sql statement" type that might exist elsewhere in DCB or the broader .NET ecosystem.
+
+### 4.4 Contexts
+
+```csharp
+public interface IMvInitContext
+{
+    DbType DbType { get; }
+    IDbConnection Connection { get; }
+
+    MvTable RegisterTable(string logicalName);
+    Task ExecuteAsync(string sql, object? param = null);
+}
+
+public interface IMvApplyContext
+{
+    DbType DbType { get; }
+    IDbConnection Connection { get; }
+
+    IEvent CurrentEvent { get; }
+    string CurrentSortableUniqueId { get; }
+
+    // Read operations (immediate)
+    Task<T?>              QuerySingleOrDefaultAsync<T>(string sql, object? param = null);
+    Task<T>               QuerySingleAsync<T>(string sql, object? param = null);
+    Task<IReadOnlyList<T>> QueryAsync<T>(string sql, object? param = null);
+    Task<TScalar>         ExecuteScalarAsync<TScalar>(string sql, object? param = null);
+
+    // IMvRow-level read (for mapper-free use)
+    Task<IMvRow?>   QuerySingleOrDefaultRowAsync(string sql, object? param = null);
+    Task<IMvRowSet> QueryRowsAsync(string sql, object? param = null);
+
+    // Cross-view table resolution
+    MvTable GetActiveViewTable(string viewName, string logicalTable);
+    MvTable GetActiveViewTable<TView>(string logicalTable)
+        where TView : IMaterializedViewProjector;
+}
+```
+
+`IDbConnection` is exposed as an escape hatch — developers who want to use Dapper directly (or Npgsql's COPY, or anything else) can do so without fighting the framework.
+
+---
+
+## 5. Physical layout
+
+### 5.1 Physical table naming
+
+```
+{prefix}_{view_name}_{version}_{logical_table}
+```
+
+Defaults:
+- `prefix` = `sekiban_mv`
+- `view_name` = `IMaterializedViewProjector.ViewName` lowercased, `[A-Za-z0-9_]` only
+- `version` = `v{ViewVersion}`
+- `logical_table` = name passed to `RegisterTable`
+
+Examples:
+
+- `sekiban_mv_ordersummary_v1_orders`
+- `sekiban_mv_ordersummary_v2_orders` (v2 coexists with v1)
+- `sekiban_mv_ordersummary_v2_items`
+
+The naming is deterministic. Overrides are allowed at DI registration time:
+
+```csharp
+services.AddSekibanMaterializedView(opts =>
+{
+    opts.PhysicalNameResolver = (view, version, logical)
+        => $"sekiban_mv_{TenantContext.Current}_{view}_v{version}_{logical}";
+});
+```
+
+### 5.2 MV registry and active tables
+
+Two framework-owned tables track MV state. They are deliberately named with the `sekiban_mv_` prefix to distinguish from the existing `dcb_multi_projection_states` table:
+
+```sql
+CREATE TABLE sekiban_mv_registry (
+    service_id               TEXT NOT NULL,
+    view_name                TEXT NOT NULL,
+    view_version             INT  NOT NULL,
+    logical_table            TEXT NOT NULL,
+    physical_table           TEXT NOT NULL,
+    status                   TEXT NOT NULL,   -- initializing / catching_up / ready / active / retired
+    current_position         TEXT,            -- last SortableUniqueId applied
+    target_position          TEXT,            -- position at which catch-up is considered "ready"
+    last_sortable_unique_id  TEXT,            -- used by cross-view integrity checks
+    last_updated             TIMESTAMPTZ NOT NULL,
+    metadata                 JSONB,
+    PRIMARY KEY (service_id, view_name, view_version, logical_table)
+);
+
+CREATE TABLE sekiban_mv_active (
+    service_id     TEXT NOT NULL,
+    view_name      TEXT NOT NULL,
+    active_version INT  NOT NULL,
+    activated_at   TIMESTAMPTZ NOT NULL,
+    PRIMARY KEY (service_id, view_name)
+);
+```
+
+`service_id` mirrors the DCB convention (already present in `DbMultiProjectionState`) for multi-tenant isolation.
+
+Note: `current_position` stores a `SortableUniqueId` string (DCB's existing ordering key), **not** a numeric offset. This aligns with `DbMultiProjectionState.LastSortableUniqueId`.
+
+### 5.3 MV data tables
+
+Data tables are authored entirely by the developer's `InitializeAsync`. The framework does not generate them. The only convention the framework **suggests** (not enforces) is the row metadata columns `_last_sortable_unique_id` and `_last_applied_at`.
+
+---
+
+## 6. Worked example
+
+```csharp
+public class OrderSummaryMvV1 : IMaterializedViewProjector
+{
+    public string ViewName => "OrderSummary";
+    public int    ViewVersion => 1;
+
+    public MvTable Orders { get; private set; } = default!;
+    public MvTable Items  { get; private set; } = default!;
+
+    public async Task InitializeAsync(IMvInitContext ctx)
+    {
+        Orders = ctx.RegisterTable("orders");
+        Items  = ctx.RegisterTable("items");
+
+        await ctx.ExecuteAsync($"""
+            CREATE TABLE IF NOT EXISTS {Orders.PhysicalName} (
+                id UUID PRIMARY KEY,
+                status TEXT NOT NULL,
+                total NUMERIC NOT NULL DEFAULT 0,
+                created_at TIMESTAMPTZ NOT NULL,
+                _last_sortable_unique_id TEXT NOT NULL,
+                _last_applied_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+            )
+            """);
+
+        await ctx.ExecuteAsync($"""
+            CREATE TABLE IF NOT EXISTS {Items.PhysicalName} (
+                id UUID PRIMARY KEY,
+                order_id UUID NOT NULL REFERENCES {Orders.PhysicalName}(id),
+                product TEXT NOT NULL,
+                qty INT NOT NULL,
+                price NUMERIC NOT NULL,
+                _last_sortable_unique_id TEXT NOT NULL,
+                _last_applied_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+            )
+            """);
+
+        await ctx.ExecuteAsync($"""
+            CREATE INDEX IF NOT EXISTS idx_{Items.LogicalName}_order_id
+            ON {Items.PhysicalName} (order_id)
+            """);
+    }
+
+    // Read helpers (encapsulate SELECT statements for readability)
+
+    private Task<OrderRow?> GetOrderByIdAsync(IMvApplyContext ctx, Guid orderId) =>
+        ctx.QuerySingleOrDefaultAsync<OrderRow>(
+            $"SELECT * FROM {Orders.PhysicalName} WHERE id = @Id",
+            new { Id = orderId });
+
+    // Write helpers (each returns an MvSqlStatement, never executes)
+
+    private MvSqlStatement UpsertOrder(OrderRow order, string sid) =>
+        new($"""
+            INSERT INTO {Orders.PhysicalName}
+                (id, status, total, created_at, _last_sortable_unique_id, _last_applied_at)
+            VALUES (@Id, @Status, @Total, @CreatedAt, @SortableId, NOW())
+            ON CONFLICT (id) DO UPDATE SET
+                status                   = EXCLUDED.status,
+                total                    = EXCLUDED.total,
+                _last_sortable_unique_id = EXCLUDED._last_sortable_unique_id,
+                _last_applied_at         = EXCLUDED._last_applied_at
+            WHERE {Orders.PhysicalName}._last_sortable_unique_id < EXCLUDED._last_sortable_unique_id
+            """, new {
+                order.Id, order.Status, order.Total, order.CreatedAt,
+                SortableId = sid
+            });
+
+    private MvSqlStatement InsertItem(OrderItemRow item, string sid) =>
+        new($"""
+            INSERT INTO {Items.PhysicalName}
+                (id, order_id, product, qty, price, _last_sortable_unique_id, _last_applied_at)
+            VALUES (@Id, @OrderId, @Product, @Qty, @Price, @SortableId, NOW())
+            """, new {
+                item.Id, item.OrderId, item.Product, item.Qty, item.Price,
+                SortableId = sid
+            });
+
+    private MvSqlStatement UpdateOrderTotal(Guid orderId, decimal total, string sid) =>
+        new($"""
+            UPDATE {Orders.PhysicalName}
+            SET total = @Total,
+                _last_sortable_unique_id = @SortableId,
+                _last_applied_at = NOW()
+            WHERE id = @Id
+              AND _last_sortable_unique_id < @SortableId
+            """, new { Id = orderId, Total = total, SortableId = sid });
+
+    // Apply: reads happen immediately, writes are returned
+
+    public async Task<IReadOnlyList<MvSqlStatement>> ApplyToViewAsync(
+        IEvent ev, IMvApplyContext ctx)
+    {
+        var sid = ctx.CurrentSortableUniqueId;
+
+        switch (ev.Payload)
+        {
+            case OrderCreated c:
+                return [UpsertOrder(
+                    new OrderRow(c.OrderId, "Pending", 0m, c.Timestamp), sid)];
+
+            case OrderItemAdded a:
+                var order = await GetOrderByIdAsync(ctx, a.OrderId);
+                if (order is null) return [];
+                return [
+                    InsertItem(new OrderItemRow(a.ItemId, a.OrderId, a.Product, a.Quantity, a.Price), sid),
+                    UpdateOrderTotal(a.OrderId, order.Total + (a.Price * a.Quantity), sid)
+                ];
+
+            case OrderCancelled c:
+                return [new($"""
+                    UPDATE {Orders.PhysicalName}
+                    SET status = 'Cancelled',
+                        _last_sortable_unique_id = @SortableId,
+                        _last_applied_at = NOW()
+                    WHERE id = @Id
+                    """, new { Id = c.OrderId, SortableId = sid })];
+
+            default:
+                return [];
+        }
+    }
+}
+```
+
+Notice the POCOs used for reads are named `OrderRow`, `OrderItemRow` — avoiding clash with any existing domain `Order` type in sample projects. This is only a convention; users can name them however they like.
+
+---
+
+## 7. ORM layering (IMvRow, MvRowMapper)
+
+### 7.1 Why we don't depend on Dapper in the public surface
+
+Dapper is an excellent library and will be used **internally** in the initial Postgres implementation. But:
+
+- The public interface must not force callers (especially WASM-based MV code) to depend on Dapper types
+- Alternative backends (Npgsql direct, ADO.NET, native Postgres driver) should be pluggable
+- WASM multi-language scenarios need an ABI-friendly row representation
+
+We therefore introduce a small `IMvRow`/`IMvRowSet` abstraction that lives in `Sekiban.Dcb.MaterializedView`. Dapper becomes an implementation detail of the default `IMvApplyContext` realizer.
+
+The names `IMvRow` / `IMvRowSet` deliberately carry the `Mv` prefix to avoid confusion with any existing `IRow`/`IRowSet` types in ADO.NET or third-party libraries.
+
+### 7.2 `IMvRow` and `IMvRowSet`
+
+```csharp
+public interface IMvRow
+{
+    int ColumnCount { get; }
+    IReadOnlyList<string> ColumnNames { get; }
+
+    bool IsNull(string columnName);
+
+    Guid           GetGuid(string columnName);
+    string         GetString(string columnName);
+    int            GetInt32(string columnName);
+    long           GetInt64(string columnName);
+    decimal        GetDecimal(string columnName);
+    double         GetDouble(string columnName);
+    bool           GetBoolean(string columnName);
+    DateTimeOffset GetDateTimeOffset(string columnName);
+    byte[]         GetBytes(string columnName);
+
+    Guid?           GetGuidOrNull(string columnName);
+    string?         GetStringOrNull(string columnName);
+    int?            GetInt32OrNull(string columnName);
+    decimal?        GetDecimalOrNull(string columnName);
+    DateTimeOffset? GetDateTimeOffsetOrNull(string columnName);
+
+    T GetAs<T>(string columnName);    // for JSONB, arrays, custom types
+
+    string ToJson();                  // escape hatch / WASM marshaling
+}
+
+public interface IMvRowSet : IReadOnlyList<IMvRow>
+{
+    IReadOnlyList<string> ColumnNames { get; }
+}
+```
+
+Column access is **by name only** — deliberately no positional accessors. This avoids the `object[] row; row[0]; row[1]` anti-pattern.
+
+### 7.3 `MvRowMapper<T>` (convention-based default)
+
+```csharp
+public static class MvRowMapper<T> where T : class, new()
+{
+    public static T MapFrom(IMvRow row);               // Expression-tree compiled, cached
+    public static IReadOnlyList<T> MapAll(IMvRowSet set);
+}
+```
+
+Convention: `snake_case` column → `PascalCase` property, with `[MvColumn("...")]` as an override. Implementation compiles to an `Expression<Func<IMvRow, T>>` once per type and caches it — reflection overhead only on first use.
+
+### 7.4 Extension methods on the context
+
+```csharp
+public static class MvApplyContextExtensions
+{
+    public static async Task<T?> QuerySingleOrDefaultAsync<T>(
+        this IMvApplyContext ctx, string sql, object? param = null)
+        where T : class, new()
+    {
+        var row = await ctx.QuerySingleOrDefaultRowAsync(sql, param);
+        return row is null ? null : MvRowMapper<T>.MapFrom(row);
+    }
+}
+```
+
+Developers who want full control drop down to `QuerySingleOrDefaultRowAsync` and map by hand. Developers who want zero ceremony use the typed `QuerySingleOrDefaultAsync<T>`. Developers who want zero-runtime-cost mapping use a future `[GeneratedMvRowMapping]` source generator.
+
+### 7.5 Source generator (future, optional)
+
+```csharp
+[GeneratedMvRowMapping]
+public partial record OrderRow(
+    [property: MvColumn("id")]         Guid           Id,
+    [property: MvColumn("status")]     string         Status,
+    [property: MvColumn("total")]      decimal        Total,
+    [property: MvColumn("created_at")] DateTimeOffset CreatedAt);
+```
+
+The generator emits a `public static OrderRow FromMvRow(IMvRow row)`. This is out of scope for the first PoC but should be feasible.
+
+---
+
+## 8. WASM ABI considerations
+
+### 8.1 The constraint
+
+WebAssembly ABIs can only pass primitive types (`i32`, `i64`, `f32`, `f64`) and byte ranges (pointer + length). Complex C# types cannot cross the boundary directly; they must be serialized.
+
+For this framework, the items that must cross the host ↔ guest boundary are:
+
+| Direction | Payload | Suggested form |
+|---|---|---|
+| guest → host | SQL string | UTF-8 bytes |
+| guest → host | SQL parameters | JSON |
+| host → guest | Event to apply | JSON |
+| host → guest | Row data (read result) | **JSON (PoC)** → MessagePack (opt) |
+| guest → host | `MvSqlStatement` list | JSON |
+
+### 8.2 Cost analysis
+
+Per-event marshaling cost estimate with JSON:
+
+| Payload | Count per event | JSON cost |
+|---|---|---|
+| Event | 1 | ~5-10μs |
+| Row reads | 1-2 | ~10-20μs |
+| Writes (`MvSqlStatement` list) | 1-3 | ~5-10μs |
+| **Total** | | **~20-40μs per event** |
+
+Throughput impact:
+
+| Target | JSON marshaling / sec | Note |
+|---|---|---|
+| 1,000 events/sec | 20-40ms (2-4%) | Negligible |
+| 10,000 events/sec | 200-400ms (20-40%) | Usable but felt |
+| 100,000 events/sec | 2-4s (200%+) | MessagePack needed |
+
+**Conclusion**: JSON is sufficient for PoC and for most operational workloads. Extreme catch-up throughput should either use MessagePack at the boundary or stay on the native (non-WASM) path entirely.
+
+### 8.3 Key observation
+
+**SQL strings and parameters have effectively zero marshaling overhead** — they're UTF-8 strings that pass as `(ptr, len)`. The only expensive direction is row data coming back from reads. This is a well-bounded optimization target.
+
+### 8.4 Decimal handling
+
+`decimal` through JSON loses precision. Options, in order of preference:
+
+1. **String-encoded** (`"1234.5678"`) — safe, universal, slightly more parsing
+2. MessagePack extension — binary efficient
+3. Custom binary — overkill for PoC
+
+For PoC, always encode `decimal` as a string at the ABI boundary.
+
+---
+
+## 9. Relationship to existing DCB components
+
+### 9.1 `IEventStore`
+
+No changes required. The new MV catch-up worker reads events via `ReadAllSerializableEventsAsync(since: currentPosition, maxCount: batchSize)` and feeds them to `ApplyToViewAsync`.
+
+### 9.2 `SortableUniqueId`
+
+Used directly as `current_position` in the MV registry. The string representation is already suitable for comparison (`<`, `<=`, `>`, `>=`). `CurrentSortableUniqueId` in `IMvApplyContext` is the event's `SortableUniqueId.Value`.
+
+### 9.3 `SafeUnsafeProjectionState` / safe window
+
+The MV model does **not** use the in-memory safe/unsafe state directly. Instead, we have two options for handling the safe window:
+
+**Option A (recommended for PoC): delay-apply**
+- Only apply events whose `SortableUniqueId` age is beyond the safe window (5s default)
+- Track two positions: `safe_position` (committed to disk) and `tentative_position` (read-ahead, not persisted)
+- On restart, always resume from `safe_position`
+
+**Option B: apply-immediately, rollback-on-reorder**
+- Apply everything as it arrives, but track a rollback point
+- Much more complex, defer to later phase
+
+The PoC uses Option A. This matches the semantics of `DbMultiProjectionState.SafeWindowThreshold`.
+
+### 9.4 `GeneralMultiProjectionActor` / Orleans
+
+MVs do **not** run inside `GeneralMultiProjectionActor`. They run in a separate catch-up worker called `MvCatchUpWorker`. This worker can be:
+
+- A hosted service (IHostedService) in a .NET host
+- A dedicated Orleans grain per view (future)
+- An external process reading events from the event store
+
+The PoC starts with a simple IHostedService-based worker. Orleans integration is a later phase.
+
+### 9.5 `MultiProjectionStateBuilder` / `IMultiProjectionStateStore`
+
+**Not touched.** MVs have their own orchestration via `MvCatchUpWorker` and `IMvRegistryStore`. The two systems are parallel — they do not share persistence code.
+
+### 9.6 `Sekiban.Dcb.Postgres`
+
+`Sekiban.Dcb.Postgres` stays exactly as it is (snapshot-based multi-projection store). A new package, `Sekiban.Dcb.MaterializedView` (core), plus `Sekiban.Dcb.MaterializedView.Postgres` (implementation), adds MVs without touching the existing code.
+
+### 9.7 Name-collision audit
+
+| Existing DCB type | New MV type | Collision? |
+|---|---|---|
+| `ICoreMultiProjector<T>` | `IMaterializedViewProjector` | No — different name, different interface style |
+| `MultiProjectionStateBuilder` | `MvCatchUpWorker` | No |
+| `MultiProjectionStateRecord` | `MvRegistryEntry` | No |
+| `MultiProjectionStateWriteRequest` | (not needed) | — |
+| `DbMultiProjectionState` | `sekiban_mv_registry` + `sekiban_mv_active` | No — different tables, different prefix |
+| `IMultiProjectionStateStore` | `IMvRegistryStore` + `IMvExecutor` | No |
+| `Sekiban.Dcb.Postgres` | `Sekiban.Dcb.MaterializedView.Postgres` | No |
+| `SafeProjection<T>` | (not used by MVs) | — |
+| `SafeUnsafeProjectionState<K,V>` | (not used by MVs) | — |
+| `IEvent`, `SortableUniqueId`, `IEventStore`, `ServiceId` | (shared) | Shared intentionally |
+
+Every publicly exposed MV type has either:
+- A unique prefix (`Mv*`)
+- The word `MaterializedView` in full
+- Or is a shared DCB primitive that both sides agree on (`IEvent`, `SortableUniqueId`)
+
+This guarantees code search like "grep -rn 'MultiProjector'" returns only the existing multi-projection ecosystem, and "grep -rn 'MaterializedView'" or "grep -rn 'Mv'" returns only the new ecosystem.
+
+---
+
+## 10. Version / catch-up lifecycle
+
+### 10.1 State machine per (view, version)
+
+```
+   [new]
+     │ (developer adds a new version)
+     ▼
+[initializing]  ← CREATE TABLE/INDEX; register in sekiban_mv_registry
+     │
+     ▼
+[catching_up]   ← MvCatchUpWorker reads events and applies them
+     │            (current_position advances)
+     │
+     │ current_position reaches safe window horizon
+     ▼
+   [ready]      ← caught up, not yet serving queries
+     │
+     │ operator activates (or auto-activate)
+     ▼
+  [active]      ← sekiban_mv_active points here; reads hit this version
+     │
+     │ new version becomes active; old version retires
+     ▼
+  [retired]     ← no longer serving queries; still on disk
+     │
+     │ cleanup (manual or TTL-based)
+     ▼
+  [deleted]     ← physical tables dropped, registry rows removed
+```
+
+### 10.2 Worker loop (pseudo-code)
+
+```csharp
+while (!cancellationToken.IsCancellationRequested)
+{
+    var batch = await eventStore.ReadAllSerializableEventsAsync(
+        since: currentPosition, maxCount: BatchSize);
+    if (!batch.Any()) { await Task.Delay(pollInterval); continue; }
+
+    foreach (var ev in batch)
+    {
+        if (!IsInsideSafeWindow(ev.SortableUniqueId, safeThreshold))
+        {
+            // Still inside unsafe window — defer
+            break;
+        }
+
+        var statements = await view.ApplyToViewAsync(ev.ToEvent(), applyContext);
+
+        using var tx = connection.BeginTransaction();
+        foreach (var stmt in statements)
+            await connection.ExecuteAsync(stmt.Sql, stmt.Parameters, tx);
+        await registry.UpdatePositionAsync(
+            viewName, viewVersion, ev.SortableUniqueId, tx);
+        tx.Commit();
+
+        currentPosition = ev.SortableUniqueId;
+    }
+}
+```
+
+### 10.3 Activation and rollback
+
+Activation is an atomic update of `sekiban_mv_active.active_version`. Optionally, a view-based read side (§11) allows activation to also `CREATE OR REPLACE VIEW` so external consumers see the switch atomically.
+
+Rollback from v2 to v1 is equally simple: update `active_version` back. Both versions' data tables remain intact until the operator issues `RETIRE`.
+
+---
+
+## 11. Read side (future)
+
+The PoC ships without a query API. Queries go through `Connection` directly using physical table names obtained from the registry. Subsequent work adds:
+
+- **Pattern A — typed query API**: `mvQuery.For("OrderSummary").Table("orders").WhereAsync<OrderRow>(...)`
+- **Pattern B — raw SQL with `{logical_table}` placeholders**
+- **Pattern C — automatic `CREATE OR REPLACE VIEW sekiban_mv_view_*` generation** so BI tools can use the logical name transparently
+
+These are in scope for a later phase.
+
+---
+
+## 12. Integration with DCB's `ServiceId`
+
+All registry and active entries are scoped by `service_id`. The default resolver reads from `IServiceIdProvider` (an existing DCB abstraction) so that multi-tenant deployments work without change. Physical table names can optionally include the service id via a custom resolver.
+
+---
+
+## 13. Error handling
+
+- SQL execution failures inside a transaction: transaction rolls back; `current_position` is NOT advanced; the event will be retried on next worker iteration
+- Non-idempotent writes: mitigated by `_last_sortable_unique_id` guards in user-written SQL
+- Schema mismatch (old code against new table): `status` stays in `initializing` until `InitializeAsync` succeeds
+- Poison events (event that always throws in `ApplyToViewAsync`): future work — for PoC, log and halt the worker
+
+---
+
+## 14. Testing strategy
+
+1. **Unit tests for `ApplyToViewAsync`**: purely check the returned `MvSqlStatement` list
+2. **Integration tests with Testcontainers for Postgres**: real database, ensure SQL is valid and results are correct
+3. **Cross-model parity tests**: a sample MV and a sample `ICoreMultiProjector<T>` fed the same events should converge to semantically equivalent read results (keys present in both, same totals, etc.)
+4. **Idempotency tests**: replay same events twice, assert final state is identical
+5. **Version switch tests**: v1 active → v2 catches up → activate v2 → validate read-side continuity
+
+---
+
+## 15. Why this design is right for DCB
+
+- **Parallel, not replacing**: zero risk to existing snapshot-based multi-projections
+- **Minimal public surface**: 3 interfaces + 1 value type + optional IMvRow/MvRowMapper
+- **No dialect abstraction leak**: developer owns SQL, framework owns orchestration
+- **Reuses DCB primitives**: `IEventStore`, `SortableUniqueId`, `ServiceId`, safe window
+- **Name-clash-free**: every new public type uses `MaterializedView` / `Mv*` naming
+- **WASM-ready**: everything at the boundary is string or JSON
+- **Testable**: `ApplyToViewAsync` is pure enough to unit-test against the returned statement list
+- **AI-convertible**: existing `ICoreMultiProjector<T>` code can be mechanically translated (see `integration-notes.md`)
+
+## 16. What this design deliberately avoids
+
+- Rich `ISqlOperation` / `IDbDialect` abstractions (rejected: leaky, expensive)
+- `Insert/Update/Upsert` methods on `MvTable` (rejected: SQL dialect differences)
+- Entity Framework integration (rejected: migration model conflicts with multi-version coexistence)
+- Query DSL on the read side (deferred: out of PoC scope)
+- Cross-view writes (forbidden: would break isolation guarantees)
+- Automatic schema diffing / auto-migration (deferred: DDL authorship stays with the developer for now)
+- Reusing any existing DCB type name (rejected: `MaterializedView` / `Mv*` is the unified prefix)
+
+## 17. Open questions
+
+See `open-questions.md`.

--- a/tasks/db-projection-read-model/design.md
+++ b/tasks/db-projection-read-model/design.md
@@ -1,7 +1,7 @@
 # DCB Materialized View — Design Document
 
 **Status**: Proposal (design-only, no implementation in this PR)
-**Scope**: New public API in `Sekiban.Dcb.Core` (new interfaces), new packages `Sekiban.Dcb.MaterializedView` + `Sekiban.Dcb.MaterializedView.Postgres`, integration with existing event store
+**Scope**: New .NET authoring API in `Sekiban.Dcb.MaterializedView` plus `Sekiban.Dcb.MaterializedView.Postgres`, with a future language-neutral runtime protocol for Wasm/remote execution, integrated with the existing event store
 **Working name**: **"DCB Materialized View"** (DCB MV / `Mv*`). The feature is distinct from the existing multi-projection model and uses a separate name to avoid confusion.
 
 ---
@@ -60,8 +60,8 @@ The term **Materialized View** was chosen deliberately because:
 4. Make the developer experience familiar to users of `ICoreMultiProjector<T>` — "same mental model, different target"
 5. Keep **SQL authorship in the developer's hands** — no SQL dialect abstraction leaks
 6. Provide **row metadata** for idempotency and debugging (`_last_sortable_unique_id`)
-7. Allow **cross-view reads** during apply, via a context helper that resolves the active version of another materialized view
-8. Be **WASM-friendly**: all boundary data is JSON or string-shaped
+7. Allow **cross-view reads** during apply, via a context helper that resolves a dependency-pinned version of another materialized view rather than a live mutable active pointer
+8. Keep the **.NET authoring API idiomatic** while reserving a separate language-neutral runtime protocol for future Wasm/remote execution
 9. Keep all names distinct from existing DCB types so code search and IntelliSense stay unambiguous
 
 ### Non-goals
@@ -92,7 +92,7 @@ A DCB materialized view has exactly two phases:
 
 **Phase 1 (Initialize)** runs once when the view version is first registered in the MV registry. It creates the physical tables, indexes, and any preparatory structures.
 
-**Phase 2 (Apply)** runs for every event during catch-up and steady-state. It consumes an event, optionally reads existing rows, and returns a list of `MvSqlStatement`s describing the writes. The framework executes the list inside a single transaction and advances `current_position`.
+**Phase 2 (Apply)** runs for every event during catch-up and steady-state. It consumes an event, optionally reads existing rows, and returns a list of `MvSqlStatement`s describing the writes. The framework opens a transaction first, binds the apply context to that transaction/snapshot, performs the reads through that context, then executes the returned list and advances `current_position` in the same transaction.
 
 The apply method is named `ApplyToViewAsync` (not `ApplyAsync` or `ProjectAsync`) to make its purpose unmistakable and avoid visual confusion with `ICoreMultiProjector.Project` when both types appear in the same file.
 
@@ -112,7 +112,7 @@ This has several benefits:
 - **Dry-run / logging is trivial** — you have all the SQL as data
 - **Pipeline optimization** — framework can log/audit/transform before executing
 
-Reads **are** executed immediately through the context, since apply logic often needs to read existing rows and branch on them. Separating "reads happen now, writes happen at the end" is conceptually clean.
+Reads **are** executed immediately through the context, since apply logic often needs to read existing rows and branch on them. The important contract is that those reads happen against the **same transaction/snapshot** that later executes the returned writes, so the read-modify-write cycle stays consistent.
 
 ### 3.3 Developer writes SQL; framework abstracts nothing
 
@@ -150,17 +150,19 @@ The `IMvApplyContext` exposes `CurrentSortableUniqueId` so user code can embed i
 
 ### 3.5 Cross-view reads
 
-Apply logic sometimes needs to read from **another** materialized view to compute its writes (e.g., `OrderSummaryMv.ApplyToViewAsync(OrderItemAdded)` reads a discount tier from `CustomerSummaryMv`). This is supported through:
+Apply logic sometimes needs to read from **another** materialized view to compute its writes (e.g., `OrderSummaryMv.ApplyToViewAsync(OrderItemAdded)` reads a discount tier from `CustomerSummaryMv`). This must **not** resolve "whatever version is active right now", because replaying the same event stream after an activation change would otherwise produce different results.
+
+When cross-view reads are added, they are supported through a **dependency-pinned** resolver:
 
 ```csharp
-MvTable GetActiveViewTable(string viewName, string logicalTable);
-MvTable GetActiveViewTable<TView>(string logicalTable)
+MvTable GetDependencyViewTable(string viewName, string logicalTable);
+MvTable GetDependencyViewTable<TView>(string logicalTable)
     where TView : IMaterializedViewProjector;
 ```
 
-The resolution uses the **MV registry + MV active** tables (see §5) to locate the currently-active version's physical table name. Writes are forbidden across views — you can only read from another view. Your own view's writes are the only thing returned from `ApplyToViewAsync`.
+The resolution uses a **pinned dependency version map** captured for the current view version and stored in MV metadata. The apply context resolves physical table names from that pinned map, not from a live `sekiban_mv_active` lookup on every call. Writes are forbidden across views — you can only read from another view. Your own view's writes are the only thing returned from `ApplyToViewAsync`.
 
-**Consistency caveat**: during catch-up, the "other view" may be at an earlier `current_position` than your view. This is an eventually-consistent system; document it clearly.
+**Consistency caveat**: during catch-up, the dependency view may still be at an earlier `current_position` than your view. This is an eventually-consistent system; the contract here is deterministic replay, not global serializability.
 
 ---
 
@@ -181,13 +183,13 @@ IMvInitContext                             (framework provides)
  └── ExecuteAsync(sql, params)              ← used for CREATE TABLE/INDEX
 
 IMvApplyContext                            (framework provides)
- ├── DbType, Connection
+ ├── DbType, Connection, Transaction
  ├── CurrentEvent, CurrentSortableUniqueId
  ├── QuerySingleOrDefaultAsync<T>(sql, params)
  ├── QueryAsync<T>(sql, params)
  ├── QuerySingleOrDefaultRowAsync(sql, params): IMvRow?
  ├── QueryRowsAsync(sql, params): IMvRowSet
- └── GetActiveViewTable(viewName, logicalTable): MvTable
+ └── GetDependencyViewTable(viewName, logicalTable): MvTable
 ```
 
 ### 4.1 `IMaterializedViewProjector`
@@ -241,6 +243,8 @@ public readonly record struct MvSqlStatement(string Sql, object? Parameters = nu
 
 A value type. `Sql` is a raw SQL string (parameterized via `@name` placeholders). `Parameters` is an anonymous object or POCO compatible with Dapper's parameter model.
 
+`MvSqlStatement` is part of the **.NET authoring surface**, not the future cross-language ABI. A Wasm/remote runtime will use a separate serialized contract and a host adapter that converts the protocol's parameter payload into this host-side form.
+
 The name `MvSqlStatement` was chosen over plain `SqlStatement` to avoid ambiguity with any general-purpose "sql statement" type that might exist elsewhere in DCB or the broader .NET ecosystem.
 
 ### 4.4 Contexts
@@ -259,6 +263,7 @@ public interface IMvApplyContext
 {
     DbType DbType { get; }
     IDbConnection Connection { get; }
+    IDbTransaction Transaction { get; }
 
     IEvent CurrentEvent { get; }
     string CurrentSortableUniqueId { get; }
@@ -274,13 +279,15 @@ public interface IMvApplyContext
     Task<IMvRowSet> QueryRowsAsync(string sql, object? param = null);
 
     // Cross-view table resolution
-    MvTable GetActiveViewTable(string viewName, string logicalTable);
-    MvTable GetActiveViewTable<TView>(string logicalTable)
+    MvTable GetDependencyViewTable(string viewName, string logicalTable);
+    MvTable GetDependencyViewTable<TView>(string logicalTable)
         where TView : IMaterializedViewProjector;
 }
 ```
 
-`IDbConnection` is exposed as an escape hatch — developers who want to use Dapper directly (or Npgsql's COPY, or anything else) can do so without fighting the framework.
+`IMvInitContext` and `IMvApplyContext` are **.NET host-side authoring interfaces**. They are intentionally idiomatic .NET and are not themselves the Wasm/remote ABI. Future multi-language execution uses a separate serialized runtime protocol whose host adapter provides these interfaces to the .NET implementation.
+
+`IDbConnection` is exposed as an escape hatch — developers who want to use Dapper directly (or Npgsql's COPY, or anything else) can do so without fighting the framework. `IMvApplyContext.Transaction` and all read methods are bound to the same transaction/snapshot that later executes the returned statements.
 
 ---
 
@@ -328,9 +335,9 @@ CREATE TABLE sekiban_mv_registry (
     status                   TEXT NOT NULL,   -- initializing / catching_up / ready / active / retired
     current_position         TEXT,            -- last SortableUniqueId applied
     target_position          TEXT,            -- position at which catch-up is considered "ready"
-    last_sortable_unique_id  TEXT,            -- used by cross-view integrity checks
+    last_sortable_unique_id  TEXT,            -- used by dependency integrity checks
     last_updated             TIMESTAMPTZ NOT NULL,
-    metadata                 JSONB,
+    metadata                 JSONB,           -- future: dependency version map, operator metadata
     PRIMARY KEY (service_id, view_name, view_version, logical_table)
 );
 
@@ -490,7 +497,7 @@ Notice the POCOs used for reads are named `OrderRow`, `OrderItemRow` — avoidin
 
 Dapper is an excellent library and will be used **internally** in the initial Postgres implementation. But:
 
-- The public interface must not force callers (especially WASM-based MV code) to depend on Dapper types
+- The public authoring surface must not force callers, adapters, or future runtime-protocol implementations to depend on Dapper types
 - Alternative backends (Npgsql direct, ADO.NET, native Postgres driver) should be pluggable
 - WASM multi-language scenarios need an ABI-friendly row representation
 
@@ -581,23 +588,41 @@ The generator emits a `public static OrderRow FromMvRow(IMvRow row)`. This is ou
 
 ---
 
-## 8. WASM ABI considerations
+## 8. Runtime protocol / WASM considerations
 
-### 8.1 The constraint
+### 8.1 Two layers, not one
+
+This design intentionally separates two concerns:
+
+1. **.NET authoring API**
+   - `IMaterializedViewProjector`
+   - `IMvInitContext`
+   - `IMvApplyContext`
+   - `MvSqlStatement`
+2. **Language-neutral runtime protocol** (future)
+   - serialized apply request / response messages
+   - serialized read request / row result messages
+   - serialized statement list messages
+
+The .NET authoring API is optimized for maintainable .NET code. The future runtime protocol is optimized for Wasm/remote execution. They are related, but they are **not the same interface**.
+
+### 8.2 The constraint
 
 WebAssembly ABIs can only pass primitive types (`i32`, `i64`, `f32`, `f64`) and byte ranges (pointer + length). Complex C# types cannot cross the boundary directly; they must be serialized.
 
-For this framework, the items that must cross the host ↔ guest boundary are:
+That means a Wasm or remote guest must never see `IDbConnection`, `IDbTransaction`, `object? param`, or `IEvent` directly. A host adapter converts between the runtime protocol and the host-side authoring API.
+
+For this framework, the items that must cross the host ↔ guest boundary are therefore:
 
 | Direction | Payload | Suggested form |
 |---|---|---|
 | guest → host | SQL string | UTF-8 bytes |
 | guest → host | SQL parameters | JSON |
-| host → guest | Event to apply | JSON |
+| host → guest | Event envelope to apply | JSON |
 | host → guest | Row data (read result) | **JSON (PoC)** → MessagePack (opt) |
 | guest → host | `MvSqlStatement` list | JSON |
 
-### 8.2 Cost analysis
+### 8.3 Cost analysis
 
 Per-event marshaling cost estimate with JSON:
 
@@ -618,11 +643,11 @@ Throughput impact:
 
 **Conclusion**: JSON is sufficient for PoC and for most operational workloads. Extreme catch-up throughput should either use MessagePack at the boundary or stay on the native (non-WASM) path entirely.
 
-### 8.3 Key observation
+### 8.4 Key observation
 
 **SQL strings and parameters have effectively zero marshaling overhead** — they're UTF-8 strings that pass as `(ptr, len)`. The only expensive direction is row data coming back from reads. This is a well-bounded optimization target.
 
-### 8.4 Decimal handling
+### 8.5 Decimal handling
 
 `decimal` through JSON loses precision. Options, in order of preference:
 
@@ -749,9 +774,12 @@ while (!cancellationToken.IsCancellationRequested)
             break;
         }
 
-        var statements = await view.ApplyToViewAsync(ev.ToEvent(), applyContext);
-
         using var tx = connection.BeginTransaction();
+        var dependencyMap = await registry.GetPinnedDependencyMapAsync(
+            viewName, viewVersion, tx);
+        var applyContext = new PostgresMvApplyContext(
+            connection, tx, ev.ToEvent(), dependencyMap);
+        var statements = await view.ApplyToViewAsync(ev.ToEvent(), applyContext);
         foreach (var stmt in statements)
             await connection.ExecuteAsync(stmt.Sql, stmt.Parameters, tx);
         await registry.UpdatePositionAsync(
@@ -765,7 +793,7 @@ while (!cancellationToken.IsCancellationRequested)
 
 ### 10.3 Activation and rollback
 
-Activation is an atomic update of `sekiban_mv_active.active_version`. Optionally, a view-based read side (§11) allows activation to also `CREATE OR REPLACE VIEW` so external consumers see the switch atomically.
+Activation is an atomic update of `sekiban_mv_active.active_version`. When dependency-aware views are introduced, activation also captures the dependency version map that the new active version will read against. Optionally, a view-based read side (§11) allows activation to also `CREATE OR REPLACE VIEW` so external consumers see the switch atomically.
 
 Rollback from v2 to v1 is equally simple: update `active_version` back. Both versions' data tables remain intact until the operator issues `RETIRE`.
 
@@ -815,7 +843,7 @@ All registry and active entries are scoped by `service_id`. The default resolver
 - **No dialect abstraction leak**: developer owns SQL, framework owns orchestration
 - **Reuses DCB primitives**: `IEventStore`, `SortableUniqueId`, `ServiceId`, safe window
 - **Name-clash-free**: every new public type uses `MaterializedView` / `Mv*` naming
-- **WASM-ready**: everything at the boundary is string or JSON
+- **Runtime-protocol-ready**: the future Wasm/remote boundary is explicitly separate from the .NET authoring API
 - **Testable**: `ApplyToViewAsync` is pure enough to unit-test against the returned statement list
 - **AI-convertible**: existing `ICoreMultiProjector<T>` code can be mechanically translated (see `integration-notes.md`)
 

--- a/tasks/db-projection-read-model/design.md
+++ b/tasks/db-projection-read-model/design.md
@@ -121,7 +121,7 @@ The framework does **not** provide `Upsert(row)`, `Insert(row)`, `Update(row)` h
 - SQL dialects diverge deeply (JSONB, UPSERT, interval types, partitioning). Any abstraction leaks.
 - Dapper already gives a great minimal API surface; we don't need another layer
 - Debugging and performance tuning are far easier when you see the actual SQL in your code
-- When a view needs to target two DBs, the developer `switch`es on `ctx.DbType` once — no framework-wide dialect system needed
+- When a view needs to target two DBs, the developer `switch`es on `ctx.DatabaseType` once — no framework-wide dialect system needed
 
 The framework provides:
 - **Physical table name resolution** (via `MvTable.PhysicalName`)
@@ -178,12 +178,12 @@ IMaterializedViewProjector                 (user implements)
 MvSqlStatement (record struct)             (value type, framework-executed)
 
 IMvInitContext                             (framework provides)
- ├── DbType, Connection
+ ├── DatabaseType, Connection
  ├── RegisterTable(logicalName): MvTable
  └── ExecuteAsync(sql, params)              ← used for CREATE TABLE/INDEX
 
 IMvApplyContext                            (framework provides)
- ├── DbType, Connection, Transaction
+ ├── DatabaseType, Connection, Transaction
  ├── CurrentEvent, CurrentSortableUniqueId
  ├── QuerySingleOrDefaultAsync<T>(sql, params)
  ├── QueryAsync<T>(sql, params)
@@ -252,7 +252,7 @@ The name `MvSqlStatement` was chosen over plain `SqlStatement` to avoid ambiguit
 ```csharp
 public interface IMvInitContext
 {
-    DbType DbType { get; }
+    MvDbType DatabaseType { get; }
     IDbConnection Connection { get; }
 
     MvTable RegisterTable(string logicalName);
@@ -261,7 +261,7 @@ public interface IMvInitContext
 
 public interface IMvApplyContext
 {
-    DbType DbType { get; }
+    MvDbType DatabaseType { get; }
     IDbConnection Connection { get; }
     IDbTransaction Transaction { get; }
 
@@ -286,6 +286,8 @@ public interface IMvApplyContext
 ```
 
 `IMvInitContext` and `IMvApplyContext` are **.NET host-side authoring interfaces**. They are intentionally idiomatic .NET and are not themselves the Wasm/remote ABI. Future multi-language execution uses a separate serialized runtime protocol whose host adapter provides these interfaces to the .NET implementation.
+
+`MvDbType` is a small MV-specific enum (`Postgres`, future `Sqlite`, etc.). It is intentionally named to avoid confusion with `System.Data.DbType`, whose values represent parameter/column types rather than a database engine.
 
 `IDbConnection` is exposed as an escape hatch — developers who want to use Dapper directly (or Npgsql's COPY, or anything else) can do so without fighting the framework. `IMvApplyContext.Transaction` and all read methods are bound to the same transaction/snapshot that later executes the returned statements.
 
@@ -314,12 +316,14 @@ Examples:
 The naming is deterministic. Overrides are allowed at DI registration time:
 
 ```csharp
-services.AddSekibanMaterializedView(opts =>
+services.AddSekibanDcbMaterializedView(opts =>
 {
     opts.PhysicalNameResolver = (view, version, logical)
-        => $"sekiban_mv_{TenantContext.Current}_{view}_v{version}_{logical}";
+        => $"sekiban_mv_{SanitizeIdentifier(TenantContext.Current)}_{view}_v{version}_{logical}";
 });
 ```
+
+Any custom `PhysicalNameResolver` must return an already-sanitized identifier segment set (`[A-Za-z0-9_]` after normalization in the default implementation). The framework should validate or reject invalid names before embedding them in DDL.
 
 ### 5.2 MV registry and active tables
 
@@ -400,7 +404,7 @@ public class OrderSummaryMvV1 : IMaterializedViewProjector
             """);
 
         await ctx.ExecuteAsync($"""
-            CREATE INDEX IF NOT EXISTS idx_{Items.LogicalName}_order_id
+            CREATE INDEX IF NOT EXISTS idx_{Items.PhysicalName}_order_id
             ON {Items.PhysicalName} (order_id)
             """);
     }
@@ -547,14 +551,14 @@ Column access is **by name only** — deliberately no positional accessors. This
 ### 7.3 `MvRowMapper<T>` (convention-based default)
 
 ```csharp
-public static class MvRowMapper<T> where T : class, new()
+public static class MvRowMapper<T> where T : class
 {
     public static T MapFrom(IMvRow row);               // Expression-tree compiled, cached
     public static IReadOnlyList<T> MapAll(IMvRowSet set);
 }
 ```
 
-Convention: `snake_case` column → `PascalCase` property, with `[MvColumn("...")]` as an override. Implementation compiles to an `Expression<Func<IMvRow, T>>` once per type and caches it — reflection overhead only on first use.
+Convention: `snake_case` column → `PascalCase` property, with `[MvColumn("...")]` as an override. Implementation compiles to an `Expression<Func<IMvRow, T>>` once per type and caches it — reflection overhead only on first use. The mapper is expected to support both property-based population and record primary constructors / `init`-only members; a parameterless constructor is not required.
 
 ### 7.4 Extension methods on the context
 
@@ -563,7 +567,7 @@ public static class MvApplyContextExtensions
 {
     public static async Task<T?> QuerySingleOrDefaultAsync<T>(
         this IMvApplyContext ctx, string sql, object? param = null)
-        where T : class, new()
+        where T : class
     {
         var row = await ctx.QuerySingleOrDefaultRowAsync(sql, param);
         return row is null ? null : MvRowMapper<T>.MapFrom(row);
@@ -663,7 +667,7 @@ For PoC, always encode `decimal` as a string at the ABI boundary.
 
 ### 9.1 `IEventStore`
 
-No changes required. The new MV catch-up worker reads events via `ReadAllSerializableEventsAsync(since: currentPosition, maxCount: batchSize)` and feeds them to `ApplyToViewAsync`.
+No changes required. The new MV catch-up worker reads events via `ReadAllSerializableEventsAsync(since: currentPosition, maxCount: batchSize)` and feeds successful results to `ApplyToViewAsync`. Read failures remain part of the worker contract because the underlying API returns `ResultBox<IEnumerable<SerializableEvent>>`.
 
 ### 9.2 `SortableUniqueId`
 
@@ -762,9 +766,29 @@ This guarantees code search like "grep -rn 'MultiProjector'" returns only the ex
 ```csharp
 while (!cancellationToken.IsCancellationRequested)
 {
-    var batch = await eventStore.ReadAllSerializableEventsAsync(
+    var readResult = await eventStore.ReadAllSerializableEventsAsync(
         since: currentPosition, maxCount: BatchSize);
-    if (!batch.Any()) { await Task.Delay(pollInterval); continue; }
+    if (!readResult.IsSuccess)
+    {
+        if (readResult.GetException() is NotSupportedException unsupported)
+        {
+            logger.LogError(
+                unsupported,
+                "ReadAllSerializableEventsAsync is not supported by the configured event store. Stopping catch-up worker for {ViewName}/{ViewVersion}.",
+                viewName, viewVersion);
+            break;
+        }
+
+        logger.LogWarning(
+            readResult.GetException(),
+            "Failed to read events for {ViewName}/{ViewVersion}. Retrying after delay.",
+            viewName, viewVersion);
+        await Task.Delay(pollInterval, cancellationToken);
+        continue;
+    }
+
+    var batch = readResult.GetValue().ToList();
+    if (batch.Count == 0) { await Task.Delay(pollInterval, cancellationToken); continue; }
 
     foreach (var ev in batch)
     {
@@ -783,7 +807,7 @@ while (!cancellationToken.IsCancellationRequested)
         foreach (var stmt in statements)
             await connection.ExecuteAsync(stmt.Sql, stmt.Parameters, tx);
         await registry.UpdatePositionAsync(
-            viewName, viewVersion, ev.SortableUniqueId, tx);
+            viewName, viewVersion, ev.SortableUniqueId, tx); // updates all logical_table rows for the view/version
         tx.Commit();
 
         currentPosition = ev.SortableUniqueId;

--- a/tasks/db-projection-read-model/integration-notes.md
+++ b/tasks/db-projection-read-model/integration-notes.md
@@ -1,0 +1,196 @@
+# DCB Materialized View — Integration Notes
+
+How the new DCB Materialized View subsystem fits alongside the existing DCB code. This document is the reference for reviewers who want to understand what will change (and what will NOT change) when the MV implementation lands.
+
+---
+
+## 1. Existing DCB concepts the MV subsystem reuses (unchanged)
+
+| Concept | Source location | Usage by MV |
+|---|---|---|
+| `IEvent` | `Sekiban.Dcb.Core.Model/Events/` | Input to `ApplyToViewAsync` |
+| `SortableUniqueId` | `Sekiban.Dcb.Core.Model/Common/SortableUniqueId.cs` | Position tracking in registry, idempotency guard |
+| `IEventStore` | `Sekiban.Dcb.Core/Storage/IEventStore.cs` | Reads events for catch-up via `ReadAllSerializableEventsAsync` |
+| `ServiceId` / `IServiceIdProvider` | existing | Multi-tenant isolation in `sekiban_mv_registry` and `sekiban_mv_active` |
+| `ResultBox<T>` | `ResultBoxes` package | Used for public method return types consistent with existing DCB style |
+| `SortableUniqueId.SafeMilliseconds` (5000ms) | existing | MV catch-up worker respects the same safe window |
+
+**Nothing in the above list changes**. MV implementation only reads these types and calls their methods.
+
+---
+
+## 2. Existing DCB concepts the MV subsystem deliberately does NOT reuse
+
+| Concept | Why not |
+|---|---|
+| `ICoreMultiProjector<T>` | MV has a completely different authoring model (instance interface vs static abstract, row writes vs record transforms, DB state vs in-memory state). Sharing the interface would force confusing compromises. |
+| `MultiProjectionStateBuilder` | MV has its own `MvCatchUpWorker`. The existing builder is deeply tied to blob snapshot semantics. |
+| `IMultiProjectionStateStore` | MV has its own `IMvRegistryStore`. Different storage shape, different contract. |
+| `DbMultiProjectionState` (Postgres) | MV has its own tables `sekiban_mv_registry` and `sekiban_mv_active`. |
+| `SafeUnsafeProjectionState<K,V>` | MV does not use in-memory dual-state; the safe window is applied at the worker level (see §5.4). |
+| `SafeProjection<T>` / `UnsafeProjection<T>` | Same reason. |
+| `GeneralMultiProjectionActor` / related Orleans grains | MV runs in `IHostedService` (PoC); Orleans integration is deferred. |
+| `MultiProjectionStateRecord` / `MultiProjectionStateWriteRequest` | MV has its own record types (`MvRegistryEntry`, `MvActiveEntry`). |
+
+This is a **deliberate parallel subsystem**, not an extension of the existing one.
+
+---
+
+## 3. What is added to the repository
+
+### 3.1 New projects
+
+```
+dcb/src/Sekiban.Dcb.MaterializedView/
+├── Sekiban.Dcb.MaterializedView.csproj
+├── Abstractions/
+│   ├── IMaterializedViewProjector.cs
+│   ├── MvTable.cs
+│   ├── MvSqlStatement.cs
+│   ├── IMvInitContext.cs
+│   ├── IMvApplyContext.cs
+│   ├── IMvRow.cs
+│   ├── IMvRowSet.cs
+│   └── MvColumnAttribute.cs
+├── Registry/
+│   ├── IMvRegistryStore.cs
+│   ├── MvRegistryEntry.cs
+│   ├── MvActiveEntry.cs
+│   ├── MvStatus.cs
+│   └── PhysicalNameResolver.cs
+├── Mapping/
+│   └── MvRowMapper.cs
+├── Execution/
+│   ├── IMvExecutor.cs
+│   ├── MvCatchUpWorker.cs
+│   └── MvWorkerOptions.cs
+└── Helpers/
+    └── MvSchemaHelper.cs
+
+dcb/src/Sekiban.Dcb.MaterializedView.Postgres/
+├── Sekiban.Dcb.MaterializedView.Postgres.csproj
+├── PostgresMvRegistryStore.cs
+├── PostgresMvInitContext.cs
+├── PostgresMvApplyContext.cs
+├── PostgresMvRow.cs
+├── PostgresMvRowSet.cs
+└── ServiceCollectionExtensions.cs
+```
+
+### 3.2 Changes to existing files
+
+**The implementation PR will touch exactly these existing files** (listed here for review planning):
+
+- `Sekiban.slnx` — add two new projects
+- `dcb/src/Directory.Build.props` — include the new projects in the family if a family-level setting exists
+- `dcb/src/Directory.Packages.props` — add `MessagePack` if MessagePack is adopted (not for PoC); `Dapper` likely already exists
+- `internalUsages/DcbOrleans.AppHost/` — register a sample MV and its worker (PoC acceptance criterion #1)
+
+**Everything else in `dcb/src/Sekiban.Dcb.Core`, `Sekiban.Dcb.Core.Model`, `Sekiban.Dcb.Postgres`, `Sekiban.Dcb.CosmosDb`, `Sekiban.Dcb.Sqlite`, `Sekiban.Dcb.DynamoDB`, `Sekiban.Dcb.Orleans.Core`, etc. — is untouched.**
+
+### 3.3 Changes in THIS design PR
+
+Only the following files are added in this design PR:
+
+```
+tasks/db-projection-read-model/
+├── README.md
+├── design.md
+├── tasks.md
+├── poc-scope.md
+├── open-questions.md
+└── integration-notes.md
+```
+
+**No code. No csproj. No sln changes.**
+
+---
+
+## 4. Comparison table: existing multi-projector vs new MV
+
+| Aspect | `ICoreMultiProjector<T>` (existing) | `IMaterializedViewProjector` (new) |
+|---|---|---|
+| Interface style | `static abstract` members | instance interface |
+| State shape | In-memory record tree `T` | Rows in real SQL tables |
+| Persistence | Gzipped JSON blob in `dcb_multi_projection_states` | Real tables in `sekiban_mv_*_v*_*` |
+| Snapshot build | `MultiProjectionStateBuilder` rebuilds from events | `MvCatchUpWorker` applies events incrementally |
+| Storage backend | Pluggable (`IMultiProjectionStateStore`): Postgres/Cosmos/DynamoDB/SQLite | Pluggable (`IMvRegistryStore` + Dapper): Postgres (first), others later |
+| Version identifier | `MultiProjectorVersion` (string) | `ViewVersion` (int) |
+| Write semantics | Return new `T` from `Project` | Return `IReadOnlyList<MvSqlStatement>` from `ApplyToViewAsync` |
+| Transaction boundary | Entire snapshot write | Per-event (returned list = 1 transaction) |
+| Reads during apply | All state in memory | SQL reads via context (`QuerySingleOrDefaultAsync` etc.) |
+| Cross-projector reads | Not directly supported | Supported via `GetActiveViewTable` |
+| Safe/unsafe handling | `SafeUnsafeProjectionState<K,V>` in memory | Worker delays apply of unsafe events |
+| Actor hosting | Orleans `GeneralMultiProjectionActor` | `IHostedService` (PoC), Orleans grain later |
+| BI tool queryable | No (blob) | Yes (real tables) |
+| Size scalability | Limited by blob size + offload | Limited by PostgreSQL |
+| Schema evolution | Replace `MultiProjectorVersion`, rebuild from scratch | Create new version alongside, catch up, atomic switch |
+
+The two models solve overlapping but distinct problems. Users will pick based on their read-access patterns and data size.
+
+---
+
+## 5. Semantic parity guarantees (what MV does NOT promise)
+
+- MV does NOT guarantee it produces identical state to an equivalent `ICoreMultiProjector<T>`. They have different write semantics.
+- MV does NOT participate in DCB's conditional-append / optimistic concurrency mechanism. MV is pure read-model materialization, downstream of the event store.
+- MV does NOT try to be an actor model. Catch-up is a background job; query access is direct DB access.
+- MV does NOT expose its state via Orleans grains (in PoC). If Orleans-based query access is needed later, that's a follow-up effort.
+
+---
+
+## 6. Data ownership and coexistence
+
+One DCB service can run both:
+
+```
+┌──────────────────────────────────────────────┐
+│ Event Store (dcb_events, dcb_tags)           │  ← shared source of truth
+└──────────┬───────────────────────────────────┘
+           │
+     ┌─────┴─────┐
+     ▼           ▼
+┌─────────┐  ┌───────────────┐
+│ Multi   │  │ Materialized  │
+│ Projector│ │ View          │
+│ (blob)  │  │ (tables)      │
+└─────────┘  └───────────────┘
+     │              │
+     ▼              ▼
+dcb_multi_   sekiban_mv_registry
+projection_  sekiban_mv_active
+states       sekiban_mv_ordersummary_v1_*
+             sekiban_mv_customersummary_v1_*
+```
+
+Both consume the same event store; neither writes to the other's tables. They can be mixed freely in the same application.
+
+---
+
+## 7. Migration path (existing → MV)
+
+For users who want to migrate an existing `ICoreMultiProjector<T>` to a materialized view:
+
+1. Keep the existing projector running (zero risk)
+2. Author a new `IMaterializedViewProjector` with equivalent logic
+3. Run both in parallel; compare query results over time
+4. When confident, switch application reads to the MV
+5. Eventually retire the old projector
+
+There is no automated migration tool. The design PR's AI-conversion mapping (see `design.md` §10 in the `ICoreMultiProjector` version of the source, or the project README) serves as guidance for machine-assisted translation.
+
+---
+
+## 8. Review checklist for the implementation PR (future)
+
+When the PoC implementation PR comes in, reviewers should verify:
+
+- [ ] No changes to any file under `dcb/src/Sekiban.Dcb.Core/MultiProjections/`
+- [ ] No changes to any file under `dcb/src/Sekiban.Dcb.Core.Model/MultiProjections/`
+- [ ] No changes to any file under `dcb/src/Sekiban.Dcb.Postgres/` (except possibly shared Dapper version bumps via `Directory.Packages.props`)
+- [ ] No changes to `GeneralMultiProjectionActor` or any `MultiProjectionStateBuilder`-related code
+- [ ] No changes to `IMultiProjectionStateStore` implementations (Postgres/Cosmos/SQLite/DynamoDB)
+- [ ] New projects `Sekiban.Dcb.MaterializedView` and `Sekiban.Dcb.MaterializedView.Postgres` have their own test projects under `dcb/tests/` or equivalent
+- [ ] All public types use `MaterializedView` / `Mv*` naming — no accidental `Projection` / `Projector` reuse
+- [ ] `sekiban_mv_*` table prefix is used consistently; no collisions with existing `dcb_*` tables
+- [ ] `ServiceId` is honored everywhere (all registry operations are service-scoped)

--- a/tasks/db-projection-read-model/integration-notes.md
+++ b/tasks/db-projection-read-model/integration-notes.md
@@ -8,7 +8,7 @@ How the new DCB Materialized View subsystem fits alongside the existing DCB code
 
 | Concept | Source location | Usage by MV |
 |---|---|---|
-| `IEvent` | `Sekiban.Dcb.Core.Model/Events/` | Input to `ApplyToViewAsync` |
+| `IEvent` | `Sekiban.Dcb.Core.Model/Events/` | Input to the .NET authoring form of `ApplyToViewAsync` |
 | `SortableUniqueId` | `Sekiban.Dcb.Core.Model/Common/SortableUniqueId.cs` | Position tracking in registry, idempotency guard |
 | `IEventStore` | `Sekiban.Dcb.Core/Storage/IEventStore.cs` | Reads events for catch-up via `ReadAllSerializableEventsAsync` |
 | `ServiceId` / `IServiceIdProvider` | existing | Multi-tenant isolation in `sekiban_mv_registry` and `sekiban_mv_active` |
@@ -117,9 +117,9 @@ tasks/db-projection-read-model/
 | Storage backend | Pluggable (`IMultiProjectionStateStore`): Postgres/Cosmos/DynamoDB/SQLite | Pluggable (`IMvRegistryStore` + Dapper): Postgres (first), others later |
 | Version identifier | `MultiProjectorVersion` (string) | `ViewVersion` (int) |
 | Write semantics | Return new `T` from `Project` | Return `IReadOnlyList<MvSqlStatement>` from `ApplyToViewAsync` |
-| Transaction boundary | Entire snapshot write | Per-event (returned list = 1 transaction) |
+| Transaction boundary | Entire snapshot write | Per-event read + returned writes + registry update in 1 transaction |
 | Reads during apply | All state in memory | SQL reads via context (`QuerySingleOrDefaultAsync` etc.) |
-| Cross-projector reads | Not directly supported | Supported via `GetActiveViewTable` |
+| Cross-projector reads | Not directly supported | Deferred in PoC; future support via dependency-pinned `GetDependencyViewTable` |
 | Safe/unsafe handling | `SafeUnsafeProjectionState<K,V>` in memory | Worker delays apply of unsafe events |
 | Actor hosting | Orleans `GeneralMultiProjectionActor` | `IHostedService` (PoC), Orleans grain later |
 | BI tool queryable | No (blob) | Yes (real tables) |
@@ -136,6 +136,7 @@ The two models solve overlapping but distinct problems. Users will pick based on
 - MV does NOT participate in DCB's conditional-append / optimistic concurrency mechanism. MV is pure read-model materialization, downstream of the event store.
 - MV does NOT try to be an actor model. Catch-up is a background job; query access is direct DB access.
 - MV does NOT expose its state via Orleans grains (in PoC). If Orleans-based query access is needed later, that's a follow-up effort.
+- MV's public .NET authoring interfaces do NOT double as the Wasm/remote ABI. Multi-language execution, when added, uses a separate serialized runtime protocol and host adapters.
 
 ---
 

--- a/tasks/db-projection-read-model/open-questions.md
+++ b/tasks/db-projection-read-model/open-questions.md
@@ -1,0 +1,92 @@
+# DCB Materialized View — Open Questions
+
+Open questions from the design discussion, grouped by category. Each is tagged as `[PoC]` (must be decided before PoC starts), `[impl]` (can be decided during implementation), or `[later]` (can be deferred to a post-PoC phase).
+
+---
+
+## Naming and public surface
+
+- `[PoC]` Should the core interface be `IMaterializedViewProjector` or simply `IMvProjector`? The longer form is more searchable, the shorter form is easier to type. **Current preference: `IMaterializedViewProjector`** with `Mv*` prefix for supporting types.
+- `[PoC]` Is `ApplyToViewAsync` the right method name, or would `MaterializeAsync` / `HandleAsync` / `ApplyEventAsync` be clearer? **Current preference: `ApplyToViewAsync`** — unambiguous and mirrors existing DCB verb style.
+- `[impl]` Should `MvSqlStatement` be a `record struct` or a regular `record`? Value type avoids allocations but complicates `List<>.Add()` scenarios.
+- `[impl]` Should `MvTable` be sealed? (Current design says yes.)
+- `[later]` Does `MvRowMapper<T>` need async variants? Probably not for PoC.
+
+## Safe window handling
+
+- `[PoC]` For PoC, use "Option A — delay-apply": only apply events older than the safe window. Confirmed.
+- `[impl]` Should the safe window value come from DCB's existing `SortableUniqueId.SafeMilliseconds` constant (5000) or be configurable per MV?
+- `[later]` Will MVs ever need Option B (apply-immediately with rollback)? Defer until a real use case emerges.
+
+## Idempotency and row metadata
+
+- `[PoC]` Are row metadata columns (`_last_sortable_unique_id`, `_last_applied_at`) enforced by the framework, or purely recommended? **Current preference: recommended via XML doc + helper constants, not enforced.**
+- `[PoC]` Should the primary idempotency mechanism be:
+  - (a) Registry `current_position` (framework-driven, transactional with writes)
+  - (b) Row `_last_sortable_unique_id < @sid` guards (user-driven, fine-grained)
+  - **Current preference: both. (a) handles whole-batch atomicity, (b) handles out-of-order replays within a batch and cross-tool protection.**
+- `[impl]` Should there be a helper method like `ctx.BuildIdempotencyGuard("_last_sortable_unique_id")` to generate the common `WHERE` snippet? Might reduce boilerplate but risks becoming a mini-DSL.
+
+## Registry and state
+
+- `[PoC]` Is the two-table design (`sekiban_mv_registry` + `sekiban_mv_active`) the right shape, or should it be a single table with an `is_active` flag? **Current preference: two tables. Single-row-per-view `sekiban_mv_active` simplifies atomic switchover.**
+- `[impl]` Does the registry schema itself need a version field (meta-meta)? Suggested solution: hardcode a `SCHEMA_VERSION = 1` constant; if it ever needs to change, write a migration in a new PR.
+- `[impl]` Should `sekiban_mv_registry.metadata JSONB` be used for anything specific in PoC, or left as an extensibility hook?
+
+## Error handling and recovery
+
+- `[PoC]` On SQL execution failure: transaction rollback + retry on next worker iteration. Confirmed.
+- `[impl]` What is the retry policy? Exponential backoff? Max retries? For PoC, a simple "retry with 1s delay up to N times, then halt" is enough.
+- `[impl]` How does the operator re-start a halted worker after fixing a poison event? Manual `UPDATE sekiban_mv_registry SET status = 'catching_up'` is acceptable for PoC.
+- `[later]` Poison event handling: skip-and-log, dead-letter, halt-and-wait. PoC halts the worker.
+
+## ORM / `IMvRow` details
+
+- `[PoC]` What types must `IMvRow` support out of the box? Minimum: `Guid`, `string`, `int`, `long`, `decimal`, `double`, `bool`, `DateTimeOffset`, `byte[]`, null-allowing variants, `GetAs<T>` for JSONB. Confirmed.
+- `[impl]` Should `GetString` on a `null` column throw or return empty string? **Current preference: throw**, and require `GetStringOrNull` for nullable columns. Matches Dapper/EF behavior.
+- `[impl]` How does `IMvRow` represent PostgreSQL-specific types like `interval`, `cidr`, `tsvector`? Via `GetAs<T>` with user-provided type mapping; PoC ignores these.
+- `[impl]` Should the reflection-based `MvRowMapper<T>` support `init`-only properties and record primary constructors? **Yes**, via expression-tree inspection of the canonical constructor. This is a small amount of extra complexity that saves users from writing a static factory for every row type.
+- `[later]` `[GeneratedMvRowMapping]` source generator — evaluate after PoC to see if the reflection version is "fast enough".
+
+## Cross-view reads
+
+- `[impl]` What happens when `GetActiveViewTable("Foo", "bar")` is called but `Foo` has no active version (e.g., still in `catching_up`)? **Current preference: throw with a descriptive error.** Alternative would be to return null, but silent null-return in apply logic is dangerous.
+- `[later]` Should cross-view reads be cached within a single `ApplyToViewAsync` call? E.g., if the user calls `GetActiveViewTable("CustomerSummary", "customers")` three times, the resolution should be cached once per apply.
+- `[later]` How are dependencies between MVs declared? Attribute-based (`[DependsOnMv(typeof(CustomerSummaryMv))]`), DI-based, or auto-detected by scanning code for `GetActiveViewTable` calls? Defer.
+- `[later]` Cycle detection — when? (compile-time analyzer? DI-time validation? first-access runtime check?)
+
+## Version management
+
+- `[PoC]` For PoC, only v1 exists. No activation API needed beyond a manual `UPDATE sekiban_mv_active`.
+- `[later]` Should version switching be gated by a "ready-for-activation" assertion (both versions reached the same position)?
+- `[later]` Retire cleanup policy: immediate drop, 7-day grace period, or manual.
+
+## DI and configuration
+
+- `[PoC]` Options type: `MvOptions` with `PhysicalNameResolver`, `SafeWindowMs`, `BatchSize`, `PollInterval`, `TablePrefix`.
+- `[impl]` Should MV projector registration be typed (`services.AddMaterializedView<OrderSummaryMvV1>()`) or collection-based (`services.AddMaterializedViews(typeof(OrderSummaryMvV1), typeof(CustomerSummaryMvV1))`)? Both are trivial; decide in implementation.
+- `[impl]` Does each MV need its own `IDbConnection` factory, or does the whole subsystem share one? For PoC, share one. Multi-database scenarios are later.
+
+## WASM
+
+- `[later]` WASM entirely out of PoC scope. Design document captures the strategy so that it's not painted into a corner, but no code.
+- `[later]` When WASM is added: native + WASM mode selection via DI config, similar to what `0216_multiprojection_wasm_abstraction` does for multi-projections.
+
+## Interaction with existing code
+
+- `[PoC]` Will any existing files be modified? **No.** Only new files in new projects.
+- `[PoC]` Will `Sekiban.slnx` be modified to include the new projects? **Yes**, in the implementation PR (not this design PR).
+- `[impl]` Will `Directory.Packages.props` need new entries? `Dapper` is likely already there; `MessagePack` is not needed for PoC.
+- `[impl]` Will `Sekiban.Dcb.Postgres` be affected? **No**, but both packages will share a Postgres instance and coordinate their DDL through different table prefixes (`dcb_*` vs `sekiban_mv_*`).
+
+## Testing
+
+- `[PoC]` Testcontainers for Postgres as the integration test harness. Confirmed.
+- `[impl]` Should unit tests for `ApplyToViewAsync` use a fake `IMvApplyContext` or a real in-memory one (e.g., SQLite)? Fake context is simpler and sufficient for PoC.
+- `[impl]` Should there be a "golden test" suite that feeds a known event stream and compares the resulting SQL list against expected SQL? Would be great for regression. Defer to post-PoC.
+
+## Documentation
+
+- `[PoC]` Every new public type gets XML doc comments.
+- `[PoC]` A short `README.md` in `Sekiban.Dcb.MaterializedView` explaining how to author an MV and register it in DI.
+- `[impl]` Migration guide for converting an existing `ICoreMultiProjector<T>` to a corresponding MV, with AI-assisted translation prompts.

--- a/tasks/db-projection-read-model/open-questions.md
+++ b/tasks/db-projection-read-model/open-questions.md
@@ -8,6 +8,7 @@ Open questions from the design discussion, grouped by category. Each is tagged a
 
 - `[PoC]` Should the core interface be `IMaterializedViewProjector` or simply `IMvProjector`? The longer form is more searchable, the shorter form is easier to type. **Current preference: `IMaterializedViewProjector`** with `Mv*` prefix for supporting types.
 - `[PoC]` Is `ApplyToViewAsync` the right method name, or would `MaterializeAsync` / `HandleAsync` / `ApplyEventAsync` be clearer? **Current preference: `ApplyToViewAsync`** — unambiguous and mirrors existing DCB verb style.
+- `[PoC]` Are `IMaterializedViewProjector` / `IMvApplyContext` / `MvSqlStatement` the cross-language ABI? **No.** They are the .NET authoring API. Wasm/remote execution will use a separate serialized runtime protocol and host adapters.
 - `[impl]` Should `MvSqlStatement` be a `record struct` or a regular `record`? Value type avoids allocations but complicates `List<>.Add()` scenarios.
 - `[impl]` Should `MvTable` be sealed? (Current design says yes.)
 - `[later]` Does `MvRowMapper<T>` need async variants? Probably not for PoC.
@@ -36,6 +37,7 @@ Open questions from the design discussion, grouped by category. Each is tagged a
 ## Error handling and recovery
 
 - `[PoC]` On SQL execution failure: transaction rollback + retry on next worker iteration. Confirmed.
+- `[PoC]` Must apply-time reads run in the same transaction/snapshot as the returned writes and registry update? **Yes.** This is required for a deterministic read-modify-write cycle.
 - `[impl]` What is the retry policy? Exponential backoff? Max retries? For PoC, a simple "retry with 1s delay up to N times, then halt" is enough.
 - `[impl]` How does the operator re-start a halted worker after fixing a poison event? Manual `UPDATE sekiban_mv_registry SET status = 'catching_up'` is acceptable for PoC.
 - `[later]` Poison event handling: skip-and-log, dead-letter, halt-and-wait. PoC halts the worker.
@@ -50,9 +52,10 @@ Open questions from the design discussion, grouped by category. Each is tagged a
 
 ## Cross-view reads
 
-- `[impl]` What happens when `GetActiveViewTable("Foo", "bar")` is called but `Foo` has no active version (e.g., still in `catching_up`)? **Current preference: throw with a descriptive error.** Alternative would be to return null, but silent null-return in apply logic is dangerous.
-- `[later]` Should cross-view reads be cached within a single `ApplyToViewAsync` call? E.g., if the user calls `GetActiveViewTable("CustomerSummary", "customers")` three times, the resolution should be cached once per apply.
-- `[later]` How are dependencies between MVs declared? Attribute-based (`[DependsOnMv(typeof(CustomerSummaryMv))]`), DI-based, or auto-detected by scanning code for `GetActiveViewTable` calls? Defer.
+- `[impl]` What happens when `GetDependencyViewTable("Foo", "bar")` is called but `Foo` is not present in the pinned dependency map? **Current preference: throw with a descriptive error.** Silent fallback to live active resolution would break replay determinism.
+- `[impl]` When is the dependency version map captured? **Current preference: at activation time or another explicit version-management checkpoint**, then persisted in metadata so replays see the same dependency versions.
+- `[later]` Should cross-view reads be cached within a single `ApplyToViewAsync` call? E.g., if the user calls `GetDependencyViewTable("CustomerSummary", "customers")` three times, the resolution should be cached once per apply.
+- `[later]` How are dependencies between MVs declared? Attribute-based (`[DependsOnMv(typeof(CustomerSummaryMv))]`), DI-based, or auto-detected by scanning code for `GetDependencyViewTable` calls? Defer.
 - `[later]` Cycle detection — when? (compile-time analyzer? DI-time validation? first-access runtime check?)
 
 ## Version management
@@ -67,9 +70,10 @@ Open questions from the design discussion, grouped by category. Each is tagged a
 - `[impl]` Should MV projector registration be typed (`services.AddMaterializedView<OrderSummaryMvV1>()`) or collection-based (`services.AddMaterializedViews(typeof(OrderSummaryMvV1), typeof(CustomerSummaryMvV1))`)? Both are trivial; decide in implementation.
 - `[impl]` Does each MV need its own `IDbConnection` factory, or does the whole subsystem share one? For PoC, share one. Multi-database scenarios are later.
 
-## WASM
+## Runtime protocol / WASM
 
-- `[later]` WASM entirely out of PoC scope. Design document captures the strategy so that it's not painted into a corner, but no code.
+- `[later]` WASM entirely out of PoC scope. The design now explicitly separates .NET authoring interfaces from the future serialized runtime protocol so that the PoC does not paint us into a corner.
+- `[impl]` What should the first runtime protocol message set look like? Current preference: apply request/response, read request/response, statement list response, all JSON in the first iteration.
 - `[later]` When WASM is added: native + WASM mode selection via DI config, similar to what `0216_multiprojection_wasm_abstraction` does for multi-projections.
 
 ## Interaction with existing code

--- a/tasks/db-projection-read-model/open-questions.md
+++ b/tasks/db-projection-read-model/open-questions.md
@@ -39,7 +39,7 @@ Open questions from the design discussion, grouped by category. Each is tagged a
 - `[PoC]` On SQL execution failure: transaction rollback + retry on next worker iteration. Confirmed.
 - `[PoC]` Must apply-time reads run in the same transaction/snapshot as the returned writes and registry update? **Yes.** This is required for a deterministic read-modify-write cycle.
 - `[impl]` What is the retry policy? Exponential backoff? Max retries? For PoC, a simple "retry with 1s delay up to N times, then halt" is enough.
-- `[impl]` How does the operator re-start a halted worker after fixing a poison event? Manual `UPDATE sekiban_mv_registry SET status = 'catching_up'` is acceptable for PoC.
+- `[impl]` How does the operator restart a halted worker after fixing a poison event? Manual `UPDATE sekiban_mv_registry SET status = 'catching_up'` is acceptable for PoC.
 - `[later]` Poison event handling: skip-and-log, dead-letter, halt-and-wait. PoC halts the worker.
 
 ## ORM / `IMvRow` details
@@ -67,6 +67,7 @@ Open questions from the design discussion, grouped by category. Each is tagged a
 ## DI and configuration
 
 - `[PoC]` Options type: `MvOptions` with `PhysicalNameResolver`, `SafeWindowMs`, `BatchSize`, `PollInterval`, `TablePrefix`.
+- `[PoC]` Database engine identifier type: `MvDbType` rather than `DbType`, to avoid confusion with `System.Data.DbType`.
 - `[impl]` Should MV projector registration be typed (`services.AddMaterializedView<OrderSummaryMvV1>()`) or collection-based (`services.AddMaterializedViews(typeof(OrderSummaryMvV1), typeof(CustomerSummaryMvV1))`)? Both are trivial; decide in implementation.
 - `[impl]` Does each MV need its own `IDbConnection` factory, or does the whole subsystem share one? For PoC, share one. Multi-database scenarios are later.
 

--- a/tasks/db-projection-read-model/poc-scope.md
+++ b/tasks/db-projection-read-model/poc-scope.md
@@ -1,0 +1,75 @@
+# DCB Materialized View — PoC Scope
+
+This document defines the minimum viable PoC for DCB Materialized View. The goal of the PoC is to validate the design end-to-end with one real materialized view running against PostgreSQL, without building any of the deferred features.
+
+## PoC goal (one sentence)
+
+> A sample `OrderSummaryMvV1` runs under `DcbOrleans.AppHost`, catches up from the existing DCB event store, writes rows to real `sekiban_mv_ordersummary_v1_orders` / `sekiban_mv_ordersummary_v1_items` tables, and can be queried with plain SQL.
+
+## PoC scope — IN
+
+| Phase | Items included |
+|---|---|
+| Phase 1 | `IMvRegistryStore`, `MvRegistryEntry`, `MvActiveEntry`, `MvStatus`, `PhysicalNameResolver` |
+| Phase 2 | `MvTable`, `MvSqlStatement`, `IMvInitContext`, `IMvApplyContext`, `IMaterializedViewProjector` |
+| Phase 3 | `IMvRow`, `IMvRowSet`, `MvRowMapper<T>` (Expression-tree version), `MvColumnAttribute` |
+| Phase 4 | Row metadata column conventions (`_last_sortable_unique_id`, `_last_applied_at`), `MvSchemaHelper` |
+| Phase 5 | `Sekiban.Dcb.MaterializedView.Postgres` with Dapper-backed implementation of all above interfaces |
+| Phase 6 | `MvCatchUpWorker` as `IHostedService`, one worker managing one view |
+| Phase 9 | One sample `OrderSummaryMvV1` in `internalUsages/` |
+| Phase 10 (subset) | Unit tests for apply logic (no DB) + at least one integration test with Testcontainers |
+
+## PoC scope — OUT (explicitly deferred)
+
+| Deferred | Reason |
+|---|---|
+| Multiple MV versions coexisting (v1 + v2) | Requires full version manager; not needed to prove the core loop |
+| Activation/rollback API | Hardcode v1 as active for PoC |
+| Cross-view reads (Phase 8) | Single-view PoC first |
+| Read-side query API (Phase 11) | Use `Connection` directly |
+| Orleans grain integration | IHostedService is enough for the first proof |
+| Source Generator for `MvRowMapper` | Reflection-based mapper is plenty for PoC |
+| MessagePack at WASM boundary | JSON is fine for PoC; WASM itself is deferred |
+| Multi-tenant physical name override | Use default resolver |
+| `IDependsOnMv` topological sort | Single view |
+| CLI for activation/retire | Manual SQL updates are fine for PoC |
+| CosmosDB/DynamoDB/SQLite backends | Postgres first |
+
+## Acceptance criteria
+
+The PoC is considered successful when all of the following are verifiable:
+
+1. **Registry tables exist**: On first run of `DcbOrleans.AppHost`, `sekiban_mv_registry` and `sekiban_mv_active` are created in PostgreSQL.
+2. **View initialization**: `OrderSummaryMvV1.InitializeAsync` successfully runs and creates `sekiban_mv_ordersummary_v1_orders` and `sekiban_mv_ordersummary_v1_items` tables.
+3. **Registry entries**: After initialization, `sekiban_mv_registry` contains 2 rows (one per logical table) with `status='catching_up'`. `sekiban_mv_active` contains 1 row pointing at `v1`.
+4. **Catch-up**: `MvCatchUpWorker` reads events via `IEventStore.ReadAllSerializableEventsAsync` and applies them. Events older than the safe window (5s) are applied.
+5. **Write atomicity**: For each event producing multiple `MvSqlStatement`s, all statements and the registry `current_position` update happen in a single transaction. Verified by intentionally failing a second statement and observing that the first is rolled back.
+6. **Idempotency**: Killing and restarting the worker mid-event results in no duplicate writes. The `_last_sortable_unique_id` guard prevents double-apply.
+7. **Row data**: After sending a series of test commands (create order → add items → cancel), running `SELECT * FROM sekiban_mv_ordersummary_v1_orders` from `psql` returns the expected row.
+8. **Metadata columns**: Every row has a non-null `_last_sortable_unique_id` and `_last_applied_at`.
+9. **Registry advances**: `sekiban_mv_registry.current_position` matches the latest event's `SortableUniqueId`.
+10. **Unit tests pass**: `ApplyToViewAsync` returns the expected `MvSqlStatement` list for each event type without touching the database.
+11. **Integration test passes**: Testcontainers spins up Postgres, the end-to-end flow runs, assertions pass.
+12. **Zero changes to existing code**: `git diff main -- dcb/src/Sekiban.Dcb.Core dcb/src/Sekiban.Dcb.Postgres dcb/src/Sekiban.Dcb.Core.Model` shows only additions to `Directory.Build.props` / `Directory.Packages.props` if new packages are added. No modifications to existing classes.
+
+## Sprint estimate
+
+Assuming one full-time developer familiar with DCB internals:
+
+| Phase | Estimate |
+|---|---|
+| Phase 1 (registry) | 1-2 days |
+| Phase 2 (abstractions) | 1 day |
+| Phase 3 (IMvRow + mapper) | 2-3 days |
+| Phase 4 (metadata conventions) | 0.5 day |
+| Phase 5 (Postgres implementation) | 2-3 days |
+| Phase 6 (catch-up worker) | 2-3 days |
+| Phase 9 (sample app) | 1-2 days |
+| Phase 10 (tests) | 2-3 days |
+| **Total** | **~2 weeks** |
+
+This includes getting the sample running under `DcbOrleans.AppHost`, writing tests, and iterating on bugs. It does not include deferred phases.
+
+## Non-goal: performance
+
+The PoC does not need to hit any specific throughput target. It only needs to be correct and observable. Performance tuning, MessagePack, batching, and native-path optimizations are all post-PoC work.

--- a/tasks/db-projection-read-model/poc-scope.md
+++ b/tasks/db-projection-read-model/poc-scope.md
@@ -25,11 +25,11 @@ This document defines the minimum viable PoC for DCB Materialized View. The goal
 |---|---|
 | Multiple MV versions coexisting (v1 + v2) | Requires full version manager; not needed to prove the core loop |
 | Activation/rollback API | Hardcode v1 as active for PoC |
-| Cross-view reads (Phase 8) | Single-view PoC first |
+| Cross-view reads (Phase 8) | Single-view PoC first; dependency-pinned resolution is a later phase |
 | Read-side query API (Phase 11) | Use `Connection` directly |
 | Orleans grain integration | IHostedService is enough for the first proof |
 | Source Generator for `MvRowMapper` | Reflection-based mapper is plenty for PoC |
-| MessagePack at WASM boundary | JSON is fine for PoC; WASM itself is deferred |
+| Runtime protocol implementation for WASM/remote execution | The contract is reserved in the design, but PoC ships only the .NET authoring path |
 | Multi-tenant physical name override | Use default resolver |
 | `IDependsOnMv` topological sort | Single view |
 | CLI for activation/retire | Manual SQL updates are fine for PoC |
@@ -43,7 +43,7 @@ The PoC is considered successful when all of the following are verifiable:
 2. **View initialization**: `OrderSummaryMvV1.InitializeAsync` successfully runs and creates `sekiban_mv_ordersummary_v1_orders` and `sekiban_mv_ordersummary_v1_items` tables.
 3. **Registry entries**: After initialization, `sekiban_mv_registry` contains 2 rows (one per logical table) with `status='catching_up'`. `sekiban_mv_active` contains 1 row pointing at `v1`.
 4. **Catch-up**: `MvCatchUpWorker` reads events via `IEventStore.ReadAllSerializableEventsAsync` and applies them. Events older than the safe window (5s) are applied.
-5. **Write atomicity**: For each event producing multiple `MvSqlStatement`s, all statements and the registry `current_position` update happen in a single transaction. Verified by intentionally failing a second statement and observing that the first is rolled back.
+5. **Read/write atomicity**: For each event, all reads performed by `ApplyToViewAsync`, all returned `MvSqlStatement`s, and the registry `current_position` update happen in a single transaction/snapshot. Verified by intentionally failing a second statement and observing that the first is rolled back.
 6. **Idempotency**: Killing and restarting the worker mid-event results in no duplicate writes. The `_last_sortable_unique_id` guard prevents double-apply.
 7. **Row data**: After sending a series of test commands (create order → add items → cancel), running `SELECT * FROM sekiban_mv_ordersummary_v1_orders` from `psql` returns the expected row.
 8. **Metadata columns**: Every row has a non-null `_last_sortable_unique_id` and `_last_applied_at`.

--- a/tasks/db-projection-read-model/tasks.md
+++ b/tasks/db-projection-read-model/tasks.md
@@ -38,7 +38,7 @@ Neither package depends on `Sekiban.Dcb.Postgres` (the existing snapshot-based s
 - [ ] **2.1** Define `MvTable` sealed class (LogicalName, PhysicalName, ViewName, ViewVersion)
 - [ ] **2.2** Define `MvSqlStatement` record struct (Sql, Parameters)
 - [ ] **2.3** Define `IMvInitContext` interface (DbType, Connection, RegisterTable, ExecuteAsync)
-- [ ] **2.4** Define `IMvApplyContext` interface (DbType, Connection, CurrentEvent, CurrentSortableUniqueId, read operations, IMvRow operations, GetActiveViewTable)
+- [ ] **2.4** Define `IMvApplyContext` interface (DbType, Connection, Transaction, CurrentEvent, CurrentSortableUniqueId, read operations, IMvRow operations, GetDependencyViewTable)
 - [ ] **2.5** Define `IMaterializedViewProjector` interface (ViewName, ViewVersion, InitializeAsync, ApplyToViewAsync)
 
 ## Phase 3 — `IMvRow` Row Abstraction
@@ -83,7 +83,7 @@ Neither package depends on `Sekiban.Dcb.Postgres` (the existing snapshot-based s
 - [ ] **6.2** Implement `MvCatchUpWorker` (IHostedService-based default implementation)
   - Reads events from `IEventStore.ReadAllSerializableEventsAsync`
   - Respects safe window (5s default)
-  - Calls `ApplyToViewAsync` and executes returned statements in a transaction
+  - Opens a transaction before `ApplyToViewAsync`, runs apply-time reads and returned statements in the same transaction/snapshot
   - Updates `current_position` atomically with writes
   - Handles restart by resuming from `registry.current_position`
 - [ ] **6.3** Configuration: `MvWorkerOptions` (BatchSize, PollInterval, SafeWindowMs, etc.)
@@ -102,11 +102,12 @@ Neither package depends on `Sekiban.Dcb.Postgres` (the existing snapshot-based s
 
 **Package**: `Sekiban.Dcb.MaterializedView`
 
-- [ ] **8.1** Implement `GetActiveViewTable(viewName, logicalTable)` in `IMvApplyContext`
-- [ ] **8.2** Implement the typed variant `GetActiveViewTable<TView>(logicalTable)`
-- [ ] **8.3** Cache active version lookups within a single apply operation
-- [ ] **8.4** Document consistency caveats in XML docs
-- [ ] **8.5** Unit test: stale read during catch-up returns the data from the other view at its own current_position
+- [ ] **8.1** Implement `GetDependencyViewTable(viewName, logicalTable)` in `IMvApplyContext`
+- [ ] **8.2** Implement the typed variant `GetDependencyViewTable<TView>(logicalTable)`
+- [ ] **8.3** Resolve tables from a persisted dependency version map, not from live `sekiban_mv_active` lookups
+- [ ] **8.4** Cache dependency table lookups within a single apply operation
+- [ ] **8.5** Document determinism and consistency caveats in XML docs
+- [ ] **8.6** Unit test: replay after dependency activation change still resolves the originally pinned dependency version
 
 ## Phase 9 — Sample Application
 
@@ -128,7 +129,7 @@ Neither package depends on `Sekiban.Dcb.Postgres` (the existing snapshot-based s
 - [ ] **10.3** Idempotency test: replay same events twice, assert final state
 - [ ] **10.4** Version coexistence test: v1 `active`, v2 `catching_up`, reads go to v1
 - [ ] **10.5** Activation test: v2 reaches `ready`, activate, reads go to v2 atomically
-- [ ] **10.6** Cross-view read test: `OrderSummaryMv` reads from `CustomerSummaryMv` during apply
+- [ ] **10.6** Cross-view read test: `OrderSummaryMv` reads from `CustomerSummaryMv` through a pinned dependency version during apply
 - [ ] **10.7** Safe window test: events within unsafe window are not yet applied
 - [ ] **10.8** Recovery test: worker crashes mid-batch, on restart resumes from last committed position
 
@@ -146,7 +147,16 @@ Explicitly out of PoC scope. Planned follow-up:
 - [ ] **12.1** `[DependsOnMv(typeof(CustomerSummaryMv))]` attribute or DI-based declaration
 - [ ] **12.2** Topological sort of MVs during catch-up worker startup
 - [ ] **12.3** Cycle detection (fail at startup with clear error)
-- [ ] **12.4** Wait-for-dependency policy during cross-view reads (configurable)
+- [ ] **12.4** Capture dependency version map during activation (or equivalent explicit checkpoint) and persist it for replay determinism
+- [ ] **12.5** Wait-for-dependency policy during cross-view reads (configurable)
+
+## Phase 13 — Runtime Protocol for Wasm/Remote Execution (Deferred)
+
+- [ ] **13.1** Define serialized apply request/response contracts separate from `IMvApplyContext`
+- [ ] **13.2** Define serialized read request/response contracts for row reads
+- [ ] **13.3** Define serialized statement-list result contract separate from `MvSqlStatement`
+- [ ] **13.4** Implement host adapters between the runtime protocol and the .NET authoring API
+- [ ] **13.5** Add protocol compatibility tests against at least one non-.NET guest
 
 ---
 

--- a/tasks/db-projection-read-model/tasks.md
+++ b/tasks/db-projection-read-model/tasks.md
@@ -22,7 +22,7 @@ Neither package depends on `Sekiban.Dcb.Postgres` (the existing snapshot-based s
 - [ ] **1.1** Define `MvRegistryEntry` record (service_id, view_name, view_version, logical_table, physical_table, status, current_position, target_position, last_sortable_unique_id, last_updated, metadata)
 - [ ] **1.2** Define `MvActiveEntry` record (service_id, view_name, active_version, activated_at)
 - [ ] **1.3** Define `MvStatus` enum (`Initializing`, `CatchingUp`, `Ready`, `Active`, `Retired`)
-- [ ] **1.4** Define `IMvRegistryStore` interface with operations:
+- [ ] **1.4** Define `IMvRegistryStore` interface with operations (`UpdatePositionAsync` / `UpdateStatusAsync` apply to all `logical_table` rows for a given `(viewName, viewVersion)` in one transactionally-consistent update):
   - `RegisterAsync(MvRegistryEntry entry)`
   - `UpdatePositionAsync(viewName, viewVersion, sortableUniqueId, IDbTransaction? tx)`
   - `UpdateStatusAsync(viewName, viewVersion, MvStatus status)`
@@ -37,8 +37,8 @@ Neither package depends on `Sekiban.Dcb.Postgres` (the existing snapshot-based s
 
 - [ ] **2.1** Define `MvTable` sealed class (LogicalName, PhysicalName, ViewName, ViewVersion)
 - [ ] **2.2** Define `MvSqlStatement` record struct (Sql, Parameters)
-- [ ] **2.3** Define `IMvInitContext` interface (DbType, Connection, RegisterTable, ExecuteAsync)
-- [ ] **2.4** Define `IMvApplyContext` interface (DbType, Connection, Transaction, CurrentEvent, CurrentSortableUniqueId, read operations, IMvRow operations, GetDependencyViewTable)
+- [ ] **2.3** Define `IMvInitContext` interface (`MvDbType`, Connection, RegisterTable, ExecuteAsync)
+- [ ] **2.4** Define `IMvApplyContext` interface (`MvDbType`, Connection, Transaction, CurrentEvent, CurrentSortableUniqueId, read operations, IMvRow operations, GetDependencyViewTable)
 - [ ] **2.5** Define `IMaterializedViewProjector` interface (ViewName, ViewVersion, InitializeAsync, ApplyToViewAsync)
 
 ## Phase 3 — `IMvRow` Row Abstraction
@@ -48,7 +48,7 @@ Neither package depends on `Sekiban.Dcb.Postgres` (the existing snapshot-based s
 - [ ] **3.1** Define `IMvRow` interface (ColumnCount, ColumnNames, IsNull, typed accessors for Guid/string/int/long/decimal/double/bool/DateTimeOffset/byte[], null-allowing variants, GetAs<T>, ToJson)
 - [ ] **3.2** Define `IMvRowSet` interface (inherits `IReadOnlyList<IMvRow>` + ColumnNames)
 - [ ] **3.3** Define `MvColumnAttribute` for property-to-column mapping overrides
-- [ ] **3.4** Implement `MvRowMapper<T>` with Expression-tree compilation and caching
+- [ ] **3.4** Implement `MvRowMapper<T>` with Expression-tree compilation and caching, supporting both property-based models and record primary constructors / `init`-only members
 - [ ] **3.5** Extension methods on `IMvApplyContext` (`QuerySingleOrDefaultAsync<T>`, `QueryAsync<T>`)
 
 ## Phase 4 — Row Metadata Conventions
@@ -72,8 +72,8 @@ Neither package depends on `Sekiban.Dcb.Postgres` (the existing snapshot-based s
 - [ ] **5.4** Implement `PostgresMvRow : IMvRow` adapter over Dapper's `IDataReader` output
 - [ ] **5.5** Implement `PostgresMvRowSet : IMvRowSet`
 - [ ] **5.6** Wire Dapper as an internal dependency (not exposed through public API)
-- [ ] **5.7** DI extension methods: `AddSekibanMaterializedView(Action<MvOptions>)` and `AddPostgresMv(connectionString)`
-- [ ] **5.8** Expose `DbType.Postgres` value
+- [ ] **5.7** DI extension methods: `AddSekibanDcbMaterializedView(Action<MvOptions>)` and `AddSekibanDcbMaterializedViewPostgres(connectionString)`
+- [ ] **5.8** Expose `MvDbType.Postgres` value
 
 ## Phase 6 — Catch-up Worker
 

--- a/tasks/db-projection-read-model/tasks.md
+++ b/tasks/db-projection-read-model/tasks.md
@@ -1,0 +1,160 @@
+# DCB Materialized View — Task Breakdown
+
+All tasks are for implementation work that follows merging this design PR. Nothing below is implemented yet.
+
+---
+
+## Package structure to be created
+
+Two new projects will be added to `Sekiban.slnx` under the `Sekiban.Dcb` family:
+
+1. **`Sekiban.Dcb.MaterializedView`** — core interfaces and abstractions (no database-specific code)
+2. **`Sekiban.Dcb.MaterializedView.Postgres`** — PostgreSQL implementation
+
+Neither package depends on `Sekiban.Dcb.Postgres` (the existing snapshot-based store). They are parallel.
+
+---
+
+## Phase 1 — MV Registry Core
+
+**Package**: `Sekiban.Dcb.MaterializedView`
+
+- [ ] **1.1** Define `MvRegistryEntry` record (service_id, view_name, view_version, logical_table, physical_table, status, current_position, target_position, last_sortable_unique_id, last_updated, metadata)
+- [ ] **1.2** Define `MvActiveEntry` record (service_id, view_name, active_version, activated_at)
+- [ ] **1.3** Define `MvStatus` enum (`Initializing`, `CatchingUp`, `Ready`, `Active`, `Retired`)
+- [ ] **1.4** Define `IMvRegistryStore` interface with operations:
+  - `RegisterAsync(MvRegistryEntry entry)`
+  - `UpdatePositionAsync(viewName, viewVersion, sortableUniqueId, IDbTransaction? tx)`
+  - `UpdateStatusAsync(viewName, viewVersion, MvStatus status)`
+  - `GetEntriesAsync(viewName, viewVersion)`
+  - `GetActiveAsync(viewName)`
+  - `SetActiveAsync(viewName, version)`
+- [ ] **1.5** Define `PhysicalNameResolver` delegate `(viewName, version, logicalTable) -> string` with default implementation
+
+## Phase 2 — Abstractions (`MvTable`, `MvSqlStatement`, Contexts)
+
+**Package**: `Sekiban.Dcb.MaterializedView`
+
+- [ ] **2.1** Define `MvTable` sealed class (LogicalName, PhysicalName, ViewName, ViewVersion)
+- [ ] **2.2** Define `MvSqlStatement` record struct (Sql, Parameters)
+- [ ] **2.3** Define `IMvInitContext` interface (DbType, Connection, RegisterTable, ExecuteAsync)
+- [ ] **2.4** Define `IMvApplyContext` interface (DbType, Connection, CurrentEvent, CurrentSortableUniqueId, read operations, IMvRow operations, GetActiveViewTable)
+- [ ] **2.5** Define `IMaterializedViewProjector` interface (ViewName, ViewVersion, InitializeAsync, ApplyToViewAsync)
+
+## Phase 3 — `IMvRow` Row Abstraction
+
+**Package**: `Sekiban.Dcb.MaterializedView`
+
+- [ ] **3.1** Define `IMvRow` interface (ColumnCount, ColumnNames, IsNull, typed accessors for Guid/string/int/long/decimal/double/bool/DateTimeOffset/byte[], null-allowing variants, GetAs<T>, ToJson)
+- [ ] **3.2** Define `IMvRowSet` interface (inherits `IReadOnlyList<IMvRow>` + ColumnNames)
+- [ ] **3.3** Define `MvColumnAttribute` for property-to-column mapping overrides
+- [ ] **3.4** Implement `MvRowMapper<T>` with Expression-tree compilation and caching
+- [ ] **3.5** Extension methods on `IMvApplyContext` (`QuerySingleOrDefaultAsync<T>`, `QueryAsync<T>`)
+
+## Phase 4 — Row Metadata Conventions
+
+**Package**: `Sekiban.Dcb.MaterializedView`
+
+- [ ] **4.1** Define constants for standard metadata column names (`_last_sortable_unique_id`, `_last_applied_at`)
+- [ ] **4.2** Document the idempotency pattern in XML doc comments on `IMvApplyContext.CurrentSortableUniqueId`
+- [ ] **4.3** Provide a `MvSchemaHelper` static class with utility methods to generate metadata column SQL snippets (pure string helpers, no SQL execution)
+- [ ] **4.4** Document that row metadata columns are recommended but not enforced
+
+## Phase 5 — PostgreSQL Implementation
+
+**Package**: `Sekiban.Dcb.MaterializedView.Postgres`
+
+- [ ] **5.1** Implement `PostgresMvRegistryStore : IMvRegistryStore`
+  - DDL for `sekiban_mv_registry` and `sekiban_mv_active` tables
+  - All registry operations via Dapper (internal implementation detail)
+- [ ] **5.2** Implement `PostgresMvInitContext : IMvInitContext`
+- [ ] **5.3** Implement `PostgresMvApplyContext : IMvApplyContext`
+- [ ] **5.4** Implement `PostgresMvRow : IMvRow` adapter over Dapper's `IDataReader` output
+- [ ] **5.5** Implement `PostgresMvRowSet : IMvRowSet`
+- [ ] **5.6** Wire Dapper as an internal dependency (not exposed through public API)
+- [ ] **5.7** DI extension methods: `AddSekibanMaterializedView(Action<MvOptions>)` and `AddPostgresMv(connectionString)`
+- [ ] **5.8** Expose `DbType.Postgres` value
+
+## Phase 6 — Catch-up Worker
+
+**Package**: `Sekiban.Dcb.MaterializedView`
+
+- [ ] **6.1** Define `IMvExecutor` interface (runs one or more MV projectors in catch-up mode)
+- [ ] **6.2** Implement `MvCatchUpWorker` (IHostedService-based default implementation)
+  - Reads events from `IEventStore.ReadAllSerializableEventsAsync`
+  - Respects safe window (5s default)
+  - Calls `ApplyToViewAsync` and executes returned statements in a transaction
+  - Updates `current_position` atomically with writes
+  - Handles restart by resuming from `registry.current_position`
+- [ ] **6.3** Configuration: `MvWorkerOptions` (BatchSize, PollInterval, SafeWindowMs, etc.)
+- [ ] **6.4** Multi-view support: one worker can manage multiple `IMaterializedViewProjector` instances
+
+## Phase 7 — Version Management & Activation
+
+**Package**: `Sekiban.Dcb.MaterializedView`
+
+- [ ] **7.1** `IMvVersionManager` interface: `InitializeAsync`, `ActivateAsync`, `RetireAsync`, `DeleteAsync`
+- [ ] **7.2** Implementation with state transition guards (only `Ready` → `Active`, etc.)
+- [ ] **7.3** CLI-friendly methods for manual activation
+- [ ] **7.4** Logging/telemetry on state transitions
+
+## Phase 8 — Cross-view Reads
+
+**Package**: `Sekiban.Dcb.MaterializedView`
+
+- [ ] **8.1** Implement `GetActiveViewTable(viewName, logicalTable)` in `IMvApplyContext`
+- [ ] **8.2** Implement the typed variant `GetActiveViewTable<TView>(logicalTable)`
+- [ ] **8.3** Cache active version lookups within a single apply operation
+- [ ] **8.4** Document consistency caveats in XML docs
+- [ ] **8.5** Unit test: stale read during catch-up returns the data from the other view at its own current_position
+
+## Phase 9 — Sample Application
+
+**Location**: `internalUsages/` or `Samples/`
+
+- [ ] **9.1** Create a sample `OrderSummaryMvV1 : IMaterializedViewProjector` demonstrating:
+  - `RegisterTable("orders")`, `RegisterTable("items")`
+  - CREATE TABLE with row metadata columns
+  - `UpsertOrder`, `InsertItem`, `UpdateOrderTotal` helpers
+  - Apply logic for `OrderCreated`, `OrderItemAdded`, `OrderCancelled`
+- [ ] **9.2** Sample POCO types: `OrderRow`, `OrderItemRow`
+- [ ] **9.3** Wire the sample into `DcbOrleans.AppHost` (as a separate optional service)
+- [ ] **9.4** Manual verification doc: spin up the host, run commands, observe rows in Postgres
+
+## Phase 10 — Testing
+
+- [ ] **10.1** Unit tests for `ApplyToViewAsync` returning expected `MvSqlStatement` lists (no DB)
+- [ ] **10.2** Integration tests with Testcontainers + PostgreSQL (real DB)
+- [ ] **10.3** Idempotency test: replay same events twice, assert final state
+- [ ] **10.4** Version coexistence test: v1 `active`, v2 `catching_up`, reads go to v1
+- [ ] **10.5** Activation test: v2 reaches `ready`, activate, reads go to v2 atomically
+- [ ] **10.6** Cross-view read test: `OrderSummaryMv` reads from `CustomerSummaryMv` during apply
+- [ ] **10.7** Safe window test: events within unsafe window are not yet applied
+- [ ] **10.8** Recovery test: worker crashes mid-batch, on restart resumes from last committed position
+
+## Phase 11 — Read-side API (Deferred)
+
+Explicitly out of PoC scope. Planned follow-up:
+
+- [ ] **11.1** `IMvQueryContext` with `For(viewName).Table(logicalTable).QueryAsync<T>(...)`
+- [ ] **11.2** Raw SQL support with `{logical_table}` placeholders
+- [ ] **11.3** Automatic `CREATE OR REPLACE VIEW sekiban_mv_view_*` generation for BI tool access
+- [ ] **11.4** Query-side unit and integration tests
+
+## Phase 12 — Explicit Dependencies & Topological Catch-up (Deferred)
+
+- [ ] **12.1** `[DependsOnMv(typeof(CustomerSummaryMv))]` attribute or DI-based declaration
+- [ ] **12.2** Topological sort of MVs during catch-up worker startup
+- [ ] **12.3** Cycle detection (fail at startup with clear error)
+- [ ] **12.4** Wait-for-dependency policy during cross-view reads (configurable)
+
+---
+
+## Out of scope entirely (not promised by this design)
+
+- Entity Framework integration
+- Cross-database projections (e.g., MV in Postgres reading from Cosmos)
+- Automatic schema diffing between versions
+- SQL dialect abstraction layers
+- Query language DSL
+- Multi-tenant isolation beyond name-prefix


### PR DESCRIPTION
## Summary

This PR adds **design documents only** for a proposed new parallel projection subsystem called **DCB Materialized View** (written `MaterializedView` / abbreviated `Mv*`). It complements the existing `ICoreMultiProjector<T>` snapshot-based model by providing a row-level, SQL-table-backed projection mechanism suitable for BI querying and large read models.

**This PR contains NO code changes** — only documents under `tasks/db-projection-read-model/`. Implementation will follow in a separate PR after design review.

## Why a new subsystem (and a new name)

Today, multi-projections are snapshotted as a single gzipped JSON blob in `dcb_multi_projection_states`. This is correct and performant, but cannot be queried with SQL / BI tools, doesn't scale well for large read models, and has no schema-evolution story for its internals.

A parallel mechanism — separate interfaces, separate storage, separate worker — fixes this without touching any of the existing code.

Every new public type uses `MaterializedView` or the `Mv*` prefix to avoid collision with existing DCB types:

| Existing | New |
|---|---|
| `ICoreMultiProjector<T>` | `IMaterializedViewProjector` |
| `MultiProjectionStateBuilder` | `MvCatchUpWorker` |
| `dcb_multi_projection_states` | `sekiban_mv_registry` + `sekiban_mv_active` |
| `IMultiProjectionStateStore` | `IMvRegistryStore` + `IMvExecutor` |

Shared DCB primitives (`IEvent`, `SortableUniqueId`, `IEventStore`, `ServiceId`, `ResultBox<T>`) are reused intentionally.

## Key design decisions

1. **Two-phase lifecycle** — `InitializeAsync` (once per view+version) + `ApplyToViewAsync` (per event)
2. **Developer writes SQL directly** — no dialect abstraction leaks, no `ISqlOperation` / `IDbDialect` indirection
3. **Writes are returned, not executed** — `ApplyToViewAsync` returns `IReadOnlyList<MvSqlStatement>`; the framework executes the whole list in one transaction per event
4. **Row metadata columns** (`_last_sortable_unique_id`, `_last_applied_at`) for idempotency and cross-view integrity
5. **Cross-view reads** via context helper `GetActiveViewTable(viewName, logicalTable)`
6. **Layered ORM** — core exposes `IMvRow`/`IMvRowSet` (Dapper-free public surface), `MvRowMapper<T>` (Expression-tree compiled), Dapper is an internal implementation detail only
7. **WASM-friendly** — JSON at the ABI boundary for PoC, MessagePack as future optimization. SQL strings cross the boundary with effectively zero cost
8. **Parallel, not replacing** — zero risk to `ICoreMultiProjector<T>` and existing snapshot stores

## Files in this PR

All under `tasks/db-projection-read-model/`:

| File | Size | Purpose |
|---|---|---|
| `README.md` | 4.5 KB | Overview & contents map |
| `design.md` | 37 KB | Full design (lifecycle, object model, contexts, worked example, name-collision audit, WASM marshaling analysis) |
| `tasks.md` | 8 KB | Phase 1-12 task breakdown |
| `poc-scope.md` | 5 KB | Minimum PoC scope + 12 acceptance criteria |
| `open-questions.md` | 8 KB | Deferred decisions tagged `[PoC]`/`[impl]`/`[later]` |
| `integration-notes.md` | 10 KB | Explicit list of files the implementation PR will/will-NOT touch, comparison table vs existing model, review checklist |

## What's NOT in this PR

- No `.cs` files
- No `.csproj` / `Sekiban.slnx` changes
- No modifications to any existing DCB source
- No test projects

## Next steps

1. **Review this design PR** for approach, naming, API shape, and scope
2. If approved, open a follow-up implementation PR that adds the two new packages `Sekiban.Dcb.MaterializedView` and `Sekiban.Dcb.MaterializedView.Postgres` with the PoC scope (~2 weeks of focused work)
3. PoC validates: one `OrderSummaryMvV1` running under `DcbOrleans.AppHost`, catching up from the event store, writing to real Postgres tables, queryable with `psql`

## Test plan

- [ ] Read `README.md` for a quick orientation
- [ ] Read `design.md` — §1-3 (background, goals, core concepts), §4 (object model), §6 (worked example), §9 (relationship to existing DCB)
- [ ] Review the name-collision audit table in `design.md` §9.7
- [ ] Check `integration-notes.md` §3 for the exact list of files that would be added/touched in the implementation PR
- [ ] Raise any concerns via `open-questions.md` — questions tagged `[PoC]` must be resolved before implementation starts

🤖 Generated with [Claude Code](https://claude.com/claude-code)