### PR TITLE
Add materialized view projects to DCB solution

### DIFF
--- a/.github/workflows/packagesDcb.yml
+++ b/.github/workflows/packagesDcb.yml
@@ -42,14 +42,7 @@ jobs:
           dotnet restore dcb/Sekiban.Dcb.slnx
 
       - name: Build with dotnet
-        run: |
-          dotnet build dcb/Sekiban.Dcb.slnx -c Release --no-restore
-
-          # These packable projects are not yet included in Sekiban.Dcb.slnx,
-          # so build them explicitly before `dotnet pack --no-build`.
-          dotnet build dcb/src/Sekiban.Dcb.MaterializedView/Sekiban.Dcb.MaterializedView.csproj -c Release --no-restore
-          dotnet build dcb/src/Sekiban.Dcb.MaterializedView.Postgres/Sekiban.Dcb.MaterializedView.Postgres.csproj -c Release --no-restore
-          dotnet build dcb/src/Sekiban.Dcb.MaterializedView.Orleans/Sekiban.Dcb.MaterializedView.Orleans.csproj -c Release --no-restore
+        run: dotnet build dcb/Sekiban.Dcb.slnx -c Release
 
       - name: Pack NuGet packages
         run: |

--- a/.github/workflows/packagesDcb.yml
+++ b/.github/workflows/packagesDcb.yml
@@ -42,7 +42,14 @@ jobs:
           dotnet restore dcb/Sekiban.Dcb.slnx
 
       - name: Build with dotnet
-        run: dotnet build dcb/Sekiban.Dcb.slnx -c Release
+        run: |
+          dotnet build dcb/Sekiban.Dcb.slnx -c Release --no-restore
+
+          # These packable projects are not yet included in Sekiban.Dcb.slnx,
+          # so build them explicitly before `dotnet pack --no-build`.
+          dotnet build dcb/src/Sekiban.Dcb.MaterializedView/Sekiban.Dcb.MaterializedView.csproj -c Release --no-restore
+          dotnet build dcb/src/Sekiban.Dcb.MaterializedView.Postgres/Sekiban.Dcb.MaterializedView.Postgres.csproj -c Release --no-restore
+          dotnet build dcb/src/Sekiban.Dcb.MaterializedView.Orleans/Sekiban.Dcb.MaterializedView.Orleans.csproj -c Release --no-restore
 
       - name: Pack NuGet packages
         run: |

--- a/dcb/Sekiban.Dcb.slnx
+++ b/dcb/Sekiban.Dcb.slnx
@@ -11,6 +11,9 @@
     <Project Path="src/Sekiban.Dcb.WithoutResult.Model/Sekiban.Dcb.WithoutResult.Model.csproj" />
     <Project Path="src/Sekiban.Dcb.WithResult/Sekiban.Dcb.WithResult.csproj" />
     <Project Path="src/Sekiban.Dcb.WithoutResult/Sekiban.Dcb.WithoutResult.csproj" />
+    <Project Path="src/Sekiban.Dcb.MaterializedView.Orleans/Sekiban.Dcb.MaterializedView.Orleans.csproj" />
+    <Project Path="src/Sekiban.Dcb.MaterializedView.Postgres/Sekiban.Dcb.MaterializedView.Postgres.csproj" />
+    <Project Path="src/Sekiban.Dcb.MaterializedView/Sekiban.Dcb.MaterializedView.csproj" />
     <Project Path="src/Sekiban.Dcb.Orleans.Core/Sekiban.Dcb.Orleans.Core.csproj" />
     <Project Path="src/Sekiban.Dcb.Orleans.WithResult/Sekiban.Dcb.Orleans.WithResult.csproj" />
     <Project Path="src/Sekiban.Dcb.Orleans.WithoutResult/Sekiban.Dcb.Orleans.WithoutResult.csproj" />


### PR DESCRIPTION
## Summary
- add the MaterializedView package projects to `dcb/Sekiban.Dcb.slnx`
- let the existing `packagesDcb.yml` solution build produce the pack artifacts
- fix the release packaging failure caused by missing `Sekiban.Dcb.MaterializedView.dll`

## Root Cause
The DCB release workflow packs `Sekiban.Dcb.MaterializedView*` with `--no-build`, but those projects were not included in `dcb/Sekiban.Dcb.slnx`. As a result, the workflow's solution build did not generate their DLLs, and package creation failed.

## Validation
- `dotnet build dcb/Sekiban.Dcb.slnx -c Release`
- `dotnet pack dcb/src/Sekiban.Dcb.MaterializedView/Sekiban.Dcb.MaterializedView.csproj -c Release -o /tmp/sekiban-dcb-pack-check -p:PackageVersion=10.1.15-test --no-build`
