### PR TITLE
Expose projection and event store head status

### DIFF
--- a/dcb/internalUsages/DcbOrleans.AppHost/Program.cs
+++ b/dcb/internalUsages/DcbOrleans.AppHost/Program.cs
@@ -74,6 +74,13 @@ var withoutResultApiService = builder
     .WithReference(orleans)
     .WithReference(multiProjectionOffload)
     .WithEnvironment("Sekiban:Database", "postgres")
+    .WithEnvironment("Sekiban:ColdEvent:Enabled", "true")
+    .WithEnvironment("Sekiban:ColdEvent:SegmentMaxEvents", "30000")
+    .WithEnvironment("Sekiban:ColdEvent:ExportMaxEventsPerRun", "30000")
+    .WithEnvironment("Sekiban:ColdEvent:Storage:Provider", "azureblob")
+    .WithEnvironment("Sekiban:ColdEvent:Storage:Format", "jsonl")
+    .WithEnvironment("Sekiban:ColdEvent:Storage:AzureBlobClientName", "MultiProjectionOffload")
+    .WithEnvironment("Sekiban:ColdEvent:Storage:AzureContainerName", "multiprojection-cold-events")
     .WaitFor(postgres)
     .WaitFor(materializedViewPostgres);
 
@@ -108,6 +115,7 @@ var bench = builder
     .WithEnvironment("ApiBaseUrl", withoutResultApiService.GetEndpoint("http"))
     .WithEnvironment("BENCH_TOTAL", "10000")
     .WithEnvironment("BENCH_CONCURRENCY", "32")
+    .WithEnvironment("BENCH_PROJECTION_CONTROL_TIMEOUT_SECONDS", "120")
     .WithHttpEndpoint(port: benchHttpPort);
 
 #endif

--- a/dcb/internalUsages/DcbOrleans.AppHost/Program.cs
+++ b/dcb/internalUsages/DcbOrleans.AppHost/Program.cs
@@ -2,6 +2,7 @@ using Projects;
 
 var builder = DistributedApplication.CreateBuilder(args);
 var benchHttpPort = GetEnvInt("BENCH_HTTP_PORT", 5411);
+const string ColdEventBatchLimit = "30000";
 
 // Add Azure Storage emulator for Orleans
 var storage = builder
@@ -75,8 +76,8 @@ var withoutResultApiService = builder
     .WithReference(multiProjectionOffload)
     .WithEnvironment("Sekiban:Database", "postgres")
     .WithEnvironment("Sekiban:ColdEvent:Enabled", "true")
-    .WithEnvironment("Sekiban:ColdEvent:SegmentMaxEvents", "30000")
-    .WithEnvironment("Sekiban:ColdEvent:ExportMaxEventsPerRun", "30000")
+    .WithEnvironment("Sekiban:ColdEvent:SegmentMaxEvents", ColdEventBatchLimit)
+    .WithEnvironment("Sekiban:ColdEvent:ExportMaxEventsPerRun", ColdEventBatchLimit)
     .WithEnvironment("Sekiban:ColdEvent:Storage:Provider", "azureblob")
     .WithEnvironment("Sekiban:ColdEvent:Storage:Format", "jsonl")
     .WithEnvironment("Sekiban:ColdEvent:Storage:AzureBlobClientName", "MultiProjectionOffload")
@@ -91,8 +92,8 @@ builder
     .WithReference(multiProjectionOffload)
     .WithEnvironment("ColdExportTimerSchedule", "0 */10 * * * *")
     .WithEnvironment("Sekiban:ColdEvent:Enabled", "true")
-    .WithEnvironment("Sekiban:ColdEvent:SegmentMaxEvents", "30000")
-    .WithEnvironment("Sekiban:ColdEvent:ExportMaxEventsPerRun", "30000")
+    .WithEnvironment("Sekiban:ColdEvent:SegmentMaxEvents", ColdEventBatchLimit)
+    .WithEnvironment("Sekiban:ColdEvent:ExportMaxEventsPerRun", ColdEventBatchLimit)
     .WithEnvironment("Sekiban:ColdEvent:Storage:Provider", "azureblob")
     .WithEnvironment("Sekiban:ColdEvent:Storage:Format", "jsonl")
     .WithEnvironment("Sekiban:ColdEvent:Storage:AzureBlobClientName", "MultiProjectionOffload")

--- a/dcb/internalUsages/DcbOrleans.Benchmark/Program.cs
+++ b/dcb/internalUsages/DcbOrleans.Benchmark/Program.cs
@@ -530,7 +530,7 @@ app.MapPost("/projection/persist", async (string? mode) =>
     var name = GetProjectorName(m);
     try
     {
-        using var http = CreateApiClient(apiBase!);
+        using var http = CreateProjectionControlApiClient(apiBase!);
         var res = await http.PostAsync($"/api/projections/persist?name={Uri.EscapeDataString(name)}", null);
         var json = await Helpers.SafeReadAsync(res, CancellationToken.None);
         if (!res.IsSuccessStatusCode) return Results.BadRequest(new { error = json });
@@ -552,7 +552,7 @@ app.MapPost("/projection/deactivate", async (string? mode) =>
     {
         try
         {
-            using var http = CreateApiClient(apiBase!);
+            using var http = CreateProjectionControlApiClient(apiBase!);
             var res = await http.PostAsync("/api/weatherforecastdb/deactivate", null);
             var json = await Helpers.SafeReadAsync(res, CancellationToken.None);
             if (!res.IsSuccessStatusCode) return Results.BadRequest(new { error = json });
@@ -566,7 +566,7 @@ app.MapPost("/projection/deactivate", async (string? mode) =>
     var name = GetProjectorName(m);
     try
     {
-        using var http = CreateApiClient(apiBase!);
+        using var http = CreateProjectionControlApiClient(apiBase!);
         var res = await http.PostAsync($"/api/projections/deactivate?name={Uri.EscapeDataString(name)}", null);
         var json = await Helpers.SafeReadAsync(res, CancellationToken.None);
         if (!res.IsSuccessStatusCode) return Results.BadRequest(new { error = json });
@@ -592,7 +592,7 @@ app.MapGet("/projection/snapshot", async (string? mode, bool? unsafeState) =>
     var unsafeFlag = unsafeState ?? true;
     try
     {
-        using var http = CreateApiClient(apiBase!);
+        using var http = CreateProjectionControlApiClient(apiBase!);
         var res = await http.GetAsync($"/api/projections/snapshot?name={Uri.EscapeDataString(name)}&unsafeState={(unsafeFlag ? "true" : "false")}");
         var txt = await Helpers.SafeReadAsync(res, CancellationToken.None);
         if (!res.IsSuccessStatusCode) return Results.BadRequest(new { error = txt });
@@ -614,7 +614,7 @@ app.MapPost("/projection/refresh", async (string? mode) =>
     {
         try
         {
-            using var http = CreateApiClient(apiBase!);
+            using var http = CreateProjectionControlApiClient(apiBase!);
             var res = await http.PostAsync("/api/weatherforecastdb/refresh", null);
             var json = await Helpers.SafeReadAsync(res, CancellationToken.None);
             if (!res.IsSuccessStatusCode) return Results.BadRequest(new { error = json });
@@ -628,7 +628,7 @@ app.MapPost("/projection/refresh", async (string? mode) =>
     var name = GetProjectorName(m);
     try
     {
-        using var http = CreateApiClient(apiBase!);
+        using var http = CreateProjectionControlApiClient(apiBase!);
         var res = await http.PostAsync($"/api/projections/refresh?name={Uri.EscapeDataString(name)}", null);
         var json = await Helpers.SafeReadAsync(res, CancellationToken.None);
         if (!res.IsSuccessStatusCode) return Results.BadRequest(new { error = json });
@@ -724,6 +724,9 @@ static HttpClient CreateApiClient(string apiBase, int? timeoutSeconds = null)
         BaseAddress = new Uri(apiBase),
         Timeout = TimeSpan.FromSeconds(timeoutSeconds ?? GetEnvInt("BENCH_API_TIMEOUT_SECONDS", 15))
     };
+
+static HttpClient CreateProjectionControlApiClient(string apiBase) =>
+    CreateApiClient(apiBase, GetEnvInt("BENCH_PROJECTION_CONTROL_TIMEOUT_SECONDS", 120));
 
 static bool IsDatabaseMode(string mode) => string.Equals(mode, DatabaseMode, StringComparison.Ordinal);
 

--- a/dcb/internalUsages/DcbOrleans.Catchup.Functions/Program.cs
+++ b/dcb/internalUsages/DcbOrleans.Catchup.Functions/Program.cs
@@ -54,6 +54,11 @@ host.Run();
 static bool ResolveColdEventEnabled(IConfiguration configuration)
 {
     var coldConfig = configuration.GetSection("Sekiban:ColdEvent");
+    if (!coldConfig.Exists())
+    {
+        return false;
+    }
+
     var configuredOptions = coldConfig.Get<ColdEventStoreOptions>() ?? new ColdEventStoreOptions();
-    return string.IsNullOrWhiteSpace(coldConfig["Enabled"]) || configuredOptions.Enabled;
+    return configuredOptions.Enabled;
 }

--- a/dcb/internalUsages/DcbOrleans.Web/Components/Layout/NavMenu.razor
+++ b/dcb/internalUsages/DcbOrleans.Web/Components/Layout/NavMenu.razor
@@ -27,6 +27,12 @@
         </div>
 
         <div class="nav-item px-3">
+            <NavLink class="nav-link" href="projection-monitor">
+                <span class="bi bi-graph-up-nav-menu" aria-hidden="true"></span> Projection Monitor
+            </NavLink>
+        </div>
+
+        <div class="nav-item px-3">
             <NavLink class="nav-link" href="students">
                 <span class="bi bi-person-fill-nav-menu" aria-hidden="true"></span> Students
             </NavLink>
@@ -45,4 +51,3 @@
         </div>
     </nav>
 </div>
-

--- a/dcb/internalUsages/DcbOrleans.Web/Components/Pages/ProjectionMonitor.razor
+++ b/dcb/internalUsages/DcbOrleans.Web/Components/Pages/ProjectionMonitor.razor
@@ -1,0 +1,229 @@
+@page "/projection-monitor"
+@attribute [StreamRendering()]
+@rendermode InteractiveServer
+
+@inject ProjectionStatusApiClient ProjectionStatusApiClient
+@inject ILogger<ProjectionMonitor> Logger
+
+<PageTitle>Projection Monitor</PageTitle>
+
+<div class="monitor-page">
+    <div class="monitor-header">
+        <div>
+            <h1>Projection Monitor</h1>
+            <p class="text-muted mb-0">Weather の multi projection と materialized view の catch-up 状態を確認します。</p>
+        </div>
+        <div class="monitor-actions">
+            <button class="btn btn-primary" @onclick="RefreshAsync" disabled="@isLoading">Refresh</button>
+        </div>
+    </div>
+
+    @if (!string.IsNullOrWhiteSpace(loadError))
+    {
+        <div class="alert alert-danger mt-3" role="alert">
+            @loadError
+        </div>
+    }
+
+    <p class="text-muted mt-3 mb-4">Last updated: @FormatDateTime(lastLoadedAt)</p>
+
+    <section class="monitor-section">
+        <div class="section-heading">
+            <h2>1. Multi Projection</h2>
+            <p class="text-muted">standard / single / generic の Orleans projection 状態です。</p>
+        </div>
+
+        <div class="status-grid">
+            @foreach (var projection in multiProjectionCards)
+            {
+                <article class="status-card">
+                    <div class="status-card-header">
+                        <h3>@projection.Label</h3>
+                        <span class="badge @(projection.Status?.IsCaughtUp == true ? "text-bg-success" : "text-bg-warning")">
+                            @(projection.Status?.IsCaughtUp == true ? "Caught Up" : "Catching Up")
+                        </span>
+                    </div>
+
+                    @if (projection.Status is null)
+                    {
+                        <p class="text-muted mb-0">No data</p>
+                    }
+                    else
+                    {
+                        <dl class="status-metrics">
+                            <div><dt>Projector</dt><dd>@projection.Status.ProjectorName</dd></div>
+                            <div><dt>Subscription</dt><dd>@BoolLabel(projection.Status.IsSubscriptionActive)</dd></div>
+                            <div><dt>Position</dt><dd>@ValueOrDash(projection.Status.CurrentPosition)</dd></div>
+                            <div><dt>Events</dt><dd>@projection.Status.EventsProcessed</dd></div>
+                            <div><dt>State Size</dt><dd>@projection.Status.StateSize</dd></div>
+                            <div><dt>Safe Size</dt><dd>@projection.Status.SafeStateSize</dd></div>
+                            <div><dt>Unsafe Size</dt><dd>@projection.Status.UnsafeStateSize</dd></div>
+                            <div><dt>Last Event</dt><dd>@FormatDateTime(projection.Status.LastEventTime)</dd></div>
+                            <div><dt>Last Persist</dt><dd>@FormatDateTime(projection.Status.LastPersistTime)</dd></div>
+                            <div><dt>Error</dt><dd class="status-error">@ValueOrDash(projection.Status.LastError)</dd></div>
+                        </dl>
+                    }
+                </article>
+            }
+        </div>
+    </section>
+
+    <section class="monitor-section">
+        <div class="section-heading">
+            <h2>2. Materialized View</h2>
+            <p class="text-muted">Weather DB projection の catch-up / stream 反映状況です。</p>
+        </div>
+
+        <div class="status-card">
+            @if (databaseStatus?.Status is null)
+            {
+                <p class="text-muted mb-0">No data</p>
+            }
+            else
+            {
+                <div class="status-card-header">
+                    <h3>@databaseStatus.Status.ViewName v@databaseStatus.Status.ViewVersion</h3>
+                    <span class="badge @(databaseStatus.Status.CatchUpInProgress ? "text-bg-warning" : "text-bg-success")">
+                        @(databaseStatus.Status.CatchUpInProgress ? "Catch Up In Progress" : "Ready")
+                    </span>
+                </div>
+
+                <dl class="status-metrics">
+                    <div><dt>Database</dt><dd>@ValueOrDash(databaseStatus.DatabaseType)</dd></div>
+                    <div><dt>Table</dt><dd>@ValueOrDash(databaseStatus.Table)</dd></div>
+                    <div><dt>Started</dt><dd>@BoolLabel(databaseStatus.Status.Started)</dd></div>
+                    <div><dt>Subscription</dt><dd>@BoolLabel(databaseStatus.Status.SubscriptionActive)</dd></div>
+                    <div><dt>Buffered</dt><dd>@databaseStatus.Status.BufferedEventCount</dd></div>
+                    <div><dt>Current Position</dt><dd>@ValueOrDash(databaseStatus.Status.CurrentPosition)</dd></div>
+                    <div><dt>Last Received</dt><dd>@ValueOrDash(databaseStatus.Status.LastReceivedSortableUniqueId)</dd></div>
+                    <div><dt>Catch Up Started</dt><dd>@FormatDateTime(databaseStatus.Status.LastCatchUpStartedAt)</dd></div>
+                    <div><dt>Catch Up Completed</dt><dd>@FormatDateTime(databaseStatus.Status.LastCatchUpCompletedAt)</dd></div>
+                    <div><dt>Error</dt><dd class="status-error">@ValueOrDash(databaseStatus.Status.LastError)</dd></div>
+                </dl>
+
+                @if (databaseStatus.Entry is not null)
+                {
+                    <div class="entry-section">
+                        <h4>Active Registry Entry</h4>
+                        <dl class="status-metrics">
+                            <div><dt>Applied Version</dt><dd>@databaseStatus.Entry.AppliedEventVersion</dd></div>
+                            <div><dt>Status</dt><dd>@databaseStatus.Entry.Status</dd></div>
+                            <div><dt>Last SortableUniqueId</dt><dd>@ValueOrDash(databaseStatus.Entry.LastSortableUniqueId)</dd></div>
+                            <div><dt>Last Applied Source</dt><dd>@ValueOrDash(databaseStatus.Entry.LastAppliedSource)</dd></div>
+                            <div><dt>Last Applied At</dt><dd>@FormatDateTime(databaseStatus.Entry.LastAppliedAt)</dd></div>
+                            <div><dt>Last Stream Received</dt><dd>@ValueOrDash(databaseStatus.Entry.LastStreamReceivedSortableUniqueId)</dd></div>
+                            <div><dt>Last Stream Applied</dt><dd>@ValueOrDash(databaseStatus.Entry.LastStreamAppliedSortableUniqueId)</dd></div>
+                            <div><dt>Last Catch Up</dt><dd>@ValueOrDash(databaseStatus.Entry.LastCatchUpSortableUniqueId)</dd></div>
+                            <div><dt>Updated</dt><dd>@FormatDateTime(databaseStatus.Entry.LastUpdated)</dd></div>
+                        </dl>
+                    </div>
+                }
+
+                @if (databaseStatus.Entries.Count > 0)
+                {
+                    <div class="entry-section">
+                        <h4>Registry Entries</h4>
+                        <div class="table-responsive">
+                            <table class="table table-sm align-middle">
+                                <thead>
+                                <tr>
+                                    <th>Logical</th>
+                                    <th>Physical</th>
+                                    <th>Status</th>
+                                    <th>Applied Version</th>
+                                    <th>Last SortableUniqueId</th>
+                                    <th>Last Catch Up</th>
+                                </tr>
+                                </thead>
+                                <tbody>
+                                @foreach (var entry in databaseStatus.Entries)
+                                {
+                                    <tr>
+                                        <td>@entry.LogicalTable</td>
+                                        <td><code>@entry.PhysicalTable</code></td>
+                                        <td>@entry.Status</td>
+                                        <td>@entry.AppliedEventVersion</td>
+                                        <td>@ValueOrDash(entry.LastSortableUniqueId)</td>
+                                        <td>@ValueOrDash(entry.LastCatchUpSortableUniqueId)</td>
+                                    </tr>
+                                }
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                }
+            }
+        </div>
+    </section>
+</div>
+
+@code {
+    private readonly List<ProjectionCardModel> multiProjectionCards =
+    [
+        new("standard"),
+        new("single"),
+        new("generic")
+    ];
+
+    private WeatherForecastDbStatusDto? databaseStatus;
+    private bool isLoading;
+    private string? loadError;
+    private DateTimeOffset? lastLoadedAt;
+
+    protected override async Task OnInitializedAsync() => await RefreshAsync();
+
+    private async Task RefreshAsync()
+    {
+        if (isLoading)
+        {
+            return;
+        }
+
+        isLoading = true;
+        loadError = null;
+
+        try
+        {
+            var standardTask = ProjectionStatusApiClient.GetStandardWeatherProjectionStatusAsync();
+            var singleTask = ProjectionStatusApiClient.GetSingleWeatherProjectionStatusAsync();
+            var genericTask = ProjectionStatusApiClient.GetGenericWeatherProjectionStatusAsync();
+            var databaseTask = ProjectionStatusApiClient.GetWeatherDatabaseProjectionStatusAsync();
+
+            await Task.WhenAll(standardTask, singleTask, genericTask, databaseTask);
+
+            multiProjectionCards[0].Status = standardTask.Result;
+            multiProjectionCards[1].Status = singleTask.Result;
+            multiProjectionCards[2].Status = genericTask.Result;
+            databaseStatus = databaseTask.Result;
+            lastLoadedAt = DateTimeOffset.Now;
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to load projection monitor status.");
+            loadError = ex.Message;
+        }
+        finally
+        {
+            isLoading = false;
+        }
+    }
+
+    private static string BoolLabel(bool value) => value ? "Yes" : "No";
+
+    private static string ValueOrDash(string? value) => string.IsNullOrWhiteSpace(value) ? "-" : value;
+
+    private static string FormatDateTime(DateTime? value) =>
+        value?.ToLocalTime().ToString("yyyy-MM-dd HH:mm:ss") ?? "-";
+
+    private static string FormatDateTime(DateTimeOffset? value) =>
+        value?.ToLocalTime().ToString("yyyy-MM-dd HH:mm:ss zzz") ?? "-";
+
+    private static string FormatDateTime(DateTimeOffset value) =>
+        value.ToLocalTime().ToString("yyyy-MM-dd HH:mm:ss zzz");
+
+    private sealed class ProjectionCardModel(string label)
+    {
+        public string Label { get; } = label;
+        public MultiProjectionStatusDto? Status { get; set; }
+    }
+}

--- a/dcb/internalUsages/DcbOrleans.Web/Components/Pages/ProjectionMonitor.razor
+++ b/dcb/internalUsages/DcbOrleans.Web/Components/Pages/ProjectionMonitor.razor
@@ -89,7 +89,7 @@
                 </div>
 
                 <dl class="status-metrics">
-                    <div><dt>Database</dt><dd>@ValueOrDash(databaseStatus.DatabaseType)</dd></div>
+                    <div><dt>Database</dt><dd>@FormatDatabaseType(databaseStatus.DatabaseType)</dd></div>
                     <div><dt>Table</dt><dd>@ValueOrDash(databaseStatus.Table)</dd></div>
                     <div><dt>Started</dt><dd>@BoolLabel(databaseStatus.Status.Started)</dd></div>
                     <div><dt>Subscription</dt><dd>@BoolLabel(databaseStatus.Status.SubscriptionActive)</dd></div>
@@ -211,6 +211,13 @@
     private static string BoolLabel(bool value) => value ? "Yes" : "No";
 
     private static string ValueOrDash(string? value) => string.IsNullOrWhiteSpace(value) ? "-" : value;
+
+    private static string FormatDatabaseType(int? value) => value switch
+    {
+        1 => "Postgres",
+        null => "-",
+        _ => value.Value.ToString()
+    };
 
     private static string FormatDateTime(DateTime? value) =>
         value?.ToLocalTime().ToString("yyyy-MM-dd HH:mm:ss") ?? "-";

--- a/dcb/internalUsages/DcbOrleans.Web/Program.cs
+++ b/dcb/internalUsages/DcbOrleans.Web/Program.cs
@@ -22,6 +22,11 @@ builder.Services.AddHttpClient<WeatherApiClient>(client =>
     client.BaseAddress = new Uri("https+http://apiservice");
 });
 
+builder.Services.AddHttpClient<ProjectionStatusApiClient>(client =>
+{
+    client.BaseAddress = new Uri("https+http://apiservice");
+});
+
 // Add StudentApiClient
 builder.Services.AddHttpClient<StudentApiClient>(client =>
 {

--- a/dcb/internalUsages/DcbOrleans.Web/ProjectionStatusApiClient.cs
+++ b/dcb/internalUsages/DcbOrleans.Web/ProjectionStatusApiClient.cs
@@ -1,0 +1,79 @@
+namespace DcbOrleans.Web;
+
+public class ProjectionStatusApiClient(HttpClient httpClient)
+{
+    public Task<MultiProjectionStatusDto?> GetStandardWeatherProjectionStatusAsync(CancellationToken cancellationToken = default) =>
+        httpClient.GetFromJsonAsync<MultiProjectionStatusDto>("/api/weatherforecast/status", cancellationToken);
+
+    public Task<MultiProjectionStatusDto?> GetSingleWeatherProjectionStatusAsync(CancellationToken cancellationToken = default) =>
+        httpClient.GetFromJsonAsync<MultiProjectionStatusDto>("/api/weatherforecastsingle/status", cancellationToken);
+
+    public Task<MultiProjectionStatusDto?> GetGenericWeatherProjectionStatusAsync(CancellationToken cancellationToken = default) =>
+        httpClient.GetFromJsonAsync<MultiProjectionStatusDto>("/api/weatherforecastgeneric/status", cancellationToken);
+
+    public Task<WeatherForecastDbStatusDto?> GetWeatherDatabaseProjectionStatusAsync(CancellationToken cancellationToken = default) =>
+        httpClient.GetFromJsonAsync<WeatherForecastDbStatusDto>("/api/weatherforecastdb/status", cancellationToken);
+}
+
+public sealed class MultiProjectionStatusDto
+{
+    public string ProjectorName { get; set; } = string.Empty;
+    public bool IsSubscriptionActive { get; set; }
+    public bool IsCaughtUp { get; set; }
+    public string? CurrentPosition { get; set; }
+    public long EventsProcessed { get; set; }
+    public DateTime? LastEventTime { get; set; }
+    public DateTime? LastPersistTime { get; set; }
+    public long StateSize { get; set; }
+    public long SafeStateSize { get; set; }
+    public long UnsafeStateSize { get; set; }
+    public bool HasError { get; set; }
+    public string? LastError { get; set; }
+}
+
+public sealed class WeatherForecastDbStatusDto
+{
+    public string? DatabaseType { get; set; }
+    public string? Table { get; set; }
+    public MaterializedViewStatusDto? Status { get; set; }
+    public MvRegistryEntryDto? Entry { get; set; }
+    public List<MvRegistryEntryDto> Entries { get; set; } = [];
+}
+
+public sealed class MaterializedViewStatusDto
+{
+    public string ServiceId { get; set; } = string.Empty;
+    public string ViewName { get; set; } = string.Empty;
+    public int ViewVersion { get; set; }
+    public bool Started { get; set; }
+    public bool CatchUpInProgress { get; set; }
+    public bool SubscriptionActive { get; set; }
+    public int BufferedEventCount { get; set; }
+    public string? CurrentPosition { get; set; }
+    public string? LastReceivedSortableUniqueId { get; set; }
+    public string? LastError { get; set; }
+    public DateTimeOffset? LastCatchUpStartedAt { get; set; }
+    public DateTimeOffset? LastCatchUpCompletedAt { get; set; }
+}
+
+public sealed class MvRegistryEntryDto
+{
+    public string ServiceId { get; set; } = string.Empty;
+    public string ViewName { get; set; } = string.Empty;
+    public int ViewVersion { get; set; }
+    public string LogicalTable { get; set; } = string.Empty;
+    public string PhysicalTable { get; set; } = string.Empty;
+    public int Status { get; set; }
+    public string? CurrentPosition { get; set; }
+    public string? TargetPosition { get; set; }
+    public string? LastSortableUniqueId { get; set; }
+    public long AppliedEventVersion { get; set; }
+    public string? LastAppliedSource { get; set; }
+    public DateTimeOffset? LastAppliedAt { get; set; }
+    public string? LastStreamReceivedSortableUniqueId { get; set; }
+    public DateTimeOffset? LastStreamReceivedAt { get; set; }
+    public string? LastStreamAppliedSortableUniqueId { get; set; }
+    public string? LastCatchUpSortableUniqueId { get; set; }
+    public DateTimeOffset LastUpdated { get; set; }
+    public string? Metadata { get; set; }
+}

--- a/dcb/internalUsages/DcbOrleans.Web/ProjectionStatusApiClient.cs
+++ b/dcb/internalUsages/DcbOrleans.Web/ProjectionStatusApiClient.cs
@@ -33,7 +33,7 @@ public sealed class MultiProjectionStatusDto
 
 public sealed class WeatherForecastDbStatusDto
 {
-    public string? DatabaseType { get; set; }
+    public int? DatabaseType { get; set; }
     public string? Table { get; set; }
     public MaterializedViewStatusDto? Status { get; set; }
     public MvRegistryEntryDto? Entry { get; set; }

--- a/dcb/internalUsages/DcbOrleans.Web/wwwroot/app.css
+++ b/dcb/internalUsages/DcbOrleans.Web/wwwroot/app.css
@@ -58,3 +58,93 @@ h1:focus {
 .form-floating > .form-control-plaintext:focus::placeholder, .form-floating > .form-control:focus::placeholder {
     text-align: start;
 }
+
+.monitor-page {
+    display: grid;
+    gap: 1.5rem;
+}
+
+.monitor-header {
+    display: flex;
+    justify-content: space-between;
+    gap: 1rem;
+    align-items: end;
+    flex-wrap: wrap;
+}
+
+.monitor-section {
+    display: grid;
+    gap: 1rem;
+}
+
+.section-heading p {
+    margin-bottom: 0;
+}
+
+.status-grid {
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.status-card {
+    border: 1px solid #d9e2ec;
+    border-radius: 0.75rem;
+    padding: 1rem 1.1rem;
+    background: #fff;
+    box-shadow: 0 10px 30px rgba(15, 23, 42, 0.04);
+}
+
+.status-card-header {
+    display: flex;
+    justify-content: space-between;
+    gap: 0.75rem;
+    align-items: start;
+    margin-bottom: 1rem;
+}
+
+.status-card-header h3 {
+    margin: 0;
+    font-size: 1.1rem;
+}
+
+.status-metrics {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 0.75rem 1rem;
+    margin: 0;
+}
+
+.status-metrics div {
+    padding: 0.65rem 0.75rem;
+    border-radius: 0.6rem;
+    background: #f8fafc;
+}
+
+.status-metrics dt {
+    font-size: 0.75rem;
+    font-weight: 700;
+    color: #64748b;
+    margin-bottom: 0.2rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+
+.status-metrics dd {
+    margin: 0;
+    color: #0f172a;
+    word-break: break-word;
+}
+
+.status-error {
+    color: #b91c1c;
+}
+
+.entry-section {
+    margin-top: 1.25rem;
+}
+
+.entry-section h4 {
+    font-size: 1rem;
+    margin-bottom: 0.75rem;
+}

--- a/dcb/internalUsages/DcbOrleans.WithoutResult.ApiService/Program.cs
+++ b/dcb/internalUsages/DcbOrleans.WithoutResult.ApiService/Program.cs
@@ -77,6 +77,7 @@ if ((builder.Configuration["ORLEANS_CLUSTERING_TYPE"] ?? "").ToLower() == "cosmo
 
 var cfgGrainDefault = builder.Configuration["ORLEANS_GRAIN_DEFAULT_TYPE"]?.ToLower() ?? "blob";
 var databaseType = builder.Configuration.GetSection("Sekiban").GetValue<string>("Database")?.ToLower();
+var coldEventEnabled = ResolveColdEventEnabled(builder.Configuration);
 
 // Configure Orleans
 builder.UseOrleans(config =>
@@ -442,16 +443,12 @@ else
     builder.Services.AddSingleton<IMultiProjectionStateStore, Sekiban.Dcb.Postgres.PostgresMultiProjectionStateStore>();
 }
 
-if (builder.Configuration.GetSection("Sekiban:ColdEvent").GetValue<bool>("Enabled"))
+if (coldEventEnabled)
 {
-    var coldConfig = builder.Configuration.GetSection("Sekiban:ColdEvent");
-    var storageOptions = coldConfig.GetSection("Storage").Get<ColdStorageOptions>() ?? new ColdStorageOptions();
-    var storageRoot = ColdObjectStorageFactory.ResolveStorageRoot(storageOptions, Directory.GetCurrentDirectory());
-    builder.Services.AddSingleton(storageOptions);
-    builder.Services.AddSingleton<IColdObjectStorage>(sp =>
-        ColdObjectStorageFactory.Create(storageOptions, storageRoot, sp));
-    builder.Services.AddSingleton<IColdLeaseManager, StorageBackedColdLeaseManager>();
-    builder.Services.AddSekibanDcbColdEvents(options => coldConfig.Bind(options));
+    builder.Services.AddSekibanDcbColdExport(
+        builder.Configuration,
+        builder.Environment.ContentRootPath,
+        addBackgroundService: false);
     builder.Services.AddSekibanDcbColdEventHybridRead();
 }
 
@@ -1484,6 +1481,13 @@ apiRoute
 app.MapDefaultEndpoints();
 
 app.Run();
+
+static bool ResolveColdEventEnabled(IConfiguration configuration)
+{
+    var coldConfig = configuration.GetSection("Sekiban:ColdEvent");
+    var configuredOptions = coldConfig.Get<ColdEventStoreOptions>() ?? new ColdEventStoreOptions();
+    return string.IsNullOrWhiteSpace(coldConfig["Enabled"]) || configuredOptions.Enabled;
+}
 
 static async Task<bool> WaitForMaterializedViewAsync(
     IMaterializedViewGrain grain,

--- a/dcb/internalUsages/DcbOrleans.WithoutResult.ApiService/Program.cs
+++ b/dcb/internalUsages/DcbOrleans.WithoutResult.ApiService/Program.cs
@@ -1485,8 +1485,13 @@ app.Run();
 static bool ResolveColdEventEnabled(IConfiguration configuration)
 {
     var coldConfig = configuration.GetSection("Sekiban:ColdEvent");
+    if (!coldConfig.Exists())
+    {
+        return false;
+    }
+
     var configuredOptions = coldConfig.Get<ColdEventStoreOptions>() ?? new ColdEventStoreOptions();
-    return string.IsNullOrWhiteSpace(coldConfig["Enabled"]) || configuredOptions.Enabled;
+    return configuredOptions.Enabled;
 }
 
 static async Task<bool> WaitForMaterializedViewAsync(

--- a/dcb/internalUsages/DcbOrleansDynamoDB.WithoutResult.ApiService/Program.cs
+++ b/dcb/internalUsages/DcbOrleansDynamoDB.WithoutResult.ApiService/Program.cs
@@ -1169,6 +1169,11 @@ static string NormalizeConfigValue(string? value) => value?.ToLowerInvariant() ?
 static bool ResolveColdEventEnabled(IConfiguration configuration)
 {
     var coldConfig = configuration.GetSection("Sekiban:ColdEvent");
+    if (!coldConfig.Exists())
+    {
+        return false;
+    }
+
     var configuredOptions = coldConfig.Get<ColdEventStoreOptions>() ?? new ColdEventStoreOptions();
-    return string.IsNullOrWhiteSpace(coldConfig["Enabled"]) || configuredOptions.Enabled;
+    return configuredOptions.Enabled;
 }

--- a/dcb/src/Sekiban.Dcb.ColdStorage/ColdEvents/SekibanDcbColdExportExtensions.cs
+++ b/dcb/src/Sekiban.Dcb.ColdStorage/ColdEvents/SekibanDcbColdExportExtensions.cs
@@ -79,9 +79,7 @@ public static class SekibanDcbColdExportExtensions
            ?? configuration[$"{connectionName}:ConnectionString"];
 
     private static bool ResolveEnabled(IConfigurationSection coldConfig, ColdEventStoreOptions configuredColdOptions)
-        => string.IsNullOrWhiteSpace(coldConfig["Enabled"])
-            ? true
-            : configuredColdOptions.Enabled;
+        => coldConfig.Exists() && configuredColdOptions.Enabled;
 
     private static TimeSpan? ParsePositiveTimeSpan(string? raw)
         => !string.IsNullOrWhiteSpace(raw)

--- a/dcb/src/Sekiban.Dcb.Core.Model/Common/ProjectionHeadStatusUtilities.cs
+++ b/dcb/src/Sekiban.Dcb.Core.Model/Common/ProjectionHeadStatusUtilities.cs
@@ -1,0 +1,116 @@
+using System.Diagnostics.CodeAnalysis;
+using ResultBoxes;
+
+namespace Sekiban.Dcb.Common;
+
+/// <summary>
+///     Shared helpers for projection head status APIs.
+/// </summary>
+public static class ProjectionHeadStatusUtilities
+{
+    public static ResultBox<string> ValidateProjectorVersion(
+        DcbDomainTypes domainTypes,
+        string projectorName,
+        string? expectedProjectorVersion)
+    {
+        if (string.IsNullOrWhiteSpace(projectorName))
+        {
+            return ResultBox.Error<string>(new ArgumentException("Projector name cannot be empty.", nameof(projectorName)));
+        }
+
+        var projectorVersionResult = domainTypes.MultiProjectorTypes.GetProjectorVersion(projectorName);
+        if (!projectorVersionResult.IsSuccess)
+        {
+            return ResultBox.Error<string>(projectorVersionResult.GetException());
+        }
+
+        var currentProjectorVersion = projectorVersionResult.GetValue();
+        if (!string.IsNullOrWhiteSpace(expectedProjectorVersion)
+            && !string.Equals(currentProjectorVersion, expectedProjectorVersion, StringComparison.Ordinal))
+        {
+            return ResultBox.Error<string>(
+                new InvalidOperationException(
+                    $"Projector version mismatch for '{projectorName}'. Expected '{expectedProjectorVersion}', but registered version is '{currentProjectorVersion}'."));
+        }
+
+        return ResultBox.FromValue(currentProjectorVersion);
+    }
+
+    [UnconditionalSuppressMessage(
+        "AOT",
+        "IL2075",
+        Justification = "Projector types are registered runtime types that expose the public static MultiProjectorName property.")]
+    public static ResultBox<string> ResolveProjectorName(ResultBox<Type> projectorTypeResult)
+    {
+        if (!projectorTypeResult.IsSuccess)
+        {
+            return ResultBox.Error<string>(projectorTypeResult.GetException());
+        }
+
+        var projectorType = projectorTypeResult.GetValue();
+        var projectorNameProperty = projectorType.GetProperty("MultiProjectorName");
+        if (projectorNameProperty == null)
+        {
+            return ResultBox.Error<string>(
+                new InvalidOperationException(
+                    $"Projector type {projectorType.Name} does not have MultiProjectorName property"));
+        }
+
+        var projectorName = projectorNameProperty.GetValue(null) as string;
+        if (string.IsNullOrWhiteSpace(projectorName))
+        {
+            return ResultBox.Error<string>(
+                new InvalidOperationException(
+                    $"Projector type {projectorType.Name} has invalid MultiProjectorName"));
+        }
+
+        return ResultBox.FromValue(projectorName);
+    }
+
+    public static ResultBox<string> EnsureProjectorNameConsistency(
+        string requestedProjectorName,
+        string? actualProjectorName)
+    {
+        if (string.IsNullOrWhiteSpace(requestedProjectorName))
+        {
+            return ResultBox.Error<string>(
+                new ArgumentException("Projector name cannot be empty.", nameof(requestedProjectorName)));
+        }
+
+        if (string.IsNullOrWhiteSpace(actualProjectorName))
+        {
+            return ResultBox.FromValue(requestedProjectorName);
+        }
+
+        if (!string.Equals(requestedProjectorName, actualProjectorName, StringComparison.Ordinal))
+        {
+            return ResultBox.Error<string>(
+                new InvalidOperationException(
+                    $"Projector name mismatch. Requested '{requestedProjectorName}', but projection returned '{actualProjectorName}'."));
+        }
+
+        return ResultBox.FromValue(requestedProjectorName);
+    }
+
+    public static ResultBox<string> EnsureProjectorVersionConsistency(
+        string registeredProjectorVersion,
+        string? actualProjectorVersion)
+    {
+        if (string.IsNullOrWhiteSpace(actualProjectorVersion))
+        {
+            return ResultBox.FromValue(registeredProjectorVersion);
+        }
+
+        if (!string.Equals(registeredProjectorVersion, actualProjectorVersion, StringComparison.Ordinal))
+        {
+            return ResultBox.Error<string>(
+                new InvalidOperationException(
+                    $"Projector version mismatch. Registered '{registeredProjectorVersion}', but projection returned '{actualProjectorVersion}'."));
+        }
+
+        return ResultBox.FromValue(registeredProjectorVersion);
+    }
+
+    public static string? NormalizeSortableUniqueId(string? sortableUniqueId) =>
+        string.IsNullOrWhiteSpace(sortableUniqueId) ? null : sortableUniqueId;
+}

--- a/dcb/src/Sekiban.Dcb.Core.Model/ProjectionHeadStatus.cs
+++ b/dcb/src/Sekiban.Dcb.Core.Model/ProjectionHeadStatus.cs
@@ -1,0 +1,34 @@
+namespace Sekiban.Dcb;
+
+/// <summary>
+///     Position information for a projection head.
+/// </summary>
+public sealed record ProjectionPosition(
+    int EventVersion,
+    string? LastSortableUniqueId);
+
+/// <summary>
+///     Catch-up progress information for a projection.
+/// </summary>
+public sealed record ProjectionCatchUpStatus(
+    bool IsInProgress,
+    string? CurrentSortableUniqueId,
+    string? TargetSortableUniqueId,
+    int PendingStreamEventCount);
+
+/// <summary>
+///     Public executor-facing status for a multi-projection.
+/// </summary>
+public sealed record ProjectionHeadStatus(
+    string ProjectorName,
+    string ProjectorVersion,
+    ProjectionPosition Current,
+    ProjectionPosition Consistent,
+    ProjectionCatchUpStatus CatchUp);
+
+/// <summary>
+///     Global event store head information.
+/// </summary>
+public sealed record EventStoreHeadStatus(
+    string? LatestSortableUniqueId,
+    long? TotalEventCount);

--- a/dcb/src/Sekiban.Dcb.Core/Actors/CoreGeneralSekibanExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Actors/CoreGeneralSekibanExecutor.cs
@@ -756,7 +756,10 @@ public class CoreGeneralSekibanExecutor
     {
         try
         {
-            var projectorVersionResult = ValidateProjectorVersion(projectorName, expectedProjectorVersion);
+            var projectorVersionResult = ProjectionHeadStatusUtilities.ValidateProjectorVersion(
+                _domainTypes,
+                projectorName,
+                expectedProjectorVersion);
             if (!projectorVersionResult.IsSuccess)
             {
                 return ResultBox.Error<ProjectionHeadStatus>(projectorVersionResult.GetException());
@@ -769,32 +772,29 @@ public class CoreGeneralSekibanExecutor
             }
 
             var actor = actorResult.GetValue();
+            var status = await actor.GetProjectionHeadStatusAsync();
 
-            var currentStateResult = await actor.GetStateAsync(canGetUnsafeState: true);
-            if (!currentStateResult.IsSuccess)
+            var projectorNameResult = ProjectionHeadStatusUtilities.EnsureProjectorNameConsistency(
+                projectorName,
+                status.ProjectorName);
+            if (!projectorNameResult.IsSuccess)
             {
-                return ResultBox.Error<ProjectionHeadStatus>(currentStateResult.GetException());
+                return ResultBox.Error<ProjectionHeadStatus>(projectorNameResult.GetException());
             }
 
-            var consistentStateResult = await actor.GetStateAsync(canGetUnsafeState: false);
-            if (!consistentStateResult.IsSuccess)
-            {
-                return ResultBox.Error<ProjectionHeadStatus>(consistentStateResult.GetException());
-            }
-
-            var currentState = currentStateResult.GetValue();
-            var consistentState = consistentStateResult.GetValue();
-
-            return ResultBox.FromValue(new ProjectionHeadStatus(
-                currentState.ProjectorName,
+            var projectorVersionConsistencyResult = ProjectionHeadStatusUtilities.EnsureProjectorVersionConsistency(
                 projectorVersionResult.GetValue(),
-                ToProjectionPosition(currentState),
-                ToProjectionPosition(consistentState),
-                new ProjectionCatchUpStatus(
-                    IsInProgress: false,
-                    CurrentSortableUniqueId: null,
-                    TargetSortableUniqueId: null,
-                    PendingStreamEventCount: 0)));
+                status.ProjectorVersion);
+            if (!projectorVersionConsistencyResult.IsSuccess)
+            {
+                return ResultBox.Error<ProjectionHeadStatus>(projectorVersionConsistencyResult.GetException());
+            }
+
+            return ResultBox.FromValue(status with
+            {
+                ProjectorName = projectorNameResult.GetValue(),
+                ProjectorVersion = projectorVersionConsistencyResult.GetValue()
+            });
         }
         catch (Exception ex)
         {
@@ -825,7 +825,7 @@ public class CoreGeneralSekibanExecutor
             }
 
             return ResultBox.FromValue(new EventStoreHeadStatus(
-                NormalizeSortableUniqueId(latestSortableUniqueIdResult.GetValue()),
+                ProjectionHeadStatusUtilities.NormalizeSortableUniqueId(latestSortableUniqueIdResult.GetValue()),
                 totalEventCount));
         }
         catch (Exception ex)
@@ -853,36 +853,4 @@ public class CoreGeneralSekibanExecutor
         return innerTag;
     }
 
-    private ResultBox<string> ValidateProjectorVersion(string projectorName, string? expectedProjectorVersion)
-    {
-        if (string.IsNullOrWhiteSpace(projectorName))
-        {
-            return ResultBox.Error<string>(new ArgumentException("Projector name cannot be empty.", nameof(projectorName)));
-        }
-
-        var projectorVersionResult = _domainTypes.MultiProjectorTypes.GetProjectorVersion(projectorName);
-        if (!projectorVersionResult.IsSuccess)
-        {
-            return ResultBox.Error<string>(projectorVersionResult.GetException());
-        }
-
-        var currentProjectorVersion = projectorVersionResult.GetValue();
-        if (!string.IsNullOrWhiteSpace(expectedProjectorVersion)
-            && !string.Equals(currentProjectorVersion, expectedProjectorVersion, StringComparison.Ordinal))
-        {
-            return ResultBox.Error<string>(
-                new InvalidOperationException(
-                    $"Projector version mismatch for '{projectorName}'. Expected '{expectedProjectorVersion}', but registered version is '{currentProjectorVersion}'."));
-        }
-
-        return ResultBox.FromValue(currentProjectorVersion);
-    }
-
-    private static ProjectionPosition ToProjectionPosition(MultiProjectionState state) =>
-        new(
-            state.Version,
-            NormalizeSortableUniqueId(state.LastSortableUniqueId));
-
-    private static string? NormalizeSortableUniqueId(string? sortableUniqueId) =>
-        string.IsNullOrWhiteSpace(sortableUniqueId) ? null : sortableUniqueId;
 }

--- a/dcb/src/Sekiban.Dcb.Core/Actors/CoreGeneralSekibanExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Actors/CoreGeneralSekibanExecutor.cs
@@ -2,6 +2,7 @@ using ResultBoxes;
 using Sekiban.Dcb.Commands;
 using Sekiban.Dcb.Common;
 using Sekiban.Dcb.Events;
+using Sekiban.Dcb.MultiProjections;
 using Sekiban.Dcb.Queries;
 using Sekiban.Dcb.Storage;
 using Sekiban.Dcb.Tags;
@@ -749,6 +750,90 @@ public class CoreGeneralSekibanExecutor
     public Task<ResultBox<string>> GetLatestSortableUniqueIdAsync() =>
         _eventStore.GetLatestSortableUniqueIdAsync();
 
+    public async Task<ResultBox<ProjectionHeadStatus>> GetProjectionHeadStatusAsync(
+        string projectorName,
+        string? expectedProjectorVersion = null)
+    {
+        try
+        {
+            var projectorVersionResult = ValidateProjectorVersion(projectorName, expectedProjectorVersion);
+            if (!projectorVersionResult.IsSuccess)
+            {
+                return ResultBox.Error<ProjectionHeadStatus>(projectorVersionResult.GetException());
+            }
+
+            var actorResult = await _actorAccessor.GetActorAsync<GeneralMultiProjectionActor>(projectorName);
+            if (!actorResult.IsSuccess)
+            {
+                return ResultBox.Error<ProjectionHeadStatus>(actorResult.GetException());
+            }
+
+            var actor = actorResult.GetValue();
+
+            var currentStateResult = await actor.GetStateAsync(canGetUnsafeState: true);
+            if (!currentStateResult.IsSuccess)
+            {
+                return ResultBox.Error<ProjectionHeadStatus>(currentStateResult.GetException());
+            }
+
+            var consistentStateResult = await actor.GetStateAsync(canGetUnsafeState: false);
+            if (!consistentStateResult.IsSuccess)
+            {
+                return ResultBox.Error<ProjectionHeadStatus>(consistentStateResult.GetException());
+            }
+
+            var currentState = currentStateResult.GetValue();
+            var consistentState = consistentStateResult.GetValue();
+
+            return ResultBox.FromValue(new ProjectionHeadStatus(
+                currentState.ProjectorName,
+                projectorVersionResult.GetValue(),
+                ToProjectionPosition(currentState),
+                ToProjectionPosition(consistentState),
+                new ProjectionCatchUpStatus(
+                    IsInProgress: false,
+                    CurrentSortableUniqueId: null,
+                    TargetSortableUniqueId: null,
+                    PendingStreamEventCount: 0)));
+        }
+        catch (Exception ex)
+        {
+            return ResultBox.Error<ProjectionHeadStatus>(ex);
+        }
+    }
+
+    public async Task<ResultBox<EventStoreHeadStatus>> GetEventStoreHeadStatusAsync(bool includeTotalEventCount = false)
+    {
+        try
+        {
+            var latestSortableUniqueIdResult = await _eventStore.GetLatestSortableUniqueIdAsync();
+            if (!latestSortableUniqueIdResult.IsSuccess)
+            {
+                return ResultBox.Error<EventStoreHeadStatus>(latestSortableUniqueIdResult.GetException());
+            }
+
+            long? totalEventCount = null;
+            if (includeTotalEventCount)
+            {
+                var totalEventCountResult = await _eventStore.GetEventCountAsync();
+                if (!totalEventCountResult.IsSuccess)
+                {
+                    return ResultBox.Error<EventStoreHeadStatus>(totalEventCountResult.GetException());
+                }
+
+                totalEventCount = totalEventCountResult.GetValue();
+            }
+
+            return ResultBox.FromValue(new EventStoreHeadStatus(
+                NormalizeSortableUniqueId(latestSortableUniqueIdResult.GetValue()),
+                totalEventCount));
+        }
+        catch (Exception ex)
+        {
+            return ResultBox.Error<EventStoreHeadStatus>(ex);
+        }
+    }
+
     /// <summary>
     ///     Parses a tag string into an ITag for serialized commit.
     ///     Consistency tags are wrapped in ConsistencyTag, others in FallbackTag.
@@ -767,4 +852,37 @@ public class CoreGeneralSekibanExecutor
 
         return innerTag;
     }
+
+    private ResultBox<string> ValidateProjectorVersion(string projectorName, string? expectedProjectorVersion)
+    {
+        if (string.IsNullOrWhiteSpace(projectorName))
+        {
+            return ResultBox.Error<string>(new ArgumentException("Projector name cannot be empty.", nameof(projectorName)));
+        }
+
+        var projectorVersionResult = _domainTypes.MultiProjectorTypes.GetProjectorVersion(projectorName);
+        if (!projectorVersionResult.IsSuccess)
+        {
+            return ResultBox.Error<string>(projectorVersionResult.GetException());
+        }
+
+        var currentProjectorVersion = projectorVersionResult.GetValue();
+        if (!string.IsNullOrWhiteSpace(expectedProjectorVersion)
+            && !string.Equals(currentProjectorVersion, expectedProjectorVersion, StringComparison.Ordinal))
+        {
+            return ResultBox.Error<string>(
+                new InvalidOperationException(
+                    $"Projector version mismatch for '{projectorName}'. Expected '{expectedProjectorVersion}', but registered version is '{currentProjectorVersion}'."));
+        }
+
+        return ResultBox.FromValue(currentProjectorVersion);
+    }
+
+    private static ProjectionPosition ToProjectionPosition(MultiProjectionState state) =>
+        new(
+            state.Version,
+            NormalizeSortableUniqueId(state.LastSortableUniqueId));
+
+    private static string? NormalizeSortableUniqueId(string? sortableUniqueId) =>
+        string.IsNullOrWhiteSpace(sortableUniqueId) ? null : sortableUniqueId;
 }

--- a/dcb/src/Sekiban.Dcb.Core/Actors/GeneralMultiProjectionActor.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Actors/GeneralMultiProjectionActor.cs
@@ -131,7 +131,14 @@ public class GeneralMultiProjectionActor
 
         if (_singleStateAccessor is IDualStateAccessor dualAccessor)
         {
-            try { dualAccessor.PromoteBufferedEvents(safeWindowThreshold, _domain); } catch { }
+            try
+            {
+                dualAccessor.PromoteBufferedEvents(safeWindowThreshold, _domain);
+            }
+            catch (Exception)
+            {
+                // Head-status reads are observational; ignore best-effort safe-window promotion failures here.
+            }
 
             var current = new ProjectionPosition(
                 dualAccessor.UnsafeVersion,

--- a/dcb/src/Sekiban.Dcb.Core/Actors/GeneralMultiProjectionActor.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Actors/GeneralMultiProjectionActor.cs
@@ -117,6 +117,50 @@ public class GeneralMultiProjectionActor
         return GetStateFromSingleAccessorAsync(canGetUnsafeState);
     }
 
+    public async Task<ProjectionHeadStatus> GetProjectionHeadStatusAsync()
+    {
+        InitializeProjectorsIfNeeded();
+
+        var versionResult = _types.GetProjectorVersion(_projectorName);
+        if (!versionResult.IsSuccess)
+        {
+            throw versionResult.GetException();
+        }
+
+        var safeWindowThreshold = GetSafeWindowThreshold();
+
+        if (_singleStateAccessor is IDualStateAccessor dualAccessor)
+        {
+            try { dualAccessor.PromoteBufferedEvents(safeWindowThreshold, _domain); } catch { }
+
+            var current = new ProjectionPosition(
+                dualAccessor.UnsafeVersion,
+                ProjectionHeadStatusUtilities.NormalizeSortableUniqueId(dualAccessor.UnsafeLastSortableUniqueId));
+            var consistent = new ProjectionPosition(
+                dualAccessor.SafeVersion,
+                ProjectionHeadStatusUtilities.NormalizeSortableUniqueId(dualAccessor.SafeLastSortableUniqueId));
+
+            return CreateProjectionHeadStatus(versionResult.GetValue(), current, consistent);
+        }
+
+        var currentStateResult = await GetStateAsync(canGetUnsafeState: true);
+        if (!currentStateResult.IsSuccess)
+        {
+            throw currentStateResult.GetException();
+        }
+
+        var consistentStateResult = await GetStateAsync(canGetUnsafeState: false);
+        if (!consistentStateResult.IsSuccess)
+        {
+            throw consistentStateResult.GetException();
+        }
+
+        return CreateProjectionHeadStatus(
+            versionResult.GetValue(),
+            ToProjectionPosition(currentStateResult.GetValue()),
+            ToProjectionPosition(consistentStateResult.GetValue()));
+    }
+
     public Task SetCurrentState(SerializableMultiProjectionState state)
     {
         // Validate projector version before restoring state
@@ -1010,5 +1054,30 @@ public class GeneralMultiProjectionActor
         var factor = Math.Pow(decay, seconds);
         return Math.Max(0, _maxLagMs * factor);
     }
+
+    private ProjectionHeadStatus CreateProjectionHeadStatus(
+        string projectorVersion,
+        ProjectionPosition current,
+        ProjectionPosition consistent)
+    {
+        var pendingUnsafeEventCount = Math.Max(0, current.EventVersion - consistent.EventVersion);
+        var isCatchUpInProgress = !_isCatchedUp;
+
+        return new ProjectionHeadStatus(
+            _projectorName,
+            projectorVersion,
+            current,
+            consistent,
+            new ProjectionCatchUpStatus(
+                isCatchUpInProgress,
+                isCatchUpInProgress ? consistent.LastSortableUniqueId : null,
+                isCatchUpInProgress ? current.LastSortableUniqueId : null,
+                pendingUnsafeEventCount));
+    }
+
+    private static ProjectionPosition ToProjectionPosition(MultiProjectionState state) =>
+        new(
+            state.Version,
+            ProjectionHeadStatusUtilities.NormalizeSortableUniqueId(state.LastSortableUniqueId));
 
 }

--- a/dcb/src/Sekiban.Dcb.MaterializedView.Orleans/MaterializedViewGrain.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.Orleans/MaterializedViewGrain.cs
@@ -257,8 +257,8 @@ public sealed class MaterializedViewGrain : Grain, IMaterializedViewGrain
         while (true)
         {
             var orderedBuffered = _pendingStreamEvents
-                .GroupBy(serializableEvent => serializableEvent.Id)
-                .Select(group => group.OrderBy(serializableEvent => serializableEvent.SortableUniqueIdValue, StringComparer.Ordinal).Last())
+                .GroupBy(serializableEvent => serializableEvent.SortableUniqueIdValue)
+                .Select(group => group.First())
                 .OrderBy(serializableEvent => serializableEvent.SortableUniqueIdValue, StringComparer.Ordinal)
                 .ToList();
             if (orderedBuffered.Count == 0)
@@ -275,10 +275,36 @@ public sealed class MaterializedViewGrain : Grain, IMaterializedViewGrain
                 return;
             }
 
-            await ApplyStreamEventsAsync(dueEvents, cancellationToken);
+            var appliedSortableUniqueIds = new HashSet<string>(StringComparer.Ordinal);
+            SerializableEvent? firstBlocked = null;
 
-            var dueIds = dueEvents.Select(serializableEvent => serializableEvent.Id).ToHashSet();
-            _pendingStreamEvents.RemoveAll(serializableEvent => dueIds.Contains(serializableEvent.Id));
+            foreach (var dueEvent in dueEvents)
+            {
+                var appliedEvents = await ApplyStreamEventsAsync([dueEvent], cancellationToken);
+                if (appliedEvents > 0)
+                {
+                    appliedSortableUniqueIds.Add(dueEvent.SortableUniqueIdValue);
+                    continue;
+                }
+
+                firstBlocked ??= dueEvent;
+            }
+
+            if (appliedSortableUniqueIds.Count == 0)
+            {
+                var blocked = firstBlocked ?? dueEvents[0];
+                _logger.LogWarning(
+                    "Materialized view grain stream apply made no progress for {ViewName}/{ViewVersion}. Pending={PendingCount}, FirstBlockedSortableUniqueId={SortableUniqueId}, FirstBlockedEventId={EventId}, FirstBlockedEventType={EventType}.",
+                    _viewName,
+                    _viewVersion,
+                    _pendingStreamEvents.Count,
+                    blocked.SortableUniqueIdValue,
+                    blocked.Id,
+                    blocked.EventPayloadName);
+                return;
+            }
+
+            _pendingStreamEvents.RemoveAll(serializableEvent => appliedSortableUniqueIds.Contains(serializableEvent.SortableUniqueIdValue));
         }
     }
 
@@ -309,12 +335,6 @@ public sealed class MaterializedViewGrain : Grain, IMaterializedViewGrain
 
         foreach (var serializableEvent in batch)
         {
-            if (!string.IsNullOrWhiteSpace(_lastAppliedSortableUniqueId) &&
-                string.Compare(serializableEvent.SortableUniqueIdValue, _lastAppliedSortableUniqueId, StringComparison.Ordinal) <= 0)
-            {
-                continue;
-            }
-
             _pendingStreamEvents.Add(serializableEvent);
         }
 
@@ -326,11 +346,11 @@ public sealed class MaterializedViewGrain : Grain, IMaterializedViewGrain
         await DrainPendingStreamEventsAsync(CancellationToken.None);
     }
 
-    private async Task ApplyStreamEventsAsync(IReadOnlyList<SerializableEvent> events, CancellationToken cancellationToken)
+    private async Task<int> ApplyStreamEventsAsync(IReadOnlyList<SerializableEvent> events, CancellationToken cancellationToken)
     {
         if (events.Count == 0)
         {
-            return;
+            return 0;
         }
 
         ResolveProjector();
@@ -340,6 +360,8 @@ public sealed class MaterializedViewGrain : Grain, IMaterializedViewGrain
         {
             await RefreshPositionFromRegistryAsync(cancellationToken);
         }
+
+        return applied;
     }
 
     private async Task RefreshPositionFromRegistryAsync(CancellationToken cancellationToken)

--- a/dcb/src/Sekiban.Dcb.MaterializedView.Postgres/PostgresMvExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.Postgres/PostgresMvExecutor.cs
@@ -155,8 +155,10 @@ public sealed class PostgresMvExecutor : IMvExecutor
             .ConfigureAwait(false);
 
         var lastAppliedSortableUniqueId = appliedEvents > 0
-            ? safeBatch[^1].SortableUniqueIdValue
+            ? safeBatch[appliedEvents - 1].SortableUniqueIdValue
             : null;
+
+        reachedUnsafeWindow |= appliedEvents < safeBatch.Count;
 
         return new MvCatchUpResult(appliedEvents, reachedUnsafeWindow, lastAppliedSortableUniqueId);
     }
@@ -196,9 +198,10 @@ public sealed class PostgresMvExecutor : IMvExecutor
             .Select(entry => entry.CurrentPosition)
             .FirstOrDefault(position => !string.IsNullOrWhiteSpace(position));
         var orderedEvents = events
-            .GroupBy(serializableEvent => serializableEvent.Id)
-            .Select(group => group.OrderBy(serializableEvent => serializableEvent.SortableUniqueIdValue, StringComparer.Ordinal).Last())
+            .GroupBy(serializableEvent => serializableEvent.SortableUniqueIdValue)
+            .Select(group => group.First())
             .Where(serializableEvent =>
+                source == MvApplySource.Stream ||
                 string.IsNullOrWhiteSpace(currentPosition) ||
                 string.Compare(serializableEvent.SortableUniqueIdValue, currentPosition, StringComparison.Ordinal) > 0)
             .OrderBy(serializableEvent => serializableEvent.SortableUniqueIdValue, StringComparer.Ordinal)
@@ -215,19 +218,32 @@ public sealed class PostgresMvExecutor : IMvExecutor
 
         foreach (var serializableEvent in orderedEvents)
         {
-            await ApplySerializableEventAsync(connection, projector, serviceId, serializableEvent, source, cancellationToken)
+            var applied = await ApplySerializableEventAsync(
+                    connection,
+                    projector,
+                    serviceId,
+                    serializableEvent,
+                    currentPosition,
+                    source,
+                    cancellationToken)
                 .ConfigureAwait(false);
+            if (!applied)
+            {
+                break;
+            }
+
             appliedEvents += 1;
         }
 
         return appliedEvents;
     }
 
-    private async Task ApplySerializableEventAsync(
+    private async Task<bool> ApplySerializableEventAsync(
         NpgsqlConnection connection,
         IMaterializedViewProjector projector,
         string serviceId,
         SerializableEvent serializableEvent,
+        string? currentPosition,
         MvApplySource source,
         CancellationToken cancellationToken)
     {
@@ -241,14 +257,28 @@ public sealed class PostgresMvExecutor : IMvExecutor
         await using var transaction = await connection.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
         var applyContext = new PostgresMvApplyContext(connection, transaction, ev, serializableEvent.SortableUniqueIdValue);
         var statements = await projector.ApplyToViewAsync(ev, applyContext, cancellationToken).ConfigureAwait(false);
+        var affectedRows = 0;
         foreach (var statement in statements)
         {
-            await connection.ExecuteAsync(
+            affectedRows += await connection.ExecuteAsync(
                 new CommandDefinition(
                     statement.Sql,
                     statement.Parameters,
                     transaction,
                     cancellationToken: cancellationToken)).ConfigureAwait(false);
+        }
+
+        if (source == MvApplySource.Stream && statements.Count > 0 && affectedRows == 0)
+        {
+            if (!string.IsNullOrWhiteSpace(currentPosition) &&
+                string.Compare(serializableEvent.SortableUniqueIdValue, currentPosition, StringComparison.Ordinal) <= 0)
+            {
+                await transaction.RollbackAsync(cancellationToken).ConfigureAwait(false);
+                return true;
+            }
+
+            await transaction.RollbackAsync(cancellationToken).ConfigureAwait(false);
+            return false;
         }
 
         await _registryStore.UpdatePositionAsync(
@@ -262,6 +292,7 @@ public sealed class PostgresMvExecutor : IMvExecutor
             cancellationToken: cancellationToken).ConfigureAwait(false);
 
         await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+        return true;
     }
 
     private string ResolveServiceId(string? serviceId) =>

--- a/dcb/src/Sekiban.Dcb.MaterializedView.Postgres/PostgresMvRegistryStore.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.Postgres/PostgresMvRegistryStore.cs
@@ -153,17 +153,29 @@ public sealed class PostgresMvRegistryStore : IMvRegistryStore
     {
         const string sql = """
             UPDATE sekiban_mv_registry
-            SET current_position = @SortableUniqueId,
-                last_sortable_unique_id = @SortableUniqueId,
+            SET current_position = CASE
+                    WHEN current_position IS NULL
+                      OR current_position < @SortableUniqueId THEN @SortableUniqueId
+                    ELSE current_position
+                END,
+                last_sortable_unique_id = CASE
+                    WHEN last_sortable_unique_id IS NULL
+                      OR last_sortable_unique_id < @SortableUniqueId THEN @SortableUniqueId
+                    ELSE last_sortable_unique_id
+                END,
                 applied_event_version = applied_event_version + @AppliedEventVersionDelta,
                 last_applied_source = @Source,
                 last_applied_at = NOW(),
                 last_stream_applied_sortable_unique_id = CASE
-                    WHEN @Source = 'stream' THEN @SortableUniqueId
+                    WHEN @Source = 'stream'
+                      AND (last_stream_applied_sortable_unique_id IS NULL
+                        OR last_stream_applied_sortable_unique_id < @SortableUniqueId) THEN @SortableUniqueId
                     ELSE last_stream_applied_sortable_unique_id
                 END,
                 last_catch_up_sortable_unique_id = CASE
-                    WHEN @Source = 'catchup' THEN @SortableUniqueId
+                    WHEN @Source = 'catchup'
+                      AND (last_catch_up_sortable_unique_id IS NULL
+                        OR last_catch_up_sortable_unique_id < @SortableUniqueId) THEN @SortableUniqueId
                     ELSE last_catch_up_sortable_unique_id
                 END,
                 last_updated = NOW()

--- a/dcb/src/Sekiban.Dcb.Orleans.Core/Grains/IMultiProjectionGrain.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.Core/Grains/IMultiProjectionGrain.cs
@@ -129,6 +129,12 @@ public interface IMultiProjectionGrain : IGrainWithStringKey
     Task<MultiProjectionCatchUpStatus> GetCatchUpStatusAsync();
 
     /// <summary>
+    ///     Get lightweight projection head status without serializing projector payloads.
+    /// </summary>
+    [AlwaysInterleave]
+    Task<MultiProjectionHeadStatusSnapshot> GetProjectionHeadStatusAsync();
+
+    /// <summary>
     ///     Get health status for monitoring and diagnostics.
     ///     This method is safe to call even before initialization completes.
     /// </summary>

--- a/dcb/src/Sekiban.Dcb.Orleans.Core/Grains/MultiProjectionGrain.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.Core/Grains/MultiProjectionGrain.cs
@@ -364,7 +364,7 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
     }
 
     private static string? NormalizeSortableUniqueId(string? sortableUniqueId) =>
-        string.IsNullOrWhiteSpace(sortableUniqueId) ? null : sortableUniqueId;
+        ProjectionHeadStatusUtilities.NormalizeSortableUniqueId(sortableUniqueId);
 
     /// <summary>
     ///     Returns the event store used for catch-up reads.
@@ -772,55 +772,53 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
     {
         await EnsureInitializedAsync();
 
-        if (_host != null)
-        {
-            await StartSubscriptionAsync();
-            _ = CatchUpFromEventStoreAsync();
-        }
-
         var (_, projectorName, _) = GetIdentity();
         var projectorVersion = _state.State?.ProjectorVersion;
-        MultiProjectionState? currentState = null;
-        MultiProjectionState? consistentState = null;
+        ProjectionHeadStatus? hostStatus = null;
 
         if (_host != null)
         {
-            var currentStateResult = await _host.GetStateAsync(canGetUnsafeState: true);
-            if (currentStateResult.IsSuccess)
+            hostStatus = await _host.GetProjectionHeadStatusAsync();
+            var projectorNameResult = ProjectionHeadStatusUtilities.EnsureProjectorNameConsistency(
+                projectorName,
+                hostStatus.ProjectorName);
+            if (!projectorNameResult.IsSuccess)
             {
-                currentState = currentStateResult.GetValue();
+                throw projectorNameResult.GetException();
             }
 
-            var consistentStateResult = await _host.GetStateAsync(canGetUnsafeState: false);
-            if (consistentStateResult.IsSuccess)
+            projectorName = projectorNameResult.GetValue();
+            if (!string.IsNullOrWhiteSpace(hostStatus.ProjectorVersion))
             {
-                consistentState = consistentStateResult.GetValue();
+                projectorVersion = hostStatus.ProjectorVersion;
             }
         }
 
-        if (!string.IsNullOrWhiteSpace(currentState?.ProjectorVersion))
-        {
-            projectorVersion = currentState.ProjectorVersion;
-        }
-        else if (!string.IsNullOrWhiteSpace(consistentState?.ProjectorVersion))
-        {
-            projectorVersion = consistentState.ProjectorVersion;
-        }
+        var currentPosition = hostStatus?.Current;
+        var consistentPosition = hostStatus?.Consistent;
+        var catchUpStatus = hostStatus?.CatchUp;
+        var currentLastSortableUniqueId = NormalizeSortableUniqueId(currentPosition?.LastSortableUniqueId)
+            ?? NormalizeSortableUniqueId(_catchUpProgress.CurrentPosition?.Value)
+            ?? NormalizeSortableUniqueId(_state.State?.LastSortableUniqueId);
+        var consistentLastSortableUniqueId = NormalizeSortableUniqueId(consistentPosition?.LastSortableUniqueId)
+            ?? NormalizeSortableUniqueId(_state.State?.LastSortableUniqueId);
 
         return new MultiProjectionHeadStatusSnapshot(
             ProjectorName: projectorName,
             ProjectorVersion: projectorVersion,
-            CurrentEventVersion: currentState?.Version ?? consistentState?.Version ?? _state.State?.LastGoodSafeVersion ?? 0,
-            CurrentLastSortableUniqueId: NormalizeSortableUniqueId(currentState?.LastSortableUniqueId)
-                ?? NormalizeSortableUniqueId(_catchUpProgress.CurrentPosition?.Value)
-                ?? NormalizeSortableUniqueId(_state.State?.LastSortableUniqueId),
-            ConsistentEventVersion: consistentState?.Version ?? _state.State?.LastGoodSafeVersion ?? 0,
-            ConsistentLastSortableUniqueId: NormalizeSortableUniqueId(consistentState?.LastSortableUniqueId)
-                ?? NormalizeSortableUniqueId(_state.State?.LastSortableUniqueId),
-            IsCatchUpInProgress: _catchUpProgress.IsActive,
-            CatchUpCurrentSortableUniqueId: NormalizeSortableUniqueId(_catchUpProgress.CurrentPosition?.Value),
-            CatchUpTargetSortableUniqueId: NormalizeSortableUniqueId(_catchUpProgress.TargetPosition?.Value),
-            PendingStreamEventCount: _pendingStreamEvents.Count);
+            CurrentEventVersion: currentPosition?.EventVersion ?? consistentPosition?.EventVersion ?? _state.State?.LastGoodSafeVersion ?? 0,
+            CurrentLastSortableUniqueId: currentLastSortableUniqueId,
+            ConsistentEventVersion: consistentPosition?.EventVersion ?? _state.State?.LastGoodSafeVersion ?? 0,
+            ConsistentLastSortableUniqueId: consistentLastSortableUniqueId,
+            IsCatchUpInProgress: _catchUpProgress.IsActive || catchUpStatus?.IsInProgress == true,
+            CatchUpCurrentSortableUniqueId: NormalizeSortableUniqueId(_catchUpProgress.CurrentPosition?.Value)
+                ?? NormalizeSortableUniqueId(catchUpStatus?.CurrentSortableUniqueId),
+            CatchUpTargetSortableUniqueId: NormalizeSortableUniqueId(_catchUpProgress.TargetPosition?.Value)
+                ?? NormalizeSortableUniqueId(catchUpStatus?.TargetSortableUniqueId)
+                ?? currentLastSortableUniqueId,
+            PendingStreamEventCount: _pendingStreamEvents.Count > 0
+                ? _pendingStreamEvents.Count
+                : catchUpStatus?.PendingStreamEventCount ?? 0);
     }
 
     /// <summary>

--- a/dcb/src/Sekiban.Dcb.Orleans.Core/Grains/MultiProjectionGrain.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.Core/Grains/MultiProjectionGrain.cs
@@ -363,6 +363,9 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
         _lastHybridReadBatchMetadata = null;
     }
 
+    private static string? NormalizeSortableUniqueId(string? sortableUniqueId) =>
+        string.IsNullOrWhiteSpace(sortableUniqueId) ? null : sortableUniqueId;
+
     /// <summary>
     ///     Returns the event store used for catch-up reads.
     ///     Preference order:
@@ -763,6 +766,61 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
             _catchUpProgress.LastAttempt,
             _pendingStreamEvents.Count);
         return Task.FromResult(status);
+    }
+
+    public async Task<MultiProjectionHeadStatusSnapshot> GetProjectionHeadStatusAsync()
+    {
+        await EnsureInitializedAsync();
+
+        if (_host != null)
+        {
+            await StartSubscriptionAsync();
+            _ = CatchUpFromEventStoreAsync();
+        }
+
+        var (_, projectorName, _) = GetIdentity();
+        var projectorVersion = _state.State?.ProjectorVersion;
+        MultiProjectionState? currentState = null;
+        MultiProjectionState? consistentState = null;
+
+        if (_host != null)
+        {
+            var currentStateResult = await _host.GetStateAsync(canGetUnsafeState: true);
+            if (currentStateResult.IsSuccess)
+            {
+                currentState = currentStateResult.GetValue();
+            }
+
+            var consistentStateResult = await _host.GetStateAsync(canGetUnsafeState: false);
+            if (consistentStateResult.IsSuccess)
+            {
+                consistentState = consistentStateResult.GetValue();
+            }
+        }
+
+        if (!string.IsNullOrWhiteSpace(currentState?.ProjectorVersion))
+        {
+            projectorVersion = currentState.ProjectorVersion;
+        }
+        else if (!string.IsNullOrWhiteSpace(consistentState?.ProjectorVersion))
+        {
+            projectorVersion = consistentState.ProjectorVersion;
+        }
+
+        return new MultiProjectionHeadStatusSnapshot(
+            ProjectorName: projectorName,
+            ProjectorVersion: projectorVersion,
+            CurrentEventVersion: currentState?.Version ?? consistentState?.Version ?? _state.State?.LastGoodSafeVersion ?? 0,
+            CurrentLastSortableUniqueId: NormalizeSortableUniqueId(currentState?.LastSortableUniqueId)
+                ?? NormalizeSortableUniqueId(_catchUpProgress.CurrentPosition?.Value)
+                ?? NormalizeSortableUniqueId(_state.State?.LastSortableUniqueId),
+            ConsistentEventVersion: consistentState?.Version ?? _state.State?.LastGoodSafeVersion ?? 0,
+            ConsistentLastSortableUniqueId: NormalizeSortableUniqueId(consistentState?.LastSortableUniqueId)
+                ?? NormalizeSortableUniqueId(_state.State?.LastSortableUniqueId),
+            IsCatchUpInProgress: _catchUpProgress.IsActive,
+            CatchUpCurrentSortableUniqueId: NormalizeSortableUniqueId(_catchUpProgress.CurrentPosition?.Value),
+            CatchUpTargetSortableUniqueId: NormalizeSortableUniqueId(_catchUpProgress.TargetPosition?.Value),
+            PendingStreamEventCount: _pendingStreamEvents.Count);
     }
 
     /// <summary>

--- a/dcb/src/Sekiban.Dcb.Orleans.Core/Grains/MultiProjectionHeadStatusSnapshot.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.Core/Grains/MultiProjectionHeadStatusSnapshot.cs
@@ -1,0 +1,17 @@
+namespace Sekiban.Dcb.Orleans.Grains;
+
+/// <summary>
+///     Lightweight projection head snapshot that avoids serializing projector payloads.
+/// </summary>
+[GenerateSerializer]
+public sealed record MultiProjectionHeadStatusSnapshot(
+    [property: Id(0)] string ProjectorName,
+    [property: Id(1)] string? ProjectorVersion,
+    [property: Id(2)] int CurrentEventVersion,
+    [property: Id(3)] string? CurrentLastSortableUniqueId,
+    [property: Id(4)] int ConsistentEventVersion,
+    [property: Id(5)] string? ConsistentLastSortableUniqueId,
+    [property: Id(6)] bool IsCatchUpInProgress,
+    [property: Id(7)] string? CatchUpCurrentSortableUniqueId,
+    [property: Id(8)] string? CatchUpTargetSortableUniqueId,
+    [property: Id(9)] int PendingStreamEventCount);

--- a/dcb/src/Sekiban.Dcb.Orleans.Core/Runtimes/IProjectionActorHost.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.Core/Runtimes/IProjectionActorHost.cs
@@ -31,6 +31,11 @@ public interface IProjectionActorHost
     Task<ResultBox<MultiProjectionState>> GetStateAsync(bool canGetUnsafeState = true);
 
     /// <summary>
+    ///     Get projection head information without materializing projector payloads.
+    /// </summary>
+    Task<ProjectionHeadStatus> GetProjectionHeadStatusAsync();
+
+    /// <summary>
      ///     Write the snapshot directly to the provided stream, avoiding byte[] allocation.
      /// </summary>
     Task<ResultBox<bool>> WriteSnapshotToStreamAsync(

--- a/dcb/src/Sekiban.Dcb.Orleans.Core/Runtimes/NativeProjectionActorHost.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.Core/Runtimes/NativeProjectionActorHost.cs
@@ -100,6 +100,11 @@ public class NativeProjectionActorHost : IProjectionActorHost
         return _actor.GetStateAsync(canGetUnsafeState);
     }
 
+    public Task<ProjectionHeadStatus> GetProjectionHeadStatusAsync()
+    {
+        return _actor.GetProjectionHeadStatusAsync();
+    }
+
     public Task<ResultBox<bool>> WriteSnapshotToStreamAsync(
         Stream target,
         bool canGetUnsafeState,

--- a/dcb/src/Sekiban.Dcb.Orleans.WithResult/OrleansDcbExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.WithResult/OrleansDcbExecutor.cs
@@ -209,7 +209,10 @@ public class OrleansDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecuto
     {
         try
         {
-            var projectorVersionResult = ValidateProjectorVersion(projectorName, expectedProjectorVersion);
+            var projectorVersionResult = ProjectionHeadStatusUtilities.ValidateProjectorVersion(
+                _domainTypes,
+                projectorName,
+                expectedProjectorVersion);
             if (!projectorVersionResult.IsSuccess)
             {
                 return ResultBox.Error<ProjectionHeadStatus>(projectorVersionResult.GetException());
@@ -218,23 +221,36 @@ public class OrleansDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecuto
             var grainId = ServiceIdGrainKey.Build(_serviceIdProvider.GetCurrentServiceId(), projectorName);
             var grain = _clusterClient.GetGrain<IMultiProjectionGrain>(grainId);
             var grainStatus = await grain.GetProjectionHeadStatusAsync();
-            var projectorVersion = string.IsNullOrWhiteSpace(grainStatus.ProjectorVersion)
-                ? projectorVersionResult.GetValue()
-                : grainStatus.ProjectorVersion;
+
+            var projectorNameResult = ProjectionHeadStatusUtilities.EnsureProjectorNameConsistency(
+                projectorName,
+                grainStatus.ProjectorName);
+            if (!projectorNameResult.IsSuccess)
+            {
+                return ResultBox.Error<ProjectionHeadStatus>(projectorNameResult.GetException());
+            }
+
+            var projectorVersionConsistencyResult = ProjectionHeadStatusUtilities.EnsureProjectorVersionConsistency(
+                projectorVersionResult.GetValue(),
+                grainStatus.ProjectorVersion);
+            if (!projectorVersionConsistencyResult.IsSuccess)
+            {
+                return ResultBox.Error<ProjectionHeadStatus>(projectorVersionConsistencyResult.GetException());
+            }
 
             return ResultBox.FromValue(new ProjectionHeadStatus(
-                projectorName,
-                projectorVersion,
+                projectorNameResult.GetValue(),
+                projectorVersionConsistencyResult.GetValue(),
                 new ProjectionPosition(
                     grainStatus.CurrentEventVersion,
-                    NormalizeSortableUniqueId(grainStatus.CurrentLastSortableUniqueId)),
+                    ProjectionHeadStatusUtilities.NormalizeSortableUniqueId(grainStatus.CurrentLastSortableUniqueId)),
                 new ProjectionPosition(
                     grainStatus.ConsistentEventVersion,
-                    NormalizeSortableUniqueId(grainStatus.ConsistentLastSortableUniqueId)),
+                    ProjectionHeadStatusUtilities.NormalizeSortableUniqueId(grainStatus.ConsistentLastSortableUniqueId)),
                 new ProjectionCatchUpStatus(
                     grainStatus.IsCatchUpInProgress,
-                    NormalizeSortableUniqueId(grainStatus.CatchUpCurrentSortableUniqueId),
-                    NormalizeSortableUniqueId(grainStatus.CatchUpTargetSortableUniqueId),
+                    ProjectionHeadStatusUtilities.NormalizeSortableUniqueId(grainStatus.CatchUpCurrentSortableUniqueId),
+                    ProjectionHeadStatusUtilities.NormalizeSortableUniqueId(grainStatus.CatchUpTargetSortableUniqueId),
                     grainStatus.PendingStreamEventCount)));
         }
         catch (Exception ex)
@@ -257,67 +273,12 @@ public class OrleansDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecuto
     private ResultBox<string> ResolveProjectorName(IQueryCommon queryCommon)
     {
         var projectorTypeResult = _domainTypes.QueryTypes.GetMultiProjectorType(queryCommon);
-        return ResolveProjectorName(projectorTypeResult);
+        return ProjectionHeadStatusUtilities.ResolveProjectorName(projectorTypeResult);
     }
 
     private ResultBox<string> ResolveProjectorName(IListQueryCommon queryCommon)
     {
         var projectorTypeResult = _domainTypes.QueryTypes.GetMultiProjectorType(queryCommon);
-        return ResolveProjectorName(projectorTypeResult);
+        return ProjectionHeadStatusUtilities.ResolveProjectorName(projectorTypeResult);
     }
-
-    private static ResultBox<string> ResolveProjectorName(ResultBox<Type> projectorTypeResult)
-    {
-        if (!projectorTypeResult.IsSuccess)
-        {
-            return ResultBox.Error<string>(projectorTypeResult.GetException());
-        }
-
-        var projectorType = projectorTypeResult.GetValue();
-        var projectorNameProperty = projectorType.GetProperty("MultiProjectorName");
-        if (projectorNameProperty == null)
-        {
-            return ResultBox.Error<string>(
-                new InvalidOperationException(
-                    $"Projector type {projectorType.Name} does not have MultiProjectorName property"));
-        }
-
-        var projectorName = projectorNameProperty.GetValue(null) as string;
-        if (string.IsNullOrWhiteSpace(projectorName))
-        {
-            return ResultBox.Error<string>(
-                new InvalidOperationException(
-                    $"Projector type {projectorType.Name} has invalid MultiProjectorName"));
-        }
-
-        return ResultBox.FromValue(projectorName);
-    }
-
-    private ResultBox<string> ValidateProjectorVersion(string projectorName, string? expectedProjectorVersion)
-    {
-        if (string.IsNullOrWhiteSpace(projectorName))
-        {
-            return ResultBox.Error<string>(new ArgumentException("Projector name cannot be empty.", nameof(projectorName)));
-        }
-
-        var projectorVersionResult = _domainTypes.MultiProjectorTypes.GetProjectorVersion(projectorName);
-        if (!projectorVersionResult.IsSuccess)
-        {
-            return ResultBox.Error<string>(projectorVersionResult.GetException());
-        }
-
-        var currentProjectorVersion = projectorVersionResult.GetValue();
-        if (!string.IsNullOrWhiteSpace(expectedProjectorVersion)
-            && !string.Equals(currentProjectorVersion, expectedProjectorVersion, StringComparison.Ordinal))
-        {
-            return ResultBox.Error<string>(
-                new InvalidOperationException(
-                    $"Projector version mismatch for '{projectorName}'. Expected '{expectedProjectorVersion}', but registered version is '{currentProjectorVersion}'."));
-        }
-
-        return ResultBox.FromValue(currentProjectorVersion);
-    }
-
-    private static string? NormalizeSortableUniqueId(string? sortableUniqueId) =>
-        string.IsNullOrWhiteSpace(sortableUniqueId) ? null : sortableUniqueId;
 }

--- a/dcb/src/Sekiban.Dcb.Orleans.WithResult/OrleansDcbExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.WithResult/OrleansDcbExecutor.cs
@@ -3,6 +3,7 @@ using Sekiban.Dcb.Actors;
 using Sekiban.Dcb.Commands;
 using Sekiban.Dcb.Common;
 using Sekiban.Dcb.Events;
+using Sekiban.Dcb.MultiProjections;
 using Sekiban.Dcb.Orleans.Grains;
 using Sekiban.Dcb.Orleans.ServiceId;
 using Sekiban.Dcb.Queries;
@@ -79,34 +80,14 @@ public class OrleansDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecuto
     {
         try
         {
-            // Get the multi-projector type for this query
-            var projectorTypeResult = _domainTypes.QueryTypes.GetMultiProjectorType(queryCommon);
-            if (!projectorTypeResult.IsSuccess)
+            var projectorNameResult = ResolveProjectorName(queryCommon);
+            if (!projectorNameResult.IsSuccess)
             {
-                return ResultBox.Error<TResult>(projectorTypeResult.GetException());
-            }
-
-            var projectorType = projectorTypeResult.GetValue();
-
-            // Get the multi-projector name
-            var projectorNameProperty = projectorType.GetProperty("MultiProjectorName");
-            if (projectorNameProperty == null)
-            {
-                return ResultBox.Error<TResult>(
-                    new InvalidOperationException(
-                        $"Projector type {projectorType.Name} does not have MultiProjectorName property"));
-            }
-
-            var projectorName = projectorNameProperty.GetValue(null) as string;
-            if (string.IsNullOrEmpty(projectorName))
-            {
-                return ResultBox.Error<TResult>(
-                    new InvalidOperationException(
-                        $"Projector type {projectorType.Name} has invalid MultiProjectorName"));
+                return ResultBox.Error<TResult>(projectorNameResult.GetException());
             }
 
             // Get the multi-projection grain directly
-            var grainId = ServiceIdGrainKey.Build(_serviceIdProvider.GetCurrentServiceId(), projectorName);
+            var grainId = ServiceIdGrainKey.Build(_serviceIdProvider.GetCurrentServiceId(), projectorNameResult.GetValue());
             var grain = _clusterClient.GetGrain<IMultiProjectionGrain>(grainId);
 
             // Wait for sortable unique ID if needed
@@ -134,34 +115,14 @@ public class OrleansDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecuto
     {
         try
         {
-            // Get the multi-projector type for this query
-            var projectorTypeResult = _domainTypes.QueryTypes.GetMultiProjectorType(queryCommon);
-            if (!projectorTypeResult.IsSuccess)
+            var projectorNameResult = ResolveProjectorName(queryCommon);
+            if (!projectorNameResult.IsSuccess)
             {
-                return ResultBox.Error<ListQueryResult<TResult>>(projectorTypeResult.GetException());
-            }
-
-            var projectorType = projectorTypeResult.GetValue();
-
-            // Get the multi-projector name
-            var projectorNameProperty = projectorType.GetProperty("MultiProjectorName");
-            if (projectorNameProperty == null)
-            {
-                return ResultBox.Error<ListQueryResult<TResult>>(
-                    new InvalidOperationException(
-                        $"Projector type {projectorType.Name} does not have MultiProjectorName property"));
-            }
-
-            var projectorName = projectorNameProperty.GetValue(null) as string;
-            if (string.IsNullOrEmpty(projectorName))
-            {
-                return ResultBox.Error<ListQueryResult<TResult>>(
-                    new InvalidOperationException(
-                        $"Projector type {projectorType.Name} has invalid MultiProjectorName"));
+                return ResultBox.Error<ListQueryResult<TResult>>(projectorNameResult.GetException());
             }
 
             // Get the multi-projection grain directly
-            var grainId = ServiceIdGrainKey.Build(_serviceIdProvider.GetCurrentServiceId(), projectorName);
+            var grainId = ServiceIdGrainKey.Build(_serviceIdProvider.GetCurrentServiceId(), projectorNameResult.GetValue());
             var grain = _clusterClient.GetGrain<IMultiProjectionGrain>(grainId);
 
             // Wait for sortable unique ID if needed
@@ -242,6 +203,49 @@ public class OrleansDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecuto
     public Task<ResultBox<string>> GetLatestSortableUniqueIdAsync() =>
         _generalExecutor.GetLatestSortableUniqueIdAsync();
 
+    public async Task<ResultBox<ProjectionHeadStatus>> GetProjectionHeadStatusAsync(
+        string projectorName,
+        string? expectedProjectorVersion = null)
+    {
+        try
+        {
+            var projectorVersionResult = ValidateProjectorVersion(projectorName, expectedProjectorVersion);
+            if (!projectorVersionResult.IsSuccess)
+            {
+                return ResultBox.Error<ProjectionHeadStatus>(projectorVersionResult.GetException());
+            }
+
+            var grainId = ServiceIdGrainKey.Build(_serviceIdProvider.GetCurrentServiceId(), projectorName);
+            var grain = _clusterClient.GetGrain<IMultiProjectionGrain>(grainId);
+            var grainStatus = await grain.GetProjectionHeadStatusAsync();
+            var projectorVersion = string.IsNullOrWhiteSpace(grainStatus.ProjectorVersion)
+                ? projectorVersionResult.GetValue()
+                : grainStatus.ProjectorVersion;
+
+            return ResultBox.FromValue(new ProjectionHeadStatus(
+                projectorName,
+                projectorVersion,
+                new ProjectionPosition(
+                    grainStatus.CurrentEventVersion,
+                    NormalizeSortableUniqueId(grainStatus.CurrentLastSortableUniqueId)),
+                new ProjectionPosition(
+                    grainStatus.ConsistentEventVersion,
+                    NormalizeSortableUniqueId(grainStatus.ConsistentLastSortableUniqueId)),
+                new ProjectionCatchUpStatus(
+                    grainStatus.IsCatchUpInProgress,
+                    NormalizeSortableUniqueId(grainStatus.CatchUpCurrentSortableUniqueId),
+                    NormalizeSortableUniqueId(grainStatus.CatchUpTargetSortableUniqueId),
+                    grainStatus.PendingStreamEventCount)));
+        }
+        catch (Exception ex)
+        {
+            return ResultBox.Error<ProjectionHeadStatus>(ex);
+        }
+    }
+
+    public Task<ResultBox<EventStoreHeadStatus>> GetEventStoreHeadStatusAsync(bool includeTotalEventCount = false) =>
+        _generalExecutor.GetEventStoreHeadStatusAsync(includeTotalEventCount);
+
     public Task<ResultBox<SerializableTagState>> GetSerializableTagStateAsync(TagStateId tagStateId) =>
         _generalExecutor.GetSerializableTagStateAsync(tagStateId);
 
@@ -249,4 +253,71 @@ public class OrleansDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecuto
         SerializedCommitRequest request,
         CancellationToken cancellationToken = default) =>
         _generalExecutor.CommitSerializableEventsAsync(request, cancellationToken);
+
+    private ResultBox<string> ResolveProjectorName(IQueryCommon queryCommon)
+    {
+        var projectorTypeResult = _domainTypes.QueryTypes.GetMultiProjectorType(queryCommon);
+        return ResolveProjectorName(projectorTypeResult);
+    }
+
+    private ResultBox<string> ResolveProjectorName(IListQueryCommon queryCommon)
+    {
+        var projectorTypeResult = _domainTypes.QueryTypes.GetMultiProjectorType(queryCommon);
+        return ResolveProjectorName(projectorTypeResult);
+    }
+
+    private static ResultBox<string> ResolveProjectorName(ResultBox<Type> projectorTypeResult)
+    {
+        if (!projectorTypeResult.IsSuccess)
+        {
+            return ResultBox.Error<string>(projectorTypeResult.GetException());
+        }
+
+        var projectorType = projectorTypeResult.GetValue();
+        var projectorNameProperty = projectorType.GetProperty("MultiProjectorName");
+        if (projectorNameProperty == null)
+        {
+            return ResultBox.Error<string>(
+                new InvalidOperationException(
+                    $"Projector type {projectorType.Name} does not have MultiProjectorName property"));
+        }
+
+        var projectorName = projectorNameProperty.GetValue(null) as string;
+        if (string.IsNullOrWhiteSpace(projectorName))
+        {
+            return ResultBox.Error<string>(
+                new InvalidOperationException(
+                    $"Projector type {projectorType.Name} has invalid MultiProjectorName"));
+        }
+
+        return ResultBox.FromValue(projectorName);
+    }
+
+    private ResultBox<string> ValidateProjectorVersion(string projectorName, string? expectedProjectorVersion)
+    {
+        if (string.IsNullOrWhiteSpace(projectorName))
+        {
+            return ResultBox.Error<string>(new ArgumentException("Projector name cannot be empty.", nameof(projectorName)));
+        }
+
+        var projectorVersionResult = _domainTypes.MultiProjectorTypes.GetProjectorVersion(projectorName);
+        if (!projectorVersionResult.IsSuccess)
+        {
+            return ResultBox.Error<string>(projectorVersionResult.GetException());
+        }
+
+        var currentProjectorVersion = projectorVersionResult.GetValue();
+        if (!string.IsNullOrWhiteSpace(expectedProjectorVersion)
+            && !string.Equals(currentProjectorVersion, expectedProjectorVersion, StringComparison.Ordinal))
+        {
+            return ResultBox.Error<string>(
+                new InvalidOperationException(
+                    $"Projector version mismatch for '{projectorName}'. Expected '{expectedProjectorVersion}', but registered version is '{currentProjectorVersion}'."));
+        }
+
+        return ResultBox.FromValue(currentProjectorVersion);
+    }
+
+    private static string? NormalizeSortableUniqueId(string? sortableUniqueId) =>
+        string.IsNullOrWhiteSpace(sortableUniqueId) ? null : sortableUniqueId;
 }

--- a/dcb/src/Sekiban.Dcb.Orleans.WithoutResult/OrleansDcbExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.WithoutResult/OrleansDcbExecutor.cs
@@ -3,6 +3,7 @@ using Sekiban.Dcb.Actors;
 using Sekiban.Dcb.Commands;
 using Sekiban.Dcb.Common;
 using Sekiban.Dcb.Events;
+using Sekiban.Dcb.MultiProjections;
 using Sekiban.Dcb.Orleans.Grains;
 using Sekiban.Dcb.Orleans.ServiceId;
 using Sekiban.Dcb.Queries;
@@ -77,29 +78,7 @@ public class OrleansDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecuto
     /// </summary>
     public async Task<TResult> QueryAsync<TResult>(IQueryCommon<TResult> queryCommon) where TResult : notnull
     {
-        // Get the multi-projector type for this query
-        var projectorTypeResult = _domainTypes.QueryTypes.GetMultiProjectorType(queryCommon);
-        if (!projectorTypeResult.IsSuccess)
-        {
-            throw projectorTypeResult.GetException();
-        }
-
-        var projectorType = projectorTypeResult.GetValue();
-
-        // Get the multi-projector name
-        var projectorNameProperty = projectorType.GetProperty("MultiProjectorName");
-        if (projectorNameProperty == null)
-        {
-            throw new InvalidOperationException(
-                $"Projector type {projectorType.Name} does not have MultiProjectorName property");
-        }
-
-        var projectorName = projectorNameProperty.GetValue(null) as string;
-        if (string.IsNullOrEmpty(projectorName))
-        {
-            throw new InvalidOperationException(
-                $"Projector type {projectorType.Name} has invalid MultiProjectorName");
-        }
+        var projectorName = ResolveProjectorName(queryCommon);
 
         // Get the multi-projection grain directly
         var grainId = ServiceIdGrainKey.Build(_serviceIdProvider.GetCurrentServiceId(), projectorName);
@@ -123,29 +102,7 @@ public class OrleansDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecuto
     public async Task<ListQueryResult<TResult>> QueryAsync<TResult>(IListQueryCommon<TResult> queryCommon)
         where TResult : notnull
     {
-        // Get the multi-projector type for this query
-        var projectorTypeResult = _domainTypes.QueryTypes.GetMultiProjectorType(queryCommon);
-        if (!projectorTypeResult.IsSuccess)
-        {
-            throw projectorTypeResult.GetException();
-        }
-
-        var projectorType = projectorTypeResult.GetValue();
-
-        // Get the multi-projector name
-        var projectorNameProperty = projectorType.GetProperty("MultiProjectorName");
-        if (projectorNameProperty == null)
-        {
-            throw new InvalidOperationException(
-                $"Projector type {projectorType.Name} does not have MultiProjectorName property");
-        }
-
-        var projectorName = projectorNameProperty.GetValue(null) as string;
-        if (string.IsNullOrEmpty(projectorName))
-        {
-            throw new InvalidOperationException(
-                $"Projector type {projectorType.Name} has invalid MultiProjectorName");
-        }
+        var projectorName = ResolveProjectorName(queryCommon);
 
         // Get the multi-projection grain directly
         var grainId = ServiceIdGrainKey.Build(_serviceIdProvider.GetCurrentServiceId(), projectorName);
@@ -224,6 +181,34 @@ public class OrleansDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecuto
     public Task<string> GetLatestSortableUniqueIdAsync() =>
         _generalExecutor.GetLatestSortableUniqueIdAsync();
 
+    public async Task<ProjectionHeadStatus> GetProjectionHeadStatusAsync(
+        string projectorName,
+        string? expectedProjectorVersion = null)
+    {
+        var projectorVersion = ValidateProjectorVersion(projectorName, expectedProjectorVersion);
+        var grainId = ServiceIdGrainKey.Build(_serviceIdProvider.GetCurrentServiceId(), projectorName);
+        var grain = _clusterClient.GetGrain<IMultiProjectionGrain>(grainId);
+        var grainStatus = await grain.GetProjectionHeadStatusAsync();
+
+        return new ProjectionHeadStatus(
+            projectorName,
+            string.IsNullOrWhiteSpace(grainStatus.ProjectorVersion) ? projectorVersion : grainStatus.ProjectorVersion,
+            new ProjectionPosition(
+                grainStatus.CurrentEventVersion,
+                NormalizeSortableUniqueId(grainStatus.CurrentLastSortableUniqueId)),
+            new ProjectionPosition(
+                grainStatus.ConsistentEventVersion,
+                NormalizeSortableUniqueId(grainStatus.ConsistentLastSortableUniqueId)),
+            new ProjectionCatchUpStatus(
+                grainStatus.IsCatchUpInProgress,
+                NormalizeSortableUniqueId(grainStatus.CatchUpCurrentSortableUniqueId),
+                NormalizeSortableUniqueId(grainStatus.CatchUpTargetSortableUniqueId),
+                grainStatus.PendingStreamEventCount));
+    }
+
+    public Task<EventStoreHeadStatus> GetEventStoreHeadStatusAsync(bool includeTotalEventCount = false) =>
+        _generalExecutor.GetEventStoreHeadStatusAsync(includeTotalEventCount);
+
     public Task<ResultBox<SerializableTagState>> GetSerializableTagStateAsync(TagStateId tagStateId) =>
         _generalExecutor.GetSerializableTagStateAsync(tagStateId);
 
@@ -231,4 +216,68 @@ public class OrleansDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecuto
         SerializedCommitRequest request,
         CancellationToken cancellationToken = default) =>
         _generalExecutor.CommitSerializableEventsAsync(request, cancellationToken);
+
+    private string ResolveProjectorName(IQueryCommon queryCommon)
+    {
+        var projectorTypeResult = _domainTypes.QueryTypes.GetMultiProjectorType(queryCommon);
+        return ResolveProjectorName(projectorTypeResult);
+    }
+
+    private string ResolveProjectorName(IListQueryCommon queryCommon)
+    {
+        var projectorTypeResult = _domainTypes.QueryTypes.GetMultiProjectorType(queryCommon);
+        return ResolveProjectorName(projectorTypeResult);
+    }
+
+    private static string ResolveProjectorName(ResultBox<Type> projectorTypeResult)
+    {
+        if (!projectorTypeResult.IsSuccess)
+        {
+            throw projectorTypeResult.GetException();
+        }
+
+        var projectorType = projectorTypeResult.GetValue();
+        var projectorNameProperty = projectorType.GetProperty("MultiProjectorName");
+        if (projectorNameProperty == null)
+        {
+            throw new InvalidOperationException(
+                $"Projector type {projectorType.Name} does not have MultiProjectorName property");
+        }
+
+        var projectorName = projectorNameProperty.GetValue(null) as string;
+        if (string.IsNullOrWhiteSpace(projectorName))
+        {
+            throw new InvalidOperationException(
+                $"Projector type {projectorType.Name} has invalid MultiProjectorName");
+        }
+
+        return projectorName;
+    }
+
+    private string ValidateProjectorVersion(string projectorName, string? expectedProjectorVersion)
+    {
+        if (string.IsNullOrWhiteSpace(projectorName))
+        {
+            throw new ArgumentException("Projector name cannot be empty.", nameof(projectorName));
+        }
+
+        var projectorVersionResult = _domainTypes.MultiProjectorTypes.GetProjectorVersion(projectorName);
+        if (!projectorVersionResult.IsSuccess)
+        {
+            throw projectorVersionResult.GetException();
+        }
+
+        var currentProjectorVersion = projectorVersionResult.GetValue();
+        if (!string.IsNullOrWhiteSpace(expectedProjectorVersion)
+            && !string.Equals(currentProjectorVersion, expectedProjectorVersion, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"Projector version mismatch for '{projectorName}'. Expected '{expectedProjectorVersion}', but registered version is '{currentProjectorVersion}'.");
+        }
+
+        return currentProjectorVersion;
+    }
+
+    private static string? NormalizeSortableUniqueId(string? sortableUniqueId) =>
+        string.IsNullOrWhiteSpace(sortableUniqueId) ? null : sortableUniqueId;
 }

--- a/dcb/src/Sekiban.Dcb.Orleans.WithoutResult/OrleansDcbExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.WithoutResult/OrleansDcbExecutor.cs
@@ -185,24 +185,48 @@ public class OrleansDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecuto
         string projectorName,
         string? expectedProjectorVersion = null)
     {
-        var projectorVersion = ValidateProjectorVersion(projectorName, expectedProjectorVersion);
+        var projectorVersionResult = ProjectionHeadStatusUtilities.ValidateProjectorVersion(
+            _domainTypes,
+            projectorName,
+            expectedProjectorVersion);
+        if (!projectorVersionResult.IsSuccess)
+        {
+            throw projectorVersionResult.GetException();
+        }
+
         var grainId = ServiceIdGrainKey.Build(_serviceIdProvider.GetCurrentServiceId(), projectorName);
         var grain = _clusterClient.GetGrain<IMultiProjectionGrain>(grainId);
         var grainStatus = await grain.GetProjectionHeadStatusAsync();
 
-        return new ProjectionHeadStatus(
+        var projectorNameResult = ProjectionHeadStatusUtilities.EnsureProjectorNameConsistency(
             projectorName,
-            string.IsNullOrWhiteSpace(grainStatus.ProjectorVersion) ? projectorVersion : grainStatus.ProjectorVersion,
+            grainStatus.ProjectorName);
+        if (!projectorNameResult.IsSuccess)
+        {
+            throw projectorNameResult.GetException();
+        }
+
+        var projectorVersionConsistencyResult = ProjectionHeadStatusUtilities.EnsureProjectorVersionConsistency(
+            projectorVersionResult.GetValue(),
+            grainStatus.ProjectorVersion);
+        if (!projectorVersionConsistencyResult.IsSuccess)
+        {
+            throw projectorVersionConsistencyResult.GetException();
+        }
+
+        return new ProjectionHeadStatus(
+            projectorNameResult.GetValue(),
+            projectorVersionConsistencyResult.GetValue(),
             new ProjectionPosition(
                 grainStatus.CurrentEventVersion,
-                NormalizeSortableUniqueId(grainStatus.CurrentLastSortableUniqueId)),
+                ProjectionHeadStatusUtilities.NormalizeSortableUniqueId(grainStatus.CurrentLastSortableUniqueId)),
             new ProjectionPosition(
                 grainStatus.ConsistentEventVersion,
-                NormalizeSortableUniqueId(grainStatus.ConsistentLastSortableUniqueId)),
+                ProjectionHeadStatusUtilities.NormalizeSortableUniqueId(grainStatus.ConsistentLastSortableUniqueId)),
             new ProjectionCatchUpStatus(
                 grainStatus.IsCatchUpInProgress,
-                NormalizeSortableUniqueId(grainStatus.CatchUpCurrentSortableUniqueId),
-                NormalizeSortableUniqueId(grainStatus.CatchUpTargetSortableUniqueId),
+                ProjectionHeadStatusUtilities.NormalizeSortableUniqueId(grainStatus.CatchUpCurrentSortableUniqueId),
+                ProjectionHeadStatusUtilities.NormalizeSortableUniqueId(grainStatus.CatchUpTargetSortableUniqueId),
                 grainStatus.PendingStreamEventCount));
     }
 
@@ -220,64 +244,24 @@ public class OrleansDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecuto
     private string ResolveProjectorName(IQueryCommon queryCommon)
     {
         var projectorTypeResult = _domainTypes.QueryTypes.GetMultiProjectorType(queryCommon);
-        return ResolveProjectorName(projectorTypeResult);
+        var projectorNameResult = ProjectionHeadStatusUtilities.ResolveProjectorName(projectorTypeResult);
+        if (!projectorNameResult.IsSuccess)
+        {
+            throw projectorNameResult.GetException();
+        }
+
+        return projectorNameResult.GetValue();
     }
 
     private string ResolveProjectorName(IListQueryCommon queryCommon)
     {
         var projectorTypeResult = _domainTypes.QueryTypes.GetMultiProjectorType(queryCommon);
-        return ResolveProjectorName(projectorTypeResult);
+        var projectorNameResult = ProjectionHeadStatusUtilities.ResolveProjectorName(projectorTypeResult);
+        if (!projectorNameResult.IsSuccess)
+        {
+            throw projectorNameResult.GetException();
+        }
+
+        return projectorNameResult.GetValue();
     }
-
-    private static string ResolveProjectorName(ResultBox<Type> projectorTypeResult)
-    {
-        if (!projectorTypeResult.IsSuccess)
-        {
-            throw projectorTypeResult.GetException();
-        }
-
-        var projectorType = projectorTypeResult.GetValue();
-        var projectorNameProperty = projectorType.GetProperty("MultiProjectorName");
-        if (projectorNameProperty == null)
-        {
-            throw new InvalidOperationException(
-                $"Projector type {projectorType.Name} does not have MultiProjectorName property");
-        }
-
-        var projectorName = projectorNameProperty.GetValue(null) as string;
-        if (string.IsNullOrWhiteSpace(projectorName))
-        {
-            throw new InvalidOperationException(
-                $"Projector type {projectorType.Name} has invalid MultiProjectorName");
-        }
-
-        return projectorName;
-    }
-
-    private string ValidateProjectorVersion(string projectorName, string? expectedProjectorVersion)
-    {
-        if (string.IsNullOrWhiteSpace(projectorName))
-        {
-            throw new ArgumentException("Projector name cannot be empty.", nameof(projectorName));
-        }
-
-        var projectorVersionResult = _domainTypes.MultiProjectorTypes.GetProjectorVersion(projectorName);
-        if (!projectorVersionResult.IsSuccess)
-        {
-            throw projectorVersionResult.GetException();
-        }
-
-        var currentProjectorVersion = projectorVersionResult.GetValue();
-        if (!string.IsNullOrWhiteSpace(expectedProjectorVersion)
-            && !string.Equals(currentProjectorVersion, expectedProjectorVersion, StringComparison.Ordinal))
-        {
-            throw new InvalidOperationException(
-                $"Projector version mismatch for '{projectorName}'. Expected '{expectedProjectorVersion}', but registered version is '{currentProjectorVersion}'.");
-        }
-
-        return currentProjectorVersion;
-    }
-
-    private static string? NormalizeSortableUniqueId(string? sortableUniqueId) =>
-        string.IsNullOrWhiteSpace(sortableUniqueId) ? null : sortableUniqueId;
 }

--- a/dcb/src/Sekiban.Dcb.WithResult/Actors/GeneralSekibanExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.WithResult/Actors/GeneralSekibanExecutor.cs
@@ -99,6 +99,14 @@ public class GeneralSekibanExecutor : ISekibanExecutor, ISerializedSekibanDcbExe
     public Task<ResultBox<string>> GetLatestSortableUniqueIdAsync() =>
         _core.GetLatestSortableUniqueIdAsync();
 
+    public Task<ResultBox<ProjectionHeadStatus>> GetProjectionHeadStatusAsync(
+        string projectorName,
+        string? expectedProjectorVersion = null) =>
+        _core.GetProjectionHeadStatusAsync(projectorName, expectedProjectorVersion);
+
+    public Task<ResultBox<EventStoreHeadStatus>> GetEventStoreHeadStatusAsync(bool includeTotalEventCount = false) =>
+        _core.GetEventStoreHeadStatusAsync(includeTotalEventCount);
+
     public Task<ResultBox<SerializableTagState>> GetSerializableTagStateAsync(TagStateId tagStateId) =>
         _core.GetSerializableTagStateAsync(tagStateId);
 

--- a/dcb/src/Sekiban.Dcb.WithResult/ISekibanExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.WithResult/ISekibanExecutor.cs
@@ -53,6 +53,8 @@ public interface ISekibanExecutor : ICommandExecutor
     /// <summary>
     ///     Gets projection head/catch-up status for a specific projector name.
     ///     When expectedProjectorVersion is provided, the executor validates it against the registered projector version.
+    ///     Backends without background catch-up may still report `CatchUp.IsInProgress == false`;
+    ///     compare `Current` and `Consistent` to detect safe-window lag in that case.
     /// </summary>
     Task<ResultBox<ProjectionHeadStatus>> GetProjectionHeadStatusAsync(
         string projectorName,
@@ -60,7 +62,8 @@ public interface ISekibanExecutor : ICommandExecutor
 
     /// <summary>
     ///     Gets the global event-store head.
-    ///     TotalEventCount is opt-in because some stores may implement counting with non-trivial cost.
+    ///     TotalEventCount is opt-in because providers such as Postgres/SQLite may execute `COUNT(*)`,
+    ///     while Cosmos DB or DynamoDB may require additional query work across partitions or shards.
     /// </summary>
     Task<ResultBox<EventStoreHeadStatus>> GetEventStoreHeadStatusAsync(bool includeTotalEventCount = false);
 }

--- a/dcb/src/Sekiban.Dcb.WithResult/ISekibanExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.WithResult/ISekibanExecutor.cs
@@ -1,5 +1,6 @@
 using ResultBoxes;
 using Sekiban.Dcb.Commands;
+using Sekiban.Dcb.MultiProjections;
 using Sekiban.Dcb.Queries;
 using Sekiban.Dcb.Tags;
 namespace Sekiban.Dcb;
@@ -41,4 +42,25 @@ public interface ISekibanExecutor : ICommandExecutor
     ///     Returns empty string if no events exist.
     /// </summary>
     Task<ResultBox<string>> GetLatestSortableUniqueIdAsync();
+
+    /// <summary>
+    ///     Gets projection head/catch-up status for a specific multi-projector type.
+    /// </summary>
+    Task<ResultBox<ProjectionHeadStatus>> GetProjectionHeadStatusAsync<TProjector>()
+        where TProjector : IMultiProjector<TProjector> =>
+        GetProjectionHeadStatusAsync(TProjector.MultiProjectorName, TProjector.MultiProjectorVersion);
+
+    /// <summary>
+    ///     Gets projection head/catch-up status for a specific projector name.
+    ///     When expectedProjectorVersion is provided, the executor validates it against the registered projector version.
+    /// </summary>
+    Task<ResultBox<ProjectionHeadStatus>> GetProjectionHeadStatusAsync(
+        string projectorName,
+        string? expectedProjectorVersion = null);
+
+    /// <summary>
+    ///     Gets the global event-store head.
+    ///     TotalEventCount is opt-in because some stores may implement counting with non-trivial cost.
+    /// </summary>
+    Task<ResultBox<EventStoreHeadStatus>> GetEventStoreHeadStatusAsync(bool includeTotalEventCount = false);
 }

--- a/dcb/src/Sekiban.Dcb.WithResult/InMemory/InMemoryDcbExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.WithResult/InMemory/InMemoryDcbExecutor.cs
@@ -69,6 +69,14 @@ public class InMemoryDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecut
     Task<ResultBox<string>> ISekibanExecutor.GetLatestSortableUniqueIdAsync() =>
         _inner.GetLatestSortableUniqueIdAsync();
 
+    Task<ResultBox<ProjectionHeadStatus>> ISekibanExecutor.GetProjectionHeadStatusAsync(
+        string projectorName,
+        string? expectedProjectorVersion) =>
+        _inner.GetProjectionHeadStatusAsync(projectorName, expectedProjectorVersion);
+
+    Task<ResultBox<EventStoreHeadStatus>> ISekibanExecutor.GetEventStoreHeadStatusAsync(bool includeTotalEventCount) =>
+        _inner.GetEventStoreHeadStatusAsync(includeTotalEventCount);
+
     Task<ResultBox<SerializableTagState>> ISerializedSekibanDcbExecutor.GetSerializableTagStateAsync(TagStateId tagStateId) =>
         _inner.GetSerializableTagStateAsync(tagStateId);
 

--- a/dcb/src/Sekiban.Dcb.WithoutResult/Actors/GeneralSekibanExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.WithoutResult/Actors/GeneralSekibanExecutor.cs
@@ -138,6 +138,20 @@ public class GeneralSekibanExecutor : ISekibanExecutor, ISerializedSekibanDcbExe
         return result.UnwrapBox();
     }
 
+    public async Task<ProjectionHeadStatus> GetProjectionHeadStatusAsync(
+        string projectorName,
+        string? expectedProjectorVersion = null)
+    {
+        var result = await _core.GetProjectionHeadStatusAsync(projectorName, expectedProjectorVersion);
+        return result.UnwrapBox();
+    }
+
+    public async Task<EventStoreHeadStatus> GetEventStoreHeadStatusAsync(bool includeTotalEventCount = false)
+    {
+        var result = await _core.GetEventStoreHeadStatusAsync(includeTotalEventCount);
+        return result.UnwrapBox();
+    }
+
     public Task<ResultBox<SerializableTagState>> GetSerializableTagStateAsync(TagStateId tagStateId) =>
         _core.GetSerializableTagStateAsync(tagStateId);
 

--- a/dcb/src/Sekiban.Dcb.WithoutResult/ISekibanExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.WithoutResult/ISekibanExecutor.cs
@@ -62,6 +62,8 @@ public interface ISekibanExecutor : ICommandExecutor
     /// <summary>
     ///     Gets projection head/catch-up status for a specific projector name.
     ///     When expectedProjectorVersion is provided, the executor validates it against the registered projector version.
+    ///     Backends without background catch-up may still report `CatchUp.IsInProgress == false`;
+    ///     compare `Current` and `Consistent` to detect safe-window lag in that case.
     /// </summary>
     Task<ProjectionHeadStatus> GetProjectionHeadStatusAsync(
         string projectorName,
@@ -69,7 +71,8 @@ public interface ISekibanExecutor : ICommandExecutor
 
     /// <summary>
     ///     Gets the global event-store head.
-    ///     TotalEventCount is opt-in because some stores may implement counting with non-trivial cost.
+    ///     TotalEventCount is opt-in because providers such as Postgres/SQLite may execute `COUNT(*)`,
+    ///     while Cosmos DB or DynamoDB may require additional query work across partitions or shards.
     /// </summary>
     Task<EventStoreHeadStatus> GetEventStoreHeadStatusAsync(bool includeTotalEventCount = false);
 }

--- a/dcb/src/Sekiban.Dcb.WithoutResult/ISekibanExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.WithoutResult/ISekibanExecutor.cs
@@ -1,5 +1,6 @@
 using Sekiban.Dcb.Commands;
 using Sekiban.Dcb.Events;
+using Sekiban.Dcb.MultiProjections;
 using Sekiban.Dcb.Queries;
 using Sekiban.Dcb.Tags;
 
@@ -50,4 +51,25 @@ public interface ISekibanExecutor : ICommandExecutor
     /// </summary>
     /// <exception cref="Exception">Thrown when the event store query fails</exception>
     Task<string> GetLatestSortableUniqueIdAsync();
+
+    /// <summary>
+    ///     Gets projection head/catch-up status for a specific multi-projector type.
+    /// </summary>
+    Task<ProjectionHeadStatus> GetProjectionHeadStatusAsync<TProjector>()
+        where TProjector : IMultiProjector<TProjector> =>
+        GetProjectionHeadStatusAsync(TProjector.MultiProjectorName, TProjector.MultiProjectorVersion);
+
+    /// <summary>
+    ///     Gets projection head/catch-up status for a specific projector name.
+    ///     When expectedProjectorVersion is provided, the executor validates it against the registered projector version.
+    /// </summary>
+    Task<ProjectionHeadStatus> GetProjectionHeadStatusAsync(
+        string projectorName,
+        string? expectedProjectorVersion = null);
+
+    /// <summary>
+    ///     Gets the global event-store head.
+    ///     TotalEventCount is opt-in because some stores may implement counting with non-trivial cost.
+    /// </summary>
+    Task<EventStoreHeadStatus> GetEventStoreHeadStatusAsync(bool includeTotalEventCount = false);
 }

--- a/dcb/src/Sekiban.Dcb.WithoutResult/InMemory/InMemoryDcbExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.WithoutResult/InMemory/InMemoryDcbExecutor.cs
@@ -71,6 +71,14 @@ public class InMemoryDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecut
     Task<string> ISekibanExecutor.GetLatestSortableUniqueIdAsync() =>
         _inner.GetLatestSortableUniqueIdAsync();
 
+    Task<ProjectionHeadStatus> ISekibanExecutor.GetProjectionHeadStatusAsync(
+        string projectorName,
+        string? expectedProjectorVersion) =>
+        _inner.GetProjectionHeadStatusAsync(projectorName, expectedProjectorVersion);
+
+    Task<EventStoreHeadStatus> ISekibanExecutor.GetEventStoreHeadStatusAsync(bool includeTotalEventCount) =>
+        _inner.GetEventStoreHeadStatusAsync(includeTotalEventCount);
+
     Task<ResultBox<SerializableTagState>> ISerializedSekibanDcbExecutor.GetSerializableTagStateAsync(TagStateId tagStateId) =>
         _inner.GetSerializableTagStateAsync(tagStateId);
 

--- a/dcb/tests/Sekiban.Dcb.MaterializedView.Postgres.Tests/MaterializedViewPostgresOrleansTests.cs
+++ b/dcb/tests/Sekiban.Dcb.MaterializedView.Postgres.Tests/MaterializedViewPostgresOrleansTests.cs
@@ -311,6 +311,379 @@ public sealed class MaterializedViewPostgresOrleansTests(MaterializedViewPostgre
         Assert.Null(registryRow.LastCatchUpSortableUniqueId);
     }
 
+    [Fact]
+    public async Task Grain_Delayed_Create_After_Streamed_Update_DoesNotAdvance_Past_Missing_Row()
+    {
+        if (!fixture.IsAvailable)
+        {
+            fixture.EnsureAvailable();
+            return;
+        }
+
+        var grainKey = MvGrainKey.Build(DefaultServiceIdProvider.DefaultServiceId, "WeatherForecast", 1);
+        var grain = fixture.Client.GetGrain<IMaterializedViewGrain>(grainKey);
+        try
+        {
+            await grain.RequestDeactivationAsync();
+            await Task.Delay(200);
+        }
+        catch
+        {
+            // The grain may not be active yet; that's fine for this reset path.
+        }
+
+        await fixture.ResetAsync();
+        await grain.EnsureStartedAsync();
+
+        var executor = fixture.CreateExecutor(publishToStream: false);
+        var forecastId = Guid.CreateVersion7();
+        await executor.ExecuteAsync(new CreateWeatherForecast
+        {
+            ForecastId = forecastId,
+            Location = "Loc-delayed",
+            Date = new DateOnly(2026, 4, 16),
+            TemperatureC = 23,
+            Summary = "Delayed create"
+        });
+        await executor.ExecuteAsync(new ChangeLocationName
+        {
+            ForecastId = forecastId,
+            NewLocationName = "Loc-delayed-U"
+        });
+
+        var events = (await fixture.EventStore.ReadAllSerializableEventsAsync()).GetValue()
+            .Where(serializableEvent =>
+            {
+                var eventResult = serializableEvent.ToEvent(fixture.DomainTypes.EventTypes);
+                if (!eventResult.IsSuccess)
+                {
+                    return false;
+                }
+
+                return eventResult.GetValue().Payload switch
+                {
+                    WeatherForecastCreated created => created.ForecastId == forecastId,
+                    LocationNameChanged changed => changed.ForecastId == forecastId,
+                    _ => false
+                };
+            })
+            .OrderBy(serializableEvent => serializableEvent.SortableUniqueIdValue, StringComparer.Ordinal)
+            .ToList();
+
+        Assert.Equal(2, events.Count);
+
+        var createEvent = events[0];
+        var updateEvent = events[1];
+
+        var streamNamespace = ServiceIdGrainKey.BuildStreamNamespace("AllEvents", DefaultServiceIdProvider.DefaultServiceId);
+        var stream = fixture.Client
+            .GetStreamProvider("EventStreamProvider")
+            .GetStream<SerializableEvent>(StreamId.Create(streamNamespace, Guid.Empty));
+
+        await stream.OnNextAsync(updateEvent);
+        await Task.Delay(TimeSpan.FromMilliseconds(1300));
+
+        var statusAfterUpdateOnly = await grain.GetStatusAsync();
+        await using (var interimConnection = await fixture.OpenConnectionAsync())
+        {
+            var interimCount = await interimConnection.ExecuteScalarAsync<int>(
+                "SELECT COUNT(*) FROM sekiban_mv_weatherforecast_v1_forecasts WHERE forecast_id = @ForecastId;",
+                new { ForecastId = forecastId });
+            Assert.Equal(0, interimCount);
+        }
+        Assert.True(
+            string.IsNullOrWhiteSpace(statusAfterUpdateOnly.CurrentPosition) ||
+            string.Compare(statusAfterUpdateOnly.CurrentPosition, updateEvent.SortableUniqueIdValue, StringComparison.Ordinal) < 0);
+
+        await stream.OnNextAsync(createEvent);
+
+        await WaitUntilAsync(async () =>
+        {
+            var status = await grain.GetStatusAsync();
+            if (status.CurrentPosition != updateEvent.SortableUniqueIdValue)
+            {
+                return false;
+            }
+
+            await using var connection = await fixture.OpenConnectionAsync();
+            var row = await connection.QuerySingleOrDefaultAsync<WeatherProjectionRow>(
+                """
+                SELECT forecast_id AS ForecastId,
+                       location AS Location,
+                       _last_sortable_unique_id AS LastSortableUniqueId
+                FROM sekiban_mv_weatherforecast_v1_forecasts
+                WHERE forecast_id = @ForecastId;
+                """,
+                new { ForecastId = forecastId });
+
+            return row is not null &&
+                   row.Location == "Loc-delayed-U" &&
+                   row.LastSortableUniqueId == updateEvent.SortableUniqueIdValue;
+        }, timeoutMs: 15000);
+
+        await using var verifyConnection = await fixture.OpenConnectionAsync();
+        var registryRow = await verifyConnection.QuerySingleAsync<RegistryProjectionRow>(
+            """
+            SELECT current_position AS CurrentPosition,
+                   last_sortable_unique_id AS LastSortableUniqueId,
+                   applied_event_version AS AppliedEventVersion,
+                   last_applied_source AS LastAppliedSource,
+                   last_applied_at AS LastAppliedAt,
+                   last_stream_received_sortable_unique_id AS LastStreamReceivedSortableUniqueId,
+                   last_stream_received_at AS LastStreamReceivedAt,
+                   last_stream_applied_sortable_unique_id AS LastStreamAppliedSortableUniqueId,
+                   last_catch_up_sortable_unique_id AS LastCatchUpSortableUniqueId
+            FROM sekiban_mv_registry
+            WHERE view_name = 'WeatherForecast' AND logical_table = 'forecasts';
+            """);
+
+        var rowCount = await verifyConnection.ExecuteScalarAsync<int>(
+            "SELECT COUNT(*) FROM sekiban_mv_weatherforecast_v1_forecasts WHERE forecast_id = @ForecastId;",
+            new { ForecastId = forecastId });
+        var updatedLocation = await verifyConnection.ExecuteScalarAsync<string>(
+            "SELECT location FROM sekiban_mv_weatherforecast_v1_forecasts WHERE forecast_id = @ForecastId;",
+            new { ForecastId = forecastId });
+
+        Assert.Equal(1, rowCount);
+        Assert.Equal("Loc-delayed-U", updatedLocation);
+        Assert.Equal(updateEvent.SortableUniqueIdValue, registryRow.CurrentPosition);
+        Assert.Equal(2, registryRow.AppliedEventVersion);
+        Assert.Equal(updateEvent.SortableUniqueIdValue, registryRow.LastStreamAppliedSortableUniqueId);
+    }
+
+    [Fact]
+    public async Task Grain_Streamed_Create_Then_Update_For_Same_Aggregate_Applies_Both_Events()
+    {
+        if (!fixture.IsAvailable)
+        {
+            fixture.EnsureAvailable();
+            return;
+        }
+
+        var grainKey = MvGrainKey.Build(DefaultServiceIdProvider.DefaultServiceId, "WeatherForecast", 1);
+        var grain = fixture.Client.GetGrain<IMaterializedViewGrain>(grainKey);
+        try
+        {
+            await grain.RequestDeactivationAsync();
+            await Task.Delay(200);
+        }
+        catch
+        {
+            // The grain may not be active yet; that's fine for this reset path.
+        }
+
+        await fixture.ResetAsync();
+        await grain.EnsureStartedAsync();
+
+        var executor = fixture.CreateExecutor(publishToStream: false);
+        var forecastId = Guid.CreateVersion7();
+        await executor.ExecuteAsync(new CreateWeatherForecast
+        {
+            ForecastId = forecastId,
+            Location = "Loc-buffered",
+            Date = new DateOnly(2026, 4, 16),
+            TemperatureC = 25,
+            Summary = "Buffered create"
+        });
+        await executor.ExecuteAsync(new ChangeLocationName
+        {
+            ForecastId = forecastId,
+            NewLocationName = "Loc-buffered-U"
+        });
+
+        var events = (await fixture.EventStore.ReadAllSerializableEventsAsync()).GetValue()
+            .Where(serializableEvent =>
+            {
+                var eventResult = serializableEvent.ToEvent(fixture.DomainTypes.EventTypes);
+                if (!eventResult.IsSuccess)
+                {
+                    return false;
+                }
+
+                return eventResult.GetValue().Payload switch
+                {
+                    WeatherForecastCreated created => created.ForecastId == forecastId,
+                    LocationNameChanged changed => changed.ForecastId == forecastId,
+                    _ => false
+                };
+            })
+            .OrderBy(serializableEvent => serializableEvent.SortableUniqueIdValue, StringComparer.Ordinal)
+            .ToList();
+
+        Assert.Equal(2, events.Count);
+
+        var createEvent = events[0];
+        var updateEvent = events[1];
+        var streamNamespace = ServiceIdGrainKey.BuildStreamNamespace("AllEvents", DefaultServiceIdProvider.DefaultServiceId);
+        var stream = fixture.Client
+            .GetStreamProvider("EventStreamProvider")
+            .GetStream<SerializableEvent>(StreamId.Create(streamNamespace, Guid.Empty));
+
+        await stream.OnNextAsync(createEvent);
+        await stream.OnNextAsync(updateEvent);
+
+        await WaitUntilAsync(async () =>
+        {
+            var status = await grain.GetStatusAsync();
+            if (status.CurrentPosition != updateEvent.SortableUniqueIdValue)
+            {
+                return false;
+            }
+
+            await using var connection = await fixture.OpenConnectionAsync();
+            var row = await connection.QuerySingleOrDefaultAsync<WeatherProjectionRow>(
+                """
+                SELECT forecast_id AS ForecastId,
+                       location AS Location,
+                       _last_sortable_unique_id AS LastSortableUniqueId
+                FROM sekiban_mv_weatherforecast_v1_forecasts
+                WHERE forecast_id = @ForecastId;
+                """,
+                new { ForecastId = forecastId });
+
+            return row is not null &&
+                   row.Location == "Loc-buffered-U" &&
+                   row.LastSortableUniqueId == updateEvent.SortableUniqueIdValue;
+        }, timeoutMs: 15000);
+
+        await using var verifyConnection = await fixture.OpenConnectionAsync();
+        var registryRow = await verifyConnection.QuerySingleAsync<RegistryProjectionRow>(
+            """
+            SELECT current_position AS CurrentPosition,
+                   applied_event_version AS AppliedEventVersion,
+                   last_stream_applied_sortable_unique_id AS LastStreamAppliedSortableUniqueId
+            FROM sekiban_mv_registry
+            WHERE view_name = 'WeatherForecast' AND logical_table = 'forecasts';
+            """);
+
+        Assert.Equal(updateEvent.SortableUniqueIdValue, registryRow.CurrentPosition);
+        Assert.Equal(2, registryRow.AppliedEventVersion);
+        Assert.Equal(updateEvent.SortableUniqueIdValue, registryRow.LastStreamAppliedSortableUniqueId);
+    }
+
+    [Fact]
+    public async Task Grain_Late_Create_Older_Than_CurrentPosition_Is_Applied_Without_Stalling_Other_Aggregates()
+    {
+        if (!fixture.IsAvailable)
+        {
+            fixture.EnsureAvailable();
+            return;
+        }
+
+        var grainKey = MvGrainKey.Build(DefaultServiceIdProvider.DefaultServiceId, "WeatherForecast", 1);
+        var grain = fixture.Client.GetGrain<IMaterializedViewGrain>(grainKey);
+        try
+        {
+            await grain.RequestDeactivationAsync();
+            await Task.Delay(200);
+        }
+        catch
+        {
+            // The grain may not be active yet; that's fine for this reset path.
+        }
+
+        await fixture.ResetAsync();
+        await grain.EnsureStartedAsync();
+
+        var executor = fixture.CreateExecutor(publishToStream: false);
+        var delayedForecastId = Guid.CreateVersion7();
+        var advancedForecastId = Guid.CreateVersion7();
+
+        await executor.ExecuteAsync(new CreateWeatherForecast
+        {
+            ForecastId = delayedForecastId,
+            Location = "Loc-late",
+            Date = new DateOnly(2026, 4, 16),
+            TemperatureC = 11,
+            Summary = "Late create"
+        });
+        await executor.ExecuteAsync(new CreateWeatherForecast
+        {
+            ForecastId = advancedForecastId,
+            Location = "Loc-advance",
+            Date = new DateOnly(2026, 4, 17),
+            TemperatureC = 12,
+            Summary = "Advance position"
+        });
+        await executor.ExecuteAsync(new ChangeLocationName
+        {
+            ForecastId = delayedForecastId,
+            NewLocationName = "Loc-late-U"
+        });
+
+        var allEvents = (await fixture.EventStore.ReadAllSerializableEventsAsync()).GetValue()
+            .Select(serializableEvent => new
+            {
+                SerializableEvent = serializableEvent,
+                Event = serializableEvent.ToEvent(fixture.DomainTypes.EventTypes).GetValue()
+            })
+            .ToList();
+
+        var delayedCreate = allEvents
+            .Single(item => item.Event.Payload is WeatherForecastCreated created && created.ForecastId == delayedForecastId)
+            .SerializableEvent;
+        var delayedUpdate = allEvents
+            .Single(item => item.Event.Payload is LocationNameChanged changed && changed.ForecastId == delayedForecastId)
+            .SerializableEvent;
+        var advancedCreate = allEvents
+            .Single(item => item.Event.Payload is WeatherForecastCreated created && created.ForecastId == advancedForecastId)
+            .SerializableEvent;
+
+        Assert.True(
+            string.Compare(delayedCreate.SortableUniqueIdValue, advancedCreate.SortableUniqueIdValue, StringComparison.Ordinal) < 0);
+        Assert.True(
+            string.Compare(advancedCreate.SortableUniqueIdValue, delayedUpdate.SortableUniqueIdValue, StringComparison.Ordinal) < 0);
+
+        var streamNamespace = ServiceIdGrainKey.BuildStreamNamespace("AllEvents", DefaultServiceIdProvider.DefaultServiceId);
+        var stream = fixture.Client
+            .GetStreamProvider("EventStreamProvider")
+            .GetStream<SerializableEvent>(StreamId.Create(streamNamespace, Guid.Empty));
+
+        await stream.OnNextAsync(advancedCreate);
+        await stream.OnNextAsync(delayedUpdate);
+        await Task.Delay(TimeSpan.FromMilliseconds(1300));
+
+        var blockedStatus = await grain.GetStatusAsync();
+        Assert.Equal(advancedCreate.SortableUniqueIdValue, blockedStatus.CurrentPosition);
+
+        await stream.OnNextAsync(delayedCreate);
+
+        await WaitUntilAsync(async () =>
+        {
+            var status = await grain.GetStatusAsync();
+            if (status.CurrentPosition != delayedUpdate.SortableUniqueIdValue)
+            {
+                return false;
+            }
+
+            await using var connection = await fixture.OpenConnectionAsync();
+            var delayedRow = await connection.QuerySingleOrDefaultAsync<WeatherProjectionRow>(
+                """
+                SELECT forecast_id AS ForecastId,
+                       location AS Location,
+                       _last_sortable_unique_id AS LastSortableUniqueId
+                FROM sekiban_mv_weatherforecast_v1_forecasts
+                WHERE forecast_id = @ForecastId;
+                """,
+                new { ForecastId = delayedForecastId });
+            var advancedRow = await connection.QuerySingleOrDefaultAsync<WeatherProjectionRow>(
+                """
+                SELECT forecast_id AS ForecastId,
+                       location AS Location,
+                       _last_sortable_unique_id AS LastSortableUniqueId
+                FROM sekiban_mv_weatherforecast_v1_forecasts
+                WHERE forecast_id = @ForecastId;
+                """,
+                new { ForecastId = advancedForecastId });
+
+            return delayedRow is not null &&
+                   delayedRow.Location == "Loc-late-U" &&
+                   delayedRow.LastSortableUniqueId == delayedUpdate.SortableUniqueIdValue &&
+                   advancedRow is not null &&
+                   advancedRow.LastSortableUniqueId == advancedCreate.SortableUniqueIdValue;
+        }, timeoutMs: 15000);
+    }
+
     private static async Task WaitUntilAsync(Func<Task<bool>> predicate, int timeoutMs = 10000, int pollMs = 100)
     {
         var until = DateTime.UtcNow.AddMilliseconds(timeoutMs);
@@ -346,5 +719,12 @@ public sealed class MaterializedViewPostgresOrleansTests(MaterializedViewPostgre
         public DateTimeOffset? LastStreamReceivedAt { get; set; }
         public string? LastStreamAppliedSortableUniqueId { get; set; }
         public string? LastCatchUpSortableUniqueId { get; set; }
+    }
+
+    private sealed class WeatherProjectionRow
+    {
+        public Guid ForecastId { get; set; }
+        public string Location { get; set; } = string.Empty;
+        public string LastSortableUniqueId { get; set; } = string.Empty;
     }
 }

--- a/dcb/tests/Sekiban.Dcb.Orleans.Tests/CatchUpQueryAwarenessTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Orleans.Tests/CatchUpQueryAwarenessTests.cs
@@ -167,34 +167,46 @@ public class CatchUpQueryAwarenessTests : IAsyncLifetime
         Assert.Equal(eventCount, storeHead.TotalEventCount);
         Assert.Equal(latestSortableUniqueId, storeHead.LatestSortableUniqueId);
 
-        await grain.RequestDeactivationAsync();
-        await Task.Delay(2000);
-
         var initialStatusResult = await executor.GetProjectionHeadStatusAsync<CatchUpCountingProjector>();
-        Assert.True(initialStatusResult.IsSuccess, initialStatusResult.IsSuccess ? string.Empty : initialStatusResult.GetException().ToString());
+        Assert.True(initialStatusResult.IsSuccess, DescribeFailure(initialStatusResult));
         var initialStatus = initialStatusResult.GetValue();
         Assert.True(initialStatus.Current.EventVersion >= initialStatus.Consistent.EventVersion);
 
-        await grain.RefreshAsync();
+        var refreshTask = Task.Run(async () => await grain.RefreshAsync());
 
         ProjectionHeadStatus? finalStatus = null;
         ProjectionHeadStatus? lastObservedStatus = null;
+        var sawCatchUpInProgress = false;
         var completionDeadline = DateTime.UtcNow.AddSeconds(20);
         while (DateTime.UtcNow < completionDeadline)
         {
             var statusResult = await executor.GetProjectionHeadStatusAsync<CatchUpCountingProjector>();
-            Assert.True(statusResult.IsSuccess, statusResult.IsSuccess ? string.Empty : statusResult.GetException().ToString());
+            Assert.True(statusResult.IsSuccess, DescribeFailure(statusResult));
             var status = statusResult.GetValue();
             lastObservedStatus = status;
+            sawCatchUpInProgress |= status.CatchUp.IsInProgress;
             if (string.Equals(status.Current.LastSortableUniqueId, latestSortableUniqueId, StringComparison.Ordinal))
             {
                 finalStatus = status;
                 break;
             }
 
-            await Task.Delay(200);
+            await Task.Delay(100);
         }
 
+        await refreshTask;
+        if (finalStatus is null)
+        {
+            var finalStatusResult = await executor.GetProjectionHeadStatusAsync<CatchUpCountingProjector>();
+            Assert.True(finalStatusResult.IsSuccess, DescribeFailure(finalStatusResult));
+            finalStatus = finalStatusResult.GetValue();
+            lastObservedStatus = finalStatus;
+            sawCatchUpInProgress |= finalStatus.CatchUp.IsInProgress;
+        }
+
+        Assert.True(
+            sawCatchUpInProgress,
+            $"Expected catch-up to be observable. Last observed: current={lastObservedStatus?.Current.EventVersion}:{lastObservedStatus?.Current.LastSortableUniqueId}, consistent={lastObservedStatus?.Consistent.EventVersion}:{lastObservedStatus?.Consistent.LastSortableUniqueId}, catchup={lastObservedStatus?.CatchUp.IsInProgress}:{lastObservedStatus?.CatchUp.CurrentSortableUniqueId}->{lastObservedStatus?.CatchUp.TargetSortableUniqueId}");
         Assert.True(
             finalStatus is not null,
             $"Last observed: current={lastObservedStatus?.Current.EventVersion}:{lastObservedStatus?.Current.LastSortableUniqueId}, consistent={lastObservedStatus?.Consistent.EventVersion}:{lastObservedStatus?.Consistent.LastSortableUniqueId}, catchup={lastObservedStatus?.CatchUp.IsInProgress}:{lastObservedStatus?.CatchUp.CurrentSortableUniqueId}->{lastObservedStatus?.CatchUp.TargetSortableUniqueId}");
@@ -233,6 +245,16 @@ public class CatchUpQueryAwarenessTests : IAsyncLifetime
                 e.Tags.ToList(),
                 e.EventType))
             .ToList();
+
+    private static string DescribeFailure<T>(ResultBox<T> result) where T : notnull
+    {
+        if (result.IsSuccess)
+        {
+            return string.Empty;
+        }
+
+        return result.GetException().ToString();
+    }
 
     internal static DcbDomainTypes CreateDomainTypes()
     {

--- a/dcb/tests/Sekiban.Dcb.Orleans.Tests/CatchUpQueryAwarenessTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Orleans.Tests/CatchUpQueryAwarenessTests.cs
@@ -148,6 +148,60 @@ public class CatchUpQueryAwarenessTests : IAsyncLifetime
         Assert.True(sw.ElapsedMilliseconds < 25000, "Default behavior should not block for catch-up");
     }
 
+    [Fact]
+    public async Task ExecutorProjectionHeadStatus_ShouldExposeCatchUpAndStoreHead()
+    {
+        const int eventCount = 4000;
+        var grain = _client.GetGrain<IMultiProjectionGrain>("catchup-counter");
+        ISekibanExecutor executor = new OrleansDcbExecutor(_client, SharedEventStore, CreateDomainTypes());
+
+        var events = CreateTestEvents(eventCount);
+        await grain.SeedEventsAsync(ToSerializableEvents(events));
+
+        var storeHeadResult = await executor.GetEventStoreHeadStatusAsync(includeTotalEventCount: true);
+        Assert.True(storeHeadResult.IsSuccess);
+        var storeHead = storeHeadResult.GetValue();
+        var latestSortableUniqueId = events
+            .MaxBy(static evt => evt.SortableUniqueIdValue, StringComparer.Ordinal)!
+            .SortableUniqueIdValue;
+        Assert.Equal(eventCount, storeHead.TotalEventCount);
+        Assert.Equal(latestSortableUniqueId, storeHead.LatestSortableUniqueId);
+
+        await grain.RequestDeactivationAsync();
+        await Task.Delay(2000);
+
+        var initialStatusResult = await executor.GetProjectionHeadStatusAsync<CatchUpCountingProjector>();
+        Assert.True(initialStatusResult.IsSuccess, initialStatusResult.IsSuccess ? string.Empty : initialStatusResult.GetException().ToString());
+        var initialStatus = initialStatusResult.GetValue();
+        Assert.True(initialStatus.Current.EventVersion >= initialStatus.Consistent.EventVersion);
+
+        await grain.RefreshAsync();
+
+        ProjectionHeadStatus? finalStatus = null;
+        ProjectionHeadStatus? lastObservedStatus = null;
+        var completionDeadline = DateTime.UtcNow.AddSeconds(20);
+        while (DateTime.UtcNow < completionDeadline)
+        {
+            var statusResult = await executor.GetProjectionHeadStatusAsync<CatchUpCountingProjector>();
+            Assert.True(statusResult.IsSuccess, statusResult.IsSuccess ? string.Empty : statusResult.GetException().ToString());
+            var status = statusResult.GetValue();
+            lastObservedStatus = status;
+            if (string.Equals(status.Current.LastSortableUniqueId, latestSortableUniqueId, StringComparison.Ordinal))
+            {
+                finalStatus = status;
+                break;
+            }
+
+            await Task.Delay(200);
+        }
+
+        Assert.True(
+            finalStatus is not null,
+            $"Last observed: current={lastObservedStatus?.Current.EventVersion}:{lastObservedStatus?.Current.LastSortableUniqueId}, consistent={lastObservedStatus?.Consistent.EventVersion}:{lastObservedStatus?.Consistent.LastSortableUniqueId}, catchup={lastObservedStatus?.CatchUp.IsInProgress}:{lastObservedStatus?.CatchUp.CurrentSortableUniqueId}->{lastObservedStatus?.CatchUp.TargetSortableUniqueId}");
+        Assert.Equal(eventCount, finalStatus!.Current.EventVersion);
+        Assert.Equal(latestSortableUniqueId, finalStatus!.Current.LastSortableUniqueId);
+    }
+
     // --- Test domain types ---
 
     private static List<Event> CreateTestEvents(int count)

--- a/dcb/tests/Sekiban.Dcb.Orleans.Tests/CatchUpQueryAwarenessTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Orleans.Tests/CatchUpQueryAwarenessTests.cs
@@ -172,7 +172,7 @@ public class CatchUpQueryAwarenessTests : IAsyncLifetime
         var initialStatus = initialStatusResult.GetValue();
         Assert.True(initialStatus.Current.EventVersion >= initialStatus.Consistent.EventVersion);
 
-        var refreshTask = Task.Run(async () => await grain.RefreshAsync());
+        var refreshTask = grain.RefreshAsync();
 
         ProjectionHeadStatus? finalStatus = null;
         ProjectionHeadStatus? lastObservedStatus = null;

--- a/dcb/tests/Sekiban.Dcb.Orleans.Tests/MultiProjectionGrainPersistPolicyTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Orleans.Tests/MultiProjectionGrainPersistPolicyTests.cs
@@ -238,6 +238,9 @@ public class MultiProjectionGrainPersistPolicyTests
         public Task<ResultBox<ProjectionStateMetadata>> GetStateMetadataAsync(bool includeUnsafe = true) =>
             throw new NotSupportedException();
 
+        public Task<ProjectionHeadStatus> GetProjectionHeadStatusAsync() =>
+            throw new NotSupportedException();
+
         public Task<ResultBox<MultiProjectionState>> GetStateAsync(bool canGetUnsafeState = true) =>
             throw new NotSupportedException();
 

--- a/dcb/tests/Sekiban.Dcb.Orleans.Tests/MultiProjectionGrainRetentionCompactionTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Orleans.Tests/MultiProjectionGrainRetentionCompactionTests.cs
@@ -174,6 +174,9 @@ public class MultiProjectionGrainRetentionCompactionTests
         public Task<ResultBox<ProjectionStateMetadata>> GetStateMetadataAsync(bool includeUnsafe = true) =>
             throw new NotSupportedException();
 
+        public Task<ProjectionHeadStatus> GetProjectionHeadStatusAsync() =>
+            throw new NotSupportedException();
+
         public Task<ResultBox<MultiProjectionState>> GetStateAsync(bool canGetUnsafeState = true) =>
             throw new NotSupportedException();
 

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/ProjectionHeadStatusTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/ProjectionHeadStatusTests.cs
@@ -1,0 +1,64 @@
+using Dcb.Domain;
+using Dcb.Domain.Student;
+using ResultBoxes;
+using Sekiban.Dcb.InMemory;
+using Sekiban.Dcb.MultiProjections;
+
+namespace Sekiban.Dcb.Tests;
+
+public class ProjectionHeadStatusTests
+{
+    [Fact]
+    public async Task InMemoryExecutor_ShouldReturnProjectionHeadStatus_ForRegisteredProjector()
+    {
+        var domain = DomainType.GetDomainTypes();
+        ISekibanExecutor executor = new InMemoryDcbExecutor(domain);
+        var studentId = Guid.NewGuid();
+
+        var executionResult = await executor.ExecuteAsync(new CreateStudent(studentId, "Projection Status", 4));
+        Assert.True(executionResult.IsSuccess);
+        var latestCommandSortableUniqueId = executionResult.GetValue().SortableUniqueId;
+
+        var projectionStatusResult =
+            await executor.GetProjectionHeadStatusAsync<GenericTagMultiProjector<StudentProjector, StudentTag>>();
+
+        Assert.True(projectionStatusResult.IsSuccess);
+        var projectionStatus = projectionStatusResult.GetValue();
+        Assert.Equal(
+            GenericTagMultiProjector<StudentProjector, StudentTag>.MultiProjectorName,
+            projectionStatus.ProjectorName);
+        Assert.Equal(
+            GenericTagMultiProjector<StudentProjector, StudentTag>.MultiProjectorVersion,
+            projectionStatus.ProjectorVersion);
+        Assert.True(projectionStatus.Current.EventVersion >= 1);
+        Assert.NotNull(projectionStatus.Current.LastSortableUniqueId);
+        Assert.True(
+            string.Compare(
+                projectionStatus.Current.LastSortableUniqueId,
+                latestCommandSortableUniqueId,
+                StringComparison.Ordinal) >= 0);
+        Assert.True(projectionStatus.Consistent.EventVersion <= projectionStatus.Current.EventVersion);
+        Assert.False(projectionStatus.CatchUp.IsInProgress);
+        Assert.Equal(0, projectionStatus.CatchUp.PendingStreamEventCount);
+    }
+
+    [Fact]
+    public async Task InMemoryExecutor_ShouldReturnEventStoreHeadStatus_WithOptInCount()
+    {
+        var domain = DomainType.GetDomainTypes();
+        ISekibanExecutor executor = new InMemoryDcbExecutor(domain);
+
+        await executor.ExecuteAsync(new CreateStudent(Guid.NewGuid(), "One", 3));
+        await executor.ExecuteAsync(new CreateStudent(Guid.NewGuid(), "Two", 5));
+
+        var withoutCountResult = await executor.GetEventStoreHeadStatusAsync();
+        Assert.True(withoutCountResult.IsSuccess);
+        Assert.Null(withoutCountResult.GetValue().TotalEventCount);
+        Assert.NotNull(withoutCountResult.GetValue().LatestSortableUniqueId);
+
+        var withCountResult = await executor.GetEventStoreHeadStatusAsync(includeTotalEventCount: true);
+        Assert.True(withCountResult.IsSuccess);
+        Assert.Equal(2, withCountResult.GetValue().TotalEventCount);
+        Assert.NotNull(withCountResult.GetValue().LatestSortableUniqueId);
+    }
+}

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/ProjectionHeadStatusTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/ProjectionHeadStatusTests.cs
@@ -39,7 +39,9 @@ public class ProjectionHeadStatusTests
                 StringComparison.Ordinal) >= 0);
         Assert.True(projectionStatus.Consistent.EventVersion <= projectionStatus.Current.EventVersion);
         Assert.False(projectionStatus.CatchUp.IsInProgress);
-        Assert.Equal(0, projectionStatus.CatchUp.PendingStreamEventCount);
+        Assert.Equal(
+            projectionStatus.Current.EventVersion - projectionStatus.Consistent.EventVersion,
+            projectionStatus.CatchUp.PendingStreamEventCount);
     }
 
     [Fact]

--- a/dcb/tests/Sekiban.Dcb.WithoutResult.Tests/ProjectionHeadStatusTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithoutResult.Tests/ProjectionHeadStatusTests.cs
@@ -1,0 +1,38 @@
+using Dcb.Domain.WithoutResult;
+using Dcb.Domain.WithoutResult.Student;
+using Sekiban.Dcb.InMemory;
+using Sekiban.Dcb.MultiProjections;
+
+namespace Sekiban.Dcb.WithoutResult.Tests;
+
+public class ProjectionHeadStatusTests
+{
+    [Fact]
+    public async Task InMemoryExecutor_ShouldReturnProjectionAndEventStoreHeadStatus()
+    {
+        var executor = (ISekibanExecutor)new InMemoryDcbExecutor(DomainType.GetDomainTypes());
+        var executionResult = await executor.ExecuteAsync(new CreateStudent(Guid.NewGuid(), "WithoutResult", 2));
+
+        var projectionStatus =
+            await executor.GetProjectionHeadStatusAsync<GenericTagMultiProjector<StudentProjector, StudentTag>>();
+
+        Assert.Equal(
+            GenericTagMultiProjector<StudentProjector, StudentTag>.MultiProjectorName,
+            projectionStatus.ProjectorName);
+        Assert.Equal(
+            GenericTagMultiProjector<StudentProjector, StudentTag>.MultiProjectorVersion,
+            projectionStatus.ProjectorVersion);
+        Assert.True(projectionStatus.Current.EventVersion >= 1);
+        Assert.NotNull(projectionStatus.Current.LastSortableUniqueId);
+        Assert.True(
+            string.Compare(
+                projectionStatus.Current.LastSortableUniqueId,
+                executionResult.SortableUniqueId,
+                StringComparison.Ordinal) >= 0);
+        Assert.False(projectionStatus.CatchUp.IsInProgress);
+
+        var eventStoreHead = await executor.GetEventStoreHeadStatusAsync(includeTotalEventCount: true);
+        Assert.Equal(1, eventStoreHead.TotalEventCount);
+        Assert.NotNull(eventStoreHead.LatestSortableUniqueId);
+    }
+}


### PR DESCRIPTION
## Summary
- add public projection head / event store head DTOs and executor APIs for WithResult / WithoutResult
- expose payload-free projection head status from Orleans grains so clients can inspect progress without serializing projector payloads
- add targeted tests for in-memory executors and Orleans head-status observation

## Validation
- dotnet test dcb/tests/Sekiban.Dcb.WithResult.Tests/Sekiban.Dcb.WithResult.Tests.csproj -c Release --filter ProjectionHeadStatusTests
- dotnet test dcb/tests/Sekiban.Dcb.WithoutResult.Tests/Sekiban.Dcb.WithoutResult.Tests.csproj -c Release --filter ProjectionHeadStatusTests
- dotnet test dcb/tests/Sekiban.Dcb.Orleans.Tests/Sekiban.Dcb.Orleans.Tests.csproj -c Release --filter "CatchUpQueryAwarenessTests.ExecutorProjectionHeadStatus_ShouldExposeCatchUpAndStoreHead"

Closes #1016