### PR TITLE
Prevent tiny cold tail segment growth

### DIFF
--- a/dcb/src/Sekiban.Dcb.Core/ColdEvents/ColdExporter.cs
+++ b/dcb/src/Sekiban.Dcb.Core/ColdEvents/ColdExporter.cs
@@ -909,6 +909,6 @@ public sealed class ColdExporter : IColdEventExporter, IColdEventProgressReader
         IReadOnlyList<StagedSegment> OwnedSegments,
         int AppliedEventCount);
 
-    private sealed class MergeCapacityExceededException : Exception;
+    public sealed class MergeCapacityExceededException : Exception;
 
 }

--- a/dcb/src/Sekiban.Dcb.Core/ColdEvents/ColdExporter.cs
+++ b/dcb/src/Sekiban.Dcb.Core/ColdEvents/ColdExporter.cs
@@ -407,6 +407,10 @@ public sealed class ColdExporter : IColdEventExporter, IColdEventProgressReader
         var mergeResult = await TryMergeTailSegmentAsync(serviceId, existingTail, firstStagedSegment, ct);
         if (!mergeResult.IsSuccess)
         {
+            _logger.LogWarning(
+                mergeResult.GetException(),
+                "Tail merge fallback for {ServiceId}: failed to merge staged segment into existing tail",
+                serviceId);
             return ManifestUpdatePlan.ForAppend(
                 existingSegments,
                 adjustedSegments,
@@ -465,18 +469,6 @@ public sealed class ColdExporter : IColdEventExporter, IColdEventProgressReader
             return ResultBox.FromValue(new MergeTailAttempt(false, null));
         }
 
-        var stagedEventsResult = await ReadEventsFromLocalSegmentAsync(firstStagedSegment, ct);
-        if (!stagedEventsResult.IsSuccess)
-        {
-            return ResultBox.Error<MergeTailAttempt>(stagedEventsResult.GetException());
-        }
-
-        var stagedEvents = stagedEventsResult.GetValue();
-        if (stagedEvents.Count == 0)
-        {
-            return ResultBox.FromValue(new MergeTailAttempt(false, null));
-        }
-
         IColdSegmentFileBuilder? builder = null;
         try
         {
@@ -487,14 +479,15 @@ public sealed class ColdExporter : IColdEventExporter, IColdEventProgressReader
             }
 
             builder = existingEventsResult.GetValue();
-            foreach (var evt in stagedEvents)
+            var appendResult = await TryAppendLocalSegmentToBuilderAsync(firstStagedSegment, builder, ct);
+            if (!appendResult.IsSuccess)
             {
-                if (!builder.CanAppend(evt, _options))
-                {
-                    return ResultBox.FromValue(new MergeTailAttempt(false, null));
-                }
+                return ResultBox.Error<MergeTailAttempt>(appendResult.GetException());
+            }
 
-                await builder.AppendAsync(evt, ct);
+            if (!appendResult.GetValue())
+            {
+                return ResultBox.FromValue(new MergeTailAttempt(false, null));
             }
 
             var completed = await builder.CompleteAsync(serviceId, ct);
@@ -603,6 +596,11 @@ public sealed class ColdExporter : IColdEventExporter, IColdEventProgressReader
             ct);
         if (!readResult.IsSuccess)
         {
+            if (builder is not null)
+            {
+                await builder.DisposeAsync();
+                builder = null;
+            }
             return ResultBox.Error<IColdSegmentFileBuilder>(readResult.GetException());
         }
 
@@ -610,6 +608,46 @@ public sealed class ColdExporter : IColdEventExporter, IColdEventProgressReader
             ? ResultBox.Error<IColdSegmentFileBuilder>(
                 new InvalidOperationException($"Cold segment {existingTail.Path} did not contain any events."))
             : ResultBox.FromValue<IColdSegmentFileBuilder>(builder);
+    }
+
+    private async Task<ResultBox<bool>> TryAppendLocalSegmentToBuilderAsync(
+        StagedSegment stagedSegment,
+        IColdSegmentFileBuilder builder,
+        CancellationToken ct)
+    {
+        await using var stream = new FileStream(
+            stagedSegment.FilePath,
+            FileMode.Open,
+            FileAccess.Read,
+            FileShare.Read,
+            bufferSize: 81920,
+            FileOptions.Asynchronous | FileOptions.SequentialScan);
+
+        try
+        {
+            var readResult = await _segmentFormatHandler.StreamSegmentAsync(
+                stream,
+                since: null,
+                maxCount: null,
+                async evt =>
+                {
+                    if (!builder.CanAppend(evt, _options))
+                    {
+                        throw new MergeCapacityExceededException();
+                    }
+
+                    await builder.AppendAsync(evt, ct);
+                },
+                ct);
+
+            return !readResult.IsSuccess
+                ? ResultBox.Error<bool>(readResult.GetException())
+                : ResultBox.FromValue(true);
+        }
+        catch (MergeCapacityExceededException)
+        {
+            return ResultBox.FromValue(false);
+        }
     }
 
     private async Task<ResultBox<List<SerializableEvent>>> ReadEventsFromLocalSegmentAsync(
@@ -681,7 +719,11 @@ public sealed class ColdExporter : IColdEventExporter, IColdEventProgressReader
     {
         foreach (var path in uploadedPaths)
         {
-            await _storage.DeleteAsync(path, ct);
+            var deleteResult = await _storage.DeleteAsync(path, ct);
+            if (!deleteResult.IsSuccess)
+            {
+                _logger.LogWarning(deleteResult.GetException(), "Failed to delete uploaded cold segment {Path}", path);
+            }
         }
     }
 
@@ -866,5 +908,7 @@ public sealed class ColdExporter : IColdEventExporter, IColdEventProgressReader
         IReadOnlyList<StagedSegment> Segments,
         IReadOnlyList<StagedSegment> OwnedSegments,
         int AppliedEventCount);
+
+    private sealed class MergeCapacityExceededException : Exception;
 
 }

--- a/dcb/src/Sekiban.Dcb.Core/ColdEvents/ColdExporter.cs
+++ b/dcb/src/Sekiban.Dcb.Core/ColdEvents/ColdExporter.cs
@@ -361,7 +361,7 @@ public sealed class ColdExporter : IColdEventExporter, IColdEventProgressReader
         await DeleteSegmentsAsync(updatePlan.ReplacedSegmentPaths, ct);
 
         return ResultBox.FromValue(new ExportResult(
-            ExportedEventCount: stage.ExportedEventCount,
+            ExportedEventCount: updatePlan.AppliedEventCount,
             NewSegments: updatePlan.ResultSegments.Select(x => x.Info).ToList(),
             UpdatedManifestVersion: newVersion,
             Reason: ReasonExported,
@@ -377,31 +377,56 @@ public sealed class ColdExporter : IColdEventExporter, IColdEventProgressReader
         var existingSegments = (existingManifest?.Segments ?? []).ToList();
         if (existingSegments.Count == 0 || stage.Segments.Count == 0)
         {
-            return ManifestUpdatePlan.ForAppend(existingSegments, stage.Segments);
+            return ManifestUpdatePlan.ForAppend(existingSegments, stage.Segments, [], stage.ExportedEventCount);
         }
 
         var existingTail = existingSegments[^1];
-        var firstStagedSegment = stage.Segments[0];
+        var adjustedStage = await RemoveTailOverlapAsync(serviceId, existingTail, stage.Segments, ct);
+        var adjustedSegments = adjustedStage.Segments;
+        if (adjustedSegments.Count == 0)
+        {
+            return new ManifestUpdatePlan(
+                UpdatedManifestSegments: existingSegments,
+                SegmentsToUpload: [],
+                ResultSegments: [],
+                ReplacedSegmentPaths: [],
+                OwnedSegments: adjustedStage.OwnedSegments,
+                AppliedEventCount: 0);
+        }
+
+        var firstStagedSegment = adjustedSegments[0];
         if (!CanMergeTail(existingTail, firstStagedSegment.Info))
         {
-            return ManifestUpdatePlan.ForAppend(existingSegments, stage.Segments);
+            return ManifestUpdatePlan.ForAppend(
+                existingSegments,
+                adjustedSegments,
+                adjustedStage.OwnedSegments,
+                adjustedStage.AppliedEventCount);
         }
 
         var mergeResult = await TryMergeTailSegmentAsync(serviceId, existingTail, firstStagedSegment, ct);
         if (!mergeResult.IsSuccess)
         {
-            return ManifestUpdatePlan.ForAppend(existingSegments, stage.Segments);
+            return ManifestUpdatePlan.ForAppend(
+                existingSegments,
+                adjustedSegments,
+                adjustedStage.OwnedSegments,
+                adjustedStage.AppliedEventCount);
         }
 
         var mergeAttempt = mergeResult.GetValue();
         if (!mergeAttempt.Merged)
         {
-            return ManifestUpdatePlan.ForAppend(existingSegments, stage.Segments);
+            return ManifestUpdatePlan.ForAppend(
+                existingSegments,
+                adjustedSegments,
+                adjustedStage.OwnedSegments,
+                adjustedStage.AppliedEventCount);
         }
         var mergedTail = mergeAttempt.Segment!;
 
         var resultSegments = new List<StagedSegment> { mergedTail };
-        resultSegments.AddRange(stage.Segments.Skip(1));
+        resultSegments.AddRange(adjustedSegments.Skip(1));
 
         var updatedSegments = existingSegments.Take(existingSegments.Count - 1).ToList();
         updatedSegments.AddRange(resultSegments.Select(x => x.Info));
@@ -415,7 +440,8 @@ public sealed class ColdExporter : IColdEventExporter, IColdEventProgressReader
             SegmentsToUpload: resultSegments,
             ResultSegments: resultSegments,
             ReplacedSegmentPaths: replacedSegmentPaths,
-            OwnedSegments: [mergedTail]);
+            OwnedSegments: adjustedStage.OwnedSegments.Concat([mergedTail]).ToList(),
+            AppliedEventCount: adjustedStage.AppliedEventCount);
     }
 
     private bool CanMergeTail(ColdSegmentInfo existingTail, ColdSegmentInfo firstStagedSegment)
@@ -488,6 +514,66 @@ public sealed class ColdExporter : IColdEventExporter, IColdEventProgressReader
         }
     }
 
+    private async Task<TailOverlapAdjustment> RemoveTailOverlapAsync(
+        string serviceId,
+        ColdSegmentInfo existingTail,
+        IReadOnlyList<StagedSegment> stagedSegments,
+        CancellationToken ct)
+    {
+        if (stagedSegments.Count == 0)
+        {
+            return new TailOverlapAdjustment([], [], 0);
+        }
+
+        var adjustedSegments = new List<StagedSegment>();
+        var ownedSegments = new List<StagedSegment>();
+        var appliedEventCount = 0;
+        var overlapResolved = false;
+
+        foreach (var stagedSegment in stagedSegments)
+        {
+            if (overlapResolved)
+            {
+                adjustedSegments.Add(stagedSegment);
+                appliedEventCount += stagedSegment.Info.EventCount;
+                continue;
+            }
+
+            if (string.Compare(stagedSegment.Info.FromSortableUniqueId, existingTail.ToSortableUniqueId, StringComparison.Ordinal) > 0)
+            {
+                overlapResolved = true;
+                adjustedSegments.Add(stagedSegment);
+                appliedEventCount += stagedSegment.Info.EventCount;
+                continue;
+            }
+
+            var stagedEvents = (await ReadEventsFromLocalSegmentAsync(stagedSegment, ct)).GetValue();
+            var filteredEvents = stagedEvents
+                .Where(evt => string.Compare(evt.SortableUniqueIdValue, existingTail.ToSortableUniqueId, StringComparison.Ordinal) > 0)
+                .ToList();
+
+            if (filteredEvents.Count == 0)
+            {
+                continue;
+            }
+
+            overlapResolved = true;
+            if (filteredEvents.Count == stagedEvents.Count)
+            {
+                adjustedSegments.Add(stagedSegment);
+                appliedEventCount += stagedSegment.Info.EventCount;
+                continue;
+            }
+
+            var rebuiltSegment = await CreateSegmentFromEventsAsync(serviceId, filteredEvents, ct);
+            ownedSegments.Add(rebuiltSegment);
+            adjustedSegments.Add(rebuiltSegment);
+            appliedEventCount += rebuiltSegment.Info.EventCount;
+        }
+
+        return new TailOverlapAdjustment(adjustedSegments, ownedSegments, appliedEventCount);
+    }
+
     private async Task<ResultBox<IColdSegmentFileBuilder>> AppendExistingTailAsync(
         ColdSegmentInfo existingTail,
         CancellationToken ct)
@@ -553,6 +639,40 @@ public sealed class ColdExporter : IColdEventExporter, IColdEventProgressReader
         return !readResult.IsSuccess
             ? ResultBox.Error<List<SerializableEvent>>(readResult.GetException())
             : ResultBox.FromValue(events);
+    }
+
+    private async Task<StagedSegment> CreateSegmentFromEventsAsync(
+        string serviceId,
+        IReadOnlyList<SerializableEvent> events,
+        CancellationToken ct)
+    {
+        if (events.Count == 0)
+        {
+            throw new InvalidOperationException("Cannot create a cold segment from an empty event list.");
+        }
+
+        IColdSegmentFileBuilder? builder = null;
+        try
+        {
+            builder = await _segmentFormatHandler.CreateBuilderAsync(events[0], ct);
+            for (var i = 1; i < events.Count; i++)
+            {
+                await builder.AppendAsync(events[i], ct);
+            }
+
+            var completed = await builder.CompleteAsync(serviceId, ct);
+            builder = null;
+            return new StagedSegment(completed.FilePath, completed.Info);
+        }
+        catch
+        {
+            if (builder is not null)
+            {
+                await builder.DisposeAsync();
+            }
+
+            throw;
+        }
     }
 
     private async Task CleanupUploadedSegmentsAsync(
@@ -715,17 +835,21 @@ public sealed class ColdExporter : IColdEventExporter, IColdEventProgressReader
         IReadOnlyList<StagedSegment> SegmentsToUpload,
         IReadOnlyList<StagedSegment> ResultSegments,
         IReadOnlyList<string> ReplacedSegmentPaths,
-        IReadOnlyList<StagedSegment> OwnedSegments) : IAsyncDisposable
+        IReadOnlyList<StagedSegment> OwnedSegments,
+        int AppliedEventCount) : IAsyncDisposable
     {
         public static ManifestUpdatePlan ForAppend(
             IReadOnlyList<ColdSegmentInfo> existingSegments,
-            IReadOnlyList<StagedSegment> stageSegments)
+            IReadOnlyList<StagedSegment> stageSegments,
+            IReadOnlyList<StagedSegment> ownedSegments,
+            int appliedEventCount)
             => new(
                 UpdatedManifestSegments: existingSegments.Concat(stageSegments.Select(x => x.Info)).ToList(),
                 SegmentsToUpload: stageSegments,
                 ResultSegments: stageSegments,
                 ReplacedSegmentPaths: [],
-                OwnedSegments: []);
+                OwnedSegments: ownedSegments,
+                AppliedEventCount: appliedEventCount);
 
         public async ValueTask DisposeAsync()
         {
@@ -737,5 +861,10 @@ public sealed class ColdExporter : IColdEventExporter, IColdEventProgressReader
     }
 
     private sealed record MergeTailAttempt(bool Merged, StagedSegment? Segment);
+
+    private sealed record TailOverlapAdjustment(
+        IReadOnlyList<StagedSegment> Segments,
+        IReadOnlyList<StagedSegment> OwnedSegments,
+        int AppliedEventCount);
 
 }

--- a/dcb/src/Sekiban.Dcb.Core/ColdEvents/ColdExporter.cs
+++ b/dcb/src/Sekiban.Dcb.Core/ColdEvents/ColdExporter.cs
@@ -238,7 +238,8 @@ public sealed class ColdExporter : IColdEventExporter, IColdEventProgressReader
             return ResultBox.FromValue(new StagedExportResult(
                 ImmediateResult: null,
                 Segments: stagedSegments,
-                LastSafeSortableUniqueId: lastSafeSortableUniqueId));
+                LastSafeSortableUniqueId: lastSafeSortableUniqueId,
+                ExportedEventCount: stagedSegments.Sum(x => x.Info.EventCount)));
         }
         catch (Exception ex)
         {
@@ -279,7 +280,8 @@ public sealed class ColdExporter : IColdEventExporter, IColdEventProgressReader
                 Reason: reason,
                 ShouldContinueWithinCycle: false),
             [],
-            null));
+            null,
+            0));
 
     private static async Task DisposeStagedResourcesAsync(
         IEnumerable<StagedSegment> stagedSegments,
@@ -303,17 +305,23 @@ public sealed class ColdExporter : IColdEventExporter, IColdEventProgressReader
     {
         var existingManifest = await ColdControlFileHelper.LoadManifestWithETagAsync(_storage, serviceId, ct);
         var existingCheckpoint = await ColdControlFileHelper.LoadCheckpointWithETagAsync(_storage, serviceId, ct);
-        var updatedSegments = (existingManifest?.Manifest?.Segments ?? []).ToList();
+        await using var updatePlan = await BuildManifestUpdatePlanAsync(
+            serviceId,
+            existingManifest?.Manifest,
+            stage,
+            ct);
+        var updatedSegments = updatePlan.UpdatedManifestSegments.ToList();
+        var uploadedPaths = new List<string>();
 
-        foreach (var segment in stage.Segments)
+        foreach (var segment in updatePlan.SegmentsToUpload)
         {
             var putResult = await segment.UploadAsync(_storage, ct);
             if (!putResult.IsSuccess)
             {
+                await CleanupUploadedSegmentsAsync(uploadedPaths, ct);
                 return ResultBox.Error<ExportResult>(putResult.GetException());
             }
-
-            updatedSegments.Add(segment.Info);
+            uploadedPaths.Add(segment.Info.Path);
         }
 
         var newVersion = Guid.NewGuid().ToString();
@@ -330,6 +338,7 @@ public sealed class ColdExporter : IColdEventExporter, IColdEventProgressReader
             manifestPath, manifestData, existingManifest?.ETag, ct);
         if (!manifestResult.IsSuccess)
         {
+            await CleanupUploadedSegmentsAsync(uploadedPaths, ct);
             return ResultBox.Error<ExportResult>(manifestResult.GetException());
         }
 
@@ -349,12 +358,225 @@ public sealed class ColdExporter : IColdEventExporter, IColdEventProgressReader
             return ResultBox.Error<ExportResult>(checkpointResult.GetException());
         }
 
+        await DeleteSegmentsAsync(updatePlan.ReplacedSegmentPaths, ct);
+
         return ResultBox.FromValue(new ExportResult(
-            ExportedEventCount: stage.Segments.Sum(x => x.Info.EventCount),
-            NewSegments: stage.Segments.Select(x => x.Info).ToList(),
+            ExportedEventCount: stage.ExportedEventCount,
+            NewSegments: updatePlan.ResultSegments.Select(x => x.Info).ToList(),
             UpdatedManifestVersion: newVersion,
             Reason: ReasonExported,
             ShouldContinueWithinCycle: true));
+    }
+
+    private async Task<ManifestUpdatePlan> BuildManifestUpdatePlanAsync(
+        string serviceId,
+        ColdManifest? existingManifest,
+        StagedExportResult stage,
+        CancellationToken ct)
+    {
+        var existingSegments = (existingManifest?.Segments ?? []).ToList();
+        if (existingSegments.Count == 0 || stage.Segments.Count == 0)
+        {
+            return ManifestUpdatePlan.ForAppend(existingSegments, stage.Segments);
+        }
+
+        var existingTail = existingSegments[^1];
+        var firstStagedSegment = stage.Segments[0];
+        if (!CanMergeTail(existingTail, firstStagedSegment.Info))
+        {
+            return ManifestUpdatePlan.ForAppend(existingSegments, stage.Segments);
+        }
+
+        var mergeResult = await TryMergeTailSegmentAsync(serviceId, existingTail, firstStagedSegment, ct);
+        if (!mergeResult.IsSuccess)
+        {
+            return ManifestUpdatePlan.ForAppend(existingSegments, stage.Segments);
+        }
+
+        var mergeAttempt = mergeResult.GetValue();
+        if (!mergeAttempt.Merged)
+        {
+            return ManifestUpdatePlan.ForAppend(existingSegments, stage.Segments);
+        }
+        var mergedTail = mergeAttempt.Segment!;
+
+        var resultSegments = new List<StagedSegment> { mergedTail };
+        resultSegments.AddRange(stage.Segments.Skip(1));
+
+        var updatedSegments = existingSegments.Take(existingSegments.Count - 1).ToList();
+        updatedSegments.AddRange(resultSegments.Select(x => x.Info));
+
+        var replacedSegmentPaths = mergedTail.Info.Path == existingTail.Path
+            ? Array.Empty<string>()
+            : new[] { existingTail.Path };
+
+        return new ManifestUpdatePlan(
+            UpdatedManifestSegments: updatedSegments,
+            SegmentsToUpload: resultSegments,
+            ResultSegments: resultSegments,
+            ReplacedSegmentPaths: replacedSegmentPaths,
+            OwnedSegments: [mergedTail]);
+    }
+
+    private bool CanMergeTail(ColdSegmentInfo existingTail, ColdSegmentInfo firstStagedSegment)
+        => firstStagedSegment.EventCount > 0
+           && existingTail.EventCount < _options.SegmentMaxEvents
+           && existingTail.SizeBytes < _options.SegmentMaxBytes
+           && existingTail.EventCount + firstStagedSegment.EventCount <= _options.SegmentMaxEvents
+           && existingTail.SizeBytes + firstStagedSegment.SizeBytes <= _options.SegmentMaxBytes;
+
+    private async Task<ResultBox<MergeTailAttempt>> TryMergeTailSegmentAsync(
+        string serviceId,
+        ColdSegmentInfo existingTail,
+        StagedSegment firstStagedSegment,
+        CancellationToken ct)
+    {
+        if (existingTail.EventCount >= _options.SegmentMaxEvents
+            || existingTail.SizeBytes >= _options.SegmentMaxBytes
+            || existingTail.EventCount + firstStagedSegment.Info.EventCount > _options.SegmentMaxEvents
+            || existingTail.SizeBytes + firstStagedSegment.Info.SizeBytes > _options.SegmentMaxBytes)
+        {
+            return ResultBox.FromValue(new MergeTailAttempt(false, null));
+        }
+
+        var stagedEventsResult = await ReadEventsFromLocalSegmentAsync(firstStagedSegment, ct);
+        if (!stagedEventsResult.IsSuccess)
+        {
+            return ResultBox.Error<MergeTailAttempt>(stagedEventsResult.GetException());
+        }
+
+        var stagedEvents = stagedEventsResult.GetValue();
+        if (stagedEvents.Count == 0)
+        {
+            return ResultBox.FromValue(new MergeTailAttempt(false, null));
+        }
+
+        IColdSegmentFileBuilder? builder = null;
+        try
+        {
+            var existingEventsResult = await AppendExistingTailAsync(existingTail, ct);
+            if (!existingEventsResult.IsSuccess)
+            {
+                return ResultBox.Error<MergeTailAttempt>(existingEventsResult.GetException());
+            }
+
+            builder = existingEventsResult.GetValue();
+            foreach (var evt in stagedEvents)
+            {
+                if (!builder.CanAppend(evt, _options))
+                {
+                    return ResultBox.FromValue(new MergeTailAttempt(false, null));
+                }
+
+                await builder.AppendAsync(evt, ct);
+            }
+
+            var completed = await builder.CompleteAsync(serviceId, ct);
+            builder = null;
+            return ResultBox.FromValue(new MergeTailAttempt(true, new StagedSegment(completed.FilePath, completed.Info)));
+        }
+        catch (Exception ex)
+        {
+            return ResultBox.Error<MergeTailAttempt>(ex);
+        }
+        finally
+        {
+            if (builder is not null)
+            {
+                await builder.DisposeAsync();
+            }
+        }
+    }
+
+    private async Task<ResultBox<IColdSegmentFileBuilder>> AppendExistingTailAsync(
+        ColdSegmentInfo existingTail,
+        CancellationToken ct)
+    {
+        IColdSegmentFileBuilder? builder = null;
+        var streamResult = await _storage.OpenReadAsync(existingTail.Path, ct);
+        if (!streamResult.IsSuccess)
+        {
+            return ResultBox.Error<IColdSegmentFileBuilder>(streamResult.GetException());
+        }
+
+        await using var stream = streamResult.GetValue();
+        var readResult = await _segmentFormatHandler.StreamSegmentAsync(
+            stream,
+            since: null,
+            maxCount: null,
+            async evt =>
+            {
+                if (builder is null)
+                {
+                    builder = await _segmentFormatHandler.CreateBuilderAsync(evt, ct);
+                    return;
+                }
+
+                await builder.AppendAsync(evt, ct);
+            },
+            ct);
+        if (!readResult.IsSuccess)
+        {
+            return ResultBox.Error<IColdSegmentFileBuilder>(readResult.GetException());
+        }
+
+        return builder is null
+            ? ResultBox.Error<IColdSegmentFileBuilder>(
+                new InvalidOperationException($"Cold segment {existingTail.Path} did not contain any events."))
+            : ResultBox.FromValue<IColdSegmentFileBuilder>(builder);
+    }
+
+    private async Task<ResultBox<List<SerializableEvent>>> ReadEventsFromLocalSegmentAsync(
+        StagedSegment stagedSegment,
+        CancellationToken ct)
+    {
+        var events = new List<SerializableEvent>(stagedSegment.Info.EventCount);
+        await using var stream = new FileStream(
+            stagedSegment.FilePath,
+            FileMode.Open,
+            FileAccess.Read,
+            FileShare.Read,
+            bufferSize: 81920,
+            FileOptions.Asynchronous | FileOptions.SequentialScan);
+
+        var readResult = await _segmentFormatHandler.StreamSegmentAsync(
+            stream,
+            since: null,
+            maxCount: null,
+            evt =>
+            {
+                events.Add(evt);
+                return ValueTask.CompletedTask;
+            },
+            ct);
+
+        return !readResult.IsSuccess
+            ? ResultBox.Error<List<SerializableEvent>>(readResult.GetException())
+            : ResultBox.FromValue(events);
+    }
+
+    private async Task CleanupUploadedSegmentsAsync(
+        IEnumerable<string> uploadedPaths,
+        CancellationToken ct)
+    {
+        foreach (var path in uploadedPaths)
+        {
+            await _storage.DeleteAsync(path, ct);
+        }
+    }
+
+    private async Task DeleteSegmentsAsync(
+        IEnumerable<string> segmentPaths,
+        CancellationToken ct)
+    {
+        foreach (var path in segmentPaths)
+        {
+            var deleteResult = await _storage.DeleteAsync(path, ct);
+            if (!deleteResult.IsSuccess)
+            {
+                _logger.LogWarning(deleteResult.GetException(), "Failed to delete replaced cold segment {Path}", path);
+            }
+        }
     }
 
     private async IAsyncEnumerable<SerializableEvent> ReadExportCandidatesAsStreamAsync(
@@ -435,7 +657,8 @@ public sealed class ColdExporter : IColdEventExporter, IColdEventProgressReader
     private sealed record StagedExportResult(
         ExportResult? ImmediateResult,
         IReadOnlyList<StagedSegment> Segments,
-        string? LastSafeSortableUniqueId) : IAsyncDisposable
+        string? LastSafeSortableUniqueId,
+        int ExportedEventCount) : IAsyncDisposable
     {
         public async ValueTask DisposeAsync()
         {
@@ -486,5 +709,33 @@ public sealed class ColdExporter : IColdEventExporter, IColdEventProgressReader
             return ValueTask.CompletedTask;
         }
     }
+
+    private sealed record ManifestUpdatePlan(
+        IReadOnlyList<ColdSegmentInfo> UpdatedManifestSegments,
+        IReadOnlyList<StagedSegment> SegmentsToUpload,
+        IReadOnlyList<StagedSegment> ResultSegments,
+        IReadOnlyList<string> ReplacedSegmentPaths,
+        IReadOnlyList<StagedSegment> OwnedSegments) : IAsyncDisposable
+    {
+        public static ManifestUpdatePlan ForAppend(
+            IReadOnlyList<ColdSegmentInfo> existingSegments,
+            IReadOnlyList<StagedSegment> stageSegments)
+            => new(
+                UpdatedManifestSegments: existingSegments.Concat(stageSegments.Select(x => x.Info)).ToList(),
+                SegmentsToUpload: stageSegments,
+                ResultSegments: stageSegments,
+                ReplacedSegmentPaths: [],
+                OwnedSegments: []);
+
+        public async ValueTask DisposeAsync()
+        {
+            foreach (var segment in OwnedSegments)
+            {
+                await segment.DisposeAsync();
+            }
+        }
+    }
+
+    private sealed record MergeTailAttempt(bool Merged, StagedSegment? Segment);
 
 }

--- a/dcb/tests/Sekiban.Dcb.ColdEvents.Tests/ColdExporterTests.cs
+++ b/dcb/tests/Sekiban.Dcb.ColdEvents.Tests/ColdExporterTests.cs
@@ -317,6 +317,50 @@ public class ColdExporterTests
     }
 
     [Fact]
+    public async Task ExportIncrementalAsync_should_not_duplicate_tail_events_when_manifest_is_ahead_of_checkpoint()
+    {
+        // Given
+        var options = EnabledOptions with { SegmentMaxEvents = 10, SegmentMaxBytes = long.MaxValue };
+        var t0 = DateTime.UtcNow.AddMinutes(-10);
+        var e1 = CreateEvent(t0, "Event1");
+        var e2 = CreateEvent(t0.AddSeconds(1), "Event2");
+        var e3 = CreateEvent(t0.AddSeconds(2), "Event3");
+
+        var baseStorage = new InMemoryColdObjectStorage();
+        var failingCheckpointStorage = new FailingCheckpointStorage(baseStorage, ServiceId);
+
+        var firstExporter = CreateExporter(new StubEventStore([e1, e2]), options, baseStorage, _leaseManager);
+        var first = await firstExporter.ExportIncrementalAsync(ServiceId, CancellationToken.None);
+        Assert.True(first.IsSuccess);
+
+        var secondExporter = CreateExporter(new StubEventStore([e1, e2, e3]), options, failingCheckpointStorage, _leaseManager);
+        var second = await secondExporter.ExportIncrementalAsync(ServiceId, CancellationToken.None);
+        Assert.False(second.IsSuccess);
+
+        var staleProgress = await CreateExporter(new StubEventStore([]), options, baseStorage, _leaseManager)
+            .GetProgressAsync(ServiceId, CancellationToken.None);
+        Assert.True(staleProgress.IsSuccess);
+        Assert.Equal(e2.SortableUniqueIdValue, staleProgress.GetValue().NextSinceSortableUniqueId);
+        Assert.Equal(e3.SortableUniqueIdValue, staleProgress.GetValue().LatestSafeSortableUniqueId);
+
+        var retryExporter = CreateExporter(new StubEventStore([e1, e2, e3]), options, baseStorage, _leaseManager);
+        var retry = await retryExporter.ExportIncrementalAsync(ServiceId, CancellationToken.None);
+
+        Assert.True(retry.IsSuccess);
+        Assert.Equal(0, retry.GetValue().ExportedEventCount);
+
+        var manifest = await ColdControlFileHelper.LoadManifestAsync(baseStorage, ServiceId, CancellationToken.None);
+        Assert.NotNull(manifest);
+        Assert.Single(manifest!.Segments);
+        Assert.Equal(3, manifest.Segments[0].EventCount);
+        Assert.Equal(e3.SortableUniqueIdValue, manifest.Segments[0].ToSortableUniqueId);
+
+        var repairedProgress = await retryExporter.GetProgressAsync(ServiceId, CancellationToken.None);
+        Assert.True(repairedProgress.IsSuccess);
+        Assert.Equal(e3.SortableUniqueIdValue, repairedProgress.GetValue().NextSinceSortableUniqueId);
+    }
+
+    [Fact]
     public async Task ExportIncrementalAsync_should_fail_when_checkpoint_write_fails()
     {
         // Given
@@ -600,4 +644,5 @@ public class ColdExporterTests
         public Task<ResultBox<bool>> DeleteAsync(string path, CancellationToken ct)
             => _inner.DeleteAsync(path, ct);
     }
+
 }

--- a/dcb/tests/Sekiban.Dcb.ColdEvents.Tests/ColdExporterTests.cs
+++ b/dcb/tests/Sekiban.Dcb.ColdEvents.Tests/ColdExporterTests.cs
@@ -38,6 +38,11 @@ public class ColdExporterTests
             EventPayloadName: name);
     }
 
+    private static SerializableEvent[] CreateEvents(DateTime start, int count, string prefix)
+        => Enumerable.Range(0, count)
+            .Select(i => CreateEvent(start.AddSeconds(i), $"{prefix}{i + 1}"))
+            .ToArray();
+
     private ColdExporter CreateExporter(
         IHotEventStore hotStore,
         ColdEventStoreOptions? options = null,
@@ -170,10 +175,10 @@ public class ColdExporterTests
     }
 
     [Fact]
-    public async Task ExportIncrementalAsync_should_create_new_segment_without_reloading_previous_segment()
+    public async Task ExportIncrementalAsync_should_merge_incremental_events_into_existing_tail_when_tail_has_capacity()
     {
         // Given
-        var options = EnabledOptions with { SegmentMaxEvents = 3, SegmentMaxBytes = long.MaxValue };
+        var options = EnabledOptions with { SegmentMaxEvents = 10, SegmentMaxBytes = long.MaxValue };
         var t0 = DateTime.UtcNow.AddMinutes(-10);
         var e1 = CreateEvent(t0, "Event1");
         var e2 = CreateEvent(t0.AddSeconds(1), "Event2");
@@ -195,11 +200,11 @@ public class ColdExporterTests
         Assert.True(second.IsSuccess);
         var manifest = await ColdControlFileHelper.LoadManifestAsync(_storage, ServiceId, CancellationToken.None);
         Assert.NotNull(manifest);
-        Assert.Equal(2, manifest!.Segments.Count);
-        Assert.Equal(firstPath, manifest.Segments[0].Path);
-        Assert.Equal(2, manifest.Segments[0].EventCount);
-        Assert.Equal(1, manifest.Segments[1].EventCount);
-        Assert.Equal(e3.SortableUniqueIdValue, manifest.Segments[1].ToSortableUniqueId);
+        Assert.Single(manifest!.Segments);
+        Assert.NotEqual(firstPath, manifest.Segments[0].Path);
+        Assert.Equal(3, manifest.Segments[0].EventCount);
+        Assert.Equal(e1.SortableUniqueIdValue, manifest.Segments[0].FromSortableUniqueId);
+        Assert.Equal(e3.SortableUniqueIdValue, manifest.Segments[0].ToSortableUniqueId);
     }
 
     [Fact]
@@ -226,6 +231,89 @@ public class ColdExporterTests
         Assert.Equal(2, manifest.Segments[0].EventCount);
         Assert.Equal(1, manifest.Segments[1].EventCount);
         Assert.Equal(e3.SortableUniqueIdValue, manifest.Segments[1].ToSortableUniqueId);
+    }
+
+    [Fact]
+    public async Task ExportIncrementalAsync_should_not_grow_tiny_tail_segments_for_repeated_trickle_exports()
+    {
+        // Given
+        var options = EnabledOptions with { SegmentMaxEvents = 16, SegmentMaxBytes = long.MaxValue };
+        var t0 = DateTime.UtcNow.AddMinutes(-20);
+        var initialEvents = CreateEvents(t0, 10, "Initial");
+        var trickleOne = CreateEvents(t0.AddMinutes(1), 3, "TrickleA");
+        var trickleTwo = CreateEvents(t0.AddMinutes(2), 5, "TrickleB");
+        var trickleThree = CreateEvents(t0.AddMinutes(3), 8, "TrickleC");
+
+        var firstExporter = CreateExporter(new StubEventStore(initialEvents), options, _storage, _leaseManager);
+        var first = await firstExporter.ExportIncrementalAsync(ServiceId, CancellationToken.None);
+        Assert.True(first.IsSuccess);
+
+        var secondExporter = CreateExporter(
+            new StubEventStore(initialEvents.Concat(trickleOne).ToArray()),
+            options,
+            _storage,
+            _leaseManager);
+        var second = await secondExporter.ExportIncrementalAsync(ServiceId, CancellationToken.None);
+        Assert.True(second.IsSuccess);
+        var secondManifest = await ColdControlFileHelper.LoadManifestAsync(_storage, ServiceId, CancellationToken.None);
+        Assert.NotNull(secondManifest);
+        Assert.Single(secondManifest!.Segments);
+        Assert.Equal(13, secondManifest.Segments[0].EventCount);
+
+        var thirdExporter = CreateExporter(
+            new StubEventStore(initialEvents.Concat(trickleOne).Concat(trickleTwo).ToArray()),
+            options,
+            _storage,
+            _leaseManager);
+        var third = await thirdExporter.ExportIncrementalAsync(ServiceId, CancellationToken.None);
+        Assert.True(third.IsSuccess);
+        var thirdManifest = await ColdControlFileHelper.LoadManifestAsync(_storage, ServiceId, CancellationToken.None);
+        Assert.NotNull(thirdManifest);
+        Assert.Equal(2, thirdManifest!.Segments.Count);
+        Assert.Equal(13, thirdManifest.Segments[0].EventCount);
+        Assert.Equal(5, thirdManifest.Segments[1].EventCount);
+
+        var fourthExporter = CreateExporter(
+            new StubEventStore(initialEvents.Concat(trickleOne).Concat(trickleTwo).Concat(trickleThree).ToArray()),
+            options,
+            _storage,
+            _leaseManager);
+        var fourth = await fourthExporter.ExportIncrementalAsync(ServiceId, CancellationToken.None);
+        Assert.True(fourth.IsSuccess);
+
+        var manifest = await ColdControlFileHelper.LoadManifestAsync(_storage, ServiceId, CancellationToken.None);
+        Assert.NotNull(manifest);
+        Assert.Equal(2, manifest!.Segments.Count);
+        Assert.Equal(13, manifest.Segments[0].EventCount);
+        Assert.Equal(13, manifest.Segments[1].EventCount);
+    }
+
+    [Fact]
+    public async Task ExportIncrementalAsync_should_retry_tail_merge_after_manifest_conflict()
+    {
+        // Given
+        var options = EnabledOptions with { SegmentMaxEvents = 10, SegmentMaxBytes = long.MaxValue };
+        var t0 = DateTime.UtcNow.AddMinutes(-10);
+        var e1 = CreateEvent(t0, "Event1");
+        var e2 = CreateEvent(t0.AddSeconds(1), "Event2");
+        var e3 = CreateEvent(t0.AddSeconds(2), "Event3");
+
+        var baseStorage = new InMemoryColdObjectStorage();
+        var flakyStorage = new FailFirstManifestWriteStorage(baseStorage, ServiceId);
+
+        var firstExporter = CreateExporter(new StubEventStore([e1, e2]), options, flakyStorage, _leaseManager);
+        var first = await firstExporter.ExportIncrementalAsync(ServiceId, CancellationToken.None);
+        Assert.True(first.IsSuccess);
+
+        var secondExporter = CreateExporter(new StubEventStore([e1, e2, e3]), options, flakyStorage, _leaseManager);
+        var second = await secondExporter.ExportIncrementalAsync(ServiceId, CancellationToken.None);
+
+        Assert.True(second.IsSuccess);
+        var manifest = await ColdControlFileHelper.LoadManifestAsync(flakyStorage, ServiceId, CancellationToken.None);
+        Assert.NotNull(manifest);
+        Assert.Single(manifest!.Segments);
+        Assert.Equal(3, manifest.Segments[0].EventCount);
+        Assert.Equal(e3.SortableUniqueIdValue, manifest.Segments[0].ToSortableUniqueId);
     }
 
     [Fact]
@@ -472,5 +560,44 @@ public class ColdExporterTests
         public Task<ResultBox<(IReadOnlyList<SerializableEvent> Events, IReadOnlyList<TagWriteResult> TagWrites)>>
             WriteSerializableEventsAsync(IEnumerable<SerializableEvent> events)
             => throw new NotSupportedException();
+    }
+
+    private sealed class FailFirstManifestWriteStorage : IColdObjectStorage
+    {
+        private readonly IColdObjectStorage _inner;
+        private readonly string _manifestPath;
+        private bool _shouldFail = true;
+
+        public FailFirstManifestWriteStorage(IColdObjectStorage inner, string serviceId)
+        {
+            _inner = inner;
+            _manifestPath = ColdStoragePaths.ManifestPath(serviceId);
+        }
+
+        public Task<ResultBox<ColdStorageObject>> GetAsync(string path, CancellationToken ct)
+            => _inner.GetAsync(path, ct);
+
+        public Task<ResultBox<bool>> PutAsync(string path, byte[] data, string? expectedETag, CancellationToken ct)
+        {
+            if (_shouldFail
+                && string.Equals(path, _manifestPath, StringComparison.Ordinal)
+                && expectedETag is not null)
+            {
+                _shouldFail = false;
+                return Task.FromResult(ResultBox.Error<bool>(
+                    new InvalidOperationException("ETag mismatch at manifest")));
+            }
+
+            return _inner.PutAsync(path, data, expectedETag, ct);
+        }
+
+        public Task<ResultBox<bool>> PutAsync(string path, Stream data, string? expectedETag, CancellationToken ct)
+            => _inner.PutAsync(path, data, expectedETag, ct);
+
+        public Task<ResultBox<IReadOnlyList<string>>> ListAsync(string prefix, CancellationToken ct)
+            => _inner.ListAsync(prefix, ct);
+
+        public Task<ResultBox<bool>> DeleteAsync(string path, CancellationToken ct)
+            => _inner.DeleteAsync(path, ct);
     }
 }


### PR DESCRIPTION
## Summary
- merge a small incremental export into the existing cold tail segment when the tail still has capacity
- replace the tail segment in the manifest instead of appending a new tiny segment
- add regression coverage for repeated trickle exports and manifest-retry behavior

## Details
This change keeps tiny incremental exports from endlessly growing the cold manifest tail when the previous segment is still under the configured limits.

The exporter now:
- reloads the current manifest tail during manifest update
- rebuilds a replacement tail segment from the existing tail plus the first staged segment when both fit within `SegmentMaxEvents` and `SegmentMaxBytes`
- swaps that replacement into the manifest and deletes the superseded tail blob after a successful manifest/checkpoint update
- cleans up newly uploaded segment blobs when the manifest write fails before the update is committed

## Validation
- `dotnet test dcb/tests/Sekiban.Dcb.ColdEvents.Tests/Sekiban.Dcb.ColdEvents.Tests.csproj -c Release --filter ColdExporterTests`
- `dotnet test dcb/tests/Sekiban.Dcb.ColdEvents.Tests/Sekiban.Dcb.ColdEvents.Tests.csproj -c Release`

Closes #1020
