### PR TITLE
Add classic MV providers for SQL Server, MySQL, and SQLite

### DIFF
--- a/.github/workflows/packagesDcb.yml
+++ b/.github/workflows/packagesDcb.yml
@@ -55,6 +55,9 @@ jobs:
           dotnet pack dcb/src/Sekiban.Dcb.WithoutResult/Sekiban.Dcb.WithoutResult.csproj -c Release -o out -p:PackageVersion=$VERSION --no-build
           dotnet pack dcb/src/Sekiban.Dcb.MaterializedView/Sekiban.Dcb.MaterializedView.csproj -c Release -o out -p:PackageVersion=$VERSION --no-build
           dotnet pack dcb/src/Sekiban.Dcb.MaterializedView.Postgres/Sekiban.Dcb.MaterializedView.Postgres.csproj -c Release -o out -p:PackageVersion=$VERSION --no-build
+          dotnet pack dcb/src/Sekiban.Dcb.MaterializedView.SqlServer/Sekiban.Dcb.MaterializedView.SqlServer.csproj -c Release -o out -p:PackageVersion=$VERSION --no-build
+          dotnet pack dcb/src/Sekiban.Dcb.MaterializedView.MySql/Sekiban.Dcb.MaterializedView.MySql.csproj -c Release -o out -p:PackageVersion=$VERSION --no-build
+          dotnet pack dcb/src/Sekiban.Dcb.MaterializedView.Sqlite/Sekiban.Dcb.MaterializedView.Sqlite.csproj -c Release -o out -p:PackageVersion=$VERSION --no-build
           dotnet pack dcb/src/Sekiban.Dcb.MaterializedView.Orleans/Sekiban.Dcb.MaterializedView.Orleans.csproj -c Release -o out -p:PackageVersion=$VERSION --no-build
           dotnet pack dcb/src/Sekiban.Dcb.Orleans.Core/Sekiban.Dcb.Orleans.Core.csproj -c Release -o out -p:PackageVersion=$VERSION --no-build
           dotnet pack dcb/src/Sekiban.Dcb.Orleans.WithResult/Sekiban.Dcb.Orleans.WithResult.csproj -c Release -o out -p:PackageVersion=$VERSION --no-build

--- a/.github/workflows/run_test_dcb.yml
+++ b/.github/workflows/run_test_dcb.yml
@@ -12,6 +12,11 @@ on:
       - 'dcb/src/Sekiban.Dcb.Orleans.Core/**'
       - 'dcb/src/Sekiban.Dcb.Orleans.WithResult/**'
       - 'dcb/src/Sekiban.Dcb.Orleans.WithoutResult/**'
+      - 'dcb/src/Sekiban.Dcb.MaterializedView/**'
+      - 'dcb/src/Sekiban.Dcb.MaterializedView.Postgres/**'
+      - 'dcb/src/Sekiban.Dcb.MaterializedView.SqlServer/**'
+      - 'dcb/src/Sekiban.Dcb.MaterializedView.MySql/**'
+      - 'dcb/src/Sekiban.Dcb.MaterializedView.Sqlite/**'
       - 'dcb/src/Sekiban.Dcb.BlobStorage.AzureStorage/**'
       - 'dcb/src/Sekiban.Dcb.BlobStorage.S3/**'
       - 'dcb/src/Sekiban.Dcb.CosmosDb/**'
@@ -20,6 +25,7 @@ on:
       - 'dcb/src/Sekiban.Dcb.Postgres.MigrationHost/**'
       - 'dcb/tests/Sekiban.Dcb.Orleans.Tests/**'
       - 'dcb/tests/Sekiban.Dcb.Postgres.Tests/**'
+      - 'dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/**'
       - 'dcb/tests/Sekiban.Dcb.WithResult.Tests/**'
       - 'dcb/tests/Sekiban.Dcb.WithoutResult.Tests/**'
       - 'dcb/tests/Sekiban.Dcb.BlobStorage.AzureStorage.Unit/**'
@@ -63,6 +69,7 @@ jobs:
           dotnet test dcb/tests/Sekiban.Dcb.WithResult.Tests/Sekiban.Dcb.WithResult.Tests.csproj -c Release --no-build -f net9.0 --verbosity normal --collect:"XPlat Code Coverage" -- RunConfiguration.MaxCpuCount=1
           dotnet test dcb/tests/Sekiban.Dcb.WithoutResult.Tests/Sekiban.Dcb.WithoutResult.Tests.csproj -c Release --no-build -f net9.0 --verbosity normal --collect:"XPlat Code Coverage" -- RunConfiguration.MaxCpuCount=1
           dotnet test dcb/tests/Sekiban.Dcb.Postgres.Tests/Sekiban.Dcb.Postgres.Tests.csproj -c Release --no-build -f net9.0 --verbosity normal --collect:"XPlat Code Coverage" -- RunConfiguration.MaxCpuCount=1
+          dotnet test dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests.csproj -c Release --no-build -f net9.0 --verbosity normal --collect:"XPlat Code Coverage" -- RunConfiguration.MaxCpuCount=1
           dotnet test dcb/tests/Sekiban.Dcb.BlobStorage.AzureStorage.Unit/Sekiban.Dcb.BlobStorage.AzureStorage.Unit.csproj -c Release --no-build -f net9.0 --verbosity normal --collect:"XPlat Code Coverage" -- RunConfiguration.MaxCpuCount=1
 
   dcbTestsNet10:
@@ -99,4 +106,5 @@ jobs:
           dotnet test dcb/tests/Sekiban.Dcb.WithResult.Tests/Sekiban.Dcb.WithResult.Tests.csproj -c Release --no-build -f net10.0 --verbosity normal --collect:"XPlat Code Coverage" -- RunConfiguration.MaxCpuCount=1
           dotnet test dcb/tests/Sekiban.Dcb.WithoutResult.Tests/Sekiban.Dcb.WithoutResult.Tests.csproj -c Release --no-build -f net10.0 --verbosity normal --collect:"XPlat Code Coverage" -- RunConfiguration.MaxCpuCount=1
           dotnet test dcb/tests/Sekiban.Dcb.Postgres.Tests/Sekiban.Dcb.Postgres.Tests.csproj -c Release --no-build -f net10.0 --verbosity normal --collect:"XPlat Code Coverage" -- RunConfiguration.MaxCpuCount=1
+          dotnet test dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests.csproj -c Release --no-build -f net10.0 --verbosity normal --collect:"XPlat Code Coverage" -- RunConfiguration.MaxCpuCount=1
           dotnet test dcb/tests/Sekiban.Dcb.BlobStorage.AzureStorage.Unit/Sekiban.Dcb.BlobStorage.AzureStorage.Unit.csproj -c Release --no-build -f net10.0 --verbosity normal --collect:"XPlat Code Coverage" -- RunConfiguration.MaxCpuCount=1

--- a/Sekiban.slnx
+++ b/Sekiban.slnx
@@ -50,6 +50,9 @@
     <Project Path="dcb/src/Sekiban.Dcb.Core/Sekiban.Dcb.Core.csproj" />
     <Project Path="dcb/src/Sekiban.Dcb.MaterializedView/Sekiban.Dcb.MaterializedView.csproj" />
     <Project Path="dcb/src/Sekiban.Dcb.MaterializedView.Postgres/Sekiban.Dcb.MaterializedView.Postgres.csproj" />
+    <Project Path="dcb/src/Sekiban.Dcb.MaterializedView.SqlServer/Sekiban.Dcb.MaterializedView.SqlServer.csproj" />
+    <Project Path="dcb/src/Sekiban.Dcb.MaterializedView.MySql/Sekiban.Dcb.MaterializedView.MySql.csproj" />
+    <Project Path="dcb/src/Sekiban.Dcb.MaterializedView.Sqlite/Sekiban.Dcb.MaterializedView.Sqlite.csproj" />
     <Project Path="dcb/src/Sekiban.Dcb.WithResult.Model/Sekiban.Dcb.WithResult.Model.csproj" />
     <Project Path="dcb/src/Sekiban.Dcb.WithResult/Sekiban.Dcb.WithResult.csproj" />
     <Project Path="dcb/src/Sekiban.Dcb.WithoutResult.Model/Sekiban.Dcb.WithoutResult.Model.csproj" />
@@ -88,6 +91,7 @@
     <Project Path="dcb/tests/Sekiban.Dcb.BlobStorage.AzureStorage.Unit/Sekiban.Dcb.BlobStorage.AzureStorage.Unit.csproj" />
     <Project Path="dcb/tests/Sekiban.Dcb.MaterializedView.Tests/Sekiban.Dcb.MaterializedView.Tests.csproj" />
     <Project Path="dcb/tests/Sekiban.Dcb.MaterializedView.Postgres.Tests/Sekiban.Dcb.MaterializedView.Postgres.Tests.csproj" />
+    <Project Path="dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests.csproj" />
     <Project Path="dcb/tests/Sekiban.Dcb.Orleans.Tests/Sekiban.Dcb.Orleans.Tests.csproj" />
     <Project Path="dcb/tests/Sekiban.Dcb.Postgres.Tests/Sekiban.Dcb.Postgres.Tests.csproj" />
     <Project Path="dcb/tests/Sekiban.Dcb.WithResult.Tests/Sekiban.Dcb.WithResult.Tests.csproj" />

--- a/dcb/Sekiban.Dcb.slnx
+++ b/dcb/Sekiban.Dcb.slnx
@@ -52,6 +52,7 @@
   </Folder>
   <Folder Name="/tests/">
     <Project Path="tests/Sekiban.Dcb.BlobStorage.AzureStorage.Unit/Sekiban.Dcb.BlobStorage.AzureStorage.Unit.csproj" />
+    <Project Path="tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests.csproj" />
     <Project Path="tests/Sekiban.Dcb.Orleans.Tests/Sekiban.Dcb.Orleans.Tests.csproj" />
     <Project Path="tests/Sekiban.Dcb.Postgres.Tests/Sekiban.Dcb.Postgres.Tests.csproj" />
     <Project Path="tests/Sekiban.Dcb.WithResult.Tests/Sekiban.Dcb.WithResult.Tests.csproj" />

--- a/dcb/Sekiban.Dcb.slnx
+++ b/dcb/Sekiban.Dcb.slnx
@@ -13,6 +13,9 @@
     <Project Path="src/Sekiban.Dcb.WithoutResult/Sekiban.Dcb.WithoutResult.csproj" />
     <Project Path="src/Sekiban.Dcb.MaterializedView.Orleans/Sekiban.Dcb.MaterializedView.Orleans.csproj" />
     <Project Path="src/Sekiban.Dcb.MaterializedView.Postgres/Sekiban.Dcb.MaterializedView.Postgres.csproj" />
+    <Project Path="src/Sekiban.Dcb.MaterializedView.SqlServer/Sekiban.Dcb.MaterializedView.SqlServer.csproj" />
+    <Project Path="src/Sekiban.Dcb.MaterializedView.MySql/Sekiban.Dcb.MaterializedView.MySql.csproj" />
+    <Project Path="src/Sekiban.Dcb.MaterializedView.Sqlite/Sekiban.Dcb.MaterializedView.Sqlite.csproj" />
     <Project Path="src/Sekiban.Dcb.MaterializedView/Sekiban.Dcb.MaterializedView.csproj" />
     <Project Path="src/Sekiban.Dcb.Orleans.Core/Sekiban.Dcb.Orleans.Core.csproj" />
     <Project Path="src/Sekiban.Dcb.Orleans.WithResult/Sekiban.Dcb.Orleans.WithResult.csproj" />

--- a/dcb/src/Sekiban.Dcb.MaterializedView.MySql/MySqlMvContexts.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.MySql/MySqlMvContexts.cs
@@ -1,0 +1,104 @@
+using System.Data;
+using System.Text.Json;
+using Dapper;
+
+namespace Sekiban.Dcb.MaterializedView.MySql;
+
+internal static class MySqlMvValueAdapter
+{
+    public static IReadOnlyDictionary<string, object?> ToDictionary(object row)
+    {
+        if (row is IReadOnlyDictionary<string, object?> readOnlyDictionary)
+        {
+            return readOnlyDictionary;
+        }
+
+        if (row is IDictionary<string, object?> dictionary)
+        {
+            return dictionary.ToDictionary(pair => pair.Key, pair => pair.Value, StringComparer.OrdinalIgnoreCase);
+        }
+
+        if (row is IDictionary<string, object> nonNullableDictionary)
+        {
+            return nonNullableDictionary
+                .Select(pair => new KeyValuePair<string, object?>(pair.Key, pair.Value))
+                .ToDictionary(pair => pair.Key, pair => pair.Value, StringComparer.OrdinalIgnoreCase);
+        }
+
+        return row.GetType()
+            .GetProperties()
+            .ToDictionary(property => property.Name, property => property.GetValue(row), StringComparer.OrdinalIgnoreCase);
+    }
+}
+
+internal sealed class MySqlMvApplyQueryPort : IMvApplyDbConnectionPort
+{
+    private readonly IDbConnection _connection;
+    private readonly IDbTransaction _transaction;
+
+    public MySqlMvApplyQueryPort(IDbConnection connection, IDbTransaction transaction)
+    {
+        _connection = connection;
+        _transaction = transaction;
+    }
+
+    public IDbConnection Connection => _connection;
+    public IDbTransaction Transaction => _transaction;
+
+    public async Task<IReadOnlyList<JsonElement>> QueryRowsAsync(
+        string sql,
+        IReadOnlyList<MvParam> parameters,
+        CancellationToken ct)
+    {
+        var rows = await _connection.QueryAsync(
+            new CommandDefinition(
+                sql,
+                ToDynamicParameters(parameters),
+                _transaction,
+                cancellationToken: ct)).ConfigureAwait(false);
+        return rows
+            .Select(row => (JsonElement)JsonSerializer.SerializeToElement(MySqlMvValueAdapter.ToDictionary(row)))
+            .ToList();
+    }
+
+    public async Task<JsonElement?> QuerySingleOrDefaultAsync(
+        string sql,
+        IReadOnlyList<MvParam> parameters,
+        CancellationToken ct)
+    {
+        var row = await _connection.QuerySingleOrDefaultAsync(
+            new CommandDefinition(
+                sql,
+                ToDynamicParameters(parameters),
+                _transaction,
+                cancellationToken: ct)).ConfigureAwait(false);
+        return row is null
+            ? null
+            : JsonSerializer.SerializeToElement(MySqlMvValueAdapter.ToDictionary(row));
+    }
+
+    public async Task<string?> ExecuteScalarJsonAsync(
+        string sql,
+        IReadOnlyList<MvParam> parameters,
+        CancellationToken ct)
+    {
+        var scalar = await _connection.ExecuteScalarAsync(
+            new CommandDefinition(
+                sql,
+                ToDynamicParameters(parameters),
+                _transaction,
+                cancellationToken: ct)).ConfigureAwait(false);
+        return MvParamConverter.SerializeScalar(scalar);
+    }
+
+    private static DynamicParameters ToDynamicParameters(IReadOnlyList<MvParam> parameters)
+    {
+        var dynamicParameters = new DynamicParameters();
+        foreach (var parameter in parameters)
+        {
+            dynamicParameters.Add(parameter.Name, MvParamConverter.ToClrValue(parameter));
+        }
+
+        return dynamicParameters;
+    }
+}

--- a/dcb/src/Sekiban.Dcb.MaterializedView.MySql/MySqlMvExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.MySql/MySqlMvExecutor.cs
@@ -1,0 +1,332 @@
+using Dapper;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using MySqlConnector;
+using Sekiban.Dcb.Common;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.ServiceId;
+using Sekiban.Dcb.Storage;
+
+namespace Sekiban.Dcb.MaterializedView.MySql;
+
+public sealed class MySqlMvExecutor : IMvExecutor
+{
+    private readonly IEventStore _eventStore;
+    private readonly ILogger<MySqlMvExecutor> _logger;
+    private readonly MvOptions _options;
+    private readonly IMvRegistryStore _registryStore;
+    private readonly string _connectionString;
+    private readonly IServiceIdProvider _serviceIdProvider;
+
+    public MySqlMvExecutor(
+        IEventStore eventStore,
+        IServiceIdProvider serviceIdProvider,
+        IMvRegistryStore registryStore,
+        IOptions<MvOptions> options,
+        ILogger<MySqlMvExecutor> logger,
+        string connectionString)
+    {
+        _eventStore = eventStore;
+        _serviceIdProvider = serviceIdProvider;
+        _registryStore = registryStore;
+        _logger = logger;
+        _connectionString = connectionString;
+        _options = options.Value;
+    }
+
+    public async Task InitializeAsync(
+        IMvApplyHost host,
+        string? serviceId = null,
+        CancellationToken cancellationToken = default)
+    {
+        await _registryStore.EnsureInfrastructureAsync(cancellationToken).ConfigureAwait(false);
+        serviceId = ResolveServiceId(serviceId);
+
+        await using var connection = new MySqlConnection(_connectionString);
+        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+        await using var transaction = await connection.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
+
+        var bindings = new MvTableBindings(host.ViewName, host.ViewVersion, _options);
+        var statements = await host.InitializeAsync(bindings, cancellationToken).ConfigureAwait(false);
+        foreach (var statement in statements)
+        {
+            await connection.ExecuteAsync(
+                new CommandDefinition(
+                    statement.Sql,
+                    ToDynamicParameters(statement.Parameters),
+                    transaction,
+                    cancellationToken: cancellationToken)).ConfigureAwait(false);
+        }
+
+        foreach (var table in bindings.Tables)
+        {
+            await _registryStore.RegisterAsync(
+                new MvRegistryEntry
+                {
+                    ServiceId = serviceId,
+                    ViewName = host.ViewName,
+                    ViewVersion = host.ViewVersion,
+                    LogicalTable = table.LogicalName,
+                    PhysicalTable = table.PhysicalName,
+                    Status = MvStatus.CatchingUp,
+                    AppliedEventVersion = 0,
+                    LastUpdated = DateTimeOffset.UtcNow
+                },
+                transaction,
+                cancellationToken).ConfigureAwait(false);
+        }
+
+        var active = await _registryStore.GetActiveAsync(serviceId, host.ViewName, cancellationToken).ConfigureAwait(false);
+        if (active is null)
+        {
+            await _registryStore.SetActiveAsync(serviceId, host.ViewName, host.ViewVersion, transaction, cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<MvCatchUpResult> CatchUpOnceAsync(
+        IMvApplyHost host,
+        string? serviceId = null,
+        CancellationToken cancellationToken = default)
+    {
+        serviceId = ResolveServiceId(serviceId);
+        var entries = await _registryStore.GetEntriesAsync(serviceId, host.ViewName, host.ViewVersion, cancellationToken)
+            .ConfigureAwait(false);
+        if (entries.Count == 0)
+        {
+            await InitializeAsync(host, serviceId, cancellationToken).ConfigureAwait(false);
+            entries = await _registryStore.GetEntriesAsync(serviceId, host.ViewName, host.ViewVersion, cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        var currentPosition = entries
+            .Select(entry => entry.CurrentPosition)
+            .FirstOrDefault(position => !string.IsNullOrWhiteSpace(position));
+        var readResult = await _eventStore.ReadAllSerializableEventsAsync(
+            SortableUniqueId.NullableValue(currentPosition),
+            _options.BatchSize).ConfigureAwait(false);
+
+        if (!readResult.IsSuccess)
+        {
+            var exception = readResult.GetException();
+            if (exception is NotSupportedException)
+            {
+                throw exception;
+            }
+
+            _logger.LogWarning(
+                exception,
+                "Failed to read events for materialized view {ViewName}/{ViewVersion}.",
+                host.ViewName,
+                host.ViewVersion);
+            return new MvCatchUpResult(0, false);
+        }
+
+        var safeThreshold = CreateSafeThreshold(_options.SafeWindowMs);
+        var reachedUnsafeWindow = false;
+        var batch = readResult.GetValue().OrderBy(serializable => serializable.SortableUniqueIdValue).ToList();
+
+        if (batch.Count == 0)
+        {
+            return new MvCatchUpResult(0, false);
+        }
+
+        var safeBatch = new List<SerializableEvent>(batch.Count);
+        foreach (var serializableEvent in batch)
+        {
+            if (!new SortableUniqueId(serializableEvent.SortableUniqueIdValue).IsEarlierThanOrEqual(safeThreshold))
+            {
+                reachedUnsafeWindow = true;
+                break;
+            }
+
+            safeBatch.Add(serializableEvent);
+        }
+
+        if (safeBatch.Count == 0)
+        {
+            return new MvCatchUpResult(0, reachedUnsafeWindow);
+        }
+
+        var appliedEvents = await ApplySerializableEventsCoreAsync(
+                host,
+                safeBatch,
+                serviceId,
+                MvApplySource.CatchUp,
+                cancellationToken)
+            .ConfigureAwait(false);
+
+        var lastAppliedSortableUniqueId = appliedEvents > 0
+            ? safeBatch[appliedEvents - 1].SortableUniqueIdValue
+            : null;
+
+        reachedUnsafeWindow |= appliedEvents < safeBatch.Count;
+
+        return new MvCatchUpResult(appliedEvents, reachedUnsafeWindow, lastAppliedSortableUniqueId);
+    }
+
+    public async Task<int> ApplySerializableEventsAsync(
+        IMvApplyHost host,
+        IReadOnlyList<SerializableEvent> events,
+        string? serviceId = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (events.Count == 0)
+        {
+            return 0;
+        }
+
+        serviceId = ResolveServiceId(serviceId);
+        return await ApplySerializableEventsCoreAsync(host, events, serviceId, MvApplySource.Stream, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<int> ApplySerializableEventsCoreAsync(
+        IMvApplyHost host,
+        IReadOnlyList<SerializableEvent> events,
+        string serviceId,
+        MvApplySource source,
+        CancellationToken cancellationToken)
+    {
+        var entries = await _registryStore.GetEntriesAsync(serviceId, host.ViewName, host.ViewVersion, cancellationToken)
+            .ConfigureAwait(false);
+        if (entries.Count == 0)
+        {
+            await InitializeAsync(host, serviceId, cancellationToken).ConfigureAwait(false);
+            entries = await _registryStore.GetEntriesAsync(serviceId, host.ViewName, host.ViewVersion, cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        var currentPosition = entries
+            .Select(entry => entry.CurrentPosition)
+            .FirstOrDefault(position => !string.IsNullOrWhiteSpace(position));
+        var orderedEvents = events
+            .GroupBy(serializableEvent => serializableEvent.SortableUniqueIdValue)
+            .Select(group => group.First())
+            .Where(serializableEvent =>
+                source == MvApplySource.Stream ||
+                string.IsNullOrWhiteSpace(currentPosition) ||
+                string.Compare(serializableEvent.SortableUniqueIdValue, currentPosition, StringComparison.Ordinal) > 0)
+            .OrderBy(serializableEvent => serializableEvent.SortableUniqueIdValue, StringComparer.Ordinal)
+            .ToList();
+
+        if (orderedEvents.Count == 0)
+        {
+            return 0;
+        }
+
+        await using var connection = new MySqlConnection(_connectionString);
+        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+        var appliedEvents = 0;
+        var bindings = CreateBindings(host, entries);
+
+        foreach (var serializableEvent in orderedEvents)
+        {
+            var applied = await ApplySerializableEventAsync(
+                    connection,
+                    host,
+                    serviceId,
+                    bindings,
+                    serializableEvent,
+                    currentPosition,
+                    source,
+                    cancellationToken)
+                .ConfigureAwait(false);
+            if (!applied)
+            {
+                break;
+            }
+
+            appliedEvents += 1;
+        }
+
+        return appliedEvents;
+    }
+
+    private async Task<bool> ApplySerializableEventAsync(
+        MySqlConnection connection,
+        IMvApplyHost host,
+        string serviceId,
+        MvTableBindings bindings,
+        SerializableEvent serializableEvent,
+        string? currentPosition,
+        MvApplySource source,
+        CancellationToken cancellationToken)
+    {
+        await using var transaction = await connection.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
+        var queryPort = new MySqlMvApplyQueryPort(connection, transaction);
+        var statements = await host.ApplyEventAsync(
+            serializableEvent,
+            bindings,
+            queryPort,
+            serializableEvent.SortableUniqueIdValue,
+            cancellationToken).ConfigureAwait(false);
+        var affectedRows = 0;
+        foreach (var statement in statements)
+        {
+            affectedRows += await connection.ExecuteAsync(
+                new CommandDefinition(
+                    statement.Sql,
+                    ToDynamicParameters(statement.Parameters),
+                    transaction,
+                    cancellationToken: cancellationToken)).ConfigureAwait(false);
+        }
+
+        if (source == MvApplySource.Stream && statements.Count > 0 && affectedRows == 0)
+        {
+            if (!string.IsNullOrWhiteSpace(currentPosition) &&
+                string.Compare(serializableEvent.SortableUniqueIdValue, currentPosition, StringComparison.Ordinal) <= 0)
+            {
+                await transaction.RollbackAsync(cancellationToken).ConfigureAwait(false);
+                return true;
+            }
+
+            await transaction.RollbackAsync(cancellationToken).ConfigureAwait(false);
+            return false;
+        }
+
+        await _registryStore.UpdatePositionAsync(
+            new MvPositionUpdate(
+                serviceId,
+                host.ViewName,
+                host.ViewVersion,
+                serializableEvent.SortableUniqueIdValue,
+                source),
+            transaction: transaction,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+        return true;
+    }
+
+    private string ResolveServiceId(string? serviceId) =>
+        string.IsNullOrWhiteSpace(serviceId)
+            ? _serviceIdProvider.GetCurrentServiceId()
+            : serviceId;
+
+    private MvTableBindings CreateBindings(IMvApplyHost host, IReadOnlyList<MvRegistryEntry> entries)
+    {
+        var bindings = new MvTableBindings(host.ViewName, host.ViewVersion, _options);
+        foreach (var entry in entries)
+        {
+            bindings.RegisterTable(entry.LogicalTable, entry.PhysicalTable);
+        }
+
+        return bindings;
+    }
+
+    private static DynamicParameters ToDynamicParameters(IReadOnlyList<MvParam> parameters)
+    {
+        var dynamicParameters = new DynamicParameters();
+        foreach (var parameter in parameters)
+        {
+            dynamicParameters.Add(parameter.Name, MvParamConverter.ToClrValue(parameter));
+        }
+
+        return dynamicParameters;
+    }
+
+    private static SortableUniqueId CreateSafeThreshold(int safeWindowMs) =>
+        new(SortableUniqueId.Generate(DateTime.UtcNow.AddMilliseconds(-safeWindowMs), Guid.Empty));
+}

--- a/dcb/src/Sekiban.Dcb.MaterializedView.MySql/MySqlMvRegistryStore.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.MySql/MySqlMvRegistryStore.cs
@@ -1,0 +1,483 @@
+using System.Data;
+using Dapper;
+using MySqlConnector;
+
+namespace Sekiban.Dcb.MaterializedView.MySql;
+
+public sealed class MySqlMvRegistryStore : IMvRegistryStore
+{
+    private readonly string _connectionString;
+
+    public MySqlMvRegistryStore(string connectionString)
+    {
+        _connectionString = connectionString;
+    }
+
+    public async Task EnsureInfrastructureAsync(CancellationToken cancellationToken = default)
+    {
+        await using var connection = new MySqlConnection(_connectionString);
+        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+        const string registrySql = """
+            CREATE TABLE IF NOT EXISTS sekiban_mv_registry (
+                service_id VARCHAR(200) NOT NULL,
+                view_name VARCHAR(200) NOT NULL,
+                view_version INT NOT NULL,
+                logical_table VARCHAR(200) NOT NULL,
+                physical_table VARCHAR(256) NOT NULL,
+                status VARCHAR(32) NOT NULL,
+                current_position VARCHAR(64) NULL,
+                target_position VARCHAR(64) NULL,
+                last_sortable_unique_id VARCHAR(64) NULL,
+                applied_event_version BIGINT NOT NULL DEFAULT 0,
+                last_applied_source VARCHAR(32) NULL,
+                last_applied_at DATETIME(6) NULL,
+                last_stream_received_sortable_unique_id VARCHAR(64) NULL,
+                last_stream_received_at DATETIME(6) NULL,
+                last_stream_applied_sortable_unique_id VARCHAR(64) NULL,
+                last_catch_up_sortable_unique_id VARCHAR(64) NULL,
+                last_updated DATETIME(6) NOT NULL,
+                metadata LONGTEXT NULL,
+                PRIMARY KEY (service_id, view_name, view_version, logical_table)
+            );
+            """;
+
+        const string activeSql = """
+            CREATE TABLE IF NOT EXISTS sekiban_mv_active (
+                service_id VARCHAR(200) NOT NULL,
+                view_name VARCHAR(200) NOT NULL,
+                active_version INT NOT NULL,
+                activated_at DATETIME(6) NOT NULL,
+                PRIMARY KEY (service_id, view_name)
+            );
+            """;
+
+        await connection.ExecuteAsync(new CommandDefinition(registrySql, cancellationToken: cancellationToken)).ConfigureAwait(false);
+        await connection.ExecuteAsync(new CommandDefinition(activeSql, cancellationToken: cancellationToken)).ConfigureAwait(false);
+    }
+
+    public async Task RegisterAsync(MvRegistryEntry entry, IDbTransaction? transaction = null, CancellationToken cancellationToken = default)
+    {
+        const string sql = """
+            INSERT INTO sekiban_mv_registry (
+                service_id,
+                view_name,
+                view_version,
+                logical_table,
+                physical_table,
+                status,
+                current_position,
+                target_position,
+                last_sortable_unique_id,
+                applied_event_version,
+                last_applied_source,
+                last_applied_at,
+                last_stream_received_sortable_unique_id,
+                last_stream_received_at,
+                last_stream_applied_sortable_unique_id,
+                last_catch_up_sortable_unique_id,
+                last_updated,
+                metadata
+            )
+            VALUES (
+                @ServiceId,
+                @ViewName,
+                @ViewVersion,
+                @LogicalTable,
+                @PhysicalTable,
+                @Status,
+                @CurrentPosition,
+                @TargetPosition,
+                @LastSortableUniqueId,
+                @AppliedEventVersion,
+                @LastAppliedSource,
+                @LastAppliedAt,
+                @LastStreamReceivedSortableUniqueId,
+                @LastStreamReceivedAt,
+                @LastStreamAppliedSortableUniqueId,
+                @LastCatchUpSortableUniqueId,
+                @LastUpdated,
+                @Metadata
+            )
+            ON DUPLICATE KEY UPDATE
+                physical_table = VALUES(physical_table),
+                last_updated = VALUES(last_updated),
+                applied_event_version = applied_event_version,
+                last_applied_source = COALESCE(last_applied_source, VALUES(last_applied_source)),
+                last_applied_at = COALESCE(last_applied_at, VALUES(last_applied_at)),
+                last_stream_received_sortable_unique_id = COALESCE(last_stream_received_sortable_unique_id, VALUES(last_stream_received_sortable_unique_id)),
+                last_stream_received_at = COALESCE(last_stream_received_at, VALUES(last_stream_received_at)),
+                last_stream_applied_sortable_unique_id = COALESCE(last_stream_applied_sortable_unique_id, VALUES(last_stream_applied_sortable_unique_id)),
+                last_catch_up_sortable_unique_id = COALESCE(last_catch_up_sortable_unique_id, VALUES(last_catch_up_sortable_unique_id)),
+                metadata = COALESCE(VALUES(metadata), metadata);
+            """;
+
+        var parameters = new
+        {
+            entry.ServiceId,
+            entry.ViewName,
+            entry.ViewVersion,
+            entry.LogicalTable,
+            entry.PhysicalTable,
+            Status = entry.Status.ToString().ToLowerInvariant(),
+            entry.CurrentPosition,
+            entry.TargetPosition,
+            entry.LastSortableUniqueId,
+            entry.AppliedEventVersion,
+            entry.LastAppliedSource,
+            entry.LastAppliedAt,
+            entry.LastStreamReceivedSortableUniqueId,
+            entry.LastStreamReceivedAt,
+            entry.LastStreamAppliedSortableUniqueId,
+            entry.LastCatchUpSortableUniqueId,
+            entry.LastUpdated,
+            entry.Metadata
+        };
+
+        await ExecuteAsync(sql, parameters, transaction, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task UpdatePositionAsync(
+        MvPositionUpdate update,
+        IDbTransaction? transaction = null,
+        CancellationToken cancellationToken = default)
+    {
+        const string sql = """
+            UPDATE sekiban_mv_registry
+            SET current_position = CASE
+                    WHEN current_position IS NULL
+                      OR current_position < @SortableUniqueId THEN @SortableUniqueId
+                    ELSE current_position
+                END,
+                last_sortable_unique_id = CASE
+                    WHEN last_sortable_unique_id IS NULL
+                      OR last_sortable_unique_id < @SortableUniqueId THEN @SortableUniqueId
+                    ELSE last_sortable_unique_id
+                END,
+                applied_event_version = applied_event_version + @AppliedEventVersionDelta,
+                last_applied_source = @Source,
+                last_applied_at = UTC_TIMESTAMP(6),
+                last_stream_applied_sortable_unique_id = CASE
+                    WHEN @Source = 'stream'
+                      AND (last_stream_applied_sortable_unique_id IS NULL
+                        OR last_stream_applied_sortable_unique_id < @SortableUniqueId) THEN @SortableUniqueId
+                    ELSE last_stream_applied_sortable_unique_id
+                END,
+                last_catch_up_sortable_unique_id = CASE
+                    WHEN @Source = 'catchup'
+                      AND (last_catch_up_sortable_unique_id IS NULL
+                        OR last_catch_up_sortable_unique_id < @SortableUniqueId) THEN @SortableUniqueId
+                    ELSE last_catch_up_sortable_unique_id
+                END,
+                last_updated = UTC_TIMESTAMP(6)
+            WHERE service_id = @ServiceId
+              AND view_name = @ViewName
+              AND view_version = @ViewVersion;
+            """;
+
+        await ExecuteAsync(
+            sql,
+            new
+            {
+                update.ServiceId,
+                update.ViewName,
+                update.ViewVersion,
+                update.SortableUniqueId,
+                update.AppliedEventVersionDelta,
+                Source = update.Source == MvApplySource.Stream ? "stream" : "catchup"
+            },
+            transaction,
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task MarkStreamReceivedAsync(
+        string serviceId,
+        string viewName,
+        int viewVersion,
+        string sortableUniqueId,
+        DateTimeOffset receivedAt,
+        IDbTransaction? transaction = null,
+        CancellationToken cancellationToken = default)
+    {
+        const string sql = """
+            UPDATE sekiban_mv_registry
+            SET last_stream_received_sortable_unique_id = CASE
+                    WHEN last_stream_received_sortable_unique_id IS NULL
+                      OR last_stream_received_sortable_unique_id < @SortableUniqueId THEN @SortableUniqueId
+                    ELSE last_stream_received_sortable_unique_id
+                END,
+                last_stream_received_at = @ReceivedAt,
+                last_updated = UTC_TIMESTAMP(6)
+            WHERE service_id = @ServiceId
+              AND view_name = @ViewName
+              AND view_version = @ViewVersion;
+            """;
+
+        await ExecuteAsync(
+            sql,
+            new
+            {
+                ServiceId = serviceId,
+                ViewName = viewName,
+                ViewVersion = viewVersion,
+                SortableUniqueId = sortableUniqueId,
+                ReceivedAt = receivedAt.UtcDateTime
+            },
+            transaction,
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task UpdateStatusAsync(
+        string serviceId,
+        string viewName,
+        int viewVersion,
+        MvStatus status,
+        IDbTransaction? transaction = null,
+        CancellationToken cancellationToken = default)
+    {
+        const string sql = """
+            UPDATE sekiban_mv_registry
+            SET status = @Status,
+                last_updated = UTC_TIMESTAMP(6)
+            WHERE service_id = @ServiceId
+              AND view_name = @ViewName
+              AND view_version = @ViewVersion;
+            """;
+
+        await ExecuteAsync(
+            sql,
+            new { ServiceId = serviceId, ViewName = viewName, ViewVersion = viewVersion, Status = status.ToString().ToLowerInvariant() },
+            transaction,
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<IReadOnlyList<MvRegistryEntry>> GetEntriesAsync(
+        string serviceId,
+        string viewName,
+        int viewVersion,
+        CancellationToken cancellationToken = default)
+    {
+        const string sql = """
+            SELECT service_id AS ServiceId,
+                   view_name AS ViewName,
+                   view_version AS ViewVersion,
+                   logical_table AS LogicalTable,
+                   physical_table AS PhysicalTable,
+                   status AS Status,
+                   current_position AS CurrentPosition,
+                   target_position AS TargetPosition,
+                   last_sortable_unique_id AS LastSortableUniqueId,
+                   applied_event_version AS AppliedEventVersion,
+                   last_applied_source AS LastAppliedSource,
+                   last_applied_at AS LastAppliedAt,
+                   last_stream_received_sortable_unique_id AS LastStreamReceivedSortableUniqueId,
+                   last_stream_received_at AS LastStreamReceivedAt,
+                   last_stream_applied_sortable_unique_id AS LastStreamAppliedSortableUniqueId,
+                   last_catch_up_sortable_unique_id AS LastCatchUpSortableUniqueId,
+                   last_updated AS LastUpdated,
+                   metadata AS Metadata
+            FROM sekiban_mv_registry
+            WHERE service_id = @ServiceId
+              AND view_name = @ViewName
+              AND view_version = @ViewVersion
+            ORDER BY logical_table;
+            """;
+
+        await using var connection = new MySqlConnection(_connectionString);
+        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+        var rows = await connection.QueryAsync(
+            new CommandDefinition(sql, new { ServiceId = serviceId, ViewName = viewName, ViewVersion = viewVersion }, cancellationToken: cancellationToken))
+            .ConfigureAwait(false);
+        return rows.Select(row => (MvRegistryEntry)MapEntry(ToDictionary(row))).ToList();
+    }
+
+    public async Task<MvActiveEntry?> GetActiveAsync(
+        string serviceId,
+        string viewName,
+        CancellationToken cancellationToken = default)
+    {
+        const string sql = """
+            SELECT service_id AS ServiceId,
+                   view_name AS ViewName,
+                   active_version AS ActiveVersion,
+                   activated_at AS ActivatedAt
+            FROM sekiban_mv_active
+            WHERE service_id = @ServiceId
+              AND view_name = @ViewName;
+            """;
+
+        await using var connection = new MySqlConnection(_connectionString);
+        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+        var row = await connection.QuerySingleOrDefaultAsync(
+            new CommandDefinition(sql, new { ServiceId = serviceId, ViewName = viewName }, cancellationToken: cancellationToken))
+            .ConfigureAwait(false);
+        return row is null ? null : MapActiveEntry(ToDictionary(row));
+    }
+
+    public async Task SetActiveAsync(
+        string serviceId,
+        string viewName,
+        int activeVersion,
+        IDbTransaction? transaction = null,
+        CancellationToken cancellationToken = default)
+    {
+        const string sql = """
+            INSERT INTO sekiban_mv_active (service_id, view_name, active_version, activated_at)
+            VALUES (@ServiceId, @ViewName, @ActiveVersion, UTC_TIMESTAMP(6))
+            ON DUPLICATE KEY UPDATE
+                active_version = VALUES(active_version),
+                activated_at = VALUES(activated_at);
+            """;
+
+        await ExecuteAsync(
+            sql,
+            new { ServiceId = serviceId, ViewName = viewName, ActiveVersion = activeVersion },
+            transaction,
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task ExecuteAsync(
+        string sql,
+        object parameters,
+        IDbTransaction? transaction,
+        CancellationToken cancellationToken)
+    {
+        if (transaction is null)
+        {
+            await using var connection = new MySqlConnection(_connectionString);
+            await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+            await connection.ExecuteAsync(new CommandDefinition(sql, parameters, cancellationToken: cancellationToken)).ConfigureAwait(false);
+            return;
+        }
+
+        await transaction.Connection!.ExecuteAsync(
+            new CommandDefinition(sql, parameters, transaction, cancellationToken: cancellationToken)).ConfigureAwait(false);
+    }
+
+    private static MvRegistryEntry MapEntry(IReadOnlyDictionary<string, object?> row) =>
+        new()
+        {
+            ServiceId = ReadRequiredString(row, "ServiceId"),
+            ViewName = ReadRequiredString(row, "ViewName"),
+            ViewVersion = ReadRequiredInt(row, "ViewVersion"),
+            LogicalTable = ReadRequiredString(row, "LogicalTable"),
+            PhysicalTable = ReadRequiredString(row, "PhysicalTable"),
+            Status = Enum.Parse<MvStatus>(ReadRequiredString(row, "Status"), ignoreCase: true),
+            CurrentPosition = ReadNullableString(row, "CurrentPosition"),
+            TargetPosition = ReadNullableString(row, "TargetPosition"),
+            LastSortableUniqueId = ReadNullableString(row, "LastSortableUniqueId"),
+            AppliedEventVersion = ReadRequiredLong(row, "AppliedEventVersion"),
+            LastAppliedSource = ReadNullableString(row, "LastAppliedSource"),
+            LastAppliedAt = ReadNullableDateTimeOffset(row, "LastAppliedAt"),
+            LastStreamReceivedSortableUniqueId = ReadNullableString(row, "LastStreamReceivedSortableUniqueId"),
+            LastStreamReceivedAt = ReadNullableDateTimeOffset(row, "LastStreamReceivedAt"),
+            LastStreamAppliedSortableUniqueId = ReadNullableString(row, "LastStreamAppliedSortableUniqueId"),
+            LastCatchUpSortableUniqueId = ReadNullableString(row, "LastCatchUpSortableUniqueId"),
+            LastUpdated = ReadRequiredDateTimeOffset(row, "LastUpdated"),
+            Metadata = ReadNullableString(row, "Metadata")
+        };
+
+    private static MvActiveEntry MapActiveEntry(IReadOnlyDictionary<string, object?> row) =>
+        new(
+            ReadRequiredString(row, "ServiceId"),
+            ReadRequiredString(row, "ViewName"),
+            ReadRequiredInt(row, "ActiveVersion"),
+            ReadRequiredDateTimeOffset(row, "ActivatedAt"));
+
+    private static IReadOnlyDictionary<string, object?> ToDictionary(object row)
+    {
+        if (row is IReadOnlyDictionary<string, object?> readOnlyDictionary)
+        {
+            return readOnlyDictionary;
+        }
+
+        if (row is IDictionary<string, object?> dictionary)
+        {
+            return new Dictionary<string, object?>(dictionary, StringComparer.OrdinalIgnoreCase);
+        }
+
+        if (row is IDictionary<string, object> nonNullableDictionary)
+        {
+            return nonNullableDictionary
+                .Select(pair => new KeyValuePair<string, object?>(pair.Key, pair.Value))
+                .ToDictionary(pair => pair.Key, pair => pair.Value, StringComparer.OrdinalIgnoreCase);
+        }
+
+        if (row is System.Collections.IDictionary legacyDictionary)
+        {
+            return legacyDictionary.Cast<System.Collections.DictionaryEntry>()
+                .ToDictionary(
+                    entry => entry.Key.ToString() ?? string.Empty,
+                    entry => entry.Value,
+                    StringComparer.OrdinalIgnoreCase);
+        }
+
+        return row.GetType()
+            .GetProperties()
+            .ToDictionary(property => property.Name, property => property.GetValue(row), StringComparer.OrdinalIgnoreCase);
+    }
+
+    private static string ReadRequiredString(IReadOnlyDictionary<string, object?> row, string key) =>
+        TryGetValue(row, key, out var value) && value is not null
+            ? value.ToString()!
+            : throw new InvalidOperationException($"Registry row is missing required value '{key}'.");
+
+    private static string? ReadNullableString(IReadOnlyDictionary<string, object?> row, string key) =>
+        TryGetValue(row, key, out var value) && value is not null
+            ? value.ToString()
+            : null;
+
+    private static int ReadRequiredInt(IReadOnlyDictionary<string, object?> row, string key) =>
+        Convert.ToInt32(TryGetValue(row, key, out var value)
+            ? value
+            : throw new InvalidOperationException($"Registry row is missing required value '{key}'."));
+
+    private static long ReadRequiredLong(IReadOnlyDictionary<string, object?> row, string key) =>
+        Convert.ToInt64(TryGetValue(row, key, out var value)
+            ? value
+            : throw new InvalidOperationException($"Registry row is missing required value '{key}'."));
+
+    private static DateTimeOffset ReadRequiredDateTimeOffset(IReadOnlyDictionary<string, object?> row, string key) =>
+        ReadDateTimeOffsetCore(
+            TryGetValue(row, key, out var value)
+                ? value
+                : throw new InvalidOperationException($"Registry row is missing required value '{key}'."),
+            key) ??
+        throw new InvalidOperationException($"Registry row is missing required timestamp '{key}'.");
+
+    private static DateTimeOffset? ReadNullableDateTimeOffset(IReadOnlyDictionary<string, object?> row, string key) =>
+        TryGetValue(row, key, out var value) ? ReadDateTimeOffsetCore(value, key) : null;
+
+    private static bool TryGetValue(IReadOnlyDictionary<string, object?> row, string key, out object? value)
+    {
+        if (row.TryGetValue(key, out value))
+        {
+            return true;
+        }
+
+        foreach (var pair in row)
+        {
+            if (string.Equals(pair.Key, key, StringComparison.OrdinalIgnoreCase))
+            {
+                value = pair.Value;
+                return true;
+            }
+        }
+
+        value = null;
+        return false;
+    }
+
+    private static DateTimeOffset? ReadDateTimeOffsetCore(object? value, string key) =>
+        value switch
+        {
+            null or DBNull => null,
+            DateTimeOffset dateTimeOffset => dateTimeOffset,
+            DateTime dateTime => Normalize(dateTime),
+            string text when DateTimeOffset.TryParse(text, out var parsed) => parsed,
+            _ => throw new InvalidOperationException($"Registry row value '{key}' must be a timestamp.")
+        };
+
+    private static DateTimeOffset Normalize(DateTime value) =>
+        new(DateTime.SpecifyKind(value, DateTimeKind.Utc));
+}

--- a/dcb/src/Sekiban.Dcb.MaterializedView.MySql/Sekiban.Dcb.MaterializedView.MySql.csproj
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.MySql/Sekiban.Dcb.MaterializedView.MySql.csproj
@@ -1,0 +1,48 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <LangVersion>preview</LangVersion>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <AssemblyName>Sekiban.Dcb.MaterializedView.MySql</AssemblyName>
+        <RootNamespace>Sekiban.Dcb.MaterializedView.MySql</RootNamespace>
+        <PackageId>Sekiban.Dcb.MaterializedView.MySql</PackageId>
+        <Authors>J-Tech Group</Authors>
+        <Company>J-Tech-Japan</Company>
+        <Copyright>Copyright (c) J-Tech-Japan 2025</Copyright>
+        <PackageDescription>Sekiban - MySQL implementation for DCB materialized views</PackageDescription>
+        <RepositoryUrl>https://github.com/J-Tech-Japan/Sekiban</RepositoryUrl>
+        <PackageProjectUrl>https://github.com/J-Tech-Japan/Sekiban</PackageProjectUrl>
+        <PackageVersion>10.0.2-preview03</PackageVersion>
+        <Description>MySQL registry, apply context, and executor for Sekiban DCB materialized views</Description>
+        <PackageTags>event-sourcing;cqrs;ddd;dcb;sekiban;mysql;materialized-view</PackageTags>
+        <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+        <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
+        <IncludeSymbols>true</IncludeSymbols>
+        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+        <GenerateSBOM>true</GenerateSBOM>
+        <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <FrameworkReference Include="Microsoft.AspNetCore.App"/>
+        <PackageReference Include="Dapper" Version="2.1.66"/>
+        <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.3"/>
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.3"/>
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.3"/>
+        <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.3"/>
+        <PackageReference Include="Microsoft.Sbom.Targets" Version="4.1.5">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="MySqlConnector" Version="2.4.0"/>
+        <None Include="../../README.md" Pack="true" PackagePath="\"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\Sekiban.Dcb.Core\Sekiban.Dcb.Core.csproj"/>
+        <ProjectReference Include="..\Sekiban.Dcb.MaterializedView\Sekiban.Dcb.MaterializedView.csproj"/>
+    </ItemGroup>
+
+</Project>

--- a/dcb/src/Sekiban.Dcb.MaterializedView.MySql/SekibanDcbMaterializedViewMySqlExtensions.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.MySql/SekibanDcbMaterializedViewMySqlExtensions.cs
@@ -1,0 +1,67 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Sekiban.Dcb.ServiceId;
+
+namespace Sekiban.Dcb.MaterializedView.MySql;
+
+public static class SekibanDcbMaterializedViewMySqlExtensions
+{
+    public static IServiceCollection AddSekibanDcbMaterializedViewMySql(
+        this IServiceCollection services,
+        IConfiguration configuration,
+        string connectionStringName = "DcbMySql",
+        bool registerHostedWorker = true)
+    {
+        var connectionString = ResolveConnectionString(configuration, connectionStringName) ??
+            throw new InvalidOperationException($"Connection string '{connectionStringName}' not found.");
+        return services.AddSekibanDcbMaterializedViewMySql(connectionString, registerHostedWorker);
+    }
+
+    public static IServiceCollection AddSekibanDcbMaterializedViewMySql(
+        this IServiceCollection services,
+        string connectionString,
+        bool registerHostedWorker = true)
+    {
+        services.AddSekibanDcbMaterializedView();
+        services.TryAddSingleton<IServiceIdProvider, DefaultServiceIdProvider>();
+        services.TryAddSingleton<IMvRegistryStore>(_ => new MySqlMvRegistryStore(connectionString));
+        services.TryAddSingleton<IMvStorageInfoProvider>(_ =>
+            new MvStorageInfoProvider(new MvStorageInfo(MvDbType.MySql, connectionString)));
+        services.TryAddSingleton<IMvExecutor>(sp =>
+            new MySqlMvExecutor(
+                sp.GetRequiredService<Sekiban.Dcb.Storage.IEventStore>(),
+                sp.GetRequiredService<IServiceIdProvider>(),
+                sp.GetRequiredService<IMvRegistryStore>(),
+                sp.GetRequiredService<IOptions<MvOptions>>(),
+                sp.GetRequiredService<ILogger<MySqlMvExecutor>>(),
+                connectionString));
+        if (registerHostedWorker)
+        {
+            services.TryAddEnumerable(ServiceDescriptor.Singleton<IHostedService, MvCatchUpWorker>());
+        }
+
+        return services;
+    }
+
+    private static string? ResolveConnectionString(IConfiguration configuration, string connectionName)
+    {
+        var direct = configuration.GetConnectionString(connectionName);
+        if (!string.IsNullOrWhiteSpace(direct))
+        {
+            return direct;
+        }
+
+        var dotted = configuration[$"ConnectionStrings:{connectionName}"];
+        if (!string.IsNullOrWhiteSpace(dotted))
+        {
+            return dotted;
+        }
+
+        var aspNetCoreStyle = configuration[connectionName];
+        return string.IsNullOrWhiteSpace(aspNetCoreStyle) ? null : aspNetCoreStyle;
+    }
+}

--- a/dcb/src/Sekiban.Dcb.MaterializedView.SqlServer/Sekiban.Dcb.MaterializedView.SqlServer.csproj
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.SqlServer/Sekiban.Dcb.MaterializedView.SqlServer.csproj
@@ -1,0 +1,48 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <LangVersion>preview</LangVersion>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <AssemblyName>Sekiban.Dcb.MaterializedView.SqlServer</AssemblyName>
+        <RootNamespace>Sekiban.Dcb.MaterializedView.SqlServer</RootNamespace>
+        <PackageId>Sekiban.Dcb.MaterializedView.SqlServer</PackageId>
+        <Authors>J-Tech Group</Authors>
+        <Company>J-Tech-Japan</Company>
+        <Copyright>Copyright (c) J-Tech-Japan 2025</Copyright>
+        <PackageDescription>Sekiban - SQL Server implementation for DCB materialized views</PackageDescription>
+        <RepositoryUrl>https://github.com/J-Tech-Japan/Sekiban</RepositoryUrl>
+        <PackageProjectUrl>https://github.com/J-Tech-Japan/Sekiban</PackageProjectUrl>
+        <PackageVersion>10.0.2-preview03</PackageVersion>
+        <Description>SQL Server registry, apply context, and executor for Sekiban DCB materialized views</Description>
+        <PackageTags>event-sourcing;cqrs;ddd;dcb;sekiban;sqlserver;materialized-view</PackageTags>
+        <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+        <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
+        <IncludeSymbols>true</IncludeSymbols>
+        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+        <GenerateSBOM>true</GenerateSBOM>
+        <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <FrameworkReference Include="Microsoft.AspNetCore.App"/>
+        <PackageReference Include="Dapper" Version="2.1.66"/>
+        <PackageReference Include="Microsoft.Data.SqlClient" Version="6.1.2"/>
+        <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.3"/>
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.3"/>
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.3"/>
+        <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.3"/>
+        <PackageReference Include="Microsoft.Sbom.Targets" Version="4.1.5">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <None Include="../../README.md" Pack="true" PackagePath="\"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\Sekiban.Dcb.Core\Sekiban.Dcb.Core.csproj"/>
+        <ProjectReference Include="..\Sekiban.Dcb.MaterializedView\Sekiban.Dcb.MaterializedView.csproj"/>
+    </ItemGroup>
+
+</Project>

--- a/dcb/src/Sekiban.Dcb.MaterializedView.SqlServer/SekibanDcbMaterializedViewSqlServerExtensions.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.SqlServer/SekibanDcbMaterializedViewSqlServerExtensions.cs
@@ -1,0 +1,67 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Sekiban.Dcb.ServiceId;
+
+namespace Sekiban.Dcb.MaterializedView.SqlServer;
+
+public static class SekibanDcbMaterializedViewSqlServerExtensions
+{
+    public static IServiceCollection AddSekibanDcbMaterializedViewSqlServer(
+        this IServiceCollection services,
+        IConfiguration configuration,
+        string connectionStringName = "DcbSqlServer",
+        bool registerHostedWorker = true)
+    {
+        var connectionString = ResolveConnectionString(configuration, connectionStringName) ??
+            throw new InvalidOperationException($"Connection string '{connectionStringName}' not found.");
+        return services.AddSekibanDcbMaterializedViewSqlServer(connectionString, registerHostedWorker);
+    }
+
+    public static IServiceCollection AddSekibanDcbMaterializedViewSqlServer(
+        this IServiceCollection services,
+        string connectionString,
+        bool registerHostedWorker = true)
+    {
+        services.AddSekibanDcbMaterializedView();
+        services.TryAddSingleton<IServiceIdProvider, DefaultServiceIdProvider>();
+        services.TryAddSingleton<IMvRegistryStore>(_ => new SqlServerMvRegistryStore(connectionString));
+        services.TryAddSingleton<IMvStorageInfoProvider>(_ =>
+            new MvStorageInfoProvider(new MvStorageInfo(MvDbType.SqlServer, connectionString)));
+        services.TryAddSingleton<IMvExecutor>(sp =>
+            new SqlServerMvExecutor(
+                sp.GetRequiredService<Sekiban.Dcb.Storage.IEventStore>(),
+                sp.GetRequiredService<IServiceIdProvider>(),
+                sp.GetRequiredService<IMvRegistryStore>(),
+                sp.GetRequiredService<IOptions<MvOptions>>(),
+                sp.GetRequiredService<ILogger<SqlServerMvExecutor>>(),
+                connectionString));
+        if (registerHostedWorker)
+        {
+            services.TryAddEnumerable(ServiceDescriptor.Singleton<IHostedService, MvCatchUpWorker>());
+        }
+
+        return services;
+    }
+
+    private static string? ResolveConnectionString(IConfiguration configuration, string connectionName)
+    {
+        var direct = configuration.GetConnectionString(connectionName);
+        if (!string.IsNullOrWhiteSpace(direct))
+        {
+            return direct;
+        }
+
+        var dotted = configuration[$"ConnectionStrings:{connectionName}"];
+        if (!string.IsNullOrWhiteSpace(dotted))
+        {
+            return dotted;
+        }
+
+        var aspNetCoreStyle = configuration[connectionName];
+        return string.IsNullOrWhiteSpace(aspNetCoreStyle) ? null : aspNetCoreStyle;
+    }
+}

--- a/dcb/src/Sekiban.Dcb.MaterializedView.SqlServer/SqlServerMvContexts.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.SqlServer/SqlServerMvContexts.cs
@@ -1,0 +1,104 @@
+using System.Data;
+using System.Text.Json;
+using Dapper;
+
+namespace Sekiban.Dcb.MaterializedView.SqlServer;
+
+internal static class SqlServerMvValueAdapter
+{
+    public static IReadOnlyDictionary<string, object?> ToDictionary(object row)
+    {
+        if (row is IReadOnlyDictionary<string, object?> readOnlyDictionary)
+        {
+            return readOnlyDictionary;
+        }
+
+        if (row is IDictionary<string, object?> dictionary)
+        {
+            return dictionary.ToDictionary(pair => pair.Key, pair => pair.Value, StringComparer.OrdinalIgnoreCase);
+        }
+
+        if (row is IDictionary<string, object> nonNullableDictionary)
+        {
+            return nonNullableDictionary
+                .Select(pair => new KeyValuePair<string, object?>(pair.Key, pair.Value))
+                .ToDictionary(pair => pair.Key, pair => pair.Value, StringComparer.OrdinalIgnoreCase);
+        }
+
+        return row.GetType()
+            .GetProperties()
+            .ToDictionary(property => property.Name, property => property.GetValue(row), StringComparer.OrdinalIgnoreCase);
+    }
+}
+
+internal sealed class SqlServerMvApplyQueryPort : IMvApplyDbConnectionPort
+{
+    private readonly IDbConnection _connection;
+    private readonly IDbTransaction _transaction;
+
+    public SqlServerMvApplyQueryPort(IDbConnection connection, IDbTransaction transaction)
+    {
+        _connection = connection;
+        _transaction = transaction;
+    }
+
+    public IDbConnection Connection => _connection;
+    public IDbTransaction Transaction => _transaction;
+
+    public async Task<IReadOnlyList<JsonElement>> QueryRowsAsync(
+        string sql,
+        IReadOnlyList<MvParam> parameters,
+        CancellationToken ct)
+    {
+        var rows = await _connection.QueryAsync(
+            new CommandDefinition(
+                sql,
+                ToDynamicParameters(parameters),
+                _transaction,
+                cancellationToken: ct)).ConfigureAwait(false);
+        return rows
+            .Select(row => (JsonElement)JsonSerializer.SerializeToElement(SqlServerMvValueAdapter.ToDictionary(row)))
+            .ToList();
+    }
+
+    public async Task<JsonElement?> QuerySingleOrDefaultAsync(
+        string sql,
+        IReadOnlyList<MvParam> parameters,
+        CancellationToken ct)
+    {
+        var row = await _connection.QuerySingleOrDefaultAsync(
+            new CommandDefinition(
+                sql,
+                ToDynamicParameters(parameters),
+                _transaction,
+                cancellationToken: ct)).ConfigureAwait(false);
+        return row is null
+            ? null
+            : JsonSerializer.SerializeToElement(SqlServerMvValueAdapter.ToDictionary(row));
+    }
+
+    public async Task<string?> ExecuteScalarJsonAsync(
+        string sql,
+        IReadOnlyList<MvParam> parameters,
+        CancellationToken ct)
+    {
+        var scalar = await _connection.ExecuteScalarAsync(
+            new CommandDefinition(
+                sql,
+                ToDynamicParameters(parameters),
+                _transaction,
+                cancellationToken: ct)).ConfigureAwait(false);
+        return MvParamConverter.SerializeScalar(scalar);
+    }
+
+    private static DynamicParameters ToDynamicParameters(IReadOnlyList<MvParam> parameters)
+    {
+        var dynamicParameters = new DynamicParameters();
+        foreach (var parameter in parameters)
+        {
+            dynamicParameters.Add(parameter.Name, MvParamConverter.ToClrValue(parameter));
+        }
+
+        return dynamicParameters;
+    }
+}

--- a/dcb/src/Sekiban.Dcb.MaterializedView.SqlServer/SqlServerMvExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.SqlServer/SqlServerMvExecutor.cs
@@ -1,0 +1,332 @@
+using Dapper;
+using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Sekiban.Dcb.Common;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.ServiceId;
+using Sekiban.Dcb.Storage;
+
+namespace Sekiban.Dcb.MaterializedView.SqlServer;
+
+public sealed class SqlServerMvExecutor : IMvExecutor
+{
+    private readonly IEventStore _eventStore;
+    private readonly ILogger<SqlServerMvExecutor> _logger;
+    private readonly MvOptions _options;
+    private readonly IMvRegistryStore _registryStore;
+    private readonly string _connectionString;
+    private readonly IServiceIdProvider _serviceIdProvider;
+
+    public SqlServerMvExecutor(
+        IEventStore eventStore,
+        IServiceIdProvider serviceIdProvider,
+        IMvRegistryStore registryStore,
+        IOptions<MvOptions> options,
+        ILogger<SqlServerMvExecutor> logger,
+        string connectionString)
+    {
+        _eventStore = eventStore;
+        _serviceIdProvider = serviceIdProvider;
+        _registryStore = registryStore;
+        _logger = logger;
+        _connectionString = connectionString;
+        _options = options.Value;
+    }
+
+    public async Task InitializeAsync(
+        IMvApplyHost host,
+        string? serviceId = null,
+        CancellationToken cancellationToken = default)
+    {
+        await _registryStore.EnsureInfrastructureAsync(cancellationToken).ConfigureAwait(false);
+        serviceId = ResolveServiceId(serviceId);
+
+        await using var connection = new SqlConnection(_connectionString);
+        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+        await using var transaction = await connection.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
+
+        var bindings = new MvTableBindings(host.ViewName, host.ViewVersion, _options);
+        var statements = await host.InitializeAsync(bindings, cancellationToken).ConfigureAwait(false);
+        foreach (var statement in statements)
+        {
+            await connection.ExecuteAsync(
+                new CommandDefinition(
+                    statement.Sql,
+                    ToDynamicParameters(statement.Parameters),
+                    transaction,
+                    cancellationToken: cancellationToken)).ConfigureAwait(false);
+        }
+
+        foreach (var table in bindings.Tables)
+        {
+            await _registryStore.RegisterAsync(
+                new MvRegistryEntry
+                {
+                    ServiceId = serviceId,
+                    ViewName = host.ViewName,
+                    ViewVersion = host.ViewVersion,
+                    LogicalTable = table.LogicalName,
+                    PhysicalTable = table.PhysicalName,
+                    Status = MvStatus.CatchingUp,
+                    AppliedEventVersion = 0,
+                    LastUpdated = DateTimeOffset.UtcNow
+                },
+                transaction,
+                cancellationToken).ConfigureAwait(false);
+        }
+
+        var active = await _registryStore.GetActiveAsync(serviceId, host.ViewName, cancellationToken).ConfigureAwait(false);
+        if (active is null)
+        {
+            await _registryStore.SetActiveAsync(serviceId, host.ViewName, host.ViewVersion, transaction, cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<MvCatchUpResult> CatchUpOnceAsync(
+        IMvApplyHost host,
+        string? serviceId = null,
+        CancellationToken cancellationToken = default)
+    {
+        serviceId = ResolveServiceId(serviceId);
+        var entries = await _registryStore.GetEntriesAsync(serviceId, host.ViewName, host.ViewVersion, cancellationToken)
+            .ConfigureAwait(false);
+        if (entries.Count == 0)
+        {
+            await InitializeAsync(host, serviceId, cancellationToken).ConfigureAwait(false);
+            entries = await _registryStore.GetEntriesAsync(serviceId, host.ViewName, host.ViewVersion, cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        var currentPosition = entries
+            .Select(entry => entry.CurrentPosition)
+            .FirstOrDefault(position => !string.IsNullOrWhiteSpace(position));
+        var readResult = await _eventStore.ReadAllSerializableEventsAsync(
+            SortableUniqueId.NullableValue(currentPosition),
+            _options.BatchSize).ConfigureAwait(false);
+
+        if (!readResult.IsSuccess)
+        {
+            var exception = readResult.GetException();
+            if (exception is NotSupportedException)
+            {
+                throw exception;
+            }
+
+            _logger.LogWarning(
+                exception,
+                "Failed to read events for materialized view {ViewName}/{ViewVersion}.",
+                host.ViewName,
+                host.ViewVersion);
+            return new MvCatchUpResult(0, false);
+        }
+
+        var safeThreshold = CreateSafeThreshold(_options.SafeWindowMs);
+        var reachedUnsafeWindow = false;
+        var batch = readResult.GetValue().OrderBy(serializable => serializable.SortableUniqueIdValue).ToList();
+
+        if (batch.Count == 0)
+        {
+            return new MvCatchUpResult(0, false);
+        }
+
+        var safeBatch = new List<SerializableEvent>(batch.Count);
+        foreach (var serializableEvent in batch)
+        {
+            if (!new SortableUniqueId(serializableEvent.SortableUniqueIdValue).IsEarlierThanOrEqual(safeThreshold))
+            {
+                reachedUnsafeWindow = true;
+                break;
+            }
+
+            safeBatch.Add(serializableEvent);
+        }
+
+        if (safeBatch.Count == 0)
+        {
+            return new MvCatchUpResult(0, reachedUnsafeWindow);
+        }
+
+        var appliedEvents = await ApplySerializableEventsCoreAsync(
+                host,
+                safeBatch,
+                serviceId,
+                MvApplySource.CatchUp,
+                cancellationToken)
+            .ConfigureAwait(false);
+
+        var lastAppliedSortableUniqueId = appliedEvents > 0
+            ? safeBatch[appliedEvents - 1].SortableUniqueIdValue
+            : null;
+
+        reachedUnsafeWindow |= appliedEvents < safeBatch.Count;
+
+        return new MvCatchUpResult(appliedEvents, reachedUnsafeWindow, lastAppliedSortableUniqueId);
+    }
+
+    public async Task<int> ApplySerializableEventsAsync(
+        IMvApplyHost host,
+        IReadOnlyList<SerializableEvent> events,
+        string? serviceId = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (events.Count == 0)
+        {
+            return 0;
+        }
+
+        serviceId = ResolveServiceId(serviceId);
+        return await ApplySerializableEventsCoreAsync(host, events, serviceId, MvApplySource.Stream, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<int> ApplySerializableEventsCoreAsync(
+        IMvApplyHost host,
+        IReadOnlyList<SerializableEvent> events,
+        string serviceId,
+        MvApplySource source,
+        CancellationToken cancellationToken)
+    {
+        var entries = await _registryStore.GetEntriesAsync(serviceId, host.ViewName, host.ViewVersion, cancellationToken)
+            .ConfigureAwait(false);
+        if (entries.Count == 0)
+        {
+            await InitializeAsync(host, serviceId, cancellationToken).ConfigureAwait(false);
+            entries = await _registryStore.GetEntriesAsync(serviceId, host.ViewName, host.ViewVersion, cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        var currentPosition = entries
+            .Select(entry => entry.CurrentPosition)
+            .FirstOrDefault(position => !string.IsNullOrWhiteSpace(position));
+        var orderedEvents = events
+            .GroupBy(serializableEvent => serializableEvent.SortableUniqueIdValue)
+            .Select(group => group.First())
+            .Where(serializableEvent =>
+                source == MvApplySource.Stream ||
+                string.IsNullOrWhiteSpace(currentPosition) ||
+                string.Compare(serializableEvent.SortableUniqueIdValue, currentPosition, StringComparison.Ordinal) > 0)
+            .OrderBy(serializableEvent => serializableEvent.SortableUniqueIdValue, StringComparer.Ordinal)
+            .ToList();
+
+        if (orderedEvents.Count == 0)
+        {
+            return 0;
+        }
+
+        await using var connection = new SqlConnection(_connectionString);
+        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+        var appliedEvents = 0;
+        var bindings = CreateBindings(host, entries);
+
+        foreach (var serializableEvent in orderedEvents)
+        {
+            var applied = await ApplySerializableEventAsync(
+                    connection,
+                    host,
+                    serviceId,
+                    bindings,
+                    serializableEvent,
+                    currentPosition,
+                    source,
+                    cancellationToken)
+                .ConfigureAwait(false);
+            if (!applied)
+            {
+                break;
+            }
+
+            appliedEvents += 1;
+        }
+
+        return appliedEvents;
+    }
+
+    private async Task<bool> ApplySerializableEventAsync(
+        SqlConnection connection,
+        IMvApplyHost host,
+        string serviceId,
+        MvTableBindings bindings,
+        SerializableEvent serializableEvent,
+        string? currentPosition,
+        MvApplySource source,
+        CancellationToken cancellationToken)
+    {
+        await using var transaction = await connection.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
+        var queryPort = new SqlServerMvApplyQueryPort(connection, transaction);
+        var statements = await host.ApplyEventAsync(
+            serializableEvent,
+            bindings,
+            queryPort,
+            serializableEvent.SortableUniqueIdValue,
+            cancellationToken).ConfigureAwait(false);
+        var affectedRows = 0;
+        foreach (var statement in statements)
+        {
+            affectedRows += await connection.ExecuteAsync(
+                new CommandDefinition(
+                    statement.Sql,
+                    ToDynamicParameters(statement.Parameters),
+                    transaction,
+                    cancellationToken: cancellationToken)).ConfigureAwait(false);
+        }
+
+        if (source == MvApplySource.Stream && statements.Count > 0 && affectedRows == 0)
+        {
+            if (!string.IsNullOrWhiteSpace(currentPosition) &&
+                string.Compare(serializableEvent.SortableUniqueIdValue, currentPosition, StringComparison.Ordinal) <= 0)
+            {
+                await transaction.RollbackAsync(cancellationToken).ConfigureAwait(false);
+                return true;
+            }
+
+            await transaction.RollbackAsync(cancellationToken).ConfigureAwait(false);
+            return false;
+        }
+
+        await _registryStore.UpdatePositionAsync(
+            new MvPositionUpdate(
+                serviceId,
+                host.ViewName,
+                host.ViewVersion,
+                serializableEvent.SortableUniqueIdValue,
+                source),
+            transaction: transaction,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+        return true;
+    }
+
+    private string ResolveServiceId(string? serviceId) =>
+        string.IsNullOrWhiteSpace(serviceId)
+            ? _serviceIdProvider.GetCurrentServiceId()
+            : serviceId;
+
+    private MvTableBindings CreateBindings(IMvApplyHost host, IReadOnlyList<MvRegistryEntry> entries)
+    {
+        var bindings = new MvTableBindings(host.ViewName, host.ViewVersion, _options);
+        foreach (var entry in entries)
+        {
+            bindings.RegisterTable(entry.LogicalTable, entry.PhysicalTable);
+        }
+
+        return bindings;
+    }
+
+    private static DynamicParameters ToDynamicParameters(IReadOnlyList<MvParam> parameters)
+    {
+        var dynamicParameters = new DynamicParameters();
+        foreach (var parameter in parameters)
+        {
+            dynamicParameters.Add(parameter.Name, MvParamConverter.ToClrValue(parameter));
+        }
+
+        return dynamicParameters;
+    }
+
+    private static SortableUniqueId CreateSafeThreshold(int safeWindowMs) =>
+        new(SortableUniqueId.Generate(DateTime.UtcNow.AddMilliseconds(-safeWindowMs), Guid.Empty));
+}

--- a/dcb/src/Sekiban.Dcb.MaterializedView.SqlServer/SqlServerMvRegistryStore.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.SqlServer/SqlServerMvRegistryStore.cs
@@ -1,0 +1,537 @@
+using System.Data;
+using Dapper;
+using Microsoft.Data.SqlClient;
+
+namespace Sekiban.Dcb.MaterializedView.SqlServer;
+
+public sealed class SqlServerMvRegistryStore : IMvRegistryStore
+{
+    private readonly string _connectionString;
+
+    public SqlServerMvRegistryStore(string connectionString)
+    {
+        _connectionString = connectionString;
+    }
+
+    public async Task EnsureInfrastructureAsync(CancellationToken cancellationToken = default)
+    {
+        await using var connection = new SqlConnection(_connectionString);
+        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+        const string sql = """
+            IF OBJECT_ID(N'sekiban_mv_registry', N'U') IS NULL
+            BEGIN
+                CREATE TABLE sekiban_mv_registry (
+                    service_id NVARCHAR(200) NOT NULL,
+                    view_name NVARCHAR(200) NOT NULL,
+                    view_version INT NOT NULL,
+                    logical_table NVARCHAR(200) NOT NULL,
+                    physical_table NVARCHAR(256) NOT NULL,
+                    status NVARCHAR(32) NOT NULL,
+                    current_position NVARCHAR(64) NULL,
+                    target_position NVARCHAR(64) NULL,
+                    last_sortable_unique_id NVARCHAR(64) NULL,
+                    applied_event_version BIGINT NOT NULL CONSTRAINT DF_sekiban_mv_registry_applied_event_version DEFAULT 0,
+                    last_applied_source NVARCHAR(32) NULL,
+                    last_applied_at DATETIMEOFFSET NULL,
+                    last_stream_received_sortable_unique_id NVARCHAR(64) NULL,
+                    last_stream_received_at DATETIMEOFFSET NULL,
+                    last_stream_applied_sortable_unique_id NVARCHAR(64) NULL,
+                    last_catch_up_sortable_unique_id NVARCHAR(64) NULL,
+                    last_updated DATETIMEOFFSET NOT NULL,
+                    metadata NVARCHAR(MAX) NULL,
+                    CONSTRAINT PK_sekiban_mv_registry PRIMARY KEY (service_id, view_name, view_version, logical_table)
+                );
+            END;
+
+            IF OBJECT_ID(N'sekiban_mv_active', N'U') IS NULL
+            BEGIN
+                CREATE TABLE sekiban_mv_active (
+                    service_id NVARCHAR(200) NOT NULL,
+                    view_name NVARCHAR(200) NOT NULL,
+                    active_version INT NOT NULL,
+                    activated_at DATETIMEOFFSET NOT NULL,
+                    CONSTRAINT PK_sekiban_mv_active PRIMARY KEY (service_id, view_name)
+                );
+            END;
+            """;
+
+        await connection.ExecuteAsync(new CommandDefinition(sql, cancellationToken: cancellationToken)).ConfigureAwait(false);
+    }
+
+    public async Task RegisterAsync(MvRegistryEntry entry, IDbTransaction? transaction = null, CancellationToken cancellationToken = default)
+    {
+        const string sql = """
+            MERGE sekiban_mv_registry AS target
+            USING (
+                VALUES (
+                    @ServiceId,
+                    @ViewName,
+                    @ViewVersion,
+                    @LogicalTable,
+                    @PhysicalTable,
+                    @Status,
+                    @CurrentPosition,
+                    @TargetPosition,
+                    @LastSortableUniqueId,
+                    @AppliedEventVersion,
+                    @LastAppliedSource,
+                    @LastAppliedAt,
+                    @LastStreamReceivedSortableUniqueId,
+                    @LastStreamReceivedAt,
+                    @LastStreamAppliedSortableUniqueId,
+                    @LastCatchUpSortableUniqueId,
+                    @LastUpdated,
+                    @Metadata
+                )
+            ) AS source (
+                service_id,
+                view_name,
+                view_version,
+                logical_table,
+                physical_table,
+                status,
+                current_position,
+                target_position,
+                last_sortable_unique_id,
+                applied_event_version,
+                last_applied_source,
+                last_applied_at,
+                last_stream_received_sortable_unique_id,
+                last_stream_received_at,
+                last_stream_applied_sortable_unique_id,
+                last_catch_up_sortable_unique_id,
+                last_updated,
+                metadata
+            )
+            ON target.service_id = source.service_id
+               AND target.view_name = source.view_name
+               AND target.view_version = source.view_version
+               AND target.logical_table = source.logical_table
+            WHEN MATCHED THEN
+                UPDATE SET
+                    physical_table = source.physical_table,
+                    last_updated = source.last_updated,
+                    applied_event_version = target.applied_event_version,
+                    last_applied_source = COALESCE(target.last_applied_source, source.last_applied_source),
+                    last_applied_at = COALESCE(target.last_applied_at, source.last_applied_at),
+                    last_stream_received_sortable_unique_id = COALESCE(target.last_stream_received_sortable_unique_id, source.last_stream_received_sortable_unique_id),
+                    last_stream_received_at = COALESCE(target.last_stream_received_at, source.last_stream_received_at),
+                    last_stream_applied_sortable_unique_id = COALESCE(target.last_stream_applied_sortable_unique_id, source.last_stream_applied_sortable_unique_id),
+                    last_catch_up_sortable_unique_id = COALESCE(target.last_catch_up_sortable_unique_id, source.last_catch_up_sortable_unique_id),
+                    metadata = COALESCE(source.metadata, target.metadata)
+            WHEN NOT MATCHED THEN
+                INSERT (
+                    service_id,
+                    view_name,
+                    view_version,
+                    logical_table,
+                    physical_table,
+                    status,
+                    current_position,
+                    target_position,
+                    last_sortable_unique_id,
+                    applied_event_version,
+                    last_applied_source,
+                    last_applied_at,
+                    last_stream_received_sortable_unique_id,
+                    last_stream_received_at,
+                    last_stream_applied_sortable_unique_id,
+                    last_catch_up_sortable_unique_id,
+                    last_updated,
+                    metadata
+                )
+                VALUES (
+                    source.service_id,
+                    source.view_name,
+                    source.view_version,
+                    source.logical_table,
+                    source.physical_table,
+                    source.status,
+                    source.current_position,
+                    source.target_position,
+                    source.last_sortable_unique_id,
+                    source.applied_event_version,
+                    source.last_applied_source,
+                    source.last_applied_at,
+                    source.last_stream_received_sortable_unique_id,
+                    source.last_stream_received_at,
+                    source.last_stream_applied_sortable_unique_id,
+                    source.last_catch_up_sortable_unique_id,
+                    source.last_updated,
+                    source.metadata
+                );
+            """;
+
+        var parameters = new
+        {
+            entry.ServiceId,
+            entry.ViewName,
+            entry.ViewVersion,
+            entry.LogicalTable,
+            entry.PhysicalTable,
+            Status = entry.Status.ToString().ToLowerInvariant(),
+            entry.CurrentPosition,
+            entry.TargetPosition,
+            entry.LastSortableUniqueId,
+            entry.AppliedEventVersion,
+            entry.LastAppliedSource,
+            entry.LastAppliedAt,
+            entry.LastStreamReceivedSortableUniqueId,
+            entry.LastStreamReceivedAt,
+            entry.LastStreamAppliedSortableUniqueId,
+            entry.LastCatchUpSortableUniqueId,
+            entry.LastUpdated,
+            entry.Metadata
+        };
+
+        await ExecuteAsync(sql, parameters, transaction, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task UpdatePositionAsync(
+        MvPositionUpdate update,
+        IDbTransaction? transaction = null,
+        CancellationToken cancellationToken = default)
+    {
+        const string sql = """
+            UPDATE sekiban_mv_registry
+            SET current_position = CASE
+                    WHEN current_position IS NULL
+                      OR current_position < @SortableUniqueId THEN @SortableUniqueId
+                    ELSE current_position
+                END,
+                last_sortable_unique_id = CASE
+                    WHEN last_sortable_unique_id IS NULL
+                      OR last_sortable_unique_id < @SortableUniqueId THEN @SortableUniqueId
+                    ELSE last_sortable_unique_id
+                END,
+                applied_event_version = applied_event_version + @AppliedEventVersionDelta,
+                last_applied_source = @Source,
+                last_applied_at = SYSUTCDATETIME(),
+                last_stream_applied_sortable_unique_id = CASE
+                    WHEN @Source = 'stream'
+                      AND (last_stream_applied_sortable_unique_id IS NULL
+                        OR last_stream_applied_sortable_unique_id < @SortableUniqueId) THEN @SortableUniqueId
+                    ELSE last_stream_applied_sortable_unique_id
+                END,
+                last_catch_up_sortable_unique_id = CASE
+                    WHEN @Source = 'catchup'
+                      AND (last_catch_up_sortable_unique_id IS NULL
+                        OR last_catch_up_sortable_unique_id < @SortableUniqueId) THEN @SortableUniqueId
+                    ELSE last_catch_up_sortable_unique_id
+                END,
+                last_updated = SYSUTCDATETIME()
+            WHERE service_id = @ServiceId
+              AND view_name = @ViewName
+              AND view_version = @ViewVersion;
+            """;
+
+        var parameters = new
+        {
+            update.ServiceId,
+            update.ViewName,
+            update.ViewVersion,
+            update.SortableUniqueId,
+            update.AppliedEventVersionDelta,
+            Source = update.Source == MvApplySource.Stream ? "stream" : "catchup"
+        };
+        await ExecuteAsync(sql, parameters, transaction, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task MarkStreamReceivedAsync(
+        string serviceId,
+        string viewName,
+        int viewVersion,
+        string sortableUniqueId,
+        DateTimeOffset receivedAt,
+        IDbTransaction? transaction = null,
+        CancellationToken cancellationToken = default)
+    {
+        const string sql = """
+            UPDATE sekiban_mv_registry
+            SET last_stream_received_sortable_unique_id = CASE
+                    WHEN last_stream_received_sortable_unique_id IS NULL
+                      OR last_stream_received_sortable_unique_id < @SortableUniqueId THEN @SortableUniqueId
+                    ELSE last_stream_received_sortable_unique_id
+                END,
+                last_stream_received_at = @ReceivedAt,
+                last_updated = SYSUTCDATETIME()
+            WHERE service_id = @ServiceId
+              AND view_name = @ViewName
+              AND view_version = @ViewVersion;
+            """;
+
+        await ExecuteAsync(
+            sql,
+            new
+            {
+                ServiceId = serviceId,
+                ViewName = viewName,
+                ViewVersion = viewVersion,
+                SortableUniqueId = sortableUniqueId,
+                ReceivedAt = receivedAt
+            },
+            transaction,
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task UpdateStatusAsync(
+        string serviceId,
+        string viewName,
+        int viewVersion,
+        MvStatus status,
+        IDbTransaction? transaction = null,
+        CancellationToken cancellationToken = default)
+    {
+        const string sql = """
+            UPDATE sekiban_mv_registry
+            SET status = @Status,
+                last_updated = SYSUTCDATETIME()
+            WHERE service_id = @ServiceId
+              AND view_name = @ViewName
+              AND view_version = @ViewVersion;
+            """;
+
+        await ExecuteAsync(
+            sql,
+            new { ServiceId = serviceId, ViewName = viewName, ViewVersion = viewVersion, Status = status.ToString().ToLowerInvariant() },
+            transaction,
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<IReadOnlyList<MvRegistryEntry>> GetEntriesAsync(
+        string serviceId,
+        string viewName,
+        int viewVersion,
+        CancellationToken cancellationToken = default)
+    {
+        const string sql = """
+            SELECT service_id AS ServiceId,
+                   view_name AS ViewName,
+                   view_version AS ViewVersion,
+                   logical_table AS LogicalTable,
+                   physical_table AS PhysicalTable,
+                   status AS Status,
+                   current_position AS CurrentPosition,
+                   target_position AS TargetPosition,
+                   last_sortable_unique_id AS LastSortableUniqueId,
+                   applied_event_version AS AppliedEventVersion,
+                   last_applied_source AS LastAppliedSource,
+                   last_applied_at AS LastAppliedAt,
+                   last_stream_received_sortable_unique_id AS LastStreamReceivedSortableUniqueId,
+                   last_stream_received_at AS LastStreamReceivedAt,
+                   last_stream_applied_sortable_unique_id AS LastStreamAppliedSortableUniqueId,
+                   last_catch_up_sortable_unique_id AS LastCatchUpSortableUniqueId,
+                   last_updated AS LastUpdated,
+                   metadata AS Metadata
+            FROM sekiban_mv_registry
+            WHERE service_id = @ServiceId
+              AND view_name = @ViewName
+              AND view_version = @ViewVersion
+            ORDER BY logical_table;
+            """;
+
+        await using var connection = new SqlConnection(_connectionString);
+        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+        var rows = await connection.QueryAsync(
+            new CommandDefinition(sql, new { ServiceId = serviceId, ViewName = viewName, ViewVersion = viewVersion }, cancellationToken: cancellationToken))
+            .ConfigureAwait(false);
+        return rows.Select(row => (MvRegistryEntry)MapEntry(ToDictionary(row))).ToList();
+    }
+
+    public async Task<MvActiveEntry?> GetActiveAsync(
+        string serviceId,
+        string viewName,
+        CancellationToken cancellationToken = default)
+    {
+        const string sql = """
+            SELECT service_id AS ServiceId,
+                   view_name AS ViewName,
+                   active_version AS ActiveVersion,
+                   activated_at AS ActivatedAt
+            FROM sekiban_mv_active
+            WHERE service_id = @ServiceId
+              AND view_name = @ViewName;
+            """;
+
+        await using var connection = new SqlConnection(_connectionString);
+        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+        var row = await connection.QuerySingleOrDefaultAsync(
+            new CommandDefinition(sql, new { ServiceId = serviceId, ViewName = viewName }, cancellationToken: cancellationToken))
+            .ConfigureAwait(false);
+        return row is null ? null : MapActiveEntry(ToDictionary(row));
+    }
+
+    public async Task SetActiveAsync(
+        string serviceId,
+        string viewName,
+        int activeVersion,
+        IDbTransaction? transaction = null,
+        CancellationToken cancellationToken = default)
+    {
+        const string sql = """
+            MERGE sekiban_mv_active AS target
+            USING (VALUES (@ServiceId, @ViewName, @ActiveVersion, SYSUTCDATETIME())) AS source (service_id, view_name, active_version, activated_at)
+            ON target.service_id = source.service_id
+               AND target.view_name = source.view_name
+            WHEN MATCHED THEN
+                UPDATE SET
+                    active_version = source.active_version,
+                    activated_at = source.activated_at
+            WHEN NOT MATCHED THEN
+                INSERT (service_id, view_name, active_version, activated_at)
+                VALUES (source.service_id, source.view_name, source.active_version, source.activated_at);
+            """;
+
+        await ExecuteAsync(
+            sql,
+            new { ServiceId = serviceId, ViewName = viewName, ActiveVersion = activeVersion },
+            transaction,
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task ExecuteAsync(
+        string sql,
+        object parameters,
+        IDbTransaction? transaction,
+        CancellationToken cancellationToken)
+    {
+        if (transaction is null)
+        {
+            await using var connection = new SqlConnection(_connectionString);
+            await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+            await connection.ExecuteAsync(new CommandDefinition(sql, parameters, cancellationToken: cancellationToken)).ConfigureAwait(false);
+            return;
+        }
+
+        await transaction.Connection!.ExecuteAsync(
+            new CommandDefinition(sql, parameters, transaction, cancellationToken: cancellationToken)).ConfigureAwait(false);
+    }
+
+    private static MvRegistryEntry MapEntry(IReadOnlyDictionary<string, object?> row) =>
+        new()
+        {
+            ServiceId = ReadRequiredString(row, "ServiceId"),
+            ViewName = ReadRequiredString(row, "ViewName"),
+            ViewVersion = ReadRequiredInt(row, "ViewVersion"),
+            LogicalTable = ReadRequiredString(row, "LogicalTable"),
+            PhysicalTable = ReadRequiredString(row, "PhysicalTable"),
+            Status = Enum.Parse<MvStatus>(ReadRequiredString(row, "Status"), ignoreCase: true),
+            CurrentPosition = ReadNullableString(row, "CurrentPosition"),
+            TargetPosition = ReadNullableString(row, "TargetPosition"),
+            LastSortableUniqueId = ReadNullableString(row, "LastSortableUniqueId"),
+            AppliedEventVersion = ReadRequiredLong(row, "AppliedEventVersion"),
+            LastAppliedSource = ReadNullableString(row, "LastAppliedSource"),
+            LastAppliedAt = ReadNullableDateTimeOffset(row, "LastAppliedAt"),
+            LastStreamReceivedSortableUniqueId = ReadNullableString(row, "LastStreamReceivedSortableUniqueId"),
+            LastStreamReceivedAt = ReadNullableDateTimeOffset(row, "LastStreamReceivedAt"),
+            LastStreamAppliedSortableUniqueId = ReadNullableString(row, "LastStreamAppliedSortableUniqueId"),
+            LastCatchUpSortableUniqueId = ReadNullableString(row, "LastCatchUpSortableUniqueId"),
+            LastUpdated = ReadRequiredDateTimeOffset(row, "LastUpdated"),
+            Metadata = ReadNullableString(row, "Metadata")
+        };
+
+    private static MvActiveEntry MapActiveEntry(IReadOnlyDictionary<string, object?> row) =>
+        new(
+            ReadRequiredString(row, "ServiceId"),
+            ReadRequiredString(row, "ViewName"),
+            ReadRequiredInt(row, "ActiveVersion"),
+            ReadRequiredDateTimeOffset(row, "ActivatedAt"));
+
+    private static IReadOnlyDictionary<string, object?> ToDictionary(object row)
+    {
+        if (row is IReadOnlyDictionary<string, object?> readOnlyDictionary)
+        {
+            return readOnlyDictionary;
+        }
+
+        if (row is IDictionary<string, object?> dictionary)
+        {
+            return new Dictionary<string, object?>(dictionary, StringComparer.OrdinalIgnoreCase);
+        }
+
+        if (row is IDictionary<string, object> nonNullableDictionary)
+        {
+            return nonNullableDictionary
+                .Select(pair => new KeyValuePair<string, object?>(pair.Key, pair.Value))
+                .ToDictionary(pair => pair.Key, pair => pair.Value, StringComparer.OrdinalIgnoreCase);
+        }
+
+        if (row is System.Collections.IDictionary legacyDictionary)
+        {
+            return legacyDictionary.Cast<System.Collections.DictionaryEntry>()
+                .ToDictionary(
+                    entry => entry.Key.ToString() ?? string.Empty,
+                    entry => entry.Value,
+                    StringComparer.OrdinalIgnoreCase);
+        }
+
+        return row.GetType()
+            .GetProperties()
+            .ToDictionary(property => property.Name, property => property.GetValue(row), StringComparer.OrdinalIgnoreCase);
+    }
+
+    private static string ReadRequiredString(IReadOnlyDictionary<string, object?> row, string key) =>
+        TryGetValue(row, key, out var value) && value is not null
+            ? value.ToString()!
+            : throw new InvalidOperationException($"Registry row is missing required value '{key}'.");
+
+    private static string? ReadNullableString(IReadOnlyDictionary<string, object?> row, string key) =>
+        TryGetValue(row, key, out var value) && value is not null
+            ? value.ToString()
+            : null;
+
+    private static int ReadRequiredInt(IReadOnlyDictionary<string, object?> row, string key) =>
+        Convert.ToInt32(TryGetValue(row, key, out var value)
+            ? value
+            : throw new InvalidOperationException($"Registry row is missing required value '{key}'."));
+
+    private static long ReadRequiredLong(IReadOnlyDictionary<string, object?> row, string key) =>
+        Convert.ToInt64(TryGetValue(row, key, out var value)
+            ? value
+            : throw new InvalidOperationException($"Registry row is missing required value '{key}'."));
+
+    private static DateTimeOffset ReadRequiredDateTimeOffset(IReadOnlyDictionary<string, object?> row, string key) =>
+        ReadDateTimeOffsetCore(
+            TryGetValue(row, key, out var value)
+                ? value
+                : throw new InvalidOperationException($"Registry row is missing required value '{key}'."),
+            key) ??
+        throw new InvalidOperationException($"Registry row is missing required timestamp '{key}'.");
+
+    private static DateTimeOffset? ReadNullableDateTimeOffset(IReadOnlyDictionary<string, object?> row, string key) =>
+        TryGetValue(row, key, out var value) ? ReadDateTimeOffsetCore(value, key) : null;
+
+    private static bool TryGetValue(IReadOnlyDictionary<string, object?> row, string key, out object? value)
+    {
+        if (row.TryGetValue(key, out value))
+        {
+            return true;
+        }
+
+        foreach (var pair in row)
+        {
+            if (string.Equals(pair.Key, key, StringComparison.OrdinalIgnoreCase))
+            {
+                value = pair.Value;
+                return true;
+            }
+        }
+
+        value = null;
+        return false;
+    }
+
+    private static DateTimeOffset? ReadDateTimeOffsetCore(object? value, string key) =>
+        value switch
+        {
+            null or DBNull => null,
+            DateTimeOffset dateTimeOffset => dateTimeOffset,
+            DateTime dateTime => Normalize(dateTime),
+            string text when DateTimeOffset.TryParse(text, out var parsed) => parsed,
+            _ => throw new InvalidOperationException($"Registry row value '{key}' must be a timestamp.")
+        };
+
+    private static DateTimeOffset Normalize(DateTime value) =>
+        new(DateTime.SpecifyKind(value, DateTimeKind.Utc));
+}

--- a/dcb/src/Sekiban.Dcb.MaterializedView.SqlServer/SqlServerMvRegistryStore.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.SqlServer/SqlServerMvRegistryStore.cs
@@ -62,66 +62,25 @@ public sealed class SqlServerMvRegistryStore : IMvRegistryStore
     public async Task RegisterAsync(MvRegistryEntry entry, IDbTransaction? transaction = null, CancellationToken cancellationToken = default)
     {
         const string sql = """
-            MERGE sekiban_mv_registry AS target
-            USING (
-                VALUES (
-                    @ServiceId,
-                    @ViewName,
-                    @ViewVersion,
-                    @LogicalTable,
-                    @PhysicalTable,
-                    @Status,
-                    @CurrentPosition,
-                    @TargetPosition,
-                    @LastSortableUniqueId,
-                    @AppliedEventVersion,
-                    @LastAppliedSource,
-                    @LastAppliedAt,
-                    @LastStreamReceivedSortableUniqueId,
-                    @LastStreamReceivedAt,
-                    @LastStreamAppliedSortableUniqueId,
-                    @LastCatchUpSortableUniqueId,
-                    @LastUpdated,
-                    @Metadata
-                )
-            ) AS source (
-                service_id,
-                view_name,
-                view_version,
-                logical_table,
-                physical_table,
-                status,
-                current_position,
-                target_position,
-                last_sortable_unique_id,
-                applied_event_version,
-                last_applied_source,
-                last_applied_at,
-                last_stream_received_sortable_unique_id,
-                last_stream_received_at,
-                last_stream_applied_sortable_unique_id,
-                last_catch_up_sortable_unique_id,
-                last_updated,
-                metadata
-            )
-            ON target.service_id = source.service_id
-               AND target.view_name = source.view_name
-               AND target.view_version = source.view_version
-               AND target.logical_table = source.logical_table
-            WHEN MATCHED THEN
-                UPDATE SET
-                    physical_table = source.physical_table,
-                    last_updated = source.last_updated,
-                    applied_event_version = target.applied_event_version,
-                    last_applied_source = COALESCE(target.last_applied_source, source.last_applied_source),
-                    last_applied_at = COALESCE(target.last_applied_at, source.last_applied_at),
-                    last_stream_received_sortable_unique_id = COALESCE(target.last_stream_received_sortable_unique_id, source.last_stream_received_sortable_unique_id),
-                    last_stream_received_at = COALESCE(target.last_stream_received_at, source.last_stream_received_at),
-                    last_stream_applied_sortable_unique_id = COALESCE(target.last_stream_applied_sortable_unique_id, source.last_stream_applied_sortable_unique_id),
-                    last_catch_up_sortable_unique_id = COALESCE(target.last_catch_up_sortable_unique_id, source.last_catch_up_sortable_unique_id),
-                    metadata = COALESCE(source.metadata, target.metadata)
-            WHEN NOT MATCHED THEN
-                INSERT (
+            UPDATE sekiban_mv_registry WITH (UPDLOCK, HOLDLOCK)
+            SET physical_table = @PhysicalTable,
+                last_updated = @LastUpdated,
+                applied_event_version = applied_event_version,
+                last_applied_source = COALESCE(last_applied_source, @LastAppliedSource),
+                last_applied_at = COALESCE(last_applied_at, @LastAppliedAt),
+                last_stream_received_sortable_unique_id = COALESCE(last_stream_received_sortable_unique_id, @LastStreamReceivedSortableUniqueId),
+                last_stream_received_at = COALESCE(last_stream_received_at, @LastStreamReceivedAt),
+                last_stream_applied_sortable_unique_id = COALESCE(last_stream_applied_sortable_unique_id, @LastStreamAppliedSortableUniqueId),
+                last_catch_up_sortable_unique_id = COALESCE(last_catch_up_sortable_unique_id, @LastCatchUpSortableUniqueId),
+                metadata = COALESCE(@Metadata, metadata)
+            WHERE service_id = @ServiceId
+              AND view_name = @ViewName
+              AND view_version = @ViewVersion
+              AND logical_table = @LogicalTable;
+
+            IF @@ROWCOUNT = 0
+            BEGIN
+                INSERT INTO sekiban_mv_registry (
                     service_id,
                     view_name,
                     view_version,
@@ -142,25 +101,26 @@ public sealed class SqlServerMvRegistryStore : IMvRegistryStore
                     metadata
                 )
                 VALUES (
-                    source.service_id,
-                    source.view_name,
-                    source.view_version,
-                    source.logical_table,
-                    source.physical_table,
-                    source.status,
-                    source.current_position,
-                    source.target_position,
-                    source.last_sortable_unique_id,
-                    source.applied_event_version,
-                    source.last_applied_source,
-                    source.last_applied_at,
-                    source.last_stream_received_sortable_unique_id,
-                    source.last_stream_received_at,
-                    source.last_stream_applied_sortable_unique_id,
-                    source.last_catch_up_sortable_unique_id,
-                    source.last_updated,
-                    source.metadata
+                    @ServiceId,
+                    @ViewName,
+                    @ViewVersion,
+                    @LogicalTable,
+                    @PhysicalTable,
+                    @Status,
+                    @CurrentPosition,
+                    @TargetPosition,
+                    @LastSortableUniqueId,
+                    @AppliedEventVersion,
+                    @LastAppliedSource,
+                    @LastAppliedAt,
+                    @LastStreamReceivedSortableUniqueId,
+                    @LastStreamReceivedAt,
+                    @LastStreamAppliedSortableUniqueId,
+                    @LastCatchUpSortableUniqueId,
+                    @LastUpdated,
+                    @Metadata
                 );
+            END;
             """;
 
         var parameters = new
@@ -370,17 +330,17 @@ public sealed class SqlServerMvRegistryStore : IMvRegistryStore
         CancellationToken cancellationToken = default)
     {
         const string sql = """
-            MERGE sekiban_mv_active AS target
-            USING (VALUES (@ServiceId, @ViewName, @ActiveVersion, SYSUTCDATETIME())) AS source (service_id, view_name, active_version, activated_at)
-            ON target.service_id = source.service_id
-               AND target.view_name = source.view_name
-            WHEN MATCHED THEN
-                UPDATE SET
-                    active_version = source.active_version,
-                    activated_at = source.activated_at
-            WHEN NOT MATCHED THEN
-                INSERT (service_id, view_name, active_version, activated_at)
-                VALUES (source.service_id, source.view_name, source.active_version, source.activated_at);
+            UPDATE sekiban_mv_active WITH (UPDLOCK, HOLDLOCK)
+            SET active_version = @ActiveVersion,
+                activated_at = SYSUTCDATETIME()
+            WHERE service_id = @ServiceId
+              AND view_name = @ViewName;
+
+            IF @@ROWCOUNT = 0
+            BEGIN
+                INSERT INTO sekiban_mv_active (service_id, view_name, active_version, activated_at)
+                VALUES (@ServiceId, @ViewName, @ActiveVersion, SYSUTCDATETIME());
+            END;
             """;
 
         await ExecuteAsync(

--- a/dcb/src/Sekiban.Dcb.MaterializedView.SqlServer/SqlServerMvRegistryStore.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.SqlServer/SqlServerMvRegistryStore.cs
@@ -65,7 +65,6 @@ public sealed class SqlServerMvRegistryStore : IMvRegistryStore
             UPDATE sekiban_mv_registry WITH (UPDLOCK, HOLDLOCK)
             SET physical_table = @PhysicalTable,
                 last_updated = @LastUpdated,
-                applied_event_version = applied_event_version,
                 last_applied_source = COALESCE(last_applied_source, @LastAppliedSource),
                 last_applied_at = COALESCE(last_applied_at, @LastAppliedAt),
                 last_stream_received_sortable_unique_id = COALESCE(last_stream_received_sortable_unique_id, @LastStreamReceivedSortableUniqueId),
@@ -145,7 +144,17 @@ public sealed class SqlServerMvRegistryStore : IMvRegistryStore
             entry.Metadata
         };
 
-        await ExecuteAsync(sql, parameters, transaction, cancellationToken).ConfigureAwait(false);
+        if (transaction is not null)
+        {
+            await ExecuteAsync(sql, parameters, transaction, cancellationToken).ConfigureAwait(false);
+            return;
+        }
+
+        await using var connection = new SqlConnection(_connectionString);
+        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+        await using var localTransaction = await connection.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
+        await connection.ExecuteAsync(new CommandDefinition(sql, parameters, localTransaction, cancellationToken: cancellationToken)).ConfigureAwait(false);
+        await localTransaction.CommitAsync(cancellationToken).ConfigureAwait(false);
     }
 
     public async Task UpdatePositionAsync(
@@ -343,11 +352,18 @@ public sealed class SqlServerMvRegistryStore : IMvRegistryStore
             END;
             """;
 
-        await ExecuteAsync(
-            sql,
-            new { ServiceId = serviceId, ViewName = viewName, ActiveVersion = activeVersion },
-            transaction,
-            cancellationToken).ConfigureAwait(false);
+        var parameters = new { ServiceId = serviceId, ViewName = viewName, ActiveVersion = activeVersion };
+        if (transaction is not null)
+        {
+            await ExecuteAsync(sql, parameters, transaction, cancellationToken).ConfigureAwait(false);
+            return;
+        }
+
+        await using var connection = new SqlConnection(_connectionString);
+        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+        await using var localTransaction = await connection.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
+        await connection.ExecuteAsync(new CommandDefinition(sql, parameters, localTransaction, cancellationToken: cancellationToken)).ConfigureAwait(false);
+        await localTransaction.CommitAsync(cancellationToken).ConfigureAwait(false);
     }
 
     private async Task ExecuteAsync(

--- a/dcb/src/Sekiban.Dcb.MaterializedView.Sqlite/Sekiban.Dcb.MaterializedView.Sqlite.csproj
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.Sqlite/Sekiban.Dcb.MaterializedView.Sqlite.csproj
@@ -1,0 +1,48 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <LangVersion>preview</LangVersion>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <AssemblyName>Sekiban.Dcb.MaterializedView.Sqlite</AssemblyName>
+        <RootNamespace>Sekiban.Dcb.MaterializedView.Sqlite</RootNamespace>
+        <PackageId>Sekiban.Dcb.MaterializedView.Sqlite</PackageId>
+        <Authors>J-Tech Group</Authors>
+        <Company>J-Tech-Japan</Company>
+        <Copyright>Copyright (c) J-Tech-Japan 2025</Copyright>
+        <PackageDescription>Sekiban - SQLite implementation for DCB materialized views</PackageDescription>
+        <RepositoryUrl>https://github.com/J-Tech-Japan/Sekiban</RepositoryUrl>
+        <PackageProjectUrl>https://github.com/J-Tech-Japan/Sekiban</PackageProjectUrl>
+        <PackageVersion>10.0.2-preview03</PackageVersion>
+        <Description>SQLite registry, apply context, and executor for Sekiban DCB materialized views</Description>
+        <PackageTags>event-sourcing;cqrs;ddd;dcb;sekiban;sqlite;materialized-view</PackageTags>
+        <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+        <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
+        <IncludeSymbols>true</IncludeSymbols>
+        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+        <GenerateSBOM>true</GenerateSBOM>
+        <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <FrameworkReference Include="Microsoft.AspNetCore.App"/>
+        <PackageReference Include="Dapper" Version="2.1.66"/>
+        <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.3"/>
+        <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.3"/>
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.3"/>
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.3"/>
+        <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.3"/>
+        <PackageReference Include="Microsoft.Sbom.Targets" Version="4.1.5">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <None Include="../../README.md" Pack="true" PackagePath="\"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\Sekiban.Dcb.Core\Sekiban.Dcb.Core.csproj"/>
+        <ProjectReference Include="..\Sekiban.Dcb.MaterializedView\Sekiban.Dcb.MaterializedView.csproj"/>
+    </ItemGroup>
+
+</Project>

--- a/dcb/src/Sekiban.Dcb.MaterializedView.Sqlite/SekibanDcbMaterializedViewSqliteExtensions.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.Sqlite/SekibanDcbMaterializedViewSqliteExtensions.cs
@@ -1,0 +1,67 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Sekiban.Dcb.ServiceId;
+
+namespace Sekiban.Dcb.MaterializedView.Sqlite;
+
+public static class SekibanDcbMaterializedViewSqliteExtensions
+{
+    public static IServiceCollection AddSekibanDcbMaterializedViewSqlite(
+        this IServiceCollection services,
+        IConfiguration configuration,
+        string connectionStringName = "DcbSqlite",
+        bool registerHostedWorker = true)
+    {
+        var connectionString = ResolveConnectionString(configuration, connectionStringName) ??
+            throw new InvalidOperationException($"Connection string '{connectionStringName}' not found.");
+        return services.AddSekibanDcbMaterializedViewSqlite(connectionString, registerHostedWorker);
+    }
+
+    public static IServiceCollection AddSekibanDcbMaterializedViewSqlite(
+        this IServiceCollection services,
+        string connectionString,
+        bool registerHostedWorker = true)
+    {
+        services.AddSekibanDcbMaterializedView();
+        services.TryAddSingleton<IServiceIdProvider, DefaultServiceIdProvider>();
+        services.TryAddSingleton<IMvRegistryStore>(_ => new SqliteMvRegistryStore(connectionString));
+        services.TryAddSingleton<IMvStorageInfoProvider>(_ =>
+            new MvStorageInfoProvider(new MvStorageInfo(MvDbType.Sqlite, connectionString)));
+        services.TryAddSingleton<IMvExecutor>(sp =>
+            new SqliteMvExecutor(
+                sp.GetRequiredService<Sekiban.Dcb.Storage.IEventStore>(),
+                sp.GetRequiredService<IServiceIdProvider>(),
+                sp.GetRequiredService<IMvRegistryStore>(),
+                sp.GetRequiredService<IOptions<MvOptions>>(),
+                sp.GetRequiredService<ILogger<SqliteMvExecutor>>(),
+                connectionString));
+        if (registerHostedWorker)
+        {
+            services.TryAddEnumerable(ServiceDescriptor.Singleton<IHostedService, MvCatchUpWorker>());
+        }
+
+        return services;
+    }
+
+    private static string? ResolveConnectionString(IConfiguration configuration, string connectionName)
+    {
+        var direct = configuration.GetConnectionString(connectionName);
+        if (!string.IsNullOrWhiteSpace(direct))
+        {
+            return direct;
+        }
+
+        var dotted = configuration[$"ConnectionStrings:{connectionName}"];
+        if (!string.IsNullOrWhiteSpace(dotted))
+        {
+            return dotted;
+        }
+
+        var aspNetCoreStyle = configuration[connectionName];
+        return string.IsNullOrWhiteSpace(aspNetCoreStyle) ? null : aspNetCoreStyle;
+    }
+}

--- a/dcb/src/Sekiban.Dcb.MaterializedView.Sqlite/SqliteMvContexts.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.Sqlite/SqliteMvContexts.cs
@@ -1,0 +1,104 @@
+using System.Data;
+using System.Text.Json;
+using Dapper;
+
+namespace Sekiban.Dcb.MaterializedView.Sqlite;
+
+internal static class SqliteMvValueAdapter
+{
+    public static IReadOnlyDictionary<string, object?> ToDictionary(object row)
+    {
+        if (row is IReadOnlyDictionary<string, object?> readOnlyDictionary)
+        {
+            return readOnlyDictionary;
+        }
+
+        if (row is IDictionary<string, object?> dictionary)
+        {
+            return dictionary.ToDictionary(pair => pair.Key, pair => pair.Value, StringComparer.OrdinalIgnoreCase);
+        }
+
+        if (row is IDictionary<string, object> nonNullableDictionary)
+        {
+            return nonNullableDictionary
+                .Select(pair => new KeyValuePair<string, object?>(pair.Key, pair.Value))
+                .ToDictionary(pair => pair.Key, pair => pair.Value, StringComparer.OrdinalIgnoreCase);
+        }
+
+        return row.GetType()
+            .GetProperties()
+            .ToDictionary(property => property.Name, property => property.GetValue(row), StringComparer.OrdinalIgnoreCase);
+    }
+}
+
+internal sealed class SqliteMvApplyQueryPort : IMvApplyDbConnectionPort
+{
+    private readonly IDbConnection _connection;
+    private readonly IDbTransaction _transaction;
+
+    public SqliteMvApplyQueryPort(IDbConnection connection, IDbTransaction transaction)
+    {
+        _connection = connection;
+        _transaction = transaction;
+    }
+
+    public IDbConnection Connection => _connection;
+    public IDbTransaction Transaction => _transaction;
+
+    public async Task<IReadOnlyList<JsonElement>> QueryRowsAsync(
+        string sql,
+        IReadOnlyList<MvParam> parameters,
+        CancellationToken ct)
+    {
+        var rows = await _connection.QueryAsync(
+            new CommandDefinition(
+                sql,
+                ToDynamicParameters(parameters),
+                _transaction,
+                cancellationToken: ct)).ConfigureAwait(false);
+        return rows
+            .Select(row => (JsonElement)JsonSerializer.SerializeToElement(SqliteMvValueAdapter.ToDictionary(row)))
+            .ToList();
+    }
+
+    public async Task<JsonElement?> QuerySingleOrDefaultAsync(
+        string sql,
+        IReadOnlyList<MvParam> parameters,
+        CancellationToken ct)
+    {
+        var row = await _connection.QuerySingleOrDefaultAsync(
+            new CommandDefinition(
+                sql,
+                ToDynamicParameters(parameters),
+                _transaction,
+                cancellationToken: ct)).ConfigureAwait(false);
+        return row is null
+            ? null
+            : JsonSerializer.SerializeToElement(SqliteMvValueAdapter.ToDictionary(row));
+    }
+
+    public async Task<string?> ExecuteScalarJsonAsync(
+        string sql,
+        IReadOnlyList<MvParam> parameters,
+        CancellationToken ct)
+    {
+        var scalar = await _connection.ExecuteScalarAsync(
+            new CommandDefinition(
+                sql,
+                ToDynamicParameters(parameters),
+                _transaction,
+                cancellationToken: ct)).ConfigureAwait(false);
+        return MvParamConverter.SerializeScalar(scalar);
+    }
+
+    private static DynamicParameters ToDynamicParameters(IReadOnlyList<MvParam> parameters)
+    {
+        var dynamicParameters = new DynamicParameters();
+        foreach (var parameter in parameters)
+        {
+            dynamicParameters.Add(parameter.Name, MvParamConverter.ToClrValue(parameter));
+        }
+
+        return dynamicParameters;
+    }
+}

--- a/dcb/src/Sekiban.Dcb.MaterializedView.Sqlite/SqliteMvExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.Sqlite/SqliteMvExecutor.cs
@@ -42,8 +42,7 @@ public sealed class SqliteMvExecutor : IMvExecutor
         await _registryStore.EnsureInfrastructureAsync(cancellationToken).ConfigureAwait(false);
         serviceId = ResolveServiceId(serviceId);
 
-        await using var connection = new SqliteConnection(_connectionString);
-        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+        await using var connection = await OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
         await using var transaction = await connection.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
 
         var bindings = new MvTableBindings(host.ViewName, host.ViewVersion, _options);
@@ -216,8 +215,7 @@ public sealed class SqliteMvExecutor : IMvExecutor
             return 0;
         }
 
-        await using var connection = new SqliteConnection(_connectionString);
-        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+        await using var connection = await OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
         var appliedEvents = 0;
         var bindings = CreateBindings(host, entries);
 
@@ -329,4 +327,12 @@ public sealed class SqliteMvExecutor : IMvExecutor
 
     private static SortableUniqueId CreateSafeThreshold(int safeWindowMs) =>
         new(SortableUniqueId.Generate(DateTime.UtcNow.AddMilliseconds(-safeWindowMs), Guid.Empty));
+
+    private async Task<SqliteConnection> OpenConnectionAsync(CancellationToken cancellationToken)
+    {
+        var connection = new SqliteConnection(_connectionString);
+        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+        await connection.ExecuteAsync(new CommandDefinition("PRAGMA synchronous=NORMAL;", cancellationToken: cancellationToken)).ConfigureAwait(false);
+        return connection;
+    }
 }

--- a/dcb/src/Sekiban.Dcb.MaterializedView.Sqlite/SqliteMvExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.Sqlite/SqliteMvExecutor.cs
@@ -1,0 +1,332 @@
+using Dapper;
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Sekiban.Dcb.Common;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.ServiceId;
+using Sekiban.Dcb.Storage;
+
+namespace Sekiban.Dcb.MaterializedView.Sqlite;
+
+public sealed class SqliteMvExecutor : IMvExecutor
+{
+    private readonly IEventStore _eventStore;
+    private readonly ILogger<SqliteMvExecutor> _logger;
+    private readonly MvOptions _options;
+    private readonly IMvRegistryStore _registryStore;
+    private readonly string _connectionString;
+    private readonly IServiceIdProvider _serviceIdProvider;
+
+    public SqliteMvExecutor(
+        IEventStore eventStore,
+        IServiceIdProvider serviceIdProvider,
+        IMvRegistryStore registryStore,
+        IOptions<MvOptions> options,
+        ILogger<SqliteMvExecutor> logger,
+        string connectionString)
+    {
+        _eventStore = eventStore;
+        _serviceIdProvider = serviceIdProvider;
+        _registryStore = registryStore;
+        _logger = logger;
+        _connectionString = connectionString;
+        _options = options.Value;
+    }
+
+    public async Task InitializeAsync(
+        IMvApplyHost host,
+        string? serviceId = null,
+        CancellationToken cancellationToken = default)
+    {
+        await _registryStore.EnsureInfrastructureAsync(cancellationToken).ConfigureAwait(false);
+        serviceId = ResolveServiceId(serviceId);
+
+        await using var connection = new SqliteConnection(_connectionString);
+        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+        await using var transaction = await connection.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
+
+        var bindings = new MvTableBindings(host.ViewName, host.ViewVersion, _options);
+        var statements = await host.InitializeAsync(bindings, cancellationToken).ConfigureAwait(false);
+        foreach (var statement in statements)
+        {
+            await connection.ExecuteAsync(
+                new CommandDefinition(
+                    statement.Sql,
+                    ToDynamicParameters(statement.Parameters),
+                    transaction,
+                    cancellationToken: cancellationToken)).ConfigureAwait(false);
+        }
+
+        foreach (var table in bindings.Tables)
+        {
+            await _registryStore.RegisterAsync(
+                new MvRegistryEntry
+                {
+                    ServiceId = serviceId,
+                    ViewName = host.ViewName,
+                    ViewVersion = host.ViewVersion,
+                    LogicalTable = table.LogicalName,
+                    PhysicalTable = table.PhysicalName,
+                    Status = MvStatus.CatchingUp,
+                    AppliedEventVersion = 0,
+                    LastUpdated = DateTimeOffset.UtcNow
+                },
+                transaction,
+                cancellationToken).ConfigureAwait(false);
+        }
+
+        var active = await _registryStore.GetActiveAsync(serviceId, host.ViewName, cancellationToken).ConfigureAwait(false);
+        if (active is null)
+        {
+            await _registryStore.SetActiveAsync(serviceId, host.ViewName, host.ViewVersion, transaction, cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<MvCatchUpResult> CatchUpOnceAsync(
+        IMvApplyHost host,
+        string? serviceId = null,
+        CancellationToken cancellationToken = default)
+    {
+        serviceId = ResolveServiceId(serviceId);
+        var entries = await _registryStore.GetEntriesAsync(serviceId, host.ViewName, host.ViewVersion, cancellationToken)
+            .ConfigureAwait(false);
+        if (entries.Count == 0)
+        {
+            await InitializeAsync(host, serviceId, cancellationToken).ConfigureAwait(false);
+            entries = await _registryStore.GetEntriesAsync(serviceId, host.ViewName, host.ViewVersion, cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        var currentPosition = entries
+            .Select(entry => entry.CurrentPosition)
+            .FirstOrDefault(position => !string.IsNullOrWhiteSpace(position));
+        var readResult = await _eventStore.ReadAllSerializableEventsAsync(
+            SortableUniqueId.NullableValue(currentPosition),
+            _options.BatchSize).ConfigureAwait(false);
+
+        if (!readResult.IsSuccess)
+        {
+            var exception = readResult.GetException();
+            if (exception is NotSupportedException)
+            {
+                throw exception;
+            }
+
+            _logger.LogWarning(
+                exception,
+                "Failed to read events for materialized view {ViewName}/{ViewVersion}.",
+                host.ViewName,
+                host.ViewVersion);
+            return new MvCatchUpResult(0, false);
+        }
+
+        var safeThreshold = CreateSafeThreshold(_options.SafeWindowMs);
+        var reachedUnsafeWindow = false;
+        var batch = readResult.GetValue().OrderBy(serializable => serializable.SortableUniqueIdValue).ToList();
+
+        if (batch.Count == 0)
+        {
+            return new MvCatchUpResult(0, false);
+        }
+
+        var safeBatch = new List<SerializableEvent>(batch.Count);
+        foreach (var serializableEvent in batch)
+        {
+            if (!new SortableUniqueId(serializableEvent.SortableUniqueIdValue).IsEarlierThanOrEqual(safeThreshold))
+            {
+                reachedUnsafeWindow = true;
+                break;
+            }
+
+            safeBatch.Add(serializableEvent);
+        }
+
+        if (safeBatch.Count == 0)
+        {
+            return new MvCatchUpResult(0, reachedUnsafeWindow);
+        }
+
+        var appliedEvents = await ApplySerializableEventsCoreAsync(
+                host,
+                safeBatch,
+                serviceId,
+                MvApplySource.CatchUp,
+                cancellationToken)
+            .ConfigureAwait(false);
+
+        var lastAppliedSortableUniqueId = appliedEvents > 0
+            ? safeBatch[appliedEvents - 1].SortableUniqueIdValue
+            : null;
+
+        reachedUnsafeWindow |= appliedEvents < safeBatch.Count;
+
+        return new MvCatchUpResult(appliedEvents, reachedUnsafeWindow, lastAppliedSortableUniqueId);
+    }
+
+    public async Task<int> ApplySerializableEventsAsync(
+        IMvApplyHost host,
+        IReadOnlyList<SerializableEvent> events,
+        string? serviceId = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (events.Count == 0)
+        {
+            return 0;
+        }
+
+        serviceId = ResolveServiceId(serviceId);
+        return await ApplySerializableEventsCoreAsync(host, events, serviceId, MvApplySource.Stream, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<int> ApplySerializableEventsCoreAsync(
+        IMvApplyHost host,
+        IReadOnlyList<SerializableEvent> events,
+        string serviceId,
+        MvApplySource source,
+        CancellationToken cancellationToken)
+    {
+        var entries = await _registryStore.GetEntriesAsync(serviceId, host.ViewName, host.ViewVersion, cancellationToken)
+            .ConfigureAwait(false);
+        if (entries.Count == 0)
+        {
+            await InitializeAsync(host, serviceId, cancellationToken).ConfigureAwait(false);
+            entries = await _registryStore.GetEntriesAsync(serviceId, host.ViewName, host.ViewVersion, cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        var currentPosition = entries
+            .Select(entry => entry.CurrentPosition)
+            .FirstOrDefault(position => !string.IsNullOrWhiteSpace(position));
+        var orderedEvents = events
+            .GroupBy(serializableEvent => serializableEvent.SortableUniqueIdValue)
+            .Select(group => group.First())
+            .Where(serializableEvent =>
+                source == MvApplySource.Stream ||
+                string.IsNullOrWhiteSpace(currentPosition) ||
+                string.Compare(serializableEvent.SortableUniqueIdValue, currentPosition, StringComparison.Ordinal) > 0)
+            .OrderBy(serializableEvent => serializableEvent.SortableUniqueIdValue, StringComparer.Ordinal)
+            .ToList();
+
+        if (orderedEvents.Count == 0)
+        {
+            return 0;
+        }
+
+        await using var connection = new SqliteConnection(_connectionString);
+        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+        var appliedEvents = 0;
+        var bindings = CreateBindings(host, entries);
+
+        foreach (var serializableEvent in orderedEvents)
+        {
+            var applied = await ApplySerializableEventAsync(
+                    connection,
+                    host,
+                    serviceId,
+                    bindings,
+                    serializableEvent,
+                    currentPosition,
+                    source,
+                    cancellationToken)
+                .ConfigureAwait(false);
+            if (!applied)
+            {
+                break;
+            }
+
+            appliedEvents += 1;
+        }
+
+        return appliedEvents;
+    }
+
+    private async Task<bool> ApplySerializableEventAsync(
+        SqliteConnection connection,
+        IMvApplyHost host,
+        string serviceId,
+        MvTableBindings bindings,
+        SerializableEvent serializableEvent,
+        string? currentPosition,
+        MvApplySource source,
+        CancellationToken cancellationToken)
+    {
+        await using var transaction = await connection.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
+        var queryPort = new SqliteMvApplyQueryPort(connection, transaction);
+        var statements = await host.ApplyEventAsync(
+            serializableEvent,
+            bindings,
+            queryPort,
+            serializableEvent.SortableUniqueIdValue,
+            cancellationToken).ConfigureAwait(false);
+        var affectedRows = 0;
+        foreach (var statement in statements)
+        {
+            affectedRows += await connection.ExecuteAsync(
+                new CommandDefinition(
+                    statement.Sql,
+                    ToDynamicParameters(statement.Parameters),
+                    transaction,
+                    cancellationToken: cancellationToken)).ConfigureAwait(false);
+        }
+
+        if (source == MvApplySource.Stream && statements.Count > 0 && affectedRows == 0)
+        {
+            if (!string.IsNullOrWhiteSpace(currentPosition) &&
+                string.Compare(serializableEvent.SortableUniqueIdValue, currentPosition, StringComparison.Ordinal) <= 0)
+            {
+                await transaction.RollbackAsync(cancellationToken).ConfigureAwait(false);
+                return true;
+            }
+
+            await transaction.RollbackAsync(cancellationToken).ConfigureAwait(false);
+            return false;
+        }
+
+        await _registryStore.UpdatePositionAsync(
+            new MvPositionUpdate(
+                serviceId,
+                host.ViewName,
+                host.ViewVersion,
+                serializableEvent.SortableUniqueIdValue,
+                source),
+            transaction: transaction,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+        return true;
+    }
+
+    private string ResolveServiceId(string? serviceId) =>
+        string.IsNullOrWhiteSpace(serviceId)
+            ? _serviceIdProvider.GetCurrentServiceId()
+            : serviceId;
+
+    private MvTableBindings CreateBindings(IMvApplyHost host, IReadOnlyList<MvRegistryEntry> entries)
+    {
+        var bindings = new MvTableBindings(host.ViewName, host.ViewVersion, _options);
+        foreach (var entry in entries)
+        {
+            bindings.RegisterTable(entry.LogicalTable, entry.PhysicalTable);
+        }
+
+        return bindings;
+    }
+
+    private static DynamicParameters ToDynamicParameters(IReadOnlyList<MvParam> parameters)
+    {
+        var dynamicParameters = new DynamicParameters();
+        foreach (var parameter in parameters)
+        {
+            dynamicParameters.Add(parameter.Name, MvParamConverter.ToClrValue(parameter));
+        }
+
+        return dynamicParameters;
+    }
+
+    private static SortableUniqueId CreateSafeThreshold(int safeWindowMs) =>
+        new(SortableUniqueId.Generate(DateTime.UtcNow.AddMilliseconds(-safeWindowMs), Guid.Empty));
+}

--- a/dcb/src/Sekiban.Dcb.MaterializedView.Sqlite/SqliteMvRegistryStore.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.Sqlite/SqliteMvRegistryStore.cs
@@ -1,0 +1,501 @@
+using System.Data;
+using Dapper;
+using Microsoft.Data.Sqlite;
+
+namespace Sekiban.Dcb.MaterializedView.Sqlite;
+
+public sealed class SqliteMvRegistryStore : IMvRegistryStore
+{
+    private readonly string _connectionString;
+
+    public SqliteMvRegistryStore(string connectionString)
+    {
+        _connectionString = connectionString;
+    }
+
+    public async Task EnsureInfrastructureAsync(CancellationToken cancellationToken = default)
+    {
+        await using var connection = new SqliteConnection(_connectionString);
+        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+        const string registrySql = """
+            CREATE TABLE IF NOT EXISTS sekiban_mv_registry (
+                service_id TEXT NOT NULL,
+                view_name TEXT NOT NULL,
+                view_version INTEGER NOT NULL,
+                logical_table TEXT NOT NULL,
+                physical_table TEXT NOT NULL,
+                status TEXT NOT NULL,
+                current_position TEXT NULL,
+                target_position TEXT NULL,
+                last_sortable_unique_id TEXT NULL,
+                applied_event_version INTEGER NOT NULL DEFAULT 0,
+                last_applied_source TEXT NULL,
+                last_applied_at TEXT NULL,
+                last_stream_received_sortable_unique_id TEXT NULL,
+                last_stream_received_at TEXT NULL,
+                last_stream_applied_sortable_unique_id TEXT NULL,
+                last_catch_up_sortable_unique_id TEXT NULL,
+                last_updated TEXT NOT NULL,
+                metadata TEXT NULL,
+                PRIMARY KEY (service_id, view_name, view_version, logical_table)
+            );
+            """;
+
+        const string activeSql = """
+            CREATE TABLE IF NOT EXISTS sekiban_mv_active (
+                service_id TEXT NOT NULL,
+                view_name TEXT NOT NULL,
+                active_version INTEGER NOT NULL,
+                activated_at TEXT NOT NULL,
+                PRIMARY KEY (service_id, view_name)
+            );
+            """;
+
+        await connection.ExecuteAsync(new CommandDefinition(registrySql, cancellationToken: cancellationToken)).ConfigureAwait(false);
+        await connection.ExecuteAsync(new CommandDefinition(activeSql, cancellationToken: cancellationToken)).ConfigureAwait(false);
+    }
+
+    public async Task RegisterAsync(MvRegistryEntry entry, IDbTransaction? transaction = null, CancellationToken cancellationToken = default)
+    {
+        const string sql = """
+            INSERT INTO sekiban_mv_registry (
+                service_id,
+                view_name,
+                view_version,
+                logical_table,
+                physical_table,
+                status,
+                current_position,
+                target_position,
+                last_sortable_unique_id,
+                applied_event_version,
+                last_applied_source,
+                last_applied_at,
+                last_stream_received_sortable_unique_id,
+                last_stream_received_at,
+                last_stream_applied_sortable_unique_id,
+                last_catch_up_sortable_unique_id,
+                last_updated,
+                metadata
+            )
+            VALUES (
+                @ServiceId,
+                @ViewName,
+                @ViewVersion,
+                @LogicalTable,
+                @PhysicalTable,
+                @Status,
+                @CurrentPosition,
+                @TargetPosition,
+                @LastSortableUniqueId,
+                @AppliedEventVersion,
+                @LastAppliedSource,
+                @LastAppliedAt,
+                @LastStreamReceivedSortableUniqueId,
+                @LastStreamReceivedAt,
+                @LastStreamAppliedSortableUniqueId,
+                @LastCatchUpSortableUniqueId,
+                @LastUpdated,
+                @Metadata
+            )
+            ON CONFLICT (service_id, view_name, view_version, logical_table) DO UPDATE SET
+                physical_table = excluded.physical_table,
+                last_updated = excluded.last_updated,
+                applied_event_version = sekiban_mv_registry.applied_event_version,
+                last_applied_source = COALESCE(sekiban_mv_registry.last_applied_source, excluded.last_applied_source),
+                last_applied_at = COALESCE(sekiban_mv_registry.last_applied_at, excluded.last_applied_at),
+                last_stream_received_sortable_unique_id = COALESCE(sekiban_mv_registry.last_stream_received_sortable_unique_id, excluded.last_stream_received_sortable_unique_id),
+                last_stream_received_at = COALESCE(sekiban_mv_registry.last_stream_received_at, excluded.last_stream_received_at),
+                last_stream_applied_sortable_unique_id = COALESCE(sekiban_mv_registry.last_stream_applied_sortable_unique_id, excluded.last_stream_applied_sortable_unique_id),
+                last_catch_up_sortable_unique_id = COALESCE(sekiban_mv_registry.last_catch_up_sortable_unique_id, excluded.last_catch_up_sortable_unique_id),
+                metadata = COALESCE(excluded.metadata, sekiban_mv_registry.metadata);
+            """;
+
+        var parameters = new
+        {
+            entry.ServiceId,
+            entry.ViewName,
+            entry.ViewVersion,
+            entry.LogicalTable,
+            entry.PhysicalTable,
+            Status = entry.Status.ToString().ToLowerInvariant(),
+            entry.CurrentPosition,
+            entry.TargetPosition,
+            entry.LastSortableUniqueId,
+            entry.AppliedEventVersion,
+            entry.LastAppliedSource,
+            LastAppliedAt = SerializeDate(entry.LastAppliedAt),
+            entry.LastStreamReceivedSortableUniqueId,
+            LastStreamReceivedAt = SerializeDate(entry.LastStreamReceivedAt),
+            entry.LastStreamAppliedSortableUniqueId,
+            entry.LastCatchUpSortableUniqueId,
+            LastUpdated = SerializeDate(entry.LastUpdated),
+            entry.Metadata
+        };
+
+        await ExecuteAsync(sql, parameters, transaction, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task UpdatePositionAsync(
+        MvPositionUpdate update,
+        IDbTransaction? transaction = null,
+        CancellationToken cancellationToken = default)
+    {
+        const string sql = """
+            UPDATE sekiban_mv_registry
+            SET current_position = CASE
+                    WHEN current_position IS NULL
+                      OR current_position < @SortableUniqueId THEN @SortableUniqueId
+                    ELSE current_position
+                END,
+                last_sortable_unique_id = CASE
+                    WHEN last_sortable_unique_id IS NULL
+                      OR last_sortable_unique_id < @SortableUniqueId THEN @SortableUniqueId
+                    ELSE last_sortable_unique_id
+                END,
+                applied_event_version = applied_event_version + @AppliedEventVersionDelta,
+                last_applied_source = @Source,
+                last_applied_at = @Now,
+                last_stream_applied_sortable_unique_id = CASE
+                    WHEN @Source = 'stream'
+                      AND (last_stream_applied_sortable_unique_id IS NULL
+                        OR last_stream_applied_sortable_unique_id < @SortableUniqueId) THEN @SortableUniqueId
+                    ELSE last_stream_applied_sortable_unique_id
+                END,
+                last_catch_up_sortable_unique_id = CASE
+                    WHEN @Source = 'catchup'
+                      AND (last_catch_up_sortable_unique_id IS NULL
+                        OR last_catch_up_sortable_unique_id < @SortableUniqueId) THEN @SortableUniqueId
+                    ELSE last_catch_up_sortable_unique_id
+                END,
+                last_updated = @Now
+            WHERE service_id = @ServiceId
+              AND view_name = @ViewName
+              AND view_version = @ViewVersion;
+            """;
+
+        await ExecuteAsync(
+            sql,
+            new
+            {
+                update.ServiceId,
+                update.ViewName,
+                update.ViewVersion,
+                update.SortableUniqueId,
+                update.AppliedEventVersionDelta,
+                Source = update.Source == MvApplySource.Stream ? "stream" : "catchup",
+                Now = SerializeDate(DateTimeOffset.UtcNow)
+            },
+            transaction,
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task MarkStreamReceivedAsync(
+        string serviceId,
+        string viewName,
+        int viewVersion,
+        string sortableUniqueId,
+        DateTimeOffset receivedAt,
+        IDbTransaction? transaction = null,
+        CancellationToken cancellationToken = default)
+    {
+        const string sql = """
+            UPDATE sekiban_mv_registry
+            SET last_stream_received_sortable_unique_id = CASE
+                    WHEN last_stream_received_sortable_unique_id IS NULL
+                      OR last_stream_received_sortable_unique_id < @SortableUniqueId THEN @SortableUniqueId
+                    ELSE last_stream_received_sortable_unique_id
+                END,
+                last_stream_received_at = @ReceivedAt,
+                last_updated = @Now
+            WHERE service_id = @ServiceId
+              AND view_name = @ViewName
+              AND view_version = @ViewVersion;
+            """;
+
+        await ExecuteAsync(
+            sql,
+            new
+            {
+                ServiceId = serviceId,
+                ViewName = viewName,
+                ViewVersion = viewVersion,
+                SortableUniqueId = sortableUniqueId,
+                ReceivedAt = SerializeDate(receivedAt),
+                Now = SerializeDate(DateTimeOffset.UtcNow)
+            },
+            transaction,
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task UpdateStatusAsync(
+        string serviceId,
+        string viewName,
+        int viewVersion,
+        MvStatus status,
+        IDbTransaction? transaction = null,
+        CancellationToken cancellationToken = default)
+    {
+        const string sql = """
+            UPDATE sekiban_mv_registry
+            SET status = @Status,
+                last_updated = @Now
+            WHERE service_id = @ServiceId
+              AND view_name = @ViewName
+              AND view_version = @ViewVersion;
+            """;
+
+        await ExecuteAsync(
+            sql,
+            new
+            {
+                ServiceId = serviceId,
+                ViewName = viewName,
+                ViewVersion = viewVersion,
+                Status = status.ToString().ToLowerInvariant(),
+                Now = SerializeDate(DateTimeOffset.UtcNow)
+            },
+            transaction,
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<IReadOnlyList<MvRegistryEntry>> GetEntriesAsync(
+        string serviceId,
+        string viewName,
+        int viewVersion,
+        CancellationToken cancellationToken = default)
+    {
+        const string sql = """
+            SELECT service_id AS ServiceId,
+                   view_name AS ViewName,
+                   view_version AS ViewVersion,
+                   logical_table AS LogicalTable,
+                   physical_table AS PhysicalTable,
+                   status AS Status,
+                   current_position AS CurrentPosition,
+                   target_position AS TargetPosition,
+                   last_sortable_unique_id AS LastSortableUniqueId,
+                   applied_event_version AS AppliedEventVersion,
+                   last_applied_source AS LastAppliedSource,
+                   last_applied_at AS LastAppliedAt,
+                   last_stream_received_sortable_unique_id AS LastStreamReceivedSortableUniqueId,
+                   last_stream_received_at AS LastStreamReceivedAt,
+                   last_stream_applied_sortable_unique_id AS LastStreamAppliedSortableUniqueId,
+                   last_catch_up_sortable_unique_id AS LastCatchUpSortableUniqueId,
+                   last_updated AS LastUpdated,
+                   metadata AS Metadata
+            FROM sekiban_mv_registry
+            WHERE service_id = @ServiceId
+              AND view_name = @ViewName
+              AND view_version = @ViewVersion
+            ORDER BY logical_table;
+            """;
+
+        await using var connection = new SqliteConnection(_connectionString);
+        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+        var rows = await connection.QueryAsync(
+            new CommandDefinition(sql, new { ServiceId = serviceId, ViewName = viewName, ViewVersion = viewVersion }, cancellationToken: cancellationToken))
+            .ConfigureAwait(false);
+        return rows.Select(row => (MvRegistryEntry)MapEntry(ToDictionary(row))).ToList();
+    }
+
+    public async Task<MvActiveEntry?> GetActiveAsync(
+        string serviceId,
+        string viewName,
+        CancellationToken cancellationToken = default)
+    {
+        const string sql = """
+            SELECT service_id AS ServiceId,
+                   view_name AS ViewName,
+                   active_version AS ActiveVersion,
+                   activated_at AS ActivatedAt
+            FROM sekiban_mv_active
+            WHERE service_id = @ServiceId
+              AND view_name = @ViewName;
+            """;
+
+        await using var connection = new SqliteConnection(_connectionString);
+        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+        var row = await connection.QuerySingleOrDefaultAsync(
+            new CommandDefinition(sql, new { ServiceId = serviceId, ViewName = viewName }, cancellationToken: cancellationToken))
+            .ConfigureAwait(false);
+        return row is null ? null : MapActiveEntry(ToDictionary(row));
+    }
+
+    public async Task SetActiveAsync(
+        string serviceId,
+        string viewName,
+        int activeVersion,
+        IDbTransaction? transaction = null,
+        CancellationToken cancellationToken = default)
+    {
+        const string sql = """
+            INSERT INTO sekiban_mv_active (service_id, view_name, active_version, activated_at)
+            VALUES (@ServiceId, @ViewName, @ActiveVersion, @ActivatedAt)
+            ON CONFLICT (service_id, view_name) DO UPDATE SET
+                active_version = excluded.active_version,
+                activated_at = excluded.activated_at;
+            """;
+
+        await ExecuteAsync(
+            sql,
+            new
+            {
+                ServiceId = serviceId,
+                ViewName = viewName,
+                ActiveVersion = activeVersion,
+                ActivatedAt = SerializeDate(DateTimeOffset.UtcNow)
+            },
+            transaction,
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task ExecuteAsync(
+        string sql,
+        object parameters,
+        IDbTransaction? transaction,
+        CancellationToken cancellationToken)
+    {
+        if (transaction is null)
+        {
+            await using var connection = new SqliteConnection(_connectionString);
+            await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+            await connection.ExecuteAsync(new CommandDefinition(sql, parameters, cancellationToken: cancellationToken)).ConfigureAwait(false);
+            return;
+        }
+
+        await transaction.Connection!.ExecuteAsync(
+            new CommandDefinition(sql, parameters, transaction, cancellationToken: cancellationToken)).ConfigureAwait(false);
+    }
+
+    private static MvRegistryEntry MapEntry(IReadOnlyDictionary<string, object?> row) =>
+        new()
+        {
+            ServiceId = ReadRequiredString(row, "ServiceId"),
+            ViewName = ReadRequiredString(row, "ViewName"),
+            ViewVersion = ReadRequiredInt(row, "ViewVersion"),
+            LogicalTable = ReadRequiredString(row, "LogicalTable"),
+            PhysicalTable = ReadRequiredString(row, "PhysicalTable"),
+            Status = Enum.Parse<MvStatus>(ReadRequiredString(row, "Status"), ignoreCase: true),
+            CurrentPosition = ReadNullableString(row, "CurrentPosition"),
+            TargetPosition = ReadNullableString(row, "TargetPosition"),
+            LastSortableUniqueId = ReadNullableString(row, "LastSortableUniqueId"),
+            AppliedEventVersion = ReadRequiredLong(row, "AppliedEventVersion"),
+            LastAppliedSource = ReadNullableString(row, "LastAppliedSource"),
+            LastAppliedAt = ReadNullableDateTimeOffset(row, "LastAppliedAt"),
+            LastStreamReceivedSortableUniqueId = ReadNullableString(row, "LastStreamReceivedSortableUniqueId"),
+            LastStreamReceivedAt = ReadNullableDateTimeOffset(row, "LastStreamReceivedAt"),
+            LastStreamAppliedSortableUniqueId = ReadNullableString(row, "LastStreamAppliedSortableUniqueId"),
+            LastCatchUpSortableUniqueId = ReadNullableString(row, "LastCatchUpSortableUniqueId"),
+            LastUpdated = ReadRequiredDateTimeOffset(row, "LastUpdated"),
+            Metadata = ReadNullableString(row, "Metadata")
+        };
+
+    private static MvActiveEntry MapActiveEntry(IReadOnlyDictionary<string, object?> row) =>
+        new(
+            ReadRequiredString(row, "ServiceId"),
+            ReadRequiredString(row, "ViewName"),
+            ReadRequiredInt(row, "ActiveVersion"),
+            ReadRequiredDateTimeOffset(row, "ActivatedAt"));
+
+    private static IReadOnlyDictionary<string, object?> ToDictionary(object row)
+    {
+        if (row is IReadOnlyDictionary<string, object?> readOnlyDictionary)
+        {
+            return readOnlyDictionary;
+        }
+
+        if (row is IDictionary<string, object?> dictionary)
+        {
+            return new Dictionary<string, object?>(dictionary, StringComparer.OrdinalIgnoreCase);
+        }
+
+        if (row is IDictionary<string, object> nonNullableDictionary)
+        {
+            return nonNullableDictionary
+                .Select(pair => new KeyValuePair<string, object?>(pair.Key, pair.Value))
+                .ToDictionary(pair => pair.Key, pair => pair.Value, StringComparer.OrdinalIgnoreCase);
+        }
+
+        if (row is System.Collections.IDictionary legacyDictionary)
+        {
+            return legacyDictionary.Cast<System.Collections.DictionaryEntry>()
+                .ToDictionary(
+                    entry => entry.Key.ToString() ?? string.Empty,
+                    entry => entry.Value,
+                    StringComparer.OrdinalIgnoreCase);
+        }
+
+        return row.GetType()
+            .GetProperties()
+            .ToDictionary(property => property.Name, property => property.GetValue(row), StringComparer.OrdinalIgnoreCase);
+    }
+
+    private static string ReadRequiredString(IReadOnlyDictionary<string, object?> row, string key) =>
+        TryGetValue(row, key, out var value) && value is not null
+            ? value.ToString()!
+            : throw new InvalidOperationException($"Registry row is missing required value '{key}'.");
+
+    private static string? ReadNullableString(IReadOnlyDictionary<string, object?> row, string key) =>
+        TryGetValue(row, key, out var value) && value is not null
+            ? value.ToString()
+            : null;
+
+    private static int ReadRequiredInt(IReadOnlyDictionary<string, object?> row, string key) =>
+        Convert.ToInt32(TryGetValue(row, key, out var value)
+            ? value
+            : throw new InvalidOperationException($"Registry row is missing required value '{key}'."));
+
+    private static long ReadRequiredLong(IReadOnlyDictionary<string, object?> row, string key) =>
+        Convert.ToInt64(TryGetValue(row, key, out var value)
+            ? value
+            : throw new InvalidOperationException($"Registry row is missing required value '{key}'."));
+
+    private static DateTimeOffset ReadRequiredDateTimeOffset(IReadOnlyDictionary<string, object?> row, string key) =>
+        ReadDateTimeOffsetCore(
+            TryGetValue(row, key, out var value)
+                ? value
+                : throw new InvalidOperationException($"Registry row is missing required value '{key}'."),
+            key) ??
+        throw new InvalidOperationException($"Registry row is missing required timestamp '{key}'.");
+
+    private static DateTimeOffset? ReadNullableDateTimeOffset(IReadOnlyDictionary<string, object?> row, string key) =>
+        TryGetValue(row, key, out var value) ? ReadDateTimeOffsetCore(value, key) : null;
+
+    private static bool TryGetValue(IReadOnlyDictionary<string, object?> row, string key, out object? value)
+    {
+        if (row.TryGetValue(key, out value))
+        {
+            return true;
+        }
+
+        foreach (var pair in row)
+        {
+            if (string.Equals(pair.Key, key, StringComparison.OrdinalIgnoreCase))
+            {
+                value = pair.Value;
+                return true;
+            }
+        }
+
+        value = null;
+        return false;
+    }
+
+    private static DateTimeOffset? ReadDateTimeOffsetCore(object? value, string key) =>
+        value switch
+        {
+            null or DBNull => null,
+            DateTimeOffset dateTimeOffset => dateTimeOffset,
+            DateTime dateTime => Normalize(dateTime),
+            string text when DateTimeOffset.TryParse(text, out var parsed) => parsed,
+            _ => throw new InvalidOperationException($"Registry row value '{key}' must be a timestamp.")
+        };
+
+    private static DateTimeOffset Normalize(DateTime value) =>
+        new(DateTime.SpecifyKind(value, DateTimeKind.Utc));
+
+    private static string? SerializeDate(DateTimeOffset? value) =>
+        value?.UtcDateTime.ToString("O");
+}

--- a/dcb/src/Sekiban.Dcb.MaterializedView.Sqlite/SqliteMvRegistryStore.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.Sqlite/SqliteMvRegistryStore.cs
@@ -18,6 +18,11 @@ public sealed class SqliteMvRegistryStore : IMvRegistryStore
         await using var connection = new SqliteConnection(_connectionString);
         await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
 
+        const string pragmaSql = """
+            PRAGMA journal_mode=WAL;
+            PRAGMA synchronous=NORMAL;
+            """;
+
         const string registrySql = """
             CREATE TABLE IF NOT EXISTS sekiban_mv_registry (
                 service_id TEXT NOT NULL,
@@ -52,6 +57,7 @@ public sealed class SqliteMvRegistryStore : IMvRegistryStore
             );
             """;
 
+        await connection.ExecuteAsync(new CommandDefinition(pragmaSql, cancellationToken: cancellationToken)).ConfigureAwait(false);
         await connection.ExecuteAsync(new CommandDefinition(registrySql, cancellationToken: cancellationToken)).ConfigureAwait(false);
         await connection.ExecuteAsync(new CommandDefinition(activeSql, cancellationToken: cancellationToken)).ConfigureAwait(false);
     }

--- a/dcb/src/Sekiban.Dcb.MaterializedView/MvApplyHostSupport.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView/MvApplyHostSupport.cs
@@ -142,10 +142,15 @@ public sealed class NativeMvApplyHostFactory : IMvApplyHostFactory
     private readonly IEventTypes _eventTypes;
     private readonly Dictionary<(string ViewName, int ViewVersion), IMaterializedViewProjector> _projectors;
     private readonly IReadOnlyList<MvApplyHostRegistration> _registrations;
+    private readonly IServiceProvider _services;
 
-    public NativeMvApplyHostFactory(IEnumerable<IMaterializedViewProjector> projectors, IEventTypes eventTypes)
+    public NativeMvApplyHostFactory(
+        IEnumerable<IMaterializedViewProjector> projectors,
+        IEventTypes eventTypes,
+        IServiceProvider services)
     {
         _eventTypes = eventTypes;
+        _services = services;
         _projectors = projectors.ToDictionary(
             projector => (projector.ViewName, projector.ViewVersion),
             projector => projector);
@@ -165,20 +170,31 @@ public sealed class NativeMvApplyHostFactory : IMvApplyHostFactory
             throw new InvalidOperationException($"Materialized view apply host '{viewName}/{viewVersion}' is not registered.");
         }
 
-        return new NativeMvApplyHost(projector, _eventTypes);
+        return new NativeMvApplyHost(projector, _eventTypes, ResolveDatabaseType());
     }
+
+    private MvDbType ResolveDatabaseType() =>
+        (_services.GetService(typeof(IMvStorageInfoProvider)) as IMvStorageInfoProvider)
+            ?.GetStorageInfo()
+            .DatabaseType
+        ?? MvDbType.Postgres;
 }
 
 public sealed class NativeMvApplyHost : IMvApplyHost
 {
+    private readonly MvDbType _databaseType;
     private readonly IEventTypes _eventTypes;
     private readonly IMaterializedViewProjector _projector;
     private readonly List<string> _logicalTables = [];
 
-    public NativeMvApplyHost(IMaterializedViewProjector projector, IEventTypes eventTypes)
+    public NativeMvApplyHost(
+        IMaterializedViewProjector projector,
+        IEventTypes eventTypes,
+        MvDbType databaseType = MvDbType.Postgres)
     {
         _projector = projector;
         _eventTypes = eventTypes;
+        _databaseType = databaseType;
     }
 
     public string ViewName => _projector.ViewName;
@@ -187,7 +203,7 @@ public sealed class NativeMvApplyHost : IMvApplyHost
 
     public async Task<IReadOnlyList<MvSqlStatementDto>> InitializeAsync(IMvTableBindings tables, CancellationToken ct)
     {
-        var recordingContext = new RecordingMvInitContext(tables);
+        var recordingContext = new RecordingMvInitContext(tables, _databaseType);
         await _projector.InitializeAsync(recordingContext, ct).ConfigureAwait(false);
 
         _logicalTables.Clear();
@@ -211,20 +227,26 @@ public sealed class NativeMvApplyHost : IMvApplyHost
         var applyContext = new NativeMvApplyContextAdapter(
             eventResult.GetValue(),
             sortableUniqueId,
-            queryPort);
+            queryPort,
+            _databaseType);
         var statements = await _projector.ApplyToViewAsync(eventResult.GetValue(), applyContext, ct).ConfigureAwait(false);
         return statements.Select(statement => new MvSqlStatementDto(statement.Sql, MvParamConverter.FromObject(statement.Parameters))).ToList();
     }
 
     private sealed class RecordingMvInitContext : IMvInitContext
     {
+        private readonly MvDbType _databaseType;
         private readonly IMvTableBindings _bindings;
         private readonly List<MvSqlStatementDto> _statements = [];
 
-        public RecordingMvInitContext(IMvTableBindings bindings) => _bindings = bindings;
+        public RecordingMvInitContext(IMvTableBindings bindings, MvDbType databaseType)
+        {
+            _bindings = bindings;
+            _databaseType = databaseType;
+        }
 
         public IReadOnlyList<MvSqlStatementDto> Statements => _statements;
-        public MvDbType DatabaseType => MvDbType.Postgres;
+        public MvDbType DatabaseType => _databaseType;
         public System.Data.IDbConnection Connection => throw new NotSupportedException("Native MV init host does not expose raw connections.");
 
         public MvTable RegisterTable(string logicalName) => _bindings.RegisterTable(logicalName);
@@ -238,16 +260,22 @@ public sealed class NativeMvApplyHost : IMvApplyHost
 
     private sealed class NativeMvApplyContextAdapter : IMvApplyContext
     {
+        private readonly MvDbType _databaseType;
         private readonly IMvApplyQueryPort _queryPort;
 
-        public NativeMvApplyContextAdapter(Event currentEvent, string sortableUniqueId, IMvApplyQueryPort queryPort)
+        public NativeMvApplyContextAdapter(
+            Event currentEvent,
+            string sortableUniqueId,
+            IMvApplyQueryPort queryPort,
+            MvDbType databaseType)
         {
             CurrentEvent = currentEvent;
             CurrentSortableUniqueId = sortableUniqueId;
             _queryPort = queryPort;
+            _databaseType = databaseType;
         }
 
-        public MvDbType DatabaseType => MvDbType.Postgres;
+        public MvDbType DatabaseType => _databaseType;
         public System.Data.IDbConnection Connection =>
             _queryPort is IMvApplyDbConnectionPort dbConnectionPort
                 ? dbConnectionPort.Connection

--- a/dcb/src/Sekiban.Dcb.MaterializedView/MvApplyHostSupport.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView/MvApplyHostSupport.cs
@@ -139,18 +139,35 @@ public static class MvParamConverter
 
 public sealed class NativeMvApplyHostFactory : IMvApplyHostFactory
 {
+    private readonly MvDbType? _defaultDatabaseType;
     private readonly IEventTypes _eventTypes;
     private readonly Dictionary<(string ViewName, int ViewVersion), IMaterializedViewProjector> _projectors;
     private readonly IReadOnlyList<MvApplyHostRegistration> _registrations;
-    private readonly IServiceProvider _services;
+    private readonly IMvStorageInfoProvider? _storageInfoProvider;
+
+    public NativeMvApplyHostFactory(
+        IEnumerable<IMaterializedViewProjector> projectors,
+        IEventTypes eventTypes)
+    {
+        _eventTypes = eventTypes;
+        _defaultDatabaseType = MvDbType.Postgres;
+        _projectors = projectors.ToDictionary(
+            projector => (projector.ViewName, projector.ViewVersion),
+            projector => projector);
+        _registrations = _projectors.Keys
+            .Select(key => new MvApplyHostRegistration(key.ViewName, key.ViewVersion))
+            .OrderBy(registration => registration.ViewName, StringComparer.Ordinal)
+            .ThenBy(registration => registration.ViewVersion)
+            .ToList();
+    }
 
     public NativeMvApplyHostFactory(
         IEnumerable<IMaterializedViewProjector> projectors,
         IEventTypes eventTypes,
-        IServiceProvider services)
+        IMvStorageInfoProvider storageInfoProvider)
     {
         _eventTypes = eventTypes;
-        _services = services;
+        _storageInfoProvider = storageInfoProvider;
         _projectors = projectors.ToDictionary(
             projector => (projector.ViewName, projector.ViewVersion),
             projector => projector);
@@ -173,11 +190,9 @@ public sealed class NativeMvApplyHostFactory : IMvApplyHostFactory
         return new NativeMvApplyHost(projector, _eventTypes, ResolveDatabaseType());
     }
 
-    private MvDbType ResolveDatabaseType() =>
-        (_services.GetService(typeof(IMvStorageInfoProvider)) as IMvStorageInfoProvider)
-            ?.GetStorageInfo()
-            .DatabaseType
-        ?? MvDbType.Postgres;
+    private MvDbType ResolveDatabaseType() => _storageInfoProvider?.GetStorageInfo().DatabaseType ??
+        _defaultDatabaseType ??
+        throw new InvalidOperationException("Materialized view storage info is not configured.");
 }
 
 public sealed class NativeMvApplyHost : IMvApplyHost

--- a/dcb/src/Sekiban.Dcb.MaterializedView/MvContracts.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView/MvContracts.cs
@@ -6,7 +6,10 @@ namespace Sekiban.Dcb.MaterializedView;
 
 public enum MvDbType
 {
-    Postgres = 1
+    Postgres = 1,
+    SqlServer = 2,
+    MySql = 3,
+    Sqlite = 4
 }
 
 public enum MvStatus

--- a/dcb/src/Sekiban.Dcb.MaterializedView/SekibanDcbMaterializedViewExtensions.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView/SekibanDcbMaterializedViewExtensions.cs
@@ -11,7 +11,16 @@ public static class SekibanDcbMaterializedViewExtensions
     {
         services.AddOptions<MvOptions>();
         services.TryAddSingleton<IEventTypes>(sp => sp.GetRequiredService<DcbDomainTypes>().EventTypes);
-        services.TryAddSingleton<IMvApplyHostFactory, NativeMvApplyHostFactory>();
+        services.TryAddSingleton<IMvApplyHostFactory>(sp =>
+        {
+            var storageInfoProvider = sp.GetService<IMvStorageInfoProvider>() ??
+                throw new InvalidOperationException(
+                    "IMvStorageInfoProvider is not registered. Call a concrete materialized view provider extension such as AddSekibanDcbMaterializedViewPostgres, AddSekibanDcbMaterializedViewSqlServer, AddSekibanDcbMaterializedViewMySql, or AddSekibanDcbMaterializedViewSqlite.");
+            return new NativeMvApplyHostFactory(
+                sp.GetServices<IMaterializedViewProjector>(),
+                sp.GetRequiredService<IEventTypes>(),
+                storageInfoProvider);
+        });
         if (configure is not null)
         {
             services.Configure(configure);

--- a/dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/MaterializedViewMultiProviderTests.cs
+++ b/dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/MaterializedViewMultiProviderTests.cs
@@ -6,6 +6,7 @@ using Sekiban.Dcb.MaterializedView.MySql;
 using Sekiban.Dcb.MaterializedView.Sqlite;
 using Sekiban.Dcb.MaterializedView.SqlServer;
 using Xunit;
+using Xunit.Sdk;
 
 namespace Sekiban.Dcb.MaterializedView.MultiProvider.Tests;
 
@@ -82,7 +83,6 @@ internal static class MultiProviderAssertions
         if (!fixture.IsAvailable)
         {
             fixture.EnsureAvailable();
-            return;
         }
 
         await fixture.ResetAsync().ConfigureAwait(false);

--- a/dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/MaterializedViewMultiProviderTests.cs
+++ b/dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/MaterializedViewMultiProviderTests.cs
@@ -1,0 +1,165 @@
+using Dapper;
+using Dcb.Domain.WithoutResult.Weather;
+using Microsoft.Extensions.DependencyInjection;
+using Sekiban.Dcb.Actors;
+using Sekiban.Dcb.MaterializedView.MySql;
+using Sekiban.Dcb.MaterializedView.Sqlite;
+using Sekiban.Dcb.MaterializedView.SqlServer;
+using Xunit;
+
+namespace Sekiban.Dcb.MaterializedView.MultiProvider.Tests;
+
+[CollectionDefinition(nameof(MySqlMvCollection))]
+public sealed class MySqlMvCollection : ICollectionFixture<MySqlMvFixture>;
+
+[CollectionDefinition(nameof(SqlServerMvCollection))]
+public sealed class SqlServerMvCollection : ICollectionFixture<SqlServerMvFixture>;
+
+[CollectionDefinition(nameof(SqliteMvCollection))]
+public sealed class SqliteMvCollection : ICollectionFixture<SqliteMvFixture>;
+
+public sealed class MaterializedViewMultiProviderRegistrationTests
+{
+    [Fact]
+    public void SqlServer_Registration_ReportsStorageInfo()
+    {
+        var services = new ServiceCollection();
+        services.AddSekibanDcbMaterializedViewSqlServer("Server=(local);Database=test;User Id=sa;Password=Password123!;", registerHostedWorker: false);
+        using var provider = services.BuildServiceProvider();
+
+        var storage = provider.GetRequiredService<IMvStorageInfoProvider>().GetStorageInfo();
+        Assert.Equal(MvDbType.SqlServer, storage.DatabaseType);
+    }
+
+    [Fact]
+    public void MySql_Registration_ReportsStorageInfo()
+    {
+        var services = new ServiceCollection();
+        services.AddSekibanDcbMaterializedViewMySql("Server=localhost;Database=test;User Id=root;Password=test;", registerHostedWorker: false);
+        using var provider = services.BuildServiceProvider();
+
+        var storage = provider.GetRequiredService<IMvStorageInfoProvider>().GetStorageInfo();
+        Assert.Equal(MvDbType.MySql, storage.DatabaseType);
+    }
+
+    [Fact]
+    public void Sqlite_Registration_ReportsStorageInfo()
+    {
+        var services = new ServiceCollection();
+        services.AddSekibanDcbMaterializedViewSqlite("Data Source=:memory:", registerHostedWorker: false);
+        using var provider = services.BuildServiceProvider();
+
+        var storage = provider.GetRequiredService<IMvStorageInfoProvider>().GetStorageInfo();
+        Assert.Equal(MvDbType.Sqlite, storage.DatabaseType);
+    }
+}
+
+[Collection(nameof(MySqlMvCollection))]
+public sealed class MySqlMvIntegrationTests(MySqlMvFixture fixture)
+{
+    [Fact]
+    public Task CatchUp_MaterializesRowsAndRegistry() => MultiProviderAssertions.AssertProviderWorksAsync(fixture);
+}
+
+[Collection(nameof(SqlServerMvCollection))]
+public sealed class SqlServerMvIntegrationTests(SqlServerMvFixture fixture)
+{
+    [Fact]
+    public Task CatchUp_MaterializesRowsAndRegistry() => MultiProviderAssertions.AssertProviderWorksAsync(fixture);
+}
+
+[Collection(nameof(SqliteMvCollection))]
+public sealed class SqliteMvIntegrationTests(SqliteMvFixture fixture)
+{
+    [Fact]
+    public Task CatchUp_MaterializesRowsAndRegistry() => MultiProviderAssertions.AssertProviderWorksAsync(fixture);
+}
+
+internal static class MultiProviderAssertions
+{
+    public static async Task AssertProviderWorksAsync(MultiProviderFixtureBase fixture)
+    {
+        if (!fixture.IsAvailable)
+        {
+            fixture.EnsureAvailable();
+            return;
+        }
+
+        await fixture.ResetAsync().ConfigureAwait(false);
+
+        var projector = fixture.Services.GetRequiredService<CrossProviderWeatherForecastMvV1>();
+        await fixture.Executor.InitializeAsync(new NativeMvApplyHost(projector, fixture.DomainTypes.EventTypes, fixture.Services.GetRequiredService<IMvStorageInfoProvider>().GetStorageInfo().DatabaseType))
+            .ConfigureAwait(false);
+
+        var executor = new GeneralSekibanExecutor(fixture.EventStore, fixture.ActorAccessor, fixture.DomainTypes);
+        var forecastId = Guid.CreateVersion7();
+        var forecastDate = DateOnly.FromDateTime(DateTime.UtcNow.Date);
+
+        await executor.ExecuteAsync(new CreateWeatherForecast
+        {
+            ForecastId = forecastId,
+            Location = "Tokyo",
+            Date = forecastDate,
+            TemperatureC = 20,
+            Summary = "Sunny"
+        }).ConfigureAwait(false);
+
+        await executor.ExecuteAsync(new UpdateWeatherForecast
+        {
+            ForecastId = forecastId,
+            Location = "Kyoto",
+            Date = forecastDate.AddDays(1),
+            TemperatureC = 21,
+            Summary = "Cloudy"
+        }).ConfigureAwait(false);
+
+        await executor.ExecuteAsync(new DeleteWeatherForecast
+        {
+            ForecastId = forecastId
+        }).ConfigureAwait(false);
+
+        var firstCatchUp = await fixture.Executor.CatchUpOnceAsync(
+            new NativeMvApplyHost(projector, fixture.DomainTypes.EventTypes, fixture.Services.GetRequiredService<IMvStorageInfoProvider>().GetStorageInfo().DatabaseType))
+            .ConfigureAwait(false);
+        var secondCatchUp = await fixture.Executor.CatchUpOnceAsync(
+            new NativeMvApplyHost(projector, fixture.DomainTypes.EventTypes, fixture.Services.GetRequiredService<IMvStorageInfoProvider>().GetStorageInfo().DatabaseType))
+            .ConfigureAwait(false);
+
+        await using var connection = await fixture.OpenConnectionAsync().ConfigureAwait(false);
+        var row = await connection.QuerySingleAsync<ForecastDbRow>(
+            $"""
+             SELECT forecast_id AS ForecastId,
+                    location AS Location,
+                    is_deleted AS IsDeleted,
+                    _last_sortable_unique_id AS LastSortableUniqueId
+             FROM {MultiProviderFixtureBase.ForecastTable}
+             WHERE forecast_id = @ForecastId;
+             """,
+            new { ForecastId = forecastId.ToString("D") }).ConfigureAwait(false);
+        var registry = await connection.QuerySingleAsync<RegistryDbRow>(
+            """
+            SELECT applied_event_version AS AppliedEventVersion,
+                   current_position AS CurrentPosition,
+                   last_applied_source AS LastAppliedSource
+            FROM sekiban_mv_registry
+            WHERE view_name = 'WeatherForecastPortable'
+              AND logical_table = 'forecasts';
+            """).ConfigureAwait(false);
+        var activeVersion = await connection.ExecuteScalarAsync<int>(
+            """
+            SELECT active_version
+            FROM sekiban_mv_active
+            WHERE view_name = 'WeatherForecastPortable';
+            """).ConfigureAwait(false);
+
+        Assert.Equal(3, firstCatchUp.AppliedEvents);
+        Assert.Equal(0, secondCatchUp.AppliedEvents);
+        Assert.Equal("Kyoto", row.Location);
+        Assert.True(row.IsDeleted);
+        Assert.False(string.IsNullOrWhiteSpace(row.LastSortableUniqueId));
+        Assert.Equal(3, registry.AppliedEventVersion);
+        Assert.Equal("catchup", registry.LastAppliedSource);
+        Assert.False(string.IsNullOrWhiteSpace(registry.CurrentPosition));
+        Assert.Equal(1, activeVersion);
+    }
+}

--- a/dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/MaterializedViewMultiProviderTests.cs
+++ b/dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/MaterializedViewMultiProviderTests.cs
@@ -6,7 +6,6 @@ using Sekiban.Dcb.MaterializedView.MySql;
 using Sekiban.Dcb.MaterializedView.Sqlite;
 using Sekiban.Dcb.MaterializedView.SqlServer;
 using Xunit;
-using Xunit.Sdk;
 
 namespace Sekiban.Dcb.MaterializedView.MultiProvider.Tests;
 
@@ -58,21 +57,21 @@ public sealed class MaterializedViewMultiProviderRegistrationTests
 [Collection(nameof(MySqlMvCollection))]
 public sealed class MySqlMvIntegrationTests(MySqlMvFixture fixture)
 {
-    [Fact]
+    [SkippableFact]
     public Task CatchUp_MaterializesRowsAndRegistry() => MultiProviderAssertions.AssertProviderWorksAsync(fixture);
 }
 
 [Collection(nameof(SqlServerMvCollection))]
 public sealed class SqlServerMvIntegrationTests(SqlServerMvFixture fixture)
 {
-    [Fact]
+    [SkippableFact]
     public Task CatchUp_MaterializesRowsAndRegistry() => MultiProviderAssertions.AssertProviderWorksAsync(fixture);
 }
 
 [Collection(nameof(SqliteMvCollection))]
 public sealed class SqliteMvIntegrationTests(SqliteMvFixture fixture)
 {
-    [Fact]
+    [SkippableFact]
     public Task CatchUp_MaterializesRowsAndRegistry() => MultiProviderAssertions.AssertProviderWorksAsync(fixture);
 }
 
@@ -80,10 +79,7 @@ internal static class MultiProviderAssertions
 {
     public static async Task AssertProviderWorksAsync(MultiProviderFixtureBase fixture)
     {
-        if (!fixture.IsAvailable)
-        {
-            fixture.EnsureAvailable();
-        }
+        Skip.IfNot(fixture.IsAvailable, fixture.AvailabilityMessage ?? "Integration fixture is unavailable.");
 
         await fixture.ResetAsync().ConfigureAwait(false);
 

--- a/dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/MultiProviderFixtures.cs
+++ b/dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/MultiProviderFixtures.cs
@@ -1,0 +1,442 @@
+using System.Data.Common;
+using Dapper;
+using Dcb.Domain.WithoutResult;
+using Dcb.Domain.WithoutResult.Weather;
+using DotNet.Testcontainers.Builders;
+using Microsoft.Data.SqlClient;
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using MySqlConnector;
+using Sekiban.Dcb.Actors;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.InMemory;
+using Sekiban.Dcb.MaterializedView;
+using Sekiban.Dcb.MaterializedView.MySql;
+using Sekiban.Dcb.MaterializedView.Sqlite;
+using Sekiban.Dcb.MaterializedView.SqlServer;
+using Sekiban.Dcb.Storage;
+using Testcontainers.MsSql;
+using Testcontainers.MySql;
+using Xunit;
+
+namespace Sekiban.Dcb.MaterializedView.MultiProvider.Tests;
+
+public sealed class CrossProviderWeatherForecastMvV1 : IMaterializedViewProjector
+{
+    public string ViewName => "WeatherForecastPortable";
+    public int ViewVersion => 1;
+
+    public MvTable Forecasts { get; private set; } = default!;
+
+    public async Task InitializeAsync(IMvInitContext ctx, CancellationToken cancellationToken = default)
+    {
+        Forecasts = ctx.RegisterTable("forecasts");
+        await ctx.ExecuteAsync(CreateTableSql(ctx.DatabaseType, Forecasts.PhysicalName), cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    public Task<IReadOnlyList<MvSqlStatement>> ApplyToViewAsync(
+        Event ev,
+        IMvApplyContext ctx,
+        CancellationToken cancellationToken = default) =>
+        Task.FromResult<IReadOnlyList<MvSqlStatement>>(
+            ev.Payload switch
+            {
+                WeatherForecastCreated created => [BuildUpsert(ctx.DatabaseType, created.ForecastId, created.Location, created.Date, created.TemperatureC, created.Summary, false, ctx.CurrentSortableUniqueId)],
+                WeatherForecastUpdated updated => [BuildUpsert(ctx.DatabaseType, updated.ForecastId, updated.Location, updated.Date, updated.TemperatureC, updated.Summary, false, ctx.CurrentSortableUniqueId)],
+                WeatherForecastDeleted deleted => [BuildDelete(ctx.DatabaseType, deleted.ForecastId, ctx.CurrentSortableUniqueId)],
+                _ => []
+            });
+
+    private MvSqlStatement BuildUpsert(
+        MvDbType dbType,
+        Guid forecastId,
+        string location,
+        DateOnly date,
+        int temperatureC,
+        string? summary,
+        bool isDeleted,
+        string sortableUniqueId)
+    {
+        var parameters = new
+        {
+            ForecastId = forecastId.ToString("D"),
+            Location = location,
+            ForecastDate = date.ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc),
+            TemperatureC = temperatureC,
+            Summary = summary,
+            IsDeleted = isDeleted,
+            SortableUniqueId = sortableUniqueId
+        };
+
+        return new MvSqlStatement(dbType switch
+        {
+            MvDbType.SqlServer => $"""
+                MERGE {Forecasts.PhysicalName} AS target
+                USING (
+                    SELECT
+                        @ForecastId AS forecast_id,
+                        @Location AS location,
+                        @ForecastDate AS forecast_date,
+                        @TemperatureC AS temperature_c,
+                        @Summary AS summary,
+                        @IsDeleted AS is_deleted,
+                        @SortableUniqueId AS _last_sortable_unique_id
+                ) AS source
+                ON target.forecast_id = source.forecast_id
+                WHEN MATCHED AND target._last_sortable_unique_id < source._last_sortable_unique_id THEN
+                    UPDATE SET
+                        location = source.location,
+                        forecast_date = source.forecast_date,
+                        temperature_c = source.temperature_c,
+                        summary = source.summary,
+                        is_deleted = source.is_deleted,
+                        _last_sortable_unique_id = source._last_sortable_unique_id,
+                        _last_applied_at = SYSUTCDATETIME()
+                WHEN NOT MATCHED THEN
+                    INSERT (forecast_id, location, forecast_date, temperature_c, summary, is_deleted, _last_sortable_unique_id, _last_applied_at)
+                    VALUES (source.forecast_id, source.location, source.forecast_date, source.temperature_c, source.summary, source.is_deleted, source._last_sortable_unique_id, SYSUTCDATETIME());
+                """,
+            MvDbType.MySql => $"""
+                INSERT INTO {Forecasts.PhysicalName}
+                    (forecast_id, location, forecast_date, temperature_c, summary, is_deleted, _last_sortable_unique_id, _last_applied_at)
+                VALUES
+                    (@ForecastId, @Location, @ForecastDate, @TemperatureC, @Summary, @IsDeleted, @SortableUniqueId, CURRENT_TIMESTAMP(6))
+                ON DUPLICATE KEY UPDATE
+                    location = IF(_last_sortable_unique_id < VALUES(_last_sortable_unique_id), VALUES(location), location),
+                    forecast_date = IF(_last_sortable_unique_id < VALUES(_last_sortable_unique_id), VALUES(forecast_date), forecast_date),
+                    temperature_c = IF(_last_sortable_unique_id < VALUES(_last_sortable_unique_id), VALUES(temperature_c), temperature_c),
+                    summary = IF(_last_sortable_unique_id < VALUES(_last_sortable_unique_id), VALUES(summary), summary),
+                    is_deleted = IF(_last_sortable_unique_id < VALUES(_last_sortable_unique_id), VALUES(is_deleted), is_deleted),
+                    _last_sortable_unique_id = IF(_last_sortable_unique_id < VALUES(_last_sortable_unique_id), VALUES(_last_sortable_unique_id), _last_sortable_unique_id),
+                    _last_applied_at = IF(_last_sortable_unique_id < VALUES(_last_sortable_unique_id), CURRENT_TIMESTAMP(6), _last_applied_at);
+                """,
+            MvDbType.Sqlite => $"""
+                INSERT INTO {Forecasts.PhysicalName}
+                    (forecast_id, location, forecast_date, temperature_c, summary, is_deleted, _last_sortable_unique_id, _last_applied_at)
+                VALUES
+                    (@ForecastId, @Location, @ForecastDate, @TemperatureC, @Summary, @IsDeleted, @SortableUniqueId, CURRENT_TIMESTAMP)
+                ON CONFLICT (forecast_id) DO UPDATE SET
+                    location = excluded.location,
+                    forecast_date = excluded.forecast_date,
+                    temperature_c = excluded.temperature_c,
+                    summary = excluded.summary,
+                    is_deleted = excluded.is_deleted,
+                    _last_sortable_unique_id = excluded._last_sortable_unique_id,
+                    _last_applied_at = CURRENT_TIMESTAMP
+                WHERE {Forecasts.PhysicalName}._last_sortable_unique_id < excluded._last_sortable_unique_id;
+                """,
+            _ => throw new NotSupportedException($"Database type '{dbType}' is not supported.")
+        }, parameters);
+    }
+
+    private static string CreateTableSql(MvDbType dbType, string tableName) =>
+        dbType switch
+        {
+            MvDbType.SqlServer => $"""
+                IF OBJECT_ID(N'{tableName}', N'U') IS NULL
+                BEGIN
+                    CREATE TABLE {tableName} (
+                        forecast_id NVARCHAR(36) NOT NULL PRIMARY KEY,
+                        location NVARCHAR(200) NOT NULL,
+                        forecast_date DATETIME2 NOT NULL,
+                        temperature_c INT NOT NULL,
+                        summary NVARCHAR(MAX) NULL,
+                        is_deleted BIT NOT NULL CONSTRAINT DF_{tableName}_is_deleted DEFAULT 0,
+                        _last_sortable_unique_id NVARCHAR(64) NOT NULL,
+                        _last_applied_at DATETIMEOFFSET NOT NULL CONSTRAINT DF_{tableName}_last_applied_at DEFAULT SYSUTCDATETIME()
+                    );
+                END;
+                """,
+            MvDbType.MySql => $"""
+                CREATE TABLE IF NOT EXISTS {tableName} (
+                    forecast_id VARCHAR(36) NOT NULL PRIMARY KEY,
+                    location VARCHAR(200) NOT NULL,
+                    forecast_date DATETIME(6) NOT NULL,
+                    temperature_c INT NOT NULL,
+                    summary TEXT NULL,
+                    is_deleted BOOLEAN NOT NULL DEFAULT FALSE,
+                    _last_sortable_unique_id VARCHAR(64) NOT NULL,
+                    _last_applied_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6)
+                );
+                """,
+            MvDbType.Sqlite => $"""
+                CREATE TABLE IF NOT EXISTS {tableName} (
+                    forecast_id TEXT NOT NULL PRIMARY KEY,
+                    location TEXT NOT NULL,
+                    forecast_date TEXT NOT NULL,
+                    temperature_c INTEGER NOT NULL,
+                    summary TEXT NULL,
+                    is_deleted INTEGER NOT NULL DEFAULT 0,
+                    _last_sortable_unique_id TEXT NOT NULL,
+                    _last_applied_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+                );
+                """,
+            _ => throw new NotSupportedException($"Database type '{dbType}' is not supported.")
+        };
+
+    private MvSqlStatement BuildDelete(MvDbType dbType, Guid forecastId, string sortableUniqueId) =>
+        new(dbType switch
+        {
+            MvDbType.SqlServer => $"""
+                UPDATE {Forecasts.PhysicalName}
+                SET is_deleted = 1,
+                    _last_sortable_unique_id = @SortableUniqueId,
+                    _last_applied_at = SYSUTCDATETIME()
+                WHERE forecast_id = @ForecastId
+                  AND _last_sortable_unique_id < @SortableUniqueId;
+                """,
+            MvDbType.MySql => $"""
+                UPDATE {Forecasts.PhysicalName}
+                SET is_deleted = TRUE,
+                    _last_sortable_unique_id = @SortableUniqueId,
+                    _last_applied_at = CURRENT_TIMESTAMP(6)
+                WHERE forecast_id = @ForecastId
+                  AND _last_sortable_unique_id < @SortableUniqueId;
+                """,
+            MvDbType.Sqlite => $"""
+                UPDATE {Forecasts.PhysicalName}
+                SET is_deleted = 1,
+                    _last_sortable_unique_id = @SortableUniqueId,
+                    _last_applied_at = CURRENT_TIMESTAMP
+                WHERE forecast_id = @ForecastId
+                  AND _last_sortable_unique_id < @SortableUniqueId;
+                """,
+            _ => throw new NotSupportedException($"Database type '{dbType}' is not supported.")
+        }, new
+        {
+            ForecastId = forecastId.ToString("D"),
+            SortableUniqueId = sortableUniqueId
+        });
+}
+
+public sealed class ForecastDbRow
+{
+    public string ForecastId { get; init; } = string.Empty;
+    public string Location { get; init; } = string.Empty;
+    public bool IsDeleted { get; init; }
+    public string LastSortableUniqueId { get; init; } = string.Empty;
+}
+
+public sealed class RegistryDbRow
+{
+    public long AppliedEventVersion { get; init; }
+    public string CurrentPosition { get; init; } = string.Empty;
+    public string LastAppliedSource { get; init; } = string.Empty;
+}
+
+public abstract class MultiProviderFixtureBase : IAsyncLifetime
+{
+    internal const string ForecastTable = "sekiban_mv_weatherforecastportable_v1_forecasts";
+
+    private ServiceProvider? _services;
+    private string? _connectionString;
+    private string? _skipReason;
+
+    public ServiceProvider Services => _services ?? throw new InvalidOperationException("Fixture not initialized.");
+    public IMvExecutor Executor => Services.GetRequiredService<IMvExecutor>();
+    public InMemoryEventStore EventStore => Services.GetRequiredService<InMemoryEventStore>();
+    public InMemoryObjectAccessor ActorAccessor => Services.GetRequiredService<InMemoryObjectAccessor>();
+    public DcbDomainTypes DomainTypes => Services.GetRequiredService<DcbDomainTypes>();
+    public bool IsAvailable => _skipReason is null;
+    public string? AvailabilityMessage => _skipReason;
+    protected string ConnectionString => _connectionString ?? throw new InvalidOperationException("Fixture not initialized.");
+
+    protected abstract MvDbType DatabaseType { get; }
+    protected abstract Task<string> CreateConnectionStringAsync();
+    protected abstract void RegisterProvider(IServiceCollection services, string connectionString);
+    protected abstract DbConnection CreateConnection(string connectionString);
+    protected abstract string ResetSql { get; }
+
+    public async Task InitializeAsync()
+    {
+        try
+        {
+            _connectionString = await CreateConnectionStringAsync().ConfigureAwait(false);
+        }
+        catch (DockerUnavailableException ex)
+        {
+            _skipReason = $"{DatabaseType} integration tests require Docker: {ex.Message}";
+            return;
+        }
+
+        var services = new ServiceCollection();
+        services.AddLogging(builder => builder.SetMinimumLevel(LogLevel.Warning));
+        services.AddSingleton(DomainType.GetDomainTypes());
+        services.AddSingleton<InMemoryEventStore>(sp => new InMemoryEventStore(sp.GetRequiredService<DcbDomainTypes>().EventTypes));
+        services.AddSingleton<IEventStore>(sp => sp.GetRequiredService<InMemoryEventStore>());
+        services.AddSingleton<InMemoryObjectAccessor>(sp =>
+            new InMemoryObjectAccessor(sp.GetRequiredService<IEventStore>(), sp.GetRequiredService<DcbDomainTypes>()));
+        services.AddMaterializedView<CrossProviderWeatherForecastMvV1>();
+        RegisterProvider(services, _connectionString);
+        _services = services.BuildServiceProvider();
+
+        await ResetAsync().ConfigureAwait(false);
+    }
+
+    public virtual Task DisposeAsync()
+    {
+        _services?.Dispose();
+        return Task.CompletedTask;
+    }
+
+    public async Task<DbConnection> OpenConnectionAsync()
+    {
+        var connection = CreateConnection(ConnectionString);
+        await connection.OpenAsync().ConfigureAwait(false);
+        return connection;
+    }
+
+    public async Task ResetAsync()
+    {
+        if (!IsAvailable)
+        {
+            return;
+        }
+
+        EventStore.Clear();
+        await using var connection = await OpenConnectionAsync().ConfigureAwait(false);
+        await connection.ExecuteAsync(ResetSql).ConfigureAwait(false);
+    }
+
+    public void EnsureAvailable()
+    {
+        if (_skipReason is not null)
+        {
+            Console.WriteLine(_skipReason);
+        }
+    }
+}
+
+public sealed class MySqlMvFixture : MultiProviderFixtureBase
+{
+    private MySqlContainer? _container;
+
+    protected override MvDbType DatabaseType => MvDbType.MySql;
+
+    protected override async Task<string> CreateConnectionStringAsync()
+    {
+        _container = new MySqlBuilder("mysql:8.4")
+            .WithDatabase("sekiban_mv_test")
+            .WithUsername("test_user")
+            .WithPassword("test_password")
+            .Build();
+
+        await _container.StartAsync().ConfigureAwait(false);
+        return _container.GetConnectionString();
+    }
+
+    protected override void RegisterProvider(IServiceCollection services, string connectionString)
+    {
+        services.AddSekibanDcbMaterializedView(options =>
+        {
+            options.BatchSize = 100;
+            options.SafeWindowMs = 0;
+            options.PollInterval = TimeSpan.FromMilliseconds(10);
+        });
+        services.AddSekibanDcbMaterializedViewMySql(connectionString, registerHostedWorker: false);
+    }
+
+    protected override DbConnection CreateConnection(string connectionString) => new MySqlConnection(connectionString);
+
+    protected override string ResetSql => """
+        DROP TABLE IF EXISTS sekiban_mv_weatherforecastportable_v1_forecasts;
+        DROP TABLE IF EXISTS sekiban_mv_active;
+        DROP TABLE IF EXISTS sekiban_mv_registry;
+        """;
+
+    public override async Task DisposeAsync()
+    {
+        await base.DisposeAsync().ConfigureAwait(false);
+        if (_container is not null)
+        {
+            await _container.DisposeAsync().ConfigureAwait(false);
+        }
+    }
+}
+
+public sealed class SqlServerMvFixture : MultiProviderFixtureBase
+{
+    private MsSqlContainer? _container;
+
+    protected override MvDbType DatabaseType => MvDbType.SqlServer;
+
+    protected override async Task<string> CreateConnectionStringAsync()
+    {
+        _container = new MsSqlBuilder("mcr.microsoft.com/mssql/server:2022-latest")
+            .Build();
+
+        await _container.StartAsync().ConfigureAwait(false);
+        return _container.GetConnectionString();
+    }
+
+    protected override void RegisterProvider(IServiceCollection services, string connectionString)
+    {
+        services.AddSekibanDcbMaterializedView(options =>
+        {
+            options.BatchSize = 100;
+            options.SafeWindowMs = 0;
+            options.PollInterval = TimeSpan.FromMilliseconds(10);
+        });
+        services.AddSekibanDcbMaterializedViewSqlServer(connectionString, registerHostedWorker: false);
+    }
+
+    protected override DbConnection CreateConnection(string connectionString) => new SqlConnection(connectionString);
+
+    protected override string ResetSql => """
+        IF OBJECT_ID(N'sekiban_mv_weatherforecastportable_v1_forecasts', N'U') IS NOT NULL DROP TABLE sekiban_mv_weatherforecastportable_v1_forecasts;
+        IF OBJECT_ID(N'sekiban_mv_active', N'U') IS NOT NULL DROP TABLE sekiban_mv_active;
+        IF OBJECT_ID(N'sekiban_mv_registry', N'U') IS NOT NULL DROP TABLE sekiban_mv_registry;
+        """;
+
+    public override async Task DisposeAsync()
+    {
+        await base.DisposeAsync().ConfigureAwait(false);
+        if (_container is not null)
+        {
+            await _container.DisposeAsync().ConfigureAwait(false);
+        }
+    }
+}
+
+public sealed class SqliteMvFixture : MultiProviderFixtureBase
+{
+    private string? _databasePath;
+
+    protected override MvDbType DatabaseType => MvDbType.Sqlite;
+
+    protected override Task<string> CreateConnectionStringAsync()
+    {
+        _databasePath = Path.Combine(Path.GetTempPath(), $"sekiban-mv-{Guid.NewGuid():N}.db");
+        return Task.FromResult($"Data Source={_databasePath}");
+    }
+
+    protected override void RegisterProvider(IServiceCollection services, string connectionString)
+    {
+        services.AddSekibanDcbMaterializedView(options =>
+        {
+            options.BatchSize = 100;
+            options.SafeWindowMs = 0;
+            options.PollInterval = TimeSpan.FromMilliseconds(10);
+        });
+        services.AddSekibanDcbMaterializedViewSqlite(connectionString, registerHostedWorker: false);
+    }
+
+    protected override DbConnection CreateConnection(string connectionString) => new SqliteConnection(connectionString);
+
+    protected override string ResetSql => """
+        DROP TABLE IF EXISTS sekiban_mv_weatherforecastportable_v1_forecasts;
+        DROP TABLE IF EXISTS sekiban_mv_active;
+        DROP TABLE IF EXISTS sekiban_mv_registry;
+        """;
+
+    public override async Task DisposeAsync()
+    {
+        await base.DisposeAsync().ConfigureAwait(false);
+        if (_databasePath is not null && File.Exists(_databasePath))
+        {
+            File.Delete(_databasePath);
+        }
+    }
+}

--- a/dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/MultiProviderFixtures.cs
+++ b/dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/MultiProviderFixtures.cs
@@ -19,6 +19,7 @@ using Sekiban.Dcb.Storage;
 using Testcontainers.MsSql;
 using Testcontainers.MySql;
 using Xunit;
+using Xunit.Sdk;
 
 namespace Sekiban.Dcb.MaterializedView.MultiProvider.Tests;
 
@@ -304,7 +305,7 @@ public abstract class MultiProviderFixtureBase : IAsyncLifetime
     {
         if (_skipReason is not null)
         {
-            Console.WriteLine(_skipReason);
+            throw SkipException.ForSkip(_skipReason);
         }
     }
 }

--- a/dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/MultiProviderFixtures.cs
+++ b/dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/MultiProviderFixtures.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Data.Common;
 using Dapper;
 using Dcb.Domain.WithoutResult;
@@ -19,7 +20,6 @@ using Sekiban.Dcb.Storage;
 using Testcontainers.MsSql;
 using Testcontainers.MySql;
 using Xunit;
-using Xunit.Sdk;
 
 namespace Sekiban.Dcb.MaterializedView.MultiProvider.Tests;
 
@@ -305,9 +305,12 @@ public abstract class MultiProviderFixtureBase : IAsyncLifetime
     {
         if (_skipReason is not null)
         {
-            throw SkipException.ForSkip(_skipReason);
+            ThrowUnavailable();
         }
     }
+
+    [DoesNotReturn]
+    private void ThrowUnavailable() => throw new InvalidOperationException(_skipReason);
 }
 
 public sealed class MySqlMvFixture : MultiProviderFixtureBase

--- a/dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests.csproj
+++ b/dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests.csproj
@@ -14,7 +14,7 @@
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
         <PackageReference Include="Testcontainers.MsSql" Version="4.10.0" />
         <PackageReference Include="Testcontainers.MySql" Version="4.10.0" />
-        <PackageReference Include="xunit" Version="2.9.3"/>
+        <PackageReference Include="xunit" Version="2.9.3" />
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
@@ -23,6 +23,7 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
+        <PackageReference Include="Xunit.SkippableFact" Version="1.5.61" />
     </ItemGroup>
 
     <ItemGroup>
@@ -30,12 +31,12 @@
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\..\src\Sekiban.Dcb.MaterializedView\Sekiban.Dcb.MaterializedView.csproj"/>
-        <ProjectReference Include="..\..\src\Sekiban.Dcb.MaterializedView.MySql\Sekiban.Dcb.MaterializedView.MySql.csproj"/>
-        <ProjectReference Include="..\..\src\Sekiban.Dcb.MaterializedView.Sqlite\Sekiban.Dcb.MaterializedView.Sqlite.csproj"/>
-        <ProjectReference Include="..\..\src\Sekiban.Dcb.MaterializedView.SqlServer\Sekiban.Dcb.MaterializedView.SqlServer.csproj"/>
-        <ProjectReference Include="..\..\src\Sekiban.Dcb.WithoutResult\Sekiban.Dcb.WithoutResult.csproj"/>
-        <ProjectReference Include="..\..\internalUsages\Dcb.Domain.WithoutResult\Dcb.Domain.WithoutResult.csproj"/>
+        <ProjectReference Include="..\..\src\Sekiban.Dcb.MaterializedView\Sekiban.Dcb.MaterializedView.csproj" />
+        <ProjectReference Include="..\..\src\Sekiban.Dcb.MaterializedView.MySql\Sekiban.Dcb.MaterializedView.MySql.csproj" />
+        <ProjectReference Include="..\..\src\Sekiban.Dcb.MaterializedView.Sqlite\Sekiban.Dcb.MaterializedView.Sqlite.csproj" />
+        <ProjectReference Include="..\..\src\Sekiban.Dcb.MaterializedView.SqlServer\Sekiban.Dcb.MaterializedView.SqlServer.csproj" />
+        <ProjectReference Include="..\..\src\Sekiban.Dcb.WithoutResult\Sekiban.Dcb.WithoutResult.csproj" />
+        <ProjectReference Include="..\..\internalUsages\Dcb.Domain.WithoutResult\Dcb.Domain.WithoutResult.csproj" />
     </ItemGroup>
 
 </Project>

--- a/dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests.csproj
+++ b/dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests.csproj
@@ -1,0 +1,41 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+        <IsTestProject>true</IsTestProject>
+        <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+        <NoWarn>$(NoWarn);MSB3277</NoWarn>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Dapper" Version="2.1.66" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+        <PackageReference Include="Testcontainers.MsSql" Version="4.10.0" />
+        <PackageReference Include="Testcontainers.MySql" Version="4.10.0" />
+        <PackageReference Include="xunit" Version="2.9.3"/>
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+        <PackageReference Include="coverlet.collector" Version="8.0.0">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+        <None Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\src\Sekiban.Dcb.MaterializedView\Sekiban.Dcb.MaterializedView.csproj"/>
+        <ProjectReference Include="..\..\src\Sekiban.Dcb.MaterializedView.MySql\Sekiban.Dcb.MaterializedView.MySql.csproj"/>
+        <ProjectReference Include="..\..\src\Sekiban.Dcb.MaterializedView.Sqlite\Sekiban.Dcb.MaterializedView.Sqlite.csproj"/>
+        <ProjectReference Include="..\..\src\Sekiban.Dcb.MaterializedView.SqlServer\Sekiban.Dcb.MaterializedView.SqlServer.csproj"/>
+        <ProjectReference Include="..\..\src\Sekiban.Dcb.WithoutResult\Sekiban.Dcb.WithoutResult.csproj"/>
+        <ProjectReference Include="..\..\internalUsages\Dcb.Domain.WithoutResult\Dcb.Domain.WithoutResult.csproj"/>
+    </ItemGroup>
+
+</Project>

--- a/dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/xunit.runner.json
+++ b/dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/xunit.runner.json
@@ -1,0 +1,4 @@
+{
+  "parallelizeTestCollections": false,
+  "maxParallelThreads": 1
+}

--- a/dcb/tests/Sekiban.Dcb.MaterializedView.Postgres.Tests/MaterializedViewPostgresFixture.cs
+++ b/dcb/tests/Sekiban.Dcb.MaterializedView.Postgres.Tests/MaterializedViewPostgresFixture.cs
@@ -12,6 +12,7 @@ using Sekiban.Dcb.MaterializedView.Postgres;
 using Sekiban.Dcb.Storage;
 using Testcontainers.PostgreSql;
 using Xunit;
+using Xunit.Sdk;
 
 namespace Sekiban.Dcb.MaterializedView.Postgres.Tests;
 
@@ -122,7 +123,7 @@ public sealed class MaterializedViewPostgresFixture : IAsyncLifetime
     {
         if (_skipReason is not null)
         {
-            Console.WriteLine(_skipReason);
+            throw SkipException.ForSkip(_skipReason);
         }
     }
 

--- a/dcb/tests/Sekiban.Dcb.MaterializedView.Postgres.Tests/MaterializedViewPostgresFixture.cs
+++ b/dcb/tests/Sekiban.Dcb.MaterializedView.Postgres.Tests/MaterializedViewPostgresFixture.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using Dcb.Domain.WithoutResult;
 using Dcb.Domain.WithoutResult.MaterializedViews;
 using Dapper;
@@ -12,7 +13,6 @@ using Sekiban.Dcb.MaterializedView.Postgres;
 using Sekiban.Dcb.Storage;
 using Testcontainers.PostgreSql;
 using Xunit;
-using Xunit.Sdk;
 
 namespace Sekiban.Dcb.MaterializedView.Postgres.Tests;
 
@@ -123,9 +123,12 @@ public sealed class MaterializedViewPostgresFixture : IAsyncLifetime
     {
         if (_skipReason is not null)
         {
-            throw SkipException.ForSkip(_skipReason);
+            ThrowUnavailable();
         }
     }
+
+    [DoesNotReturn]
+    private void ThrowUnavailable() => throw new InvalidOperationException(_skipReason);
 
     private static string? ResolveExternalConnectionString() =>
         Environment.GetEnvironmentVariable("SEKIBAN_TEST_POSTGRES_CONNECTION_STRING") ??

--- a/dcb/tests/Sekiban.Dcb.MaterializedView.Postgres.Tests/MaterializedViewPostgresOrleansFixture.cs
+++ b/dcb/tests/Sekiban.Dcb.MaterializedView.Postgres.Tests/MaterializedViewPostgresOrleansFixture.cs
@@ -21,6 +21,7 @@ using Sekiban.Dcb.ServiceId;
 using Sekiban.Dcb.Storage;
 using Testcontainers.PostgreSql;
 using Xunit;
+using Xunit.Sdk;
 
 namespace Sekiban.Dcb.MaterializedView.Postgres.Tests;
 
@@ -175,7 +176,7 @@ public sealed class MaterializedViewPostgresOrleansFixture : IAsyncLifetime
     {
         if (_skipReason is not null)
         {
-            Console.WriteLine(_skipReason);
+            throw SkipException.ForSkip(_skipReason);
         }
     }
 

--- a/dcb/tests/Sekiban.Dcb.MaterializedView.Postgres.Tests/MaterializedViewPostgresOrleansFixture.cs
+++ b/dcb/tests/Sekiban.Dcb.MaterializedView.Postgres.Tests/MaterializedViewPostgresOrleansFixture.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using Dapper;
 using Dcb.Domain.WithoutResult;
 using Dcb.Domain.WithoutResult.MaterializedViews;
@@ -21,7 +22,6 @@ using Sekiban.Dcb.ServiceId;
 using Sekiban.Dcb.Storage;
 using Testcontainers.PostgreSql;
 using Xunit;
-using Xunit.Sdk;
 
 namespace Sekiban.Dcb.MaterializedView.Postgres.Tests;
 
@@ -176,9 +176,12 @@ public sealed class MaterializedViewPostgresOrleansFixture : IAsyncLifetime
     {
         if (_skipReason is not null)
         {
-            throw SkipException.ForSkip(_skipReason);
+            ThrowUnavailable();
         }
     }
+
+    [DoesNotReturn]
+    private void ThrowUnavailable() => throw new InvalidOperationException(_skipReason);
 
     private static string? ResolveExternalConnectionString() =>
         Environment.GetEnvironmentVariable("SEKIBAN_TEST_POSTGRES_CONNECTION_STRING") ??

--- a/dcb/tests/Sekiban.Dcb.MaterializedView.Postgres.Tests/MaterializedViewPostgresOrleansTests.cs
+++ b/dcb/tests/Sekiban.Dcb.MaterializedView.Postgres.Tests/MaterializedViewPostgresOrleansTests.cs
@@ -17,14 +17,10 @@ public sealed class MaterializedViewPostgresOrleansCollection : ICollectionFixtu
 [Collection(nameof(MaterializedViewPostgresOrleansCollection))]
 public sealed class MaterializedViewPostgresOrleansTests(MaterializedViewPostgresOrleansFixture fixture)
 {
-    [Fact]
+    [SkippableFact]
     public async Task Grain_CatchesUp_Then_Applies_Streamed_Event_To_Postgres_View()
     {
-        if (!fixture.IsAvailable)
-        {
-            fixture.EnsureAvailable();
-            return;
-        }
+        Skip.IfNot(fixture.IsAvailable, fixture.AvailabilityMessage ?? "Postgres Orleans fixture is unavailable.");
 
         var grainKey = MvGrainKey.Build(DefaultServiceIdProvider.DefaultServiceId, "OrderSummary", 1);
         var grain = fixture.Client.GetGrain<IMaterializedViewGrain>(grainKey);
@@ -162,14 +158,10 @@ public sealed class MaterializedViewPostgresOrleansTests(MaterializedViewPostgre
         }
     }
 
-    [Fact]
+    [SkippableFact]
     public async Task Grain_OutOfOrder_StreamDelivery_DoesNotLose_WeatherForecastRows()
     {
-        if (!fixture.IsAvailable)
-        {
-            fixture.EnsureAvailable();
-            return;
-        }
+        Skip.IfNot(fixture.IsAvailable, fixture.AvailabilityMessage ?? "Postgres Orleans fixture is unavailable.");
 
         var grainKey = MvGrainKey.Build(DefaultServiceIdProvider.DefaultServiceId, "WeatherForecast", 1);
         var grain = fixture.Client.GetGrain<IMaterializedViewGrain>(grainKey);
@@ -311,14 +303,10 @@ public sealed class MaterializedViewPostgresOrleansTests(MaterializedViewPostgre
         Assert.Null(registryRow.LastCatchUpSortableUniqueId);
     }
 
-    [Fact]
+    [SkippableFact]
     public async Task Grain_Delayed_Create_After_Streamed_Update_DoesNotAdvance_Past_Missing_Row()
     {
-        if (!fixture.IsAvailable)
-        {
-            fixture.EnsureAvailable();
-            return;
-        }
+        Skip.IfNot(fixture.IsAvailable, fixture.AvailabilityMessage ?? "Postgres Orleans fixture is unavailable.");
 
         var grainKey = MvGrainKey.Build(DefaultServiceIdProvider.DefaultServiceId, "WeatherForecast", 1);
         var grain = fixture.Client.GetGrain<IMaterializedViewGrain>(grainKey);
@@ -451,14 +439,10 @@ public sealed class MaterializedViewPostgresOrleansTests(MaterializedViewPostgre
         Assert.Equal(updateEvent.SortableUniqueIdValue, registryRow.LastStreamAppliedSortableUniqueId);
     }
 
-    [Fact]
+    [SkippableFact]
     public async Task Grain_Streamed_Create_Then_Update_For_Same_Aggregate_Applies_Both_Events()
     {
-        if (!fixture.IsAvailable)
-        {
-            fixture.EnsureAvailable();
-            return;
-        }
+        Skip.IfNot(fixture.IsAvailable, fixture.AvailabilityMessage ?? "Postgres Orleans fixture is unavailable.");
 
         var grainKey = MvGrainKey.Build(DefaultServiceIdProvider.DefaultServiceId, "WeatherForecast", 1);
         var grain = fixture.Client.GetGrain<IMaterializedViewGrain>(grainKey);
@@ -561,14 +545,10 @@ public sealed class MaterializedViewPostgresOrleansTests(MaterializedViewPostgre
         Assert.Equal(updateEvent.SortableUniqueIdValue, registryRow.LastStreamAppliedSortableUniqueId);
     }
 
-    [Fact]
+    [SkippableFact]
     public async Task Grain_Late_Create_Older_Than_CurrentPosition_Is_Applied_Without_Stalling_Other_Aggregates()
     {
-        if (!fixture.IsAvailable)
-        {
-            fixture.EnsureAvailable();
-            return;
-        }
+        Skip.IfNot(fixture.IsAvailable, fixture.AvailabilityMessage ?? "Postgres Orleans fixture is unavailable.");
 
         var grainKey = MvGrainKey.Build(DefaultServiceIdProvider.DefaultServiceId, "WeatherForecast", 1);
         var grain = fixture.Client.GetGrain<IMaterializedViewGrain>(grainKey);

--- a/dcb/tests/Sekiban.Dcb.MaterializedView.Postgres.Tests/MaterializedViewPostgresTests.cs
+++ b/dcb/tests/Sekiban.Dcb.MaterializedView.Postgres.Tests/MaterializedViewPostgresTests.cs
@@ -17,14 +17,10 @@ public sealed class MaterializedViewPostgresCollection : ICollectionFixture<Mate
 [Collection(nameof(MaterializedViewPostgresCollection))]
 public sealed class MaterializedViewPostgresTests(MaterializedViewPostgresFixture fixture)
 {
-    [Fact]
+    [SkippableFact]
     public async Task Initialize_CreatesRegistryAndTables()
     {
-        if (!fixture.IsAvailable)
-        {
-            fixture.EnsureAvailable();
-            return;
-        }
+        Skip.IfNot(fixture.IsAvailable, fixture.AvailabilityMessage ?? "Postgres fixture is unavailable.");
         await fixture.ResetAsync();
 
         await fixture.Executor.InitializeAsync(ApplyHost(fixture.Projector));
@@ -43,14 +39,10 @@ public sealed class MaterializedViewPostgresTests(MaterializedViewPostgresFixtur
         Assert.True(itemsExists);
     }
 
-    [Fact]
+    [SkippableFact]
     public async Task CatchUp_MaterializesRowsAndIsIdempotent()
     {
-        if (!fixture.IsAvailable)
-        {
-            fixture.EnsureAvailable();
-            return;
-        }
+        Skip.IfNot(fixture.IsAvailable, fixture.AvailabilityMessage ?? "Postgres fixture is unavailable.");
         await fixture.ResetAsync();
         await fixture.Executor.InitializeAsync(ApplyHost(fixture.Projector));
 
@@ -142,14 +134,10 @@ public sealed class MaterializedViewPostgresTests(MaterializedViewPostgresFixtur
         Assert.NotEqual(default, itemRow.LastAppliedAt);
     }
 
-    [Fact]
+    [SkippableFact]
     public async Task CatchUp_RemainsIdempotentWhenRegistryPositionIsRewound()
     {
-        if (!fixture.IsAvailable)
-        {
-            fixture.EnsureAvailable();
-            return;
-        }
+        Skip.IfNot(fixture.IsAvailable, fixture.AvailabilityMessage ?? "Postgres fixture is unavailable.");
         await fixture.ResetAsync();
         await fixture.Executor.InitializeAsync(ApplyHost(fixture.Projector));
 
@@ -207,14 +195,10 @@ public sealed class MaterializedViewPostgresTests(MaterializedViewPostgresFixtur
         Assert.NotEqual(default, orderRow.LastAppliedAt);
     }
 
-    [Fact]
+    [SkippableFact]
     public async Task CatchUp_RollsBackWhenApplyStatementFails()
     {
-        if (!fixture.IsAvailable)
-        {
-            fixture.EnsureAvailable();
-            return;
-        }
+        Skip.IfNot(fixture.IsAvailable, fixture.AvailabilityMessage ?? "Postgres fixture is unavailable.");
         await fixture.ResetAsync();
         var failingProjector = new FailingMvProjector();
         await fixture.Executor.InitializeAsync(ApplyHost(failingProjector));
@@ -238,14 +222,10 @@ public sealed class MaterializedViewPostgresTests(MaterializedViewPostgresFixtur
         Assert.Null(registryPosition);
     }
 
-    [Fact]
+    [SkippableFact]
     public async Task CatchUp_WeatherForecastMaterializesSingleForecastTable()
     {
-        if (!fixture.IsAvailable)
-        {
-            fixture.EnsureAvailable();
-            return;
-        }
+        Skip.IfNot(fixture.IsAvailable, fixture.AvailabilityMessage ?? "Postgres fixture is unavailable.");
 
         await fixture.ResetAsync();
         var projector = new WeatherForecastMvV1();
@@ -304,14 +284,10 @@ public sealed class MaterializedViewPostgresTests(MaterializedViewPostgresFixtur
         Assert.False(string.IsNullOrWhiteSpace(row.LastSortableUniqueId));
     }
 
-    [Fact]
+    [SkippableFact]
     public async Task CatchUp_NativeHost_PreservesConnectionAndTransactionAccess_OnPostgresPath()
     {
-        if (!fixture.IsAvailable)
-        {
-            fixture.EnsureAvailable();
-            return;
-        }
+        Skip.IfNot(fixture.IsAvailable, fixture.AvailabilityMessage ?? "Postgres fixture is unavailable.");
 
         await fixture.ResetAsync();
         var projector = new RawConnectionMvProjector();

--- a/dcb/tests/Sekiban.Dcb.MaterializedView.Postgres.Tests/Sekiban.Dcb.MaterializedView.Postgres.Tests.csproj
+++ b/dcb/tests/Sekiban.Dcb.MaterializedView.Postgres.Tests/Sekiban.Dcb.MaterializedView.Postgres.Tests.csproj
@@ -12,7 +12,7 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
         <PackageReference Include="Microsoft.Orleans.TestingHost" Version="10.0.1" />
-        <PackageReference Include="xunit" Version="2.9.3"/>
+        <PackageReference Include="xunit" Version="2.9.3" />
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
@@ -22,16 +22,17 @@
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
         <PackageReference Include="Testcontainers.PostgreSql" Version="4.10.0" />
+        <PackageReference Include="Xunit.SkippableFact" Version="1.5.61" />
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\..\src\Sekiban.Dcb.MaterializedView\Sekiban.Dcb.MaterializedView.csproj"/>
-        <ProjectReference Include="..\..\src\Sekiban.Dcb.MaterializedView.Orleans\Sekiban.Dcb.MaterializedView.Orleans.csproj"/>
-        <ProjectReference Include="..\..\src\Sekiban.Dcb.MaterializedView.Postgres\Sekiban.Dcb.MaterializedView.Postgres.csproj"/>
-        <ProjectReference Include="..\..\src\Sekiban.Dcb.Orleans.Core\Sekiban.Dcb.Orleans.Core.csproj"/>
-        <ProjectReference Include="..\..\src\Sekiban.Dcb.Postgres\Sekiban.Dcb.Postgres.csproj"/>
-        <ProjectReference Include="..\..\src\Sekiban.Dcb.WithoutResult\Sekiban.Dcb.WithoutResult.csproj"/>
-        <ProjectReference Include="..\..\internalUsages\Dcb.Domain.WithoutResult\Dcb.Domain.WithoutResult.csproj"/>
+        <ProjectReference Include="..\..\src\Sekiban.Dcb.MaterializedView\Sekiban.Dcb.MaterializedView.csproj" />
+        <ProjectReference Include="..\..\src\Sekiban.Dcb.MaterializedView.Orleans\Sekiban.Dcb.MaterializedView.Orleans.csproj" />
+        <ProjectReference Include="..\..\src\Sekiban.Dcb.MaterializedView.Postgres\Sekiban.Dcb.MaterializedView.Postgres.csproj" />
+        <ProjectReference Include="..\..\src\Sekiban.Dcb.Orleans.Core\Sekiban.Dcb.Orleans.Core.csproj" />
+        <ProjectReference Include="..\..\src\Sekiban.Dcb.Postgres\Sekiban.Dcb.Postgres.csproj" />
+        <ProjectReference Include="..\..\src\Sekiban.Dcb.WithoutResult\Sekiban.Dcb.WithoutResult.csproj" />
+        <ProjectReference Include="..\..\internalUsages\Dcb.Domain.WithoutResult\Dcb.Domain.WithoutResult.csproj" />
     </ItemGroup>
 
 </Project>

--- a/dcb/tests/Sekiban.Dcb.MaterializedView.Tests/MaterializedViewUnitTests.cs
+++ b/dcb/tests/Sekiban.Dcb.MaterializedView.Tests/MaterializedViewUnitTests.cs
@@ -1,6 +1,7 @@
 using Dcb.Domain.WithoutResult;
 using Dcb.Domain.WithoutResult.MaterializedViews;
 using Dcb.Domain.WithoutResult.Order;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Sekiban.Dcb.Domains;
@@ -251,6 +252,35 @@ public class MaterializedViewUnitTests
 
         Assert.Equal(MvDbType.Postgres, resolved.DatabaseType);
         Assert.Equal("Host=test;Database=mv;", resolved.ConnectionString);
+    }
+
+    [Fact]
+    public void AddSekibanDcbMaterializedView_WithoutStorageInfoProvider_ThrowsOnFactoryResolution()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton(DomainType.GetDomainTypes());
+        services.AddSekibanDcbMaterializedView();
+        services.AddMaterializedView<OrderSummaryMvV1>();
+
+        using var provider = services.BuildServiceProvider();
+        var exception = Assert.Throws<InvalidOperationException>(() => provider.GetRequiredService<IMvApplyHostFactory>());
+
+        Assert.Contains("IMvStorageInfoProvider", exception.Message);
+    }
+
+    [Fact]
+    public async Task NativeMvApplyHostFactory_LegacyConstructor_RemainsUsable()
+    {
+        var domainTypes = DomainType.GetDomainTypes();
+        var factory = new NativeMvApplyHostFactory([new OrderSummaryMvV1()], domainTypes.EventTypes);
+
+        var host = factory.Create("OrderSummary", 1);
+        var bindings = new MvTableBindings("OrderSummary", 1, new MvOptions());
+        var statements = await host.InitializeAsync(bindings, CancellationToken.None);
+
+        Assert.NotEmpty(statements);
+        Assert.Equal("OrderSummary", host.ViewName);
+        Assert.Equal(1, host.ViewVersion);
     }
 
     private sealed record RecordTarget(

--- a/docs/dcb_llm/01_core_concepts.md
+++ b/docs/dcb_llm/01_core_concepts.md
@@ -74,9 +74,10 @@ intermediate queues, and eventual reconciliation. DCB removes that friction:
 - **Event Store**: Provides ordered persistence and tag lookup. Postgres (`src/Sekiban.Dcb.Postgres/PostgresEventStore.cs`),
   Cosmos DB (`src/Sekiban.Dcb.CosmosDb/CosmosDbEventStore.cs`), and DynamoDB (`src/Sekiban.Dcb.DynamoDB/DynamoDbEventStore.cs`) share the same contract.
 - **Materialized View Runtime**: A database-backed read model pipeline that applies ordered events into SQL tables.
-  Core contracts live in `src/Sekiban.Dcb.MaterializedView`, PostgreSQL execution lives in
-  `src/Sekiban.Dcb.MaterializedView.Postgres`, and Orleans orchestration lives in
-  `src/Sekiban.Dcb.MaterializedView.Orleans`.
+  Core contracts live in `src/Sekiban.Dcb.MaterializedView`, classic provider packages live in
+  `src/Sekiban.Dcb.MaterializedView.Postgres`, `src/Sekiban.Dcb.MaterializedView.SqlServer`,
+  `src/Sekiban.Dcb.MaterializedView.MySql`, and `src/Sekiban.Dcb.MaterializedView.Sqlite`, and Orleans orchestration
+  lives in `src/Sekiban.Dcb.MaterializedView.Orleans`.
 
 ## Benefits
 

--- a/docs/dcb_llm/20_materialized_view.md
+++ b/docs/dcb_llm/20_materialized_view.md
@@ -38,13 +38,19 @@ database.
 
 ## Runtime Shape
 
-The current runtime is split into three packages:
+The current runtime is split into provider-neutral core plus provider packages:
 
 - `Sekiban.Dcb.MaterializedView`
   Core contracts such as `IMaterializedViewProjector`, `IMvInitContext`, `IMvApplyContext`, `MvRegistryEntry`, and the
   catch-up worker.
 - `Sekiban.Dcb.MaterializedView.Postgres`
   PostgreSQL implementation for table registration, row access, registry persistence, and event application.
+- `Sekiban.Dcb.MaterializedView.SqlServer`
+  SQL Server implementation for registry persistence and ordered event application.
+- `Sekiban.Dcb.MaterializedView.MySql`
+  MySQL implementation for registry persistence and ordered event application.
+- `Sekiban.Dcb.MaterializedView.Sqlite`
+  SQLite implementation for registry persistence and ordered event application.
 - `Sekiban.Dcb.MaterializedView.Orleans`
   Orleans grain orchestration, startup activation, and `IMvOrleansQueryAccessor`.
 
@@ -89,7 +95,20 @@ Notes:
 - `AddSekibanDcbMaterializedView` registers shared options.
 - `AddMaterializedView<TView>` registers one projector.
 - `AddSekibanDcbMaterializedViewPostgres` wires the registry and executor.
+- `AddSekibanDcbMaterializedViewSqlServer`, `AddSekibanDcbMaterializedViewMySql`, and `AddSekibanDcbMaterializedViewSqlite`
+  provide the same classic MV runtime for their respective databases.
 - `AddSekibanDcbMaterializedViewOrleans` adds Orleans-side activation and query access.
+
+Provider-specific registration examples:
+
+```csharp
+builder.Services.AddSekibanDcbMaterializedViewSqlServer(configuration, "DcbMaterializedViewSqlServer");
+builder.Services.AddSekibanDcbMaterializedViewMySql(configuration, "DcbMaterializedViewMySql");
+builder.Services.AddSekibanDcbMaterializedViewSqlite(configuration, "DcbMaterializedViewSqlite");
+```
+
+Projectors still emit SQL directly. For portable projectors, branch on `ctx.DatabaseType` and emit the SQL dialect that
+matches the selected provider. Unsafe Window MV remains PostgreSQL-only in v1.
 
 ## Writing a Projector
 

--- a/docs/dcb_llm_ja/01_core_concepts.md
+++ b/docs/dcb_llm_ja/01_core_concepts.md
@@ -67,8 +67,9 @@ Dynamic Consistency Boundary (DCB) は Sekiban が採用する次世代のイベ
   - Cosmos DB: `src/Sekiban.Dcb.CosmosDb/CosmosDbEventStore.cs`
   - DynamoDB: `src/Sekiban.Dcb.DynamoDB/DynamoDbEventStore.cs`
 - **マテリアライズドビュー runtime**: 順序付きイベントを SQL テーブルへ反映する DB リードモデル基盤です。
-  共通契約は `src/Sekiban.Dcb.MaterializedView`、Postgres 実装は
-  `src/Sekiban.Dcb.MaterializedView.Postgres`、Orleans 側の制御は
+  共通契約は `src/Sekiban.Dcb.MaterializedView`、classic provider 実装は
+  `src/Sekiban.Dcb.MaterializedView.Postgres`、`src/Sekiban.Dcb.MaterializedView.SqlServer`、
+  `src/Sekiban.Dcb.MaterializedView.MySql`、`src/Sekiban.Dcb.MaterializedView.Sqlite`、Orleans 側の制御は
   `src/Sekiban.Dcb.MaterializedView.Orleans` にあります。
 
 ## メリット

--- a/docs/dcb_llm_ja/20_materialized_view.md
+++ b/docs/dcb_llm_ja/20_materialized_view.md
@@ -39,13 +39,19 @@
 
 ## ランタイム構成
 
-現在の実装は 3 つのパッケージに分かれています。
+現在の実装は、共通 core と provider package に分かれています。
 
 - `Sekiban.Dcb.MaterializedView`
   共通契約。`IMaterializedViewProjector`、`IMvInitContext`、`IMvApplyContext`、`MvRegistryEntry`、
   キャッチアップワーカーなどを含みます。
 - `Sekiban.Dcb.MaterializedView.Postgres`
   PostgreSQL 向けのテーブル登録、レジストリ保存、イベント適用、行アクセス実装です。
+- `Sekiban.Dcb.MaterializedView.SqlServer`
+  SQL Server 向け classic MV 実装です。
+- `Sekiban.Dcb.MaterializedView.MySql`
+  MySQL 向け classic MV 実装です。
+- `Sekiban.Dcb.MaterializedView.Sqlite`
+  SQLite 向け classic MV 実装です。
 - `Sekiban.Dcb.MaterializedView.Orleans`
   Orleans Grain による起動、状態確認、`IMvOrleansQueryAccessor` を提供します。
 
@@ -93,8 +99,21 @@ builder.Services.AddSekibanDcbMaterializedViewOrleans();
   1 つのプロジェクター登録
 - `AddSekibanDcbMaterializedViewPostgres`
   PostgreSQL 向けレジストリと executor の登録
+- `AddSekibanDcbMaterializedViewSqlServer` / `AddSekibanDcbMaterializedViewMySql` / `AddSekibanDcbMaterializedViewSqlite`
+  各 DB 向けの classic MV runtime 登録
 - `AddSekibanDcbMaterializedViewOrleans`
   Orleans 側の起動と query accessor の登録
+
+provider ごとの登録例:
+
+```csharp
+builder.Services.AddSekibanDcbMaterializedViewSqlServer(configuration, "DcbMaterializedViewSqlServer");
+builder.Services.AddSekibanDcbMaterializedViewMySql(configuration, "DcbMaterializedViewMySql");
+builder.Services.AddSekibanDcbMaterializedViewSqlite(configuration, "DcbMaterializedViewSqlite");
+```
+
+プロジェクターは引き続き SQL を直接返します。複数 provider で 1 つの projector を使いたい場合は、
+`ctx.DatabaseType` を見て SQL 方言を切り替えてください。Unsafe Window MV は v1 時点では PostgreSQL のみです。
 
 ## プロジェクターの書き方
 


### PR DESCRIPTION
## Summary
- add classic MV provider packages for SQL Server, MySQL, and SQLite
- extend `MvDbType` and make `NativeMvApplyHost` surface the active provider database type
- add multi-provider integration tests and wire new packages into build/package/docs

## Scope
This PR implements classic materialized view providers for:
- `Sekiban.Dcb.MaterializedView.SqlServer`
- `Sekiban.Dcb.MaterializedView.MySql`
- `Sekiban.Dcb.MaterializedView.Sqlite`

Unsafe Window MV remains out of scope in this PR and stays PostgreSQL-only.

## Validation
- `dotnet build dcb/src/Sekiban.Dcb.MaterializedView.SqlServer/Sekiban.Dcb.MaterializedView.SqlServer.csproj -v minimal`
- `dotnet build dcb/src/Sekiban.Dcb.MaterializedView.MySql/Sekiban.Dcb.MaterializedView.MySql.csproj -v minimal`
- `dotnet build dcb/src/Sekiban.Dcb.MaterializedView.Sqlite/Sekiban.Dcb.MaterializedView.Sqlite.csproj -v minimal`
- `dotnet test dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests.csproj -v minimal`
- `dotnet build dcb/Sekiban.Dcb.slnx -v minimal`

Closes #1033
