### PR TITLE
Implement MV apply-host abstraction for issue #1029

### DIFF
--- a/dcb/src/Sekiban.Dcb.Core/Actors/CoreGeneralSekibanExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Actors/CoreGeneralSekibanExecutor.cs
@@ -270,7 +270,7 @@ public class CoreGeneralSekibanExecutor
 
             // Convert SerializableTagState to TagState
             // We need to deserialize the payload from the serializable state
-            if (state.TagPayloadName == nameof(EmptyTagStatePayload))
+            if (state.ResolvedPayloadName == nameof(EmptyTagStatePayload))
             {
                 return ResultBox.FromValue(
                     new TagState(
@@ -284,15 +284,15 @@ public class CoreGeneralSekibanExecutor
             }
 
             // Deserialize the payload using domain types
-            var payloadTypeResult = _domainTypes.TagStatePayloadTypes.GetPayloadType(state.TagPayloadName);
+            var payloadTypeResult = _domainTypes.TagStatePayloadTypes.GetPayloadType(state.ResolvedPayloadName);
             if (payloadTypeResult == null)
             {
                 return ResultBox.Error<TagState>(
-                    new InvalidOperationException($"Unknown payload type: {state.TagPayloadName}"));
+                    new InvalidOperationException($"Unknown payload type: {state.ResolvedPayloadName}"));
             }
 
             var deserializeResult = _domainTypes.TagStatePayloadTypes.DeserializePayload(
-                state.TagPayloadName,
+                state.ResolvedPayloadName,
                 state.Payload);
 
             if (!deserializeResult.IsSuccess)

--- a/dcb/src/Sekiban.Dcb.Core/Actors/GeneralTagStateActor.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Actors/GeneralTagStateActor.cs
@@ -346,7 +346,8 @@ public class GeneralTagStateActor : ITagStateActorCommon
                 tagState.TagContent,
                 tagState.TagProjector,
                 "EmptyTagStatePayload",
-                tagState.ProjectorVersion);
+                tagState.ProjectorVersion,
+                nameof(EmptyTagStatePayload));
         }
 
         // Use ITagStatePayloadTypes for serialization
@@ -365,12 +366,13 @@ public class GeneralTagStateActor : ITagStateActorCommon
             tagState.TagContent,
             tagState.TagProjector,
             tagState.Payload.GetType().Name,
-            tagState.ProjectorVersion);
+            tagState.ProjectorVersion,
+            tagState.Payload.GetType().Name);
     }
 
     private TagState DeserializeTagState(SerializableTagState state)
     {
-        if (state.TagPayloadName == nameof(EmptyTagStatePayload))
+        if (state.ResolvedPayloadName == nameof(EmptyTagStatePayload))
         {
             return new TagState(
                 new EmptyTagStatePayload(),
@@ -382,11 +384,11 @@ public class GeneralTagStateActor : ITagStateActorCommon
                 state.ProjectorVersion);
         }
 
-        var deserializeResult = _tagStatePayloadTypes.DeserializePayload(state.TagPayloadName, state.Payload);
+        var deserializeResult = _tagStatePayloadTypes.DeserializePayload(state.ResolvedPayloadName, state.Payload);
         if (!deserializeResult.IsSuccess)
         {
             throw new InvalidOperationException(
-                $"Failed to deserialize payload '{state.TagPayloadName}': {deserializeResult.GetException().Message}");
+                $"Failed to deserialize payload '{state.ResolvedPayloadName}': {deserializeResult.GetException().Message}");
         }
 
         return new TagState(

--- a/dcb/src/Sekiban.Dcb.Core/Commands/CoreGeneralCommandContext.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Commands/CoreGeneralCommandContext.cs
@@ -64,7 +64,7 @@ public class CoreGeneralCommandContext : ICoreCommandContext, ICommandContextRes
 
             // Deserialize the payload
             var payloadResult = _domainTypes.TagStatePayloadTypes.DeserializePayload(
-                serializableState.TagPayloadName,
+                serializableState.ResolvedPayloadName,
                 serializableState.Payload);
 
             if (!payloadResult.IsSuccess)
@@ -143,7 +143,7 @@ public class CoreGeneralCommandContext : ICoreCommandContext, ICommandContextRes
 
             // Deserialize the payload
             var payloadResult = _domainTypes.TagStatePayloadTypes.DeserializePayload(
-                serializableState.TagPayloadName,
+                serializableState.ResolvedPayloadName,
                 serializableState.Payload);
 
             if (!payloadResult.IsSuccess)

--- a/dcb/src/Sekiban.Dcb.Core/Tags/SerializableTagState.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Tags/SerializableTagState.cs
@@ -8,4 +8,11 @@ public record SerializableTagState(
     string TagContent,
     string TagProjector,
     string TagPayloadName,
-    string ProjectorVersion);
+    string ProjectorVersion,
+    string? ActualPayloadName = null)
+{
+    public string ResolvedPayloadName =>
+        string.IsNullOrWhiteSpace(ActualPayloadName)
+            ? TagPayloadName
+            : ActualPayloadName;
+}

--- a/dcb/src/Sekiban.Dcb.MaterializedView.Orleans/MaterializedViewGrain.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.Orleans/MaterializedViewGrain.cs
@@ -11,9 +11,9 @@ namespace Sekiban.Dcb.MaterializedView.Orleans;
 public sealed class MaterializedViewGrain : Grain, IMaterializedViewGrain
 {
     private readonly IMvExecutor _executor;
+    private readonly IMvApplyHostFactory _hostFactory;
     private readonly ILogger<MaterializedViewGrain> _logger;
     private readonly MvOptions _options;
-    private readonly IReadOnlyList<IMaterializedViewProjector> _projectors;
     private readonly IMvRegistryStore _registryStore;
     private readonly IEventSubscriptionResolver _subscriptionResolver;
 
@@ -27,7 +27,7 @@ public sealed class MaterializedViewGrain : Grain, IMaterializedViewGrain
     private string? _serviceId;
     private string? _viewName;
     private int _viewVersion;
-    private IMaterializedViewProjector? _projector;
+    private IMvApplyHost? _host;
     private string? _lastAppliedSortableUniqueId;
     private string? _lastReceivedSortableUniqueId;
     private string? _lastError;
@@ -36,19 +36,19 @@ public sealed class MaterializedViewGrain : Grain, IMaterializedViewGrain
     private bool _started;
 
     public MaterializedViewGrain(
-        IEnumerable<IMaterializedViewProjector> projectors,
+        IMvApplyHostFactory hostFactory,
         IMvExecutor executor,
         IMvRegistryStore registryStore,
         IEventSubscriptionResolver subscriptionResolver,
         IOptions<MvOptions> options,
         ILogger<MaterializedViewGrain> logger)
     {
+        _hostFactory = hostFactory;
         _executor = executor;
         _registryStore = registryStore;
         _subscriptionResolver = subscriptionResolver;
         _logger = logger;
         _options = options.Value;
-        _projectors = projectors.ToList();
     }
 
     public override async Task OnActivateAsync(CancellationToken cancellationToken)
@@ -77,8 +77,8 @@ public sealed class MaterializedViewGrain : Grain, IMaterializedViewGrain
             return;
         }
 
-        ResolveProjector();
-        await _executor.InitializeAsync(_projector!, _serviceId, CancellationToken.None);
+        ResolveHost();
+        await _executor.InitializeAsync(_host!, _serviceId, CancellationToken.None);
         await RefreshPositionFromRegistryAsync(CancellationToken.None);
         await StartSubscriptionAsync();
         await CatchUpAndDrainAsync(CancellationToken.None);
@@ -196,7 +196,7 @@ public sealed class MaterializedViewGrain : Grain, IMaterializedViewGrain
             return;
         }
 
-        ResolveProjector();
+        ResolveHost();
         _catchUpInProgress = true;
         _lastCatchUpStartedAt = DateTimeOffset.UtcNow;
         _lastError = null;
@@ -205,15 +205,15 @@ public sealed class MaterializedViewGrain : Grain, IMaterializedViewGrain
         {
             await _registryStore.UpdateStatusAsync(
                     _serviceId!,
-                    _projector!.ViewName,
-                    _projector.ViewVersion,
+                    _host!.ViewName,
+                    _host.ViewVersion,
                     MvStatus.CatchingUp,
                     cancellationToken: cancellationToken)
                 ;
 
             while (true)
             {
-                var result = await _executor.CatchUpOnceAsync(_projector, _serviceId, cancellationToken);
+                var result = await _executor.CatchUpOnceAsync(_host, _serviceId, cancellationToken);
                 if (!string.IsNullOrWhiteSpace(result.LastAppliedSortableUniqueId))
                 {
                     _lastAppliedSortableUniqueId = result.LastAppliedSortableUniqueId;
@@ -229,8 +229,8 @@ public sealed class MaterializedViewGrain : Grain, IMaterializedViewGrain
             await RefreshPositionFromRegistryAsync(cancellationToken);
             await _registryStore.UpdateStatusAsync(
                     _serviceId!,
-                    _projector.ViewName,
-                    _projector.ViewVersion,
+                    _host.ViewName,
+                    _host.ViewVersion,
                     MvStatus.Ready,
                     cancellationToken: cancellationToken)
                 ;
@@ -353,8 +353,8 @@ public sealed class MaterializedViewGrain : Grain, IMaterializedViewGrain
             return 0;
         }
 
-        ResolveProjector();
-        var applied = await _executor.ApplySerializableEventsAsync(_projector!, events, _serviceId, cancellationToken)
+        ResolveHost();
+        var applied = await _executor.ApplySerializableEventsAsync(_host!, events, _serviceId, cancellationToken)
             ;
         if (applied > 0)
         {
@@ -366,8 +366,8 @@ public sealed class MaterializedViewGrain : Grain, IMaterializedViewGrain
 
     private async Task RefreshPositionFromRegistryAsync(CancellationToken cancellationToken)
     {
-        ResolveProjector();
-        var entries = await _registryStore.GetEntriesAsync(_serviceId!, _projector!.ViewName, _projector.ViewVersion, cancellationToken)
+        ResolveHost();
+        var entries = await _registryStore.GetEntriesAsync(_serviceId!, _host!.ViewName, _host.ViewVersion, cancellationToken)
             ;
         var currentPosition = entries
             .Select(entry => entry.CurrentPosition)
@@ -427,22 +427,15 @@ public sealed class MaterializedViewGrain : Grain, IMaterializedViewGrain
         _viewVersion = viewVersion;
     }
 
-    private void ResolveProjector()
+    private void ResolveHost()
     {
         ResolveIdentity();
-        if (_projector is not null)
+        if (_host is not null)
         {
             return;
         }
 
-        _projector = _projectors.SingleOrDefault(candidate =>
-            string.Equals(candidate.ViewName, _viewName, StringComparison.Ordinal) &&
-            candidate.ViewVersion == _viewVersion);
-        if (_projector is null)
-        {
-            throw new InvalidOperationException(
-                $"Materialized view projector '{_viewName}/{_viewVersion}' is not registered.");
-        }
+        _host = _hostFactory.Create(_viewName!, _viewVersion);
     }
 
     private sealed class StreamBatchObserver : IAsyncBatchObserver<SerializableEvent>

--- a/dcb/src/Sekiban.Dcb.MaterializedView.Orleans/MaterializedViewGrainActivator.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.Orleans/MaterializedViewGrainActivator.cs
@@ -7,11 +7,11 @@ internal sealed class MaterializedViewGrainActivator : BackgroundService
 {
     private readonly IGrainFactory _grainFactory;
     private readonly ILogger<MaterializedViewGrainActivator> _logger;
-    private readonly IReadOnlyList<IMaterializedViewProjector> _projectors;
+    private readonly IReadOnlyList<MvApplyHostRegistration> _registrations;
     private readonly Sekiban.Dcb.ServiceId.IServiceIdProvider _serviceIdProvider;
 
     public MaterializedViewGrainActivator(
-        IEnumerable<IMaterializedViewProjector> projectors,
+        IMvApplyHostFactory hostFactory,
         IGrainFactory grainFactory,
         Sekiban.Dcb.ServiceId.IServiceIdProvider serviceIdProvider,
         ILogger<MaterializedViewGrainActivator> logger)
@@ -19,17 +19,17 @@ internal sealed class MaterializedViewGrainActivator : BackgroundService
         _grainFactory = grainFactory;
         _serviceIdProvider = serviceIdProvider;
         _logger = logger;
-        _projectors = projectors.ToList();
+        _registrations = hostFactory.GetRegistrations();
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
         var serviceId = _serviceIdProvider.GetCurrentServiceId();
-        foreach (var projector in _projectors)
+        foreach (var registration in _registrations)
         {
             try
             {
-                var grainKey = MvGrainKey.Build(serviceId, projector.ViewName, projector.ViewVersion);
+                var grainKey = MvGrainKey.Build(serviceId, registration.ViewName, registration.ViewVersion);
                 var grain = _grainFactory.GetGrain<IMaterializedViewGrain>(grainKey);
                 await grain.EnsureStartedAsync().ConfigureAwait(false);
             }
@@ -38,8 +38,8 @@ internal sealed class MaterializedViewGrainActivator : BackgroundService
                 _logger.LogError(
                     ex,
                     "Failed to activate materialized view grain for {ViewName}/{ViewVersion}.",
-                    projector.ViewName,
-                    projector.ViewVersion);
+                    registration.ViewName,
+                    registration.ViewVersion);
             }
         }
     }

--- a/dcb/src/Sekiban.Dcb.MaterializedView.Postgres/PostgresMvContexts.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.Postgres/PostgresMvContexts.cs
@@ -115,7 +115,7 @@ internal static class PostgresMvValueAdapter
     }
 }
 
-internal sealed class PostgresMvApplyQueryPort : IMvApplyQueryPort
+internal sealed class PostgresMvApplyQueryPort : IMvApplyDbConnectionPort
 {
     private readonly IDbConnection _connection;
     private readonly IDbTransaction _transaction;
@@ -125,6 +125,9 @@ internal sealed class PostgresMvApplyQueryPort : IMvApplyQueryPort
         _connection = connection;
         _transaction = transaction;
     }
+
+    public IDbConnection Connection => _connection;
+    public IDbTransaction Transaction => _transaction;
 
     public async Task<IReadOnlyList<JsonElement>> QueryRowsAsync(
         string sql,

--- a/dcb/src/Sekiban.Dcb.MaterializedView.Postgres/PostgresMvContexts.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.Postgres/PostgresMvContexts.cs
@@ -1,5 +1,6 @@
 using System.Data;
 using Dapper;
+using System.Text.Json;
 using Sekiban.Dcb.Events;
 
 namespace Sekiban.Dcb.MaterializedView.Postgres;
@@ -65,14 +66,14 @@ internal sealed class PostgresMvApplyContext : IMvApplyContext
     {
         var row = await Connection.QuerySingleOrDefaultAsync(
             new CommandDefinition(sql, param, Transaction, cancellationToken: cancellationToken)).ConfigureAwait(false);
-        return row is null ? null : new PostgresMvRow(ToDictionary(row));
+        return row is null ? null : new PostgresMvRow(PostgresMvValueAdapter.ToDictionary(row));
     }
 
     public async Task<IMvRowSet> QueryRowsAsync(string sql, object? param = null, CancellationToken cancellationToken = default)
     {
         var rows = await Connection.QueryAsync(
             new CommandDefinition(sql, param, Transaction, cancellationToken: cancellationToken)).ConfigureAwait(false);
-        return new PostgresMvRowSet(rows.Select(row => (IMvRow)new PostgresMvRow(ToDictionary(row))).ToList());
+        return new PostgresMvRowSet(rows.Select(row => (IMvRow)new PostgresMvRow(PostgresMvValueAdapter.ToDictionary(row))).ToList());
     }
 
     public Task<TScalar> ExecuteScalarAsync<TScalar>(string sql, object? param = null, CancellationToken cancellationToken = default) =>
@@ -85,7 +86,11 @@ internal sealed class PostgresMvApplyContext : IMvApplyContext
     public MvTable GetDependencyViewTable<TView>(string logicalTable) where TView : IMaterializedViewProjector =>
         throw new NotSupportedException("Cross-view reads are out of scope for the materialized view PoC and are planned for a later phase.");
 
-    private static IReadOnlyDictionary<string, object?> ToDictionary(object row)
+}
+
+internal static class PostgresMvValueAdapter
+{
+    public static IReadOnlyDictionary<string, object?> ToDictionary(object row)
     {
         if (row is IReadOnlyDictionary<string, object?> readOnlyDictionary)
         {
@@ -107,5 +112,74 @@ internal sealed class PostgresMvApplyContext : IMvApplyContext
         return row.GetType()
             .GetProperties()
             .ToDictionary(property => property.Name, property => property.GetValue(row), StringComparer.OrdinalIgnoreCase);
+    }
+}
+
+internal sealed class PostgresMvApplyQueryPort : IMvApplyQueryPort
+{
+    private readonly IDbConnection _connection;
+    private readonly IDbTransaction _transaction;
+
+    public PostgresMvApplyQueryPort(IDbConnection connection, IDbTransaction transaction)
+    {
+        _connection = connection;
+        _transaction = transaction;
+    }
+
+    public async Task<IReadOnlyList<JsonElement>> QueryRowsAsync(
+        string sql,
+        IReadOnlyList<MvParam> parameters,
+        CancellationToken ct)
+    {
+        var rows = await _connection.QueryAsync(
+            new CommandDefinition(
+                sql,
+                ToDynamicParameters(parameters),
+                _transaction,
+                cancellationToken: ct)).ConfigureAwait(false);
+        return rows
+            .Select(row => (JsonElement)JsonSerializer.SerializeToElement(PostgresMvValueAdapter.ToDictionary(row)))
+            .ToList();
+    }
+
+    public async Task<JsonElement?> QuerySingleOrDefaultAsync(
+        string sql,
+        IReadOnlyList<MvParam> parameters,
+        CancellationToken ct)
+    {
+        var row = await _connection.QuerySingleOrDefaultAsync(
+            new CommandDefinition(
+                sql,
+                ToDynamicParameters(parameters),
+                _transaction,
+                cancellationToken: ct)).ConfigureAwait(false);
+        return row is null
+            ? null
+            : JsonSerializer.SerializeToElement(PostgresMvValueAdapter.ToDictionary(row));
+    }
+
+    public async Task<string?> ExecuteScalarJsonAsync(
+        string sql,
+        IReadOnlyList<MvParam> parameters,
+        CancellationToken ct)
+    {
+        var scalar = await _connection.ExecuteScalarAsync(
+            new CommandDefinition(
+                sql,
+                ToDynamicParameters(parameters),
+                _transaction,
+                cancellationToken: ct)).ConfigureAwait(false);
+        return MvParamConverter.SerializeScalar(scalar);
+    }
+
+    private static DynamicParameters ToDynamicParameters(IReadOnlyList<MvParam> parameters)
+    {
+        var dynamicParameters = new DynamicParameters();
+        foreach (var parameter in parameters)
+        {
+            dynamicParameters.Add(parameter.Name, MvParamConverter.ToClrValue(parameter));
+        }
+
+        return dynamicParameters;
     }
 }

--- a/dcb/src/Sekiban.Dcb.MaterializedView.Postgres/PostgresMvExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.Postgres/PostgresMvExecutor.cs
@@ -4,7 +4,6 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Npgsql;
 using Sekiban.Dcb.Common;
-using Sekiban.Dcb.Domains;
 using Sekiban.Dcb.Events;
 using Sekiban.Dcb.ServiceId;
 using Sekiban.Dcb.Storage;
@@ -14,7 +13,6 @@ namespace Sekiban.Dcb.MaterializedView.Postgres;
 public sealed class PostgresMvExecutor : IMvExecutor
 {
     private readonly IEventStore _eventStore;
-    private readonly IEventTypes _eventTypes;
     private readonly ILogger<PostgresMvExecutor> _logger;
     private readonly MvOptions _options;
     private readonly IMvRegistryStore _registryStore;
@@ -23,7 +21,6 @@ public sealed class PostgresMvExecutor : IMvExecutor
 
     public PostgresMvExecutor(
         IEventStore eventStore,
-        IEventTypes eventTypes,
         IServiceIdProvider serviceIdProvider,
         IMvRegistryStore registryStore,
         IOptions<MvOptions> options,
@@ -31,7 +28,6 @@ public sealed class PostgresMvExecutor : IMvExecutor
         string connectionString)
     {
         _eventStore = eventStore;
-        _eventTypes = eventTypes;
         _serviceIdProvider = serviceIdProvider;
         _registryStore = registryStore;
         _logger = logger;
@@ -40,7 +36,7 @@ public sealed class PostgresMvExecutor : IMvExecutor
     }
 
     public async Task InitializeAsync(
-        IMaterializedViewProjector projector,
+        IMvApplyHost host,
         string? serviceId = null,
         CancellationToken cancellationToken = default)
     {
@@ -51,17 +47,26 @@ public sealed class PostgresMvExecutor : IMvExecutor
         await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
         await using var transaction = await connection.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
 
-        var initContext = new PostgresMvInitContext(connection, transaction, projector.ViewName, projector.ViewVersion, _options);
-        await projector.InitializeAsync(initContext, cancellationToken).ConfigureAwait(false);
+        var bindings = new MvTableBindings(host.ViewName, host.ViewVersion, _options);
+        var statements = await host.InitializeAsync(bindings, cancellationToken).ConfigureAwait(false);
+        foreach (var statement in statements)
+        {
+            await connection.ExecuteAsync(
+                new CommandDefinition(
+                    statement.Sql,
+                    ToDynamicParameters(statement.Parameters),
+                    transaction,
+                    cancellationToken: cancellationToken)).ConfigureAwait(false);
+        }
 
-        foreach (var table in initContext.RegisteredTables)
+        foreach (var table in bindings.Tables)
         {
             await _registryStore.RegisterAsync(
                 new MvRegistryEntry
                 {
                     ServiceId = serviceId,
-                    ViewName = projector.ViewName,
-                    ViewVersion = projector.ViewVersion,
+                    ViewName = host.ViewName,
+                    ViewVersion = host.ViewVersion,
                     LogicalTable = table.LogicalName,
                     PhysicalTable = table.PhysicalName,
                     Status = MvStatus.CatchingUp,
@@ -72,10 +77,10 @@ public sealed class PostgresMvExecutor : IMvExecutor
                 cancellationToken).ConfigureAwait(false);
         }
 
-        var active = await _registryStore.GetActiveAsync(serviceId, projector.ViewName, cancellationToken).ConfigureAwait(false);
+        var active = await _registryStore.GetActiveAsync(serviceId, host.ViewName, cancellationToken).ConfigureAwait(false);
         if (active is null)
         {
-            await _registryStore.SetActiveAsync(serviceId, projector.ViewName, projector.ViewVersion, transaction, cancellationToken)
+            await _registryStore.SetActiveAsync(serviceId, host.ViewName, host.ViewVersion, transaction, cancellationToken)
                 .ConfigureAwait(false);
         }
 
@@ -83,17 +88,17 @@ public sealed class PostgresMvExecutor : IMvExecutor
     }
 
     public async Task<MvCatchUpResult> CatchUpOnceAsync(
-        IMaterializedViewProjector projector,
+        IMvApplyHost host,
         string? serviceId = null,
         CancellationToken cancellationToken = default)
     {
         serviceId = ResolveServiceId(serviceId);
-        var entries = await _registryStore.GetEntriesAsync(serviceId, projector.ViewName, projector.ViewVersion, cancellationToken)
+        var entries = await _registryStore.GetEntriesAsync(serviceId, host.ViewName, host.ViewVersion, cancellationToken)
             .ConfigureAwait(false);
         if (entries.Count == 0)
         {
-            await InitializeAsync(projector, serviceId, cancellationToken).ConfigureAwait(false);
-            entries = await _registryStore.GetEntriesAsync(serviceId, projector.ViewName, projector.ViewVersion, cancellationToken)
+            await InitializeAsync(host, serviceId, cancellationToken).ConfigureAwait(false);
+            entries = await _registryStore.GetEntriesAsync(serviceId, host.ViewName, host.ViewVersion, cancellationToken)
                 .ConfigureAwait(false);
         }
 
@@ -115,8 +120,8 @@ public sealed class PostgresMvExecutor : IMvExecutor
             _logger.LogWarning(
                 exception,
                 "Failed to read events for materialized view {ViewName}/{ViewVersion}.",
-                projector.ViewName,
-                projector.ViewVersion);
+                host.ViewName,
+                host.ViewVersion);
             return new MvCatchUpResult(0, false);
         }
 
@@ -147,7 +152,7 @@ public sealed class PostgresMvExecutor : IMvExecutor
         }
 
         var appliedEvents = await ApplySerializableEventsCoreAsync(
-                projector,
+                host,
                 safeBatch,
                 serviceId,
                 MvApplySource.CatchUp,
@@ -164,7 +169,7 @@ public sealed class PostgresMvExecutor : IMvExecutor
     }
 
     public async Task<int> ApplySerializableEventsAsync(
-        IMaterializedViewProjector projector,
+        IMvApplyHost host,
         IReadOnlyList<SerializableEvent> events,
         string? serviceId = null,
         CancellationToken cancellationToken = default)
@@ -175,22 +180,22 @@ public sealed class PostgresMvExecutor : IMvExecutor
         }
 
         serviceId = ResolveServiceId(serviceId);
-        return await ApplySerializableEventsCoreAsync(projector, events, serviceId, MvApplySource.Stream, cancellationToken).ConfigureAwait(false);
+        return await ApplySerializableEventsCoreAsync(host, events, serviceId, MvApplySource.Stream, cancellationToken).ConfigureAwait(false);
     }
 
     private async Task<int> ApplySerializableEventsCoreAsync(
-        IMaterializedViewProjector projector,
+        IMvApplyHost host,
         IReadOnlyList<SerializableEvent> events,
         string serviceId,
         MvApplySource source,
         CancellationToken cancellationToken)
     {
-        var entries = await _registryStore.GetEntriesAsync(serviceId, projector.ViewName, projector.ViewVersion, cancellationToken)
+        var entries = await _registryStore.GetEntriesAsync(serviceId, host.ViewName, host.ViewVersion, cancellationToken)
             .ConfigureAwait(false);
         if (entries.Count == 0)
         {
-            await InitializeAsync(projector, serviceId, cancellationToken).ConfigureAwait(false);
-            entries = await _registryStore.GetEntriesAsync(serviceId, projector.ViewName, projector.ViewVersion, cancellationToken)
+            await InitializeAsync(host, serviceId, cancellationToken).ConfigureAwait(false);
+            entries = await _registryStore.GetEntriesAsync(serviceId, host.ViewName, host.ViewVersion, cancellationToken)
                 .ConfigureAwait(false);
         }
 
@@ -220,7 +225,7 @@ public sealed class PostgresMvExecutor : IMvExecutor
         {
             var applied = await ApplySerializableEventAsync(
                     connection,
-                    projector,
+                    host,
                     serviceId,
                     serializableEvent,
                     currentPosition,
@@ -240,30 +245,29 @@ public sealed class PostgresMvExecutor : IMvExecutor
 
     private async Task<bool> ApplySerializableEventAsync(
         NpgsqlConnection connection,
-        IMaterializedViewProjector projector,
+        IMvApplyHost host,
         string serviceId,
         SerializableEvent serializableEvent,
         string? currentPosition,
         MvApplySource source,
         CancellationToken cancellationToken)
     {
-        var eventResult = serializableEvent.ToEvent(_eventTypes);
-        if (!eventResult.IsSuccess)
-        {
-            throw eventResult.GetException();
-        }
-
-        var ev = eventResult.GetValue();
         await using var transaction = await connection.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
-        var applyContext = new PostgresMvApplyContext(connection, transaction, ev, serializableEvent.SortableUniqueIdValue);
-        var statements = await projector.ApplyToViewAsync(ev, applyContext, cancellationToken).ConfigureAwait(false);
+        var queryPort = new PostgresMvApplyQueryPort(connection, transaction);
+        var bindings = await GetBindingsAsync(host, serviceId, cancellationToken).ConfigureAwait(false);
+        var statements = await host.ApplyEventAsync(
+            serializableEvent,
+            bindings,
+            queryPort,
+            serializableEvent.SortableUniqueIdValue,
+            cancellationToken).ConfigureAwait(false);
         var affectedRows = 0;
         foreach (var statement in statements)
         {
             affectedRows += await connection.ExecuteAsync(
                 new CommandDefinition(
                     statement.Sql,
-                    statement.Parameters,
+                    ToDynamicParameters(statement.Parameters),
                     transaction,
                     cancellationToken: cancellationToken)).ConfigureAwait(false);
         }
@@ -284,8 +288,8 @@ public sealed class PostgresMvExecutor : IMvExecutor
         await _registryStore.UpdatePositionAsync(
             new MvPositionUpdate(
                 serviceId,
-                projector.ViewName,
-                projector.ViewVersion,
+                host.ViewName,
+                host.ViewVersion,
                 serializableEvent.SortableUniqueIdValue,
                 source),
             transaction: transaction,
@@ -299,6 +303,30 @@ public sealed class PostgresMvExecutor : IMvExecutor
         string.IsNullOrWhiteSpace(serviceId)
             ? _serviceIdProvider.GetCurrentServiceId()
             : serviceId;
+
+    private async Task<MvTableBindings> GetBindingsAsync(IMvApplyHost host, string serviceId, CancellationToken cancellationToken)
+    {
+        var bindings = new MvTableBindings(host.ViewName, host.ViewVersion, _options);
+        var entries = await _registryStore.GetEntriesAsync(serviceId, host.ViewName, host.ViewVersion, cancellationToken)
+            .ConfigureAwait(false);
+        foreach (var entry in entries)
+        {
+            bindings.RegisterTable(entry.LogicalTable, entry.PhysicalTable);
+        }
+
+        return bindings;
+    }
+
+    private static DynamicParameters ToDynamicParameters(IReadOnlyList<MvParam> parameters)
+    {
+        var dynamicParameters = new DynamicParameters();
+        foreach (var parameter in parameters)
+        {
+            dynamicParameters.Add(parameter.Name, MvParamConverter.ToClrValue(parameter));
+        }
+
+        return dynamicParameters;
+    }
 
     private static SortableUniqueId CreateSafeThreshold(int safeWindowMs) =>
         new(SortableUniqueId.Generate(DateTime.UtcNow.AddMilliseconds(-safeWindowMs), Guid.Empty));

--- a/dcb/src/Sekiban.Dcb.MaterializedView.Postgres/PostgresMvExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.Postgres/PostgresMvExecutor.cs
@@ -220,6 +220,7 @@ public sealed class PostgresMvExecutor : IMvExecutor
         await using var connection = new NpgsqlConnection(_connectionString);
         await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
         var appliedEvents = 0;
+        var bindings = CreateBindings(host, entries);
 
         foreach (var serializableEvent in orderedEvents)
         {
@@ -227,6 +228,7 @@ public sealed class PostgresMvExecutor : IMvExecutor
                     connection,
                     host,
                     serviceId,
+                    bindings,
                     serializableEvent,
                     currentPosition,
                     source,
@@ -247,6 +249,7 @@ public sealed class PostgresMvExecutor : IMvExecutor
         NpgsqlConnection connection,
         IMvApplyHost host,
         string serviceId,
+        MvTableBindings bindings,
         SerializableEvent serializableEvent,
         string? currentPosition,
         MvApplySource source,
@@ -254,7 +257,6 @@ public sealed class PostgresMvExecutor : IMvExecutor
     {
         await using var transaction = await connection.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
         var queryPort = new PostgresMvApplyQueryPort(connection, transaction);
-        var bindings = await GetBindingsAsync(host, serviceId, cancellationToken).ConfigureAwait(false);
         var statements = await host.ApplyEventAsync(
             serializableEvent,
             bindings,
@@ -304,11 +306,9 @@ public sealed class PostgresMvExecutor : IMvExecutor
             ? _serviceIdProvider.GetCurrentServiceId()
             : serviceId;
 
-    private async Task<MvTableBindings> GetBindingsAsync(IMvApplyHost host, string serviceId, CancellationToken cancellationToken)
+    private MvTableBindings CreateBindings(IMvApplyHost host, IReadOnlyList<MvRegistryEntry> entries)
     {
         var bindings = new MvTableBindings(host.ViewName, host.ViewVersion, _options);
-        var entries = await _registryStore.GetEntriesAsync(serviceId, host.ViewName, host.ViewVersion, cancellationToken)
-            .ConfigureAwait(false);
         foreach (var entry in entries)
         {
             bindings.RegisterTable(entry.LogicalTable, entry.PhysicalTable);

--- a/dcb/src/Sekiban.Dcb.MaterializedView.Postgres/SekibanDcbMaterializedViewPostgresExtensions.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.Postgres/SekibanDcbMaterializedViewPostgresExtensions.cs
@@ -34,7 +34,6 @@ public static class SekibanDcbMaterializedViewPostgresExtensions
         services.TryAddSingleton<IMvExecutor>(sp =>
             new PostgresMvExecutor(
                 sp.GetRequiredService<Sekiban.Dcb.Storage.IEventStore>(),
-                sp.GetRequiredService<Sekiban.Dcb.Domains.IEventTypes>(),
                 sp.GetRequiredService<IServiceIdProvider>(),
                 sp.GetRequiredService<IMvRegistryStore>(),
                 sp.GetRequiredService<IOptions<MvOptions>>(),

--- a/dcb/src/Sekiban.Dcb.MaterializedView/MvApplyHostSupport.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView/MvApplyHostSupport.cs
@@ -1,0 +1,346 @@
+using System.Collections;
+using System.Reflection;
+using System.Text.Json;
+using Sekiban.Dcb.Domains;
+using Sekiban.Dcb.Events;
+
+namespace Sekiban.Dcb.MaterializedView;
+
+public sealed class MvTableBindings : IMvTableBindings
+{
+    private readonly Dictionary<string, MvTable> _tables = new(StringComparer.Ordinal);
+    private readonly MvOptions _options;
+    private readonly string _viewName;
+    private readonly int _viewVersion;
+
+    public MvTableBindings(string viewName, int viewVersion, MvOptions options)
+    {
+        _viewName = viewName;
+        _viewVersion = viewVersion;
+        _options = options;
+    }
+
+    public IReadOnlyDictionary<string, string> LogicalToPhysical =>
+        _tables.ToDictionary(pair => pair.Key, pair => pair.Value.PhysicalName, StringComparer.Ordinal);
+
+    public string GetPhysicalName(string logicalName) => RegisterTable(logicalName).PhysicalName;
+
+    public IReadOnlyList<MvTable> Tables => _tables.Values.ToList();
+
+    public MvTable RegisterTable(string logicalName, string? physicalName = null)
+    {
+        if (_tables.TryGetValue(logicalName, out var existing))
+        {
+            return existing;
+        }
+
+        var table = new MvTable(
+            logicalName,
+            physicalName ?? MvPhysicalName.Resolve(_options, _viewName, _viewVersion, logicalName),
+            _viewName,
+            _viewVersion);
+        _tables[logicalName] = table;
+        return table;
+    }
+}
+
+public static class MvParamConverter
+{
+    public static IReadOnlyList<MvParam> FromObject(object? parameters)
+    {
+        if (parameters is null)
+        {
+            return [];
+        }
+
+        if (parameters is IReadOnlyList<MvParam> readOnlyParams)
+        {
+            return readOnlyParams;
+        }
+
+        if (parameters is IEnumerable<MvParam> enumerableParams)
+        {
+            return enumerableParams.ToList();
+        }
+
+        if (parameters is IEnumerable<KeyValuePair<string, object?>> keyValuePairs)
+        {
+            return keyValuePairs.Select(pair => ToParam(pair.Key, pair.Value)).ToList();
+        }
+
+        return parameters.GetType()
+            .GetProperties(BindingFlags.Instance | BindingFlags.Public)
+            .Where(property => property.CanRead)
+            .Select(property => ToParam(property.Name, property.GetValue(parameters)))
+            .ToList();
+    }
+
+    public static object? ToClrValue(MvParam param) =>
+        param.Kind switch
+        {
+            MvParamKind.Null => DBNull.Value,
+            MvParamKind.String => Deserialize<string>(param.ValueJson),
+            MvParamKind.Int32 => Deserialize<int>(param.ValueJson),
+            MvParamKind.Int64 => Deserialize<long>(param.ValueJson),
+            MvParamKind.Boolean => Deserialize<bool>(param.ValueJson),
+            MvParamKind.Guid => Deserialize<Guid>(param.ValueJson),
+            MvParamKind.DateTimeOffset => Deserialize<DateTimeOffset>(param.ValueJson),
+            MvParamKind.Decimal => Deserialize<decimal>(param.ValueJson),
+            MvParamKind.Double => Deserialize<double>(param.ValueJson),
+            MvParamKind.Bytes => Deserialize<byte[]>(param.ValueJson),
+            MvParamKind.DateTime => Deserialize<DateTime>(param.ValueJson),
+            _ => throw new NotSupportedException($"Unsupported materialized view parameter kind '{param.Kind}'.")
+        };
+
+    public static string? SerializeScalar(object? value) =>
+        value is null or DBNull ? null : JsonSerializer.Serialize(value);
+
+    private static MvParam ToParam(string name, object? value)
+    {
+        if (value is null)
+        {
+            return new MvParam(name, MvParamKind.Null, null);
+        }
+
+        return value switch
+        {
+            string stringValue => new MvParam(name, MvParamKind.String, JsonSerializer.Serialize(stringValue)),
+            int intValue => new MvParam(name, MvParamKind.Int32, JsonSerializer.Serialize(intValue)),
+            long longValue => new MvParam(name, MvParamKind.Int64, JsonSerializer.Serialize(longValue)),
+            bool boolValue => new MvParam(name, MvParamKind.Boolean, JsonSerializer.Serialize(boolValue)),
+            Guid guidValue => new MvParam(name, MvParamKind.Guid, JsonSerializer.Serialize(guidValue)),
+            DateTimeOffset dtoValue => new MvParam(name, MvParamKind.DateTimeOffset, JsonSerializer.Serialize(dtoValue)),
+            DateTime dateTimeValue => new MvParam(name, MvParamKind.DateTime, JsonSerializer.Serialize(dateTimeValue)),
+            decimal decimalValue => new MvParam(name, MvParamKind.Decimal, JsonSerializer.Serialize(decimalValue)),
+            double doubleValue => new MvParam(name, MvParamKind.Double, JsonSerializer.Serialize(doubleValue)),
+            float floatValue => new MvParam(name, MvParamKind.Double, JsonSerializer.Serialize((double)floatValue)),
+            byte[] bytesValue => new MvParam(name, MvParamKind.Bytes, JsonSerializer.Serialize(bytesValue)),
+            _ => throw new NotSupportedException(
+                $"Unsupported materialized view SQL parameter type '{value.GetType().FullName}' for '{name}'.")
+        };
+    }
+
+    private static T Deserialize<T>(string? valueJson)
+    {
+        if (valueJson is null)
+        {
+            return default!;
+        }
+
+        return JsonSerializer.Deserialize<T>(valueJson)!;
+    }
+}
+
+public sealed class NativeMvApplyHostFactory : IMvApplyHostFactory
+{
+    private readonly IEventTypes _eventTypes;
+    private readonly Dictionary<(string ViewName, int ViewVersion), IMaterializedViewProjector> _projectors;
+    private readonly IReadOnlyList<MvApplyHostRegistration> _registrations;
+
+    public NativeMvApplyHostFactory(IEnumerable<IMaterializedViewProjector> projectors, IEventTypes eventTypes)
+    {
+        _eventTypes = eventTypes;
+        _projectors = projectors.ToDictionary(
+            projector => (projector.ViewName, projector.ViewVersion),
+            projector => projector);
+        _registrations = _projectors.Keys
+            .Select(key => new MvApplyHostRegistration(key.ViewName, key.ViewVersion))
+            .OrderBy(registration => registration.ViewName, StringComparer.Ordinal)
+            .ThenBy(registration => registration.ViewVersion)
+            .ToList();
+    }
+
+    public IReadOnlyList<MvApplyHostRegistration> GetRegistrations() => _registrations;
+
+    public IMvApplyHost Create(string viewName, int viewVersion)
+    {
+        if (!_projectors.TryGetValue((viewName, viewVersion), out var projector))
+        {
+            throw new InvalidOperationException($"Materialized view apply host '{viewName}/{viewVersion}' is not registered.");
+        }
+
+        return new NativeMvApplyHost(projector, _eventTypes);
+    }
+}
+
+public sealed class NativeMvApplyHost : IMvApplyHost
+{
+    private readonly IEventTypes _eventTypes;
+    private readonly IMaterializedViewProjector _projector;
+    private readonly List<string> _logicalTables = [];
+
+    public NativeMvApplyHost(IMaterializedViewProjector projector, IEventTypes eventTypes)
+    {
+        _projector = projector;
+        _eventTypes = eventTypes;
+    }
+
+    public string ViewName => _projector.ViewName;
+    public int ViewVersion => _projector.ViewVersion;
+    public IReadOnlyList<string> LogicalTables => _logicalTables;
+
+    public async Task<IReadOnlyList<MvSqlStatementDto>> InitializeAsync(IMvTableBindings tables, CancellationToken ct)
+    {
+        if (tables is not MvTableBindings tableBindings)
+        {
+            throw new InvalidOperationException("Native materialized view apply host requires mutable table bindings.");
+        }
+
+        var recordingContext = new RecordingMvInitContext(tableBindings);
+        await _projector.InitializeAsync(recordingContext, ct).ConfigureAwait(false);
+
+        _logicalTables.Clear();
+        _logicalTables.AddRange(tableBindings.Tables.Select(table => table.LogicalName));
+        return recordingContext.Statements;
+    }
+
+    public async Task<IReadOnlyList<MvSqlStatementDto>> ApplyEventAsync(
+        SerializableEvent ev,
+        IMvTableBindings tables,
+        IMvApplyQueryPort queryPort,
+        string sortableUniqueId,
+        CancellationToken ct)
+    {
+        var eventResult = ev.ToEvent(_eventTypes);
+        if (!eventResult.IsSuccess)
+        {
+            throw eventResult.GetException();
+        }
+
+        var applyContext = new NativeMvApplyContextAdapter(
+            eventResult.GetValue(),
+            sortableUniqueId,
+            queryPort);
+        var statements = await _projector.ApplyToViewAsync(eventResult.GetValue(), applyContext, ct).ConfigureAwait(false);
+        return statements.Select(statement => new MvSqlStatementDto(statement.Sql, MvParamConverter.FromObject(statement.Parameters))).ToList();
+    }
+
+    private sealed class RecordingMvInitContext : IMvInitContext
+    {
+        private readonly MvTableBindings _bindings;
+        private readonly List<MvSqlStatementDto> _statements = [];
+
+        public RecordingMvInitContext(MvTableBindings bindings) => _bindings = bindings;
+
+        public IReadOnlyList<MvSqlStatementDto> Statements => _statements;
+        public MvDbType DatabaseType => MvDbType.Postgres;
+        public System.Data.IDbConnection Connection => throw new NotSupportedException("Native MV init host does not expose raw connections.");
+
+        public MvTable RegisterTable(string logicalName) => _bindings.RegisterTable(logicalName);
+
+        public Task ExecuteAsync(string sql, object? param = null, CancellationToken cancellationToken = default)
+        {
+            _statements.Add(new MvSqlStatementDto(sql, MvParamConverter.FromObject(param)));
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class NativeMvApplyContextAdapter : IMvApplyContext
+    {
+        private readonly IMvApplyQueryPort _queryPort;
+
+        public NativeMvApplyContextAdapter(Event currentEvent, string sortableUniqueId, IMvApplyQueryPort queryPort)
+        {
+            CurrentEvent = currentEvent;
+            CurrentSortableUniqueId = sortableUniqueId;
+            _queryPort = queryPort;
+        }
+
+        public MvDbType DatabaseType => MvDbType.Postgres;
+        public System.Data.IDbConnection Connection => throw new NotSupportedException("Native MV apply host does not expose raw connections.");
+        public System.Data.IDbTransaction Transaction => throw new NotSupportedException("Native MV apply host does not expose raw transactions.");
+        public Event CurrentEvent { get; }
+        public string CurrentSortableUniqueId { get; }
+
+        public async Task<IMvRow?> QuerySingleOrDefaultRowAsync(string sql, object? param = null, CancellationToken cancellationToken = default)
+        {
+            var row = await _queryPort.QuerySingleOrDefaultAsync(sql, MvParamConverter.FromObject(param), cancellationToken)
+                .ConfigureAwait(false);
+            return row is null ? null : new JsonElementMvRow(row.Value);
+        }
+
+        public async Task<IMvRowSet> QueryRowsAsync(string sql, object? param = null, CancellationToken cancellationToken = default)
+        {
+            var rows = await _queryPort.QueryRowsAsync(sql, MvParamConverter.FromObject(param), cancellationToken)
+                .ConfigureAwait(false);
+            return new JsonElementMvRowSet(rows.Select(row => (IMvRow)new JsonElementMvRow(row)).ToList());
+        }
+
+        public async Task<TScalar> ExecuteScalarAsync<TScalar>(string sql, object? param = null, CancellationToken cancellationToken = default)
+        {
+            var json = await _queryPort.ExecuteScalarJsonAsync(sql, MvParamConverter.FromObject(param), cancellationToken)
+                .ConfigureAwait(false);
+            if (json is null)
+            {
+                return default!;
+            }
+
+            return JsonSerializer.Deserialize<TScalar>(json)!;
+        }
+
+        public MvTable GetDependencyViewTable(string viewName, string logicalTable) =>
+            throw new NotSupportedException("Cross-view reads are not supported by the native MV apply host adapter.");
+
+        public MvTable GetDependencyViewTable<TView>(string logicalTable) where TView : IMaterializedViewProjector =>
+            throw new NotSupportedException("Cross-view reads are not supported by the native MV apply host adapter.");
+    }
+
+    private sealed class JsonElementMvRow : IMvRow
+    {
+        private readonly IReadOnlyDictionary<string, JsonElement> _values;
+
+        public JsonElementMvRow(JsonElement row)
+        {
+            if (row.ValueKind != JsonValueKind.Object)
+            {
+                throw new InvalidOperationException("Materialized view row payload must be a JSON object.");
+            }
+
+            _values = row.EnumerateObject()
+                .ToDictionary(property => property.Name, property => property.Value, StringComparer.OrdinalIgnoreCase);
+        }
+
+        public int ColumnCount => _values.Count;
+        public IReadOnlyList<string> ColumnNames => _values.Keys.ToList();
+        public bool IsNull(string columnName) => !_values.TryGetValue(columnName, out var value) || value.ValueKind is JsonValueKind.Null or JsonValueKind.Undefined;
+        public Guid GetGuid(string columnName) => GetAs<Guid>(columnName);
+        public string GetString(string columnName) => GetAs<string>(columnName);
+        public int GetInt32(string columnName) => GetAs<int>(columnName);
+        public long GetInt64(string columnName) => GetAs<long>(columnName);
+        public decimal GetDecimal(string columnName) => GetAs<decimal>(columnName);
+        public double GetDouble(string columnName) => GetAs<double>(columnName);
+        public bool GetBoolean(string columnName) => GetAs<bool>(columnName);
+        public DateTimeOffset GetDateTimeOffset(string columnName) => GetAs<DateTimeOffset>(columnName);
+        public byte[] GetBytes(string columnName) => GetAs<byte[]>(columnName);
+        public Guid? GetGuidOrNull(string columnName) => GetAs<Guid?>(columnName);
+        public string? GetStringOrNull(string columnName) => GetAs<string?>(columnName);
+        public int? GetInt32OrNull(string columnName) => GetAs<int?>(columnName);
+        public decimal? GetDecimalOrNull(string columnName) => GetAs<decimal?>(columnName);
+        public DateTimeOffset? GetDateTimeOffsetOrNull(string columnName) => GetAs<DateTimeOffset?>(columnName);
+
+        public T GetAs<T>(string columnName)
+        {
+            if (!_values.TryGetValue(columnName, out var value))
+            {
+                throw new KeyNotFoundException($"Column '{columnName}' does not exist.");
+            }
+
+            return MvRowValueConverter.ConvertValue<T>(value);
+        }
+
+        public string ToJson() => JsonSerializer.Serialize(_values);
+    }
+
+    private sealed class JsonElementMvRowSet : IMvRowSet
+    {
+        private readonly IReadOnlyList<IMvRow> _rows;
+
+        public JsonElementMvRowSet(IReadOnlyList<IMvRow> rows) => _rows = rows;
+
+        public IReadOnlyList<string> ColumnNames => _rows.FirstOrDefault()?.ColumnNames ?? [];
+        public int Count => _rows.Count;
+        public IMvRow this[int index] => _rows[index];
+        public IEnumerator<IMvRow> GetEnumerator() => _rows.GetEnumerator();
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+}

--- a/dcb/src/Sekiban.Dcb.MaterializedView/MvApplyHostSupport.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView/MvApplyHostSupport.cs
@@ -9,6 +9,7 @@ namespace Sekiban.Dcb.MaterializedView;
 public sealed class MvTableBindings : IMvTableBindings
 {
     private readonly Dictionary<string, MvTable> _tables = new(StringComparer.Ordinal);
+    private readonly List<MvTable> _tableList = [];
     private readonly MvOptions _options;
     private readonly string _viewName;
     private readonly int _viewVersion;
@@ -25,7 +26,7 @@ public sealed class MvTableBindings : IMvTableBindings
 
     public string GetPhysicalName(string logicalName) => RegisterTable(logicalName).PhysicalName;
 
-    public IReadOnlyList<MvTable> Tables => _tables.Values.ToList();
+    public IReadOnlyList<MvTable> Tables => _tableList;
 
     public MvTable RegisterTable(string logicalName, string? physicalName = null)
     {
@@ -40,6 +41,7 @@ public sealed class MvTableBindings : IMvTableBindings
             _viewName,
             _viewVersion);
         _tables[logicalName] = table;
+        _tableList.Add(table);
         return table;
     }
 }
@@ -288,6 +290,7 @@ public sealed class NativeMvApplyHost : IMvApplyHost
     private sealed class JsonElementMvRow : IMvRow
     {
         private readonly IReadOnlyDictionary<string, JsonElement> _values;
+        private readonly IReadOnlyList<string> _columnNames;
 
         public JsonElementMvRow(JsonElement row)
         {
@@ -298,10 +301,11 @@ public sealed class NativeMvApplyHost : IMvApplyHost
 
             _values = row.EnumerateObject()
                 .ToDictionary(property => property.Name, property => property.Value, StringComparer.OrdinalIgnoreCase);
+            _columnNames = _values.Keys.ToList();
         }
 
         public int ColumnCount => _values.Count;
-        public IReadOnlyList<string> ColumnNames => _values.Keys.ToList();
+        public IReadOnlyList<string> ColumnNames => _columnNames;
         public bool IsNull(string columnName) => !_values.TryGetValue(columnName, out var value) || value.ValueKind is JsonValueKind.Null or JsonValueKind.Undefined;
         public Guid GetGuid(string columnName) => GetAs<Guid>(columnName);
         public string GetString(string columnName) => GetAs<string>(columnName);

--- a/dcb/src/Sekiban.Dcb.MaterializedView/MvApplyHostSupport.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView/MvApplyHostSupport.cs
@@ -9,6 +9,7 @@ namespace Sekiban.Dcb.MaterializedView;
 public sealed class MvTableBindings : IMvTableBindings
 {
     private readonly Dictionary<string, MvTable> _tables = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, string> _logicalToPhysical = new(StringComparer.Ordinal);
     private readonly List<MvTable> _tableList = [];
     private readonly MvOptions _options;
     private readonly string _viewName;
@@ -21,8 +22,7 @@ public sealed class MvTableBindings : IMvTableBindings
         _options = options;
     }
 
-    public IReadOnlyDictionary<string, string> LogicalToPhysical =>
-        _tables.ToDictionary(pair => pair.Key, pair => pair.Value.PhysicalName, StringComparer.Ordinal);
+    public IReadOnlyDictionary<string, string> LogicalToPhysical => _logicalToPhysical;
 
     public string GetPhysicalName(string logicalName) => RegisterTable(logicalName).PhysicalName;
 
@@ -41,6 +41,7 @@ public sealed class MvTableBindings : IMvTableBindings
             _viewName,
             _viewVersion);
         _tables[logicalName] = table;
+        _logicalToPhysical[logicalName] = table.PhysicalName;
         _tableList.Add(table);
         return table;
     }
@@ -78,7 +79,10 @@ public static class MvParamConverter
     }
 
     public static object? ToClrValue(MvParam param) =>
-        param.Kind switch
+        param.Kind != MvParamKind.Null && param.ValueJson is null
+            ? throw new InvalidOperationException(
+                $"Materialized view parameter '{param.Name}' has kind '{param.Kind}' but no serialized value.")
+            : param.Kind switch
         {
             MvParamKind.Null => DBNull.Value,
             MvParamKind.String => Deserialize<string>(param.ValueJson),
@@ -183,16 +187,11 @@ public sealed class NativeMvApplyHost : IMvApplyHost
 
     public async Task<IReadOnlyList<MvSqlStatementDto>> InitializeAsync(IMvTableBindings tables, CancellationToken ct)
     {
-        if (tables is not MvTableBindings tableBindings)
-        {
-            throw new InvalidOperationException("Native materialized view apply host requires mutable table bindings.");
-        }
-
-        var recordingContext = new RecordingMvInitContext(tableBindings);
+        var recordingContext = new RecordingMvInitContext(tables);
         await _projector.InitializeAsync(recordingContext, ct).ConfigureAwait(false);
 
         _logicalTables.Clear();
-        _logicalTables.AddRange(tableBindings.Tables.Select(table => table.LogicalName));
+        _logicalTables.AddRange(tables.LogicalToPhysical.Keys.Order(StringComparer.Ordinal));
         return recordingContext.Statements;
     }
 
@@ -219,10 +218,10 @@ public sealed class NativeMvApplyHost : IMvApplyHost
 
     private sealed class RecordingMvInitContext : IMvInitContext
     {
-        private readonly MvTableBindings _bindings;
+        private readonly IMvTableBindings _bindings;
         private readonly List<MvSqlStatementDto> _statements = [];
 
-        public RecordingMvInitContext(MvTableBindings bindings) => _bindings = bindings;
+        public RecordingMvInitContext(IMvTableBindings bindings) => _bindings = bindings;
 
         public IReadOnlyList<MvSqlStatementDto> Statements => _statements;
         public MvDbType DatabaseType => MvDbType.Postgres;
@@ -249,8 +248,14 @@ public sealed class NativeMvApplyHost : IMvApplyHost
         }
 
         public MvDbType DatabaseType => MvDbType.Postgres;
-        public System.Data.IDbConnection Connection => throw new NotSupportedException("Native MV apply host does not expose raw connections.");
-        public System.Data.IDbTransaction Transaction => throw new NotSupportedException("Native MV apply host does not expose raw transactions.");
+        public System.Data.IDbConnection Connection =>
+            _queryPort is IMvApplyDbConnectionPort dbConnectionPort
+                ? dbConnectionPort.Connection
+                : throw new NotSupportedException("Native MV apply host does not expose raw connections.");
+        public System.Data.IDbTransaction Transaction =>
+            _queryPort is IMvApplyDbConnectionPort dbConnectionPort
+                ? dbConnectionPort.Transaction
+                : throw new NotSupportedException("Native MV apply host does not expose raw transactions.");
         public Event CurrentEvent { get; }
         public string CurrentSortableUniqueId { get; }
 

--- a/dcb/src/Sekiban.Dcb.MaterializedView/MvCatchUpWorker.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView/MvCatchUpWorker.cs
@@ -8,19 +8,21 @@ public sealed class MvCatchUpWorker : BackgroundService
 {
     private readonly Dictionary<string, int> _failureCounts = new(StringComparer.Ordinal);
     private readonly IMvExecutor _executor;
+    private readonly IMvApplyHostFactory _hostFactory;
     private readonly ILogger<MvCatchUpWorker> _logger;
-    private readonly IReadOnlyList<IMaterializedViewProjector> _projectors;
+    private readonly IReadOnlyList<MvApplyHostRegistration> _registrations;
     private readonly MvOptions _options;
 
     public MvCatchUpWorker(
-        IEnumerable<IMaterializedViewProjector> projectors,
+        IMvApplyHostFactory hostFactory,
         IMvExecutor executor,
         IOptions<MvOptions> options,
         ILogger<MvCatchUpWorker> logger)
     {
         _executor = executor;
+        _hostFactory = hostFactory;
         _logger = logger;
-        _projectors = projectors.ToList();
+        _registrations = hostFactory.GetRegistrations();
         _options = options.Value;
     }
 
@@ -45,9 +47,10 @@ public sealed class MvCatchUpWorker : BackgroundService
 
     private async Task InitializeProjectorsAsync(CancellationToken stoppingToken)
     {
-        foreach (var projector in _projectors)
+        foreach (var registration in _registrations)
         {
-            await _executor.InitializeAsync(projector, cancellationToken: stoppingToken).ConfigureAwait(false);
+            var host = _hostFactory.Create(registration.ViewName, registration.ViewVersion);
+            await _executor.InitializeAsync(host, cancellationToken: stoppingToken).ConfigureAwait(false);
         }
     }
 
@@ -56,9 +59,9 @@ public sealed class MvCatchUpWorker : BackgroundService
         var appliedEvents = 0;
         var shouldDelay = false;
 
-        foreach (var projector in _projectors)
+        foreach (var registration in _registrations)
         {
-            var projectorResult = await ProcessProjectorAsync(projector, stoppingToken).ConfigureAwait(false);
+            var projectorResult = await ProcessProjectorAsync(registration, stoppingToken).ConfigureAwait(false);
             if (projectorResult.ShouldStop)
             {
                 return projectorResult;
@@ -72,13 +75,14 @@ public sealed class MvCatchUpWorker : BackgroundService
     }
 
     private async Task<CatchUpCycleResult> ProcessProjectorAsync(
-        IMaterializedViewProjector projector,
+        MvApplyHostRegistration registration,
         CancellationToken stoppingToken)
     {
+        var host = _hostFactory.Create(registration.ViewName, registration.ViewVersion);
         try
         {
-            var result = await _executor.CatchUpOnceAsync(projector, cancellationToken: stoppingToken).ConfigureAwait(false);
-            _failureCounts.Remove(GetProjectorKey(projector));
+            var result = await _executor.CatchUpOnceAsync(host, cancellationToken: stoppingToken).ConfigureAwait(false);
+            _failureCounts.Remove(GetProjectorKey(registration));
             return new CatchUpCycleResult(result.AppliedEvents, result.ReachedUnsafeWindow, ShouldStop: false);
         }
         catch (NotSupportedException ex)
@@ -86,20 +90,20 @@ public sealed class MvCatchUpWorker : BackgroundService
             _logger.LogError(
                 ex,
                 "Materialized view worker stopped because the configured event store cannot stream all events for {ViewName}/{ViewVersion}.",
-                projector.ViewName,
-                projector.ViewVersion);
+                registration.ViewName,
+                registration.ViewVersion);
             return new CatchUpCycleResult(0, ShouldDelay: false, ShouldStop: true);
         }
         catch (Exception ex)
         {
-            var failures = IncrementFailureCount(projector);
+            var failures = IncrementFailureCount(registration);
             if (failures >= _options.MaxConsecutiveFailuresBeforeStop)
             {
                 _logger.LogError(
                     ex,
                     "Materialized view worker halted on {ViewName}/{ViewVersion} after {FailureCount} consecutive failures.",
-                    projector.ViewName,
-                    projector.ViewVersion,
+                    registration.ViewName,
+                    registration.ViewVersion,
                     failures);
                 return new CatchUpCycleResult(0, ShouldDelay: false, ShouldStop: true);
             }
@@ -107,24 +111,24 @@ public sealed class MvCatchUpWorker : BackgroundService
             _logger.LogWarning(
                 ex,
                 "Materialized view worker retrying {ViewName}/{ViewVersion} after failure {FailureCount}/{MaxFailures}.",
-                projector.ViewName,
-                projector.ViewVersion,
+                registration.ViewName,
+                registration.ViewVersion,
                 failures,
                 _options.MaxConsecutiveFailuresBeforeStop);
             return new CatchUpCycleResult(0, ShouldDelay: true, ShouldStop: false);
         }
     }
 
-    private int IncrementFailureCount(IMaterializedViewProjector projector)
+    private int IncrementFailureCount(MvApplyHostRegistration registration)
     {
-        var key = GetProjectorKey(projector);
+        var key = GetProjectorKey(registration);
         var failures = _failureCounts.TryGetValue(key, out var currentFailures) ? currentFailures + 1 : 1;
         _failureCounts[key] = failures;
         return failures;
     }
 
-    private static string GetProjectorKey(IMaterializedViewProjector projector) =>
-        $"{projector.ViewName}:{projector.ViewVersion}";
+    private static string GetProjectorKey(MvApplyHostRegistration registration) =>
+        $"{registration.ViewName}:{registration.ViewVersion}";
 
     private sealed record CatchUpCycleResult(int AppliedEvents, bool ShouldDelay, bool ShouldStop);
 }

--- a/dcb/src/Sekiban.Dcb.MaterializedView/MvContracts.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView/MvContracts.cs
@@ -1,4 +1,5 @@
 using System.Data;
+using System.Text.Json;
 using Sekiban.Dcb.Events;
 
 namespace Sekiban.Dcb.MaterializedView;
@@ -41,7 +42,26 @@ public sealed class MvTable
     public int ViewVersion { get; }
 }
 
+public enum MvParamKind
+{
+    Null = 0,
+    String = 1,
+    Int32 = 2,
+    Int64 = 3,
+    Boolean = 4,
+    Guid = 5,
+    DateTimeOffset = 6,
+    Decimal = 7,
+    Double = 8,
+    Bytes = 9,
+    DateTime = 10
+}
+
+public readonly record struct MvParam(string Name, MvParamKind Kind, string? ValueJson);
+
 public readonly record struct MvSqlStatement(string Sql, object? Parameters = null);
+public readonly record struct MvSqlStatementDto(string Sql, IReadOnlyList<MvParam> Parameters);
+public readonly record struct MvApplyHostRegistration(string ViewName, int ViewVersion);
 
 public sealed record MvRegistryEntry
 {
@@ -78,6 +98,54 @@ public sealed record MvPositionUpdate(
     string SortableUniqueId,
     MvApplySource Source,
     long AppliedEventVersionDelta = 1);
+
+public interface IMvTableBindings
+{
+    string GetPhysicalName(string logicalName);
+    IReadOnlyDictionary<string, string> LogicalToPhysical { get; }
+}
+
+public interface IMvApplyQueryPort
+{
+    Task<IReadOnlyList<JsonElement>> QueryRowsAsync(
+        string sql,
+        IReadOnlyList<MvParam> parameters,
+        CancellationToken ct);
+
+    Task<JsonElement?> QuerySingleOrDefaultAsync(
+        string sql,
+        IReadOnlyList<MvParam> parameters,
+        CancellationToken ct);
+
+    Task<string?> ExecuteScalarJsonAsync(
+        string sql,
+        IReadOnlyList<MvParam> parameters,
+        CancellationToken ct);
+}
+
+public interface IMvApplyHost
+{
+    string ViewName { get; }
+    int ViewVersion { get; }
+    IReadOnlyList<string> LogicalTables { get; }
+
+    Task<IReadOnlyList<MvSqlStatementDto>> InitializeAsync(
+        IMvTableBindings tables,
+        CancellationToken ct);
+
+    Task<IReadOnlyList<MvSqlStatementDto>> ApplyEventAsync(
+        SerializableEvent ev,
+        IMvTableBindings tables,
+        IMvApplyQueryPort queryPort,
+        string sortableUniqueId,
+        CancellationToken ct);
+}
+
+public interface IMvApplyHostFactory
+{
+    IReadOnlyList<MvApplyHostRegistration> GetRegistrations();
+    IMvApplyHost Create(string viewName, int viewVersion);
+}
 
 public interface IMvInitContext
 {
@@ -168,17 +236,17 @@ public interface IMvStorageInfoProvider
 public interface IMvExecutor
 {
     Task InitializeAsync(
-        IMaterializedViewProjector projector,
+        IMvApplyHost host,
         string? serviceId = null,
         CancellationToken cancellationToken = default);
 
     Task<MvCatchUpResult> CatchUpOnceAsync(
-        IMaterializedViewProjector projector,
+        IMvApplyHost host,
         string? serviceId = null,
         CancellationToken cancellationToken = default);
 
     Task<int> ApplySerializableEventsAsync(
-        IMaterializedViewProjector projector,
+        IMvApplyHost host,
         IReadOnlyList<SerializableEvent> events,
         string? serviceId = null,
         CancellationToken cancellationToken = default);

--- a/dcb/src/Sekiban.Dcb.MaterializedView/MvContracts.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView/MvContracts.cs
@@ -44,6 +44,7 @@ public sealed class MvTable
 
 public enum MvParamKind
 {
+    // Wire contract for non-CLR hosts. Values are append-only and must not be reordered.
     Null = 0,
     String = 1,
     Int32 = 2,
@@ -103,6 +104,7 @@ public interface IMvTableBindings
 {
     string GetPhysicalName(string logicalName);
     IReadOnlyDictionary<string, string> LogicalToPhysical { get; }
+    MvTable RegisterTable(string logicalName, string? physicalName = null);
 }
 
 public interface IMvApplyQueryPort
@@ -123,10 +125,19 @@ public interface IMvApplyQueryPort
         CancellationToken ct);
 }
 
+public interface IMvApplyDbConnectionPort : IMvApplyQueryPort
+{
+    IDbConnection Connection { get; }
+    IDbTransaction Transaction { get; }
+}
+
 public interface IMvApplyHost
 {
     string ViewName { get; }
     int ViewVersion { get; }
+    /// <summary>
+    ///     Some hosts only discover logical tables during <see cref="InitializeAsync" /> and may return an empty list before initialization.
+    /// </summary>
     IReadOnlyList<string> LogicalTables { get; }
 
     Task<IReadOnlyList<MvSqlStatementDto>> InitializeAsync(

--- a/dcb/src/Sekiban.Dcb.MaterializedView/SekibanDcbMaterializedViewExtensions.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView/SekibanDcbMaterializedViewExtensions.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Sekiban.Dcb.Domains;
 namespace Sekiban.Dcb.MaterializedView;
 
 public static class SekibanDcbMaterializedViewExtensions
@@ -9,6 +10,8 @@ public static class SekibanDcbMaterializedViewExtensions
         Action<MvOptions>? configure = null)
     {
         services.AddOptions<MvOptions>();
+        services.TryAddSingleton<IEventTypes>(sp => sp.GetRequiredService<DcbDomainTypes>().EventTypes);
+        services.TryAddSingleton<IMvApplyHostFactory, NativeMvApplyHostFactory>();
         if (configure is not null)
         {
             services.Configure(configure);

--- a/dcb/src/Sekiban.Dcb.Orleans.Core/Grains/OrleansTagStatePersistent.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.Core/Grains/OrleansTagStatePersistent.cs
@@ -26,7 +26,7 @@ public class OrleansTagStatePersistent : ITagStatePersistent, ISerializableTagSt
         {
             // Deserialize payload from SerializableTagState
             var deserializeResult = _tagStatePayloadTypes.DeserializePayload(
-                serializable.TagPayloadName,
+                serializable.ResolvedPayloadName,
                 serializable.Payload);
 
             if (!deserializeResult.IsSuccess)
@@ -67,7 +67,8 @@ public class OrleansTagStatePersistent : ITagStatePersistent, ISerializableTagSt
             state.TagContent,
             state.TagProjector,
             state.Payload.GetType().Name,
-            state.ProjectorVersion);
+            state.ProjectorVersion,
+            state.Payload.GetType().Name);
 
         _cache.State = new TagStateCacheState { CachedState = serializable };
         await _cache.WriteStateAsync();

--- a/dcb/src/Sekiban.Dcb.Orleans.Core/Grains/TagStateGrain.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.Core/Grains/TagStateGrain.cs
@@ -68,7 +68,8 @@ public class TagStateGrain : Grain, ITagStateGrain
                 string.Empty,
                 string.Empty,
                 nameof(EmptyTagStatePayload),
-                string.Empty);
+                string.Empty,
+                nameof(EmptyTagStatePayload));
         }
 
         var latestSortableUniqueId = await GetLatestSortableUniqueIdAsync(_tagStateId);
@@ -132,7 +133,7 @@ public class TagStateGrain : Grain, ITagStateGrain
         }
 
         var serialized = await GetStateAsync();
-        if (serialized.TagPayloadName == nameof(EmptyTagStatePayload))
+        if (serialized.ResolvedPayloadName == nameof(EmptyTagStatePayload))
         {
             return new TagState(
                 new EmptyTagStatePayload(),
@@ -145,12 +146,12 @@ public class TagStateGrain : Grain, ITagStateGrain
         }
 
         var deserializeResult = _tagStatePayloadTypes.DeserializePayload(
-            serialized.TagPayloadName,
+            serialized.ResolvedPayloadName,
             serialized.Payload);
         if (!deserializeResult.IsSuccess)
         {
             throw new InvalidOperationException(
-                $"Failed to deserialize payload '{serialized.TagPayloadName}': {deserializeResult.GetException().Message}",
+                $"Failed to deserialize payload '{serialized.ResolvedPayloadName}': {deserializeResult.GetException().Message}",
                 deserializeResult.GetException());
         }
 
@@ -190,7 +191,8 @@ public class TagStateGrain : Grain, ITagStateGrain
                 newState.TagContent,
                 newState.TagProjector,
                 nameof(EmptyTagStatePayload),
-                newState.ProjectorVersion);
+                newState.ProjectorVersion,
+                nameof(EmptyTagStatePayload));
         }
         else
         {
@@ -210,7 +212,8 @@ public class TagStateGrain : Grain, ITagStateGrain
                 newState.TagContent,
                 newState.TagProjector,
                 newState.Payload.GetType().Name,
-                newState.ProjectorVersion);
+                newState.ProjectorVersion,
+                newState.Payload.GetType().Name);
         }
 
         _cache.State = new TagStateCacheState { CachedState = serialized };

--- a/dcb/src/Sekiban.Dcb.Orleans.Core/Runtimes/NativeTagStateProjectionPrimitive.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.Core/Runtimes/NativeTagStateProjectionPrimitive.cs
@@ -94,7 +94,7 @@ public sealed class NativeTagStateProjectionPrimitive : ITagStateProjectionPrimi
                 return true;
             }
 
-            if (_cachedState.TagPayloadName == nameof(EmptyTagStatePayload))
+            if (_cachedState.ResolvedPayloadName == nameof(EmptyTagStatePayload))
             {
                 _currentPayload = new EmptyTagStatePayload();
                 _version = _cachedState.Version;
@@ -102,7 +102,7 @@ public sealed class NativeTagStateProjectionPrimitive : ITagStateProjectionPrimi
                 return true;
             }
 
-            var deserializeResult = _tagStatePayloadTypes.DeserializePayload(_cachedState.TagPayloadName, _cachedState.Payload);
+            var deserializeResult = _tagStatePayloadTypes.DeserializePayload(_cachedState.ResolvedPayloadName, _cachedState.Payload);
             if (!deserializeResult.IsSuccess)
             {
                 return false;
@@ -185,7 +185,8 @@ public sealed class NativeTagStateProjectionPrimitive : ITagStateProjectionPrimi
                 _tagContent,
                 _tagProjector,
                 serializationResult.GetValue().PayloadName,
-                _projectorVersion);
+                _projectorVersion,
+                serializationResult.GetValue().PayloadName);
         }
 
         public void Dispose()
@@ -218,5 +219,6 @@ public sealed class NativeTagStateProjectionPrimitive : ITagStateProjectionPrimi
             tagStateId.TagContent,
             tagStateId.TagProjectorName,
             nameof(EmptyTagStatePayload),
-            projectorVersion);
+            projectorVersion,
+            nameof(EmptyTagStatePayload));
 }

--- a/dcb/src/Sekiban.Dcb.Orleans.Core/Surrogates/SerializableTagStateSurrogate.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.Core/Surrogates/SerializableTagStateSurrogate.cs
@@ -26,4 +26,7 @@ public struct SerializableTagStateSurrogate
 
     [Id(7)]
     public string ProjectorVersion { get; set; }
+
+    [Id(8)]
+    public string? ActualPayloadName { get; set; }
 }

--- a/dcb/src/Sekiban.Dcb.Orleans.Core/Surrogates/SerializableTagStateSurrogateConverter.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.Core/Surrogates/SerializableTagStateSurrogateConverter.cs
@@ -14,7 +14,8 @@ public sealed class
             surrogate.TagContent,
             surrogate.TagProjector,
             surrogate.TagPayloadName,
-            surrogate.ProjectorVersion);
+            surrogate.ProjectorVersion,
+            surrogate.ActualPayloadName);
 
     public SerializableTagStateSurrogate ConvertToSurrogate(in SerializableTagState value) =>
         new()
@@ -26,6 +27,7 @@ public sealed class
             TagContent = value.TagContent,
             TagProjector = value.TagProjector,
             TagPayloadName = value.TagPayloadName,
-            ProjectorVersion = value.ProjectorVersion
+            ProjectorVersion = value.ProjectorVersion,
+            ActualPayloadName = value.ActualPayloadName
         };
 }

--- a/dcb/src/Sekiban.Dcb.WithResult/Actors/GeneralCommandContext.cs
+++ b/dcb/src/Sekiban.Dcb.WithResult/Actors/GeneralCommandContext.cs
@@ -63,7 +63,7 @@ public class GeneralCommandContext : ICommandContext, ICommandContextResultAcces
 
             // Deserialize the payload
             var payloadResult = _domainTypes.TagStatePayloadTypes.DeserializePayload(
-                serializableState.TagPayloadName,
+                serializableState.ResolvedPayloadName,
                 serializableState.Payload);
 
             if (!payloadResult.IsSuccess)
@@ -142,7 +142,7 @@ public class GeneralCommandContext : ICommandContext, ICommandContextResultAcces
 
             // Deserialize the payload
             var payloadResult = _domainTypes.TagStatePayloadTypes.DeserializePayload(
-                serializableState.TagPayloadName,
+                serializableState.ResolvedPayloadName,
                 serializableState.Payload);
 
             if (!payloadResult.IsSuccess)

--- a/dcb/tests/Sekiban.Dcb.MaterializedView.Postgres.Tests/MaterializedViewPostgresTests.cs
+++ b/dcb/tests/Sekiban.Dcb.MaterializedView.Postgres.Tests/MaterializedViewPostgresTests.cs
@@ -304,6 +304,34 @@ public sealed class MaterializedViewPostgresTests(MaterializedViewPostgresFixtur
         Assert.False(string.IsNullOrWhiteSpace(row.LastSortableUniqueId));
     }
 
+    [Fact]
+    public async Task CatchUp_NativeHost_PreservesConnectionAndTransactionAccess_OnPostgresPath()
+    {
+        if (!fixture.IsAvailable)
+        {
+            fixture.EnsureAvailable();
+            return;
+        }
+
+        await fixture.ResetAsync();
+        var projector = new RawConnectionMvProjector();
+        await fixture.Executor.InitializeAsync(ApplyHost(projector));
+
+        var executor = new GeneralSekibanExecutor(fixture.EventStore, fixture.ActorAccessor, fixture.DomainTypes);
+        var orderId = Guid.CreateVersion7();
+        await executor.ExecuteAsync(new CreateOrder { OrderId = orderId, CreatedAt = DateTimeOffset.UtcNow.AddMinutes(-1) });
+
+        var catchUp = await fixture.Executor.CatchUpOnceAsync(ApplyHost(projector));
+
+        await using var connection = await fixture.OpenConnectionAsync();
+        var insertedId = await connection.ExecuteScalarAsync<Guid?>(
+            $"SELECT id FROM {RawConnectionMvProjector.TableName} WHERE id = @Id;",
+            new { Id = orderId });
+
+        Assert.Equal(1, catchUp.AppliedEvents);
+        Assert.Equal(orderId, insertedId);
+    }
+
     private sealed class OrderQueryRow
     {
         public Guid Id { get; set; }
@@ -381,6 +409,54 @@ public sealed class MaterializedViewPostgresTests(MaterializedViewPostgresFixtur
                     new { Id = created.OrderId, SortableUniqueId = ctx.CurrentSortableUniqueId }),
                 new MvSqlStatement("INSERT INTO definitely_missing_table(id) VALUES (1);")
             ]);
+        }
+    }
+
+    private sealed class RawConnectionMvProjector : IMaterializedViewProjector
+    {
+        public const string TableName = "sekiban_mv_rawconnection_v1_orders";
+
+        public string ViewName => "RawConnection";
+        public int ViewVersion => 1;
+
+        public async Task InitializeAsync(IMvInitContext ctx, CancellationToken cancellationToken = default)
+        {
+            ctx.RegisterTable("orders");
+            await ctx.ExecuteAsync(
+                $"""
+                 CREATE TABLE IF NOT EXISTS {TableName} (
+                     id UUID PRIMARY KEY,
+                     _last_sortable_unique_id TEXT NOT NULL,
+                     _last_applied_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+                 );
+                 """,
+                cancellationToken: cancellationToken);
+        }
+
+        public async Task<IReadOnlyList<MvSqlStatement>> ApplyToViewAsync(
+            Event ev,
+            IMvApplyContext ctx,
+            CancellationToken cancellationToken = default)
+        {
+            if (ev.Payload is not OrderCreated created)
+            {
+                return [];
+            }
+
+            await ctx.Connection.ExecuteAsync(
+                new CommandDefinition(
+                    $"""
+                     INSERT INTO {TableName} (id, _last_sortable_unique_id, _last_applied_at)
+                     VALUES (@Id, @SortableUniqueId, NOW())
+                     ON CONFLICT (id) DO UPDATE
+                     SET _last_sortable_unique_id = EXCLUDED._last_sortable_unique_id,
+                         _last_applied_at = EXCLUDED._last_applied_at;
+                     """,
+                    new { Id = created.OrderId, SortableUniqueId = ctx.CurrentSortableUniqueId },
+                    ctx.Transaction,
+                    cancellationToken: cancellationToken));
+
+            return [];
         }
     }
 

--- a/dcb/tests/Sekiban.Dcb.MaterializedView.Postgres.Tests/MaterializedViewPostgresTests.cs
+++ b/dcb/tests/Sekiban.Dcb.MaterializedView.Postgres.Tests/MaterializedViewPostgresTests.cs
@@ -27,7 +27,7 @@ public sealed class MaterializedViewPostgresTests(MaterializedViewPostgresFixtur
         }
         await fixture.ResetAsync();
 
-        await fixture.Executor.InitializeAsync(fixture.Projector);
+        await fixture.Executor.InitializeAsync(ApplyHost(fixture.Projector));
 
         await using var connection = await fixture.OpenConnectionAsync();
         var registryCount = await connection.ExecuteScalarAsync<int>("SELECT COUNT(*) FROM sekiban_mv_registry;");
@@ -52,7 +52,7 @@ public sealed class MaterializedViewPostgresTests(MaterializedViewPostgresFixtur
             return;
         }
         await fixture.ResetAsync();
-        await fixture.Executor.InitializeAsync(fixture.Projector);
+        await fixture.Executor.InitializeAsync(ApplyHost(fixture.Projector));
 
         var executor = new GeneralSekibanExecutor(fixture.EventStore, fixture.ActorAccessor, fixture.DomainTypes);
         var orderId = Guid.CreateVersion7();
@@ -70,8 +70,8 @@ public sealed class MaterializedViewPostgresTests(MaterializedViewPostgresFixtur
         });
         await executor.ExecuteAsync(new CancelOrder { OrderId = orderId, CancelledAt = DateTimeOffset.UtcNow.AddSeconds(-10) });
 
-        var firstCatchUp = await fixture.Executor.CatchUpOnceAsync(fixture.Projector);
-        var secondCatchUp = await fixture.Executor.CatchUpOnceAsync(fixture.Projector);
+        var firstCatchUp = await fixture.Executor.CatchUpOnceAsync(ApplyHost(fixture.Projector));
+        var secondCatchUp = await fixture.Executor.CatchUpOnceAsync(ApplyHost(fixture.Projector));
 
         await using var connection = await fixture.OpenConnectionAsync();
         var orderRow = await connection.QuerySingleAsync<OrderQueryRow>(
@@ -151,7 +151,7 @@ public sealed class MaterializedViewPostgresTests(MaterializedViewPostgresFixtur
             return;
         }
         await fixture.ResetAsync();
-        await fixture.Executor.InitializeAsync(fixture.Projector);
+        await fixture.Executor.InitializeAsync(ApplyHost(fixture.Projector));
 
         var executor = new GeneralSekibanExecutor(fixture.EventStore, fixture.ActorAccessor, fixture.DomainTypes);
         var orderId = Guid.CreateVersion7();
@@ -169,7 +169,7 @@ public sealed class MaterializedViewPostgresTests(MaterializedViewPostgresFixtur
         });
         await executor.ExecuteAsync(new CancelOrder { OrderId = orderId, CancelledAt = DateTimeOffset.UtcNow.AddSeconds(-10) });
 
-        await fixture.Executor.CatchUpOnceAsync(fixture.Projector);
+        await fixture.Executor.CatchUpOnceAsync(ApplyHost(fixture.Projector));
 
         await using (var rewindConnection = await fixture.OpenConnectionAsync())
         {
@@ -182,7 +182,7 @@ public sealed class MaterializedViewPostgresTests(MaterializedViewPostgresFixtur
                 """);
         }
 
-        var replayCatchUp = await fixture.Executor.CatchUpOnceAsync(fixture.Projector);
+        var replayCatchUp = await fixture.Executor.CatchUpOnceAsync(ApplyHost(fixture.Projector));
 
         await using var connection = await fixture.OpenConnectionAsync();
         var orderRow = await connection.QuerySingleAsync<OrderQueryRow>(
@@ -217,13 +217,13 @@ public sealed class MaterializedViewPostgresTests(MaterializedViewPostgresFixtur
         }
         await fixture.ResetAsync();
         var failingProjector = new FailingMvProjector();
-        await fixture.Executor.InitializeAsync(failingProjector);
+        await fixture.Executor.InitializeAsync(ApplyHost(failingProjector));
 
         var executor = new GeneralSekibanExecutor(fixture.EventStore, fixture.ActorAccessor, fixture.DomainTypes);
         var orderId = Guid.CreateVersion7();
         await executor.ExecuteAsync(new CreateOrder { OrderId = orderId, CreatedAt = DateTimeOffset.UtcNow.AddMinutes(-1) });
 
-        await Assert.ThrowsAnyAsync<PostgresException>(() => fixture.Executor.CatchUpOnceAsync(failingProjector));
+        await Assert.ThrowsAnyAsync<PostgresException>(() => fixture.Executor.CatchUpOnceAsync(ApplyHost(failingProjector)));
 
         await using var connection = await fixture.OpenConnectionAsync();
         var rowCount = await connection.ExecuteScalarAsync<int>("SELECT COUNT(*) FROM sekiban_mv_failure_v1_orders;");
@@ -249,7 +249,7 @@ public sealed class MaterializedViewPostgresTests(MaterializedViewPostgresFixtur
 
         await fixture.ResetAsync();
         var projector = new WeatherForecastMvV1();
-        await fixture.Executor.InitializeAsync(projector);
+        await fixture.Executor.InitializeAsync(ApplyHost(projector));
 
         var executor = new GeneralSekibanExecutor(fixture.EventStore, fixture.ActorAccessor, fixture.DomainTypes);
         var forecastId = Guid.CreateVersion7();
@@ -277,7 +277,7 @@ public sealed class MaterializedViewPostgresTests(MaterializedViewPostgresFixtur
             Summary = "Cloudy"
         });
 
-        var catchUp = await fixture.Executor.CatchUpOnceAsync(projector);
+        var catchUp = await fixture.Executor.CatchUpOnceAsync(ApplyHost(projector));
 
         await using var connection = await fixture.OpenConnectionAsync();
         var row = await connection.QuerySingleAsync<WeatherForecastQueryRow>(
@@ -383,4 +383,7 @@ public sealed class MaterializedViewPostgresTests(MaterializedViewPostgresFixtur
             ]);
         }
     }
+
+    private NativeMvApplyHost ApplyHost(IMaterializedViewProjector projector) =>
+        new(projector, fixture.DomainTypes.EventTypes);
 }

--- a/dcb/tests/Sekiban.Dcb.MaterializedView.Tests/MaterializedViewUnitTests.cs
+++ b/dcb/tests/Sekiban.Dcb.MaterializedView.Tests/MaterializedViewUnitTests.cs
@@ -217,6 +217,15 @@ public class MaterializedViewUnitTests
     }
 
     [Fact]
+    public void MvParamConverter_RejectsNullPayloadForNonNullKind()
+    {
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => MvParamConverter.ToClrValue(new MvParam("Name", MvParamKind.String, null)));
+
+        Assert.Contains("Name", exception.Message);
+    }
+
+    [Fact]
     public void SerializableTagState_ResolvedPayloadName_PrefersActualPayloadName()
     {
         var state = new SerializableTagState(

--- a/dcb/tests/Sekiban.Dcb.MaterializedView.Tests/MaterializedViewUnitTests.cs
+++ b/dcb/tests/Sekiban.Dcb.MaterializedView.Tests/MaterializedViewUnitTests.cs
@@ -1,9 +1,12 @@
+using Dcb.Domain.WithoutResult;
 using Dcb.Domain.WithoutResult.MaterializedViews;
 using Dcb.Domain.WithoutResult.Order;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
+using Sekiban.Dcb.Domains;
 using Sekiban.Dcb.Events;
 using Sekiban.Dcb.MaterializedView;
+using Sekiban.Dcb.Tags;
 using Xunit;
 
 namespace Sekiban.Dcb.MaterializedView.Tests;
@@ -138,9 +141,9 @@ public class MaterializedViewUnitTests
     public async Task CatchUpWorker_UsesPollDelayWhenNothingProcessed()
     {
         var executor = new FakeMvExecutor();
-        var projector = new FakeProjector();
+        var hostFactory = new FakeApplyHostFactory(new FakeApplyHost("Fake", 1));
         using var worker = new MvCatchUpWorker(
-            [projector],
+            hostFactory,
             executor,
             Options.Create(new MvOptions { PollInterval = TimeSpan.FromMilliseconds(10) }),
             NullLogger<MvCatchUpWorker>.Instance);
@@ -152,6 +155,82 @@ public class MaterializedViewUnitTests
 
         Assert.True(executor.InitializeCalls >= 1);
         Assert.True(executor.CatchUpCalls >= 1);
+    }
+
+    [Fact]
+    public async Task NativeMvApplyHost_AdaptsExistingProjector_ToTypedStatements()
+    {
+        var domainTypes = DomainType.GetDomainTypes();
+        var host = new NativeMvApplyHost(new OrderSummaryMvV1(), domainTypes.EventTypes);
+        var bindings = new MvTableBindings("OrderSummary", 1, new MvOptions());
+
+        var initStatements = await host.InitializeAsync(bindings, CancellationToken.None);
+
+        Assert.NotEmpty(initStatements);
+        Assert.Contains(bindings.Tables, table => table.LogicalName == "orders");
+        Assert.Contains(bindings.Tables, table => table.LogicalName == "items");
+
+        var evt = new Event(
+            new OrderCreated(Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"), DateTimeOffset.UtcNow),
+            "100",
+            nameof(OrderCreated),
+            Guid.NewGuid(),
+            new EventMetadata("cause", "corr", "tester"),
+            []);
+        var serializable = evt.ToSerializableEvent(domainTypes.EventTypes);
+        var statements = await host.ApplyEventAsync(
+            serializable,
+            bindings,
+            new FakeApplyQueryPort(),
+            "999",
+            CancellationToken.None);
+
+        Assert.Single(statements);
+        Assert.Contains("INSERT INTO sekiban_mv_ordersummary_v1_orders", statements[0].Sql);
+        Assert.Contains(statements[0].Parameters, parameter => parameter.Name == "SortableUniqueId" && parameter.Kind == MvParamKind.String);
+    }
+
+    [Fact]
+    public void MvParamConverter_RoundTripsTypedParameters()
+    {
+        var when = new DateTimeOffset(2026, 4, 17, 10, 0, 0, TimeSpan.Zero);
+        var id = Guid.Parse("11111111-1111-1111-1111-111111111111");
+        var parameters = MvParamConverter.FromObject(new
+        {
+            Name = "sekiban",
+            Count = 3,
+            Amount = 12.5m,
+            Active = true,
+            When = when,
+            Id = id
+        });
+
+        Assert.Equal(MvParamKind.String, parameters.Single(parameter => parameter.Name == "Name").Kind);
+        Assert.Equal(MvParamKind.Int32, parameters.Single(parameter => parameter.Name == "Count").Kind);
+        Assert.Equal(MvParamKind.Decimal, parameters.Single(parameter => parameter.Name == "Amount").Kind);
+        Assert.Equal(MvParamKind.Boolean, parameters.Single(parameter => parameter.Name == "Active").Kind);
+        Assert.Equal(MvParamKind.DateTimeOffset, parameters.Single(parameter => parameter.Name == "When").Kind);
+        Assert.Equal(MvParamKind.Guid, parameters.Single(parameter => parameter.Name == "Id").Kind);
+        Assert.Equal(3, MvParamConverter.ToClrValue(parameters.Single(parameter => parameter.Name == "Count")));
+        Assert.Equal(when, MvParamConverter.ToClrValue(parameters.Single(parameter => parameter.Name == "When")));
+        Assert.Equal(id, MvParamConverter.ToClrValue(parameters.Single(parameter => parameter.Name == "Id")));
+    }
+
+    [Fact]
+    public void SerializableTagState_ResolvedPayloadName_PrefersActualPayloadName()
+    {
+        var state = new SerializableTagState(
+            [],
+            1,
+            "0001",
+            "group",
+            "content",
+            "projector",
+            "UnionPayload",
+            "v1",
+            "ActualPayload");
+
+        Assert.Equal("ActualPayload", state.ResolvedPayloadName);
     }
 
     [Fact]
@@ -272,7 +351,7 @@ public class MaterializedViewUnitTests
         public int CatchUpCalls { get; private set; }
 
         public Task InitializeAsync(
-            IMaterializedViewProjector projector,
+            IMvApplyHost host,
             string? serviceId = null,
             CancellationToken cancellationToken = default)
         {
@@ -281,7 +360,7 @@ public class MaterializedViewUnitTests
         }
 
         public Task<MvCatchUpResult> CatchUpOnceAsync(
-            IMaterializedViewProjector projector,
+            IMvApplyHost host,
             string? serviceId = null,
             CancellationToken cancellationToken = default)
         {
@@ -290,10 +369,71 @@ public class MaterializedViewUnitTests
         }
 
         public Task<int> ApplySerializableEventsAsync(
-            IMaterializedViewProjector projector,
+            IMvApplyHost host,
             IReadOnlyList<SerializableEvent> events,
             string? serviceId = null,
             CancellationToken cancellationToken = default) => Task.FromResult(0);
+    }
+
+    private sealed class FakeApplyHostFactory : IMvApplyHostFactory
+    {
+        private readonly IMvApplyHost _host;
+
+        public FakeApplyHostFactory(IMvApplyHost host) => _host = host;
+
+        public IReadOnlyList<MvApplyHostRegistration> GetRegistrations() => [new(_host.ViewName, _host.ViewVersion)];
+
+        public IMvApplyHost Create(string viewName, int viewVersion)
+        {
+            if (_host.ViewName != viewName || _host.ViewVersion != viewVersion)
+            {
+                throw new InvalidOperationException("Unexpected host lookup.");
+            }
+
+            return _host;
+        }
+    }
+
+    private sealed class FakeApplyHost : IMvApplyHost
+    {
+        public FakeApplyHost(string viewName, int viewVersion)
+        {
+            ViewName = viewName;
+            ViewVersion = viewVersion;
+        }
+
+        public string ViewName { get; }
+        public int ViewVersion { get; }
+        public IReadOnlyList<string> LogicalTables => ["main"];
+
+        public Task<IReadOnlyList<MvSqlStatementDto>> InitializeAsync(IMvTableBindings tables, CancellationToken ct) =>
+            Task.FromResult<IReadOnlyList<MvSqlStatementDto>>([]);
+
+        public Task<IReadOnlyList<MvSqlStatementDto>> ApplyEventAsync(
+            SerializableEvent ev,
+            IMvTableBindings tables,
+            IMvApplyQueryPort queryPort,
+            string sortableUniqueId,
+            CancellationToken ct) =>
+            Task.FromResult<IReadOnlyList<MvSqlStatementDto>>([]);
+    }
+
+    private sealed class FakeApplyQueryPort : IMvApplyQueryPort
+    {
+        public Task<IReadOnlyList<System.Text.Json.JsonElement>> QueryRowsAsync(
+            string sql,
+            IReadOnlyList<MvParam> parameters,
+            CancellationToken ct) => Task.FromResult<IReadOnlyList<System.Text.Json.JsonElement>>([]);
+
+        public Task<System.Text.Json.JsonElement?> QuerySingleOrDefaultAsync(
+            string sql,
+            IReadOnlyList<MvParam> parameters,
+            CancellationToken ct) => Task.FromResult<System.Text.Json.JsonElement?>(null);
+
+        public Task<string?> ExecuteScalarJsonAsync(
+            string sql,
+            IReadOnlyList<MvParam> parameters,
+            CancellationToken ct) => Task.FromResult<string?>(null);
     }
 
     private sealed class FakeProjector : IMaterializedViewProjector

--- a/dcb/tests/Sekiban.Dcb.Orleans.Tests/MaterializedViewGrainTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Orleans.Tests/MaterializedViewGrainTests.cs
@@ -4,6 +4,7 @@ using Orleans.Streams;
 using Orleans.TestingHost;
 using Sekiban.Dcb.Actors;
 using Sekiban.Dcb.Common;
+using Sekiban.Dcb.Domains;
 using Sekiban.Dcb.Events;
 using Sekiban.Dcb.MaterializedView;
 using Sekiban.Dcb.MaterializedView.Orleans;
@@ -122,6 +123,7 @@ public class MaterializedViewGrainTests : IAsyncLifetime
                 .ConfigureServices(services =>
                 {
                     services.AddSekibanDcbMaterializedView();
+                    services.AddSingleton<IEventTypes>(_ => new SimpleEventTypes());
                     services.Configure<MvOptions>(options =>
                     {
                         options.PollInterval = TimeSpan.FromMilliseconds(20);
@@ -186,23 +188,23 @@ public class MaterializedViewGrainTests : IAsyncLifetime
         public void SeedInitial(params SerializableEvent[] events) => InitialEvents.AddRange(events);
 
         public Task InitializeAsync(
-            IMaterializedViewProjector projector,
+            IMvApplyHost host,
             string? serviceId = null,
             CancellationToken cancellationToken = default)
         {
             serviceId ??= DefaultServiceIdProvider.DefaultServiceId;
-            return _registry.RegisterViewAsync(serviceId, projector.ViewName, projector.ViewVersion, cancellationToken);
+            return _registry.RegisterViewAsync(serviceId, host.ViewName, host.ViewVersion, cancellationToken);
         }
 
         public async Task<MvCatchUpResult> CatchUpOnceAsync(
-            IMaterializedViewProjector projector,
+            IMvApplyHost host,
             string? serviceId = null,
             CancellationToken cancellationToken = default)
         {
             serviceId ??= DefaultServiceIdProvider.DefaultServiceId;
-            await InitializeAsync(projector, serviceId, cancellationToken);
+            await InitializeAsync(host, serviceId, cancellationToken);
 
-            var currentPosition = await _registry.GetCurrentPositionAsync(serviceId, projector.ViewName, projector.ViewVersion, cancellationToken);
+            var currentPosition = await _registry.GetCurrentPositionAsync(serviceId, host.ViewName, host.ViewVersion, cancellationToken);
             var batch = InitialEvents
                 .Where(serializableEvent =>
                     string.IsNullOrWhiteSpace(currentPosition) ||
@@ -224,8 +226,8 @@ public class MaterializedViewGrainTests : IAsyncLifetime
             await _registry.UpdatePositionAsync(
                 new MvPositionUpdate(
                     serviceId,
-                    projector.ViewName,
-                    projector.ViewVersion,
+                    host.ViewName,
+                    host.ViewVersion,
                     batch[^1].SortableUniqueIdValue,
                     MvApplySource.CatchUp,
                     batch.Count),
@@ -234,15 +236,15 @@ public class MaterializedViewGrainTests : IAsyncLifetime
         }
 
         public async Task<int> ApplySerializableEventsAsync(
-            IMaterializedViewProjector projector,
+            IMvApplyHost host,
             IReadOnlyList<SerializableEvent> events,
             string? serviceId = null,
             CancellationToken cancellationToken = default)
         {
             serviceId ??= DefaultServiceIdProvider.DefaultServiceId;
-            await InitializeAsync(projector, serviceId, cancellationToken);
+            await InitializeAsync(host, serviceId, cancellationToken);
 
-            var currentPosition = await _registry.GetCurrentPositionAsync(serviceId, projector.ViewName, projector.ViewVersion, cancellationToken);
+            var currentPosition = await _registry.GetCurrentPositionAsync(serviceId, host.ViewName, host.ViewVersion, cancellationToken);
             var ordered = events
                 .Where(serializableEvent =>
                     string.IsNullOrWhiteSpace(currentPosition) ||
@@ -263,8 +265,8 @@ public class MaterializedViewGrainTests : IAsyncLifetime
             await _registry.UpdatePositionAsync(
                 new MvPositionUpdate(
                     serviceId,
-                    projector.ViewName,
-                    projector.ViewVersion,
+                    host.ViewName,
+                    host.ViewVersion,
                     ordered[^1].SortableUniqueIdValue,
                     MvApplySource.Stream,
                     ordered.Count),


### PR DESCRIPTION
## Summary
- introduce typed MV SQL parameter DTOs and a runtime-swappable apply-host abstraction
- refactor the Postgres and Orleans MV runtime paths to execute through IMvApplyHost / IMvApplyHostFactory
- add SerializableTagState actual payload discrimination and regression tests for native, Orleans, and Postgres MV flows

## Testing
- dotnet test dcb/tests/Sekiban.Dcb.MaterializedView.Tests/Sekiban.Dcb.MaterializedView.Tests.csproj -v minimal
- dotnet test dcb/tests/Sekiban.Dcb.Orleans.Tests/Sekiban.Dcb.Orleans.Tests.csproj -v minimal --filter MaterializedViewGrainTests
- dotnet test dcb/tests/Sekiban.Dcb.MaterializedView.Postgres.Tests/Sekiban.Dcb.MaterializedView.Postgres.Tests.csproj -v minimal

Refs #1029