### PR TITLE
Bump Sekiban.Dcb.* to 10.1.18 and finish MV wiring for all DCB Orleans templates

### DIFF
--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.ApiService/Endpoints/MaterializedViewEndpoints.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.ApiService/Endpoints/MaterializedViewEndpoints.cs
@@ -1,0 +1,218 @@
+using Dapper;
+using Dcb.EventSource.ClassRoom;
+using Dcb.EventSource.MaterializedViews;
+using Dcb.ImmutableModels.States.Student;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Npgsql;
+using Sekiban.Dcb.MaterializedView.Orleans;
+
+namespace SekibanDcbDeciderAws.ApiService.Endpoints;
+
+/// <summary>
+///     Read-side endpoints backed by the PostgreSQL materialized view.
+///     They mirror the in-memory projection endpoints in
+///     <see cref="StudentEndpoints" /> and <see cref="ClassRoomEndpoints" />,
+///     so the UI can switch between query modes without changing the rest of the request shape.
+/// </summary>
+public static class MaterializedViewEndpoints
+{
+    private const string OpenApiTag = "Materialized View";
+
+    public static void MapMaterializedViewEndpoints(this IEndpointRouteBuilder endpoints)
+    {
+        var students = endpoints.MapGroup("/mv/students").WithTags(OpenApiTag);
+        students.MapGet("/", GetStudentListAsync).WithName("GetStudentListMv");
+
+        var classrooms = endpoints.MapGroup("/mv/classrooms").WithTags(OpenApiTag);
+        classrooms.MapGet("/", GetClassRoomListAsync).WithName("GetClassRoomListMv");
+
+        var enrollments = endpoints.MapGroup("/mv/enrollments").WithTags(OpenApiTag);
+        enrollments.MapGet("/", GetEnrollmentListAsync).WithName("GetEnrollmentListMv");
+
+        var status = endpoints.MapGroup("/mv").WithTags(OpenApiTag);
+        status.MapGet("/status", GetStatusAsync).WithName("GetMaterializedViewStatus");
+    }
+
+    private static async Task<IResult> GetStudentListAsync(
+        [FromQuery] string? waitForSortableUniqueId,
+        [FromQuery] int? pageNumber,
+        [FromQuery] int? pageSize,
+        [FromServices] IMvOrleansQueryAccessor mvQueryAccessor,
+        [FromServices] ClassRoomEnrollmentMvV1 projector)
+    {
+        var context = await mvQueryAccessor.GetAsync(projector);
+        if (!await TryWaitForReceivedAsync(context, waitForSortableUniqueId))
+        {
+            return Results.StatusCode(StatusCodes.Status504GatewayTimeout);
+        }
+
+        var studentsTable = context.GetRequiredTable(ClassRoomEnrollmentMvV1.StudentsLogicalTable);
+        var enrollmentsTable = context.GetRequiredTable(ClassRoomEnrollmentMvV1.EnrollmentsLogicalTable);
+
+        await using var connection = new NpgsqlConnection(context.ConnectionString);
+        await connection.OpenAsync();
+
+        var (limit, offset) = ResolvePaging(pageNumber, pageSize);
+        var students = (await connection.QueryAsync<StudentMvRow>(
+            $"""
+             SELECT student_id, name, max_class_count, enrolled_count,
+                    _last_sortable_unique_id, _last_applied_at
+             FROM {studentsTable.PhysicalTable}
+             ORDER BY name
+             LIMIT @Limit OFFSET @Offset;
+             """,
+            new { Limit = limit, Offset = offset })).ToList();
+
+        var ids = students.Select(s => s.StudentId).ToArray();
+        var enrollmentMap = ids.Length == 0
+            ? new Dictionary<Guid, List<Guid>>()
+            : (await connection.QueryAsync<(Guid student_id, Guid class_room_id)>(
+                    $"""
+                     SELECT student_id, class_room_id
+                     FROM {enrollmentsTable.PhysicalTable}
+                     WHERE student_id = ANY(@Ids);
+                     """,
+                    new { Ids = ids }))
+                .GroupBy(row => row.student_id)
+                .ToDictionary(g => g.Key, g => g.Select(r => r.class_room_id).ToList());
+
+        var items = students
+            .Select(s => new StudentState(
+                s.StudentId,
+                s.Name,
+                s.MaxClassCount,
+                enrollmentMap.TryGetValue(s.StudentId, out var ec) ? ec : []))
+            .ToList();
+
+        return Results.Ok(items);
+    }
+
+    private static async Task<IResult> GetClassRoomListAsync(
+        [FromQuery] string? waitForSortableUniqueId,
+        [FromQuery] int? pageNumber,
+        [FromQuery] int? pageSize,
+        [FromServices] IMvOrleansQueryAccessor mvQueryAccessor,
+        [FromServices] ClassRoomEnrollmentMvV1 projector)
+    {
+        var context = await mvQueryAccessor.GetAsync(projector);
+        if (!await TryWaitForReceivedAsync(context, waitForSortableUniqueId))
+        {
+            return Results.StatusCode(StatusCodes.Status504GatewayTimeout);
+        }
+
+        var classRoomsTable = context.GetRequiredTable(ClassRoomEnrollmentMvV1.ClassRoomsLogicalTable);
+
+        await using var connection = new NpgsqlConnection(context.ConnectionString);
+        await connection.OpenAsync();
+
+        var (limit, offset) = ResolvePaging(pageNumber, pageSize);
+        var rows = (await connection.QueryAsync<ClassRoomMvRow>(
+            $"""
+             SELECT class_room_id, name, max_students, enrolled_count,
+                    _last_sortable_unique_id, _last_applied_at
+             FROM {classRoomsTable.PhysicalTable}
+             ORDER BY name
+             LIMIT @Limit OFFSET @Offset;
+             """,
+            new { Limit = limit, Offset = offset })).ToList();
+
+        var items = rows
+            .Select(r => new ClassRoomItem
+            {
+                ClassRoomId = r.ClassRoomId,
+                Name = r.Name,
+                MaxStudents = r.MaxStudents,
+                EnrolledCount = r.EnrolledCount,
+                IsFull = r.EnrolledCount >= r.MaxStudents,
+                RemainingCapacity = Math.Max(0, r.MaxStudents - r.EnrolledCount)
+            })
+            .ToList();
+
+        return Results.Ok(items);
+    }
+
+    private static async Task<IResult> GetEnrollmentListAsync(
+        [FromQuery] Guid? classRoomId,
+        [FromQuery] Guid? studentId,
+        [FromQuery] string? waitForSortableUniqueId,
+        [FromServices] IMvOrleansQueryAccessor mvQueryAccessor,
+        [FromServices] ClassRoomEnrollmentMvV1 projector)
+    {
+        var context = await mvQueryAccessor.GetAsync(projector);
+        if (!await TryWaitForReceivedAsync(context, waitForSortableUniqueId))
+        {
+            return Results.StatusCode(StatusCodes.Status504GatewayTimeout);
+        }
+
+        var enrollmentsTable = context.GetRequiredTable(ClassRoomEnrollmentMvV1.EnrollmentsLogicalTable);
+
+        await using var connection = new NpgsqlConnection(context.ConnectionString);
+        await connection.OpenAsync();
+
+        var sql = $"SELECT student_id, class_room_id, enrolled_at, _last_sortable_unique_id FROM {enrollmentsTable.PhysicalTable}";
+        var filters = new List<string>();
+        var parameters = new DynamicParameters();
+        if (classRoomId is { } cid)
+        {
+            filters.Add("class_room_id = @ClassRoomId");
+            parameters.Add("ClassRoomId", cid);
+        }
+        if (studentId is { } sid)
+        {
+            filters.Add("student_id = @StudentId");
+            parameters.Add("StudentId", sid);
+        }
+        if (filters.Count > 0)
+        {
+            sql += " WHERE " + string.Join(" AND ", filters);
+        }
+        sql += " ORDER BY enrolled_at DESC;";
+
+        var rows = (await connection.QueryAsync<EnrollmentMvRow>(sql, parameters)).ToList();
+        return Results.Ok(rows);
+    }
+
+    private static async Task<IResult> GetStatusAsync(
+        [FromServices] IMvOrleansQueryAccessor mvQueryAccessor,
+        [FromServices] ClassRoomEnrollmentMvV1 projector)
+    {
+        var context = await mvQueryAccessor.GetAsync(projector);
+        var status = await context.Grain.GetStatusAsync();
+        return Results.Ok(new
+        {
+            databaseType = context.DatabaseType,
+            entries = context.Entries,
+            status
+        });
+    }
+
+    private static async Task<bool> TryWaitForReceivedAsync(
+        MvOrleansQueryContext context,
+        string? sortableUniqueId,
+        int timeoutMs = 10_000)
+    {
+        if (string.IsNullOrWhiteSpace(sortableUniqueId))
+        {
+            return true;
+        }
+
+        var until = DateTime.UtcNow.AddMilliseconds(timeoutMs);
+        while (DateTime.UtcNow < until)
+        {
+            if (await context.Grain.IsSortableUniqueIdReceived(sortableUniqueId))
+            {
+                return true;
+            }
+            await Task.Delay(100);
+        }
+        return false;
+    }
+
+    private static (int Limit, int Offset) ResolvePaging(int? pageNumber, int? pageSize)
+    {
+        var size = pageSize is > 0 ? pageSize.Value : 20;
+        var page = pageNumber is > 0 ? pageNumber.Value : 1;
+        return (size, (page - 1) * size);
+    }
+}

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.ApiService/Endpoints/MaterializedViewEndpoints.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.ApiService/Endpoints/MaterializedViewEndpoints.cs
@@ -11,9 +11,8 @@ namespace SekibanDcbDeciderAws.ApiService.Endpoints;
 
 /// <summary>
 ///     Read-side endpoints backed by the PostgreSQL materialized view.
-///     They mirror the in-memory projection endpoints in
-///     <see cref="StudentEndpoints" /> and <see cref="ClassRoomEndpoints" />,
-///     so the UI can switch between query modes without changing the rest of the request shape.
+///     Mirrors the in-memory MultiProjection endpoints so the UI can switch between
+///     query modes without changing the rest of the request shape.
 /// </summary>
 public static class MaterializedViewEndpoints
 {
@@ -39,10 +38,11 @@ public static class MaterializedViewEndpoints
         [FromQuery] int? pageNumber,
         [FromQuery] int? pageSize,
         [FromServices] IMvOrleansQueryAccessor mvQueryAccessor,
-        [FromServices] ClassRoomEnrollmentMvV1 projector)
+        [FromServices] ClassRoomEnrollmentMvV1 projector,
+        CancellationToken cancellationToken)
     {
-        var context = await mvQueryAccessor.GetAsync(projector);
-        if (!await TryWaitForReceivedAsync(context, waitForSortableUniqueId))
+        var context = await mvQueryAccessor.GetAsync(projector, cancellationToken: cancellationToken);
+        if (!await TryWaitForReceivedAsync(context, waitForSortableUniqueId, cancellationToken: cancellationToken))
         {
             return Results.StatusCode(StatusCodes.Status504GatewayTimeout);
         }
@@ -51,10 +51,10 @@ public static class MaterializedViewEndpoints
         var enrollmentsTable = context.GetRequiredTable(ClassRoomEnrollmentMvV1.EnrollmentsLogicalTable);
 
         await using var connection = new NpgsqlConnection(context.ConnectionString);
-        await connection.OpenAsync();
+        await connection.OpenAsync(cancellationToken);
 
         var (limit, offset) = ResolvePaging(pageNumber, pageSize);
-        var students = (await connection.QueryAsync<StudentMvRow>(
+        var students = (await connection.QueryAsync<StudentMvRow>(new CommandDefinition(
             $"""
              SELECT student_id, name, max_class_count, enrolled_count,
                     _last_sortable_unique_id, _last_applied_at
@@ -62,18 +62,20 @@ public static class MaterializedViewEndpoints
              ORDER BY name
              LIMIT @Limit OFFSET @Offset;
              """,
-            new { Limit = limit, Offset = offset })).ToList();
+            new { Limit = limit, Offset = offset },
+            cancellationToken: cancellationToken))).ToList();
 
         var ids = students.Select(s => s.StudentId).ToArray();
         var enrollmentMap = ids.Length == 0
             ? new Dictionary<Guid, List<Guid>>()
-            : (await connection.QueryAsync<(Guid student_id, Guid class_room_id)>(
+            : (await connection.QueryAsync<(Guid student_id, Guid class_room_id)>(new CommandDefinition(
                     $"""
                      SELECT student_id, class_room_id
                      FROM {enrollmentsTable.PhysicalTable}
                      WHERE student_id = ANY(@Ids);
                      """,
-                    new { Ids = ids }))
+                    new { Ids = ids },
+                    cancellationToken: cancellationToken)))
                 .GroupBy(row => row.student_id)
                 .ToDictionary(g => g.Key, g => g.Select(r => r.class_room_id).ToList());
 
@@ -93,10 +95,11 @@ public static class MaterializedViewEndpoints
         [FromQuery] int? pageNumber,
         [FromQuery] int? pageSize,
         [FromServices] IMvOrleansQueryAccessor mvQueryAccessor,
-        [FromServices] ClassRoomEnrollmentMvV1 projector)
+        [FromServices] ClassRoomEnrollmentMvV1 projector,
+        CancellationToken cancellationToken)
     {
-        var context = await mvQueryAccessor.GetAsync(projector);
-        if (!await TryWaitForReceivedAsync(context, waitForSortableUniqueId))
+        var context = await mvQueryAccessor.GetAsync(projector, cancellationToken: cancellationToken);
+        if (!await TryWaitForReceivedAsync(context, waitForSortableUniqueId, cancellationToken: cancellationToken))
         {
             return Results.StatusCode(StatusCodes.Status504GatewayTimeout);
         }
@@ -104,10 +107,10 @@ public static class MaterializedViewEndpoints
         var classRoomsTable = context.GetRequiredTable(ClassRoomEnrollmentMvV1.ClassRoomsLogicalTable);
 
         await using var connection = new NpgsqlConnection(context.ConnectionString);
-        await connection.OpenAsync();
+        await connection.OpenAsync(cancellationToken);
 
         var (limit, offset) = ResolvePaging(pageNumber, pageSize);
-        var rows = (await connection.QueryAsync<ClassRoomMvRow>(
+        var rows = (await connection.QueryAsync<ClassRoomMvRow>(new CommandDefinition(
             $"""
              SELECT class_room_id, name, max_students, enrolled_count,
                     _last_sortable_unique_id, _last_applied_at
@@ -115,7 +118,8 @@ public static class MaterializedViewEndpoints
              ORDER BY name
              LIMIT @Limit OFFSET @Offset;
              """,
-            new { Limit = limit, Offset = offset })).ToList();
+            new { Limit = limit, Offset = offset },
+            cancellationToken: cancellationToken))).ToList();
 
         var items = rows
             .Select(r => new ClassRoomItem
@@ -137,10 +141,11 @@ public static class MaterializedViewEndpoints
         [FromQuery] Guid? studentId,
         [FromQuery] string? waitForSortableUniqueId,
         [FromServices] IMvOrleansQueryAccessor mvQueryAccessor,
-        [FromServices] ClassRoomEnrollmentMvV1 projector)
+        [FromServices] ClassRoomEnrollmentMvV1 projector,
+        CancellationToken cancellationToken)
     {
-        var context = await mvQueryAccessor.GetAsync(projector);
-        if (!await TryWaitForReceivedAsync(context, waitForSortableUniqueId))
+        var context = await mvQueryAccessor.GetAsync(projector, cancellationToken: cancellationToken);
+        if (!await TryWaitForReceivedAsync(context, waitForSortableUniqueId, cancellationToken: cancellationToken))
         {
             return Results.StatusCode(StatusCodes.Status504GatewayTimeout);
         }
@@ -148,7 +153,7 @@ public static class MaterializedViewEndpoints
         var enrollmentsTable = context.GetRequiredTable(ClassRoomEnrollmentMvV1.EnrollmentsLogicalTable);
 
         await using var connection = new NpgsqlConnection(context.ConnectionString);
-        await connection.OpenAsync();
+        await connection.OpenAsync(cancellationToken);
 
         var sql = $"SELECT student_id, class_room_id, enrolled_at, _last_sortable_unique_id FROM {enrollmentsTable.PhysicalTable}";
         var filters = new List<string>();
@@ -169,15 +174,19 @@ public static class MaterializedViewEndpoints
         }
         sql += " ORDER BY enrolled_at DESC;";
 
-        var rows = (await connection.QueryAsync<EnrollmentMvRow>(sql, parameters)).ToList();
+        var rows = (await connection.QueryAsync<EnrollmentMvRow>(new CommandDefinition(
+            sql,
+            parameters,
+            cancellationToken: cancellationToken))).ToList();
         return Results.Ok(rows);
     }
 
     private static async Task<IResult> GetStatusAsync(
         [FromServices] IMvOrleansQueryAccessor mvQueryAccessor,
-        [FromServices] ClassRoomEnrollmentMvV1 projector)
+        [FromServices] ClassRoomEnrollmentMvV1 projector,
+        CancellationToken cancellationToken)
     {
-        var context = await mvQueryAccessor.GetAsync(projector);
+        var context = await mvQueryAccessor.GetAsync(projector, cancellationToken: cancellationToken);
         var status = await context.Grain.GetStatusAsync();
         return Results.Ok(new
         {
@@ -190,7 +199,8 @@ public static class MaterializedViewEndpoints
     private static async Task<bool> TryWaitForReceivedAsync(
         MvOrleansQueryContext context,
         string? sortableUniqueId,
-        int timeoutMs = 10_000)
+        int timeoutMs = 10_000,
+        CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrWhiteSpace(sortableUniqueId))
         {
@@ -200,11 +210,12 @@ public static class MaterializedViewEndpoints
         var until = DateTime.UtcNow.AddMilliseconds(timeoutMs);
         while (DateTime.UtcNow < until)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             if (await context.Grain.IsSortableUniqueIdReceived(sortableUniqueId))
             {
                 return true;
             }
-            await Task.Delay(100);
+            await Task.Delay(100, cancellationToken);
         }
         return false;
     }

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.ApiService/Program.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.ApiService/Program.cs
@@ -14,7 +14,12 @@ using Sekiban.Dcb.DynamoDB;
 using Sekiban.Dcb.BlobStorage.S3;
 using Sekiban.Dcb.Storage;
 using Sekiban.Dcb.ColdEvents;
+using Sekiban.Dcb.MaterializedView;
+using Sekiban.Dcb.MaterializedView.Orleans;
+using Sekiban.Dcb.MaterializedView.Postgres;
 using Sekiban.Dcb.Snapshots;
+using Dcb.EventSource.MaterializedViews;
+using Dapper;
 using SekibanDcbDeciderAws.ApiService;
 using SekibanDcbDeciderAws.ApiService.Endpoints;
 using SekibanDcbDeciderAws.ApiService.Auth;
@@ -251,6 +256,28 @@ builder.Services.AddSingleton(domainTypes);
 builder.Services.AddSekibanDcbNativeRuntime();
 builder.Services.AddSekibanDcbColdEventDefaults();
 
+// Register the materialized view runtime. The Postgres + Orleans pieces are wired only when a
+// `DcbMaterializedViewPostgres` connection string is supplied — the AWS template runs with
+// DynamoDB by default but can opt into a Postgres-backed read model.
+builder.Services.AddSekibanDcbMaterializedView(options =>
+{
+    options.BatchSize = 100;
+    options.PollInterval = TimeSpan.FromSeconds(1);
+});
+builder.Services.AddMaterializedView<ClassRoomEnrollmentMvV1>();
+
+if (!string.IsNullOrWhiteSpace(builder.Configuration.GetConnectionString("DcbMaterializedViewPostgres")))
+{
+    builder.Services.AddSekibanDcbMaterializedViewPostgres(
+        builder.Configuration,
+        connectionStringName: "DcbMaterializedViewPostgres",
+        registerHostedWorker: false);
+    builder.Services.AddSekibanDcbMaterializedViewOrleans();
+}
+
+// Map snake_case Postgres columns onto PascalCase row classes used by the materialized view endpoints.
+DefaultTypeMap.MatchNamesWithUnderscores = true;
+
 builder.Services.AddSingleton<SseTopicHub>();
 builder.Services.AddHostedService<OrleansStreamEventRouter>();
 
@@ -334,6 +361,14 @@ apiRoute.MapStreamEndpoints();
 
 // Test data endpoints
 apiRoute.MapTestDataEndpoints();
+
+// Materialized view endpoints depend on the Orleans MV runtime, which is registered only when a
+// `DcbMaterializedViewPostgres` connection string is supplied. Skip the route when MV is off so
+// requests get a clean 404 rather than a DI resolution failure.
+if (app.Services.GetService<IMvOrleansQueryAccessor>() is not null)
+{
+    apiRoute.MapMaterializedViewEndpoints();
+}
 
 app.MapDefaultEndpoints();
 

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.ApiService/SekibanDcbDeciderAws.ApiService.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.ApiService/SekibanDcbDeciderAws.ApiService.csproj
@@ -33,13 +33,13 @@
 
         <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.3" />
         <PackageReference Include="Scalar.AspNetCore" Version="2.12.50" />
-        <PackageReference Include="Sekiban.Dcb.Orleans.WithoutResult" Version="10.1.17" />
-        <PackageReference Include="Sekiban.Dcb.DynamoDB" Version="10.1.17" />
-        <PackageReference Include="Sekiban.Dcb.BlobStorage.S3" Version="10.1.17" />
-        <PackageReference Include="Sekiban.Dcb.Postgres" Version="10.1.17" />
-        <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.1.17" />
-        <PackageReference Include="Sekiban.Dcb.MaterializedView.Postgres" Version="10.1.17" />
-        <PackageReference Include="Sekiban.Dcb.MaterializedView.Orleans" Version="10.1.17" />
+        <PackageReference Include="Sekiban.Dcb.Orleans.WithoutResult" Version="10.1.18" />
+        <PackageReference Include="Sekiban.Dcb.DynamoDB" Version="10.1.18" />
+        <PackageReference Include="Sekiban.Dcb.BlobStorage.S3" Version="10.1.18" />
+        <PackageReference Include="Sekiban.Dcb.Postgres" Version="10.1.18" />
+        <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.1.18" />
+        <PackageReference Include="Sekiban.Dcb.MaterializedView.Postgres" Version="10.1.18" />
+        <PackageReference Include="Sekiban.Dcb.MaterializedView.Orleans" Version="10.1.18" />
         <PackageReference Include="Dapper" Version="2.1.66" />
         <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />
     </ItemGroup>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.ApiService/SekibanDcbDeciderAws.ApiService.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.ApiService/SekibanDcbDeciderAws.ApiService.csproj
@@ -29,13 +29,18 @@
         <PackageReference Include="Microsoft.Orleans.Clustering.AdoNet" Version="10.0.1" />
         <PackageReference Include="Microsoft.Orleans.Persistence.AdoNet" Version="10.0.1" />
         <PackageReference Include="Microsoft.Orleans.Reminders.AdoNet" Version="10.0.1" />
-        <PackageReference Include="Npgsql" Version="10.0.1" />
+        <PackageReference Include="Npgsql" Version="10.0.2" />
 
         <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.3" />
         <PackageReference Include="Scalar.AspNetCore" Version="2.12.50" />
-        <PackageReference Include="Sekiban.Dcb.Orleans.WithoutResult" Version="10.1.8" />
-        <PackageReference Include="Sekiban.Dcb.DynamoDB" Version="10.1.8" />
-        <PackageReference Include="Sekiban.Dcb.BlobStorage.S3" Version="10.1.8" />
+        <PackageReference Include="Sekiban.Dcb.Orleans.WithoutResult" Version="10.1.17" />
+        <PackageReference Include="Sekiban.Dcb.DynamoDB" Version="10.1.17" />
+        <PackageReference Include="Sekiban.Dcb.BlobStorage.S3" Version="10.1.17" />
+        <PackageReference Include="Sekiban.Dcb.Postgres" Version="10.1.17" />
+        <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.1.17" />
+        <PackageReference Include="Sekiban.Dcb.MaterializedView.Postgres" Version="10.1.17" />
+        <PackageReference Include="Sekiban.Dcb.MaterializedView.Orleans" Version="10.1.17" />
+        <PackageReference Include="Dapper" Version="2.1.66" />
         <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />
     </ItemGroup>
 

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.AppHost/Program.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.AppHost/Program.cs
@@ -17,12 +17,19 @@ var postgresServer = builder
 
 var identityPostgres = postgresServer.AddDatabase("IdentityPostgres");
 
+// Materialized view database (kept separate from the DynamoDB event store so the read-side schema
+// can evolve independently). Optional — the ApiService only enables the MV runtime when this
+// connection string is wired through.
+var materializedViewPostgres = postgresServer.AddDatabase("DcbMaterializedViewPostgres");
+
 // Add the API Service with DynamoDB configuration
 var apiService = builder
     .AddProject<SekibanDcbDeciderAws_ApiService>("apiservice")
     .WaitFor(localstack)
     .WaitFor(identityPostgres)
+    .WaitFor(materializedViewPostgres)
     .WithReference(identityPostgres)
+    .WithReference(materializedViewPostgres)
     .WithEnvironment("Sekiban__Database", "dynamodb")
     .WithEnvironment("Orleans__UseInMemoryStreams", "true")
     .WithEnvironment("AWS__Region", "us-east-1")

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.EventSource/MaterializedViews/ClassRoomEnrollmentMvV1.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.EventSource/MaterializedViews/ClassRoomEnrollmentMvV1.cs
@@ -1,0 +1,301 @@
+using Dcb.ImmutableModels.Events.ClassRoom;
+using Dcb.ImmutableModels.Events.Enrollment;
+using Dcb.ImmutableModels.Events.Student;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.MaterializedView;
+
+namespace Dcb.EventSource.MaterializedViews;
+
+/// <summary>
+///     Materialized view for classrooms, students and enrollments.
+///     Mirrors what the in-memory <c>ClassRoomListProjection</c> and
+///     <c>StudentListProjection</c> expose, but persisted into PostgreSQL tables
+///     so that they can be queried as a SQL read model.
+/// </summary>
+public sealed class ClassRoomEnrollmentMvV1 : IMaterializedViewProjector
+{
+    public const string ClassRoomsLogicalTable = "classrooms";
+    public const string StudentsLogicalTable = "students";
+    public const string EnrollmentsLogicalTable = "enrollments";
+
+    public string ViewName => "ClassRoomEnrollment";
+    public int ViewVersion => 1;
+
+    public MvTable ClassRooms { get; private set; } = default!;
+    public MvTable Students { get; private set; } = default!;
+    public MvTable Enrollments { get; private set; } = default!;
+
+    public async Task InitializeAsync(IMvInitContext ctx, CancellationToken cancellationToken = default)
+    {
+        ClassRooms = ctx.RegisterTable(ClassRoomsLogicalTable);
+        Students = ctx.RegisterTable(StudentsLogicalTable);
+        Enrollments = ctx.RegisterTable(EnrollmentsLogicalTable);
+
+        await ctx.ExecuteAsync(
+            $"""
+             CREATE TABLE IF NOT EXISTS {ClassRooms.PhysicalName} (
+                 class_room_id UUID PRIMARY KEY,
+                 name TEXT NOT NULL,
+                 max_students INT NOT NULL,
+                 enrolled_count INT NOT NULL DEFAULT 0,
+                 _last_sortable_unique_id TEXT NOT NULL,
+                 _last_applied_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+             );
+             """,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        await ctx.ExecuteAsync(
+            $"""
+             CREATE TABLE IF NOT EXISTS {Students.PhysicalName} (
+                 student_id UUID PRIMARY KEY,
+                 name TEXT NOT NULL,
+                 max_class_count INT NOT NULL,
+                 enrolled_count INT NOT NULL DEFAULT 0,
+                 _last_sortable_unique_id TEXT NOT NULL,
+                 _last_applied_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+             );
+             """,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        await ctx.ExecuteAsync(
+            $"""
+             CREATE TABLE IF NOT EXISTS {Enrollments.PhysicalName} (
+                 student_id UUID NOT NULL,
+                 class_room_id UUID NOT NULL,
+                 enrolled_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                 _last_sortable_unique_id TEXT NOT NULL,
+                 PRIMARY KEY (student_id, class_room_id)
+             );
+             """,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        await ctx.ExecuteAsync(
+            $"""
+             CREATE INDEX IF NOT EXISTS {BuildIndexName(Enrollments.PhysicalName, "class_room")}
+             ON {Enrollments.PhysicalName} (class_room_id);
+             """,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+    }
+
+    // PostgreSQL identifier length limit is 63 bytes. The materialized view runtime already
+    // truncates physical table names to fit, but a naive `idx_{table}_{col}` template can still
+    // overflow once the prefix and suffix are added. Build a name that fits by shortening the
+    // table portion and appending a short stable hash so it stays unique.
+    private static string BuildIndexName(string physicalTable, string suffix)
+    {
+        const int maxLength = 63;
+        var prefix = "idx_";
+        var tail = "_" + suffix;
+        var available = maxLength - prefix.Length - tail.Length;
+
+        if (physicalTable.Length <= available)
+        {
+            return prefix + physicalTable + tail;
+        }
+
+        // Reserve 9 chars for "_" + 8-char hex hash so the truncated table name still has room.
+        var hash = Convert.ToHexString(System.Security.Cryptography.SHA1.HashData(System.Text.Encoding.UTF8.GetBytes(physicalTable))).Substring(0, 8).ToLowerInvariant();
+        var headroom = available - 9;
+        if (headroom < 1) headroom = 1;
+        var head = physicalTable.Substring(0, Math.Min(headroom, physicalTable.Length));
+        return prefix + head + "_" + hash + tail;
+    }
+
+    public Task<IReadOnlyList<MvSqlStatement>> ApplyToViewAsync(
+        Event ev,
+        IMvApplyContext ctx,
+        CancellationToken cancellationToken = default) =>
+        Task.FromResult<IReadOnlyList<MvSqlStatement>>(
+            ev.Payload switch
+            {
+                ClassRoomCreated created => [InsertClassRoom(created, ctx.CurrentSortableUniqueId)],
+                StudentCreated created => [InsertStudent(created, ctx.CurrentSortableUniqueId)],
+                StudentEnrolledInClassRoom enrolled => InsertEnrollment(enrolled, ctx.CurrentSortableUniqueId),
+                StudentDroppedFromClassRoom dropped => DeleteEnrollment(dropped, ctx.CurrentSortableUniqueId),
+                _ => []
+            });
+
+    private MvSqlStatement InsertClassRoom(ClassRoomCreated created, string sortableUniqueId) =>
+        new(
+            $"""
+             INSERT INTO {ClassRooms.PhysicalName}
+                 (class_room_id, name, max_students, enrolled_count, _last_sortable_unique_id, _last_applied_at)
+             VALUES
+                 (@ClassRoomId, @Name, @MaxStudents, 0, @SortableUniqueId, NOW())
+             ON CONFLICT (class_room_id) DO UPDATE SET
+                 name = EXCLUDED.name,
+                 max_students = EXCLUDED.max_students,
+                 _last_sortable_unique_id = EXCLUDED._last_sortable_unique_id,
+                 _last_applied_at = EXCLUDED._last_applied_at
+             WHERE {ClassRooms.PhysicalName}._last_sortable_unique_id < EXCLUDED._last_sortable_unique_id;
+             """,
+            new
+            {
+                created.ClassRoomId,
+                created.Name,
+                created.MaxStudents,
+                SortableUniqueId = sortableUniqueId
+            });
+
+    private MvSqlStatement InsertStudent(StudentCreated created, string sortableUniqueId) =>
+        new(
+            $"""
+             INSERT INTO {Students.PhysicalName}
+                 (student_id, name, max_class_count, enrolled_count, _last_sortable_unique_id, _last_applied_at)
+             VALUES
+                 (@StudentId, @Name, @MaxClassCount, 0, @SortableUniqueId, NOW())
+             ON CONFLICT (student_id) DO UPDATE SET
+                 name = EXCLUDED.name,
+                 max_class_count = EXCLUDED.max_class_count,
+                 _last_sortable_unique_id = EXCLUDED._last_sortable_unique_id,
+                 _last_applied_at = EXCLUDED._last_applied_at
+             WHERE {Students.PhysicalName}._last_sortable_unique_id < EXCLUDED._last_sortable_unique_id;
+             """,
+            new
+            {
+                created.StudentId,
+                created.Name,
+                created.MaxClassCount,
+                SortableUniqueId = sortableUniqueId
+            });
+
+    private IReadOnlyList<MvSqlStatement> InsertEnrollment(
+        StudentEnrolledInClassRoom enrolled,
+        string sortableUniqueId) =>
+    [
+        new(
+            $"""
+             INSERT INTO {Enrollments.PhysicalName}
+                 (student_id, class_room_id, enrolled_at, _last_sortable_unique_id)
+             VALUES
+                 (@StudentId, @ClassRoomId, NOW(), @SortableUniqueId)
+             ON CONFLICT (student_id, class_room_id) DO UPDATE SET
+                 _last_sortable_unique_id = EXCLUDED._last_sortable_unique_id
+             WHERE {Enrollments.PhysicalName}._last_sortable_unique_id < EXCLUDED._last_sortable_unique_id;
+             """,
+            new
+            {
+                enrolled.StudentId,
+                enrolled.ClassRoomId,
+                SortableUniqueId = sortableUniqueId
+            }),
+        RecountClassRoom(enrolled.ClassRoomId, sortableUniqueId),
+        RecountStudent(enrolled.StudentId, sortableUniqueId)
+    ];
+
+    private IReadOnlyList<MvSqlStatement> DeleteEnrollment(
+        StudentDroppedFromClassRoom dropped,
+        string sortableUniqueId) =>
+    [
+        new(
+            $"""
+             DELETE FROM {Enrollments.PhysicalName}
+             WHERE student_id = @StudentId
+               AND class_room_id = @ClassRoomId
+               AND _last_sortable_unique_id < @SortableUniqueId;
+             """,
+            new
+            {
+                dropped.StudentId,
+                dropped.ClassRoomId,
+                SortableUniqueId = sortableUniqueId
+            }),
+        RecountClassRoom(dropped.ClassRoomId, sortableUniqueId),
+        RecountStudent(dropped.StudentId, sortableUniqueId)
+    ];
+
+    private MvSqlStatement RecountClassRoom(Guid classRoomId, string sortableUniqueId) =>
+        new(
+            $"""
+             UPDATE {ClassRooms.PhysicalName}
+             SET enrolled_count = (
+                     SELECT COUNT(*) FROM {Enrollments.PhysicalName}
+                     WHERE class_room_id = @ClassRoomId
+                 ),
+                 _last_sortable_unique_id = @SortableUniqueId,
+                 _last_applied_at = NOW()
+             WHERE class_room_id = @ClassRoomId
+               AND _last_sortable_unique_id < @SortableUniqueId;
+             """,
+            new
+            {
+                ClassRoomId = classRoomId,
+                SortableUniqueId = sortableUniqueId
+            });
+
+    private MvSqlStatement RecountStudent(Guid studentId, string sortableUniqueId) =>
+        new(
+            $"""
+             UPDATE {Students.PhysicalName}
+             SET enrolled_count = (
+                     SELECT COUNT(*) FROM {Enrollments.PhysicalName}
+                     WHERE student_id = @StudentId
+                 ),
+                 _last_sortable_unique_id = @SortableUniqueId,
+                 _last_applied_at = NOW()
+             WHERE student_id = @StudentId
+               AND _last_sortable_unique_id < @SortableUniqueId;
+             """,
+            new
+            {
+                StudentId = studentId,
+                SortableUniqueId = sortableUniqueId
+            });
+}
+
+public sealed class ClassRoomMvRow
+{
+    [MvColumn("class_room_id")]
+    public Guid ClassRoomId { get; set; }
+
+    [MvColumn("name")]
+    public string Name { get; set; } = string.Empty;
+
+    [MvColumn("max_students")]
+    public int MaxStudents { get; set; }
+
+    [MvColumn("enrolled_count")]
+    public int EnrolledCount { get; set; }
+
+    [MvColumn("_last_sortable_unique_id")]
+    public string LastSortableUniqueId { get; set; } = string.Empty;
+
+    [MvColumn("_last_applied_at")]
+    public DateTimeOffset LastAppliedAt { get; set; }
+}
+
+public sealed class StudentMvRow
+{
+    [MvColumn("student_id")]
+    public Guid StudentId { get; set; }
+
+    [MvColumn("name")]
+    public string Name { get; set; } = string.Empty;
+
+    [MvColumn("max_class_count")]
+    public int MaxClassCount { get; set; }
+
+    [MvColumn("enrolled_count")]
+    public int EnrolledCount { get; set; }
+
+    [MvColumn("_last_sortable_unique_id")]
+    public string LastSortableUniqueId { get; set; } = string.Empty;
+
+    [MvColumn("_last_applied_at")]
+    public DateTimeOffset LastAppliedAt { get; set; }
+}
+
+public sealed class EnrollmentMvRow
+{
+    [MvColumn("student_id")]
+    public Guid StudentId { get; set; }
+
+    [MvColumn("class_room_id")]
+    public Guid ClassRoomId { get; set; }
+
+    [MvColumn("enrolled_at")]
+    public DateTimeOffset EnrolledAt { get; set; }
+
+    [MvColumn("_last_sortable_unique_id")]
+    public string LastSortableUniqueId { get; set; } = string.Empty;
+}

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.EventSource/SekibanDcbDeciderAws.EventSource.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.EventSource/SekibanDcbDeciderAws.EventSource.csproj
@@ -11,7 +11,8 @@
     <ProjectReference Include="..\SekibanDcbDeciderAws.MeetingRoomModels\SekibanDcbDeciderAws.MeetingRoomModels.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.1.8" />
+    <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.1.17" />
+    <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.1.17" />
     <PackageReference Include="ResultBoxes" Version="0.4.0" />
     <PackageReference Include="Microsoft.Orleans.Serialization" Version="10.0.1" />
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.EventSource/SekibanDcbDeciderAws.EventSource.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.EventSource/SekibanDcbDeciderAws.EventSource.csproj
@@ -11,8 +11,8 @@
     <ProjectReference Include="..\SekibanDcbDeciderAws.MeetingRoomModels\SekibanDcbDeciderAws.MeetingRoomModels.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.1.17" />
-    <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.1.17" />
+    <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.1.18" />
+    <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.1.18" />
     <PackageReference Include="ResultBoxes" Version="0.4.0" />
     <PackageReference Include="Microsoft.Orleans.Serialization" Version="10.0.1" />
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.ImmutableModels/SekibanDcbDeciderAws.ImmutableModels.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.ImmutableModels/SekibanDcbDeciderAws.ImmutableModels.csproj
@@ -7,7 +7,7 @@
     <IsPackable>true</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Sekiban.Dcb.Core.Model" Version="10.1.8" />
+    <PackageReference Include="Sekiban.Dcb.Core.Model" Version="10.1.17" />
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />
   </ItemGroup>
 </Project>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.ImmutableModels/SekibanDcbDeciderAws.ImmutableModels.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.ImmutableModels/SekibanDcbDeciderAws.ImmutableModels.csproj
@@ -7,7 +7,7 @@
     <IsPackable>true</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Sekiban.Dcb.Core.Model" Version="10.1.17" />
+    <PackageReference Include="Sekiban.Dcb.Core.Model" Version="10.1.18" />
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />
   </ItemGroup>
 </Project>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.Interactions.Unit/SekibanDcbDeciderAws.Interactions.Unit.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.Interactions.Unit/SekibanDcbDeciderAws.Interactions.Unit.csproj
@@ -28,7 +28,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.1.8" />
+      <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.1.18" />
     </ItemGroup>
 
 </Project>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.Interactions/SekibanDcbDeciderAws.Interactions.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.Interactions/SekibanDcbDeciderAws.Interactions.csproj
@@ -10,7 +10,7 @@
     <ProjectReference Include="..\SekibanDcbDeciderAws.EventSource\SekibanDcbDeciderAws.EventSource.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.1.17" />
+    <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.1.18" />
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />
   </ItemGroup>
 </Project>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.Interactions/SekibanDcbDeciderAws.Interactions.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.Interactions/SekibanDcbDeciderAws.Interactions.csproj
@@ -10,7 +10,7 @@
     <ProjectReference Include="..\SekibanDcbDeciderAws.EventSource\SekibanDcbDeciderAws.EventSource.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.1.8" />
+    <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.1.17" />
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />
   </ItemGroup>
 </Project>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.MeetingRoomModels/SekibanDcbDeciderAws.MeetingRoomModels.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.MeetingRoomModels/SekibanDcbDeciderAws.MeetingRoomModels.csproj
@@ -7,7 +7,7 @@
     <IsPackable>true</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Sekiban.Dcb.Core.Model" Version="10.1.8" />
+    <PackageReference Include="Sekiban.Dcb.Core.Model" Version="10.1.17" />
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />
   </ItemGroup>
 </Project>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.MeetingRoomModels/SekibanDcbDeciderAws.MeetingRoomModels.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.MeetingRoomModels/SekibanDcbDeciderAws.MeetingRoomModels.csproj
@@ -7,7 +7,7 @@
     <IsPackable>true</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Sekiban.Dcb.Core.Model" Version="10.1.17" />
+    <PackageReference Include="Sekiban.Dcb.Core.Model" Version="10.1.18" />
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />
   </ItemGroup>
 </Project>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.Unit/SekibanDcbDeciderAws.Unit.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.Unit/SekibanDcbDeciderAws.Unit.csproj
@@ -15,7 +15,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.1.8" />
+    <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.1.18" />
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />
   </ItemGroup>
   <ItemGroup>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.Web/ClassRoomApiClient.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.Web/ClassRoomApiClient.cs
@@ -21,6 +21,7 @@ public class ClassRoomApiClient(HttpClient httpClient)
         int? pageNumber = null,
         int? pageSize = null,
         string? waitForSortableUniqueId = null,
+        bool useMaterializedView = false,
         CancellationToken cancellationToken = default)
     {
         var queryParams = new List<string>();
@@ -34,9 +35,10 @@ public class ClassRoomApiClient(HttpClient httpClient)
         if (pageSize.HasValue)
             queryParams.Add($"pageSize={pageSize.Value}");
 
+        var basePath = useMaterializedView ? "/api/mv/classrooms" : "/api/classrooms";
         var requestUri = queryParams.Count > 0
-            ? $"/api/classrooms?{string.Join("&", queryParams)}"
-            : "/api/classrooms";
+            ? $"{basePath}?{string.Join("&", queryParams)}"
+            : basePath;
 
         var classrooms = await httpClient.GetFromJsonAsync<List<ClassRoomItem>>(requestUri, cancellationToken);
 

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.Web/Components/Pages/Classrooms.razor
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.Web/Components/Pages/Classrooms.razor
@@ -16,6 +16,16 @@
     <button class="btn btn-primary mb-3" @onclick="OpenAddClassroomModal">Add New Classroom</button>
 </div>
 
+<div class="mb-3">
+    <label class="me-2"><strong>Query source:</strong></label>
+    <div class="btn-group" role="group" aria-label="Query source">
+        <input type="radio" class="btn-check" name="query-source" id="qs-mem" autocomplete="off" checked="@(!useMaterializedView)" @onchange="() => OnQueryModeChanged(false)">
+        <label class="btn btn-outline-primary" for="qs-mem">Memory projection</label>
+        <input type="radio" class="btn-check" name="query-source" id="qs-mv" autocomplete="off" checked="@useMaterializedView" @onchange="() => OnQueryModeChanged(true)">
+        <label class="btn btn-outline-primary" for="qs-mv">Materialized view</label>
+    </div>
+</div>
+
 <h3>Classroom List</h3>
 
 <div class="row mb-3">
@@ -154,12 +164,20 @@
     private ClassroomModel classroomModel = new();
     private string errorMessage = string.Empty;
     private string? lastSortableUniqueId;
+    private bool useMaterializedView;
 
     // Pagination fields
     private int currentPage = 1;
     private int pageSize = 10;
     private int totalPages = 1;
     private int totalItems;
+
+    private async Task OnQueryModeChanged(bool useMv)
+    {
+        useMaterializedView = useMv;
+        currentPage = 1;
+        await LoadClassrooms(lastSortableUniqueId);
+    }
 
 
     public class ClassroomModel
@@ -177,7 +195,7 @@
     {
         try
         {
-            var result = await ClassRoomApiClient.GetClassRoomsAsync(currentPage, pageSize, waitForSortableUniqueId);
+            var result = await ClassRoomApiClient.GetClassRoomsAsync(currentPage, pageSize, waitForSortableUniqueId, useMaterializedView);
             classrooms = result?.ToList() ?? new List<ClassRoomItem>();
 
             // For now, estimate total pages based on if we got a full page

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.Web/Components/Pages/Enrollments.razor
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.Web/Components/Pages/Enrollments.razor
@@ -14,6 +14,16 @@
 
 <h1>Enrollment Management</h1>
 
+<div class="mb-3">
+    <label class="me-2"><strong>Query source:</strong></label>
+    <div class="btn-group" role="group" aria-label="Query source">
+        <input type="radio" class="btn-check" name="enroll-query-source" id="enroll-qs-mem" autocomplete="off" checked="@(!useMaterializedView)" @onchange="() => OnQueryModeChanged(false)">
+        <label class="btn btn-outline-primary" for="enroll-qs-mem">Memory projection</label>
+        <input type="radio" class="btn-check" name="enroll-query-source" id="enroll-qs-mv" autocomplete="off" checked="@useMaterializedView" @onchange="() => OnQueryModeChanged(true)">
+        <label class="btn btn-outline-primary" for="enroll-qs-mv">Materialized view</label>
+    </div>
+</div>
+
 <div class="row">
     <div class="col-md-6">
         <div class="card">
@@ -162,6 +172,16 @@
     private bool dropError;
 
     private string? lastSortableUniqueId;
+    private bool useMaterializedView;
+
+    private string StudentsBasePath => useMaterializedView ? "api/mv/students" : "api/students";
+    private string ClassroomsBasePath => useMaterializedView ? "api/mv/classrooms" : "api/classrooms";
+
+    private async Task OnQueryModeChanged(bool useMv)
+    {
+        useMaterializedView = useMv;
+        await LoadData(lastSortableUniqueId);
+    }
 
     public class StudentView
     {
@@ -213,8 +233,8 @@
         {
             var httpClient = HttpClientFactory.CreateClient("ApiService");
             var requestUri = !string.IsNullOrEmpty(waitForSortableUniqueId)
-                ? $"api/students?waitForSortableUniqueId={Uri.EscapeDataString(waitForSortableUniqueId)}"
-                : "api/students";
+                ? $"{StudentsBasePath}?waitForSortableUniqueId={Uri.EscapeDataString(waitForSortableUniqueId)}"
+                : StudentsBasePath;
             var response = await httpClient.GetFromJsonAsync<List<StudentState>>(requestUri);
             if (response != null)
             {
@@ -243,8 +263,8 @@
         {
             var httpClient = HttpClientFactory.CreateClient("ApiService");
             var requestUri = !string.IsNullOrEmpty(waitForSortableUniqueId)
-                ? $"api/classrooms?waitForSortableUniqueId={Uri.EscapeDataString(waitForSortableUniqueId)}"
-                : "api/classrooms";
+                ? $"{ClassroomsBasePath}?waitForSortableUniqueId={Uri.EscapeDataString(waitForSortableUniqueId)}"
+                : ClassroomsBasePath;
             var response = await httpClient.GetFromJsonAsync<List<ClassRoomItem>>(requestUri);
             if (response != null)
             {
@@ -279,11 +299,11 @@
             
             // Build query string with waitForSortableUniqueId if provided
             var studentsUri = !string.IsNullOrEmpty(waitForSortableUniqueId)
-                ? $"api/students?waitForSortableUniqueId={Uri.EscapeDataString(waitForSortableUniqueId)}"
-                : "api/students";
+                ? $"{StudentsBasePath}?waitForSortableUniqueId={Uri.EscapeDataString(waitForSortableUniqueId)}"
+                : StudentsBasePath;
             var classroomsUri = !string.IsNullOrEmpty(waitForSortableUniqueId)
-                ? $"api/classrooms?waitForSortableUniqueId={Uri.EscapeDataString(waitForSortableUniqueId)}"
-                : "api/classrooms";
+                ? $"{ClassroomsBasePath}?waitForSortableUniqueId={Uri.EscapeDataString(waitForSortableUniqueId)}"
+                : ClassroomsBasePath;
             
             // Get all students with their enrolled classrooms, waiting for the sortableUniqueId if provided
             var studentsResponse = await httpClient.GetFromJsonAsync<List<StudentState>>(studentsUri);

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.Web/Components/Pages/Students.razor
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.Web/Components/Pages/Students.razor
@@ -17,6 +17,16 @@
     <button class="btn btn-primary mb-3" @onclick="OpenAddStudentModal">Add New Student</button>
 </div>
 
+<div class="mb-3">
+    <label class="me-2"><strong>Query source:</strong></label>
+    <div class="btn-group" role="group" aria-label="Query source">
+        <input type="radio" class="btn-check" name="query-source" id="qs-mem" autocomplete="off" checked="@(!useMaterializedView)" @onchange="() => OnQueryModeChanged(false)">
+        <label class="btn btn-outline-primary" for="qs-mem">Memory projection</label>
+        <input type="radio" class="btn-check" name="query-source" id="qs-mv" autocomplete="off" checked="@useMaterializedView" @onchange="() => OnQueryModeChanged(true)">
+        <label class="btn btn-outline-primary" for="qs-mv">Materialized view</label>
+    </div>
+</div>
+
 <h3>Student List</h3>
 
 <div class="row mb-3">
@@ -148,12 +158,20 @@
     private List<StudentState>? students;
     private StudentModel studentModel = new();
     private string? lastSortableUniqueId;
+    private bool useMaterializedView;
 
     // Pagination fields
     private int currentPage = 1;
     private int pageSize = 10;
     private int totalPages = 1;
     private int totalItems;
+
+    private async Task OnQueryModeChanged(bool useMv)
+    {
+        useMaterializedView = useMv;
+        currentPage = 1;
+        await LoadStudents(lastSortableUniqueId);
+    }
 
     public class StudentModel
     {
@@ -175,7 +193,7 @@
     {
         try
         {
-            var result = await StudentApiClient.GetStudentsAsync(currentPage, pageSize, waitForSortableUniqueId);
+            var result = await StudentApiClient.GetStudentsAsync(currentPage, pageSize, waitForSortableUniqueId, useMaterializedView);
 
             students = result?.ToList() ?? new List<StudentState>();
 

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.Web/StudentApiClient.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.Web/StudentApiClient.cs
@@ -22,6 +22,7 @@ public class StudentApiClient(HttpClient httpClient)
         int? pageNumber = null,
         int? pageSize = null,
         string? waitForSortableUniqueId = null,
+        bool useMaterializedView = false,
         CancellationToken cancellationToken = default)
     {
         var queryParams = new List<string>();
@@ -35,9 +36,10 @@ public class StudentApiClient(HttpClient httpClient)
         if (pageSize.HasValue)
             queryParams.Add($"pageSize={pageSize.Value}");
 
+        var basePath = useMaterializedView ? "/api/mv/students" : "/api/students";
         var requestUri = queryParams.Count > 0
-            ? $"/api/students?{string.Join("&", queryParams)}"
-            : "/api/students";
+            ? $"{basePath}?{string.Join("&", queryParams)}"
+            : basePath;
 
         var students = await httpClient.GetFromJsonAsync<List<StudentState>>(requestUri, cancellationToken);
 

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.WebNext/src/app/classrooms/page.tsx
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.WebNext/src/app/classrooms/page.tsx
@@ -22,6 +22,7 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
+import { QueryModeToggle, type QueryMode } from "@/components/query-mode-toggle";
 
 export default function ClassroomsPage() {
   const [pageSize, setPageSize] = useState(10);
@@ -31,11 +32,13 @@ export default function ClassroomsPage() {
   const [newClassName, setNewClassName] = useState("");
   const [newMaxCapacity, setNewMaxCapacity] = useState(20);
   const [formError, setFormError] = useState("");
+  const [queryMode, setQueryMode] = useState<QueryMode>("memory");
 
   const { data: classrooms, isLoading, refetch } = trpc.classrooms.list.useQuery({
     pageNumber: currentPage,
     pageSize,
     waitForSortableUniqueId: lastSortableUniqueId,
+    queryMode,
   });
 
   const createMutation = trpc.classrooms.create.useMutation({
@@ -96,12 +99,15 @@ export default function ClassroomsPage() {
             Manage classrooms and their capacity settings
           </p>
         </div>
-        <Button onClick={() => setIsAddModalOpen(true)} className="gap-2">
-          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
-          </svg>
-          Add Classroom
-        </Button>
+        <div className="flex items-center gap-3">
+          <QueryModeToggle value={queryMode} onChange={setQueryMode} />
+          <Button onClick={() => setIsAddModalOpen(true)} className="gap-2">
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+            </svg>
+            Add Classroom
+          </Button>
+        </div>
       </div>
 
       {/* Stats Cards */}

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.WebNext/src/app/enrollments/page.tsx
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.WebNext/src/app/enrollments/page.tsx
@@ -21,9 +21,11 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
+import { QueryModeToggle, type QueryMode } from "@/components/query-mode-toggle";
 
 export default function EnrollmentsPage() {
   const [lastSortableUniqueId, setLastSortableUniqueId] = useState<string | undefined>();
+  const [queryMode, setQueryMode] = useState<QueryMode>("memory");
 
   // Selection state
   const [selectedStudentId, setSelectedStudentId] = useState("");
@@ -40,16 +42,19 @@ export default function EnrollmentsPage() {
     pageNumber: 1,
     pageSize: 100,
     waitForSortableUniqueId: lastSortableUniqueId,
+    queryMode,
   });
 
   const { data: classrooms, refetch: refetchClassrooms } = trpc.classrooms.list.useQuery({
     pageNumber: 1,
     pageSize: 100,
     waitForSortableUniqueId: lastSortableUniqueId,
+    queryMode,
   });
 
   const { data: enrollments, isLoading, refetch: refetchEnrollments } = trpc.enrollments.list.useQuery({
     waitForSortableUniqueId: lastSortableUniqueId,
+    queryMode,
   });
 
   const enrollMutation = trpc.enrollments.enroll.useMutation({
@@ -117,11 +122,14 @@ export default function EnrollmentsPage() {
   return (
     <div className="space-y-6">
       {/* Page Header */}
-      <div>
-        <h1 className="text-2xl font-semibold text-foreground">Enrollment Management</h1>
-        <p className="text-sm text-muted-foreground mt-1">
-          Manage student enrollments in classrooms
-        </p>
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h1 className="text-2xl font-semibold text-foreground">Enrollment Management</h1>
+          <p className="text-sm text-muted-foreground mt-1">
+            Manage student enrollments in classrooms
+          </p>
+        </div>
+        <QueryModeToggle value={queryMode} onChange={setQueryMode} />
       </div>
 
       {/* Stats Cards */}

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.WebNext/src/app/students/page.tsx
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.WebNext/src/app/students/page.tsx
@@ -22,6 +22,7 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
+import { QueryModeToggle, type QueryMode } from "@/components/query-mode-toggle";
 
 export default function StudentsPage() {
   const [pageSize, setPageSize] = useState(10);
@@ -31,11 +32,13 @@ export default function StudentsPage() {
   const [newName, setNewName] = useState("");
   const [newMaxClassCount, setNewMaxClassCount] = useState(5);
   const [formError, setFormError] = useState("");
+  const [queryMode, setQueryMode] = useState<QueryMode>("memory");
 
   const { data: students, isLoading, refetch } = trpc.students.list.useQuery({
     pageNumber: currentPage,
     pageSize,
     waitForSortableUniqueId: lastSortableUniqueId,
+    queryMode,
   });
 
   const createMutation = trpc.students.create.useMutation({
@@ -94,12 +97,15 @@ export default function StudentsPage() {
             Register and manage student records
           </p>
         </div>
-        <Button onClick={() => setIsAddModalOpen(true)} className="gap-2">
-          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
-          </svg>
-          Add Student
-        </Button>
+        <div className="flex items-center gap-3">
+          <QueryModeToggle value={queryMode} onChange={setQueryMode} />
+          <Button onClick={() => setIsAddModalOpen(true)} className="gap-2">
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+            </svg>
+            Add Student
+          </Button>
+        </div>
       </div>
 
       {/* Stats Cards */}

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.WebNext/src/components/query-mode-toggle.tsx
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.WebNext/src/components/query-mode-toggle.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+
+export type QueryMode = "memory" | "materialized";
+
+interface QueryModeToggleProps {
+  readonly value: QueryMode;
+  readonly onChange: (mode: QueryMode) => void;
+  readonly className?: string;
+}
+
+/**
+ * Lets the user pick between the in-memory MultiProjection (Orleans grain state)
+ * and the SQL-backed materialized view as the source for list queries.
+ *
+ * The two views read the same event stream but expose different latency,
+ * freshness and query-shape characteristics, so making the selection visible
+ * helps when comparing them side by side.
+ */
+export function QueryModeToggle({ value, onChange, className }: Readonly<QueryModeToggleProps>) {
+  return (
+    <div className={`inline-flex items-center gap-2 ${className ?? ""}`}>
+      <span className="text-sm text-muted-foreground">Query source:</span>
+      <div className="inline-flex rounded-md border bg-background p-0.5">
+        <Button
+          type="button"
+          size="sm"
+          variant={value === "memory" ? "default" : "ghost"}
+          onClick={() => onChange("memory")}
+        >
+          Memory projection
+        </Button>
+        <Button
+          type="button"
+          size="sm"
+          variant={value === "materialized" ? "default" : "ghost"}
+          onClick={() => onChange("materialized")}
+        >
+          Materialized view
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.WebNext/src/server/routers/classrooms.ts
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.WebNext/src/server/routers/classrooms.ts
@@ -22,6 +22,7 @@ export const classroomsRouter = router({
         pageNumber: z.number().default(1),
         pageSize: z.number().default(10),
         waitForSortableUniqueId: z.string().optional(),
+        queryMode: z.enum(["memory", "materialized"]).default("memory"),
       })
     )
     .query(async ({ input }) => {
@@ -32,8 +33,9 @@ export const classroomsRouter = router({
         params.set("waitForSortableUniqueId", input.waitForSortableUniqueId);
       }
 
+      const path = input.queryMode === "materialized" ? "/api/mv/classrooms" : "/api/classrooms";
       const res = await fetch(
-        `${process.env.API_BASE_URL}/api/classrooms?${params.toString()}`
+        `${process.env.API_BASE_URL}${path}?${params.toString()}`
       );
       if (!res.ok) {
         throw new Error("Failed to fetch classrooms");

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.WebNext/src/server/routers/enrollments.ts
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.WebNext/src/server/routers/enrollments.ts
@@ -24,18 +24,23 @@ export const enrollmentsRouter = router({
     .input(
       z.object({
         waitForSortableUniqueId: z.string().optional(),
+        queryMode: z.enum(["memory", "materialized"]).default("memory"),
       })
     )
     .query(async ({ input }) => {
-      // Build enrollments from students and classrooms data
       const params = new URLSearchParams();
       if (input.waitForSortableUniqueId) {
         params.set("waitForSortableUniqueId", input.waitForSortableUniqueId);
       }
 
+      const studentsPath =
+        input.queryMode === "materialized" ? "/api/mv/students" : "/api/students";
+      const classroomsPath =
+        input.queryMode === "materialized" ? "/api/mv/classrooms" : "/api/classrooms";
+
       const [studentsRes, classroomsRes] = await Promise.all([
-        fetch(`${process.env.API_BASE_URL}/api/students?${params.toString()}`),
-        fetch(`${process.env.API_BASE_URL}/api/classrooms?${params.toString()}`),
+        fetch(`${process.env.API_BASE_URL}${studentsPath}?${params.toString()}`),
+        fetch(`${process.env.API_BASE_URL}${classroomsPath}?${params.toString()}`),
       ]);
 
       if (!studentsRes.ok || !classroomsRes.ok) {

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.WebNext/src/server/routers/students.ts
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.WebNext/src/server/routers/students.ts
@@ -20,6 +20,7 @@ export const studentsRouter = router({
         pageNumber: z.number().default(1),
         pageSize: z.number().default(10),
         waitForSortableUniqueId: z.string().optional(),
+        queryMode: z.enum(["memory", "materialized"]).default("memory"),
       })
     )
     .query(async ({ input }) => {
@@ -30,8 +31,9 @@ export const studentsRouter = router({
         params.set("waitForSortableUniqueId", input.waitForSortableUniqueId);
       }
 
+      const path = input.queryMode === "materialized" ? "/api/mv/students" : "/api/students";
       const res = await fetch(
-        `${process.env.API_BASE_URL}/api/students?${params.toString()}`
+        `${process.env.API_BASE_URL}${path}?${params.toString()}`
       );
       if (!res.ok) {
         throw new Error("Failed to fetch students");

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.ApiService/Endpoints/MaterializedViewEndpoints.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.ApiService/Endpoints/MaterializedViewEndpoints.cs
@@ -11,9 +11,8 @@ namespace SekibanDcbDecider.ApiService.Endpoints;
 
 /// <summary>
 ///     Read-side endpoints backed by the PostgreSQL materialized view.
-///     They mirror the in-memory projection endpoints in
-///     <see cref="StudentEndpoints" /> and <see cref="ClassRoomEndpoints" />,
-///     so the UI can switch between query modes without changing the rest of the request shape.
+///     Mirrors the in-memory MultiProjection endpoints so the UI can switch between
+///     query modes without changing the rest of the request shape.
 /// </summary>
 public static class MaterializedViewEndpoints
 {
@@ -39,10 +38,11 @@ public static class MaterializedViewEndpoints
         [FromQuery] int? pageNumber,
         [FromQuery] int? pageSize,
         [FromServices] IMvOrleansQueryAccessor mvQueryAccessor,
-        [FromServices] ClassRoomEnrollmentMvV1 projector)
+        [FromServices] ClassRoomEnrollmentMvV1 projector,
+        CancellationToken cancellationToken)
     {
-        var context = await mvQueryAccessor.GetAsync(projector);
-        if (!await TryWaitForReceivedAsync(context, waitForSortableUniqueId))
+        var context = await mvQueryAccessor.GetAsync(projector, cancellationToken: cancellationToken);
+        if (!await TryWaitForReceivedAsync(context, waitForSortableUniqueId, cancellationToken: cancellationToken))
         {
             return Results.StatusCode(StatusCodes.Status504GatewayTimeout);
         }
@@ -51,10 +51,10 @@ public static class MaterializedViewEndpoints
         var enrollmentsTable = context.GetRequiredTable(ClassRoomEnrollmentMvV1.EnrollmentsLogicalTable);
 
         await using var connection = new NpgsqlConnection(context.ConnectionString);
-        await connection.OpenAsync();
+        await connection.OpenAsync(cancellationToken);
 
         var (limit, offset) = ResolvePaging(pageNumber, pageSize);
-        var students = (await connection.QueryAsync<StudentMvRow>(
+        var students = (await connection.QueryAsync<StudentMvRow>(new CommandDefinition(
             $"""
              SELECT student_id, name, max_class_count, enrolled_count,
                     _last_sortable_unique_id, _last_applied_at
@@ -62,18 +62,20 @@ public static class MaterializedViewEndpoints
              ORDER BY name
              LIMIT @Limit OFFSET @Offset;
              """,
-            new { Limit = limit, Offset = offset })).ToList();
+            new { Limit = limit, Offset = offset },
+            cancellationToken: cancellationToken))).ToList();
 
         var ids = students.Select(s => s.StudentId).ToArray();
         var enrollmentMap = ids.Length == 0
             ? new Dictionary<Guid, List<Guid>>()
-            : (await connection.QueryAsync<(Guid student_id, Guid class_room_id)>(
+            : (await connection.QueryAsync<(Guid student_id, Guid class_room_id)>(new CommandDefinition(
                     $"""
                      SELECT student_id, class_room_id
                      FROM {enrollmentsTable.PhysicalTable}
                      WHERE student_id = ANY(@Ids);
                      """,
-                    new { Ids = ids }))
+                    new { Ids = ids },
+                    cancellationToken: cancellationToken)))
                 .GroupBy(row => row.student_id)
                 .ToDictionary(g => g.Key, g => g.Select(r => r.class_room_id).ToList());
 
@@ -93,10 +95,11 @@ public static class MaterializedViewEndpoints
         [FromQuery] int? pageNumber,
         [FromQuery] int? pageSize,
         [FromServices] IMvOrleansQueryAccessor mvQueryAccessor,
-        [FromServices] ClassRoomEnrollmentMvV1 projector)
+        [FromServices] ClassRoomEnrollmentMvV1 projector,
+        CancellationToken cancellationToken)
     {
-        var context = await mvQueryAccessor.GetAsync(projector);
-        if (!await TryWaitForReceivedAsync(context, waitForSortableUniqueId))
+        var context = await mvQueryAccessor.GetAsync(projector, cancellationToken: cancellationToken);
+        if (!await TryWaitForReceivedAsync(context, waitForSortableUniqueId, cancellationToken: cancellationToken))
         {
             return Results.StatusCode(StatusCodes.Status504GatewayTimeout);
         }
@@ -104,10 +107,10 @@ public static class MaterializedViewEndpoints
         var classRoomsTable = context.GetRequiredTable(ClassRoomEnrollmentMvV1.ClassRoomsLogicalTable);
 
         await using var connection = new NpgsqlConnection(context.ConnectionString);
-        await connection.OpenAsync();
+        await connection.OpenAsync(cancellationToken);
 
         var (limit, offset) = ResolvePaging(pageNumber, pageSize);
-        var rows = (await connection.QueryAsync<ClassRoomMvRow>(
+        var rows = (await connection.QueryAsync<ClassRoomMvRow>(new CommandDefinition(
             $"""
              SELECT class_room_id, name, max_students, enrolled_count,
                     _last_sortable_unique_id, _last_applied_at
@@ -115,7 +118,8 @@ public static class MaterializedViewEndpoints
              ORDER BY name
              LIMIT @Limit OFFSET @Offset;
              """,
-            new { Limit = limit, Offset = offset })).ToList();
+            new { Limit = limit, Offset = offset },
+            cancellationToken: cancellationToken))).ToList();
 
         var items = rows
             .Select(r => new ClassRoomItem
@@ -137,10 +141,11 @@ public static class MaterializedViewEndpoints
         [FromQuery] Guid? studentId,
         [FromQuery] string? waitForSortableUniqueId,
         [FromServices] IMvOrleansQueryAccessor mvQueryAccessor,
-        [FromServices] ClassRoomEnrollmentMvV1 projector)
+        [FromServices] ClassRoomEnrollmentMvV1 projector,
+        CancellationToken cancellationToken)
     {
-        var context = await mvQueryAccessor.GetAsync(projector);
-        if (!await TryWaitForReceivedAsync(context, waitForSortableUniqueId))
+        var context = await mvQueryAccessor.GetAsync(projector, cancellationToken: cancellationToken);
+        if (!await TryWaitForReceivedAsync(context, waitForSortableUniqueId, cancellationToken: cancellationToken))
         {
             return Results.StatusCode(StatusCodes.Status504GatewayTimeout);
         }
@@ -148,7 +153,7 @@ public static class MaterializedViewEndpoints
         var enrollmentsTable = context.GetRequiredTable(ClassRoomEnrollmentMvV1.EnrollmentsLogicalTable);
 
         await using var connection = new NpgsqlConnection(context.ConnectionString);
-        await connection.OpenAsync();
+        await connection.OpenAsync(cancellationToken);
 
         var sql = $"SELECT student_id, class_room_id, enrolled_at, _last_sortable_unique_id FROM {enrollmentsTable.PhysicalTable}";
         var filters = new List<string>();
@@ -169,15 +174,19 @@ public static class MaterializedViewEndpoints
         }
         sql += " ORDER BY enrolled_at DESC;";
 
-        var rows = (await connection.QueryAsync<EnrollmentMvRow>(sql, parameters)).ToList();
+        var rows = (await connection.QueryAsync<EnrollmentMvRow>(new CommandDefinition(
+            sql,
+            parameters,
+            cancellationToken: cancellationToken))).ToList();
         return Results.Ok(rows);
     }
 
     private static async Task<IResult> GetStatusAsync(
         [FromServices] IMvOrleansQueryAccessor mvQueryAccessor,
-        [FromServices] ClassRoomEnrollmentMvV1 projector)
+        [FromServices] ClassRoomEnrollmentMvV1 projector,
+        CancellationToken cancellationToken)
     {
-        var context = await mvQueryAccessor.GetAsync(projector);
+        var context = await mvQueryAccessor.GetAsync(projector, cancellationToken: cancellationToken);
         var status = await context.Grain.GetStatusAsync();
         return Results.Ok(new
         {
@@ -190,7 +199,8 @@ public static class MaterializedViewEndpoints
     private static async Task<bool> TryWaitForReceivedAsync(
         MvOrleansQueryContext context,
         string? sortableUniqueId,
-        int timeoutMs = 10_000)
+        int timeoutMs = 10_000,
+        CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrWhiteSpace(sortableUniqueId))
         {
@@ -200,11 +210,12 @@ public static class MaterializedViewEndpoints
         var until = DateTime.UtcNow.AddMilliseconds(timeoutMs);
         while (DateTime.UtcNow < until)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             if (await context.Grain.IsSortableUniqueIdReceived(sortableUniqueId))
             {
                 return true;
             }
-            await Task.Delay(100);
+            await Task.Delay(100, cancellationToken);
         }
         return false;
     }

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.ApiService/Program.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.ApiService/Program.cs
@@ -189,17 +189,18 @@ else
     builder.Services.AddSingleton<IEventStore, PostgresEventStore>();
     builder.Services.AddSekibanDcbPostgresWithAspire();
     builder.Services.AddSingleton<IMultiProjectionStateStore, Sekiban.Dcb.Postgres.PostgresMultiProjectionStateStore>();
+}
 
-    // Wire materialized views to the dedicated Postgres database. This is only attempted when a
-    // connection string named "DcbMaterializedViewPostgres" is provided by the host.
-    if (!string.IsNullOrWhiteSpace(builder.Configuration.GetConnectionString("DcbMaterializedViewPostgres")))
-    {
-        builder.Services.AddSekibanDcbMaterializedViewPostgres(
-            builder.Configuration,
-            connectionStringName: "DcbMaterializedViewPostgres",
-            registerHostedWorker: false);
-        builder.Services.AddSekibanDcbMaterializedViewOrleans();
-    }
+// Wire materialized views to the dedicated Postgres database when the host supplies the
+// connection string. This is independent of the event-store backend — a host that runs the
+// event store on Cosmos or SQLite can still project into a Postgres-backed materialized view.
+if (!string.IsNullOrWhiteSpace(builder.Configuration.GetConnectionString("DcbMaterializedViewPostgres")))
+{
+    builder.Services.AddSekibanDcbMaterializedViewPostgres(
+        builder.Configuration,
+        connectionStringName: "DcbMaterializedViewPostgres",
+        registerHostedWorker: false);
+    builder.Services.AddSekibanDcbMaterializedViewOrleans();
 }
 
 builder.Services.AddTransient<IGrainStorageSerializer, NewtonsoftJsonDcbOrleansSerializer>();

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.ApiService/SekibanDcbDecider.ApiService.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.ApiService/SekibanDcbDecider.ApiService.csproj
@@ -44,14 +44,14 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Sekiban.Dcb.BlobStorage.AzureStorage" Version="10.1.17" />
-        <PackageReference Include="Sekiban.Dcb.Orleans.WithoutResult" Version="10.1.17" />
-        <PackageReference Include="Sekiban.Dcb.Postgres" Version="10.1.17" />
-        <PackageReference Include="Sekiban.Dcb.CosmosDb" Version="10.1.17" />
-        <PackageReference Include="Sekiban.Dcb.Sqlite" Version="10.1.17" />
-        <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.1.17" />
-        <PackageReference Include="Sekiban.Dcb.MaterializedView.Postgres" Version="10.1.17" />
-        <PackageReference Include="Sekiban.Dcb.MaterializedView.Orleans" Version="10.1.17" />
+        <PackageReference Include="Sekiban.Dcb.BlobStorage.AzureStorage" Version="10.1.18" />
+        <PackageReference Include="Sekiban.Dcb.Orleans.WithoutResult" Version="10.1.18" />
+        <PackageReference Include="Sekiban.Dcb.Postgres" Version="10.1.18" />
+        <PackageReference Include="Sekiban.Dcb.CosmosDb" Version="10.1.18" />
+        <PackageReference Include="Sekiban.Dcb.Sqlite" Version="10.1.18" />
+        <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.1.18" />
+        <PackageReference Include="Sekiban.Dcb.MaterializedView.Postgres" Version="10.1.18" />
+        <PackageReference Include="Sekiban.Dcb.MaterializedView.Orleans" Version="10.1.18" />
         <PackageReference Include="Dapper" Version="2.1.66" />
     </ItemGroup>
 </Project>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.Cli/SekibanDcbDecider.Cli.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.Cli/SekibanDcbDecider.Cli.csproj
@@ -14,10 +14,10 @@
         <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.3" />
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.3" />
         <PackageReference Include="System.CommandLine" Version="2.0.2" />
-        <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.1.8" />
-        <PackageReference Include="Sekiban.Dcb.Postgres" Version="10.1.8" />
-        <PackageReference Include="Sekiban.Dcb.CosmosDb" Version="10.1.8" />
-        <PackageReference Include="Sekiban.Dcb.Sqlite" Version="10.1.8" />
+        <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.1.18" />
+        <PackageReference Include="Sekiban.Dcb.Postgres" Version="10.1.18" />
+        <PackageReference Include="Sekiban.Dcb.CosmosDb" Version="10.1.18" />
+        <PackageReference Include="Sekiban.Dcb.Sqlite" Version="10.1.18" />
         <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />
     </ItemGroup>
 

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.EventSource/SekibanDcbDecider.EventSource.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.EventSource/SekibanDcbDecider.EventSource.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="ResultBoxes" Version="0.4.0" />
     <PackageReference Include="Microsoft.Orleans.Serialization" Version="10.0.1" />
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />
-    <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.1.17" />
-    <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.1.17" />
+    <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.1.18" />
+    <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.1.18" />
   </ItemGroup>
 </Project>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.ImmutableModels/SekibanDcbDecider.ImmutableModels.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.ImmutableModels/SekibanDcbDecider.ImmutableModels.csproj
@@ -10,6 +10,6 @@
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Sekiban.Dcb.Core.Model" Version="10.1.17" />
+    <PackageReference Include="Sekiban.Dcb.Core.Model" Version="10.1.18" />
   </ItemGroup>
 </Project>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.Interactions.Unit/SekibanDcbDecider.Interactions.Unit.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.Interactions.Unit/SekibanDcbDecider.Interactions.Unit.csproj
@@ -28,7 +28,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.1.8" />
+      <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.1.18" />
     </ItemGroup>
 
 </Project>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.Interactions/SekibanDcbDecider.Interactions.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.Interactions/SekibanDcbDecider.Interactions.csproj
@@ -11,6 +11,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />
-    <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.1.17" />
+    <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.1.18" />
   </ItemGroup>
 </Project>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.MeetingRoomModels/SekibanDcbDecider.MeetingRoomModels.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.MeetingRoomModels/SekibanDcbDecider.MeetingRoomModels.csproj
@@ -10,6 +10,6 @@
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Sekiban.Dcb.Core.Model" Version="10.1.17" />
+    <PackageReference Include="Sekiban.Dcb.Core.Model" Version="10.1.18" />
   </ItemGroup>
 </Project>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.Unit/SekibanDcbDecider.Unit.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.Unit/SekibanDcbDecider.Unit.csproj
@@ -15,7 +15,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.1.8" />
+    <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.1.18" />
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />
   </ItemGroup>
   <ItemGroup>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult.Aws/SekibanDcbOrleansAws.ApiService/Endpoints/MaterializedViewEndpoints.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult.Aws/SekibanDcbOrleansAws.ApiService/Endpoints/MaterializedViewEndpoints.cs
@@ -1,0 +1,217 @@
+using Dapper;
+using Dcb.Domain.WithoutResult.ClassRoom;
+using Dcb.Domain.WithoutResult.MaterializedViews;
+using Dcb.Domain.WithoutResult.Student;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Npgsql;
+using Sekiban.Dcb.MaterializedView.Orleans;
+
+namespace DcbOrleans.WithoutResult.ApiService.Endpoints;
+
+/// <summary>
+///     Read-side endpoints backed by the PostgreSQL materialized view.
+///     Mirrors the in-memory MultiProjection endpoints so the UI can switch between
+///     query modes without changing the rest of the request shape.
+/// </summary>
+public static class MaterializedViewEndpoints
+{
+    private const string OpenApiTag = "Materialized View";
+
+    public static void MapMaterializedViewEndpoints(this IEndpointRouteBuilder endpoints)
+    {
+        var students = endpoints.MapGroup("/mv/students").WithTags(OpenApiTag);
+        students.MapGet("/", GetStudentListAsync).WithName("GetStudentListMv");
+
+        var classrooms = endpoints.MapGroup("/mv/classrooms").WithTags(OpenApiTag);
+        classrooms.MapGet("/", GetClassRoomListAsync).WithName("GetClassRoomListMv");
+
+        var enrollments = endpoints.MapGroup("/mv/enrollments").WithTags(OpenApiTag);
+        enrollments.MapGet("/", GetEnrollmentListAsync).WithName("GetEnrollmentListMv");
+
+        var status = endpoints.MapGroup("/mv").WithTags(OpenApiTag);
+        status.MapGet("/status", GetStatusAsync).WithName("GetMaterializedViewStatus");
+    }
+
+    private static async Task<IResult> GetStudentListAsync(
+        [FromQuery] string? waitForSortableUniqueId,
+        [FromQuery] int? pageNumber,
+        [FromQuery] int? pageSize,
+        [FromServices] IMvOrleansQueryAccessor mvQueryAccessor,
+        [FromServices] ClassRoomEnrollmentMvV1 projector)
+    {
+        var context = await mvQueryAccessor.GetAsync(projector);
+        if (!await TryWaitForReceivedAsync(context, waitForSortableUniqueId))
+        {
+            return Results.StatusCode(StatusCodes.Status504GatewayTimeout);
+        }
+
+        var studentsTable = context.GetRequiredTable(ClassRoomEnrollmentMvV1.StudentsLogicalTable);
+        var enrollmentsTable = context.GetRequiredTable(ClassRoomEnrollmentMvV1.EnrollmentsLogicalTable);
+
+        await using var connection = new NpgsqlConnection(context.ConnectionString);
+        await connection.OpenAsync();
+
+        var (limit, offset) = ResolvePaging(pageNumber, pageSize);
+        var students = (await connection.QueryAsync<StudentMvRow>(
+            $"""
+             SELECT student_id, name, max_class_count, enrolled_count,
+                    _last_sortable_unique_id, _last_applied_at
+             FROM {studentsTable.PhysicalTable}
+             ORDER BY name
+             LIMIT @Limit OFFSET @Offset;
+             """,
+            new { Limit = limit, Offset = offset })).ToList();
+
+        var ids = students.Select(s => s.StudentId).ToArray();
+        var enrollmentMap = ids.Length == 0
+            ? new Dictionary<Guid, List<Guid>>()
+            : (await connection.QueryAsync<(Guid student_id, Guid class_room_id)>(
+                    $"""
+                     SELECT student_id, class_room_id
+                     FROM {enrollmentsTable.PhysicalTable}
+                     WHERE student_id = ANY(@Ids);
+                     """,
+                    new { Ids = ids }))
+                .GroupBy(row => row.student_id)
+                .ToDictionary(g => g.Key, g => g.Select(r => r.class_room_id).ToList());
+
+        var items = students
+            .Select(s => new StudentState(
+                s.StudentId,
+                s.Name,
+                s.MaxClassCount,
+                enrollmentMap.TryGetValue(s.StudentId, out var ec) ? ec : []))
+            .ToList();
+
+        return Results.Ok(items);
+    }
+
+    private static async Task<IResult> GetClassRoomListAsync(
+        [FromQuery] string? waitForSortableUniqueId,
+        [FromQuery] int? pageNumber,
+        [FromQuery] int? pageSize,
+        [FromServices] IMvOrleansQueryAccessor mvQueryAccessor,
+        [FromServices] ClassRoomEnrollmentMvV1 projector)
+    {
+        var context = await mvQueryAccessor.GetAsync(projector);
+        if (!await TryWaitForReceivedAsync(context, waitForSortableUniqueId))
+        {
+            return Results.StatusCode(StatusCodes.Status504GatewayTimeout);
+        }
+
+        var classRoomsTable = context.GetRequiredTable(ClassRoomEnrollmentMvV1.ClassRoomsLogicalTable);
+
+        await using var connection = new NpgsqlConnection(context.ConnectionString);
+        await connection.OpenAsync();
+
+        var (limit, offset) = ResolvePaging(pageNumber, pageSize);
+        var rows = (await connection.QueryAsync<ClassRoomMvRow>(
+            $"""
+             SELECT class_room_id, name, max_students, enrolled_count,
+                    _last_sortable_unique_id, _last_applied_at
+             FROM {classRoomsTable.PhysicalTable}
+             ORDER BY name
+             LIMIT @Limit OFFSET @Offset;
+             """,
+            new { Limit = limit, Offset = offset })).ToList();
+
+        var items = rows
+            .Select(r => new ClassRoomItem
+            {
+                ClassRoomId = r.ClassRoomId,
+                Name = r.Name,
+                MaxStudents = r.MaxStudents,
+                EnrolledCount = r.EnrolledCount,
+                IsFull = r.EnrolledCount >= r.MaxStudents,
+                RemainingCapacity = Math.Max(0, r.MaxStudents - r.EnrolledCount)
+            })
+            .ToList();
+
+        return Results.Ok(items);
+    }
+
+    private static async Task<IResult> GetEnrollmentListAsync(
+        [FromQuery] Guid? classRoomId,
+        [FromQuery] Guid? studentId,
+        [FromQuery] string? waitForSortableUniqueId,
+        [FromServices] IMvOrleansQueryAccessor mvQueryAccessor,
+        [FromServices] ClassRoomEnrollmentMvV1 projector)
+    {
+        var context = await mvQueryAccessor.GetAsync(projector);
+        if (!await TryWaitForReceivedAsync(context, waitForSortableUniqueId))
+        {
+            return Results.StatusCode(StatusCodes.Status504GatewayTimeout);
+        }
+
+        var enrollmentsTable = context.GetRequiredTable(ClassRoomEnrollmentMvV1.EnrollmentsLogicalTable);
+
+        await using var connection = new NpgsqlConnection(context.ConnectionString);
+        await connection.OpenAsync();
+
+        var sql = $"SELECT student_id, class_room_id, enrolled_at, _last_sortable_unique_id FROM {enrollmentsTable.PhysicalTable}";
+        var filters = new List<string>();
+        var parameters = new DynamicParameters();
+        if (classRoomId is { } cid)
+        {
+            filters.Add("class_room_id = @ClassRoomId");
+            parameters.Add("ClassRoomId", cid);
+        }
+        if (studentId is { } sid)
+        {
+            filters.Add("student_id = @StudentId");
+            parameters.Add("StudentId", sid);
+        }
+        if (filters.Count > 0)
+        {
+            sql += " WHERE " + string.Join(" AND ", filters);
+        }
+        sql += " ORDER BY enrolled_at DESC;";
+
+        var rows = (await connection.QueryAsync<EnrollmentMvRow>(sql, parameters)).ToList();
+        return Results.Ok(rows);
+    }
+
+    private static async Task<IResult> GetStatusAsync(
+        [FromServices] IMvOrleansQueryAccessor mvQueryAccessor,
+        [FromServices] ClassRoomEnrollmentMvV1 projector)
+    {
+        var context = await mvQueryAccessor.GetAsync(projector);
+        var status = await context.Grain.GetStatusAsync();
+        return Results.Ok(new
+        {
+            databaseType = context.DatabaseType,
+            entries = context.Entries,
+            status
+        });
+    }
+
+    private static async Task<bool> TryWaitForReceivedAsync(
+        MvOrleansQueryContext context,
+        string? sortableUniqueId,
+        int timeoutMs = 10_000)
+    {
+        if (string.IsNullOrWhiteSpace(sortableUniqueId))
+        {
+            return true;
+        }
+
+        var until = DateTime.UtcNow.AddMilliseconds(timeoutMs);
+        while (DateTime.UtcNow < until)
+        {
+            if (await context.Grain.IsSortableUniqueIdReceived(sortableUniqueId))
+            {
+                return true;
+            }
+            await Task.Delay(100);
+        }
+        return false;
+    }
+
+    private static (int Limit, int Offset) ResolvePaging(int? pageNumber, int? pageSize)
+    {
+        var size = pageSize is > 0 ? pageSize.Value : 20;
+        var page = pageNumber is > 0 ? pageNumber.Value : 1;
+        return (size, (page - 1) * size);
+    }
+}

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult.Aws/SekibanDcbOrleansAws.ApiService/Endpoints/MaterializedViewEndpoints.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult.Aws/SekibanDcbOrleansAws.ApiService/Endpoints/MaterializedViewEndpoints.cs
@@ -38,10 +38,11 @@ public static class MaterializedViewEndpoints
         [FromQuery] int? pageNumber,
         [FromQuery] int? pageSize,
         [FromServices] IMvOrleansQueryAccessor mvQueryAccessor,
-        [FromServices] ClassRoomEnrollmentMvV1 projector)
+        [FromServices] ClassRoomEnrollmentMvV1 projector,
+        CancellationToken cancellationToken)
     {
-        var context = await mvQueryAccessor.GetAsync(projector);
-        if (!await TryWaitForReceivedAsync(context, waitForSortableUniqueId))
+        var context = await mvQueryAccessor.GetAsync(projector, cancellationToken: cancellationToken);
+        if (!await TryWaitForReceivedAsync(context, waitForSortableUniqueId, cancellationToken: cancellationToken))
         {
             return Results.StatusCode(StatusCodes.Status504GatewayTimeout);
         }
@@ -50,10 +51,10 @@ public static class MaterializedViewEndpoints
         var enrollmentsTable = context.GetRequiredTable(ClassRoomEnrollmentMvV1.EnrollmentsLogicalTable);
 
         await using var connection = new NpgsqlConnection(context.ConnectionString);
-        await connection.OpenAsync();
+        await connection.OpenAsync(cancellationToken);
 
         var (limit, offset) = ResolvePaging(pageNumber, pageSize);
-        var students = (await connection.QueryAsync<StudentMvRow>(
+        var students = (await connection.QueryAsync<StudentMvRow>(new CommandDefinition(
             $"""
              SELECT student_id, name, max_class_count, enrolled_count,
                     _last_sortable_unique_id, _last_applied_at
@@ -61,18 +62,20 @@ public static class MaterializedViewEndpoints
              ORDER BY name
              LIMIT @Limit OFFSET @Offset;
              """,
-            new { Limit = limit, Offset = offset })).ToList();
+            new { Limit = limit, Offset = offset },
+            cancellationToken: cancellationToken))).ToList();
 
         var ids = students.Select(s => s.StudentId).ToArray();
         var enrollmentMap = ids.Length == 0
             ? new Dictionary<Guid, List<Guid>>()
-            : (await connection.QueryAsync<(Guid student_id, Guid class_room_id)>(
+            : (await connection.QueryAsync<(Guid student_id, Guid class_room_id)>(new CommandDefinition(
                     $"""
                      SELECT student_id, class_room_id
                      FROM {enrollmentsTable.PhysicalTable}
                      WHERE student_id = ANY(@Ids);
                      """,
-                    new { Ids = ids }))
+                    new { Ids = ids },
+                    cancellationToken: cancellationToken)))
                 .GroupBy(row => row.student_id)
                 .ToDictionary(g => g.Key, g => g.Select(r => r.class_room_id).ToList());
 
@@ -92,10 +95,11 @@ public static class MaterializedViewEndpoints
         [FromQuery] int? pageNumber,
         [FromQuery] int? pageSize,
         [FromServices] IMvOrleansQueryAccessor mvQueryAccessor,
-        [FromServices] ClassRoomEnrollmentMvV1 projector)
+        [FromServices] ClassRoomEnrollmentMvV1 projector,
+        CancellationToken cancellationToken)
     {
-        var context = await mvQueryAccessor.GetAsync(projector);
-        if (!await TryWaitForReceivedAsync(context, waitForSortableUniqueId))
+        var context = await mvQueryAccessor.GetAsync(projector, cancellationToken: cancellationToken);
+        if (!await TryWaitForReceivedAsync(context, waitForSortableUniqueId, cancellationToken: cancellationToken))
         {
             return Results.StatusCode(StatusCodes.Status504GatewayTimeout);
         }
@@ -103,10 +107,10 @@ public static class MaterializedViewEndpoints
         var classRoomsTable = context.GetRequiredTable(ClassRoomEnrollmentMvV1.ClassRoomsLogicalTable);
 
         await using var connection = new NpgsqlConnection(context.ConnectionString);
-        await connection.OpenAsync();
+        await connection.OpenAsync(cancellationToken);
 
         var (limit, offset) = ResolvePaging(pageNumber, pageSize);
-        var rows = (await connection.QueryAsync<ClassRoomMvRow>(
+        var rows = (await connection.QueryAsync<ClassRoomMvRow>(new CommandDefinition(
             $"""
              SELECT class_room_id, name, max_students, enrolled_count,
                     _last_sortable_unique_id, _last_applied_at
@@ -114,7 +118,8 @@ public static class MaterializedViewEndpoints
              ORDER BY name
              LIMIT @Limit OFFSET @Offset;
              """,
-            new { Limit = limit, Offset = offset })).ToList();
+            new { Limit = limit, Offset = offset },
+            cancellationToken: cancellationToken))).ToList();
 
         var items = rows
             .Select(r => new ClassRoomItem
@@ -136,10 +141,11 @@ public static class MaterializedViewEndpoints
         [FromQuery] Guid? studentId,
         [FromQuery] string? waitForSortableUniqueId,
         [FromServices] IMvOrleansQueryAccessor mvQueryAccessor,
-        [FromServices] ClassRoomEnrollmentMvV1 projector)
+        [FromServices] ClassRoomEnrollmentMvV1 projector,
+        CancellationToken cancellationToken)
     {
-        var context = await mvQueryAccessor.GetAsync(projector);
-        if (!await TryWaitForReceivedAsync(context, waitForSortableUniqueId))
+        var context = await mvQueryAccessor.GetAsync(projector, cancellationToken: cancellationToken);
+        if (!await TryWaitForReceivedAsync(context, waitForSortableUniqueId, cancellationToken: cancellationToken))
         {
             return Results.StatusCode(StatusCodes.Status504GatewayTimeout);
         }
@@ -147,7 +153,7 @@ public static class MaterializedViewEndpoints
         var enrollmentsTable = context.GetRequiredTable(ClassRoomEnrollmentMvV1.EnrollmentsLogicalTable);
 
         await using var connection = new NpgsqlConnection(context.ConnectionString);
-        await connection.OpenAsync();
+        await connection.OpenAsync(cancellationToken);
 
         var sql = $"SELECT student_id, class_room_id, enrolled_at, _last_sortable_unique_id FROM {enrollmentsTable.PhysicalTable}";
         var filters = new List<string>();
@@ -168,15 +174,19 @@ public static class MaterializedViewEndpoints
         }
         sql += " ORDER BY enrolled_at DESC;";
 
-        var rows = (await connection.QueryAsync<EnrollmentMvRow>(sql, parameters)).ToList();
+        var rows = (await connection.QueryAsync<EnrollmentMvRow>(new CommandDefinition(
+            sql,
+            parameters,
+            cancellationToken: cancellationToken))).ToList();
         return Results.Ok(rows);
     }
 
     private static async Task<IResult> GetStatusAsync(
         [FromServices] IMvOrleansQueryAccessor mvQueryAccessor,
-        [FromServices] ClassRoomEnrollmentMvV1 projector)
+        [FromServices] ClassRoomEnrollmentMvV1 projector,
+        CancellationToken cancellationToken)
     {
-        var context = await mvQueryAccessor.GetAsync(projector);
+        var context = await mvQueryAccessor.GetAsync(projector, cancellationToken: cancellationToken);
         var status = await context.Grain.GetStatusAsync();
         return Results.Ok(new
         {
@@ -189,7 +199,8 @@ public static class MaterializedViewEndpoints
     private static async Task<bool> TryWaitForReceivedAsync(
         MvOrleansQueryContext context,
         string? sortableUniqueId,
-        int timeoutMs = 10_000)
+        int timeoutMs = 10_000,
+        CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrWhiteSpace(sortableUniqueId))
         {
@@ -199,11 +210,12 @@ public static class MaterializedViewEndpoints
         var until = DateTime.UtcNow.AddMilliseconds(timeoutMs);
         while (DateTime.UtcNow < until)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             if (await context.Grain.IsSortableUniqueIdReceived(sortableUniqueId))
             {
                 return true;
             }
-            await Task.Delay(100);
+            await Task.Delay(100, cancellationToken);
         }
         return false;
     }

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult.Aws/SekibanDcbOrleansAws.ApiService/Program.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult.Aws/SekibanDcbOrleansAws.ApiService/Program.cs
@@ -18,8 +18,14 @@ using Sekiban.Dcb.Orleans.Grains;
 using Sekiban.Dcb.Orleans.Streams;
 using Sekiban.Dcb.Storage;
 using Sekiban.Dcb.ColdEvents;
+using Sekiban.Dcb.MaterializedView;
+using Sekiban.Dcb.MaterializedView.Orleans;
+using Sekiban.Dcb.MaterializedView.Postgres;
 using Sekiban.Dcb.Tags;
 using DcbOrleans.WithoutResult.ApiService;
+using DcbOrleans.WithoutResult.ApiService.Endpoints;
+using Dcb.Domain.WithoutResult.MaterializedViews;
+using Dapper;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -256,6 +262,28 @@ builder.Services.AddSingleton(domainTypes);
 // Register native runtime abstraction interfaces
 builder.Services.AddSekibanDcbNativeRuntime();
 builder.Services.AddSekibanDcbColdEventDefaults();
+
+// Register the materialized view runtime. The Postgres + Orleans pieces are wired only when a
+// `DcbMaterializedViewPostgres` connection string is supplied — the AWS template runs with
+// DynamoDB by default but can opt into a Postgres-backed read model.
+builder.Services.AddSekibanDcbMaterializedView(options =>
+{
+    options.BatchSize = 100;
+    options.PollInterval = TimeSpan.FromSeconds(1);
+});
+builder.Services.AddMaterializedView<ClassRoomEnrollmentMvV1>();
+
+if (!string.IsNullOrWhiteSpace(builder.Configuration.GetConnectionString("DcbMaterializedViewPostgres")))
+{
+    builder.Services.AddSekibanDcbMaterializedViewPostgres(
+        builder.Configuration,
+        connectionStringName: "DcbMaterializedViewPostgres",
+        registerHostedWorker: false);
+    builder.Services.AddSekibanDcbMaterializedViewOrleans();
+}
+
+// Map snake_case Postgres columns onto PascalCase row classes used by the materialized view endpoints.
+DefaultTypeMap.MatchNamesWithUnderscores = true;
 
 // Configure database storage based on configuration
 if (databaseType != "dynamodb")
@@ -867,6 +895,14 @@ apiRoute
         })
     .WithOpenApi()
     .WithName("TestOrleans");
+
+// Materialized view endpoints depend on the Orleans MV runtime, which is registered only when a
+// `DcbMaterializedViewPostgres` connection string is supplied. Skip the route when MV is off so
+// requests get a clean 404 rather than a DI resolution failure.
+if (app.Services.GetService<IMvOrleansQueryAccessor>() is not null)
+{
+    apiRoute.MapMaterializedViewEndpoints();
+}
 
 app.MapDefaultEndpoints();
 

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult.Aws/SekibanDcbOrleansAws.ApiService/SekibanDcbOrleansAws.ApiService.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult.Aws/SekibanDcbOrleansAws.ApiService/SekibanDcbOrleansAws.ApiService.csproj
@@ -27,13 +27,13 @@
         <!-- SQS streaming will be added when Orleans SQS package supports AWS SDK v4 -->
         <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.3" />
         <PackageReference Include="Scalar.AspNetCore" Version="2.12.50" />
-        <PackageReference Include="Sekiban.Dcb.Orleans.WithoutResult" Version="10.1.17" />
-        <PackageReference Include="Sekiban.Dcb.DynamoDB" Version="10.1.17" />
-        <PackageReference Include="Sekiban.Dcb.BlobStorage.S3" Version="10.1.17" />
-        <PackageReference Include="Sekiban.Dcb.Postgres" Version="10.1.17" />
-        <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.1.17" />
-        <PackageReference Include="Sekiban.Dcb.MaterializedView.Postgres" Version="10.1.17" />
-        <PackageReference Include="Sekiban.Dcb.MaterializedView.Orleans" Version="10.1.17" />
+        <PackageReference Include="Sekiban.Dcb.Orleans.WithoutResult" Version="10.1.18" />
+        <PackageReference Include="Sekiban.Dcb.DynamoDB" Version="10.1.18" />
+        <PackageReference Include="Sekiban.Dcb.BlobStorage.S3" Version="10.1.18" />
+        <PackageReference Include="Sekiban.Dcb.Postgres" Version="10.1.18" />
+        <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.1.18" />
+        <PackageReference Include="Sekiban.Dcb.MaterializedView.Postgres" Version="10.1.18" />
+        <PackageReference Include="Sekiban.Dcb.MaterializedView.Orleans" Version="10.1.18" />
         <PackageReference Include="Dapper" Version="2.1.66" />
         <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />
     </ItemGroup>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult.Aws/SekibanDcbOrleansAws.ApiService/SekibanDcbOrleansAws.ApiService.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult.Aws/SekibanDcbOrleansAws.ApiService/SekibanDcbOrleansAws.ApiService.csproj
@@ -22,14 +22,19 @@
         <PackageReference Include="Microsoft.Orleans.Clustering.AdoNet" Version="10.0.1" />
         <PackageReference Include="Microsoft.Orleans.Persistence.AdoNet" Version="10.0.1" />
         <PackageReference Include="Microsoft.Orleans.Reminders.AdoNet" Version="10.0.1" />
-        <PackageReference Include="Npgsql" Version="10.0.0" />
+        <PackageReference Include="Npgsql" Version="10.0.2" />
         <!-- Note: Microsoft.Orleans.Streaming.SQS conflicts with AWS SDK v4 used by DynamoDB -->
         <!-- SQS streaming will be added when Orleans SQS package supports AWS SDK v4 -->
         <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.3" />
         <PackageReference Include="Scalar.AspNetCore" Version="2.12.50" />
-        <PackageReference Include="Sekiban.Dcb.Orleans.WithoutResult" Version="10.1.8" />
-        <PackageReference Include="Sekiban.Dcb.DynamoDB" Version="10.1.8" />
-        <PackageReference Include="Sekiban.Dcb.BlobStorage.S3" Version="10.1.8" />
+        <PackageReference Include="Sekiban.Dcb.Orleans.WithoutResult" Version="10.1.17" />
+        <PackageReference Include="Sekiban.Dcb.DynamoDB" Version="10.1.17" />
+        <PackageReference Include="Sekiban.Dcb.BlobStorage.S3" Version="10.1.17" />
+        <PackageReference Include="Sekiban.Dcb.Postgres" Version="10.1.17" />
+        <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.1.17" />
+        <PackageReference Include="Sekiban.Dcb.MaterializedView.Postgres" Version="10.1.17" />
+        <PackageReference Include="Sekiban.Dcb.MaterializedView.Orleans" Version="10.1.17" />
+        <PackageReference Include="Dapper" Version="2.1.66" />
         <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />
     </ItemGroup>
 

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult.Aws/SekibanDcbOrleansAws.AppHost/Program.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult.Aws/SekibanDcbOrleansAws.AppHost/Program.cs
@@ -10,10 +10,19 @@ var localstack = builder
     .WithEnvironment("PERSISTENCE", "1")
     .WithEnvironment("AWS_DEFAULT_REGION", "us-east-1");
 
+// Materialized view database (kept separate from the DynamoDB event store so the read-side schema
+// can evolve independently). Optional — the ApiService only enables the MV runtime when the
+// connection string is wired through.
+var materializedViewPostgres = builder
+    .AddPostgres("dcbOrleansAwsPostgres")
+    .AddDatabase("DcbMaterializedViewPostgres");
+
 // Add the API Service with DynamoDB configuration
 var apiService = builder
     .AddProject<SekibanDcbOrleansAws_ApiService>("apiservice")
     .WaitFor(localstack)
+    .WaitFor(materializedViewPostgres)
+    .WithReference(materializedViewPostgres)
     .WithEnvironment("Sekiban__Database", "dynamodb")
     .WithEnvironment("Orleans__UseInMemoryStreams", "true")
     .WithEnvironment("AWS__Region", "us-east-1")

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult.Aws/SekibanDcbOrleansAws.Domain/MaterializedViews/ClassRoomEnrollmentMvV1.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult.Aws/SekibanDcbOrleansAws.Domain/MaterializedViews/ClassRoomEnrollmentMvV1.cs
@@ -1,0 +1,296 @@
+using Dcb.Domain.WithoutResult.ClassRoom;
+using Dcb.Domain.WithoutResult.Enrollment;
+using Dcb.Domain.WithoutResult.Student;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.MaterializedView;
+
+namespace Dcb.Domain.WithoutResult.MaterializedViews;
+
+/// <summary>
+///     Materialized view for classrooms, students and enrollments.
+///     Mirrors the in-memory MultiProjections but persisted into PostgreSQL tables.
+/// </summary>
+public sealed class ClassRoomEnrollmentMvV1 : IMaterializedViewProjector
+{
+    public const string ClassRoomsLogicalTable = "classrooms";
+    public const string StudentsLogicalTable = "students";
+    public const string EnrollmentsLogicalTable = "enrollments";
+
+    public string ViewName => "ClassRoomEnrollment";
+    public int ViewVersion => 1;
+
+    public MvTable ClassRooms { get; private set; } = default!;
+    public MvTable Students { get; private set; } = default!;
+    public MvTable Enrollments { get; private set; } = default!;
+
+    public async Task InitializeAsync(IMvInitContext ctx, CancellationToken cancellationToken = default)
+    {
+        ClassRooms = ctx.RegisterTable(ClassRoomsLogicalTable);
+        Students = ctx.RegisterTable(StudentsLogicalTable);
+        Enrollments = ctx.RegisterTable(EnrollmentsLogicalTable);
+
+        await ctx.ExecuteAsync(
+            $"""
+             CREATE TABLE IF NOT EXISTS {ClassRooms.PhysicalName} (
+                 class_room_id UUID PRIMARY KEY,
+                 name TEXT NOT NULL,
+                 max_students INT NOT NULL,
+                 enrolled_count INT NOT NULL DEFAULT 0,
+                 _last_sortable_unique_id TEXT NOT NULL,
+                 _last_applied_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+             );
+             """,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        await ctx.ExecuteAsync(
+            $"""
+             CREATE TABLE IF NOT EXISTS {Students.PhysicalName} (
+                 student_id UUID PRIMARY KEY,
+                 name TEXT NOT NULL,
+                 max_class_count INT NOT NULL,
+                 enrolled_count INT NOT NULL DEFAULT 0,
+                 _last_sortable_unique_id TEXT NOT NULL,
+                 _last_applied_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+             );
+             """,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        await ctx.ExecuteAsync(
+            $"""
+             CREATE TABLE IF NOT EXISTS {Enrollments.PhysicalName} (
+                 student_id UUID NOT NULL,
+                 class_room_id UUID NOT NULL,
+                 enrolled_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                 _last_sortable_unique_id TEXT NOT NULL,
+                 PRIMARY KEY (student_id, class_room_id)
+             );
+             """,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        await ctx.ExecuteAsync(
+            $"""
+             CREATE INDEX IF NOT EXISTS {BuildIndexName(Enrollments.PhysicalName, "class_room")}
+             ON {Enrollments.PhysicalName} (class_room_id);
+             """,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+    }
+
+    public Task<IReadOnlyList<MvSqlStatement>> ApplyToViewAsync(
+        Event ev,
+        IMvApplyContext ctx,
+        CancellationToken cancellationToken = default) =>
+        Task.FromResult<IReadOnlyList<MvSqlStatement>>(
+            ev.Payload switch
+            {
+                ClassRoomCreated created => [InsertClassRoom(created, ctx.CurrentSortableUniqueId)],
+                StudentCreated created => [InsertStudent(created, ctx.CurrentSortableUniqueId)],
+                StudentEnrolledInClassRoom enrolled => InsertEnrollment(enrolled, ctx.CurrentSortableUniqueId),
+                StudentDroppedFromClassRoom dropped => DeleteEnrollment(dropped, ctx.CurrentSortableUniqueId),
+                _ => []
+            });
+
+    private MvSqlStatement InsertClassRoom(ClassRoomCreated created, string sortableUniqueId) =>
+        new(
+            $"""
+             INSERT INTO {ClassRooms.PhysicalName}
+                 (class_room_id, name, max_students, enrolled_count, _last_sortable_unique_id, _last_applied_at)
+             VALUES
+                 (@ClassRoomId, @Name, @MaxStudents, 0, @SortableUniqueId, NOW())
+             ON CONFLICT (class_room_id) DO UPDATE SET
+                 name = EXCLUDED.name,
+                 max_students = EXCLUDED.max_students,
+                 _last_sortable_unique_id = EXCLUDED._last_sortable_unique_id,
+                 _last_applied_at = EXCLUDED._last_applied_at
+             WHERE {ClassRooms.PhysicalName}._last_sortable_unique_id < EXCLUDED._last_sortable_unique_id;
+             """,
+            new
+            {
+                created.ClassRoomId,
+                created.Name,
+                created.MaxStudents,
+                SortableUniqueId = sortableUniqueId
+            });
+
+    private MvSqlStatement InsertStudent(StudentCreated created, string sortableUniqueId) =>
+        new(
+            $"""
+             INSERT INTO {Students.PhysicalName}
+                 (student_id, name, max_class_count, enrolled_count, _last_sortable_unique_id, _last_applied_at)
+             VALUES
+                 (@StudentId, @Name, @MaxClassCount, 0, @SortableUniqueId, NOW())
+             ON CONFLICT (student_id) DO UPDATE SET
+                 name = EXCLUDED.name,
+                 max_class_count = EXCLUDED.max_class_count,
+                 _last_sortable_unique_id = EXCLUDED._last_sortable_unique_id,
+                 _last_applied_at = EXCLUDED._last_applied_at
+             WHERE {Students.PhysicalName}._last_sortable_unique_id < EXCLUDED._last_sortable_unique_id;
+             """,
+            new
+            {
+                created.StudentId,
+                created.Name,
+                created.MaxClassCount,
+                SortableUniqueId = sortableUniqueId
+            });
+
+    private IReadOnlyList<MvSqlStatement> InsertEnrollment(
+        StudentEnrolledInClassRoom enrolled,
+        string sortableUniqueId) =>
+    [
+        new(
+            $"""
+             INSERT INTO {Enrollments.PhysicalName}
+                 (student_id, class_room_id, enrolled_at, _last_sortable_unique_id)
+             VALUES
+                 (@StudentId, @ClassRoomId, NOW(), @SortableUniqueId)
+             ON CONFLICT (student_id, class_room_id) DO UPDATE SET
+                 _last_sortable_unique_id = EXCLUDED._last_sortable_unique_id
+             WHERE {Enrollments.PhysicalName}._last_sortable_unique_id < EXCLUDED._last_sortable_unique_id;
+             """,
+            new
+            {
+                enrolled.StudentId,
+                enrolled.ClassRoomId,
+                SortableUniqueId = sortableUniqueId
+            }),
+        RecountClassRoom(enrolled.ClassRoomId, sortableUniqueId),
+        RecountStudent(enrolled.StudentId, sortableUniqueId)
+    ];
+
+    private IReadOnlyList<MvSqlStatement> DeleteEnrollment(
+        StudentDroppedFromClassRoom dropped,
+        string sortableUniqueId) =>
+    [
+        new(
+            $"""
+             DELETE FROM {Enrollments.PhysicalName}
+             WHERE student_id = @StudentId
+               AND class_room_id = @ClassRoomId
+               AND _last_sortable_unique_id < @SortableUniqueId;
+             """,
+            new
+            {
+                dropped.StudentId,
+                dropped.ClassRoomId,
+                SortableUniqueId = sortableUniqueId
+            }),
+        RecountClassRoom(dropped.ClassRoomId, sortableUniqueId),
+        RecountStudent(dropped.StudentId, sortableUniqueId)
+    ];
+
+    private MvSqlStatement RecountClassRoom(Guid classRoomId, string sortableUniqueId) =>
+        new(
+            $"""
+             UPDATE {ClassRooms.PhysicalName}
+             SET enrolled_count = (
+                     SELECT COUNT(*) FROM {Enrollments.PhysicalName}
+                     WHERE class_room_id = @ClassRoomId
+                 ),
+                 _last_sortable_unique_id = @SortableUniqueId,
+                 _last_applied_at = NOW()
+             WHERE class_room_id = @ClassRoomId
+               AND _last_sortable_unique_id < @SortableUniqueId;
+             """,
+            new
+            {
+                ClassRoomId = classRoomId,
+                SortableUniqueId = sortableUniqueId
+            });
+
+    private MvSqlStatement RecountStudent(Guid studentId, string sortableUniqueId) =>
+        new(
+            $"""
+             UPDATE {Students.PhysicalName}
+             SET enrolled_count = (
+                     SELECT COUNT(*) FROM {Enrollments.PhysicalName}
+                     WHERE student_id = @StudentId
+                 ),
+                 _last_sortable_unique_id = @SortableUniqueId,
+                 _last_applied_at = NOW()
+             WHERE student_id = @StudentId
+               AND _last_sortable_unique_id < @SortableUniqueId;
+             """,
+            new
+            {
+                StudentId = studentId,
+                SortableUniqueId = sortableUniqueId
+            });
+
+    // PostgreSQL identifier length limit is 63 bytes. Build a name that fits even when the
+    // resolved physical table name is close to the limit.
+    private static string BuildIndexName(string physicalTable, string suffix)
+    {
+        const int maxLength = 63;
+        var prefix = "idx_";
+        var tail = "_" + suffix;
+        var available = maxLength - prefix.Length - tail.Length;
+
+        if (physicalTable.Length <= available)
+        {
+            return prefix + physicalTable + tail;
+        }
+
+        var hash = Convert.ToHexString(System.Security.Cryptography.SHA1.HashData(System.Text.Encoding.UTF8.GetBytes(physicalTable))).Substring(0, 8).ToLowerInvariant();
+        var headroom = available - 9;
+        if (headroom < 1) headroom = 1;
+        var head = physicalTable.Substring(0, Math.Min(headroom, physicalTable.Length));
+        return prefix + head + "_" + hash + tail;
+    }
+}
+
+public sealed class ClassRoomMvRow
+{
+    [MvColumn("class_room_id")]
+    public Guid ClassRoomId { get; set; }
+
+    [MvColumn("name")]
+    public string Name { get; set; } = string.Empty;
+
+    [MvColumn("max_students")]
+    public int MaxStudents { get; set; }
+
+    [MvColumn("enrolled_count")]
+    public int EnrolledCount { get; set; }
+
+    [MvColumn("_last_sortable_unique_id")]
+    public string LastSortableUniqueId { get; set; } = string.Empty;
+
+    [MvColumn("_last_applied_at")]
+    public DateTimeOffset LastAppliedAt { get; set; }
+}
+
+public sealed class StudentMvRow
+{
+    [MvColumn("student_id")]
+    public Guid StudentId { get; set; }
+
+    [MvColumn("name")]
+    public string Name { get; set; } = string.Empty;
+
+    [MvColumn("max_class_count")]
+    public int MaxClassCount { get; set; }
+
+    [MvColumn("enrolled_count")]
+    public int EnrolledCount { get; set; }
+
+    [MvColumn("_last_sortable_unique_id")]
+    public string LastSortableUniqueId { get; set; } = string.Empty;
+
+    [MvColumn("_last_applied_at")]
+    public DateTimeOffset LastAppliedAt { get; set; }
+}
+
+public sealed class EnrollmentMvRow
+{
+    [MvColumn("student_id")]
+    public Guid StudentId { get; set; }
+
+    [MvColumn("class_room_id")]
+    public Guid ClassRoomId { get; set; }
+
+    [MvColumn("enrolled_at")]
+    public DateTimeOffset EnrolledAt { get; set; }
+
+    [MvColumn("_last_sortable_unique_id")]
+    public string LastSortableUniqueId { get; set; } = string.Empty;
+}

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult.Aws/SekibanDcbOrleansAws.Domain/SekibanDcbOrleansAws.Domain.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult.Aws/SekibanDcbOrleansAws.Domain/SekibanDcbOrleansAws.Domain.csproj
@@ -7,8 +7,8 @@
     <IsPackable>true</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.1.17" />
-    <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.1.17" />
+    <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.1.18" />
+    <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.1.18" />
     <PackageReference Include="ResultBoxes" Version="0.4.0" />
     <PackageReference Include="Microsoft.Orleans.Serialization" Version="10.0.1" />
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult.Aws/SekibanDcbOrleansAws.Domain/SekibanDcbOrleansAws.Domain.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult.Aws/SekibanDcbOrleansAws.Domain/SekibanDcbOrleansAws.Domain.csproj
@@ -7,7 +7,8 @@
     <IsPackable>true</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.1.8" />
+    <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.1.17" />
+    <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.1.17" />
     <PackageReference Include="ResultBoxes" Version="0.4.0" />
     <PackageReference Include="Microsoft.Orleans.Serialization" Version="10.0.1" />
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult.Aws/SekibanDcbOrleansAws.Web/ClassRoomApiClient.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult.Aws/SekibanDcbOrleansAws.Web/ClassRoomApiClient.cs
@@ -21,6 +21,7 @@ public class ClassRoomApiClient(HttpClient httpClient)
         int? pageNumber = null,
         int? pageSize = null,
         string? waitForSortableUniqueId = null,
+        bool useMaterializedView = false,
         CancellationToken cancellationToken = default)
     {
         var queryParams = new List<string>();
@@ -34,9 +35,10 @@ public class ClassRoomApiClient(HttpClient httpClient)
         if (pageSize.HasValue)
             queryParams.Add($"pageSize={pageSize.Value}");
 
+        var basePath = useMaterializedView ? "/api/mv/classrooms" : "/api/classrooms";
         var requestUri = queryParams.Count > 0
-            ? $"/api/classrooms?{string.Join("&", queryParams)}"
-            : "/api/classrooms";
+            ? $"{basePath}?{string.Join("&", queryParams)}"
+            : basePath;
 
         var classrooms = await httpClient.GetFromJsonAsync<List<ClassRoomItem>>(requestUri, cancellationToken);
 

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult.Aws/SekibanDcbOrleansAws.Web/Components/Pages/Classrooms.razor
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult.Aws/SekibanDcbOrleansAws.Web/Components/Pages/Classrooms.razor
@@ -16,6 +16,16 @@
     <button class="btn btn-primary mb-3" @onclick="OpenAddClassroomModal">Add New Classroom</button>
 </div>
 
+<div class="mb-3">
+    <label class="me-2"><strong>Query source:</strong></label>
+    <div class="btn-group" role="group" aria-label="Query source">
+        <input type="radio" class="btn-check" name="query-source" id="qs-mem" autocomplete="off" checked="@(!useMaterializedView)" @onchange="() => OnQueryModeChanged(false)">
+        <label class="btn btn-outline-primary" for="qs-mem">Memory projection</label>
+        <input type="radio" class="btn-check" name="query-source" id="qs-mv" autocomplete="off" checked="@useMaterializedView" @onchange="() => OnQueryModeChanged(true)">
+        <label class="btn btn-outline-primary" for="qs-mv">Materialized view</label>
+    </div>
+</div>
+
 <h3>Classroom List</h3>
 
 <div class="row mb-3">
@@ -154,6 +164,14 @@
     private ClassroomModel classroomModel = new();
     private string errorMessage = string.Empty;
     private string? lastSortableUniqueId;
+    private bool useMaterializedView;
+
+    private async Task OnQueryModeChanged(bool useMv)
+    {
+        useMaterializedView = useMv;
+        currentPage = 1;
+        await LoadClassrooms(lastSortableUniqueId);
+    }
 
     // Pagination fields
     private int currentPage = 1;
@@ -177,7 +195,7 @@
     {
         try
         {
-            var result = await ClassRoomApiClient.GetClassRoomsAsync(currentPage, pageSize, waitForSortableUniqueId);
+            var result = await ClassRoomApiClient.GetClassRoomsAsync(currentPage, pageSize, waitForSortableUniqueId, useMaterializedView);
             classrooms = result?.ToList() ?? new List<ClassRoomItem>();
 
             // For now, estimate total pages based on if we got a full page

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult.Aws/SekibanDcbOrleansAws.Web/Components/Pages/Enrollments.razor
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult.Aws/SekibanDcbOrleansAws.Web/Components/Pages/Enrollments.razor
@@ -13,6 +13,16 @@
 
 <h1>Enrollment Management</h1>
 
+<div class="mb-3">
+    <label class="me-2"><strong>Query source:</strong></label>
+    <div class="btn-group" role="group" aria-label="Query source">
+        <input type="radio" class="btn-check" name="enroll-query-source" id="enroll-qs-mem" autocomplete="off" checked="@(!useMaterializedView)" @onchange="() => OnQueryModeChanged(false)">
+        <label class="btn btn-outline-primary" for="enroll-qs-mem">Memory projection</label>
+        <input type="radio" class="btn-check" name="enroll-query-source" id="enroll-qs-mv" autocomplete="off" checked="@useMaterializedView" @onchange="() => OnQueryModeChanged(true)">
+        <label class="btn btn-outline-primary" for="enroll-qs-mv">Materialized view</label>
+    </div>
+</div>
+
 <div class="row">
     <div class="col-md-6">
         <div class="card">
@@ -161,6 +171,16 @@
     private bool dropError;
 
     private string? lastSortableUniqueId;
+    private bool useMaterializedView;
+
+    private string StudentsBasePath => useMaterializedView ? "api/mv/students" : "api/students";
+    private string ClassroomsBasePath => useMaterializedView ? "api/mv/classrooms" : "api/classrooms";
+
+    private async Task OnQueryModeChanged(bool useMv)
+    {
+        useMaterializedView = useMv;
+        await LoadData(lastSortableUniqueId);
+    }
 
     public class StudentView
     {
@@ -212,8 +232,8 @@
         {
             var httpClient = HttpClientFactory.CreateClient("ApiService");
             var requestUri = !string.IsNullOrEmpty(waitForSortableUniqueId)
-                ? $"api/students?waitForSortableUniqueId={Uri.EscapeDataString(waitForSortableUniqueId)}"
-                : "api/students";
+                ? $"{StudentsBasePath}?waitForSortableUniqueId={Uri.EscapeDataString(waitForSortableUniqueId)}"
+                : StudentsBasePath;
             var response = await httpClient.GetFromJsonAsync<List<StudentState>>(requestUri);
             if (response != null)
             {
@@ -242,8 +262,8 @@
         {
             var httpClient = HttpClientFactory.CreateClient("ApiService");
             var requestUri = !string.IsNullOrEmpty(waitForSortableUniqueId)
-                ? $"api/classrooms?waitForSortableUniqueId={Uri.EscapeDataString(waitForSortableUniqueId)}"
-                : "api/classrooms";
+                ? $"{ClassroomsBasePath}?waitForSortableUniqueId={Uri.EscapeDataString(waitForSortableUniqueId)}"
+                : ClassroomsBasePath;
             var response = await httpClient.GetFromJsonAsync<List<ClassRoomItem>>(requestUri);
             if (response != null)
             {
@@ -278,11 +298,11 @@
             
             // Build query string with waitForSortableUniqueId if provided
             var studentsUri = !string.IsNullOrEmpty(waitForSortableUniqueId)
-                ? $"api/students?waitForSortableUniqueId={Uri.EscapeDataString(waitForSortableUniqueId)}"
-                : "api/students";
+                ? $"{StudentsBasePath}?waitForSortableUniqueId={Uri.EscapeDataString(waitForSortableUniqueId)}"
+                : StudentsBasePath;
             var classroomsUri = !string.IsNullOrEmpty(waitForSortableUniqueId)
-                ? $"api/classrooms?waitForSortableUniqueId={Uri.EscapeDataString(waitForSortableUniqueId)}"
-                : "api/classrooms";
+                ? $"{ClassroomsBasePath}?waitForSortableUniqueId={Uri.EscapeDataString(waitForSortableUniqueId)}"
+                : ClassroomsBasePath;
             
             // Get all students with their enrolled classrooms, waiting for the sortableUniqueId if provided
             var studentsResponse = await httpClient.GetFromJsonAsync<List<StudentState>>(studentsUri);

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult.Aws/SekibanDcbOrleansAws.Web/Components/Pages/Students.razor
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult.Aws/SekibanDcbOrleansAws.Web/Components/Pages/Students.razor
@@ -16,6 +16,16 @@
     <button class="btn btn-primary mb-3" @onclick="OpenAddStudentModal">Add New Student</button>
 </div>
 
+<div class="mb-3">
+    <label class="me-2"><strong>Query source:</strong></label>
+    <div class="btn-group" role="group" aria-label="Query source">
+        <input type="radio" class="btn-check" name="query-source" id="qs-mem" autocomplete="off" checked="@(!useMaterializedView)" @onchange="() => OnQueryModeChanged(false)">
+        <label class="btn btn-outline-primary" for="qs-mem">Memory projection</label>
+        <input type="radio" class="btn-check" name="query-source" id="qs-mv" autocomplete="off" checked="@useMaterializedView" @onchange="() => OnQueryModeChanged(true)">
+        <label class="btn btn-outline-primary" for="qs-mv">Materialized view</label>
+    </div>
+</div>
+
 <h3>Student List</h3>
 
 <div class="row mb-3">
@@ -147,6 +157,14 @@
     private List<StudentState>? students;
     private StudentModel studentModel = new();
     private string? lastSortableUniqueId;
+    private bool useMaterializedView;
+
+    private async Task OnQueryModeChanged(bool useMv)
+    {
+        useMaterializedView = useMv;
+        currentPage = 1;
+        await LoadStudents(lastSortableUniqueId);
+    }
 
     // Pagination fields
     private int currentPage = 1;
@@ -174,7 +192,7 @@
     {
         try
         {
-            var result = await StudentApiClient.GetStudentsAsync(currentPage, pageSize, waitForSortableUniqueId);
+            var result = await StudentApiClient.GetStudentsAsync(currentPage, pageSize, waitForSortableUniqueId, useMaterializedView);
 
             students = result?.ToList() ?? new List<StudentState>();
 

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult.Aws/SekibanDcbOrleansAws.Web/StudentApiClient.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult.Aws/SekibanDcbOrleansAws.Web/StudentApiClient.cs
@@ -21,6 +21,7 @@ public class StudentApiClient(HttpClient httpClient)
         int? pageNumber = null,
         int? pageSize = null,
         string? waitForSortableUniqueId = null,
+        bool useMaterializedView = false,
         CancellationToken cancellationToken = default)
     {
         var queryParams = new List<string>();
@@ -34,9 +35,10 @@ public class StudentApiClient(HttpClient httpClient)
         if (pageSize.HasValue)
             queryParams.Add($"pageSize={pageSize.Value}");
 
+        var basePath = useMaterializedView ? "/api/mv/students" : "/api/students";
         var requestUri = queryParams.Count > 0
-            ? $"/api/students?{string.Join("&", queryParams)}"
-            : "/api/students";
+            ? $"{basePath}?{string.Join("&", queryParams)}"
+            : basePath;
 
         var students = await httpClient.GetFromJsonAsync<List<StudentState>>(requestUri, cancellationToken);
 

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.ApiService/Endpoints/MaterializedViewEndpoints.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.ApiService/Endpoints/MaterializedViewEndpoints.cs
@@ -1,0 +1,217 @@
+using Dapper;
+using Dcb.Domain.WithoutResult.ClassRoom;
+using Dcb.Domain.WithoutResult.MaterializedViews;
+using Dcb.Domain.WithoutResult.Student;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Npgsql;
+using Sekiban.Dcb.MaterializedView.Orleans;
+
+namespace SekibanDcbOrleans.ApiService.Endpoints;
+
+/// <summary>
+///     Read-side endpoints backed by the PostgreSQL materialized view.
+///     Mirrors the in-memory MultiProjection endpoints so the UI can switch between
+///     query modes without changing the rest of the request shape.
+/// </summary>
+public static class MaterializedViewEndpoints
+{
+    private const string OpenApiTag = "Materialized View";
+
+    public static void MapMaterializedViewEndpoints(this IEndpointRouteBuilder endpoints)
+    {
+        var students = endpoints.MapGroup("/mv/students").WithTags(OpenApiTag);
+        students.MapGet("/", GetStudentListAsync).WithName("GetStudentListMv");
+
+        var classrooms = endpoints.MapGroup("/mv/classrooms").WithTags(OpenApiTag);
+        classrooms.MapGet("/", GetClassRoomListAsync).WithName("GetClassRoomListMv");
+
+        var enrollments = endpoints.MapGroup("/mv/enrollments").WithTags(OpenApiTag);
+        enrollments.MapGet("/", GetEnrollmentListAsync).WithName("GetEnrollmentListMv");
+
+        var status = endpoints.MapGroup("/mv").WithTags(OpenApiTag);
+        status.MapGet("/status", GetStatusAsync).WithName("GetMaterializedViewStatus");
+    }
+
+    private static async Task<IResult> GetStudentListAsync(
+        [FromQuery] string? waitForSortableUniqueId,
+        [FromQuery] int? pageNumber,
+        [FromQuery] int? pageSize,
+        [FromServices] IMvOrleansQueryAccessor mvQueryAccessor,
+        [FromServices] ClassRoomEnrollmentMvV1 projector)
+    {
+        var context = await mvQueryAccessor.GetAsync(projector);
+        if (!await TryWaitForReceivedAsync(context, waitForSortableUniqueId))
+        {
+            return Results.StatusCode(StatusCodes.Status504GatewayTimeout);
+        }
+
+        var studentsTable = context.GetRequiredTable(ClassRoomEnrollmentMvV1.StudentsLogicalTable);
+        var enrollmentsTable = context.GetRequiredTable(ClassRoomEnrollmentMvV1.EnrollmentsLogicalTable);
+
+        await using var connection = new NpgsqlConnection(context.ConnectionString);
+        await connection.OpenAsync();
+
+        var (limit, offset) = ResolvePaging(pageNumber, pageSize);
+        var students = (await connection.QueryAsync<StudentMvRow>(
+            $"""
+             SELECT student_id, name, max_class_count, enrolled_count,
+                    _last_sortable_unique_id, _last_applied_at
+             FROM {studentsTable.PhysicalTable}
+             ORDER BY name
+             LIMIT @Limit OFFSET @Offset;
+             """,
+            new { Limit = limit, Offset = offset })).ToList();
+
+        var ids = students.Select(s => s.StudentId).ToArray();
+        var enrollmentMap = ids.Length == 0
+            ? new Dictionary<Guid, List<Guid>>()
+            : (await connection.QueryAsync<(Guid student_id, Guid class_room_id)>(
+                    $"""
+                     SELECT student_id, class_room_id
+                     FROM {enrollmentsTable.PhysicalTable}
+                     WHERE student_id = ANY(@Ids);
+                     """,
+                    new { Ids = ids }))
+                .GroupBy(row => row.student_id)
+                .ToDictionary(g => g.Key, g => g.Select(r => r.class_room_id).ToList());
+
+        var items = students
+            .Select(s => new StudentState(
+                s.StudentId,
+                s.Name,
+                s.MaxClassCount,
+                enrollmentMap.TryGetValue(s.StudentId, out var ec) ? ec : []))
+            .ToList();
+
+        return Results.Ok(items);
+    }
+
+    private static async Task<IResult> GetClassRoomListAsync(
+        [FromQuery] string? waitForSortableUniqueId,
+        [FromQuery] int? pageNumber,
+        [FromQuery] int? pageSize,
+        [FromServices] IMvOrleansQueryAccessor mvQueryAccessor,
+        [FromServices] ClassRoomEnrollmentMvV1 projector)
+    {
+        var context = await mvQueryAccessor.GetAsync(projector);
+        if (!await TryWaitForReceivedAsync(context, waitForSortableUniqueId))
+        {
+            return Results.StatusCode(StatusCodes.Status504GatewayTimeout);
+        }
+
+        var classRoomsTable = context.GetRequiredTable(ClassRoomEnrollmentMvV1.ClassRoomsLogicalTable);
+
+        await using var connection = new NpgsqlConnection(context.ConnectionString);
+        await connection.OpenAsync();
+
+        var (limit, offset) = ResolvePaging(pageNumber, pageSize);
+        var rows = (await connection.QueryAsync<ClassRoomMvRow>(
+            $"""
+             SELECT class_room_id, name, max_students, enrolled_count,
+                    _last_sortable_unique_id, _last_applied_at
+             FROM {classRoomsTable.PhysicalTable}
+             ORDER BY name
+             LIMIT @Limit OFFSET @Offset;
+             """,
+            new { Limit = limit, Offset = offset })).ToList();
+
+        var items = rows
+            .Select(r => new ClassRoomItem
+            {
+                ClassRoomId = r.ClassRoomId,
+                Name = r.Name,
+                MaxStudents = r.MaxStudents,
+                EnrolledCount = r.EnrolledCount,
+                IsFull = r.EnrolledCount >= r.MaxStudents,
+                RemainingCapacity = Math.Max(0, r.MaxStudents - r.EnrolledCount)
+            })
+            .ToList();
+
+        return Results.Ok(items);
+    }
+
+    private static async Task<IResult> GetEnrollmentListAsync(
+        [FromQuery] Guid? classRoomId,
+        [FromQuery] Guid? studentId,
+        [FromQuery] string? waitForSortableUniqueId,
+        [FromServices] IMvOrleansQueryAccessor mvQueryAccessor,
+        [FromServices] ClassRoomEnrollmentMvV1 projector)
+    {
+        var context = await mvQueryAccessor.GetAsync(projector);
+        if (!await TryWaitForReceivedAsync(context, waitForSortableUniqueId))
+        {
+            return Results.StatusCode(StatusCodes.Status504GatewayTimeout);
+        }
+
+        var enrollmentsTable = context.GetRequiredTable(ClassRoomEnrollmentMvV1.EnrollmentsLogicalTable);
+
+        await using var connection = new NpgsqlConnection(context.ConnectionString);
+        await connection.OpenAsync();
+
+        var sql = $"SELECT student_id, class_room_id, enrolled_at, _last_sortable_unique_id FROM {enrollmentsTable.PhysicalTable}";
+        var filters = new List<string>();
+        var parameters = new DynamicParameters();
+        if (classRoomId is { } cid)
+        {
+            filters.Add("class_room_id = @ClassRoomId");
+            parameters.Add("ClassRoomId", cid);
+        }
+        if (studentId is { } sid)
+        {
+            filters.Add("student_id = @StudentId");
+            parameters.Add("StudentId", sid);
+        }
+        if (filters.Count > 0)
+        {
+            sql += " WHERE " + string.Join(" AND ", filters);
+        }
+        sql += " ORDER BY enrolled_at DESC;";
+
+        var rows = (await connection.QueryAsync<EnrollmentMvRow>(sql, parameters)).ToList();
+        return Results.Ok(rows);
+    }
+
+    private static async Task<IResult> GetStatusAsync(
+        [FromServices] IMvOrleansQueryAccessor mvQueryAccessor,
+        [FromServices] ClassRoomEnrollmentMvV1 projector)
+    {
+        var context = await mvQueryAccessor.GetAsync(projector);
+        var status = await context.Grain.GetStatusAsync();
+        return Results.Ok(new
+        {
+            databaseType = context.DatabaseType,
+            entries = context.Entries,
+            status
+        });
+    }
+
+    private static async Task<bool> TryWaitForReceivedAsync(
+        MvOrleansQueryContext context,
+        string? sortableUniqueId,
+        int timeoutMs = 10_000)
+    {
+        if (string.IsNullOrWhiteSpace(sortableUniqueId))
+        {
+            return true;
+        }
+
+        var until = DateTime.UtcNow.AddMilliseconds(timeoutMs);
+        while (DateTime.UtcNow < until)
+        {
+            if (await context.Grain.IsSortableUniqueIdReceived(sortableUniqueId))
+            {
+                return true;
+            }
+            await Task.Delay(100);
+        }
+        return false;
+    }
+
+    private static (int Limit, int Offset) ResolvePaging(int? pageNumber, int? pageSize)
+    {
+        var size = pageSize is > 0 ? pageSize.Value : 20;
+        var page = pageNumber is > 0 ? pageNumber.Value : 1;
+        return (size, (page - 1) * size);
+    }
+}

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.ApiService/Endpoints/MaterializedViewEndpoints.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.ApiService/Endpoints/MaterializedViewEndpoints.cs
@@ -38,10 +38,11 @@ public static class MaterializedViewEndpoints
         [FromQuery] int? pageNumber,
         [FromQuery] int? pageSize,
         [FromServices] IMvOrleansQueryAccessor mvQueryAccessor,
-        [FromServices] ClassRoomEnrollmentMvV1 projector)
+        [FromServices] ClassRoomEnrollmentMvV1 projector,
+        CancellationToken cancellationToken)
     {
-        var context = await mvQueryAccessor.GetAsync(projector);
-        if (!await TryWaitForReceivedAsync(context, waitForSortableUniqueId))
+        var context = await mvQueryAccessor.GetAsync(projector, cancellationToken: cancellationToken);
+        if (!await TryWaitForReceivedAsync(context, waitForSortableUniqueId, cancellationToken: cancellationToken))
         {
             return Results.StatusCode(StatusCodes.Status504GatewayTimeout);
         }
@@ -50,10 +51,10 @@ public static class MaterializedViewEndpoints
         var enrollmentsTable = context.GetRequiredTable(ClassRoomEnrollmentMvV1.EnrollmentsLogicalTable);
 
         await using var connection = new NpgsqlConnection(context.ConnectionString);
-        await connection.OpenAsync();
+        await connection.OpenAsync(cancellationToken);
 
         var (limit, offset) = ResolvePaging(pageNumber, pageSize);
-        var students = (await connection.QueryAsync<StudentMvRow>(
+        var students = (await connection.QueryAsync<StudentMvRow>(new CommandDefinition(
             $"""
              SELECT student_id, name, max_class_count, enrolled_count,
                     _last_sortable_unique_id, _last_applied_at
@@ -61,18 +62,20 @@ public static class MaterializedViewEndpoints
              ORDER BY name
              LIMIT @Limit OFFSET @Offset;
              """,
-            new { Limit = limit, Offset = offset })).ToList();
+            new { Limit = limit, Offset = offset },
+            cancellationToken: cancellationToken))).ToList();
 
         var ids = students.Select(s => s.StudentId).ToArray();
         var enrollmentMap = ids.Length == 0
             ? new Dictionary<Guid, List<Guid>>()
-            : (await connection.QueryAsync<(Guid student_id, Guid class_room_id)>(
+            : (await connection.QueryAsync<(Guid student_id, Guid class_room_id)>(new CommandDefinition(
                     $"""
                      SELECT student_id, class_room_id
                      FROM {enrollmentsTable.PhysicalTable}
                      WHERE student_id = ANY(@Ids);
                      """,
-                    new { Ids = ids }))
+                    new { Ids = ids },
+                    cancellationToken: cancellationToken)))
                 .GroupBy(row => row.student_id)
                 .ToDictionary(g => g.Key, g => g.Select(r => r.class_room_id).ToList());
 
@@ -92,10 +95,11 @@ public static class MaterializedViewEndpoints
         [FromQuery] int? pageNumber,
         [FromQuery] int? pageSize,
         [FromServices] IMvOrleansQueryAccessor mvQueryAccessor,
-        [FromServices] ClassRoomEnrollmentMvV1 projector)
+        [FromServices] ClassRoomEnrollmentMvV1 projector,
+        CancellationToken cancellationToken)
     {
-        var context = await mvQueryAccessor.GetAsync(projector);
-        if (!await TryWaitForReceivedAsync(context, waitForSortableUniqueId))
+        var context = await mvQueryAccessor.GetAsync(projector, cancellationToken: cancellationToken);
+        if (!await TryWaitForReceivedAsync(context, waitForSortableUniqueId, cancellationToken: cancellationToken))
         {
             return Results.StatusCode(StatusCodes.Status504GatewayTimeout);
         }
@@ -103,10 +107,10 @@ public static class MaterializedViewEndpoints
         var classRoomsTable = context.GetRequiredTable(ClassRoomEnrollmentMvV1.ClassRoomsLogicalTable);
 
         await using var connection = new NpgsqlConnection(context.ConnectionString);
-        await connection.OpenAsync();
+        await connection.OpenAsync(cancellationToken);
 
         var (limit, offset) = ResolvePaging(pageNumber, pageSize);
-        var rows = (await connection.QueryAsync<ClassRoomMvRow>(
+        var rows = (await connection.QueryAsync<ClassRoomMvRow>(new CommandDefinition(
             $"""
              SELECT class_room_id, name, max_students, enrolled_count,
                     _last_sortable_unique_id, _last_applied_at
@@ -114,7 +118,8 @@ public static class MaterializedViewEndpoints
              ORDER BY name
              LIMIT @Limit OFFSET @Offset;
              """,
-            new { Limit = limit, Offset = offset })).ToList();
+            new { Limit = limit, Offset = offset },
+            cancellationToken: cancellationToken))).ToList();
 
         var items = rows
             .Select(r => new ClassRoomItem
@@ -136,10 +141,11 @@ public static class MaterializedViewEndpoints
         [FromQuery] Guid? studentId,
         [FromQuery] string? waitForSortableUniqueId,
         [FromServices] IMvOrleansQueryAccessor mvQueryAccessor,
-        [FromServices] ClassRoomEnrollmentMvV1 projector)
+        [FromServices] ClassRoomEnrollmentMvV1 projector,
+        CancellationToken cancellationToken)
     {
-        var context = await mvQueryAccessor.GetAsync(projector);
-        if (!await TryWaitForReceivedAsync(context, waitForSortableUniqueId))
+        var context = await mvQueryAccessor.GetAsync(projector, cancellationToken: cancellationToken);
+        if (!await TryWaitForReceivedAsync(context, waitForSortableUniqueId, cancellationToken: cancellationToken))
         {
             return Results.StatusCode(StatusCodes.Status504GatewayTimeout);
         }
@@ -147,7 +153,7 @@ public static class MaterializedViewEndpoints
         var enrollmentsTable = context.GetRequiredTable(ClassRoomEnrollmentMvV1.EnrollmentsLogicalTable);
 
         await using var connection = new NpgsqlConnection(context.ConnectionString);
-        await connection.OpenAsync();
+        await connection.OpenAsync(cancellationToken);
 
         var sql = $"SELECT student_id, class_room_id, enrolled_at, _last_sortable_unique_id FROM {enrollmentsTable.PhysicalTable}";
         var filters = new List<string>();
@@ -168,15 +174,19 @@ public static class MaterializedViewEndpoints
         }
         sql += " ORDER BY enrolled_at DESC;";
 
-        var rows = (await connection.QueryAsync<EnrollmentMvRow>(sql, parameters)).ToList();
+        var rows = (await connection.QueryAsync<EnrollmentMvRow>(new CommandDefinition(
+            sql,
+            parameters,
+            cancellationToken: cancellationToken))).ToList();
         return Results.Ok(rows);
     }
 
     private static async Task<IResult> GetStatusAsync(
         [FromServices] IMvOrleansQueryAccessor mvQueryAccessor,
-        [FromServices] ClassRoomEnrollmentMvV1 projector)
+        [FromServices] ClassRoomEnrollmentMvV1 projector,
+        CancellationToken cancellationToken)
     {
-        var context = await mvQueryAccessor.GetAsync(projector);
+        var context = await mvQueryAccessor.GetAsync(projector, cancellationToken: cancellationToken);
         var status = await context.Grain.GetStatusAsync();
         return Results.Ok(new
         {
@@ -189,7 +199,8 @@ public static class MaterializedViewEndpoints
     private static async Task<bool> TryWaitForReceivedAsync(
         MvOrleansQueryContext context,
         string? sortableUniqueId,
-        int timeoutMs = 10_000)
+        int timeoutMs = 10_000,
+        CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrWhiteSpace(sortableUniqueId))
         {
@@ -199,11 +210,12 @@ public static class MaterializedViewEndpoints
         var until = DateTime.UtcNow.AddMilliseconds(timeoutMs);
         while (DateTime.UtcNow < until)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             if (await context.Grain.IsSortableUniqueIdReceived(sortableUniqueId))
             {
                 return true;
             }
-            await Task.Delay(100);
+            await Task.Delay(100, cancellationToken);
         }
         return false;
     }

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.ApiService/Program.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.ApiService/Program.cs
@@ -387,16 +387,18 @@ else
     builder.Services.AddSingleton<IEventStore, PostgresEventStore>();
     builder.Services.AddSekibanDcbPostgresWithAspire();
     builder.Services.AddSingleton<IMultiProjectionStateStore, Sekiban.Dcb.Postgres.PostgresMultiProjectionStateStore>();
+}
 
-    // Wire the materialized view to a dedicated Postgres database when supplied by the host.
-    if (!string.IsNullOrWhiteSpace(builder.Configuration.GetConnectionString("DcbMaterializedViewPostgres")))
-    {
-        builder.Services.AddSekibanDcbMaterializedViewPostgres(
-            builder.Configuration,
-            connectionStringName: "DcbMaterializedViewPostgres",
-            registerHostedWorker: false);
-        builder.Services.AddSekibanDcbMaterializedViewOrleans();
-    }
+// Wire the materialized view to a dedicated Postgres database when the host supplies the
+// connection string. This is independent of the event-store backend — a host that runs the
+// event store on Cosmos or SQLite can still project into a Postgres-backed materialized view.
+if (!string.IsNullOrWhiteSpace(builder.Configuration.GetConnectionString("DcbMaterializedViewPostgres")))
+{
+    builder.Services.AddSekibanDcbMaterializedViewPostgres(
+        builder.Configuration,
+        connectionStringName: "DcbMaterializedViewPostgres",
+        registerHostedWorker: false);
+    builder.Services.AddSekibanDcbMaterializedViewOrleans();
 }
 builder.Services.AddTransient<IGrainStorageSerializer, NewtonsoftJsonDcbOrleansSerializer>();
 builder.Services.AddTransient<NewtonsoftJsonDcbOrleansSerializer>();

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.ApiService/Program.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.ApiService/Program.cs
@@ -27,8 +27,14 @@ using Sekiban.Dcb.Tags;
 using Sekiban.Dcb.Snapshots;
 using Sekiban.Dcb.BlobStorage.AzureStorage;
 using Sekiban.Dcb.ColdEvents;
+using Sekiban.Dcb.MaterializedView;
+using Sekiban.Dcb.MaterializedView.Orleans;
+using Sekiban.Dcb.MaterializedView.Postgres;
 using Sekiban.Dcb.ServiceId;
+using SekibanDcbOrleans.ApiService.Endpoints;
 using SekibanDcbOrleans.ApiService.Health;
+using Dcb.Domain.WithoutResult.MaterializedViews;
+using Dapper;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -349,6 +355,18 @@ builder.Services.AddSingleton(domainTypes);
 builder.Services.AddSekibanDcbNativeRuntime();
 builder.Services.AddSekibanDcbColdEventDefaults();
 
+// Register the materialized view runtime. The Postgres + Orleans pieces are wired only when a
+// dedicated `DcbMaterializedViewPostgres` connection string is supplied (see below).
+builder.Services.AddSekibanDcbMaterializedView(options =>
+{
+    options.BatchSize = 100;
+    options.PollInterval = TimeSpan.FromSeconds(1);
+});
+builder.Services.AddMaterializedView<ClassRoomEnrollmentMvV1>();
+
+// Map snake_case Postgres columns onto PascalCase row classes used by the materialized view endpoints.
+DefaultTypeMap.MatchNamesWithUnderscores = true;
+
 // Configure database storage based on configuration
 string? configuredDatabasePath = null;
 if (databaseType == "cosmos")
@@ -369,6 +387,16 @@ else
     builder.Services.AddSingleton<IEventStore, PostgresEventStore>();
     builder.Services.AddSekibanDcbPostgresWithAspire();
     builder.Services.AddSingleton<IMultiProjectionStateStore, Sekiban.Dcb.Postgres.PostgresMultiProjectionStateStore>();
+
+    // Wire the materialized view to a dedicated Postgres database when supplied by the host.
+    if (!string.IsNullOrWhiteSpace(builder.Configuration.GetConnectionString("DcbMaterializedViewPostgres")))
+    {
+        builder.Services.AddSekibanDcbMaterializedViewPostgres(
+            builder.Configuration,
+            connectionStringName: "DcbMaterializedViewPostgres",
+            registerHostedWorker: false);
+        builder.Services.AddSekibanDcbMaterializedViewOrleans();
+    }
 }
 builder.Services.AddTransient<IGrainStorageSerializer, NewtonsoftJsonDcbOrleansSerializer>();
 builder.Services.AddTransient<NewtonsoftJsonDcbOrleansSerializer>();
@@ -958,6 +986,14 @@ apiRoute
                 });
         })
         .WithName("TestOrleans");
+
+// Materialized view endpoints depend on the Orleans MV runtime, which is registered only when a
+// `DcbMaterializedViewPostgres` connection string is supplied. Skip the route when MV is off so
+// requests get a clean 404 rather than a DI resolution failure.
+if (app.Services.GetService<IMvOrleansQueryAccessor>() is not null)
+{
+    apiRoute.MapMaterializedViewEndpoints();
+}
 
 app.MapDefaultEndpoints();
 

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.ApiService/SekibanDcbOrleans.ApiService.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.ApiService/SekibanDcbOrleans.ApiService.csproj
@@ -30,11 +30,15 @@
         <PackageReference Include="Microsoft.Orleans.Streaming" Version="10.0.1" />
         <PackageReference Include="Microsoft.Orleans.Streaming.AzureStorage" Version="10.0.1" />
         <PackageReference Include="Scalar.AspNetCore" Version="2.12.50" />
-        <PackageReference Include="Sekiban.Dcb.BlobStorage.AzureStorage" Version="10.1.8" />
-        <PackageReference Include="Sekiban.Dcb.Orleans.WithoutResult" Version="10.1.8" />
-        <PackageReference Include="Sekiban.Dcb.Postgres" Version="10.1.8" />
-        <PackageReference Include="Sekiban.Dcb.CosmosDb" Version="10.1.8" />
-        <PackageReference Include="Sekiban.Dcb.Sqlite" Version="10.1.8" />
+        <PackageReference Include="Sekiban.Dcb.BlobStorage.AzureStorage" Version="10.1.17" />
+        <PackageReference Include="Sekiban.Dcb.Orleans.WithoutResult" Version="10.1.17" />
+        <PackageReference Include="Sekiban.Dcb.Postgres" Version="10.1.17" />
+        <PackageReference Include="Sekiban.Dcb.CosmosDb" Version="10.1.17" />
+        <PackageReference Include="Sekiban.Dcb.Sqlite" Version="10.1.17" />
+        <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.1.17" />
+        <PackageReference Include="Sekiban.Dcb.MaterializedView.Postgres" Version="10.1.17" />
+        <PackageReference Include="Sekiban.Dcb.MaterializedView.Orleans" Version="10.1.17" />
+        <PackageReference Include="Dapper" Version="2.1.66" />
         <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />
     </ItemGroup>
 

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.ApiService/SekibanDcbOrleans.ApiService.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.ApiService/SekibanDcbOrleans.ApiService.csproj
@@ -30,14 +30,14 @@
         <PackageReference Include="Microsoft.Orleans.Streaming" Version="10.0.1" />
         <PackageReference Include="Microsoft.Orleans.Streaming.AzureStorage" Version="10.0.1" />
         <PackageReference Include="Scalar.AspNetCore" Version="2.12.50" />
-        <PackageReference Include="Sekiban.Dcb.BlobStorage.AzureStorage" Version="10.1.17" />
-        <PackageReference Include="Sekiban.Dcb.Orleans.WithoutResult" Version="10.1.17" />
-        <PackageReference Include="Sekiban.Dcb.Postgres" Version="10.1.17" />
-        <PackageReference Include="Sekiban.Dcb.CosmosDb" Version="10.1.17" />
-        <PackageReference Include="Sekiban.Dcb.Sqlite" Version="10.1.17" />
-        <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.1.17" />
-        <PackageReference Include="Sekiban.Dcb.MaterializedView.Postgres" Version="10.1.17" />
-        <PackageReference Include="Sekiban.Dcb.MaterializedView.Orleans" Version="10.1.17" />
+        <PackageReference Include="Sekiban.Dcb.BlobStorage.AzureStorage" Version="10.1.18" />
+        <PackageReference Include="Sekiban.Dcb.Orleans.WithoutResult" Version="10.1.18" />
+        <PackageReference Include="Sekiban.Dcb.Postgres" Version="10.1.18" />
+        <PackageReference Include="Sekiban.Dcb.CosmosDb" Version="10.1.18" />
+        <PackageReference Include="Sekiban.Dcb.Sqlite" Version="10.1.18" />
+        <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.1.18" />
+        <PackageReference Include="Sekiban.Dcb.MaterializedView.Postgres" Version="10.1.18" />
+        <PackageReference Include="Sekiban.Dcb.MaterializedView.Orleans" Version="10.1.18" />
         <PackageReference Include="Dapper" Version="2.1.66" />
         <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />
     </ItemGroup>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.AppHost/Program.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.AppHost/Program.cs
@@ -15,12 +15,16 @@ var queue = storage.AddQueues("DcbOrleansQueue");
 var multiProjectionOffload = storage.AddBlobs("MultiProjectionOffload");
 
 // Add PostgreSQL for event storage (optional - can use in-memory for development)
-var postgres = builder
+var postgresServer = builder
     .AddPostgres("dcbOrleansPostgres")
     .WithPgAdmin()
-    .WithDbGate()
-    // .WithDataVolume()
-    .AddDatabase("DcbPostgres");
+    .WithDbGate();
+// .WithDataVolume()
+var postgres = postgresServer.AddDatabase("DcbPostgres");
+
+// Materialized view database (kept separate from the event store so that the read-side schema can
+// evolve without touching the source-of-truth event log).
+var materializedViewPostgres = postgresServer.AddDatabase("DcbMaterializedViewPostgres");
 
 // Configure Orleans
 var orleans = builder
@@ -36,9 +40,11 @@ var orleans = builder
 var apiService = builder
     .AddProject<SekibanDcbOrleans_ApiService>("apiservice")
     .WithReference(postgres)
+    .WithReference(materializedViewPostgres)
     .WithReference(orleans)
     .WithReference(multiProjectionOffload)
-    .WaitFor(postgres);
+    .WaitFor(postgres)
+    .WaitFor(materializedViewPostgres);
 
 // Add the Web frontend
 builder

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.Cli/SekibanDcbOrleans.Cli.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.Cli/SekibanDcbOrleans.Cli.csproj
@@ -14,10 +14,10 @@
         <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.3" />
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.3" />
         <PackageReference Include="System.CommandLine" Version="2.0.2" />
-        <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.1.8" />
-        <PackageReference Include="Sekiban.Dcb.Postgres" Version="10.1.8" />
-        <PackageReference Include="Sekiban.Dcb.CosmosDb" Version="10.1.8" />
-        <PackageReference Include="Sekiban.Dcb.Sqlite" Version="10.1.8" />
+        <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.1.18" />
+        <PackageReference Include="Sekiban.Dcb.Postgres" Version="10.1.18" />
+        <PackageReference Include="Sekiban.Dcb.CosmosDb" Version="10.1.18" />
+        <PackageReference Include="Sekiban.Dcb.Sqlite" Version="10.1.18" />
         <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />
     </ItemGroup>
 

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.Domain/MaterializedViews/ClassRoomEnrollmentMvV1.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.Domain/MaterializedViews/ClassRoomEnrollmentMvV1.cs
@@ -1,0 +1,296 @@
+using Dcb.Domain.WithoutResult.ClassRoom;
+using Dcb.Domain.WithoutResult.Enrollment;
+using Dcb.Domain.WithoutResult.Student;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.MaterializedView;
+
+namespace Dcb.Domain.WithoutResult.MaterializedViews;
+
+/// <summary>
+///     Materialized view for classrooms, students and enrollments.
+///     Mirrors the in-memory MultiProjections but persisted into PostgreSQL tables.
+/// </summary>
+public sealed class ClassRoomEnrollmentMvV1 : IMaterializedViewProjector
+{
+    public const string ClassRoomsLogicalTable = "classrooms";
+    public const string StudentsLogicalTable = "students";
+    public const string EnrollmentsLogicalTable = "enrollments";
+
+    public string ViewName => "ClassRoomEnrollment";
+    public int ViewVersion => 1;
+
+    public MvTable ClassRooms { get; private set; } = default!;
+    public MvTable Students { get; private set; } = default!;
+    public MvTable Enrollments { get; private set; } = default!;
+
+    public async Task InitializeAsync(IMvInitContext ctx, CancellationToken cancellationToken = default)
+    {
+        ClassRooms = ctx.RegisterTable(ClassRoomsLogicalTable);
+        Students = ctx.RegisterTable(StudentsLogicalTable);
+        Enrollments = ctx.RegisterTable(EnrollmentsLogicalTable);
+
+        await ctx.ExecuteAsync(
+            $"""
+             CREATE TABLE IF NOT EXISTS {ClassRooms.PhysicalName} (
+                 class_room_id UUID PRIMARY KEY,
+                 name TEXT NOT NULL,
+                 max_students INT NOT NULL,
+                 enrolled_count INT NOT NULL DEFAULT 0,
+                 _last_sortable_unique_id TEXT NOT NULL,
+                 _last_applied_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+             );
+             """,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        await ctx.ExecuteAsync(
+            $"""
+             CREATE TABLE IF NOT EXISTS {Students.PhysicalName} (
+                 student_id UUID PRIMARY KEY,
+                 name TEXT NOT NULL,
+                 max_class_count INT NOT NULL,
+                 enrolled_count INT NOT NULL DEFAULT 0,
+                 _last_sortable_unique_id TEXT NOT NULL,
+                 _last_applied_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+             );
+             """,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        await ctx.ExecuteAsync(
+            $"""
+             CREATE TABLE IF NOT EXISTS {Enrollments.PhysicalName} (
+                 student_id UUID NOT NULL,
+                 class_room_id UUID NOT NULL,
+                 enrolled_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                 _last_sortable_unique_id TEXT NOT NULL,
+                 PRIMARY KEY (student_id, class_room_id)
+             );
+             """,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        await ctx.ExecuteAsync(
+            $"""
+             CREATE INDEX IF NOT EXISTS {BuildIndexName(Enrollments.PhysicalName, "class_room")}
+             ON {Enrollments.PhysicalName} (class_room_id);
+             """,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+    }
+
+    public Task<IReadOnlyList<MvSqlStatement>> ApplyToViewAsync(
+        Event ev,
+        IMvApplyContext ctx,
+        CancellationToken cancellationToken = default) =>
+        Task.FromResult<IReadOnlyList<MvSqlStatement>>(
+            ev.Payload switch
+            {
+                ClassRoomCreated created => [InsertClassRoom(created, ctx.CurrentSortableUniqueId)],
+                StudentCreated created => [InsertStudent(created, ctx.CurrentSortableUniqueId)],
+                StudentEnrolledInClassRoom enrolled => InsertEnrollment(enrolled, ctx.CurrentSortableUniqueId),
+                StudentDroppedFromClassRoom dropped => DeleteEnrollment(dropped, ctx.CurrentSortableUniqueId),
+                _ => []
+            });
+
+    private MvSqlStatement InsertClassRoom(ClassRoomCreated created, string sortableUniqueId) =>
+        new(
+            $"""
+             INSERT INTO {ClassRooms.PhysicalName}
+                 (class_room_id, name, max_students, enrolled_count, _last_sortable_unique_id, _last_applied_at)
+             VALUES
+                 (@ClassRoomId, @Name, @MaxStudents, 0, @SortableUniqueId, NOW())
+             ON CONFLICT (class_room_id) DO UPDATE SET
+                 name = EXCLUDED.name,
+                 max_students = EXCLUDED.max_students,
+                 _last_sortable_unique_id = EXCLUDED._last_sortable_unique_id,
+                 _last_applied_at = EXCLUDED._last_applied_at
+             WHERE {ClassRooms.PhysicalName}._last_sortable_unique_id < EXCLUDED._last_sortable_unique_id;
+             """,
+            new
+            {
+                created.ClassRoomId,
+                created.Name,
+                created.MaxStudents,
+                SortableUniqueId = sortableUniqueId
+            });
+
+    private MvSqlStatement InsertStudent(StudentCreated created, string sortableUniqueId) =>
+        new(
+            $"""
+             INSERT INTO {Students.PhysicalName}
+                 (student_id, name, max_class_count, enrolled_count, _last_sortable_unique_id, _last_applied_at)
+             VALUES
+                 (@StudentId, @Name, @MaxClassCount, 0, @SortableUniqueId, NOW())
+             ON CONFLICT (student_id) DO UPDATE SET
+                 name = EXCLUDED.name,
+                 max_class_count = EXCLUDED.max_class_count,
+                 _last_sortable_unique_id = EXCLUDED._last_sortable_unique_id,
+                 _last_applied_at = EXCLUDED._last_applied_at
+             WHERE {Students.PhysicalName}._last_sortable_unique_id < EXCLUDED._last_sortable_unique_id;
+             """,
+            new
+            {
+                created.StudentId,
+                created.Name,
+                created.MaxClassCount,
+                SortableUniqueId = sortableUniqueId
+            });
+
+    private IReadOnlyList<MvSqlStatement> InsertEnrollment(
+        StudentEnrolledInClassRoom enrolled,
+        string sortableUniqueId) =>
+    [
+        new(
+            $"""
+             INSERT INTO {Enrollments.PhysicalName}
+                 (student_id, class_room_id, enrolled_at, _last_sortable_unique_id)
+             VALUES
+                 (@StudentId, @ClassRoomId, NOW(), @SortableUniqueId)
+             ON CONFLICT (student_id, class_room_id) DO UPDATE SET
+                 _last_sortable_unique_id = EXCLUDED._last_sortable_unique_id
+             WHERE {Enrollments.PhysicalName}._last_sortable_unique_id < EXCLUDED._last_sortable_unique_id;
+             """,
+            new
+            {
+                enrolled.StudentId,
+                enrolled.ClassRoomId,
+                SortableUniqueId = sortableUniqueId
+            }),
+        RecountClassRoom(enrolled.ClassRoomId, sortableUniqueId),
+        RecountStudent(enrolled.StudentId, sortableUniqueId)
+    ];
+
+    private IReadOnlyList<MvSqlStatement> DeleteEnrollment(
+        StudentDroppedFromClassRoom dropped,
+        string sortableUniqueId) =>
+    [
+        new(
+            $"""
+             DELETE FROM {Enrollments.PhysicalName}
+             WHERE student_id = @StudentId
+               AND class_room_id = @ClassRoomId
+               AND _last_sortable_unique_id < @SortableUniqueId;
+             """,
+            new
+            {
+                dropped.StudentId,
+                dropped.ClassRoomId,
+                SortableUniqueId = sortableUniqueId
+            }),
+        RecountClassRoom(dropped.ClassRoomId, sortableUniqueId),
+        RecountStudent(dropped.StudentId, sortableUniqueId)
+    ];
+
+    private MvSqlStatement RecountClassRoom(Guid classRoomId, string sortableUniqueId) =>
+        new(
+            $"""
+             UPDATE {ClassRooms.PhysicalName}
+             SET enrolled_count = (
+                     SELECT COUNT(*) FROM {Enrollments.PhysicalName}
+                     WHERE class_room_id = @ClassRoomId
+                 ),
+                 _last_sortable_unique_id = @SortableUniqueId,
+                 _last_applied_at = NOW()
+             WHERE class_room_id = @ClassRoomId
+               AND _last_sortable_unique_id < @SortableUniqueId;
+             """,
+            new
+            {
+                ClassRoomId = classRoomId,
+                SortableUniqueId = sortableUniqueId
+            });
+
+    private MvSqlStatement RecountStudent(Guid studentId, string sortableUniqueId) =>
+        new(
+            $"""
+             UPDATE {Students.PhysicalName}
+             SET enrolled_count = (
+                     SELECT COUNT(*) FROM {Enrollments.PhysicalName}
+                     WHERE student_id = @StudentId
+                 ),
+                 _last_sortable_unique_id = @SortableUniqueId,
+                 _last_applied_at = NOW()
+             WHERE student_id = @StudentId
+               AND _last_sortable_unique_id < @SortableUniqueId;
+             """,
+            new
+            {
+                StudentId = studentId,
+                SortableUniqueId = sortableUniqueId
+            });
+
+    // PostgreSQL identifier length limit is 63 bytes. Build a name that fits even when the
+    // resolved physical table name is close to the limit.
+    private static string BuildIndexName(string physicalTable, string suffix)
+    {
+        const int maxLength = 63;
+        var prefix = "idx_";
+        var tail = "_" + suffix;
+        var available = maxLength - prefix.Length - tail.Length;
+
+        if (physicalTable.Length <= available)
+        {
+            return prefix + physicalTable + tail;
+        }
+
+        var hash = Convert.ToHexString(System.Security.Cryptography.SHA1.HashData(System.Text.Encoding.UTF8.GetBytes(physicalTable))).Substring(0, 8).ToLowerInvariant();
+        var headroom = available - 9;
+        if (headroom < 1) headroom = 1;
+        var head = physicalTable.Substring(0, Math.Min(headroom, physicalTable.Length));
+        return prefix + head + "_" + hash + tail;
+    }
+}
+
+public sealed class ClassRoomMvRow
+{
+    [MvColumn("class_room_id")]
+    public Guid ClassRoomId { get; set; }
+
+    [MvColumn("name")]
+    public string Name { get; set; } = string.Empty;
+
+    [MvColumn("max_students")]
+    public int MaxStudents { get; set; }
+
+    [MvColumn("enrolled_count")]
+    public int EnrolledCount { get; set; }
+
+    [MvColumn("_last_sortable_unique_id")]
+    public string LastSortableUniqueId { get; set; } = string.Empty;
+
+    [MvColumn("_last_applied_at")]
+    public DateTimeOffset LastAppliedAt { get; set; }
+}
+
+public sealed class StudentMvRow
+{
+    [MvColumn("student_id")]
+    public Guid StudentId { get; set; }
+
+    [MvColumn("name")]
+    public string Name { get; set; } = string.Empty;
+
+    [MvColumn("max_class_count")]
+    public int MaxClassCount { get; set; }
+
+    [MvColumn("enrolled_count")]
+    public int EnrolledCount { get; set; }
+
+    [MvColumn("_last_sortable_unique_id")]
+    public string LastSortableUniqueId { get; set; } = string.Empty;
+
+    [MvColumn("_last_applied_at")]
+    public DateTimeOffset LastAppliedAt { get; set; }
+}
+
+public sealed class EnrollmentMvRow
+{
+    [MvColumn("student_id")]
+    public Guid StudentId { get; set; }
+
+    [MvColumn("class_room_id")]
+    public Guid ClassRoomId { get; set; }
+
+    [MvColumn("enrolled_at")]
+    public DateTimeOffset EnrolledAt { get; set; }
+
+    [MvColumn("_last_sortable_unique_id")]
+    public string LastSortableUniqueId { get; set; } = string.Empty;
+}

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.Domain/SekibanDcbOrleans.Domain.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.Domain/SekibanDcbOrleans.Domain.csproj
@@ -7,8 +7,8 @@
     <IsPackable>true</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.1.17" />
-    <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.1.17" />
+    <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.1.18" />
+    <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.1.18" />
     <PackageReference Include="ResultBoxes" Version="0.4.0" />
     <PackageReference Include="Microsoft.Orleans.Serialization" Version="10.0.1" />
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.Domain/SekibanDcbOrleans.Domain.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.Domain/SekibanDcbOrleans.Domain.csproj
@@ -7,7 +7,8 @@
     <IsPackable>true</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.1.8" />
+    <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.1.17" />
+    <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.1.17" />
     <PackageReference Include="ResultBoxes" Version="0.4.0" />
     <PackageReference Include="Microsoft.Orleans.Serialization" Version="10.0.1" />
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.Web/ClassRoomApiClient.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.Web/ClassRoomApiClient.cs
@@ -21,6 +21,7 @@ public class ClassRoomApiClient(HttpClient httpClient)
         int? pageNumber = null,
         int? pageSize = null,
         string? waitForSortableUniqueId = null,
+        bool useMaterializedView = false,
         CancellationToken cancellationToken = default)
     {
         var queryParams = new List<string>();
@@ -34,9 +35,10 @@ public class ClassRoomApiClient(HttpClient httpClient)
         if (pageSize.HasValue)
             queryParams.Add($"pageSize={pageSize.Value}");
 
+        var basePath = useMaterializedView ? "/api/mv/classrooms" : "/api/classrooms";
         var requestUri = queryParams.Count > 0
-            ? $"/api/classrooms?{string.Join("&", queryParams)}"
-            : "/api/classrooms";
+            ? $"{basePath}?{string.Join("&", queryParams)}"
+            : basePath;
 
         var classrooms = await httpClient.GetFromJsonAsync<List<ClassRoomItem>>(requestUri, cancellationToken);
 

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.Web/Components/Pages/Classrooms.razor
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.Web/Components/Pages/Classrooms.razor
@@ -16,6 +16,16 @@
     <button class="btn btn-primary mb-3" @onclick="OpenAddClassroomModal">Add New Classroom</button>
 </div>
 
+<div class="mb-3">
+    <label class="me-2"><strong>Query source:</strong></label>
+    <div class="btn-group" role="group" aria-label="Query source">
+        <input type="radio" class="btn-check" name="query-source" id="qs-mem" autocomplete="off" checked="@(!useMaterializedView)" @onchange="() => OnQueryModeChanged(false)">
+        <label class="btn btn-outline-primary" for="qs-mem">Memory projection</label>
+        <input type="radio" class="btn-check" name="query-source" id="qs-mv" autocomplete="off" checked="@useMaterializedView" @onchange="() => OnQueryModeChanged(true)">
+        <label class="btn btn-outline-primary" for="qs-mv">Materialized view</label>
+    </div>
+</div>
+
 <h3>Classroom List</h3>
 
 <div class="row mb-3">
@@ -154,12 +164,20 @@
     private ClassroomModel classroomModel = new();
     private string errorMessage = string.Empty;
     private string? lastSortableUniqueId;
+    private bool useMaterializedView;
 
     // Pagination fields
     private int currentPage = 1;
     private int pageSize = 10;
     private int totalPages = 1;
     private int totalItems;
+
+    private async Task OnQueryModeChanged(bool useMv)
+    {
+        useMaterializedView = useMv;
+        currentPage = 1;
+        await LoadClassrooms(lastSortableUniqueId);
+    }
 
 
     public class ClassroomModel
@@ -177,7 +195,7 @@
     {
         try
         {
-            var result = await ClassRoomApiClient.GetClassRoomsAsync(currentPage, pageSize, waitForSortableUniqueId);
+            var result = await ClassRoomApiClient.GetClassRoomsAsync(currentPage, pageSize, waitForSortableUniqueId, useMaterializedView);
             classrooms = result?.ToList() ?? new List<ClassRoomItem>();
 
             // For now, estimate total pages based on if we got a full page

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.Web/Components/Pages/Enrollments.razor
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.Web/Components/Pages/Enrollments.razor
@@ -13,6 +13,16 @@
 
 <h1>Enrollment Management</h1>
 
+<div class="mb-3">
+    <label class="me-2"><strong>Query source:</strong></label>
+    <div class="btn-group" role="group" aria-label="Query source">
+        <input type="radio" class="btn-check" name="enroll-query-source" id="enroll-qs-mem" autocomplete="off" checked="@(!useMaterializedView)" @onchange="() => OnQueryModeChanged(false)">
+        <label class="btn btn-outline-primary" for="enroll-qs-mem">Memory projection</label>
+        <input type="radio" class="btn-check" name="enroll-query-source" id="enroll-qs-mv" autocomplete="off" checked="@useMaterializedView" @onchange="() => OnQueryModeChanged(true)">
+        <label class="btn btn-outline-primary" for="enroll-qs-mv">Materialized view</label>
+    </div>
+</div>
+
 <div class="row">
     <div class="col-md-6">
         <div class="card">
@@ -161,6 +171,7 @@
     private bool dropError;
 
     private string? lastSortableUniqueId;
+    private bool useMaterializedView;
 
     public class StudentView
     {
@@ -201,9 +212,18 @@
     private async Task LoadData(string? waitForSortableUniqueId = null)
     {
         await Task.WhenAll(
-            LoadStudents(waitForSortableUniqueId), 
-            LoadClassrooms(waitForSortableUniqueId), 
+            LoadStudents(waitForSortableUniqueId),
+            LoadClassrooms(waitForSortableUniqueId),
             LoadEnrollments(waitForSortableUniqueId));
+    }
+
+    private string StudentsBasePath => useMaterializedView ? "api/mv/students" : "api/students";
+    private string ClassroomsBasePath => useMaterializedView ? "api/mv/classrooms" : "api/classrooms";
+
+    private async Task OnQueryModeChanged(bool useMv)
+    {
+        useMaterializedView = useMv;
+        await LoadData(lastSortableUniqueId);
     }
 
     private async Task LoadStudents(string? waitForSortableUniqueId = null)
@@ -212,8 +232,8 @@
         {
             var httpClient = HttpClientFactory.CreateClient("ApiService");
             var requestUri = !string.IsNullOrEmpty(waitForSortableUniqueId)
-                ? $"api/students?waitForSortableUniqueId={Uri.EscapeDataString(waitForSortableUniqueId)}"
-                : "api/students";
+                ? $"{StudentsBasePath}?waitForSortableUniqueId={Uri.EscapeDataString(waitForSortableUniqueId)}"
+                : StudentsBasePath;
             var response = await httpClient.GetFromJsonAsync<List<StudentState>>(requestUri);
             if (response != null)
             {
@@ -242,8 +262,8 @@
         {
             var httpClient = HttpClientFactory.CreateClient("ApiService");
             var requestUri = !string.IsNullOrEmpty(waitForSortableUniqueId)
-                ? $"api/classrooms?waitForSortableUniqueId={Uri.EscapeDataString(waitForSortableUniqueId)}"
-                : "api/classrooms";
+                ? $"{ClassroomsBasePath}?waitForSortableUniqueId={Uri.EscapeDataString(waitForSortableUniqueId)}"
+                : ClassroomsBasePath;
             var response = await httpClient.GetFromJsonAsync<List<ClassRoomItem>>(requestUri);
             if (response != null)
             {
@@ -278,11 +298,11 @@
             
             // Build query string with waitForSortableUniqueId if provided
             var studentsUri = !string.IsNullOrEmpty(waitForSortableUniqueId)
-                ? $"api/students?waitForSortableUniqueId={Uri.EscapeDataString(waitForSortableUniqueId)}"
-                : "api/students";
+                ? $"{StudentsBasePath}?waitForSortableUniqueId={Uri.EscapeDataString(waitForSortableUniqueId)}"
+                : StudentsBasePath;
             var classroomsUri = !string.IsNullOrEmpty(waitForSortableUniqueId)
-                ? $"api/classrooms?waitForSortableUniqueId={Uri.EscapeDataString(waitForSortableUniqueId)}"
-                : "api/classrooms";
+                ? $"{ClassroomsBasePath}?waitForSortableUniqueId={Uri.EscapeDataString(waitForSortableUniqueId)}"
+                : ClassroomsBasePath;
             
             // Get all students with their enrolled classrooms, waiting for the sortableUniqueId if provided
             var studentsResponse = await httpClient.GetFromJsonAsync<List<StudentState>>(studentsUri);

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.Web/Components/Pages/Students.razor
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.Web/Components/Pages/Students.razor
@@ -16,6 +16,16 @@
     <button class="btn btn-primary mb-3" @onclick="OpenAddStudentModal">Add New Student</button>
 </div>
 
+<div class="mb-3">
+    <label class="me-2"><strong>Query source:</strong></label>
+    <div class="btn-group" role="group" aria-label="Query source">
+        <input type="radio" class="btn-check" name="query-source" id="qs-mem" autocomplete="off" checked="@(!useMaterializedView)" @onchange="() => OnQueryModeChanged(false)">
+        <label class="btn btn-outline-primary" for="qs-mem">Memory projection</label>
+        <input type="radio" class="btn-check" name="query-source" id="qs-mv" autocomplete="off" checked="@useMaterializedView" @onchange="() => OnQueryModeChanged(true)">
+        <label class="btn btn-outline-primary" for="qs-mv">Materialized view</label>
+    </div>
+</div>
+
 <h3>Student List</h3>
 
 <div class="row mb-3">
@@ -147,12 +157,20 @@
     private List<StudentState>? students;
     private StudentModel studentModel = new();
     private string? lastSortableUniqueId;
+    private bool useMaterializedView;
 
     // Pagination fields
     private int currentPage = 1;
     private int pageSize = 10;
     private int totalPages = 1;
     private int totalItems;
+
+    private async Task OnQueryModeChanged(bool useMv)
+    {
+        useMaterializedView = useMv;
+        currentPage = 1;
+        await LoadStudents(lastSortableUniqueId);
+    }
 
     public class StudentModel
     {
@@ -174,7 +192,7 @@
     {
         try
         {
-            var result = await StudentApiClient.GetStudentsAsync(currentPage, pageSize, waitForSortableUniqueId);
+            var result = await StudentApiClient.GetStudentsAsync(currentPage, pageSize, waitForSortableUniqueId, useMaterializedView);
 
             students = result?.ToList() ?? new List<StudentState>();
 

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.Web/StudentApiClient.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.Web/StudentApiClient.cs
@@ -21,6 +21,7 @@ public class StudentApiClient(HttpClient httpClient)
         int? pageNumber = null,
         int? pageSize = null,
         string? waitForSortableUniqueId = null,
+        bool useMaterializedView = false,
         CancellationToken cancellationToken = default)
     {
         var queryParams = new List<string>();
@@ -34,9 +35,10 @@ public class StudentApiClient(HttpClient httpClient)
         if (pageSize.HasValue)
             queryParams.Add($"pageSize={pageSize.Value}");
 
+        var basePath = useMaterializedView ? "/api/mv/students" : "/api/students";
         var requestUri = queryParams.Count > 0
-            ? $"/api/students?{string.Join("&", queryParams)}"
-            : "/api/students";
+            ? $"{basePath}?{string.Join("&", queryParams)}"
+            : basePath;
 
         var students = await httpClient.GetFromJsonAsync<List<StudentState>>(requestUri, cancellationToken);
 

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans/SekibanDcbOrleans.ApiService/Endpoints/MaterializedViewEndpoints.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans/SekibanDcbOrleans.ApiService/Endpoints/MaterializedViewEndpoints.cs
@@ -38,10 +38,11 @@ public static class MaterializedViewEndpoints
         [FromQuery] int? pageNumber,
         [FromQuery] int? pageSize,
         [FromServices] IMvOrleansQueryAccessor mvQueryAccessor,
-        [FromServices] ClassRoomEnrollmentMvV1 projector)
+        [FromServices] ClassRoomEnrollmentMvV1 projector,
+        CancellationToken cancellationToken)
     {
-        var context = await mvQueryAccessor.GetAsync(projector);
-        if (!await TryWaitForReceivedAsync(context, waitForSortableUniqueId))
+        var context = await mvQueryAccessor.GetAsync(projector, cancellationToken: cancellationToken);
+        if (!await TryWaitForReceivedAsync(context, waitForSortableUniqueId, cancellationToken: cancellationToken))
         {
             return Results.StatusCode(StatusCodes.Status504GatewayTimeout);
         }
@@ -50,10 +51,10 @@ public static class MaterializedViewEndpoints
         var enrollmentsTable = context.GetRequiredTable(ClassRoomEnrollmentMvV1.EnrollmentsLogicalTable);
 
         await using var connection = new NpgsqlConnection(context.ConnectionString);
-        await connection.OpenAsync();
+        await connection.OpenAsync(cancellationToken);
 
         var (limit, offset) = ResolvePaging(pageNumber, pageSize);
-        var students = (await connection.QueryAsync<StudentMvRow>(
+        var students = (await connection.QueryAsync<StudentMvRow>(new CommandDefinition(
             $"""
              SELECT student_id, name, max_class_count, enrolled_count,
                     _last_sortable_unique_id, _last_applied_at
@@ -61,18 +62,20 @@ public static class MaterializedViewEndpoints
              ORDER BY name
              LIMIT @Limit OFFSET @Offset;
              """,
-            new { Limit = limit, Offset = offset })).ToList();
+            new { Limit = limit, Offset = offset },
+            cancellationToken: cancellationToken))).ToList();
 
         var ids = students.Select(s => s.StudentId).ToArray();
         var enrollmentMap = ids.Length == 0
             ? new Dictionary<Guid, List<Guid>>()
-            : (await connection.QueryAsync<(Guid student_id, Guid class_room_id)>(
+            : (await connection.QueryAsync<(Guid student_id, Guid class_room_id)>(new CommandDefinition(
                     $"""
                      SELECT student_id, class_room_id
                      FROM {enrollmentsTable.PhysicalTable}
                      WHERE student_id = ANY(@Ids);
                      """,
-                    new { Ids = ids }))
+                    new { Ids = ids },
+                    cancellationToken: cancellationToken)))
                 .GroupBy(row => row.student_id)
                 .ToDictionary(g => g.Key, g => g.Select(r => r.class_room_id).ToList());
 
@@ -92,10 +95,11 @@ public static class MaterializedViewEndpoints
         [FromQuery] int? pageNumber,
         [FromQuery] int? pageSize,
         [FromServices] IMvOrleansQueryAccessor mvQueryAccessor,
-        [FromServices] ClassRoomEnrollmentMvV1 projector)
+        [FromServices] ClassRoomEnrollmentMvV1 projector,
+        CancellationToken cancellationToken)
     {
-        var context = await mvQueryAccessor.GetAsync(projector);
-        if (!await TryWaitForReceivedAsync(context, waitForSortableUniqueId))
+        var context = await mvQueryAccessor.GetAsync(projector, cancellationToken: cancellationToken);
+        if (!await TryWaitForReceivedAsync(context, waitForSortableUniqueId, cancellationToken: cancellationToken))
         {
             return Results.StatusCode(StatusCodes.Status504GatewayTimeout);
         }
@@ -103,10 +107,10 @@ public static class MaterializedViewEndpoints
         var classRoomsTable = context.GetRequiredTable(ClassRoomEnrollmentMvV1.ClassRoomsLogicalTable);
 
         await using var connection = new NpgsqlConnection(context.ConnectionString);
-        await connection.OpenAsync();
+        await connection.OpenAsync(cancellationToken);
 
         var (limit, offset) = ResolvePaging(pageNumber, pageSize);
-        var rows = (await connection.QueryAsync<ClassRoomMvRow>(
+        var rows = (await connection.QueryAsync<ClassRoomMvRow>(new CommandDefinition(
             $"""
              SELECT class_room_id, name, max_students, enrolled_count,
                     _last_sortable_unique_id, _last_applied_at
@@ -114,7 +118,8 @@ public static class MaterializedViewEndpoints
              ORDER BY name
              LIMIT @Limit OFFSET @Offset;
              """,
-            new { Limit = limit, Offset = offset })).ToList();
+            new { Limit = limit, Offset = offset },
+            cancellationToken: cancellationToken))).ToList();
 
         var items = rows
             .Select(r => new ClassRoomItem
@@ -136,10 +141,11 @@ public static class MaterializedViewEndpoints
         [FromQuery] Guid? studentId,
         [FromQuery] string? waitForSortableUniqueId,
         [FromServices] IMvOrleansQueryAccessor mvQueryAccessor,
-        [FromServices] ClassRoomEnrollmentMvV1 projector)
+        [FromServices] ClassRoomEnrollmentMvV1 projector,
+        CancellationToken cancellationToken)
     {
-        var context = await mvQueryAccessor.GetAsync(projector);
-        if (!await TryWaitForReceivedAsync(context, waitForSortableUniqueId))
+        var context = await mvQueryAccessor.GetAsync(projector, cancellationToken: cancellationToken);
+        if (!await TryWaitForReceivedAsync(context, waitForSortableUniqueId, cancellationToken: cancellationToken))
         {
             return Results.StatusCode(StatusCodes.Status504GatewayTimeout);
         }
@@ -147,7 +153,7 @@ public static class MaterializedViewEndpoints
         var enrollmentsTable = context.GetRequiredTable(ClassRoomEnrollmentMvV1.EnrollmentsLogicalTable);
 
         await using var connection = new NpgsqlConnection(context.ConnectionString);
-        await connection.OpenAsync();
+        await connection.OpenAsync(cancellationToken);
 
         var sql = $"SELECT student_id, class_room_id, enrolled_at, _last_sortable_unique_id FROM {enrollmentsTable.PhysicalTable}";
         var filters = new List<string>();
@@ -168,15 +174,19 @@ public static class MaterializedViewEndpoints
         }
         sql += " ORDER BY enrolled_at DESC;";
 
-        var rows = (await connection.QueryAsync<EnrollmentMvRow>(sql, parameters)).ToList();
+        var rows = (await connection.QueryAsync<EnrollmentMvRow>(new CommandDefinition(
+            sql,
+            parameters,
+            cancellationToken: cancellationToken))).ToList();
         return Results.Ok(rows);
     }
 
     private static async Task<IResult> GetStatusAsync(
         [FromServices] IMvOrleansQueryAccessor mvQueryAccessor,
-        [FromServices] ClassRoomEnrollmentMvV1 projector)
+        [FromServices] ClassRoomEnrollmentMvV1 projector,
+        CancellationToken cancellationToken)
     {
-        var context = await mvQueryAccessor.GetAsync(projector);
+        var context = await mvQueryAccessor.GetAsync(projector, cancellationToken: cancellationToken);
         var status = await context.Grain.GetStatusAsync();
         return Results.Ok(new
         {
@@ -189,7 +199,8 @@ public static class MaterializedViewEndpoints
     private static async Task<bool> TryWaitForReceivedAsync(
         MvOrleansQueryContext context,
         string? sortableUniqueId,
-        int timeoutMs = 10_000)
+        int timeoutMs = 10_000,
+        CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrWhiteSpace(sortableUniqueId))
         {
@@ -199,11 +210,12 @@ public static class MaterializedViewEndpoints
         var until = DateTime.UtcNow.AddMilliseconds(timeoutMs);
         while (DateTime.UtcNow < until)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             if (await context.Grain.IsSortableUniqueIdReceived(sortableUniqueId))
             {
                 return true;
             }
-            await Task.Delay(100);
+            await Task.Delay(100, cancellationToken);
         }
         return false;
     }

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans/SekibanDcbOrleans.ApiService/Endpoints/MaterializedViewEndpoints.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans/SekibanDcbOrleans.ApiService/Endpoints/MaterializedViewEndpoints.cs
@@ -1,0 +1,217 @@
+using Dapper;
+using Dcb.Domain.ClassRoom;
+using Dcb.Domain.MaterializedViews;
+using Dcb.Domain.Student;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Npgsql;
+using Sekiban.Dcb.MaterializedView.Orleans;
+
+namespace SekibanDcbOrleans.ApiService.Endpoints;
+
+/// <summary>
+///     Read-side endpoints backed by the PostgreSQL materialized view.
+///     Mirrors the in-memory MultiProjection endpoints so the UI can switch between
+///     query modes without changing the rest of the request shape.
+/// </summary>
+public static class MaterializedViewEndpoints
+{
+    private const string OpenApiTag = "Materialized View";
+
+    public static void MapMaterializedViewEndpoints(this IEndpointRouteBuilder endpoints)
+    {
+        var students = endpoints.MapGroup("/mv/students").WithTags(OpenApiTag);
+        students.MapGet("/", GetStudentListAsync).WithName("GetStudentListMv");
+
+        var classrooms = endpoints.MapGroup("/mv/classrooms").WithTags(OpenApiTag);
+        classrooms.MapGet("/", GetClassRoomListAsync).WithName("GetClassRoomListMv");
+
+        var enrollments = endpoints.MapGroup("/mv/enrollments").WithTags(OpenApiTag);
+        enrollments.MapGet("/", GetEnrollmentListAsync).WithName("GetEnrollmentListMv");
+
+        var status = endpoints.MapGroup("/mv").WithTags(OpenApiTag);
+        status.MapGet("/status", GetStatusAsync).WithName("GetMaterializedViewStatus");
+    }
+
+    private static async Task<IResult> GetStudentListAsync(
+        [FromQuery] string? waitForSortableUniqueId,
+        [FromQuery] int? pageNumber,
+        [FromQuery] int? pageSize,
+        [FromServices] IMvOrleansQueryAccessor mvQueryAccessor,
+        [FromServices] ClassRoomEnrollmentMvV1 projector)
+    {
+        var context = await mvQueryAccessor.GetAsync(projector);
+        if (!await TryWaitForReceivedAsync(context, waitForSortableUniqueId))
+        {
+            return Results.StatusCode(StatusCodes.Status504GatewayTimeout);
+        }
+
+        var studentsTable = context.GetRequiredTable(ClassRoomEnrollmentMvV1.StudentsLogicalTable);
+        var enrollmentsTable = context.GetRequiredTable(ClassRoomEnrollmentMvV1.EnrollmentsLogicalTable);
+
+        await using var connection = new NpgsqlConnection(context.ConnectionString);
+        await connection.OpenAsync();
+
+        var (limit, offset) = ResolvePaging(pageNumber, pageSize);
+        var students = (await connection.QueryAsync<StudentMvRow>(
+            $"""
+             SELECT student_id, name, max_class_count, enrolled_count,
+                    _last_sortable_unique_id, _last_applied_at
+             FROM {studentsTable.PhysicalTable}
+             ORDER BY name
+             LIMIT @Limit OFFSET @Offset;
+             """,
+            new { Limit = limit, Offset = offset })).ToList();
+
+        var ids = students.Select(s => s.StudentId).ToArray();
+        var enrollmentMap = ids.Length == 0
+            ? new Dictionary<Guid, List<Guid>>()
+            : (await connection.QueryAsync<(Guid student_id, Guid class_room_id)>(
+                    $"""
+                     SELECT student_id, class_room_id
+                     FROM {enrollmentsTable.PhysicalTable}
+                     WHERE student_id = ANY(@Ids);
+                     """,
+                    new { Ids = ids }))
+                .GroupBy(row => row.student_id)
+                .ToDictionary(g => g.Key, g => g.Select(r => r.class_room_id).ToList());
+
+        var items = students
+            .Select(s => new StudentState(
+                s.StudentId,
+                s.Name,
+                s.MaxClassCount,
+                enrollmentMap.TryGetValue(s.StudentId, out var ec) ? ec : []))
+            .ToList();
+
+        return Results.Ok(items);
+    }
+
+    private static async Task<IResult> GetClassRoomListAsync(
+        [FromQuery] string? waitForSortableUniqueId,
+        [FromQuery] int? pageNumber,
+        [FromQuery] int? pageSize,
+        [FromServices] IMvOrleansQueryAccessor mvQueryAccessor,
+        [FromServices] ClassRoomEnrollmentMvV1 projector)
+    {
+        var context = await mvQueryAccessor.GetAsync(projector);
+        if (!await TryWaitForReceivedAsync(context, waitForSortableUniqueId))
+        {
+            return Results.StatusCode(StatusCodes.Status504GatewayTimeout);
+        }
+
+        var classRoomsTable = context.GetRequiredTable(ClassRoomEnrollmentMvV1.ClassRoomsLogicalTable);
+
+        await using var connection = new NpgsqlConnection(context.ConnectionString);
+        await connection.OpenAsync();
+
+        var (limit, offset) = ResolvePaging(pageNumber, pageSize);
+        var rows = (await connection.QueryAsync<ClassRoomMvRow>(
+            $"""
+             SELECT class_room_id, name, max_students, enrolled_count,
+                    _last_sortable_unique_id, _last_applied_at
+             FROM {classRoomsTable.PhysicalTable}
+             ORDER BY name
+             LIMIT @Limit OFFSET @Offset;
+             """,
+            new { Limit = limit, Offset = offset })).ToList();
+
+        var items = rows
+            .Select(r => new ClassRoomItem
+            {
+                ClassRoomId = r.ClassRoomId,
+                Name = r.Name,
+                MaxStudents = r.MaxStudents,
+                EnrolledCount = r.EnrolledCount,
+                IsFull = r.EnrolledCount >= r.MaxStudents,
+                RemainingCapacity = Math.Max(0, r.MaxStudents - r.EnrolledCount)
+            })
+            .ToList();
+
+        return Results.Ok(items);
+    }
+
+    private static async Task<IResult> GetEnrollmentListAsync(
+        [FromQuery] Guid? classRoomId,
+        [FromQuery] Guid? studentId,
+        [FromQuery] string? waitForSortableUniqueId,
+        [FromServices] IMvOrleansQueryAccessor mvQueryAccessor,
+        [FromServices] ClassRoomEnrollmentMvV1 projector)
+    {
+        var context = await mvQueryAccessor.GetAsync(projector);
+        if (!await TryWaitForReceivedAsync(context, waitForSortableUniqueId))
+        {
+            return Results.StatusCode(StatusCodes.Status504GatewayTimeout);
+        }
+
+        var enrollmentsTable = context.GetRequiredTable(ClassRoomEnrollmentMvV1.EnrollmentsLogicalTable);
+
+        await using var connection = new NpgsqlConnection(context.ConnectionString);
+        await connection.OpenAsync();
+
+        var sql = $"SELECT student_id, class_room_id, enrolled_at, _last_sortable_unique_id FROM {enrollmentsTable.PhysicalTable}";
+        var filters = new List<string>();
+        var parameters = new DynamicParameters();
+        if (classRoomId is { } cid)
+        {
+            filters.Add("class_room_id = @ClassRoomId");
+            parameters.Add("ClassRoomId", cid);
+        }
+        if (studentId is { } sid)
+        {
+            filters.Add("student_id = @StudentId");
+            parameters.Add("StudentId", sid);
+        }
+        if (filters.Count > 0)
+        {
+            sql += " WHERE " + string.Join(" AND ", filters);
+        }
+        sql += " ORDER BY enrolled_at DESC;";
+
+        var rows = (await connection.QueryAsync<EnrollmentMvRow>(sql, parameters)).ToList();
+        return Results.Ok(rows);
+    }
+
+    private static async Task<IResult> GetStatusAsync(
+        [FromServices] IMvOrleansQueryAccessor mvQueryAccessor,
+        [FromServices] ClassRoomEnrollmentMvV1 projector)
+    {
+        var context = await mvQueryAccessor.GetAsync(projector);
+        var status = await context.Grain.GetStatusAsync();
+        return Results.Ok(new
+        {
+            databaseType = context.DatabaseType,
+            entries = context.Entries,
+            status
+        });
+    }
+
+    private static async Task<bool> TryWaitForReceivedAsync(
+        MvOrleansQueryContext context,
+        string? sortableUniqueId,
+        int timeoutMs = 10_000)
+    {
+        if (string.IsNullOrWhiteSpace(sortableUniqueId))
+        {
+            return true;
+        }
+
+        var until = DateTime.UtcNow.AddMilliseconds(timeoutMs);
+        while (DateTime.UtcNow < until)
+        {
+            if (await context.Grain.IsSortableUniqueIdReceived(sortableUniqueId))
+            {
+                return true;
+            }
+            await Task.Delay(100);
+        }
+        return false;
+    }
+
+    private static (int Limit, int Offset) ResolvePaging(int? pageNumber, int? pageSize)
+    {
+        var size = pageSize is > 0 ? pageSize.Value : 20;
+        var page = pageNumber is > 0 ? pageNumber.Value : 1;
+        return (size, (page - 1) * size);
+    }
+}

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans/SekibanDcbOrleans.ApiService/Program.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans/SekibanDcbOrleans.ApiService/Program.cs
@@ -19,6 +19,12 @@ using Sekiban.Dcb.Actors;
 using Sekiban.Dcb.BlobStorage.AzureStorage;
 using Sekiban.Dcb.ColdEvents;
 using Sekiban.Dcb.CosmosDb;
+using Sekiban.Dcb.MaterializedView;
+using Sekiban.Dcb.MaterializedView.Orleans;
+using Sekiban.Dcb.MaterializedView.Postgres;
+using Dcb.Domain.MaterializedViews;
+using SekibanDcbOrleans.ApiService.Endpoints;
+using Dapper;
 using Sekiban.Dcb.MultiProjections;
 using Sekiban.Dcb.Orleans;
 using Sekiban.Dcb.Orleans.Grains;
@@ -427,6 +433,18 @@ builder.Services.AddSingleton(domainTypes);
 builder.Services.AddSekibanDcbNativeRuntime();
 builder.Services.AddSekibanDcbColdEventDefaults();
 
+// Register the materialized view runtime. The Postgres + Orleans pieces are wired only when a
+// dedicated `DcbMaterializedViewPostgres` connection string is supplied (see below).
+builder.Services.AddSekibanDcbMaterializedView(options =>
+{
+    options.BatchSize = 100;
+    options.PollInterval = TimeSpan.FromSeconds(1);
+});
+builder.Services.AddMaterializedView<ClassRoomEnrollmentMvV1>();
+
+// Map snake_case Postgres columns onto PascalCase row classes used by the materialized view endpoints.
+DefaultTypeMap.MatchNamesWithUnderscores = true;
+
 // Configure database storage based on configuration
 string? configuredDatabasePath = null;
 if (databaseType == "cosmos")
@@ -448,6 +466,16 @@ else
     builder.Services.AddSingleton<IEventStore, PostgresEventStore>();
     builder.Services.AddSekibanDcbPostgresWithAspire();
     builder.Services.AddSingleton<IMultiProjectionStateStore, Sekiban.Dcb.Postgres.PostgresMultiProjectionStateStore>();
+
+    // Wire the materialized view to a dedicated Postgres database when supplied by the host.
+    if (!string.IsNullOrWhiteSpace(builder.Configuration.GetConnectionString("DcbMaterializedViewPostgres")))
+    {
+        builder.Services.AddSekibanDcbMaterializedViewPostgres(
+            builder.Configuration,
+            connectionStringName: "DcbMaterializedViewPostgres",
+            registerHostedWorker: false);
+        builder.Services.AddSekibanDcbMaterializedViewOrleans();
+    }
 }
 
 builder.Services.AddTransient<IGrainStorageSerializer, NewtonsoftJsonDcbOrleansSerializer>();
@@ -1124,5 +1152,14 @@ apiRoute
             }
         })
         .WithName("TestOrleans");
+
+// Materialized view endpoints depend on the Orleans MV runtime, which is registered only when a
+// `DcbMaterializedViewPostgres` connection string is supplied. Skip the route when MV is off so
+// requests get a clean 404 rather than a DI resolution failure.
+if (app.Services.GetService<IMvOrleansQueryAccessor>() is not null)
+{
+    apiRoute.MapMaterializedViewEndpoints();
+}
+
 app.MapDefaultEndpoints();
 app.Run();

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans/SekibanDcbOrleans.ApiService/Program.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans/SekibanDcbOrleans.ApiService/Program.cs
@@ -466,16 +466,18 @@ else
     builder.Services.AddSingleton<IEventStore, PostgresEventStore>();
     builder.Services.AddSekibanDcbPostgresWithAspire();
     builder.Services.AddSingleton<IMultiProjectionStateStore, Sekiban.Dcb.Postgres.PostgresMultiProjectionStateStore>();
+}
 
-    // Wire the materialized view to a dedicated Postgres database when supplied by the host.
-    if (!string.IsNullOrWhiteSpace(builder.Configuration.GetConnectionString("DcbMaterializedViewPostgres")))
-    {
-        builder.Services.AddSekibanDcbMaterializedViewPostgres(
-            builder.Configuration,
-            connectionStringName: "DcbMaterializedViewPostgres",
-            registerHostedWorker: false);
-        builder.Services.AddSekibanDcbMaterializedViewOrleans();
-    }
+// Wire the materialized view to a dedicated Postgres database when the host supplies the
+// connection string. This is independent of the event-store backend — a host that runs the
+// event store on Cosmos or SQLite can still project into a Postgres-backed materialized view.
+if (!string.IsNullOrWhiteSpace(builder.Configuration.GetConnectionString("DcbMaterializedViewPostgres")))
+{
+    builder.Services.AddSekibanDcbMaterializedViewPostgres(
+        builder.Configuration,
+        connectionStringName: "DcbMaterializedViewPostgres",
+        registerHostedWorker: false);
+    builder.Services.AddSekibanDcbMaterializedViewOrleans();
 }
 
 builder.Services.AddTransient<IGrainStorageSerializer, NewtonsoftJsonDcbOrleansSerializer>();

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans/SekibanDcbOrleans.ApiService/SekibanDcbOrleans.ApiService.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans/SekibanDcbOrleans.ApiService/SekibanDcbOrleans.ApiService.csproj
@@ -28,14 +28,14 @@
     <PackageReference Include="Microsoft.Orleans.Streaming.AzureStorage" Version="10.0.1" />
     <PackageReference Include="Microsoft.Orleans.Streaming.EventHubs" Version="10.0.1" />
     <PackageReference Include="Scalar.AspNetCore" Version="2.12.50" />
-    <PackageReference Include="Sekiban.Dcb.BlobStorage.AzureStorage" Version="10.1.17" />
-    <PackageReference Include="Sekiban.Dcb.Orleans.WithResult" Version="10.1.17" />
-    <PackageReference Include="Sekiban.Dcb.Postgres" Version="10.1.17" />
-    <PackageReference Include="Sekiban.Dcb.CosmosDb" Version="10.1.17" />
-    <PackageReference Include="Sekiban.Dcb.Sqlite" Version="10.1.17" />
-    <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.1.17" />
-    <PackageReference Include="Sekiban.Dcb.MaterializedView.Postgres" Version="10.1.17" />
-    <PackageReference Include="Sekiban.Dcb.MaterializedView.Orleans" Version="10.1.17" />
+    <PackageReference Include="Sekiban.Dcb.BlobStorage.AzureStorage" Version="10.1.18" />
+    <PackageReference Include="Sekiban.Dcb.Orleans.WithResult" Version="10.1.18" />
+    <PackageReference Include="Sekiban.Dcb.Postgres" Version="10.1.18" />
+    <PackageReference Include="Sekiban.Dcb.CosmosDb" Version="10.1.18" />
+    <PackageReference Include="Sekiban.Dcb.Sqlite" Version="10.1.18" />
+    <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.1.18" />
+    <PackageReference Include="Sekiban.Dcb.MaterializedView.Postgres" Version="10.1.18" />
+    <PackageReference Include="Sekiban.Dcb.MaterializedView.Orleans" Version="10.1.18" />
     <PackageReference Include="Dapper" Version="2.1.66" />
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />
   </ItemGroup>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans/SekibanDcbOrleans.ApiService/SekibanDcbOrleans.ApiService.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans/SekibanDcbOrleans.ApiService/SekibanDcbOrleans.ApiService.csproj
@@ -28,11 +28,15 @@
     <PackageReference Include="Microsoft.Orleans.Streaming.AzureStorage" Version="10.0.1" />
     <PackageReference Include="Microsoft.Orleans.Streaming.EventHubs" Version="10.0.1" />
     <PackageReference Include="Scalar.AspNetCore" Version="2.12.50" />
-    <PackageReference Include="Sekiban.Dcb.BlobStorage.AzureStorage" Version="10.1.8" />
-    <PackageReference Include="Sekiban.Dcb.Orleans.WithResult" Version="10.1.8" />
-    <PackageReference Include="Sekiban.Dcb.Postgres" Version="10.1.8" />
-    <PackageReference Include="Sekiban.Dcb.CosmosDb" Version="10.1.8" />
-    <PackageReference Include="Sekiban.Dcb.Sqlite" Version="10.1.8" />
+    <PackageReference Include="Sekiban.Dcb.BlobStorage.AzureStorage" Version="10.1.17" />
+    <PackageReference Include="Sekiban.Dcb.Orleans.WithResult" Version="10.1.17" />
+    <PackageReference Include="Sekiban.Dcb.Postgres" Version="10.1.17" />
+    <PackageReference Include="Sekiban.Dcb.CosmosDb" Version="10.1.17" />
+    <PackageReference Include="Sekiban.Dcb.Sqlite" Version="10.1.17" />
+    <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.1.17" />
+    <PackageReference Include="Sekiban.Dcb.MaterializedView.Postgres" Version="10.1.17" />
+    <PackageReference Include="Sekiban.Dcb.MaterializedView.Orleans" Version="10.1.17" />
+    <PackageReference Include="Dapper" Version="2.1.66" />
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />
   </ItemGroup>
 </Project>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans/SekibanDcbOrleans.AppHost/Program.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans/SekibanDcbOrleans.AppHost/Program.cs
@@ -15,12 +15,16 @@ var queue = storage.AddQueues("DcbOrleansQueue");
 var multiProjectionOffload = storage.AddBlobs("MultiProjectionOffload");
 
 // Add PostgreSQL for event storage (optional - can use in-memory for development)
-var postgres = builder
+var postgresServer = builder
     .AddPostgres("dcbOrleansPostgres")
     .WithPgAdmin()
-    .WithDbGate()
-    // .WithDataVolume()
-    .AddDatabase("DcbPostgres");
+    .WithDbGate();
+// .WithDataVolume()
+var postgres = postgresServer.AddDatabase("DcbPostgres");
+
+// Materialized view database (kept separate from the event store so that the read-side schema can
+// evolve without touching the source-of-truth event log).
+var materializedViewPostgres = postgresServer.AddDatabase("DcbMaterializedViewPostgres");
 
 // Configure Orleans
 var orleans = builder
@@ -36,9 +40,11 @@ var orleans = builder
 var apiService = builder
     .AddProject<SekibanDcbOrleans_ApiService>("apiservice")
     .WithReference(postgres)
+    .WithReference(materializedViewPostgres)
     .WithReference(orleans)
     .WithReference(multiProjectionOffload)
-    .WaitFor(postgres);
+    .WaitFor(postgres)
+    .WaitFor(materializedViewPostgres);
 
 // Add the Web frontend
 builder

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans/SekibanDcbOrleans.Cli/SekibanDcbOrleans.Cli.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans/SekibanDcbOrleans.Cli/SekibanDcbOrleans.Cli.csproj
@@ -14,10 +14,10 @@
         <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.3" />
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.3" />
         <PackageReference Include="System.CommandLine" Version="2.0.2" />
-        <PackageReference Include="Sekiban.Dcb.WithResult" Version="10.1.8" />
-        <PackageReference Include="Sekiban.Dcb.Postgres" Version="10.1.8" />
-        <PackageReference Include="Sekiban.Dcb.CosmosDb" Version="10.1.8" />
-        <PackageReference Include="Sekiban.Dcb.Sqlite" Version="10.1.8" />
+        <PackageReference Include="Sekiban.Dcb.WithResult" Version="10.1.18" />
+        <PackageReference Include="Sekiban.Dcb.Postgres" Version="10.1.18" />
+        <PackageReference Include="Sekiban.Dcb.CosmosDb" Version="10.1.18" />
+        <PackageReference Include="Sekiban.Dcb.Sqlite" Version="10.1.18" />
         <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />
     </ItemGroup>
 

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans/SekibanDcbOrleans.Domain/MaterializedViews/ClassRoomEnrollmentMvV1.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans/SekibanDcbOrleans.Domain/MaterializedViews/ClassRoomEnrollmentMvV1.cs
@@ -1,0 +1,294 @@
+using Dcb.Domain.ClassRoom;
+using Dcb.Domain.Enrollment;
+using Dcb.Domain.Student;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.MaterializedView;
+
+namespace Dcb.Domain.MaterializedViews;
+
+/// <summary>
+///     Materialized view for classrooms, students and enrollments.
+///     Mirrors the in-memory MultiProjections but persisted into PostgreSQL tables.
+/// </summary>
+public sealed class ClassRoomEnrollmentMvV1 : IMaterializedViewProjector
+{
+    public const string ClassRoomsLogicalTable = "classrooms";
+    public const string StudentsLogicalTable = "students";
+    public const string EnrollmentsLogicalTable = "enrollments";
+
+    public string ViewName => "ClassRoomEnrollment";
+    public int ViewVersion => 1;
+
+    public MvTable ClassRooms { get; private set; } = default!;
+    public MvTable Students { get; private set; } = default!;
+    public MvTable Enrollments { get; private set; } = default!;
+
+    public async Task InitializeAsync(IMvInitContext ctx, CancellationToken cancellationToken = default)
+    {
+        ClassRooms = ctx.RegisterTable(ClassRoomsLogicalTable);
+        Students = ctx.RegisterTable(StudentsLogicalTable);
+        Enrollments = ctx.RegisterTable(EnrollmentsLogicalTable);
+
+        await ctx.ExecuteAsync(
+            $"""
+             CREATE TABLE IF NOT EXISTS {ClassRooms.PhysicalName} (
+                 class_room_id UUID PRIMARY KEY,
+                 name TEXT NOT NULL,
+                 max_students INT NOT NULL,
+                 enrolled_count INT NOT NULL DEFAULT 0,
+                 _last_sortable_unique_id TEXT NOT NULL,
+                 _last_applied_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+             );
+             """,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        await ctx.ExecuteAsync(
+            $"""
+             CREATE TABLE IF NOT EXISTS {Students.PhysicalName} (
+                 student_id UUID PRIMARY KEY,
+                 name TEXT NOT NULL,
+                 max_class_count INT NOT NULL,
+                 enrolled_count INT NOT NULL DEFAULT 0,
+                 _last_sortable_unique_id TEXT NOT NULL,
+                 _last_applied_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+             );
+             """,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        await ctx.ExecuteAsync(
+            $"""
+             CREATE TABLE IF NOT EXISTS {Enrollments.PhysicalName} (
+                 student_id UUID NOT NULL,
+                 class_room_id UUID NOT NULL,
+                 enrolled_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                 _last_sortable_unique_id TEXT NOT NULL,
+                 PRIMARY KEY (student_id, class_room_id)
+             );
+             """,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        await ctx.ExecuteAsync(
+            $"""
+             CREATE INDEX IF NOT EXISTS {BuildIndexName(Enrollments.PhysicalName, "class_room")}
+             ON {Enrollments.PhysicalName} (class_room_id);
+             """,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+    }
+
+    public Task<IReadOnlyList<MvSqlStatement>> ApplyToViewAsync(
+        Event ev,
+        IMvApplyContext ctx,
+        CancellationToken cancellationToken = default) =>
+        Task.FromResult<IReadOnlyList<MvSqlStatement>>(
+            ev.Payload switch
+            {
+                ClassRoomCreated created => [InsertClassRoom(created, ctx.CurrentSortableUniqueId)],
+                StudentCreated created => [InsertStudent(created, ctx.CurrentSortableUniqueId)],
+                StudentEnrolledInClassRoom enrolled => InsertEnrollment(enrolled, ctx.CurrentSortableUniqueId),
+                StudentDroppedFromClassRoom dropped => DeleteEnrollment(dropped, ctx.CurrentSortableUniqueId),
+                _ => []
+            });
+
+    private MvSqlStatement InsertClassRoom(ClassRoomCreated created, string sortableUniqueId) =>
+        new(
+            $"""
+             INSERT INTO {ClassRooms.PhysicalName}
+                 (class_room_id, name, max_students, enrolled_count, _last_sortable_unique_id, _last_applied_at)
+             VALUES
+                 (@ClassRoomId, @Name, @MaxStudents, 0, @SortableUniqueId, NOW())
+             ON CONFLICT (class_room_id) DO UPDATE SET
+                 name = EXCLUDED.name,
+                 max_students = EXCLUDED.max_students,
+                 _last_sortable_unique_id = EXCLUDED._last_sortable_unique_id,
+                 _last_applied_at = EXCLUDED._last_applied_at
+             WHERE {ClassRooms.PhysicalName}._last_sortable_unique_id < EXCLUDED._last_sortable_unique_id;
+             """,
+            new
+            {
+                created.ClassRoomId,
+                created.Name,
+                created.MaxStudents,
+                SortableUniqueId = sortableUniqueId
+            });
+
+    private MvSqlStatement InsertStudent(StudentCreated created, string sortableUniqueId) =>
+        new(
+            $"""
+             INSERT INTO {Students.PhysicalName}
+                 (student_id, name, max_class_count, enrolled_count, _last_sortable_unique_id, _last_applied_at)
+             VALUES
+                 (@StudentId, @Name, @MaxClassCount, 0, @SortableUniqueId, NOW())
+             ON CONFLICT (student_id) DO UPDATE SET
+                 name = EXCLUDED.name,
+                 max_class_count = EXCLUDED.max_class_count,
+                 _last_sortable_unique_id = EXCLUDED._last_sortable_unique_id,
+                 _last_applied_at = EXCLUDED._last_applied_at
+             WHERE {Students.PhysicalName}._last_sortable_unique_id < EXCLUDED._last_sortable_unique_id;
+             """,
+            new
+            {
+                created.StudentId,
+                created.Name,
+                created.MaxClassCount,
+                SortableUniqueId = sortableUniqueId
+            });
+
+    private IReadOnlyList<MvSqlStatement> InsertEnrollment(
+        StudentEnrolledInClassRoom enrolled,
+        string sortableUniqueId) =>
+    [
+        new(
+            $"""
+             INSERT INTO {Enrollments.PhysicalName}
+                 (student_id, class_room_id, enrolled_at, _last_sortable_unique_id)
+             VALUES
+                 (@StudentId, @ClassRoomId, NOW(), @SortableUniqueId)
+             ON CONFLICT (student_id, class_room_id) DO UPDATE SET
+                 _last_sortable_unique_id = EXCLUDED._last_sortable_unique_id
+             WHERE {Enrollments.PhysicalName}._last_sortable_unique_id < EXCLUDED._last_sortable_unique_id;
+             """,
+            new
+            {
+                enrolled.StudentId,
+                enrolled.ClassRoomId,
+                SortableUniqueId = sortableUniqueId
+            }),
+        RecountClassRoom(enrolled.ClassRoomId, sortableUniqueId),
+        RecountStudent(enrolled.StudentId, sortableUniqueId)
+    ];
+
+    private IReadOnlyList<MvSqlStatement> DeleteEnrollment(
+        StudentDroppedFromClassRoom dropped,
+        string sortableUniqueId) =>
+    [
+        new(
+            $"""
+             DELETE FROM {Enrollments.PhysicalName}
+             WHERE student_id = @StudentId
+               AND class_room_id = @ClassRoomId
+               AND _last_sortable_unique_id < @SortableUniqueId;
+             """,
+            new
+            {
+                dropped.StudentId,
+                dropped.ClassRoomId,
+                SortableUniqueId = sortableUniqueId
+            }),
+        RecountClassRoom(dropped.ClassRoomId, sortableUniqueId),
+        RecountStudent(dropped.StudentId, sortableUniqueId)
+    ];
+
+    private MvSqlStatement RecountClassRoom(Guid classRoomId, string sortableUniqueId) =>
+        new(
+            $"""
+             UPDATE {ClassRooms.PhysicalName}
+             SET enrolled_count = (
+                     SELECT COUNT(*) FROM {Enrollments.PhysicalName}
+                     WHERE class_room_id = @ClassRoomId
+                 ),
+                 _last_sortable_unique_id = @SortableUniqueId,
+                 _last_applied_at = NOW()
+             WHERE class_room_id = @ClassRoomId
+               AND _last_sortable_unique_id < @SortableUniqueId;
+             """,
+            new
+            {
+                ClassRoomId = classRoomId,
+                SortableUniqueId = sortableUniqueId
+            });
+
+    private MvSqlStatement RecountStudent(Guid studentId, string sortableUniqueId) =>
+        new(
+            $"""
+             UPDATE {Students.PhysicalName}
+             SET enrolled_count = (
+                     SELECT COUNT(*) FROM {Enrollments.PhysicalName}
+                     WHERE student_id = @StudentId
+                 ),
+                 _last_sortable_unique_id = @SortableUniqueId,
+                 _last_applied_at = NOW()
+             WHERE student_id = @StudentId
+               AND _last_sortable_unique_id < @SortableUniqueId;
+             """,
+            new
+            {
+                StudentId = studentId,
+                SortableUniqueId = sortableUniqueId
+            });
+
+    private static string BuildIndexName(string physicalTable, string suffix)
+    {
+        const int maxLength = 63;
+        var prefix = "idx_";
+        var tail = "_" + suffix;
+        var available = maxLength - prefix.Length - tail.Length;
+
+        if (physicalTable.Length <= available)
+        {
+            return prefix + physicalTable + tail;
+        }
+
+        var hash = Convert.ToHexString(System.Security.Cryptography.SHA1.HashData(System.Text.Encoding.UTF8.GetBytes(physicalTable))).Substring(0, 8).ToLowerInvariant();
+        var headroom = available - 9;
+        if (headroom < 1) headroom = 1;
+        var head = physicalTable.Substring(0, Math.Min(headroom, physicalTable.Length));
+        return prefix + head + "_" + hash + tail;
+    }
+}
+
+public sealed class ClassRoomMvRow
+{
+    [MvColumn("class_room_id")]
+    public Guid ClassRoomId { get; set; }
+
+    [MvColumn("name")]
+    public string Name { get; set; } = string.Empty;
+
+    [MvColumn("max_students")]
+    public int MaxStudents { get; set; }
+
+    [MvColumn("enrolled_count")]
+    public int EnrolledCount { get; set; }
+
+    [MvColumn("_last_sortable_unique_id")]
+    public string LastSortableUniqueId { get; set; } = string.Empty;
+
+    [MvColumn("_last_applied_at")]
+    public DateTimeOffset LastAppliedAt { get; set; }
+}
+
+public sealed class StudentMvRow
+{
+    [MvColumn("student_id")]
+    public Guid StudentId { get; set; }
+
+    [MvColumn("name")]
+    public string Name { get; set; } = string.Empty;
+
+    [MvColumn("max_class_count")]
+    public int MaxClassCount { get; set; }
+
+    [MvColumn("enrolled_count")]
+    public int EnrolledCount { get; set; }
+
+    [MvColumn("_last_sortable_unique_id")]
+    public string LastSortableUniqueId { get; set; } = string.Empty;
+
+    [MvColumn("_last_applied_at")]
+    public DateTimeOffset LastAppliedAt { get; set; }
+}
+
+public sealed class EnrollmentMvRow
+{
+    [MvColumn("student_id")]
+    public Guid StudentId { get; set; }
+
+    [MvColumn("class_room_id")]
+    public Guid ClassRoomId { get; set; }
+
+    [MvColumn("enrolled_at")]
+    public DateTimeOffset EnrolledAt { get; set; }
+
+    [MvColumn("_last_sortable_unique_id")]
+    public string LastSortableUniqueId { get; set; } = string.Empty;
+}

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans/SekibanDcbOrleans.Domain/SekibanDcbOrleans.Domain.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans/SekibanDcbOrleans.Domain/SekibanDcbOrleans.Domain.csproj
@@ -7,7 +7,8 @@
     <IsPackable>true</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Sekiban.Dcb.WithResult" Version="10.1.8" />
+    <PackageReference Include="Sekiban.Dcb.WithResult" Version="10.1.17" />
+    <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.1.17" />
     <PackageReference Include="ResultBoxes" Version="0.4.0" />
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />
   </ItemGroup>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans/SekibanDcbOrleans.Domain/SekibanDcbOrleans.Domain.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans/SekibanDcbOrleans.Domain/SekibanDcbOrleans.Domain.csproj
@@ -7,8 +7,8 @@
     <IsPackable>true</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Sekiban.Dcb.WithResult" Version="10.1.17" />
-    <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.1.17" />
+    <PackageReference Include="Sekiban.Dcb.WithResult" Version="10.1.18" />
+    <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.1.18" />
     <PackageReference Include="ResultBoxes" Version="0.4.0" />
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />
   </ItemGroup>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans/SekibanDcbOrleans.Web/ClassRoomApiClient.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans/SekibanDcbOrleans.Web/ClassRoomApiClient.cs
@@ -21,6 +21,7 @@ public class ClassRoomApiClient(HttpClient httpClient)
         int? pageNumber = null,
         int? pageSize = null,
         string? waitForSortableUniqueId = null,
+        bool useMaterializedView = false,
         CancellationToken cancellationToken = default)
     {
         var queryParams = new List<string>();
@@ -34,9 +35,10 @@ public class ClassRoomApiClient(HttpClient httpClient)
         if (pageSize.HasValue)
             queryParams.Add($"pageSize={pageSize.Value}");
 
+        var basePath = useMaterializedView ? "/api/mv/classrooms" : "/api/classrooms";
         var requestUri = queryParams.Count > 0
-            ? $"/api/classrooms?{string.Join("&", queryParams)}"
-            : "/api/classrooms";
+            ? $"{basePath}?{string.Join("&", queryParams)}"
+            : basePath;
 
         var classrooms = await httpClient.GetFromJsonAsync<List<ClassRoomItem>>(requestUri, cancellationToken);
 

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans/SekibanDcbOrleans.Web/Components/Pages/Classrooms.razor
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans/SekibanDcbOrleans.Web/Components/Pages/Classrooms.razor
@@ -16,6 +16,16 @@
     <button class="btn btn-primary mb-3" @onclick="OpenAddClassroomModal">Add New Classroom</button>
 </div>
 
+<div class="mb-3">
+    <label class="me-2"><strong>Query source:</strong></label>
+    <div class="btn-group" role="group" aria-label="Query source">
+        <input type="radio" class="btn-check" name="query-source" id="qs-mem" autocomplete="off" checked="@(!useMaterializedView)" @onchange="() => OnQueryModeChanged(false)">
+        <label class="btn btn-outline-primary" for="qs-mem">Memory projection</label>
+        <input type="radio" class="btn-check" name="query-source" id="qs-mv" autocomplete="off" checked="@useMaterializedView" @onchange="() => OnQueryModeChanged(true)">
+        <label class="btn btn-outline-primary" for="qs-mv">Materialized view</label>
+    </div>
+</div>
+
 <h3>Classroom List</h3>
 
 <div class="row mb-3">
@@ -154,12 +164,20 @@
     private ClassroomModel classroomModel = new();
     private string errorMessage = string.Empty;
     private string? lastSortableUniqueId;
+    private bool useMaterializedView;
 
     // Pagination fields
     private int currentPage = 1;
     private int pageSize = 10;
     private int totalPages = 1;
     private int totalItems;
+
+    private async Task OnQueryModeChanged(bool useMv)
+    {
+        useMaterializedView = useMv;
+        currentPage = 1;
+        await LoadClassrooms(lastSortableUniqueId);
+    }
 
 
     public class ClassroomModel
@@ -177,7 +195,7 @@
     {
         try
         {
-            var result = await ClassRoomApiClient.GetClassRoomsAsync(currentPage, pageSize, waitForSortableUniqueId);
+            var result = await ClassRoomApiClient.GetClassRoomsAsync(currentPage, pageSize, waitForSortableUniqueId, useMaterializedView);
             classrooms = result?.ToList() ?? new List<ClassRoomItem>();
 
             // For now, estimate total pages based on if we got a full page

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans/SekibanDcbOrleans.Web/Components/Pages/Enrollments.razor
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans/SekibanDcbOrleans.Web/Components/Pages/Enrollments.razor
@@ -13,6 +13,16 @@
 
 <h1>Enrollment Management</h1>
 
+<div class="mb-3">
+    <label class="me-2"><strong>Query source:</strong></label>
+    <div class="btn-group" role="group" aria-label="Query source">
+        <input type="radio" class="btn-check" name="enroll-query-source" id="enroll-qs-mem" autocomplete="off" checked="@(!useMaterializedView)" @onchange="() => OnQueryModeChanged(false)">
+        <label class="btn btn-outline-primary" for="enroll-qs-mem">Memory projection</label>
+        <input type="radio" class="btn-check" name="enroll-query-source" id="enroll-qs-mv" autocomplete="off" checked="@useMaterializedView" @onchange="() => OnQueryModeChanged(true)">
+        <label class="btn btn-outline-primary" for="enroll-qs-mv">Materialized view</label>
+    </div>
+</div>
+
 <div class="row">
     <div class="col-md-6">
         <div class="card">
@@ -161,6 +171,16 @@
     private bool dropError;
 
     private string? lastSortableUniqueId;
+    private bool useMaterializedView;
+
+    private string StudentsBasePath => useMaterializedView ? "api/mv/students" : "api/students";
+    private string ClassroomsBasePath => useMaterializedView ? "api/mv/classrooms" : "api/classrooms";
+
+    private async Task OnQueryModeChanged(bool useMv)
+    {
+        useMaterializedView = useMv;
+        await LoadData(lastSortableUniqueId);
+    }
 
     public class StudentView
     {
@@ -212,8 +232,8 @@
         {
             var httpClient = HttpClientFactory.CreateClient("ApiService");
             var requestUri = !string.IsNullOrEmpty(waitForSortableUniqueId)
-                ? $"api/students?waitForSortableUniqueId={Uri.EscapeDataString(waitForSortableUniqueId)}"
-                : "api/students";
+                ? $"{StudentsBasePath}?waitForSortableUniqueId={Uri.EscapeDataString(waitForSortableUniqueId)}"
+                : StudentsBasePath;
             var response = await httpClient.GetFromJsonAsync<List<StudentState>>(requestUri);
             if (response != null)
             {
@@ -242,8 +262,8 @@
         {
             var httpClient = HttpClientFactory.CreateClient("ApiService");
             var requestUri = !string.IsNullOrEmpty(waitForSortableUniqueId)
-                ? $"api/classrooms?waitForSortableUniqueId={Uri.EscapeDataString(waitForSortableUniqueId)}"
-                : "api/classrooms";
+                ? $"{ClassroomsBasePath}?waitForSortableUniqueId={Uri.EscapeDataString(waitForSortableUniqueId)}"
+                : ClassroomsBasePath;
             var response = await httpClient.GetFromJsonAsync<List<ClassRoomItem>>(requestUri);
             if (response != null)
             {
@@ -278,11 +298,11 @@
             
             // Build query string with waitForSortableUniqueId if provided
             var studentsUri = !string.IsNullOrEmpty(waitForSortableUniqueId)
-                ? $"api/students?waitForSortableUniqueId={Uri.EscapeDataString(waitForSortableUniqueId)}"
-                : "api/students";
+                ? $"{StudentsBasePath}?waitForSortableUniqueId={Uri.EscapeDataString(waitForSortableUniqueId)}"
+                : StudentsBasePath;
             var classroomsUri = !string.IsNullOrEmpty(waitForSortableUniqueId)
-                ? $"api/classrooms?waitForSortableUniqueId={Uri.EscapeDataString(waitForSortableUniqueId)}"
-                : "api/classrooms";
+                ? $"{ClassroomsBasePath}?waitForSortableUniqueId={Uri.EscapeDataString(waitForSortableUniqueId)}"
+                : ClassroomsBasePath;
             
             // Get all students with their enrolled classrooms, waiting for the sortableUniqueId if provided
             var studentsResponse = await httpClient.GetFromJsonAsync<List<StudentState>>(studentsUri);

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans/SekibanDcbOrleans.Web/Components/Pages/Students.razor
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans/SekibanDcbOrleans.Web/Components/Pages/Students.razor
@@ -16,6 +16,16 @@
     <button class="btn btn-primary mb-3" @onclick="OpenAddStudentModal">Add New Student</button>
 </div>
 
+<div class="mb-3">
+    <label class="me-2"><strong>Query source:</strong></label>
+    <div class="btn-group" role="group" aria-label="Query source">
+        <input type="radio" class="btn-check" name="query-source" id="qs-mem" autocomplete="off" checked="@(!useMaterializedView)" @onchange="() => OnQueryModeChanged(false)">
+        <label class="btn btn-outline-primary" for="qs-mem">Memory projection</label>
+        <input type="radio" class="btn-check" name="query-source" id="qs-mv" autocomplete="off" checked="@useMaterializedView" @onchange="() => OnQueryModeChanged(true)">
+        <label class="btn btn-outline-primary" for="qs-mv">Materialized view</label>
+    </div>
+</div>
+
 <h3>Student List</h3>
 
 <div class="row mb-3">
@@ -147,12 +157,20 @@
     private List<StudentState>? students;
     private StudentModel studentModel = new();
     private string? lastSortableUniqueId;
+    private bool useMaterializedView;
 
     // Pagination fields
     private int currentPage = 1;
     private int pageSize = 10;
     private int totalPages = 1;
     private int totalItems;
+
+    private async Task OnQueryModeChanged(bool useMv)
+    {
+        useMaterializedView = useMv;
+        currentPage = 1;
+        await LoadStudents(lastSortableUniqueId);
+    }
 
     public class StudentModel
     {
@@ -174,7 +192,7 @@
     {
         try
         {
-            var result = await StudentApiClient.GetStudentsAsync(currentPage, pageSize, waitForSortableUniqueId);
+            var result = await StudentApiClient.GetStudentsAsync(currentPage, pageSize, waitForSortableUniqueId, useMaterializedView);
 
             students = result?.ToList() ?? new List<StudentState>();
 

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans/SekibanDcbOrleans.Web/StudentApiClient.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans/SekibanDcbOrleans.Web/StudentApiClient.cs
@@ -21,6 +21,7 @@ public class StudentApiClient(HttpClient httpClient)
         int? pageNumber = null,
         int? pageSize = null,
         string? waitForSortableUniqueId = null,
+        bool useMaterializedView = false,
         CancellationToken cancellationToken = default)
     {
         var queryParams = new List<string>();
@@ -34,9 +35,10 @@ public class StudentApiClient(HttpClient httpClient)
         if (pageSize.HasValue)
             queryParams.Add($"pageSize={pageSize.Value}");
 
+        var basePath = useMaterializedView ? "/api/mv/students" : "/api/students";
         var requestUri = queryParams.Count > 0
-            ? $"/api/students?{string.Join("&", queryParams)}"
-            : "/api/students";
+            ? $"{basePath}?{string.Join("&", queryParams)}"
+            : basePath;
 
         var students = await httpClient.GetFromJsonAsync<List<StudentState>>(requestUri, cancellationToken);
 


### PR DESCRIPTION
## Summary
Finishes the materialized view wiring across the remaining four DCB Orleans templates and bumps every Sekiban.Dcb.* package in the template tree to the freshly published **10.1.18** release. Pairs with [J-Tech-Japan/Sekiban#1025](https://github.com/J-Tech-Japan/Sekiban/pull/1025) (which landed MV on the base Decider template); this PR extends the same pattern so users can pick either the in-memory MultiProjection or a PostgreSQL-backed materialized view from any of the five templates.

Templates touched:
- `Sekiban.Dcb.Orleans` (WithResult)
- `Sekiban.Dcb.Orleans.WithoutResult`
- `Sekiban.Dcb.Orleans.Decider` (bump + cleanup)
- `Sekiban.Dcb.Orleans.Decider.Aws` (DynamoDB + LocalStack)
- `Sekiban.Dcb.Orleans.WithoutResult.Aws` (DynamoDB + LocalStack)

## What's added per template
- `ClassRoomEnrollmentMvV1` PostgreSQL projector covering classrooms / students / enrollments. Idempotent via `_last_sortable_unique_id`, recounts `enrolled_count` on add/drop, index name bounded to PostgreSQL's 63-byte limit.
- `/api/mv/{students,classrooms,enrollments,status}` endpoints mapped only when `IMvOrleansQueryAccessor` is registered, so configurations without MV return a clean 404 instead of a DI failure.
- MV packages + Dapper added to ApiService, `DefaultTypeMap.MatchNamesWithUnderscores = true` so snake_case columns hydrate into the PascalCase row classes.
- `DcbMaterializedViewPostgres` Postgres database wired through in AppHost — on the existing Postgres server for most templates, on a new dedicated server for `WithoutResult.Aws` (which previously had no Postgres).
- "Query source" toggle on the Blazor Web pages and on the Next.js WebNext pages (Decider / Decider.Aws), wired through API clients / tRPC routers so the selection flows to `/api/...` vs `/api/mv/...`.

## Version bump
Every Sekiban.Dcb.* PackageReference across the five templates is now pinned to **10.1.18**. Also fixes the pre-existing NU1605 package-downgrade warnings in the Cli / Unit / Interactions.Unit projects, which had been stuck on 10.1.8 since before this PR and caused `dotnet restore` of the solutions to fail.

## MV is opt-in
The Postgres + Orleans MV pieces are registered only when the host supplies a `DcbMaterializedViewPostgres` connection string. Hosts that don't wire that connection get the existing behaviour and the `/api/mv/*` routes return 404 cleanly.

## Test plan — E2E against each template's Aspire AppHost (Docker)
For each of the 5 templates I:
1. `dotnet build` the template's AppHost (0 warnings / 0 errors for all five).
2. Started the AppHost via `dotnet run` with `dotnet run --launch-profile http`, which spins up Postgres (and LocalStack for AWS variants) through Docker.
3. Issued `CreateClassRoom` → `CreateStudent` → `EnrollStudentInClassRoom` through `/api/*`.
4. Queried both `/api/{classrooms,students}` (memory projection) and `/api/mv/{classrooms,students,enrollments}` (materialized view) with the `sortableUniqueId` returned by the enroll command.
5. Confirmed both views return identical classroom/student state and the MV enrollments table holds the enrollment row.

| Template | Storage | Result |
| --- | --- | --- |
| Sekiban.Dcb.Orleans (WithResult) | Postgres events + Postgres MV | memory ≡ MV ✅ |
| Sekiban.Dcb.Orleans.WithoutResult | Postgres events + Postgres MV | memory ≡ MV ✅ |
| Sekiban.Dcb.Orleans.Decider | Postgres events + Postgres MV | memory ≡ MV ✅ |
| Sekiban.Dcb.Orleans.WithoutResult.Aws | DynamoDB events (LocalStack) + Postgres MV | memory ≡ MV ✅ |
| Sekiban.Dcb.Orleans.Decider.Aws | DynamoDB events (LocalStack) + Postgres MV | memory ≡ MV ✅ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)