### PR TITLE
Add classroom/student materialized view to Decider template

### DIFF
--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.ApiService/Endpoints/MaterializedViewEndpoints.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.ApiService/Endpoints/MaterializedViewEndpoints.cs
@@ -1,0 +1,216 @@
+using Dapper;
+using Dcb.EventSource.ClassRoom;
+using Dcb.EventSource.MaterializedViews;
+using Dcb.ImmutableModels.States.Student;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Npgsql;
+using Sekiban.Dcb.MaterializedView.Orleans;
+
+namespace SekibanDcbDecider.ApiService.Endpoints;
+
+/// <summary>
+///     Read-side endpoints backed by the PostgreSQL materialized view.
+///     They mirror the in-memory projection endpoints in
+///     <see cref="StudentEndpoints" /> and <see cref="ClassRoomEndpoints" />,
+///     so the UI can switch between query modes without changing the rest of the request shape.
+/// </summary>
+public static class MaterializedViewEndpoints
+{
+    public static void MapMaterializedViewEndpoints(this IEndpointRouteBuilder endpoints)
+    {
+        var students = endpoints.MapGroup("/mv/students").WithTags("Materialized View");
+        students.MapGet("/", GetStudentListAsync).WithName("GetStudentListMv");
+
+        var classrooms = endpoints.MapGroup("/mv/classrooms").WithTags("Materialized View");
+        classrooms.MapGet("/", GetClassRoomListAsync).WithName("GetClassRoomListMv");
+
+        var enrollments = endpoints.MapGroup("/mv/enrollments").WithTags("Materialized View");
+        enrollments.MapGet("/", GetEnrollmentListAsync).WithName("GetEnrollmentListMv");
+
+        var status = endpoints.MapGroup("/mv").WithTags("Materialized View");
+        status.MapGet("/status", GetStatusAsync).WithName("GetMaterializedViewStatus");
+    }
+
+    private static async Task<IResult> GetStudentListAsync(
+        [FromQuery] string? waitForSortableUniqueId,
+        [FromQuery] int? pageNumber,
+        [FromQuery] int? pageSize,
+        [FromServices] IMvOrleansQueryAccessor mvQueryAccessor,
+        [FromServices] ClassRoomEnrollmentMvV1 projector)
+    {
+        var context = await mvQueryAccessor.GetAsync(projector);
+        if (!await TryWaitForReceivedAsync(context, waitForSortableUniqueId))
+        {
+            return Results.StatusCode(StatusCodes.Status504GatewayTimeout);
+        }
+
+        var studentsTable = context.GetRequiredTable(ClassRoomEnrollmentMvV1.StudentsLogicalTable);
+        var enrollmentsTable = context.GetRequiredTable(ClassRoomEnrollmentMvV1.EnrollmentsLogicalTable);
+
+        await using var connection = new NpgsqlConnection(context.ConnectionString);
+        await connection.OpenAsync();
+
+        var (limit, offset) = ResolvePaging(pageNumber, pageSize);
+        var students = (await connection.QueryAsync<StudentMvRow>(
+            $"""
+             SELECT student_id, name, max_class_count, enrolled_count,
+                    _last_sortable_unique_id, _last_applied_at
+             FROM {studentsTable.PhysicalTable}
+             ORDER BY name
+             LIMIT @Limit OFFSET @Offset;
+             """,
+            new { Limit = limit, Offset = offset })).ToList();
+
+        var ids = students.Select(s => s.StudentId).ToArray();
+        var enrollmentMap = ids.Length == 0
+            ? new Dictionary<Guid, List<Guid>>()
+            : (await connection.QueryAsync<(Guid student_id, Guid class_room_id)>(
+                    $"""
+                     SELECT student_id, class_room_id
+                     FROM {enrollmentsTable.PhysicalTable}
+                     WHERE student_id = ANY(@Ids);
+                     """,
+                    new { Ids = ids }))
+                .GroupBy(row => row.student_id)
+                .ToDictionary(g => g.Key, g => g.Select(r => r.class_room_id).ToList());
+
+        var items = students
+            .Select(s => new StudentState(
+                s.StudentId,
+                s.Name,
+                s.MaxClassCount,
+                enrollmentMap.TryGetValue(s.StudentId, out var ec) ? ec : []))
+            .ToList();
+
+        return Results.Ok(items);
+    }
+
+    private static async Task<IResult> GetClassRoomListAsync(
+        [FromQuery] string? waitForSortableUniqueId,
+        [FromQuery] int? pageNumber,
+        [FromQuery] int? pageSize,
+        [FromServices] IMvOrleansQueryAccessor mvQueryAccessor,
+        [FromServices] ClassRoomEnrollmentMvV1 projector)
+    {
+        var context = await mvQueryAccessor.GetAsync(projector);
+        if (!await TryWaitForReceivedAsync(context, waitForSortableUniqueId))
+        {
+            return Results.StatusCode(StatusCodes.Status504GatewayTimeout);
+        }
+
+        var classRoomsTable = context.GetRequiredTable(ClassRoomEnrollmentMvV1.ClassRoomsLogicalTable);
+
+        await using var connection = new NpgsqlConnection(context.ConnectionString);
+        await connection.OpenAsync();
+
+        var (limit, offset) = ResolvePaging(pageNumber, pageSize);
+        var rows = (await connection.QueryAsync<ClassRoomMvRow>(
+            $"""
+             SELECT class_room_id, name, max_students, enrolled_count,
+                    _last_sortable_unique_id, _last_applied_at
+             FROM {classRoomsTable.PhysicalTable}
+             ORDER BY name
+             LIMIT @Limit OFFSET @Offset;
+             """,
+            new { Limit = limit, Offset = offset })).ToList();
+
+        var items = rows
+            .Select(r => new ClassRoomItem
+            {
+                ClassRoomId = r.ClassRoomId,
+                Name = r.Name,
+                MaxStudents = r.MaxStudents,
+                EnrolledCount = r.EnrolledCount,
+                IsFull = r.EnrolledCount >= r.MaxStudents,
+                RemainingCapacity = Math.Max(0, r.MaxStudents - r.EnrolledCount)
+            })
+            .ToList();
+
+        return Results.Ok(items);
+    }
+
+    private static async Task<IResult> GetEnrollmentListAsync(
+        [FromQuery] Guid? classRoomId,
+        [FromQuery] Guid? studentId,
+        [FromQuery] string? waitForSortableUniqueId,
+        [FromServices] IMvOrleansQueryAccessor mvQueryAccessor,
+        [FromServices] ClassRoomEnrollmentMvV1 projector)
+    {
+        var context = await mvQueryAccessor.GetAsync(projector);
+        if (!await TryWaitForReceivedAsync(context, waitForSortableUniqueId))
+        {
+            return Results.StatusCode(StatusCodes.Status504GatewayTimeout);
+        }
+
+        var enrollmentsTable = context.GetRequiredTable(ClassRoomEnrollmentMvV1.EnrollmentsLogicalTable);
+
+        await using var connection = new NpgsqlConnection(context.ConnectionString);
+        await connection.OpenAsync();
+
+        var sql = $"SELECT student_id, class_room_id, enrolled_at, _last_sortable_unique_id FROM {enrollmentsTable.PhysicalTable}";
+        var filters = new List<string>();
+        var parameters = new DynamicParameters();
+        if (classRoomId is { } cid)
+        {
+            filters.Add("class_room_id = @ClassRoomId");
+            parameters.Add("ClassRoomId", cid);
+        }
+        if (studentId is { } sid)
+        {
+            filters.Add("student_id = @StudentId");
+            parameters.Add("StudentId", sid);
+        }
+        if (filters.Count > 0)
+        {
+            sql += " WHERE " + string.Join(" AND ", filters);
+        }
+        sql += " ORDER BY enrolled_at DESC;";
+
+        var rows = (await connection.QueryAsync<EnrollmentMvRow>(sql, parameters)).ToList();
+        return Results.Ok(rows);
+    }
+
+    private static async Task<IResult> GetStatusAsync(
+        [FromServices] IMvOrleansQueryAccessor mvQueryAccessor,
+        [FromServices] ClassRoomEnrollmentMvV1 projector)
+    {
+        var context = await mvQueryAccessor.GetAsync(projector);
+        var status = await context.Grain.GetStatusAsync();
+        return Results.Ok(new
+        {
+            databaseType = context.DatabaseType,
+            entries = context.Entries,
+            status
+        });
+    }
+
+    private static async Task<bool> TryWaitForReceivedAsync(
+        MvOrleansQueryContext context,
+        string? sortableUniqueId,
+        int timeoutMs = 10_000)
+    {
+        if (string.IsNullOrWhiteSpace(sortableUniqueId))
+        {
+            return true;
+        }
+
+        var until = DateTime.UtcNow.AddMilliseconds(timeoutMs);
+        while (DateTime.UtcNow < until)
+        {
+            if (await context.Grain.IsSortableUniqueIdReceived(sortableUniqueId))
+            {
+                return true;
+            }
+            await Task.Delay(100);
+        }
+        return false;
+    }
+
+    private static (int Limit, int Offset) ResolvePaging(int? pageNumber, int? pageSize)
+    {
+        var size = pageSize is > 0 ? pageSize.Value : 20;
+        var page = pageNumber is > 0 ? pageNumber.Value : 1;
+        return (size, (page - 1) * size);
+    }
+}

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.ApiService/Endpoints/MaterializedViewEndpoints.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.ApiService/Endpoints/MaterializedViewEndpoints.cs
@@ -17,18 +17,20 @@ namespace SekibanDcbDecider.ApiService.Endpoints;
 /// </summary>
 public static class MaterializedViewEndpoints
 {
+    private const string OpenApiTag = "Materialized View";
+
     public static void MapMaterializedViewEndpoints(this IEndpointRouteBuilder endpoints)
     {
-        var students = endpoints.MapGroup("/mv/students").WithTags("Materialized View");
+        var students = endpoints.MapGroup("/mv/students").WithTags(OpenApiTag);
         students.MapGet("/", GetStudentListAsync).WithName("GetStudentListMv");
 
-        var classrooms = endpoints.MapGroup("/mv/classrooms").WithTags("Materialized View");
+        var classrooms = endpoints.MapGroup("/mv/classrooms").WithTags(OpenApiTag);
         classrooms.MapGet("/", GetClassRoomListAsync).WithName("GetClassRoomListMv");
 
-        var enrollments = endpoints.MapGroup("/mv/enrollments").WithTags("Materialized View");
+        var enrollments = endpoints.MapGroup("/mv/enrollments").WithTags(OpenApiTag);
         enrollments.MapGet("/", GetEnrollmentListAsync).WithName("GetEnrollmentListMv");
 
-        var status = endpoints.MapGroup("/mv").WithTags("Materialized View");
+        var status = endpoints.MapGroup("/mv").WithTags(OpenApiTag);
         status.MapGet("/status", GetStatusAsync).WithName("GetMaterializedViewStatus");
     }
 

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.ApiService/Program.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.ApiService/Program.cs
@@ -262,7 +262,14 @@ apiRoute.MapApprovalEndpoints();
 apiRoute.MapUserDirectoryEndpoints();
 apiRoute.MapStreamEndpoints();
 apiRoute.MapTestDataEndpoints();
-apiRoute.MapMaterializedViewEndpoints();
+
+// Materialized view endpoints depend on the Orleans MV runtime, which is only registered when a
+// `DcbMaterializedViewPostgres` connection string is provided. When MV is not configured, skip the
+// route registration so requests get a clean 404 instead of a DI resolution failure at request time.
+if (app.Services.GetService<IMvOrleansQueryAccessor>() is not null)
+{
+    apiRoute.MapMaterializedViewEndpoints();
+}
 
 app.MapDefaultEndpoints();
 

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.ApiService/Program.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.ApiService/Program.cs
@@ -22,13 +22,22 @@ using Sekiban.Dcb.Storage;
 using Sekiban.Dcb.Snapshots;
 using Sekiban.Dcb.BlobStorage.AzureStorage;
 using Sekiban.Dcb.ColdEvents;
+using Sekiban.Dcb.MaterializedView;
+using Sekiban.Dcb.MaterializedView.Orleans;
+using Sekiban.Dcb.MaterializedView.Postgres;
 using Sekiban.Dcb.ServiceId;
+using Dcb.EventSource.MaterializedViews;
+using Dapper;
 using SekibanDcbDecider.ApiService.Endpoints;
 using SekibanDcbDecider.ApiService.Auth;
 using SekibanDcbDecider.ApiService;
 using SekibanDcbDecider.ApiService.Exceptions;
 using SekibanDcbDecider.ApiService.Health;
 using SekibanDcbDecider.ApiService.Realtime;
+
+// Map snake_case Postgres columns onto PascalCase row properties when Dapper hydrates rows
+// returned from the materialized view tables.
+DefaultTypeMap.MatchNamesWithUnderscores = true;
 
 const string InMemoryStreamsConfigKey = "Orleans:UseInMemoryStreams";
 const string InMemoryGrainStorageConfigKey = "Orleans:UseInMemoryGrainStorage";
@@ -79,15 +88,18 @@ var orleansQueueType = builder.Configuration["ORLEANS_QUEUE_TYPE"]?.ToLower() ??
 var useInMemoryStreams = builder.Configuration.GetValue<bool>(InMemoryStreamsConfigKey);
 var useInMemoryGrainStorage = builder.Configuration.GetValue<bool>(InMemoryGrainStorageConfigKey);
 
-// Add Azure Storage clients for Orleans only when NOT using Cosmos for clustering
-// (Aspire clients add health checks that require connection strings)
-if (!builder.Environment.IsDevelopment() && orleansClusterType != "cosmos")
+// Add Azure Storage clients for Orleans (Aspire's WithReference(orleans).WithClustering(...)
+// injects connection strings and expects a keyed TableServiceClient — even in development —
+// so always register unless we are clustering through Cosmos DB).
+if (orleansClusterType != "cosmos")
 {
     builder.AddKeyedAzureTableServiceClient("DcbOrleansClusteringTable");
 }
 
-// Table client for grain storage (used for checkpointer, PubSub, etc.)
-if (!useInMemoryGrainStorage && orleansGrainType != "cosmos")
+// Table/blob clients for grain storage (used for checkpointer, PubSub, etc.).
+// These keyed clients must be registered whenever the AppHost wires the matching Aspire resources,
+// even when development overrides switch the silo to in-memory storage.
+if (orleansGrainType != "cosmos")
 {
     builder.AddKeyedAzureTableServiceClient("DcbOrleansGrainTable");
     builder.AddKeyedAzureBlobServiceClient("DcbOrleansGrainState");
@@ -96,8 +108,9 @@ if (!useInMemoryGrainStorage && orleansGrainType != "cosmos")
 // Blob storage for projection offload (always needed)
 builder.AddKeyedAzureBlobServiceClient("MultiProjectionOffload");
 
-// Queue client only when using Azure Storage queues
-if (!useInMemoryStreams && orleansQueueType != "eventhub")
+// Queue client only when using Azure Storage queues. Required even with in-memory streams,
+// because Aspire's WithStreaming(queue) still injects the queue connection string.
+if (orleansQueueType != "eventhub")
 {
     builder.AddKeyedAzureQueueServiceClient("DcbOrleansQueue");
 }
@@ -148,6 +161,14 @@ builder.Services.AddSingleton(domainTypes);
 builder.Services.AddSekibanDcbNativeRuntime();
 builder.Services.AddSekibanDcbColdEventDefaults();
 
+// Register materialized view runtime (only effective when Postgres is the storage backend)
+builder.Services.AddSekibanDcbMaterializedView(options =>
+{
+    options.BatchSize = 100;
+    options.PollInterval = TimeSpan.FromSeconds(1);
+});
+builder.Services.AddMaterializedView<ClassRoomEnrollmentMvV1>();
+
 builder.Services.AddSingleton<SseTopicHub>();
 builder.Services.AddHostedService<OrleansStreamEventRouter>();
 
@@ -168,6 +189,17 @@ else
     builder.Services.AddSingleton<IEventStore, PostgresEventStore>();
     builder.Services.AddSekibanDcbPostgresWithAspire();
     builder.Services.AddSingleton<IMultiProjectionStateStore, Sekiban.Dcb.Postgres.PostgresMultiProjectionStateStore>();
+
+    // Wire materialized views to the dedicated Postgres database. This is only attempted when a
+    // connection string named "DcbMaterializedViewPostgres" is provided by the host.
+    if (!string.IsNullOrWhiteSpace(builder.Configuration.GetConnectionString("DcbMaterializedViewPostgres")))
+    {
+        builder.Services.AddSekibanDcbMaterializedViewPostgres(
+            builder.Configuration,
+            connectionStringName: "DcbMaterializedViewPostgres",
+            registerHostedWorker: false);
+        builder.Services.AddSekibanDcbMaterializedViewOrleans();
+    }
 }
 
 builder.Services.AddTransient<IGrainStorageSerializer, NewtonsoftJsonDcbOrleansSerializer>();
@@ -230,6 +262,7 @@ apiRoute.MapApprovalEndpoints();
 apiRoute.MapUserDirectoryEndpoints();
 apiRoute.MapStreamEndpoints();
 apiRoute.MapTestDataEndpoints();
+apiRoute.MapMaterializedViewEndpoints();
 
 app.MapDefaultEndpoints();
 

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.ApiService/SekibanDcbDecider.ApiService.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.ApiService/SekibanDcbDecider.ApiService.csproj
@@ -44,10 +44,14 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Sekiban.Dcb.BlobStorage.AzureStorage" Version="10.1.12" />
-        <PackageReference Include="Sekiban.Dcb.Orleans.WithoutResult" Version="10.1.12" />
-        <PackageReference Include="Sekiban.Dcb.Postgres" Version="10.1.12" />
-        <PackageReference Include="Sekiban.Dcb.CosmosDb" Version="10.1.12" />
-        <PackageReference Include="Sekiban.Dcb.Sqlite" Version="10.1.12" />
+        <PackageReference Include="Sekiban.Dcb.BlobStorage.AzureStorage" Version="10.1.17" />
+        <PackageReference Include="Sekiban.Dcb.Orleans.WithoutResult" Version="10.1.17" />
+        <PackageReference Include="Sekiban.Dcb.Postgres" Version="10.1.17" />
+        <PackageReference Include="Sekiban.Dcb.CosmosDb" Version="10.1.17" />
+        <PackageReference Include="Sekiban.Dcb.Sqlite" Version="10.1.17" />
+        <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.1.17" />
+        <PackageReference Include="Sekiban.Dcb.MaterializedView.Postgres" Version="10.1.17" />
+        <PackageReference Include="Sekiban.Dcb.MaterializedView.Orleans" Version="10.1.17" />
+        <PackageReference Include="Dapper" Version="2.1.66" />
     </ItemGroup>
 </Project>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.AppHost/Program.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.AppHost/Program.cs
@@ -38,6 +38,10 @@ var postgres = postgresServer.AddDatabase("DcbPostgres");
 // Identity database (separate from Sekiban to avoid EnsureCreated conflicts)
 var identityPostgres = postgresServer.AddDatabase("IdentityPostgres");
 
+// Materialized view database (kept separate from the event store so that the
+// read-side schema can evolve without touching the source-of-truth event log).
+var materializedViewPostgres = postgresServer.AddDatabase("DcbMaterializedViewPostgres");
+
 // Configure Orleans
 var orleans = builder
     .AddOrleans("default")
@@ -53,9 +57,11 @@ var apiService = builder
     .AddProject<SekibanDcbDecider_ApiService>("apiservice")
     .WithReference(postgres)
     .WithReference(identityPostgres)
+    .WithReference(materializedViewPostgres)
     .WithReference(multiProjectionOffload)
     .WaitFor(postgres)
     .WaitFor(identityPostgres)
+    .WaitFor(materializedViewPostgres)
     .WithEndpoint("http", endpoint =>
     {
         endpoint.Port = apiServicePort;

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.EventSource/MaterializedViews/ClassRoomEnrollmentMvV1.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.EventSource/MaterializedViews/ClassRoomEnrollmentMvV1.cs
@@ -71,10 +71,34 @@ public sealed class ClassRoomEnrollmentMvV1 : IMaterializedViewProjector
 
         await ctx.ExecuteAsync(
             $"""
-             CREATE INDEX IF NOT EXISTS idx_{Enrollments.PhysicalName}_class_room
+             CREATE INDEX IF NOT EXISTS {BuildIndexName(Enrollments.PhysicalName, "class_room")}
              ON {Enrollments.PhysicalName} (class_room_id);
              """,
             cancellationToken: cancellationToken).ConfigureAwait(false);
+    }
+
+    // PostgreSQL identifier length limit is 63 bytes. The materialized view runtime already
+    // truncates physical table names to fit, but a naive `idx_{table}_{col}` template can still
+    // overflow once the prefix and suffix are added. Build a name that fits by shortening the
+    // table portion and appending a short stable hash so it stays unique.
+    private static string BuildIndexName(string physicalTable, string suffix)
+    {
+        const int maxLength = 63;
+        var prefix = "idx_";
+        var tail = "_" + suffix;
+        var available = maxLength - prefix.Length - tail.Length;
+
+        if (physicalTable.Length <= available)
+        {
+            return prefix + physicalTable + tail;
+        }
+
+        // Reserve 9 chars for "_" + 8-char hex hash so the truncated table name still has room.
+        var hash = Convert.ToHexString(System.Security.Cryptography.SHA1.HashData(System.Text.Encoding.UTF8.GetBytes(physicalTable))).Substring(0, 8).ToLowerInvariant();
+        var headroom = available - 9;
+        if (headroom < 1) headroom = 1;
+        var head = physicalTable.Substring(0, Math.Min(headroom, physicalTable.Length));
+        return prefix + head + "_" + hash + tail;
     }
 
     public Task<IReadOnlyList<MvSqlStatement>> ApplyToViewAsync(

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.EventSource/MaterializedViews/ClassRoomEnrollmentMvV1.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.EventSource/MaterializedViews/ClassRoomEnrollmentMvV1.cs
@@ -1,0 +1,277 @@
+using Dcb.ImmutableModels.Events.ClassRoom;
+using Dcb.ImmutableModels.Events.Enrollment;
+using Dcb.ImmutableModels.Events.Student;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.MaterializedView;
+
+namespace Dcb.EventSource.MaterializedViews;
+
+/// <summary>
+///     Materialized view for classrooms, students and enrollments.
+///     Mirrors what the in-memory <c>ClassRoomListProjection</c> and
+///     <c>StudentListProjection</c> expose, but persisted into PostgreSQL tables
+///     so that they can be queried as a SQL read model.
+/// </summary>
+public sealed class ClassRoomEnrollmentMvV1 : IMaterializedViewProjector
+{
+    public const string ClassRoomsLogicalTable = "classrooms";
+    public const string StudentsLogicalTable = "students";
+    public const string EnrollmentsLogicalTable = "enrollments";
+
+    public string ViewName => "ClassRoomEnrollment";
+    public int ViewVersion => 1;
+
+    public MvTable ClassRooms { get; private set; } = default!;
+    public MvTable Students { get; private set; } = default!;
+    public MvTable Enrollments { get; private set; } = default!;
+
+    public async Task InitializeAsync(IMvInitContext ctx, CancellationToken cancellationToken = default)
+    {
+        ClassRooms = ctx.RegisterTable(ClassRoomsLogicalTable);
+        Students = ctx.RegisterTable(StudentsLogicalTable);
+        Enrollments = ctx.RegisterTable(EnrollmentsLogicalTable);
+
+        await ctx.ExecuteAsync(
+            $"""
+             CREATE TABLE IF NOT EXISTS {ClassRooms.PhysicalName} (
+                 class_room_id UUID PRIMARY KEY,
+                 name TEXT NOT NULL,
+                 max_students INT NOT NULL,
+                 enrolled_count INT NOT NULL DEFAULT 0,
+                 _last_sortable_unique_id TEXT NOT NULL,
+                 _last_applied_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+             );
+             """,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        await ctx.ExecuteAsync(
+            $"""
+             CREATE TABLE IF NOT EXISTS {Students.PhysicalName} (
+                 student_id UUID PRIMARY KEY,
+                 name TEXT NOT NULL,
+                 max_class_count INT NOT NULL,
+                 enrolled_count INT NOT NULL DEFAULT 0,
+                 _last_sortable_unique_id TEXT NOT NULL,
+                 _last_applied_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+             );
+             """,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        await ctx.ExecuteAsync(
+            $"""
+             CREATE TABLE IF NOT EXISTS {Enrollments.PhysicalName} (
+                 student_id UUID NOT NULL,
+                 class_room_id UUID NOT NULL,
+                 enrolled_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                 _last_sortable_unique_id TEXT NOT NULL,
+                 PRIMARY KEY (student_id, class_room_id)
+             );
+             """,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        await ctx.ExecuteAsync(
+            $"""
+             CREATE INDEX IF NOT EXISTS idx_{Enrollments.PhysicalName}_class_room
+             ON {Enrollments.PhysicalName} (class_room_id);
+             """,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+    }
+
+    public Task<IReadOnlyList<MvSqlStatement>> ApplyToViewAsync(
+        Event ev,
+        IMvApplyContext ctx,
+        CancellationToken cancellationToken = default) =>
+        Task.FromResult<IReadOnlyList<MvSqlStatement>>(
+            ev.Payload switch
+            {
+                ClassRoomCreated created => [InsertClassRoom(created, ctx.CurrentSortableUniqueId)],
+                StudentCreated created => [InsertStudent(created, ctx.CurrentSortableUniqueId)],
+                StudentEnrolledInClassRoom enrolled => InsertEnrollment(enrolled, ctx.CurrentSortableUniqueId),
+                StudentDroppedFromClassRoom dropped => DeleteEnrollment(dropped, ctx.CurrentSortableUniqueId),
+                _ => []
+            });
+
+    private MvSqlStatement InsertClassRoom(ClassRoomCreated created, string sortableUniqueId) =>
+        new(
+            $"""
+             INSERT INTO {ClassRooms.PhysicalName}
+                 (class_room_id, name, max_students, enrolled_count, _last_sortable_unique_id, _last_applied_at)
+             VALUES
+                 (@ClassRoomId, @Name, @MaxStudents, 0, @SortableUniqueId, NOW())
+             ON CONFLICT (class_room_id) DO UPDATE SET
+                 name = EXCLUDED.name,
+                 max_students = EXCLUDED.max_students,
+                 _last_sortable_unique_id = EXCLUDED._last_sortable_unique_id,
+                 _last_applied_at = EXCLUDED._last_applied_at
+             WHERE {ClassRooms.PhysicalName}._last_sortable_unique_id < EXCLUDED._last_sortable_unique_id;
+             """,
+            new
+            {
+                created.ClassRoomId,
+                created.Name,
+                created.MaxStudents,
+                SortableUniqueId = sortableUniqueId
+            });
+
+    private MvSqlStatement InsertStudent(StudentCreated created, string sortableUniqueId) =>
+        new(
+            $"""
+             INSERT INTO {Students.PhysicalName}
+                 (student_id, name, max_class_count, enrolled_count, _last_sortable_unique_id, _last_applied_at)
+             VALUES
+                 (@StudentId, @Name, @MaxClassCount, 0, @SortableUniqueId, NOW())
+             ON CONFLICT (student_id) DO UPDATE SET
+                 name = EXCLUDED.name,
+                 max_class_count = EXCLUDED.max_class_count,
+                 _last_sortable_unique_id = EXCLUDED._last_sortable_unique_id,
+                 _last_applied_at = EXCLUDED._last_applied_at
+             WHERE {Students.PhysicalName}._last_sortable_unique_id < EXCLUDED._last_sortable_unique_id;
+             """,
+            new
+            {
+                created.StudentId,
+                created.Name,
+                created.MaxClassCount,
+                SortableUniqueId = sortableUniqueId
+            });
+
+    private IReadOnlyList<MvSqlStatement> InsertEnrollment(
+        StudentEnrolledInClassRoom enrolled,
+        string sortableUniqueId) =>
+    [
+        new(
+            $"""
+             INSERT INTO {Enrollments.PhysicalName}
+                 (student_id, class_room_id, enrolled_at, _last_sortable_unique_id)
+             VALUES
+                 (@StudentId, @ClassRoomId, NOW(), @SortableUniqueId)
+             ON CONFLICT (student_id, class_room_id) DO UPDATE SET
+                 _last_sortable_unique_id = EXCLUDED._last_sortable_unique_id
+             WHERE {Enrollments.PhysicalName}._last_sortable_unique_id < EXCLUDED._last_sortable_unique_id;
+             """,
+            new
+            {
+                enrolled.StudentId,
+                enrolled.ClassRoomId,
+                SortableUniqueId = sortableUniqueId
+            }),
+        RecountClassRoom(enrolled.ClassRoomId, sortableUniqueId),
+        RecountStudent(enrolled.StudentId, sortableUniqueId)
+    ];
+
+    private IReadOnlyList<MvSqlStatement> DeleteEnrollment(
+        StudentDroppedFromClassRoom dropped,
+        string sortableUniqueId) =>
+    [
+        new(
+            $"""
+             DELETE FROM {Enrollments.PhysicalName}
+             WHERE student_id = @StudentId
+               AND class_room_id = @ClassRoomId
+               AND _last_sortable_unique_id < @SortableUniqueId;
+             """,
+            new
+            {
+                dropped.StudentId,
+                dropped.ClassRoomId,
+                SortableUniqueId = sortableUniqueId
+            }),
+        RecountClassRoom(dropped.ClassRoomId, sortableUniqueId),
+        RecountStudent(dropped.StudentId, sortableUniqueId)
+    ];
+
+    private MvSqlStatement RecountClassRoom(Guid classRoomId, string sortableUniqueId) =>
+        new(
+            $"""
+             UPDATE {ClassRooms.PhysicalName}
+             SET enrolled_count = (
+                     SELECT COUNT(*) FROM {Enrollments.PhysicalName}
+                     WHERE class_room_id = @ClassRoomId
+                 ),
+                 _last_sortable_unique_id = @SortableUniqueId,
+                 _last_applied_at = NOW()
+             WHERE class_room_id = @ClassRoomId
+               AND _last_sortable_unique_id < @SortableUniqueId;
+             """,
+            new
+            {
+                ClassRoomId = classRoomId,
+                SortableUniqueId = sortableUniqueId
+            });
+
+    private MvSqlStatement RecountStudent(Guid studentId, string sortableUniqueId) =>
+        new(
+            $"""
+             UPDATE {Students.PhysicalName}
+             SET enrolled_count = (
+                     SELECT COUNT(*) FROM {Enrollments.PhysicalName}
+                     WHERE student_id = @StudentId
+                 ),
+                 _last_sortable_unique_id = @SortableUniqueId,
+                 _last_applied_at = NOW()
+             WHERE student_id = @StudentId
+               AND _last_sortable_unique_id < @SortableUniqueId;
+             """,
+            new
+            {
+                StudentId = studentId,
+                SortableUniqueId = sortableUniqueId
+            });
+}
+
+public sealed class ClassRoomMvRow
+{
+    [MvColumn("class_room_id")]
+    public Guid ClassRoomId { get; set; }
+
+    [MvColumn("name")]
+    public string Name { get; set; } = string.Empty;
+
+    [MvColumn("max_students")]
+    public int MaxStudents { get; set; }
+
+    [MvColumn("enrolled_count")]
+    public int EnrolledCount { get; set; }
+
+    [MvColumn("_last_sortable_unique_id")]
+    public string LastSortableUniqueId { get; set; } = string.Empty;
+
+    [MvColumn("_last_applied_at")]
+    public DateTimeOffset LastAppliedAt { get; set; }
+}
+
+public sealed class StudentMvRow
+{
+    [MvColumn("student_id")]
+    public Guid StudentId { get; set; }
+
+    [MvColumn("name")]
+    public string Name { get; set; } = string.Empty;
+
+    [MvColumn("max_class_count")]
+    public int MaxClassCount { get; set; }
+
+    [MvColumn("enrolled_count")]
+    public int EnrolledCount { get; set; }
+
+    [MvColumn("_last_sortable_unique_id")]
+    public string LastSortableUniqueId { get; set; } = string.Empty;
+
+    [MvColumn("_last_applied_at")]
+    public DateTimeOffset LastAppliedAt { get; set; }
+}
+
+public sealed class EnrollmentMvRow
+{
+    [MvColumn("student_id")]
+    public Guid StudentId { get; set; }
+
+    [MvColumn("class_room_id")]
+    public Guid ClassRoomId { get; set; }
+
+    [MvColumn("enrolled_at")]
+    public DateTimeOffset EnrolledAt { get; set; }
+
+    [MvColumn("_last_sortable_unique_id")]
+    public string LastSortableUniqueId { get; set; } = string.Empty;
+}

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.EventSource/SekibanDcbDecider.EventSource.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.EventSource/SekibanDcbDecider.EventSource.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="ResultBoxes" Version="0.4.0" />
     <PackageReference Include="Microsoft.Orleans.Serialization" Version="10.0.1" />
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />
-    <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.1.12" />
+    <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.1.17" />
+    <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.1.17" />
   </ItemGroup>
 </Project>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.ImmutableModels/SekibanDcbDecider.ImmutableModels.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.ImmutableModels/SekibanDcbDecider.ImmutableModels.csproj
@@ -10,6 +10,6 @@
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Sekiban.Dcb.Core.Model" Version="10.1.12" />
+    <PackageReference Include="Sekiban.Dcb.Core.Model" Version="10.1.17" />
   </ItemGroup>
 </Project>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.Interactions/SekibanDcbDecider.Interactions.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.Interactions/SekibanDcbDecider.Interactions.csproj
@@ -11,6 +11,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />
-    <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.1.12" />
+    <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.1.17" />
   </ItemGroup>
 </Project>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.MeetingRoomModels/SekibanDcbDecider.MeetingRoomModels.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.MeetingRoomModels/SekibanDcbDecider.MeetingRoomModels.csproj
@@ -10,6 +10,6 @@
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Sekiban.Dcb.Core.Model" Version="10.1.12" />
+    <PackageReference Include="Sekiban.Dcb.Core.Model" Version="10.1.17" />
   </ItemGroup>
 </Project>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.WebNext/src/app/classrooms/page.tsx
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.WebNext/src/app/classrooms/page.tsx
@@ -22,6 +22,7 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
+import { QueryModeToggle, type QueryMode } from "@/components/query-mode-toggle";
 
 export default function ClassroomsPage() {
   const [pageSize, setPageSize] = useState(10);
@@ -31,11 +32,13 @@ export default function ClassroomsPage() {
   const [newClassName, setNewClassName] = useState("");
   const [newMaxCapacity, setNewMaxCapacity] = useState(20);
   const [formError, setFormError] = useState("");
+  const [queryMode, setQueryMode] = useState<QueryMode>("memory");
 
   const { data: classrooms, isLoading, refetch } = trpc.classrooms.list.useQuery({
     pageNumber: currentPage,
     pageSize,
     waitForSortableUniqueId: lastSortableUniqueId,
+    queryMode,
   });
 
   const createMutation = trpc.classrooms.create.useMutation({
@@ -96,12 +99,15 @@ export default function ClassroomsPage() {
             Manage classrooms and their capacity settings
           </p>
         </div>
-        <Button onClick={() => setIsAddModalOpen(true)} className="gap-2">
-          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
-          </svg>
-          Add Classroom
-        </Button>
+        <div className="flex items-center gap-3">
+          <QueryModeToggle value={queryMode} onChange={setQueryMode} />
+          <Button onClick={() => setIsAddModalOpen(true)} className="gap-2">
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+            </svg>
+            Add Classroom
+          </Button>
+        </div>
       </div>
 
       {/* Stats Cards */}

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.WebNext/src/app/enrollments/page.tsx
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.WebNext/src/app/enrollments/page.tsx
@@ -21,9 +21,11 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
+import { QueryModeToggle, type QueryMode } from "@/components/query-mode-toggle";
 
 export default function EnrollmentsPage() {
   const [lastSortableUniqueId, setLastSortableUniqueId] = useState<string | undefined>();
+  const [queryMode, setQueryMode] = useState<QueryMode>("memory");
 
   // Selection state
   const [selectedStudentId, setSelectedStudentId] = useState("");
@@ -40,16 +42,19 @@ export default function EnrollmentsPage() {
     pageNumber: 1,
     pageSize: 100,
     waitForSortableUniqueId: lastSortableUniqueId,
+    queryMode,
   });
 
   const { data: classrooms, refetch: refetchClassrooms } = trpc.classrooms.list.useQuery({
     pageNumber: 1,
     pageSize: 100,
     waitForSortableUniqueId: lastSortableUniqueId,
+    queryMode,
   });
 
   const { data: enrollments, isLoading, refetch: refetchEnrollments } = trpc.enrollments.list.useQuery({
     waitForSortableUniqueId: lastSortableUniqueId,
+    queryMode,
   });
 
   const enrollMutation = trpc.enrollments.enroll.useMutation({
@@ -117,11 +122,14 @@ export default function EnrollmentsPage() {
   return (
     <div className="space-y-6">
       {/* Page Header */}
-      <div>
-        <h1 className="text-2xl font-semibold text-foreground">Enrollment Management</h1>
-        <p className="text-sm text-muted-foreground mt-1">
-          Manage student enrollments in classrooms
-        </p>
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h1 className="text-2xl font-semibold text-foreground">Enrollment Management</h1>
+          <p className="text-sm text-muted-foreground mt-1">
+            Manage student enrollments in classrooms
+          </p>
+        </div>
+        <QueryModeToggle value={queryMode} onChange={setQueryMode} />
       </div>
 
       {/* Stats Cards */}

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.WebNext/src/app/students/page.tsx
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.WebNext/src/app/students/page.tsx
@@ -22,6 +22,7 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
+import { QueryModeToggle, type QueryMode } from "@/components/query-mode-toggle";
 
 export default function StudentsPage() {
   const [pageSize, setPageSize] = useState(10);
@@ -31,11 +32,13 @@ export default function StudentsPage() {
   const [newName, setNewName] = useState("");
   const [newMaxClassCount, setNewMaxClassCount] = useState(5);
   const [formError, setFormError] = useState("");
+  const [queryMode, setQueryMode] = useState<QueryMode>("memory");
 
   const { data: students, isLoading, refetch } = trpc.students.list.useQuery({
     pageNumber: currentPage,
     pageSize,
     waitForSortableUniqueId: lastSortableUniqueId,
+    queryMode,
   });
 
   const createMutation = trpc.students.create.useMutation({
@@ -94,12 +97,15 @@ export default function StudentsPage() {
             Register and manage student records
           </p>
         </div>
-        <Button onClick={() => setIsAddModalOpen(true)} className="gap-2">
-          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
-          </svg>
-          Add Student
-        </Button>
+        <div className="flex items-center gap-3">
+          <QueryModeToggle value={queryMode} onChange={setQueryMode} />
+          <Button onClick={() => setIsAddModalOpen(true)} className="gap-2">
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+            </svg>
+            Add Student
+          </Button>
+        </div>
       </div>
 
       {/* Stats Cards */}

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.WebNext/src/components/query-mode-toggle.tsx
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.WebNext/src/components/query-mode-toggle.tsx
@@ -5,9 +5,9 @@ import { Button } from "@/components/ui/button";
 export type QueryMode = "memory" | "materialized";
 
 interface QueryModeToggleProps {
-  value: QueryMode;
-  onChange: (mode: QueryMode) => void;
-  className?: string;
+  readonly value: QueryMode;
+  readonly onChange: (mode: QueryMode) => void;
+  readonly className?: string;
 }
 
 /**
@@ -18,7 +18,7 @@ interface QueryModeToggleProps {
  * freshness and query-shape characteristics, so making the selection visible
  * helps when comparing them side by side.
  */
-export function QueryModeToggle({ value, onChange, className }: QueryModeToggleProps) {
+export function QueryModeToggle({ value, onChange, className }: Readonly<QueryModeToggleProps>) {
   return (
     <div className={`inline-flex items-center gap-2 ${className ?? ""}`}>
       <span className="text-sm text-muted-foreground">Query source:</span>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.WebNext/src/components/query-mode-toggle.tsx
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.WebNext/src/components/query-mode-toggle.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+
+export type QueryMode = "memory" | "materialized";
+
+interface QueryModeToggleProps {
+  value: QueryMode;
+  onChange: (mode: QueryMode) => void;
+  className?: string;
+}
+
+/**
+ * Lets the user pick between the in-memory MultiProjection (Orleans grain state)
+ * and the SQL-backed materialized view as the source for list queries.
+ *
+ * The two views read the same event stream but expose different latency,
+ * freshness and query-shape characteristics, so making the selection visible
+ * helps when comparing them side by side.
+ */
+export function QueryModeToggle({ value, onChange, className }: QueryModeToggleProps) {
+  return (
+    <div className={`inline-flex items-center gap-2 ${className ?? ""}`}>
+      <span className="text-sm text-muted-foreground">Query source:</span>
+      <div className="inline-flex rounded-md border bg-background p-0.5">
+        <Button
+          type="button"
+          size="sm"
+          variant={value === "memory" ? "default" : "ghost"}
+          onClick={() => onChange("memory")}
+        >
+          Memory projection
+        </Button>
+        <Button
+          type="button"
+          size="sm"
+          variant={value === "materialized" ? "default" : "ghost"}
+          onClick={() => onChange("materialized")}
+        >
+          Materialized view
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.WebNext/src/server/routers/classrooms.ts
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.WebNext/src/server/routers/classrooms.ts
@@ -22,6 +22,7 @@ export const classroomsRouter = router({
         pageNumber: z.number().default(1),
         pageSize: z.number().default(10),
         waitForSortableUniqueId: z.string().optional(),
+        queryMode: z.enum(["memory", "materialized"]).default("memory"),
       })
     )
     .query(async ({ input }) => {
@@ -32,8 +33,9 @@ export const classroomsRouter = router({
         params.set("waitForSortableUniqueId", input.waitForSortableUniqueId);
       }
 
+      const path = input.queryMode === "materialized" ? "/api/mv/classrooms" : "/api/classrooms";
       const res = await fetch(
-        `${process.env.API_BASE_URL}/api/classrooms?${params.toString()}`
+        `${process.env.API_BASE_URL}${path}?${params.toString()}`
       );
       if (!res.ok) {
         throw new Error("Failed to fetch classrooms");

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.WebNext/src/server/routers/enrollments.ts
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.WebNext/src/server/routers/enrollments.ts
@@ -24,18 +24,23 @@ export const enrollmentsRouter = router({
     .input(
       z.object({
         waitForSortableUniqueId: z.string().optional(),
+        queryMode: z.enum(["memory", "materialized"]).default("memory"),
       })
     )
     .query(async ({ input }) => {
-      // Build enrollments from students and classrooms data
       const params = new URLSearchParams();
       if (input.waitForSortableUniqueId) {
         params.set("waitForSortableUniqueId", input.waitForSortableUniqueId);
       }
 
+      const studentsPath =
+        input.queryMode === "materialized" ? "/api/mv/students" : "/api/students";
+      const classroomsPath =
+        input.queryMode === "materialized" ? "/api/mv/classrooms" : "/api/classrooms";
+
       const [studentsRes, classroomsRes] = await Promise.all([
-        fetch(`${process.env.API_BASE_URL}/api/students?${params.toString()}`),
-        fetch(`${process.env.API_BASE_URL}/api/classrooms?${params.toString()}`),
+        fetch(`${process.env.API_BASE_URL}${studentsPath}?${params.toString()}`),
+        fetch(`${process.env.API_BASE_URL}${classroomsPath}?${params.toString()}`),
       ]);
 
       if (!studentsRes.ok || !classroomsRes.ok) {

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.WebNext/src/server/routers/students.ts
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.WebNext/src/server/routers/students.ts
@@ -20,6 +20,8 @@ export const studentsRouter = router({
         pageNumber: z.number().default(1),
         pageSize: z.number().default(10),
         waitForSortableUniqueId: z.string().optional(),
+        // "memory" → in-memory MultiProjection; "materialized" → SQL materialized view
+        queryMode: z.enum(["memory", "materialized"]).default("memory"),
       })
     )
     .query(async ({ input }) => {
@@ -30,8 +32,9 @@ export const studentsRouter = router({
         params.set("waitForSortableUniqueId", input.waitForSortableUniqueId);
       }
 
+      const path = input.queryMode === "materialized" ? "/api/mv/students" : "/api/students";
       const res = await fetch(
-        `${process.env.API_BASE_URL}/api/students?${params.toString()}`
+        `${process.env.API_BASE_URL}${path}?${params.toString()}`
       );
       if (!res.ok) {
         throw new Error("Failed to fetch students");


### PR DESCRIPTION
## Summary
- Adds a `ClassRoomEnrollmentMvV1` materialized view (PostgreSQL) covering classrooms, students and enrollments to the `Sekiban.Dcb.Orleans.Decider` template.
- Adds parallel `/api/mv/{students,classrooms,enrollments,status}` endpoints and a "Memory projection / Materialized view" toggle on the WebNext students/classrooms/enrollments pages.
- Wires the MV runtime in ApiService + a dedicated `DcbMaterializedViewPostgres` database in AppHost.

## Why
Issue requested a worked example of running the materialized view runtime side by side with the existing in-memory MultiProjection in the Decider template, so users can compare the two read paths from the UI.

## Notes for reviewers
A few non-obvious infrastructure fixes were needed to actually run the template against the new MV runtime:

- **Sekiban.Dcb.* package bump 10.1.12 → 10.1.17** across EventSource / Interactions / ImmutableModels / MeetingRoomModels / ApiService. Needed because `Sekiban.Dcb.MaterializedView` 10.1.17 calls `IEventStore.GetLatestSortableUniqueIdAsync`, which `Sekiban.Dcb.Postgres` 10.1.12 did not implement (silo crashed at startup with `TypeLoadException`).
- **Always register Aspire keyed Azure Storage clients** (drop the `IsDevelopment()` / `useInMemoryStreams` gating). Aspire's `WithReference(orleans).WithClustering(...)` and `WithStreaming(queue)` inject Azure clustering/queue stream providers even when the silo runs with localhost clustering and in-memory streams in development, so the keyed `TableServiceClient` / `QueueServiceClient` must always exist in DI when the matching AppHost resources are wired.
- **`Dapper.DefaultTypeMap.MatchNamesWithUnderscores = true`** in ApiService so snake_case Postgres columns (`class_room_id`, `enrolled_count`, …) hydrate onto the PascalCase Mv row classes — without it the API returned rows of `Guid.Empty` and `0`s.

The `Sekiban.Dcb.MaterializedView*` runtime is only attached when a `DcbMaterializedViewPostgres` connection string is present, so non-Postgres backends (Cosmos / SQLite / users who don't add the AppHost database) keep the existing behaviour.

## Test plan
- [x] `dotnet build` for ApiService / AppHost / Web (0 errors)
- [x] `dotnet run` template AppHost on alt ports → API reachable on :5241
- [x] Created classroom + student + enrollment via `/api/{classrooms,students,enrollments/add}`, confirmed `/api/classrooms`, `/api/students` and `/api/mv/classrooms`, `/api/mv/students` returned identical data; `/api/mv/enrollments` showed the student/classroom pair with timestamp.
- [x] Drove WebNext (Next.js, port 3100) with Playwright on `/students`, `/classrooms`, `/enrollments`; toggled "Materialized view"; confirmed UI re-renders identical data via the MV path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)