### PR TITLE
Add cold tail merge temp budget controls

### DIFF
--- a/dcb/src/Sekiban.Dcb.Core/ColdEvents/ColdEventStoreOptions.cs
+++ b/dcb/src/Sekiban.Dcb.Core/ColdEvents/ColdEventStoreOptions.cs
@@ -11,7 +11,7 @@ public record ColdEventStoreOptions
     public int ExportMaxEventsPerRun { get; init; } = 100_000;
     public long SegmentMaxBytes { get; init; } = 512L * 1024 * 1024;
     public bool EnableTailMerge { get; init; } = true;
-    public long? TailMergeMaxLocalBytes { get; init; } = 64L * 1024 * 1024;
+    public long? TailMergeMaxLocalBytes { get; init; }
     public int ColdCatchUpBatchSize { get; init; } = 100_000;
     public bool AlignCatchUpReadsToSegmentBoundary { get; init; } = true;
     public bool PersistSnapshotOnColdSegmentBoundary { get; init; } = true;

--- a/dcb/src/Sekiban.Dcb.Core/ColdEvents/ColdEventStoreOptions.cs
+++ b/dcb/src/Sekiban.Dcb.Core/ColdEvents/ColdEventStoreOptions.cs
@@ -10,6 +10,8 @@ public record ColdEventStoreOptions
     public int SegmentMaxEvents { get; init; } = 100_000;
     public int ExportMaxEventsPerRun { get; init; } = 100_000;
     public long SegmentMaxBytes { get; init; } = 512L * 1024 * 1024;
+    public bool EnableTailMerge { get; init; } = true;
+    public long? TailMergeMaxLocalBytes { get; init; } = 64L * 1024 * 1024;
     public int ColdCatchUpBatchSize { get; init; } = 100_000;
     public bool AlignCatchUpReadsToSegmentBoundary { get; init; } = true;
     public bool PersistSnapshotOnColdSegmentBoundary { get; init; } = true;

--- a/dcb/src/Sekiban.Dcb.Core/ColdEvents/ColdExporter.cs
+++ b/dcb/src/Sekiban.Dcb.Core/ColdEvents/ColdExporter.cs
@@ -456,7 +456,7 @@ public sealed class ColdExporter : IColdEventExporter, IColdEventProgressReader
     {
         if (!_options.EnableTailMerge)
         {
-            return new TailMergeDecision(false, "disabled", null, _options.TailMergeMaxLocalBytes);
+            return new TailMergeDecision(false, TailMergeSkipReason.Disabled, null, _options.TailMergeMaxLocalBytes);
         }
 
         if (firstStagedSegment.EventCount <= 0
@@ -465,7 +465,7 @@ public sealed class ColdExporter : IColdEventExporter, IColdEventProgressReader
             || existingTail.EventCount + firstStagedSegment.EventCount > _options.SegmentMaxEvents
             || existingTail.SizeBytes + firstStagedSegment.SizeBytes > _options.SegmentMaxBytes)
         {
-            return new TailMergeDecision(false, "segment_limits", null, _options.TailMergeMaxLocalBytes);
+            return new TailMergeDecision(false, TailMergeSkipReason.SegmentLimits, null, _options.TailMergeMaxLocalBytes);
         }
 
         var estimatedLocalBytes = EstimateTailMergeLocalBytes(existingTail, firstStagedSegment);
@@ -473,7 +473,7 @@ public sealed class ColdExporter : IColdEventExporter, IColdEventProgressReader
         {
             return new TailMergeDecision(
                 false,
-                "local_budget_exceeded",
+                TailMergeSkipReason.LocalBudgetExceeded,
                 estimatedLocalBytes,
                 _options.TailMergeMaxLocalBytes);
         }
@@ -487,7 +487,7 @@ public sealed class ColdExporter : IColdEventExporter, IColdEventProgressReader
     {
         try
         {
-            return checked(existingTail.SizeBytes + firstStagedSegment.SizeBytes);
+            return checked(existingTail.SizeBytes + firstStagedSegment.SizeBytes + firstStagedSegment.SizeBytes);
         }
         catch (OverflowException)
         {
@@ -502,7 +502,7 @@ public sealed class ColdExporter : IColdEventExporter, IColdEventProgressReader
             return;
         }
 
-        if (decision.Reason == "local_budget_exceeded")
+        if (decision.Reason == TailMergeSkipReason.LocalBudgetExceeded)
         {
             _logger.LogInformation(
                 "Skipping tail merge for {ServiceId}: estimated local merge size {EstimatedBytes} exceeds budget {BudgetBytes}",
@@ -512,7 +512,7 @@ public sealed class ColdExporter : IColdEventExporter, IColdEventProgressReader
             return;
         }
 
-        if (decision.Reason == "disabled")
+        if (decision.Reason == TailMergeSkipReason.Disabled)
         {
             _logger.LogInformation(
                 "Skipping tail merge for {ServiceId}: tail merge is disabled by configuration",
@@ -976,9 +976,16 @@ public sealed class ColdExporter : IColdEventExporter, IColdEventProgressReader
 
     private sealed record TailMergeDecision(
         bool CanMerge,
-        string? Reason,
+        TailMergeSkipReason? Reason,
         long? EstimatedLocalBytes,
         long? LocalBudgetBytes);
+
+    private enum TailMergeSkipReason
+    {
+        Disabled = 1,
+        SegmentLimits = 2,
+        LocalBudgetExceeded = 3
+    }
 
     public sealed class MergeCapacityExceededException : Exception;
 

--- a/dcb/src/Sekiban.Dcb.Core/ColdEvents/ColdExporter.cs
+++ b/dcb/src/Sekiban.Dcb.Core/ColdEvents/ColdExporter.cs
@@ -395,8 +395,10 @@ public sealed class ColdExporter : IColdEventExporter, IColdEventProgressReader
         }
 
         var firstStagedSegment = adjustedSegments[0];
-        if (!CanMergeTail(existingTail, firstStagedSegment.Info))
+        var tailMergeDecision = EvaluateTailMerge(existingTail, firstStagedSegment.Info);
+        if (!tailMergeDecision.CanMerge)
         {
+            LogTailMergeSkip(serviceId, tailMergeDecision);
             return ManifestUpdatePlan.ForAppend(
                 existingSegments,
                 adjustedSegments,
@@ -448,12 +450,75 @@ public sealed class ColdExporter : IColdEventExporter, IColdEventProgressReader
             AppliedEventCount: adjustedStage.AppliedEventCount);
     }
 
-    private bool CanMergeTail(ColdSegmentInfo existingTail, ColdSegmentInfo firstStagedSegment)
-        => firstStagedSegment.EventCount > 0
-           && existingTail.EventCount < _options.SegmentMaxEvents
-           && existingTail.SizeBytes < _options.SegmentMaxBytes
-           && existingTail.EventCount + firstStagedSegment.EventCount <= _options.SegmentMaxEvents
-           && existingTail.SizeBytes + firstStagedSegment.SizeBytes <= _options.SegmentMaxBytes;
+    private TailMergeDecision EvaluateTailMerge(
+        ColdSegmentInfo existingTail,
+        ColdSegmentInfo firstStagedSegment)
+    {
+        if (!_options.EnableTailMerge)
+        {
+            return new TailMergeDecision(false, "disabled", null, _options.TailMergeMaxLocalBytes);
+        }
+
+        if (firstStagedSegment.EventCount <= 0
+            || existingTail.EventCount >= _options.SegmentMaxEvents
+            || existingTail.SizeBytes >= _options.SegmentMaxBytes
+            || existingTail.EventCount + firstStagedSegment.EventCount > _options.SegmentMaxEvents
+            || existingTail.SizeBytes + firstStagedSegment.SizeBytes > _options.SegmentMaxBytes)
+        {
+            return new TailMergeDecision(false, "segment_limits", null, _options.TailMergeMaxLocalBytes);
+        }
+
+        var estimatedLocalBytes = EstimateTailMergeLocalBytes(existingTail, firstStagedSegment);
+        if (_options.TailMergeMaxLocalBytes is > 0 && estimatedLocalBytes > _options.TailMergeMaxLocalBytes.Value)
+        {
+            return new TailMergeDecision(
+                false,
+                "local_budget_exceeded",
+                estimatedLocalBytes,
+                _options.TailMergeMaxLocalBytes);
+        }
+
+        return new TailMergeDecision(true, null, estimatedLocalBytes, _options.TailMergeMaxLocalBytes);
+    }
+
+    private static long EstimateTailMergeLocalBytes(
+        ColdSegmentInfo existingTail,
+        ColdSegmentInfo firstStagedSegment)
+    {
+        try
+        {
+            return checked(existingTail.SizeBytes + firstStagedSegment.SizeBytes);
+        }
+        catch (OverflowException)
+        {
+            return long.MaxValue;
+        }
+    }
+
+    private void LogTailMergeSkip(string serviceId, TailMergeDecision decision)
+    {
+        if (decision.Reason is null)
+        {
+            return;
+        }
+
+        if (decision.Reason == "local_budget_exceeded")
+        {
+            _logger.LogInformation(
+                "Skipping tail merge for {ServiceId}: estimated local merge size {EstimatedBytes} exceeds budget {BudgetBytes}",
+                serviceId,
+                decision.EstimatedLocalBytes,
+                decision.LocalBudgetBytes);
+            return;
+        }
+
+        if (decision.Reason == "disabled")
+        {
+            _logger.LogInformation(
+                "Skipping tail merge for {ServiceId}: tail merge is disabled by configuration",
+                serviceId);
+        }
+    }
 
     private async Task<ResultBox<MergeTailAttempt>> TryMergeTailSegmentAsync(
         string serviceId,
@@ -908,6 +973,12 @@ public sealed class ColdExporter : IColdEventExporter, IColdEventProgressReader
         IReadOnlyList<StagedSegment> Segments,
         IReadOnlyList<StagedSegment> OwnedSegments,
         int AppliedEventCount);
+
+    private sealed record TailMergeDecision(
+        bool CanMerge,
+        string? Reason,
+        long? EstimatedLocalBytes,
+        long? LocalBudgetBytes);
 
     public sealed class MergeCapacityExceededException : Exception;
 

--- a/dcb/tests/Sekiban.Dcb.ColdEvents.Tests/ColdExporterTests.cs
+++ b/dcb/tests/Sekiban.Dcb.ColdEvents.Tests/ColdExporterTests.cs
@@ -234,6 +234,64 @@ public class ColdExporterTests
     }
 
     [Fact]
+    public async Task ExportIncrementalAsync_should_append_when_tail_merge_is_disabled()
+    {
+        var options = EnabledOptions with
+        {
+            SegmentMaxEvents = 10,
+            SegmentMaxBytes = long.MaxValue,
+            EnableTailMerge = false
+        };
+        var t0 = DateTime.UtcNow.AddMinutes(-10);
+        var e1 = CreateEvent(t0, "Event1");
+        var e2 = CreateEvent(t0.AddSeconds(1), "Event2");
+        var e3 = CreateEvent(t0.AddSeconds(2), "Event3");
+
+        var firstExporter = CreateExporter(new StubEventStore([e1, e2]), options, _storage, _leaseManager);
+        var first = await firstExporter.ExportIncrementalAsync(ServiceId, CancellationToken.None);
+        Assert.True(first.IsSuccess);
+
+        var secondExporter = CreateExporter(new StubEventStore([e1, e2, e3]), options, _storage, _leaseManager);
+        var second = await secondExporter.ExportIncrementalAsync(ServiceId, CancellationToken.None);
+        Assert.True(second.IsSuccess);
+
+        var manifest = await ColdControlFileHelper.LoadManifestAsync(_storage, ServiceId, CancellationToken.None);
+        Assert.NotNull(manifest);
+        Assert.Equal(2, manifest!.Segments.Count);
+        Assert.Equal(2, manifest.Segments[0].EventCount);
+        Assert.Equal(1, manifest.Segments[1].EventCount);
+    }
+
+    [Fact]
+    public async Task ExportIncrementalAsync_should_append_when_tail_merge_exceeds_local_budget()
+    {
+        var options = EnabledOptions with
+        {
+            SegmentMaxEvents = 10,
+            SegmentMaxBytes = long.MaxValue,
+            TailMergeMaxLocalBytes = 1
+        };
+        var t0 = DateTime.UtcNow.AddMinutes(-10);
+        var e1 = CreateEvent(t0, "Event1");
+        var e2 = CreateEvent(t0.AddSeconds(1), "Event2");
+        var e3 = CreateEvent(t0.AddSeconds(2), "Event3");
+
+        var firstExporter = CreateExporter(new StubEventStore([e1, e2]), options, _storage, _leaseManager);
+        var first = await firstExporter.ExportIncrementalAsync(ServiceId, CancellationToken.None);
+        Assert.True(first.IsSuccess);
+
+        var secondExporter = CreateExporter(new StubEventStore([e1, e2, e3]), options, _storage, _leaseManager);
+        var second = await secondExporter.ExportIncrementalAsync(ServiceId, CancellationToken.None);
+        Assert.True(second.IsSuccess);
+
+        var manifest = await ColdControlFileHelper.LoadManifestAsync(_storage, ServiceId, CancellationToken.None);
+        Assert.NotNull(manifest);
+        Assert.Equal(2, manifest!.Segments.Count);
+        Assert.Equal(2, manifest.Segments[0].EventCount);
+        Assert.Equal(1, manifest.Segments[1].EventCount);
+    }
+
+    [Fact]
     public async Task ExportIncrementalAsync_should_not_grow_tiny_tail_segments_for_repeated_trickle_exports()
     {
         // Given

--- a/dcb/tests/Sekiban.Dcb.ColdEvents.Tests/ColdExporterTests.cs
+++ b/dcb/tests/Sekiban.Dcb.ColdEvents.Tests/ColdExporterTests.cs
@@ -269,7 +269,7 @@ public class ColdExporterTests
         {
             SegmentMaxEvents = 10,
             SegmentMaxBytes = long.MaxValue,
-            TailMergeMaxLocalBytes = 1
+            TailMergeMaxLocalBytes = 512
         };
         var t0 = DateTime.UtcNow.AddMinutes(-10);
         var e1 = CreateEvent(t0, "Event1");
@@ -289,6 +289,34 @@ public class ColdExporterTests
         Assert.Equal(2, manifest!.Segments.Count);
         Assert.Equal(2, manifest.Segments[0].EventCount);
         Assert.Equal(1, manifest.Segments[1].EventCount);
+    }
+
+    [Fact]
+    public async Task ExportIncrementalAsync_should_keep_existing_behavior_when_tail_merge_local_budget_is_unset()
+    {
+        var options = EnabledOptions with
+        {
+            SegmentMaxEvents = 10,
+            SegmentMaxBytes = long.MaxValue,
+            TailMergeMaxLocalBytes = null
+        };
+        var t0 = DateTime.UtcNow.AddMinutes(-10);
+        var e1 = CreateEvent(t0, "Event1");
+        var e2 = CreateEvent(t0.AddSeconds(1), "Event2");
+        var e3 = CreateEvent(t0.AddSeconds(2), "Event3");
+
+        var firstExporter = CreateExporter(new StubEventStore([e1, e2]), options, _storage, _leaseManager);
+        var first = await firstExporter.ExportIncrementalAsync(ServiceId, CancellationToken.None);
+        Assert.True(first.IsSuccess);
+
+        var secondExporter = CreateExporter(new StubEventStore([e1, e2, e3]), options, _storage, _leaseManager);
+        var second = await secondExporter.ExportIncrementalAsync(ServiceId, CancellationToken.None);
+        Assert.True(second.IsSuccess);
+
+        var manifest = await ColdControlFileHelper.LoadManifestAsync(_storage, ServiceId, CancellationToken.None);
+        Assert.NotNull(manifest);
+        Assert.Single(manifest!.Segments);
+        Assert.Equal(3, manifest.Segments[0].EventCount);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- add `EnableTailMerge` so environments with small ephemeral temp disks can disable tail merge explicitly
- add `TailMergeMaxLocalBytes` so the exporter skips tail merge before reconstructing a large local temp file
- fall back to append when tail merge is disabled or over the local budget, with targeted tests for both paths

## Validation
- `dotnet test dcb/tests/Sekiban.Dcb.ColdEvents.Tests/Sekiban.Dcb.ColdEvents.Tests.csproj -c Release --filter ColdExporterTests`
- `dotnet test dcb/tests/Sekiban.Dcb.ColdEvents.Tests/Sekiban.Dcb.ColdEvents.Tests.csproj -c Release`

## Notes
- This PR implements the framework-side guardrails requested in #1022 via explicit disable + local temp budget fallback.
- I did not run a real App Service / Functions full rebuild benchmark in this local pass, so production-scale before/after measurements are not attached here.

Closes #1022
