### PR TITLE
Bump Sekiban.Dcb.* to 10.2.0 and wire Unsafe Window MV in all templates

### DIFF
--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.ApiService/Program.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.ApiService/Program.cs
@@ -399,10 +399,17 @@ if (app.Services.GetService<IMvOrleansQueryAccessor>() is not null)
                 await connection.OpenAsync(ct);
 
                 var view = (includeDeleted ?? false) ? resolver.CurrentView : resolver.CurrentLiveView;
-                var rows = await Dapper.SqlMapper.QueryAsync(
+                // Select only business columns (plus opt-in metadata) so the response shape is
+                // stable even if the framework adds or renames internal UWMV metadata columns.
+                var rows = await Dapper.SqlMapper.QueryAsync<WeatherForecastUnsafeMvReadModel>(
                     connection,
                     new Dapper.CommandDefinition(
-                        $"SELECT * FROM {view} ORDER BY forecast_date DESC, forecast_id",
+                        $"""
+                        SELECT forecast_id, location, forecast_date, temperature_c, summary,
+                               _is_deleted, _last_event_version, _last_sortable_unique_id
+                        FROM {view}
+                        ORDER BY forecast_date DESC, forecast_id
+                        """,
                         cancellationToken: ct));
                 return Results.Ok(rows);
             })
@@ -482,3 +489,16 @@ static System.Net.IPAddress GetPrivateIpAddress()
 
     return System.Net.IPAddress.Loopback;
 }
+
+// Response shape for /api/weatherforecast-uwmv. Declared as a file-scoped record so the
+// endpoint can avoid `SELECT *` (which would couple the API to framework-managed metadata
+// columns in the underlying UWMV view).
+public sealed record WeatherForecastUnsafeMvReadModel(
+    Guid ForecastId,
+    string Location,
+    DateOnly ForecastDate,
+    int TemperatureC,
+    string? Summary,
+    bool IsDeleted,
+    long LastEventVersion,
+    string LastSortableUniqueId);

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.ApiService/Program.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.ApiService/Program.cs
@@ -273,6 +273,13 @@ if (!string.IsNullOrWhiteSpace(builder.Configuration.GetConnectionString("DcbMat
         connectionStringName: "DcbMaterializedViewPostgres",
         registerHostedWorker: false);
     builder.Services.AddSekibanDcbMaterializedViewOrleans();
+
+    // Unsafe Window materialized view (v10.2.0) — safe/unsafe split read model
+    // with automatic safe promotion. Shares the `DcbMaterializedViewPostgres`
+    // database; the runtime owns DDL, catchup and promotion as a hosted service.
+    builder.Services.AddSekibanDcbUnsafeWindowMv<WeatherForecastUnsafeWindowMvV1, WeatherForecastUnsafeRow>(
+        builder.Configuration,
+        connectionStringName: "DcbMaterializedViewPostgres");
 }
 
 // Map snake_case Postgres columns onto PascalCase row classes used by the materialized view endpoints.
@@ -368,6 +375,80 @@ apiRoute.MapTestDataEndpoints();
 if (app.Services.GetService<IMvOrleansQueryAccessor>() is not null)
 {
     apiRoute.MapMaterializedViewEndpoints();
+
+    // Unsafe Window MV sample endpoints — unsafe-first reads via the generated
+    // `current` / `current_live` Postgres views plus a diagnostics counter.
+    // Registered only when the UWMV runtime was wired above.
+    var uwmvResolverKey = Sekiban.Dcb.MaterializedView.Postgres.UnsafeWindowMvRegistration
+        .SchemaResolverKey<WeatherForecastUnsafeWindowMvV1>();
+    var uwmvConnectionKey = Sekiban.Dcb.MaterializedView.Postgres.UnsafeWindowMvRegistration
+        .ConnectionStringKey<WeatherForecastUnsafeWindowMvV1>();
+
+    apiRoute
+        .MapGet(
+            "/weatherforecast-uwmv",
+            async (
+                [FromServices] IServiceProvider sp,
+                [FromQuery] bool? includeDeleted,
+                CancellationToken ct) =>
+            {
+                var resolver = sp.GetRequiredKeyedService<Sekiban.Dcb.MaterializedView.Postgres.UnsafeWindowMvSchemaResolver>(uwmvResolverKey);
+                var connectionString = sp.GetRequiredKeyedService<string>(uwmvConnectionKey);
+
+                await using var connection = new Npgsql.NpgsqlConnection(connectionString);
+                await connection.OpenAsync(ct);
+
+                var view = (includeDeleted ?? false) ? resolver.CurrentView : resolver.CurrentLiveView;
+                var rows = await Dapper.SqlMapper.QueryAsync(
+                    connection,
+                    new Dapper.CommandDefinition(
+                        $"SELECT * FROM {view} ORDER BY forecast_date DESC, forecast_id",
+                        cancellationToken: ct));
+                return Results.Ok(rows);
+            })
+        .WithOpenApi()
+        .WithName("GetWeatherForecastUnsafeWindowMv");
+
+    apiRoute
+        .MapGet(
+            "/weatherforecast-uwmv/diagnostics",
+            async (
+                [FromServices] IServiceProvider sp,
+                CancellationToken ct) =>
+            {
+                var resolver = sp.GetRequiredKeyedService<Sekiban.Dcb.MaterializedView.Postgres.UnsafeWindowMvSchemaResolver>(uwmvResolverKey);
+                var connectionString = sp.GetRequiredKeyedService<string>(uwmvConnectionKey);
+
+                await using var connection = new Npgsql.NpgsqlConnection(connectionString);
+                await connection.OpenAsync(ct);
+
+                var safeCount = await Dapper.SqlMapper.ExecuteScalarAsync<long>(
+                    connection,
+                    new Dapper.CommandDefinition($"SELECT COUNT(*) FROM {resolver.SafeTable}", cancellationToken: ct));
+                var unsafeCount = await Dapper.SqlMapper.ExecuteScalarAsync<long>(
+                    connection,
+                    new Dapper.CommandDefinition($"SELECT COUNT(*) FROM {resolver.UnsafeTable}", cancellationToken: ct));
+                var needsRebuildCount = await Dapper.SqlMapper.ExecuteScalarAsync<long>(
+                    connection,
+                    new Dapper.CommandDefinition($"SELECT COUNT(*) FROM {resolver.UnsafeTable} WHERE _needs_rebuild = TRUE", cancellationToken: ct));
+                var tombstoneCount = await Dapper.SqlMapper.ExecuteScalarAsync<long>(
+                    connection,
+                    new Dapper.CommandDefinition($"SELECT COUNT(*) FROM {resolver.SafeTable} WHERE _is_deleted = TRUE", cancellationToken: ct));
+
+                return Results.Ok(new
+                {
+                    safeTable = resolver.SafeTable,
+                    unsafeTable = resolver.UnsafeTable,
+                    currentView = resolver.CurrentView,
+                    currentLiveView = resolver.CurrentLiveView,
+                    safeCount,
+                    unsafeCount,
+                    needsRebuildCount,
+                    tombstoneCount
+                });
+            })
+        .WithOpenApi()
+        .WithName("GetWeatherForecastUnsafeWindowMvDiagnostics");
 }
 
 app.MapDefaultEndpoints();

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.ApiService/SekibanDcbDeciderAws.ApiService.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.ApiService/SekibanDcbDeciderAws.ApiService.csproj
@@ -33,13 +33,13 @@
 
         <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.3" />
         <PackageReference Include="Scalar.AspNetCore" Version="2.12.50" />
-        <PackageReference Include="Sekiban.Dcb.Orleans.WithoutResult" Version="10.1.18" />
-        <PackageReference Include="Sekiban.Dcb.DynamoDB" Version="10.1.18" />
-        <PackageReference Include="Sekiban.Dcb.BlobStorage.S3" Version="10.1.18" />
-        <PackageReference Include="Sekiban.Dcb.Postgres" Version="10.1.18" />
-        <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.1.18" />
-        <PackageReference Include="Sekiban.Dcb.MaterializedView.Postgres" Version="10.1.18" />
-        <PackageReference Include="Sekiban.Dcb.MaterializedView.Orleans" Version="10.1.18" />
+        <PackageReference Include="Sekiban.Dcb.Orleans.WithoutResult" Version="10.2.0" />
+        <PackageReference Include="Sekiban.Dcb.DynamoDB" Version="10.2.0" />
+        <PackageReference Include="Sekiban.Dcb.BlobStorage.S3" Version="10.2.0" />
+        <PackageReference Include="Sekiban.Dcb.Postgres" Version="10.2.0" />
+        <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.2.0" />
+        <PackageReference Include="Sekiban.Dcb.MaterializedView.Postgres" Version="10.2.0" />
+        <PackageReference Include="Sekiban.Dcb.MaterializedView.Orleans" Version="10.2.0" />
         <PackageReference Include="Dapper" Version="2.1.66" />
         <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />
     </ItemGroup>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.EventSource/MaterializedViews/WeatherForecastUnsafeWindowMvV1.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.EventSource/MaterializedViews/WeatherForecastUnsafeWindowMvV1.cs
@@ -1,0 +1,108 @@
+using Dcb.ImmutableModels.Events.Weather;
+using Dcb.ImmutableModels.Tags;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.MaterializedView;
+using Sekiban.Dcb.Tags;
+
+namespace Dcb.EventSource.MaterializedViews;
+
+/// <summary>
+///     Sample Unsafe Window materialized view for WeatherForecast (v10.2.0).
+///
+///     One row per forecast id. Business columns are declared through
+///     <see cref="Schema" />; framework metadata columns
+///     (_projection_key / _last_sortable_unique_id / _is_deleted / …) are
+///     managed by the runtime on top of this schema.
+/// </summary>
+public sealed class WeatherForecastUnsafeWindowMvV1 : IUnsafeWindowMvProjector<WeatherForecastUnsafeRow>
+{
+    public string ViewName => "WeatherForecastUnsafeWindow";
+    public int ViewVersion => 1;
+
+    // Short safe window for the sample so promotions are observable without
+    // waiting minutes. Production projectors should match the MultiProjection
+    // dynamic-safe-window heuristic.
+    public TimeSpan SafeWindow => TimeSpan.FromSeconds(2);
+
+    public UnsafeWindowMvSchema Schema { get; } = new(
+        new UnsafeWindowMvColumn(
+            "forecast_id",
+            "UUID NOT NULL",
+            row => ((WeatherForecastUnsafeRow)row).ForecastId),
+        new UnsafeWindowMvColumn(
+            "location",
+            "TEXT NOT NULL",
+            row => ((WeatherForecastUnsafeRow)row).Location),
+        new UnsafeWindowMvColumn(
+            "forecast_date",
+            "DATE NOT NULL",
+            row => ((WeatherForecastUnsafeRow)row).ForecastDate.ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc)),
+        new UnsafeWindowMvColumn(
+            "temperature_c",
+            "INT NOT NULL",
+            row => ((WeatherForecastUnsafeRow)row).TemperatureC),
+        new UnsafeWindowMvColumn(
+            "summary",
+            "TEXT NULL",
+            row => (object?)((WeatherForecastUnsafeRow)row).Summary));
+
+    public string? GetProjectionKey(Event ev) => ev.Payload switch
+    {
+        WeatherForecastCreated c => ProjectionKeyFor(c.ForecastId),
+        WeatherForecastUpdated u => ProjectionKeyFor(u.ForecastId),
+        LocationNameChanged l => ProjectionKeyFor(l.ForecastId),
+        WeatherForecastDeleted d => ProjectionKeyFor(d.ForecastId),
+        _ => null
+    };
+
+    public UnsafeWindowMvApplyOutcome Apply(WeatherForecastUnsafeRow? current, Event ev) =>
+        ev.Payload switch
+        {
+            WeatherForecastCreated created => new UnsafeWindowMvApplyOutcome.Upsert(
+                ProjectionKeyFor(created.ForecastId),
+                new WeatherForecastUnsafeRow
+                {
+                    ForecastId = created.ForecastId,
+                    Location = created.Location,
+                    ForecastDate = created.Date,
+                    TemperatureC = created.TemperatureC,
+                    Summary = created.Summary
+                }),
+
+            WeatherForecastUpdated updated => new UnsafeWindowMvApplyOutcome.Upsert(
+                ProjectionKeyFor(updated.ForecastId),
+                new WeatherForecastUnsafeRow
+                {
+                    ForecastId = updated.ForecastId,
+                    Location = updated.Location,
+                    ForecastDate = updated.Date,
+                    TemperatureC = updated.TemperatureC,
+                    Summary = updated.Summary
+                }),
+
+            LocationNameChanged changed when current is not null => new UnsafeWindowMvApplyOutcome.Upsert(
+                ProjectionKeyFor(changed.ForecastId),
+                current with { Location = changed.NewLocationName }),
+
+            WeatherForecastDeleted deleted => new UnsafeWindowMvApplyOutcome.Delete(
+                ProjectionKeyFor(deleted.ForecastId)),
+
+            _ => new UnsafeWindowMvApplyOutcome.NoChange()
+        };
+
+    public IReadOnlyList<ITag> TagsForProjectionKey(string projectionKey) =>
+        Guid.TryParse(projectionKey, out var forecastId)
+            ? [new WeatherForecastTag(forecastId)]
+            : [];
+
+    private static string ProjectionKeyFor(Guid forecastId) => forecastId.ToString();
+}
+
+public sealed record WeatherForecastUnsafeRow
+{
+    public Guid ForecastId { get; init; }
+    public string Location { get; init; } = string.Empty;
+    public DateOnly ForecastDate { get; init; }
+    public int TemperatureC { get; init; }
+    public string? Summary { get; init; }
+}

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.EventSource/SekibanDcbDeciderAws.EventSource.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.EventSource/SekibanDcbDeciderAws.EventSource.csproj
@@ -11,8 +11,8 @@
     <ProjectReference Include="..\SekibanDcbDeciderAws.MeetingRoomModels\SekibanDcbDeciderAws.MeetingRoomModels.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.1.18" />
-    <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.1.18" />
+    <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.2.0" />
+    <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.2.0" />
     <PackageReference Include="ResultBoxes" Version="0.4.0" />
     <PackageReference Include="Microsoft.Orleans.Serialization" Version="10.0.1" />
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.ImmutableModels/SekibanDcbDeciderAws.ImmutableModels.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.ImmutableModels/SekibanDcbDeciderAws.ImmutableModels.csproj
@@ -7,7 +7,7 @@
     <IsPackable>true</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Sekiban.Dcb.Core.Model" Version="10.1.18" />
+    <PackageReference Include="Sekiban.Dcb.Core.Model" Version="10.2.0" />
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />
   </ItemGroup>
 </Project>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.Interactions.Unit/SekibanDcbDeciderAws.Interactions.Unit.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.Interactions.Unit/SekibanDcbDeciderAws.Interactions.Unit.csproj
@@ -28,7 +28,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.1.18" />
+      <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.2.0" />
     </ItemGroup>
 
 </Project>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.Interactions/SekibanDcbDeciderAws.Interactions.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.Interactions/SekibanDcbDeciderAws.Interactions.csproj
@@ -10,7 +10,7 @@
     <ProjectReference Include="..\SekibanDcbDeciderAws.EventSource\SekibanDcbDeciderAws.EventSource.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.1.18" />
+    <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.2.0" />
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />
   </ItemGroup>
 </Project>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.MeetingRoomModels/SekibanDcbDeciderAws.MeetingRoomModels.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.MeetingRoomModels/SekibanDcbDeciderAws.MeetingRoomModels.csproj
@@ -7,7 +7,7 @@
     <IsPackable>true</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Sekiban.Dcb.Core.Model" Version="10.1.18" />
+    <PackageReference Include="Sekiban.Dcb.Core.Model" Version="10.2.0" />
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />
   </ItemGroup>
 </Project>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.Unit/SekibanDcbDeciderAws.Unit.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.Unit/SekibanDcbDeciderAws.Unit.csproj
@@ -15,7 +15,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.1.18" />
+    <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.2.0" />
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />
   </ItemGroup>
   <ItemGroup>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.ApiService/Program.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.ApiService/Program.cs
@@ -302,10 +302,17 @@ if (app.Services.GetService<IMvOrleansQueryAccessor>() is not null)
                 await connection.OpenAsync(ct);
 
                 var view = (includeDeleted ?? false) ? resolver.CurrentView : resolver.CurrentLiveView;
-                var rows = await Dapper.SqlMapper.QueryAsync(
+                // Select only business columns (plus opt-in metadata) so the response shape is
+                // stable even if the framework adds or renames internal UWMV metadata columns.
+                var rows = await Dapper.SqlMapper.QueryAsync<WeatherForecastUnsafeMvReadModel>(
                     connection,
                     new Dapper.CommandDefinition(
-                        $"SELECT * FROM {view} ORDER BY forecast_date DESC, forecast_id",
+                        $"""
+                        SELECT forecast_id, location, forecast_date, temperature_c, summary,
+                               _is_deleted, _last_event_version, _last_sortable_unique_id
+                        FROM {view}
+                        ORDER BY forecast_date DESC, forecast_id
+                        """,
                         cancellationToken: ct));
                 return Results.Ok(rows);
             })
@@ -827,3 +834,16 @@ static bool TryCreatePostgresBootstrapSettings(string? connectionString, out Pos
         }.ConnectionString);
     return true;
 }
+
+// Response shape for /api/weatherforecast-uwmv. Declared as a file-scoped record so the
+// endpoint can avoid `SELECT *` (which would couple the API to framework-managed metadata
+// columns in the underlying UWMV view).
+public sealed record WeatherForecastUnsafeMvReadModel(
+    Guid ForecastId,
+    string Location,
+    DateOnly ForecastDate,
+    int TemperatureC,
+    string? Summary,
+    bool IsDeleted,
+    long LastEventVersion,
+    string LastSortableUniqueId);

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.ApiService/Program.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.ApiService/Program.cs
@@ -2,6 +2,7 @@ using System.Net;
 using Azure.Data.Tables;
 using Azure.Storage.Blobs;
 using Azure.Storage.Queues;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
 using Dcb.EventSource;
 using Orleans.Configuration;
@@ -201,6 +202,13 @@ if (!string.IsNullOrWhiteSpace(builder.Configuration.GetConnectionString("DcbMat
         connectionStringName: "DcbMaterializedViewPostgres",
         registerHostedWorker: false);
     builder.Services.AddSekibanDcbMaterializedViewOrleans();
+
+    // Unsafe Window materialized view (v10.2.0) — safe/unsafe split read model
+    // with automatic safe promotion. Shares the `DcbMaterializedViewPostgres`
+    // database; the runtime owns DDL, catchup and promotion as a hosted service.
+    builder.Services.AddSekibanDcbUnsafeWindowMv<WeatherForecastUnsafeWindowMvV1, WeatherForecastUnsafeRow>(
+        builder.Configuration,
+        connectionStringName: "DcbMaterializedViewPostgres");
 }
 
 builder.Services.AddTransient<IGrainStorageSerializer, NewtonsoftJsonDcbOrleansSerializer>();
@@ -270,6 +278,80 @@ apiRoute.MapTestDataEndpoints();
 if (app.Services.GetService<IMvOrleansQueryAccessor>() is not null)
 {
     apiRoute.MapMaterializedViewEndpoints();
+
+    // Unsafe Window MV sample endpoints — unsafe-first reads via the generated
+    // `current` / `current_live` Postgres views plus a diagnostics counter.
+    // Registered only when the UWMV runtime was wired above.
+    var uwmvResolverKey = Sekiban.Dcb.MaterializedView.Postgres.UnsafeWindowMvRegistration
+        .SchemaResolverKey<WeatherForecastUnsafeWindowMvV1>();
+    var uwmvConnectionKey = Sekiban.Dcb.MaterializedView.Postgres.UnsafeWindowMvRegistration
+        .ConnectionStringKey<WeatherForecastUnsafeWindowMvV1>();
+
+    apiRoute
+        .MapGet(
+            "/weatherforecast-uwmv",
+            async (
+                [FromServices] IServiceProvider sp,
+                [FromQuery] bool? includeDeleted,
+                CancellationToken ct) =>
+            {
+                var resolver = sp.GetRequiredKeyedService<Sekiban.Dcb.MaterializedView.Postgres.UnsafeWindowMvSchemaResolver>(uwmvResolverKey);
+                var connectionString = sp.GetRequiredKeyedService<string>(uwmvConnectionKey);
+
+                await using var connection = new Npgsql.NpgsqlConnection(connectionString);
+                await connection.OpenAsync(ct);
+
+                var view = (includeDeleted ?? false) ? resolver.CurrentView : resolver.CurrentLiveView;
+                var rows = await Dapper.SqlMapper.QueryAsync(
+                    connection,
+                    new Dapper.CommandDefinition(
+                        $"SELECT * FROM {view} ORDER BY forecast_date DESC, forecast_id",
+                        cancellationToken: ct));
+                return Results.Ok(rows);
+            })
+        .WithOpenApi()
+        .WithName("GetWeatherForecastUnsafeWindowMv");
+
+    apiRoute
+        .MapGet(
+            "/weatherforecast-uwmv/diagnostics",
+            async (
+                [FromServices] IServiceProvider sp,
+                CancellationToken ct) =>
+            {
+                var resolver = sp.GetRequiredKeyedService<Sekiban.Dcb.MaterializedView.Postgres.UnsafeWindowMvSchemaResolver>(uwmvResolverKey);
+                var connectionString = sp.GetRequiredKeyedService<string>(uwmvConnectionKey);
+
+                await using var connection = new Npgsql.NpgsqlConnection(connectionString);
+                await connection.OpenAsync(ct);
+
+                var safeCount = await Dapper.SqlMapper.ExecuteScalarAsync<long>(
+                    connection,
+                    new Dapper.CommandDefinition($"SELECT COUNT(*) FROM {resolver.SafeTable}", cancellationToken: ct));
+                var unsafeCount = await Dapper.SqlMapper.ExecuteScalarAsync<long>(
+                    connection,
+                    new Dapper.CommandDefinition($"SELECT COUNT(*) FROM {resolver.UnsafeTable}", cancellationToken: ct));
+                var needsRebuildCount = await Dapper.SqlMapper.ExecuteScalarAsync<long>(
+                    connection,
+                    new Dapper.CommandDefinition($"SELECT COUNT(*) FROM {resolver.UnsafeTable} WHERE _needs_rebuild = TRUE", cancellationToken: ct));
+                var tombstoneCount = await Dapper.SqlMapper.ExecuteScalarAsync<long>(
+                    connection,
+                    new Dapper.CommandDefinition($"SELECT COUNT(*) FROM {resolver.SafeTable} WHERE _is_deleted = TRUE", cancellationToken: ct));
+
+                return Results.Ok(new
+                {
+                    safeTable = resolver.SafeTable,
+                    unsafeTable = resolver.UnsafeTable,
+                    currentView = resolver.CurrentView,
+                    currentLiveView = resolver.CurrentLiveView,
+                    safeCount,
+                    unsafeCount,
+                    needsRebuildCount,
+                    tombstoneCount
+                });
+            })
+        .WithOpenApi()
+        .WithName("GetWeatherForecastUnsafeWindowMvDiagnostics");
 }
 
 app.MapDefaultEndpoints();

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.ApiService/SekibanDcbDecider.ApiService.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.ApiService/SekibanDcbDecider.ApiService.csproj
@@ -44,14 +44,14 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Sekiban.Dcb.BlobStorage.AzureStorage" Version="10.1.18" />
-        <PackageReference Include="Sekiban.Dcb.Orleans.WithoutResult" Version="10.1.18" />
-        <PackageReference Include="Sekiban.Dcb.Postgres" Version="10.1.18" />
-        <PackageReference Include="Sekiban.Dcb.CosmosDb" Version="10.1.18" />
-        <PackageReference Include="Sekiban.Dcb.Sqlite" Version="10.1.18" />
-        <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.1.18" />
-        <PackageReference Include="Sekiban.Dcb.MaterializedView.Postgres" Version="10.1.18" />
-        <PackageReference Include="Sekiban.Dcb.MaterializedView.Orleans" Version="10.1.18" />
+        <PackageReference Include="Sekiban.Dcb.BlobStorage.AzureStorage" Version="10.2.0" />
+        <PackageReference Include="Sekiban.Dcb.Orleans.WithoutResult" Version="10.2.0" />
+        <PackageReference Include="Sekiban.Dcb.Postgres" Version="10.2.0" />
+        <PackageReference Include="Sekiban.Dcb.CosmosDb" Version="10.2.0" />
+        <PackageReference Include="Sekiban.Dcb.Sqlite" Version="10.2.0" />
+        <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.2.0" />
+        <PackageReference Include="Sekiban.Dcb.MaterializedView.Postgres" Version="10.2.0" />
+        <PackageReference Include="Sekiban.Dcb.MaterializedView.Orleans" Version="10.2.0" />
         <PackageReference Include="Dapper" Version="2.1.66" />
     </ItemGroup>
 </Project>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.Cli/SekibanDcbDecider.Cli.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.Cli/SekibanDcbDecider.Cli.csproj
@@ -14,10 +14,10 @@
         <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.3" />
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.3" />
         <PackageReference Include="System.CommandLine" Version="2.0.2" />
-        <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.1.18" />
-        <PackageReference Include="Sekiban.Dcb.Postgres" Version="10.1.18" />
-        <PackageReference Include="Sekiban.Dcb.CosmosDb" Version="10.1.18" />
-        <PackageReference Include="Sekiban.Dcb.Sqlite" Version="10.1.18" />
+        <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.2.0" />
+        <PackageReference Include="Sekiban.Dcb.Postgres" Version="10.2.0" />
+        <PackageReference Include="Sekiban.Dcb.CosmosDb" Version="10.2.0" />
+        <PackageReference Include="Sekiban.Dcb.Sqlite" Version="10.2.0" />
         <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />
     </ItemGroup>
 

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.EventSource/MaterializedViews/WeatherForecastUnsafeWindowMvV1.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.EventSource/MaterializedViews/WeatherForecastUnsafeWindowMvV1.cs
@@ -1,0 +1,108 @@
+using Dcb.ImmutableModels.Events.Weather;
+using Dcb.ImmutableModels.Tags;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.MaterializedView;
+using Sekiban.Dcb.Tags;
+
+namespace Dcb.EventSource.MaterializedViews;
+
+/// <summary>
+///     Sample Unsafe Window materialized view for WeatherForecast (v10.2.0).
+///
+///     One row per forecast id. Business columns are declared through
+///     <see cref="Schema" />; framework metadata columns
+///     (_projection_key / _last_sortable_unique_id / _is_deleted / …) are
+///     managed by the runtime on top of this schema.
+/// </summary>
+public sealed class WeatherForecastUnsafeWindowMvV1 : IUnsafeWindowMvProjector<WeatherForecastUnsafeRow>
+{
+    public string ViewName => "WeatherForecastUnsafeWindow";
+    public int ViewVersion => 1;
+
+    // Short safe window for the sample so promotions are observable without
+    // waiting minutes. Production projectors should match the MultiProjection
+    // dynamic-safe-window heuristic.
+    public TimeSpan SafeWindow => TimeSpan.FromSeconds(2);
+
+    public UnsafeWindowMvSchema Schema { get; } = new(
+        new UnsafeWindowMvColumn(
+            "forecast_id",
+            "UUID NOT NULL",
+            row => ((WeatherForecastUnsafeRow)row).ForecastId),
+        new UnsafeWindowMvColumn(
+            "location",
+            "TEXT NOT NULL",
+            row => ((WeatherForecastUnsafeRow)row).Location),
+        new UnsafeWindowMvColumn(
+            "forecast_date",
+            "DATE NOT NULL",
+            row => ((WeatherForecastUnsafeRow)row).ForecastDate.ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc)),
+        new UnsafeWindowMvColumn(
+            "temperature_c",
+            "INT NOT NULL",
+            row => ((WeatherForecastUnsafeRow)row).TemperatureC),
+        new UnsafeWindowMvColumn(
+            "summary",
+            "TEXT NULL",
+            row => (object?)((WeatherForecastUnsafeRow)row).Summary));
+
+    public string? GetProjectionKey(Event ev) => ev.Payload switch
+    {
+        WeatherForecastCreated c => ProjectionKeyFor(c.ForecastId),
+        WeatherForecastUpdated u => ProjectionKeyFor(u.ForecastId),
+        LocationNameChanged l => ProjectionKeyFor(l.ForecastId),
+        WeatherForecastDeleted d => ProjectionKeyFor(d.ForecastId),
+        _ => null
+    };
+
+    public UnsafeWindowMvApplyOutcome Apply(WeatherForecastUnsafeRow? current, Event ev) =>
+        ev.Payload switch
+        {
+            WeatherForecastCreated created => new UnsafeWindowMvApplyOutcome.Upsert(
+                ProjectionKeyFor(created.ForecastId),
+                new WeatherForecastUnsafeRow
+                {
+                    ForecastId = created.ForecastId,
+                    Location = created.Location,
+                    ForecastDate = created.Date,
+                    TemperatureC = created.TemperatureC,
+                    Summary = created.Summary
+                }),
+
+            WeatherForecastUpdated updated => new UnsafeWindowMvApplyOutcome.Upsert(
+                ProjectionKeyFor(updated.ForecastId),
+                new WeatherForecastUnsafeRow
+                {
+                    ForecastId = updated.ForecastId,
+                    Location = updated.Location,
+                    ForecastDate = updated.Date,
+                    TemperatureC = updated.TemperatureC,
+                    Summary = updated.Summary
+                }),
+
+            LocationNameChanged changed when current is not null => new UnsafeWindowMvApplyOutcome.Upsert(
+                ProjectionKeyFor(changed.ForecastId),
+                current with { Location = changed.NewLocationName }),
+
+            WeatherForecastDeleted deleted => new UnsafeWindowMvApplyOutcome.Delete(
+                ProjectionKeyFor(deleted.ForecastId)),
+
+            _ => new UnsafeWindowMvApplyOutcome.NoChange()
+        };
+
+    public IReadOnlyList<ITag> TagsForProjectionKey(string projectionKey) =>
+        Guid.TryParse(projectionKey, out var forecastId)
+            ? [new WeatherForecastTag(forecastId)]
+            : [];
+
+    private static string ProjectionKeyFor(Guid forecastId) => forecastId.ToString();
+}
+
+public sealed record WeatherForecastUnsafeRow
+{
+    public Guid ForecastId { get; init; }
+    public string Location { get; init; } = string.Empty;
+    public DateOnly ForecastDate { get; init; }
+    public int TemperatureC { get; init; }
+    public string? Summary { get; init; }
+}

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.EventSource/SekibanDcbDecider.EventSource.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.EventSource/SekibanDcbDecider.EventSource.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="ResultBoxes" Version="0.4.0" />
     <PackageReference Include="Microsoft.Orleans.Serialization" Version="10.0.1" />
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />
-    <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.1.18" />
-    <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.1.18" />
+    <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.2.0" />
+    <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.2.0" />
   </ItemGroup>
 </Project>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.ImmutableModels/SekibanDcbDecider.ImmutableModels.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.ImmutableModels/SekibanDcbDecider.ImmutableModels.csproj
@@ -10,6 +10,6 @@
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Sekiban.Dcb.Core.Model" Version="10.1.18" />
+    <PackageReference Include="Sekiban.Dcb.Core.Model" Version="10.2.0" />
   </ItemGroup>
 </Project>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.Interactions.Unit/SekibanDcbDecider.Interactions.Unit.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.Interactions.Unit/SekibanDcbDecider.Interactions.Unit.csproj
@@ -28,7 +28,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.1.18" />
+      <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.2.0" />
     </ItemGroup>
 
 </Project>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.Interactions/SekibanDcbDecider.Interactions.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.Interactions/SekibanDcbDecider.Interactions.csproj
@@ -11,6 +11,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />
-    <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.1.18" />
+    <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.2.0" />
   </ItemGroup>
 </Project>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.MeetingRoomModels/SekibanDcbDecider.MeetingRoomModels.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.MeetingRoomModels/SekibanDcbDecider.MeetingRoomModels.csproj
@@ -10,6 +10,6 @@
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Sekiban.Dcb.Core.Model" Version="10.1.18" />
+    <PackageReference Include="Sekiban.Dcb.Core.Model" Version="10.2.0" />
   </ItemGroup>
 </Project>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.Unit/SekibanDcbDecider.Unit.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.Unit/SekibanDcbDecider.Unit.csproj
@@ -15,7 +15,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.1.18" />
+    <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.2.0" />
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />
   </ItemGroup>
   <ItemGroup>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult.Aws/SekibanDcbOrleansAws.ApiService/Program.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult.Aws/SekibanDcbOrleansAws.ApiService/Program.cs
@@ -280,6 +280,13 @@ if (!string.IsNullOrWhiteSpace(builder.Configuration.GetConnectionString("DcbMat
         connectionStringName: "DcbMaterializedViewPostgres",
         registerHostedWorker: false);
     builder.Services.AddSekibanDcbMaterializedViewOrleans();
+
+    // Unsafe Window materialized view (v10.2.0) — safe/unsafe split read model
+    // with automatic safe promotion. Shares the `DcbMaterializedViewPostgres`
+    // database; the runtime owns DDL, catchup and promotion as a hosted service.
+    builder.Services.AddSekibanDcbUnsafeWindowMv<WeatherForecastUnsafeWindowMvV1, WeatherForecastUnsafeRow>(
+        builder.Configuration,
+        connectionStringName: "DcbMaterializedViewPostgres");
 }
 
 // Map snake_case Postgres columns onto PascalCase row classes used by the materialized view endpoints.
@@ -902,6 +909,80 @@ apiRoute
 if (app.Services.GetService<IMvOrleansQueryAccessor>() is not null)
 {
     apiRoute.MapMaterializedViewEndpoints();
+
+    // Unsafe Window MV sample endpoints — unsafe-first reads via the generated
+    // `current` / `current_live` Postgres views plus a diagnostics counter.
+    // Registered only when the UWMV runtime was wired above.
+    var uwmvResolverKey = Sekiban.Dcb.MaterializedView.Postgres.UnsafeWindowMvRegistration
+        .SchemaResolverKey<WeatherForecastUnsafeWindowMvV1>();
+    var uwmvConnectionKey = Sekiban.Dcb.MaterializedView.Postgres.UnsafeWindowMvRegistration
+        .ConnectionStringKey<WeatherForecastUnsafeWindowMvV1>();
+
+    apiRoute
+        .MapGet(
+            "/weatherforecast-uwmv",
+            async (
+                [FromServices] IServiceProvider sp,
+                [FromQuery] bool? includeDeleted,
+                CancellationToken ct) =>
+            {
+                var resolver = sp.GetRequiredKeyedService<Sekiban.Dcb.MaterializedView.Postgres.UnsafeWindowMvSchemaResolver>(uwmvResolverKey);
+                var connectionString = sp.GetRequiredKeyedService<string>(uwmvConnectionKey);
+
+                await using var connection = new Npgsql.NpgsqlConnection(connectionString);
+                await connection.OpenAsync(ct);
+
+                var view = (includeDeleted ?? false) ? resolver.CurrentView : resolver.CurrentLiveView;
+                var rows = await Dapper.SqlMapper.QueryAsync(
+                    connection,
+                    new Dapper.CommandDefinition(
+                        $"SELECT * FROM {view} ORDER BY forecast_date DESC, forecast_id",
+                        cancellationToken: ct));
+                return Results.Ok(rows);
+            })
+        .WithOpenApi()
+        .WithName("GetWeatherForecastUnsafeWindowMv");
+
+    apiRoute
+        .MapGet(
+            "/weatherforecast-uwmv/diagnostics",
+            async (
+                [FromServices] IServiceProvider sp,
+                CancellationToken ct) =>
+            {
+                var resolver = sp.GetRequiredKeyedService<Sekiban.Dcb.MaterializedView.Postgres.UnsafeWindowMvSchemaResolver>(uwmvResolverKey);
+                var connectionString = sp.GetRequiredKeyedService<string>(uwmvConnectionKey);
+
+                await using var connection = new Npgsql.NpgsqlConnection(connectionString);
+                await connection.OpenAsync(ct);
+
+                var safeCount = await Dapper.SqlMapper.ExecuteScalarAsync<long>(
+                    connection,
+                    new Dapper.CommandDefinition($"SELECT COUNT(*) FROM {resolver.SafeTable}", cancellationToken: ct));
+                var unsafeCount = await Dapper.SqlMapper.ExecuteScalarAsync<long>(
+                    connection,
+                    new Dapper.CommandDefinition($"SELECT COUNT(*) FROM {resolver.UnsafeTable}", cancellationToken: ct));
+                var needsRebuildCount = await Dapper.SqlMapper.ExecuteScalarAsync<long>(
+                    connection,
+                    new Dapper.CommandDefinition($"SELECT COUNT(*) FROM {resolver.UnsafeTable} WHERE _needs_rebuild = TRUE", cancellationToken: ct));
+                var tombstoneCount = await Dapper.SqlMapper.ExecuteScalarAsync<long>(
+                    connection,
+                    new Dapper.CommandDefinition($"SELECT COUNT(*) FROM {resolver.SafeTable} WHERE _is_deleted = TRUE", cancellationToken: ct));
+
+                return Results.Ok(new
+                {
+                    safeTable = resolver.SafeTable,
+                    unsafeTable = resolver.UnsafeTable,
+                    currentView = resolver.CurrentView,
+                    currentLiveView = resolver.CurrentLiveView,
+                    safeCount,
+                    unsafeCount,
+                    needsRebuildCount,
+                    tombstoneCount
+                });
+            })
+        .WithOpenApi()
+        .WithName("GetWeatherForecastUnsafeWindowMvDiagnostics");
 }
 
 app.MapDefaultEndpoints();

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult.Aws/SekibanDcbOrleansAws.ApiService/Program.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult.Aws/SekibanDcbOrleansAws.ApiService/Program.cs
@@ -933,10 +933,17 @@ if (app.Services.GetService<IMvOrleansQueryAccessor>() is not null)
                 await connection.OpenAsync(ct);
 
                 var view = (includeDeleted ?? false) ? resolver.CurrentView : resolver.CurrentLiveView;
-                var rows = await Dapper.SqlMapper.QueryAsync(
+                // Select only business columns (plus opt-in metadata) so the response shape is
+                // stable even if the framework adds or renames internal UWMV metadata columns.
+                var rows = await Dapper.SqlMapper.QueryAsync<WeatherForecastUnsafeMvReadModel>(
                     connection,
                     new Dapper.CommandDefinition(
-                        $"SELECT * FROM {view} ORDER BY forecast_date DESC, forecast_id",
+                        $"""
+                        SELECT forecast_id, location, forecast_date, temperature_c, summary,
+                               _is_deleted, _last_event_version, _last_sortable_unique_id
+                        FROM {view}
+                        ORDER BY forecast_date DESC, forecast_id
+                        """,
                         cancellationToken: ct));
                 return Results.Ok(rows);
             })
@@ -1025,3 +1032,16 @@ static System.Net.IPAddress GetPrivateIpAddress()
     // Last resort: return loopback
     return System.Net.IPAddress.Loopback;
 }
+
+// Response shape for /api/weatherforecast-uwmv. Declared as a file-scoped record so the
+// endpoint can avoid `SELECT *` (which would couple the API to framework-managed metadata
+// columns in the underlying UWMV view).
+public sealed record WeatherForecastUnsafeMvReadModel(
+    Guid ForecastId,
+    string Location,
+    DateOnly ForecastDate,
+    int TemperatureC,
+    string? Summary,
+    bool IsDeleted,
+    long LastEventVersion,
+    string LastSortableUniqueId);

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult.Aws/SekibanDcbOrleansAws.ApiService/SekibanDcbOrleansAws.ApiService.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult.Aws/SekibanDcbOrleansAws.ApiService/SekibanDcbOrleansAws.ApiService.csproj
@@ -27,13 +27,13 @@
         <!-- SQS streaming will be added when Orleans SQS package supports AWS SDK v4 -->
         <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.3" />
         <PackageReference Include="Scalar.AspNetCore" Version="2.12.50" />
-        <PackageReference Include="Sekiban.Dcb.Orleans.WithoutResult" Version="10.1.18" />
-        <PackageReference Include="Sekiban.Dcb.DynamoDB" Version="10.1.18" />
-        <PackageReference Include="Sekiban.Dcb.BlobStorage.S3" Version="10.1.18" />
-        <PackageReference Include="Sekiban.Dcb.Postgres" Version="10.1.18" />
-        <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.1.18" />
-        <PackageReference Include="Sekiban.Dcb.MaterializedView.Postgres" Version="10.1.18" />
-        <PackageReference Include="Sekiban.Dcb.MaterializedView.Orleans" Version="10.1.18" />
+        <PackageReference Include="Sekiban.Dcb.Orleans.WithoutResult" Version="10.2.0" />
+        <PackageReference Include="Sekiban.Dcb.DynamoDB" Version="10.2.0" />
+        <PackageReference Include="Sekiban.Dcb.BlobStorage.S3" Version="10.2.0" />
+        <PackageReference Include="Sekiban.Dcb.Postgres" Version="10.2.0" />
+        <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.2.0" />
+        <PackageReference Include="Sekiban.Dcb.MaterializedView.Postgres" Version="10.2.0" />
+        <PackageReference Include="Sekiban.Dcb.MaterializedView.Orleans" Version="10.2.0" />
         <PackageReference Include="Dapper" Version="2.1.66" />
         <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />
     </ItemGroup>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult.Aws/SekibanDcbOrleansAws.Domain/MaterializedViews/WeatherForecastUnsafeWindowMvV1.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult.Aws/SekibanDcbOrleansAws.Domain/MaterializedViews/WeatherForecastUnsafeWindowMvV1.cs
@@ -1,0 +1,107 @@
+using Dcb.Domain.WithoutResult.Weather;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.MaterializedView;
+using Sekiban.Dcb.Tags;
+
+namespace Dcb.Domain.WithoutResult.MaterializedViews;
+
+/// <summary>
+///     Sample Unsafe Window materialized view for WeatherForecast (v10.2.0).
+///
+///     One row per forecast id. Business columns are declared through
+///     <see cref="Schema" />; framework metadata columns
+///     (_projection_key / _last_sortable_unique_id / _is_deleted / …) are
+///     managed by the runtime on top of this schema.
+/// </summary>
+public sealed class WeatherForecastUnsafeWindowMvV1 : IUnsafeWindowMvProjector<WeatherForecastUnsafeRow>
+{
+    public string ViewName => "WeatherForecastUnsafeWindow";
+    public int ViewVersion => 1;
+
+    // Short safe window for the sample so promotions are observable without
+    // waiting minutes. Production projectors should match the MultiProjection
+    // dynamic-safe-window heuristic.
+    public TimeSpan SafeWindow => TimeSpan.FromSeconds(2);
+
+    public UnsafeWindowMvSchema Schema { get; } = new(
+        new UnsafeWindowMvColumn(
+            "forecast_id",
+            "UUID NOT NULL",
+            row => ((WeatherForecastUnsafeRow)row).ForecastId),
+        new UnsafeWindowMvColumn(
+            "location",
+            "TEXT NOT NULL",
+            row => ((WeatherForecastUnsafeRow)row).Location),
+        new UnsafeWindowMvColumn(
+            "forecast_date",
+            "DATE NOT NULL",
+            row => ((WeatherForecastUnsafeRow)row).ForecastDate.ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc)),
+        new UnsafeWindowMvColumn(
+            "temperature_c",
+            "INT NOT NULL",
+            row => ((WeatherForecastUnsafeRow)row).TemperatureC),
+        new UnsafeWindowMvColumn(
+            "summary",
+            "TEXT NULL",
+            row => (object?)((WeatherForecastUnsafeRow)row).Summary));
+
+    public string? GetProjectionKey(Event ev) => ev.Payload switch
+    {
+        WeatherForecastCreated c => ProjectionKeyFor(c.ForecastId),
+        WeatherForecastUpdated u => ProjectionKeyFor(u.ForecastId),
+        LocationNameChanged l => ProjectionKeyFor(l.ForecastId),
+        WeatherForecastDeleted d => ProjectionKeyFor(d.ForecastId),
+        _ => null
+    };
+
+    public UnsafeWindowMvApplyOutcome Apply(WeatherForecastUnsafeRow? current, Event ev) =>
+        ev.Payload switch
+        {
+            WeatherForecastCreated created => new UnsafeWindowMvApplyOutcome.Upsert(
+                ProjectionKeyFor(created.ForecastId),
+                new WeatherForecastUnsafeRow
+                {
+                    ForecastId = created.ForecastId,
+                    Location = created.Location,
+                    ForecastDate = created.Date,
+                    TemperatureC = created.TemperatureC,
+                    Summary = created.Summary
+                }),
+
+            WeatherForecastUpdated updated => new UnsafeWindowMvApplyOutcome.Upsert(
+                ProjectionKeyFor(updated.ForecastId),
+                new WeatherForecastUnsafeRow
+                {
+                    ForecastId = updated.ForecastId,
+                    Location = updated.Location,
+                    ForecastDate = updated.Date,
+                    TemperatureC = updated.TemperatureC,
+                    Summary = updated.Summary
+                }),
+
+            LocationNameChanged changed when current is not null => new UnsafeWindowMvApplyOutcome.Upsert(
+                ProjectionKeyFor(changed.ForecastId),
+                current with { Location = changed.NewLocationName }),
+
+            WeatherForecastDeleted deleted => new UnsafeWindowMvApplyOutcome.Delete(
+                ProjectionKeyFor(deleted.ForecastId)),
+
+            _ => new UnsafeWindowMvApplyOutcome.NoChange()
+        };
+
+    public IReadOnlyList<ITag> TagsForProjectionKey(string projectionKey) =>
+        Guid.TryParse(projectionKey, out var forecastId)
+            ? [new WeatherForecastTag(forecastId)]
+            : [];
+
+    private static string ProjectionKeyFor(Guid forecastId) => forecastId.ToString();
+}
+
+public sealed record WeatherForecastUnsafeRow
+{
+    public Guid ForecastId { get; init; }
+    public string Location { get; init; } = string.Empty;
+    public DateOnly ForecastDate { get; init; }
+    public int TemperatureC { get; init; }
+    public string? Summary { get; init; }
+}

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult.Aws/SekibanDcbOrleansAws.Domain/SekibanDcbOrleansAws.Domain.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult.Aws/SekibanDcbOrleansAws.Domain/SekibanDcbOrleansAws.Domain.csproj
@@ -7,8 +7,8 @@
     <IsPackable>true</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.1.18" />
-    <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.1.18" />
+    <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.2.0" />
+    <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.2.0" />
     <PackageReference Include="ResultBoxes" Version="0.4.0" />
     <PackageReference Include="Microsoft.Orleans.Serialization" Version="10.0.1" />
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.ApiService/Program.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.ApiService/Program.cs
@@ -1026,10 +1026,17 @@ if (app.Services.GetService<IMvOrleansQueryAccessor>() is not null)
                 await connection.OpenAsync(ct);
 
                 var view = (includeDeleted ?? false) ? resolver.CurrentView : resolver.CurrentLiveView;
-                var rows = await Dapper.SqlMapper.QueryAsync(
+                // Select only business columns (plus opt-in metadata) so the response shape is
+                // stable even if the framework adds or renames internal UWMV metadata columns.
+                var rows = await Dapper.SqlMapper.QueryAsync<WeatherForecastUnsafeMvReadModel>(
                     connection,
                     new Dapper.CommandDefinition(
-                        $"SELECT * FROM {view} ORDER BY forecast_date DESC, forecast_id",
+                        $"""
+                        SELECT forecast_id, location, forecast_date, temperature_c, summary,
+                               _is_deleted, _last_event_version, _last_sortable_unique_id
+                        FROM {view}
+                        ORDER BY forecast_date DESC, forecast_id
+                        """,
                         cancellationToken: ct));
                 return Results.Ok(rows);
             })
@@ -1081,3 +1088,16 @@ if (app.Services.GetService<IMvOrleansQueryAccessor>() is not null)
 app.MapDefaultEndpoints();
 
 app.Run();
+
+// Response shape for /api/weatherforecast-uwmv. Declared as a file-scoped record so the
+// endpoint can avoid `SELECT *` (which would couple the API to framework-managed metadata
+// columns in the underlying UWMV view).
+public sealed record WeatherForecastUnsafeMvReadModel(
+    Guid ForecastId,
+    string Location,
+    DateOnly ForecastDate,
+    int TemperatureC,
+    string? Summary,
+    bool IsDeleted,
+    long LastEventVersion,
+    string LastSortableUniqueId);

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.ApiService/Program.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.ApiService/Program.cs
@@ -399,6 +399,13 @@ if (!string.IsNullOrWhiteSpace(builder.Configuration.GetConnectionString("DcbMat
         connectionStringName: "DcbMaterializedViewPostgres",
         registerHostedWorker: false);
     builder.Services.AddSekibanDcbMaterializedViewOrleans();
+
+    // Unsafe Window materialized view (v10.2.0) — safe/unsafe split read model
+    // with automatic safe promotion. Shares the `DcbMaterializedViewPostgres`
+    // database; the runtime owns DDL, catchup and promotion as a hosted service.
+    builder.Services.AddSekibanDcbUnsafeWindowMv<WeatherForecastUnsafeWindowMvV1, WeatherForecastUnsafeRow>(
+        builder.Configuration,
+        connectionStringName: "DcbMaterializedViewPostgres");
 }
 builder.Services.AddTransient<IGrainStorageSerializer, NewtonsoftJsonDcbOrleansSerializer>();
 builder.Services.AddTransient<NewtonsoftJsonDcbOrleansSerializer>();
@@ -995,6 +1002,80 @@ apiRoute
 if (app.Services.GetService<IMvOrleansQueryAccessor>() is not null)
 {
     apiRoute.MapMaterializedViewEndpoints();
+
+    // Unsafe Window MV sample endpoints — unsafe-first reads via the generated
+    // `current` / `current_live` Postgres views plus a diagnostics counter.
+    // Registered only when the UWMV runtime was wired above.
+    var uwmvResolverKey = Sekiban.Dcb.MaterializedView.Postgres.UnsafeWindowMvRegistration
+        .SchemaResolverKey<WeatherForecastUnsafeWindowMvV1>();
+    var uwmvConnectionKey = Sekiban.Dcb.MaterializedView.Postgres.UnsafeWindowMvRegistration
+        .ConnectionStringKey<WeatherForecastUnsafeWindowMvV1>();
+
+    apiRoute
+        .MapGet(
+            "/weatherforecast-uwmv",
+            async (
+                [FromServices] IServiceProvider sp,
+                [FromQuery] bool? includeDeleted,
+                CancellationToken ct) =>
+            {
+                var resolver = sp.GetRequiredKeyedService<Sekiban.Dcb.MaterializedView.Postgres.UnsafeWindowMvSchemaResolver>(uwmvResolverKey);
+                var connectionString = sp.GetRequiredKeyedService<string>(uwmvConnectionKey);
+
+                await using var connection = new Npgsql.NpgsqlConnection(connectionString);
+                await connection.OpenAsync(ct);
+
+                var view = (includeDeleted ?? false) ? resolver.CurrentView : resolver.CurrentLiveView;
+                var rows = await Dapper.SqlMapper.QueryAsync(
+                    connection,
+                    new Dapper.CommandDefinition(
+                        $"SELECT * FROM {view} ORDER BY forecast_date DESC, forecast_id",
+                        cancellationToken: ct));
+                return Results.Ok(rows);
+            })
+        .WithOpenApi()
+        .WithName("GetWeatherForecastUnsafeWindowMv");
+
+    apiRoute
+        .MapGet(
+            "/weatherforecast-uwmv/diagnostics",
+            async (
+                [FromServices] IServiceProvider sp,
+                CancellationToken ct) =>
+            {
+                var resolver = sp.GetRequiredKeyedService<Sekiban.Dcb.MaterializedView.Postgres.UnsafeWindowMvSchemaResolver>(uwmvResolverKey);
+                var connectionString = sp.GetRequiredKeyedService<string>(uwmvConnectionKey);
+
+                await using var connection = new Npgsql.NpgsqlConnection(connectionString);
+                await connection.OpenAsync(ct);
+
+                var safeCount = await Dapper.SqlMapper.ExecuteScalarAsync<long>(
+                    connection,
+                    new Dapper.CommandDefinition($"SELECT COUNT(*) FROM {resolver.SafeTable}", cancellationToken: ct));
+                var unsafeCount = await Dapper.SqlMapper.ExecuteScalarAsync<long>(
+                    connection,
+                    new Dapper.CommandDefinition($"SELECT COUNT(*) FROM {resolver.UnsafeTable}", cancellationToken: ct));
+                var needsRebuildCount = await Dapper.SqlMapper.ExecuteScalarAsync<long>(
+                    connection,
+                    new Dapper.CommandDefinition($"SELECT COUNT(*) FROM {resolver.UnsafeTable} WHERE _needs_rebuild = TRUE", cancellationToken: ct));
+                var tombstoneCount = await Dapper.SqlMapper.ExecuteScalarAsync<long>(
+                    connection,
+                    new Dapper.CommandDefinition($"SELECT COUNT(*) FROM {resolver.SafeTable} WHERE _is_deleted = TRUE", cancellationToken: ct));
+
+                return Results.Ok(new
+                {
+                    safeTable = resolver.SafeTable,
+                    unsafeTable = resolver.UnsafeTable,
+                    currentView = resolver.CurrentView,
+                    currentLiveView = resolver.CurrentLiveView,
+                    safeCount,
+                    unsafeCount,
+                    needsRebuildCount,
+                    tombstoneCount
+                });
+            })
+        .WithOpenApi()
+        .WithName("GetWeatherForecastUnsafeWindowMvDiagnostics");
 }
 
 app.MapDefaultEndpoints();

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.ApiService/SekibanDcbOrleans.ApiService.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.ApiService/SekibanDcbOrleans.ApiService.csproj
@@ -30,14 +30,14 @@
         <PackageReference Include="Microsoft.Orleans.Streaming" Version="10.0.1" />
         <PackageReference Include="Microsoft.Orleans.Streaming.AzureStorage" Version="10.0.1" />
         <PackageReference Include="Scalar.AspNetCore" Version="2.12.50" />
-        <PackageReference Include="Sekiban.Dcb.BlobStorage.AzureStorage" Version="10.1.18" />
-        <PackageReference Include="Sekiban.Dcb.Orleans.WithoutResult" Version="10.1.18" />
-        <PackageReference Include="Sekiban.Dcb.Postgres" Version="10.1.18" />
-        <PackageReference Include="Sekiban.Dcb.CosmosDb" Version="10.1.18" />
-        <PackageReference Include="Sekiban.Dcb.Sqlite" Version="10.1.18" />
-        <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.1.18" />
-        <PackageReference Include="Sekiban.Dcb.MaterializedView.Postgres" Version="10.1.18" />
-        <PackageReference Include="Sekiban.Dcb.MaterializedView.Orleans" Version="10.1.18" />
+        <PackageReference Include="Sekiban.Dcb.BlobStorage.AzureStorage" Version="10.2.0" />
+        <PackageReference Include="Sekiban.Dcb.Orleans.WithoutResult" Version="10.2.0" />
+        <PackageReference Include="Sekiban.Dcb.Postgres" Version="10.2.0" />
+        <PackageReference Include="Sekiban.Dcb.CosmosDb" Version="10.2.0" />
+        <PackageReference Include="Sekiban.Dcb.Sqlite" Version="10.2.0" />
+        <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.2.0" />
+        <PackageReference Include="Sekiban.Dcb.MaterializedView.Postgres" Version="10.2.0" />
+        <PackageReference Include="Sekiban.Dcb.MaterializedView.Orleans" Version="10.2.0" />
         <PackageReference Include="Dapper" Version="2.1.66" />
         <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />
     </ItemGroup>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.Cli/SekibanDcbOrleans.Cli.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.Cli/SekibanDcbOrleans.Cli.csproj
@@ -14,10 +14,10 @@
         <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.3" />
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.3" />
         <PackageReference Include="System.CommandLine" Version="2.0.2" />
-        <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.1.18" />
-        <PackageReference Include="Sekiban.Dcb.Postgres" Version="10.1.18" />
-        <PackageReference Include="Sekiban.Dcb.CosmosDb" Version="10.1.18" />
-        <PackageReference Include="Sekiban.Dcb.Sqlite" Version="10.1.18" />
+        <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.2.0" />
+        <PackageReference Include="Sekiban.Dcb.Postgres" Version="10.2.0" />
+        <PackageReference Include="Sekiban.Dcb.CosmosDb" Version="10.2.0" />
+        <PackageReference Include="Sekiban.Dcb.Sqlite" Version="10.2.0" />
         <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />
     </ItemGroup>
 

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.Domain/MaterializedViews/WeatherForecastUnsafeWindowMvV1.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.Domain/MaterializedViews/WeatherForecastUnsafeWindowMvV1.cs
@@ -1,0 +1,107 @@
+using Dcb.Domain.WithoutResult.Weather;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.MaterializedView;
+using Sekiban.Dcb.Tags;
+
+namespace Dcb.Domain.WithoutResult.MaterializedViews;
+
+/// <summary>
+///     Sample Unsafe Window materialized view for WeatherForecast (v10.2.0).
+///
+///     One row per forecast id. Business columns are declared through
+///     <see cref="Schema" />; framework metadata columns
+///     (_projection_key / _last_sortable_unique_id / _is_deleted / …) are
+///     managed by the runtime on top of this schema.
+/// </summary>
+public sealed class WeatherForecastUnsafeWindowMvV1 : IUnsafeWindowMvProjector<WeatherForecastUnsafeRow>
+{
+    public string ViewName => "WeatherForecastUnsafeWindow";
+    public int ViewVersion => 1;
+
+    // Short safe window for the sample so promotions are observable without
+    // waiting minutes. Production projectors should match the MultiProjection
+    // dynamic-safe-window heuristic.
+    public TimeSpan SafeWindow => TimeSpan.FromSeconds(2);
+
+    public UnsafeWindowMvSchema Schema { get; } = new(
+        new UnsafeWindowMvColumn(
+            "forecast_id",
+            "UUID NOT NULL",
+            row => ((WeatherForecastUnsafeRow)row).ForecastId),
+        new UnsafeWindowMvColumn(
+            "location",
+            "TEXT NOT NULL",
+            row => ((WeatherForecastUnsafeRow)row).Location),
+        new UnsafeWindowMvColumn(
+            "forecast_date",
+            "DATE NOT NULL",
+            row => ((WeatherForecastUnsafeRow)row).ForecastDate.ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc)),
+        new UnsafeWindowMvColumn(
+            "temperature_c",
+            "INT NOT NULL",
+            row => ((WeatherForecastUnsafeRow)row).TemperatureC),
+        new UnsafeWindowMvColumn(
+            "summary",
+            "TEXT NULL",
+            row => (object?)((WeatherForecastUnsafeRow)row).Summary));
+
+    public string? GetProjectionKey(Event ev) => ev.Payload switch
+    {
+        WeatherForecastCreated c => ProjectionKeyFor(c.ForecastId),
+        WeatherForecastUpdated u => ProjectionKeyFor(u.ForecastId),
+        LocationNameChanged l => ProjectionKeyFor(l.ForecastId),
+        WeatherForecastDeleted d => ProjectionKeyFor(d.ForecastId),
+        _ => null
+    };
+
+    public UnsafeWindowMvApplyOutcome Apply(WeatherForecastUnsafeRow? current, Event ev) =>
+        ev.Payload switch
+        {
+            WeatherForecastCreated created => new UnsafeWindowMvApplyOutcome.Upsert(
+                ProjectionKeyFor(created.ForecastId),
+                new WeatherForecastUnsafeRow
+                {
+                    ForecastId = created.ForecastId,
+                    Location = created.Location,
+                    ForecastDate = created.Date,
+                    TemperatureC = created.TemperatureC,
+                    Summary = created.Summary
+                }),
+
+            WeatherForecastUpdated updated => new UnsafeWindowMvApplyOutcome.Upsert(
+                ProjectionKeyFor(updated.ForecastId),
+                new WeatherForecastUnsafeRow
+                {
+                    ForecastId = updated.ForecastId,
+                    Location = updated.Location,
+                    ForecastDate = updated.Date,
+                    TemperatureC = updated.TemperatureC,
+                    Summary = updated.Summary
+                }),
+
+            LocationNameChanged changed when current is not null => new UnsafeWindowMvApplyOutcome.Upsert(
+                ProjectionKeyFor(changed.ForecastId),
+                current with { Location = changed.NewLocationName }),
+
+            WeatherForecastDeleted deleted => new UnsafeWindowMvApplyOutcome.Delete(
+                ProjectionKeyFor(deleted.ForecastId)),
+
+            _ => new UnsafeWindowMvApplyOutcome.NoChange()
+        };
+
+    public IReadOnlyList<ITag> TagsForProjectionKey(string projectionKey) =>
+        Guid.TryParse(projectionKey, out var forecastId)
+            ? [new WeatherForecastTag(forecastId)]
+            : [];
+
+    private static string ProjectionKeyFor(Guid forecastId) => forecastId.ToString();
+}
+
+public sealed record WeatherForecastUnsafeRow
+{
+    public Guid ForecastId { get; init; }
+    public string Location { get; init; } = string.Empty;
+    public DateOnly ForecastDate { get; init; }
+    public int TemperatureC { get; init; }
+    public string? Summary { get; init; }
+}

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.Domain/SekibanDcbOrleans.Domain.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.Domain/SekibanDcbOrleans.Domain.csproj
@@ -7,8 +7,8 @@
     <IsPackable>true</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.1.18" />
-    <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.1.18" />
+    <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.2.0" />
+    <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.2.0" />
     <PackageReference Include="ResultBoxes" Version="0.4.0" />
     <PackageReference Include="Microsoft.Orleans.Serialization" Version="10.0.1" />
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans/SekibanDcbOrleans.ApiService/Program.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans/SekibanDcbOrleans.ApiService/Program.cs
@@ -478,6 +478,13 @@ if (!string.IsNullOrWhiteSpace(builder.Configuration.GetConnectionString("DcbMat
         connectionStringName: "DcbMaterializedViewPostgres",
         registerHostedWorker: false);
     builder.Services.AddSekibanDcbMaterializedViewOrleans();
+
+    // Unsafe Window materialized view (v10.2.0) — safe/unsafe split read model
+    // with automatic safe promotion. Shares the `DcbMaterializedViewPostgres`
+    // database; the runtime owns DDL, catchup and promotion as a hosted service.
+    builder.Services.AddSekibanDcbUnsafeWindowMv<WeatherForecastUnsafeWindowMvV1, WeatherForecastUnsafeRow>(
+        builder.Configuration,
+        connectionStringName: "DcbMaterializedViewPostgres");
 }
 
 builder.Services.AddTransient<IGrainStorageSerializer, NewtonsoftJsonDcbOrleansSerializer>();
@@ -1161,6 +1168,80 @@ apiRoute
 if (app.Services.GetService<IMvOrleansQueryAccessor>() is not null)
 {
     apiRoute.MapMaterializedViewEndpoints();
+
+    // Unsafe Window MV sample endpoints — unsafe-first reads via the generated
+    // `current` / `current_live` Postgres views plus a diagnostics counter.
+    // Registered only when the UWMV runtime was wired above.
+    var uwmvResolverKey = Sekiban.Dcb.MaterializedView.Postgres.UnsafeWindowMvRegistration
+        .SchemaResolverKey<WeatherForecastUnsafeWindowMvV1>();
+    var uwmvConnectionKey = Sekiban.Dcb.MaterializedView.Postgres.UnsafeWindowMvRegistration
+        .ConnectionStringKey<WeatherForecastUnsafeWindowMvV1>();
+
+    apiRoute
+        .MapGet(
+            "/weatherforecast-uwmv",
+            async (
+                [FromServices] IServiceProvider sp,
+                [FromQuery] bool? includeDeleted,
+                CancellationToken ct) =>
+            {
+                var resolver = sp.GetRequiredKeyedService<Sekiban.Dcb.MaterializedView.Postgres.UnsafeWindowMvSchemaResolver>(uwmvResolverKey);
+                var connectionString = sp.GetRequiredKeyedService<string>(uwmvConnectionKey);
+
+                await using var connection = new Npgsql.NpgsqlConnection(connectionString);
+                await connection.OpenAsync(ct);
+
+                var view = (includeDeleted ?? false) ? resolver.CurrentView : resolver.CurrentLiveView;
+                var rows = await Dapper.SqlMapper.QueryAsync(
+                    connection,
+                    new Dapper.CommandDefinition(
+                        $"SELECT * FROM {view} ORDER BY forecast_date DESC, forecast_id",
+                        cancellationToken: ct));
+                return Results.Ok(rows);
+            })
+        .WithOpenApi()
+        .WithName("GetWeatherForecastUnsafeWindowMv");
+
+    apiRoute
+        .MapGet(
+            "/weatherforecast-uwmv/diagnostics",
+            async (
+                [FromServices] IServiceProvider sp,
+                CancellationToken ct) =>
+            {
+                var resolver = sp.GetRequiredKeyedService<Sekiban.Dcb.MaterializedView.Postgres.UnsafeWindowMvSchemaResolver>(uwmvResolverKey);
+                var connectionString = sp.GetRequiredKeyedService<string>(uwmvConnectionKey);
+
+                await using var connection = new Npgsql.NpgsqlConnection(connectionString);
+                await connection.OpenAsync(ct);
+
+                var safeCount = await Dapper.SqlMapper.ExecuteScalarAsync<long>(
+                    connection,
+                    new Dapper.CommandDefinition($"SELECT COUNT(*) FROM {resolver.SafeTable}", cancellationToken: ct));
+                var unsafeCount = await Dapper.SqlMapper.ExecuteScalarAsync<long>(
+                    connection,
+                    new Dapper.CommandDefinition($"SELECT COUNT(*) FROM {resolver.UnsafeTable}", cancellationToken: ct));
+                var needsRebuildCount = await Dapper.SqlMapper.ExecuteScalarAsync<long>(
+                    connection,
+                    new Dapper.CommandDefinition($"SELECT COUNT(*) FROM {resolver.UnsafeTable} WHERE _needs_rebuild = TRUE", cancellationToken: ct));
+                var tombstoneCount = await Dapper.SqlMapper.ExecuteScalarAsync<long>(
+                    connection,
+                    new Dapper.CommandDefinition($"SELECT COUNT(*) FROM {resolver.SafeTable} WHERE _is_deleted = TRUE", cancellationToken: ct));
+
+                return Results.Ok(new
+                {
+                    safeTable = resolver.SafeTable,
+                    unsafeTable = resolver.UnsafeTable,
+                    currentView = resolver.CurrentView,
+                    currentLiveView = resolver.CurrentLiveView,
+                    safeCount,
+                    unsafeCount,
+                    needsRebuildCount,
+                    tombstoneCount
+                });
+            })
+        .WithOpenApi()
+        .WithName("GetWeatherForecastUnsafeWindowMvDiagnostics");
 }
 
 app.MapDefaultEndpoints();

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans/SekibanDcbOrleans.ApiService/Program.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans/SekibanDcbOrleans.ApiService/Program.cs
@@ -1192,10 +1192,17 @@ if (app.Services.GetService<IMvOrleansQueryAccessor>() is not null)
                 await connection.OpenAsync(ct);
 
                 var view = (includeDeleted ?? false) ? resolver.CurrentView : resolver.CurrentLiveView;
-                var rows = await Dapper.SqlMapper.QueryAsync(
+                // Select only business columns (plus opt-in metadata) so the response shape is
+                // stable even if the framework adds or renames internal UWMV metadata columns.
+                var rows = await Dapper.SqlMapper.QueryAsync<WeatherForecastUnsafeMvReadModel>(
                     connection,
                     new Dapper.CommandDefinition(
-                        $"SELECT * FROM {view} ORDER BY forecast_date DESC, forecast_id",
+                        $"""
+                        SELECT forecast_id, location, forecast_date, temperature_c, summary,
+                               _is_deleted, _last_event_version, _last_sortable_unique_id
+                        FROM {view}
+                        ORDER BY forecast_date DESC, forecast_id
+                        """,
                         cancellationToken: ct));
                 return Results.Ok(rows);
             })
@@ -1246,3 +1253,16 @@ if (app.Services.GetService<IMvOrleansQueryAccessor>() is not null)
 
 app.MapDefaultEndpoints();
 app.Run();
+
+// Response shape for /api/weatherforecast-uwmv. Declared as a file-scoped record so the
+// endpoint can avoid `SELECT *` (which would couple the API to framework-managed metadata
+// columns in the underlying UWMV view).
+public sealed record WeatherForecastUnsafeMvReadModel(
+    Guid ForecastId,
+    string Location,
+    DateOnly ForecastDate,
+    int TemperatureC,
+    string? Summary,
+    bool IsDeleted,
+    long LastEventVersion,
+    string LastSortableUniqueId);

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans/SekibanDcbOrleans.ApiService/SekibanDcbOrleans.ApiService.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans/SekibanDcbOrleans.ApiService/SekibanDcbOrleans.ApiService.csproj
@@ -28,14 +28,14 @@
     <PackageReference Include="Microsoft.Orleans.Streaming.AzureStorage" Version="10.0.1" />
     <PackageReference Include="Microsoft.Orleans.Streaming.EventHubs" Version="10.0.1" />
     <PackageReference Include="Scalar.AspNetCore" Version="2.12.50" />
-    <PackageReference Include="Sekiban.Dcb.BlobStorage.AzureStorage" Version="10.1.18" />
-    <PackageReference Include="Sekiban.Dcb.Orleans.WithResult" Version="10.1.18" />
-    <PackageReference Include="Sekiban.Dcb.Postgres" Version="10.1.18" />
-    <PackageReference Include="Sekiban.Dcb.CosmosDb" Version="10.1.18" />
-    <PackageReference Include="Sekiban.Dcb.Sqlite" Version="10.1.18" />
-    <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.1.18" />
-    <PackageReference Include="Sekiban.Dcb.MaterializedView.Postgres" Version="10.1.18" />
-    <PackageReference Include="Sekiban.Dcb.MaterializedView.Orleans" Version="10.1.18" />
+    <PackageReference Include="Sekiban.Dcb.BlobStorage.AzureStorage" Version="10.2.0" />
+    <PackageReference Include="Sekiban.Dcb.Orleans.WithResult" Version="10.2.0" />
+    <PackageReference Include="Sekiban.Dcb.Postgres" Version="10.2.0" />
+    <PackageReference Include="Sekiban.Dcb.CosmosDb" Version="10.2.0" />
+    <PackageReference Include="Sekiban.Dcb.Sqlite" Version="10.2.0" />
+    <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.2.0" />
+    <PackageReference Include="Sekiban.Dcb.MaterializedView.Postgres" Version="10.2.0" />
+    <PackageReference Include="Sekiban.Dcb.MaterializedView.Orleans" Version="10.2.0" />
     <PackageReference Include="Dapper" Version="2.1.66" />
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />
   </ItemGroup>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans/SekibanDcbOrleans.Cli/SekibanDcbOrleans.Cli.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans/SekibanDcbOrleans.Cli/SekibanDcbOrleans.Cli.csproj
@@ -14,10 +14,10 @@
         <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.3" />
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.3" />
         <PackageReference Include="System.CommandLine" Version="2.0.2" />
-        <PackageReference Include="Sekiban.Dcb.WithResult" Version="10.1.18" />
-        <PackageReference Include="Sekiban.Dcb.Postgres" Version="10.1.18" />
-        <PackageReference Include="Sekiban.Dcb.CosmosDb" Version="10.1.18" />
-        <PackageReference Include="Sekiban.Dcb.Sqlite" Version="10.1.18" />
+        <PackageReference Include="Sekiban.Dcb.WithResult" Version="10.2.0" />
+        <PackageReference Include="Sekiban.Dcb.Postgres" Version="10.2.0" />
+        <PackageReference Include="Sekiban.Dcb.CosmosDb" Version="10.2.0" />
+        <PackageReference Include="Sekiban.Dcb.Sqlite" Version="10.2.0" />
         <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />
     </ItemGroup>
 

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans/SekibanDcbOrleans.Domain/MaterializedViews/WeatherForecastUnsafeWindowMvV1.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans/SekibanDcbOrleans.Domain/MaterializedViews/WeatherForecastUnsafeWindowMvV1.cs
@@ -1,0 +1,107 @@
+using Dcb.Domain.Weather;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.MaterializedView;
+using Sekiban.Dcb.Tags;
+
+namespace Dcb.Domain.MaterializedViews;
+
+/// <summary>
+///     Sample Unsafe Window materialized view for WeatherForecast (v10.2.0).
+///
+///     One row per forecast id. Business columns are declared through
+///     <see cref="Schema" />; framework metadata columns
+///     (_projection_key / _last_sortable_unique_id / _is_deleted / …) are
+///     managed by the runtime on top of this schema.
+/// </summary>
+public sealed class WeatherForecastUnsafeWindowMvV1 : IUnsafeWindowMvProjector<WeatherForecastUnsafeRow>
+{
+    public string ViewName => "WeatherForecastUnsafeWindow";
+    public int ViewVersion => 1;
+
+    // Short safe window for the sample so promotions are observable without
+    // waiting minutes. Production projectors should match the MultiProjection
+    // dynamic-safe-window heuristic.
+    public TimeSpan SafeWindow => TimeSpan.FromSeconds(2);
+
+    public UnsafeWindowMvSchema Schema { get; } = new(
+        new UnsafeWindowMvColumn(
+            "forecast_id",
+            "UUID NOT NULL",
+            row => ((WeatherForecastUnsafeRow)row).ForecastId),
+        new UnsafeWindowMvColumn(
+            "location",
+            "TEXT NOT NULL",
+            row => ((WeatherForecastUnsafeRow)row).Location),
+        new UnsafeWindowMvColumn(
+            "forecast_date",
+            "DATE NOT NULL",
+            row => ((WeatherForecastUnsafeRow)row).ForecastDate.ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc)),
+        new UnsafeWindowMvColumn(
+            "temperature_c",
+            "INT NOT NULL",
+            row => ((WeatherForecastUnsafeRow)row).TemperatureC),
+        new UnsafeWindowMvColumn(
+            "summary",
+            "TEXT NULL",
+            row => (object?)((WeatherForecastUnsafeRow)row).Summary));
+
+    public string? GetProjectionKey(Event ev) => ev.Payload switch
+    {
+        WeatherForecastCreated c => ProjectionKeyFor(c.ForecastId),
+        WeatherForecastUpdated u => ProjectionKeyFor(u.ForecastId),
+        LocationNameChanged l => ProjectionKeyFor(l.ForecastId),
+        WeatherForecastDeleted d => ProjectionKeyFor(d.ForecastId),
+        _ => null
+    };
+
+    public UnsafeWindowMvApplyOutcome Apply(WeatherForecastUnsafeRow? current, Event ev) =>
+        ev.Payload switch
+        {
+            WeatherForecastCreated created => new UnsafeWindowMvApplyOutcome.Upsert(
+                ProjectionKeyFor(created.ForecastId),
+                new WeatherForecastUnsafeRow
+                {
+                    ForecastId = created.ForecastId,
+                    Location = created.Location,
+                    ForecastDate = created.Date,
+                    TemperatureC = created.TemperatureC,
+                    Summary = created.Summary
+                }),
+
+            WeatherForecastUpdated updated => new UnsafeWindowMvApplyOutcome.Upsert(
+                ProjectionKeyFor(updated.ForecastId),
+                new WeatherForecastUnsafeRow
+                {
+                    ForecastId = updated.ForecastId,
+                    Location = updated.Location,
+                    ForecastDate = updated.Date,
+                    TemperatureC = updated.TemperatureC,
+                    Summary = updated.Summary
+                }),
+
+            LocationNameChanged changed when current is not null => new UnsafeWindowMvApplyOutcome.Upsert(
+                ProjectionKeyFor(changed.ForecastId),
+                current with { Location = changed.NewLocationName }),
+
+            WeatherForecastDeleted deleted => new UnsafeWindowMvApplyOutcome.Delete(
+                ProjectionKeyFor(deleted.ForecastId)),
+
+            _ => new UnsafeWindowMvApplyOutcome.NoChange()
+        };
+
+    public IReadOnlyList<ITag> TagsForProjectionKey(string projectionKey) =>
+        Guid.TryParse(projectionKey, out var forecastId)
+            ? [new WeatherForecastTag(forecastId)]
+            : [];
+
+    private static string ProjectionKeyFor(Guid forecastId) => forecastId.ToString();
+}
+
+public sealed record WeatherForecastUnsafeRow
+{
+    public Guid ForecastId { get; init; }
+    public string Location { get; init; } = string.Empty;
+    public DateOnly ForecastDate { get; init; }
+    public int TemperatureC { get; init; }
+    public string? Summary { get; init; }
+}

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans/SekibanDcbOrleans.Domain/SekibanDcbOrleans.Domain.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans/SekibanDcbOrleans.Domain/SekibanDcbOrleans.Domain.csproj
@@ -7,8 +7,8 @@
     <IsPackable>true</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Sekiban.Dcb.WithResult" Version="10.1.18" />
-    <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.1.18" />
+    <PackageReference Include="Sekiban.Dcb.WithResult" Version="10.2.0" />
+    <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.2.0" />
     <PackageReference Include="ResultBoxes" Version="0.4.0" />
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />
   </ItemGroup>


### PR DESCRIPTION
## Summary

Follow-up to [#1031](https://github.com/J-Tech-Japan/Sekiban/pull/1031) / [dcb-v10.2.0](https://github.com/J-Tech-Japan/Sekiban/releases/tag/dcb-v10.2.0). Propagates the Unsafe Window MV v1 feature into every template under \`templates/Sekiban.Dcb.Templates/content/\`.

- Bumps all \`Sekiban.Dcb.*\` package references from **10.1.18 → 10.2.0** across the 5 template variants (Orleans / Orleans.WithoutResult / Orleans.Decider + two AWS variants).
- Adds a sample \`WeatherForecastUnsafeWindowMvV1\` projector (with \`WeatherForecastUnsafeRow\`) to each template's domain / event-source project, mirroring the reference projector in \`internalUsages\`.
- Registers \`AddSekibanDcbUnsafeWindowMv<...>()\` and maps \`/weatherforecast-uwmv\` + \`/weatherforecast-uwmv/diagnostics\` endpoints — all inside the existing \`DcbMaterializedViewPostgres\` connection-string guard so templates that don't opt into the Postgres MV database keep working unchanged.
- Adds a missing \`using Microsoft.AspNetCore.Mvc;\` to \`SekibanDcbDecider.ApiService/Program.cs\` so the new \`[FromServices]\` / \`[FromQuery]\` parameter bindings compile there.

## Test plan

- [x] \`dotnet build\` of every template solution with the 10.2.0 packages restored from NuGet
  - \`Sekiban.Dcb.Orleans.WithoutResult\` — 0 errors
  - \`Sekiban.Dcb.Orleans\` — 0 errors
  - \`Sekiban.Dcb.Orleans.Decider\` — 0 errors
  - \`Sekiban.Dcb.Orleans.WithoutResult.Aws\` — 0 errors
  - \`Sekiban.Dcb.Orleans.Decider.Aws\` — 0 errors
- [x] \`dotnet pack\` of \`templates/Sekiban.Dcb.Templates\` succeeds
- [ ] Optional follow-up: smoke test \`dotnet new --install\` → \`dotnet new\` for at least one template and verify the new \`/weatherforecast-uwmv\` endpoint returns after an AppHost run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)