### PR TITLE
Refactor MaterializedViewGrain catch-up for backlog-safe batching

### DIFF
--- a/dcb/src/Sekiban.Dcb.MaterializedView.Orleans/MaterializedViewGrain.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.Orleans/MaterializedViewGrain.cs
@@ -13,7 +13,10 @@ public sealed class MaterializedViewGrain : Grain, IMaterializedViewGrain
     // Global catch-up concurrency gate. Shared across all MaterializedViewGrain activations
     // in the current process/silo to protect the event store and MV relational store from
     // concurrent catch-up floods when many grains activate together.
-    private static readonly SemaphoreSlim CatchUpBatchSemaphore = new(1, 1);
+    // Constructed with no maxCount so Release(delta) is safe when grains raise the limit
+    // via MvOptions.CatchUpMaxConcurrentBatches. Narrowing is not supported.
+    private static readonly SemaphoreSlim CatchUpBatchSemaphore = new(1);
+    private static readonly object s_catchUpSemaphoreSync = new();
     private static int s_catchUpMaxConcurrentBatches = 1;
 
     private readonly IMvExecutor _executor;
@@ -129,17 +132,37 @@ public sealed class MaterializedViewGrain : Grain, IMaterializedViewGrain
         // classic RefreshAsync semantics used by integration tests).
         // Orleans grain single-threading guarantees the scheduled timer will
         // not interleave with this loop inside the same grain.
+        //
+        // A tick may return madeProgress=false because (a) catch-up settled
+        // in that tick, (b) the global concurrency gate was busy, or (c)
+        // another grain turn has a batch in flight. Only (a) means "done";
+        // for (b) and (c) we must wait briefly and retry, otherwise
+        // RefreshAsync returns while catch-up is still active.
+        var settleDeadline = DateTime.UtcNow + _options.CatchUpStallThreshold;
         while (_isCatchUpActive)
         {
             var madeProgress = await RunCatchUpTickAsync(ignoreImmediateFlag: true, CancellationToken.None);
-            if (!madeProgress && !_isCatchUpActive)
+            if (!_isCatchUpActive)
             {
                 break;
             }
 
             if (!madeProgress)
             {
-                break;
+                if (DateTime.UtcNow >= settleDeadline)
+                {
+                    _logger.LogWarning(
+                        "RefreshAsync timed out waiting for catch-up to settle for {ViewName}/{ViewVersion}. IsCatchUpActive={IsCatchUpActive}, BatchInFlight={BatchInFlight}.",
+                        _viewName,
+                        _viewVersion,
+                        _isCatchUpActive,
+                        _batchInFlight);
+                    break;
+                }
+
+                // Brief back-off when a tick was gated/in-flight; keeps this
+                // loop from spinning while another turn owns the semaphore.
+                await Task.Delay(TimeSpan.FromMilliseconds(10), CancellationToken.None);
             }
         }
 
@@ -172,7 +195,7 @@ public sealed class MaterializedViewGrain : Grain, IMaterializedViewGrain
                 _viewName!,
                 _viewVersion,
                 _started,
-                _batchInFlight,
+                _isCatchUpActive || _batchInFlight,
                 _streamHandle is not null,
                 _pendingStreamEvents.Count,
                 _lastAppliedSortableUniqueId,
@@ -194,11 +217,11 @@ public sealed class MaterializedViewGrain : Grain, IMaterializedViewGrain
         return Task.CompletedTask;
     }
 
-    private async Task PrepareStreamAsync()
+    private Task PrepareStreamAsync()
     {
         if (_stream is not null)
         {
-            return;
+            return Task.CompletedTask;
         }
 
         var streamInfo = _subscriptionResolver.Resolve(_grainKey!);
@@ -211,7 +234,7 @@ public sealed class MaterializedViewGrain : Grain, IMaterializedViewGrain
         var streamProvider = this.GetStreamProvider(orleansStream.ProviderName);
         _stream = streamProvider.GetStream<SerializableEvent>(
             StreamId.Create(orleansStream.StreamNamespace, orleansStream.StreamId));
-        await Task.CompletedTask;
+        return Task.CompletedTask;
     }
 
     private async Task StartSubscriptionAsync()
@@ -253,9 +276,12 @@ public sealed class MaterializedViewGrain : Grain, IMaterializedViewGrain
             return;
         }
 
+        // Start the first tick immediately so initial backlog catch-up does
+        // not wait for an entire PollInterval before beginning. This also
+        // makes NeedsImmediateCatchUp effective on the very first cycle.
         _catchUpTimer = this.RegisterGrainTimer(
             _ => ProcessCatchUpTickAsync(),
-            _options.PollInterval,
+            TimeSpan.Zero,
             _options.PollInterval);
     }
 
@@ -439,16 +465,33 @@ public sealed class MaterializedViewGrain : Grain, IMaterializedViewGrain
             return;
         }
 
+        // If a batch is still truly in-flight (the grain is yielded on an
+        // awaited DB/executor call), leave _batchInFlight alone. The batch's
+        // finally block will release the semaphore and clear the flag.
+        // Clearing _batchInFlight here would let OnStreamBatchAsync drain
+        // stream events while catch-up is still writing to the MV store,
+        // breaking single-flight ordering. If the underlying task is hung,
+        // the grain is hung regardless, so clearing the flag would not help.
+        if (_batchInFlight)
+        {
+            _logger.LogWarning(
+                "Materialized view catch-up appears stalled for {ViewName}/{ViewVersion} but a batch is still marked in-flight; leaving single-flight state intact. LastAttemptAt={LastAttempt}, PendingStreamEvents={PendingStreamEvents}.",
+                _viewName,
+                _viewVersion,
+                lastAttempt,
+                _pendingStreamEvents.Count);
+            _lastCatchUpAttemptAt = DateTimeOffset.UtcNow;
+            return;
+        }
+
         _logger.LogWarning(
-            "Recovering stale materialized view catch-up state for {ViewName}/{ViewVersion}. LastAttemptAt={LastAttempt}, BatchInFlight={BatchInFlight}, PendingStreamEvents={PendingStreamEvents}.",
+            "Recovering stale materialized view catch-up state for {ViewName}/{ViewVersion}. LastAttemptAt={LastAttempt}, PendingStreamEvents={PendingStreamEvents}.",
             _viewName,
             _viewVersion,
             lastAttempt,
-            _batchInFlight,
             _pendingStreamEvents.Count);
 
         // Reset orchestration-only state. Registry state stays authoritative.
-        _batchInFlight = false;
         _consecutiveEmptyBatches = 0;
         _needsImmediateCatchUp = true;
         _lastCatchUpAttemptAt = DateTimeOffset.UtcNow;
@@ -622,8 +665,7 @@ public sealed class MaterializedViewGrain : Grain, IMaterializedViewGrain
     private static void ReconfigureCatchUpSemaphore(int desiredConcurrency)
     {
         var target = Math.Max(1, desiredConcurrency);
-        var current = Volatile.Read(ref s_catchUpMaxConcurrentBatches);
-        if (target == current)
+        if (Volatile.Read(ref s_catchUpMaxConcurrentBatches) >= target)
         {
             return;
         }
@@ -631,10 +673,18 @@ public sealed class MaterializedViewGrain : Grain, IMaterializedViewGrain
         // The concurrency limit is process-wide. We only raise it here; the
         // effective bound is 1 by default, which matches the documented goal
         // of protecting the event store / relational store during backlog.
-        if (target > current)
+        // The semaphore is constructed without a maxCount so Release(delta)
+        // will not throw when multiple grains raise the limit concurrently.
+        lock (s_catchUpSemaphoreSync)
         {
+            var current = s_catchUpMaxConcurrentBatches;
+            if (target <= current)
+            {
+                return;
+            }
+
             var delta = target - current;
-            Interlocked.Exchange(ref s_catchUpMaxConcurrentBatches, target);
+            s_catchUpMaxConcurrentBatches = target;
             CatchUpBatchSemaphore.Release(delta);
         }
     }

--- a/dcb/src/Sekiban.Dcb.MaterializedView.Orleans/MaterializedViewGrain.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.Orleans/MaterializedViewGrain.cs
@@ -10,6 +10,12 @@ namespace Sekiban.Dcb.MaterializedView.Orleans;
 
 public sealed class MaterializedViewGrain : Grain, IMaterializedViewGrain
 {
+    // Global catch-up concurrency gate. Shared across all MaterializedViewGrain activations
+    // in the current process/silo to protect the event store and MV relational store from
+    // concurrent catch-up floods when many grains activate together.
+    private static readonly SemaphoreSlim CatchUpBatchSemaphore = new(1, 1);
+    private static int s_catchUpMaxConcurrentBatches = 1;
+
     private readonly IMvExecutor _executor;
     private readonly IMvApplyHostFactory _hostFactory;
     private readonly ILogger<MaterializedViewGrain> _logger;
@@ -17,7 +23,6 @@ public sealed class MaterializedViewGrain : Grain, IMaterializedViewGrain
     private readonly IMvRegistryStore _registryStore;
     private readonly IEventSubscriptionResolver _subscriptionResolver;
 
-    private bool _catchUpInProgress;
     private readonly List<SerializableEvent> _pendingStreamEvents = [];
     private IAsyncStream<SerializableEvent>? _stream;
     private StreamSubscriptionHandle<SerializableEvent>? _streamHandle;
@@ -35,6 +40,16 @@ public sealed class MaterializedViewGrain : Grain, IMaterializedViewGrain
     private DateTimeOffset? _lastCatchUpCompletedAt;
     private bool _started;
 
+    // Batch-driven catch-up orchestration state.
+    private bool _isCatchUpActive;
+    private bool _needsImmediateCatchUp;
+    private bool _batchInFlight;
+    private DateTimeOffset? _lastCatchUpAttemptAt;
+    private int _consecutiveEmptyBatches;
+    private string? _lastProgressSortableUniqueId;
+    private long _catchUpBatchSkipCount;
+    private bool _statusMarkedCatchingUp;
+
     public MaterializedViewGrain(
         IMvApplyHostFactory hostFactory,
         IMvExecutor executor,
@@ -49,6 +64,7 @@ public sealed class MaterializedViewGrain : Grain, IMaterializedViewGrain
         _subscriptionResolver = subscriptionResolver;
         _logger = logger;
         _options = options.Value;
+        ReconfigureCatchUpSemaphore(_options.CatchUpMaxConcurrentBatches);
     }
 
     public override async Task OnActivateAsync(CancellationToken cancellationToken)
@@ -61,6 +77,7 @@ public sealed class MaterializedViewGrain : Grain, IMaterializedViewGrain
     public override async Task OnDeactivateAsync(DeactivationReason reason, CancellationToken cancellationToken)
     {
         _catchUpTimer?.Dispose();
+        _catchUpTimer = null;
         if (_streamHandle is not null)
         {
             await _streamHandle.UnsubscribeAsync();
@@ -81,19 +98,52 @@ public sealed class MaterializedViewGrain : Grain, IMaterializedViewGrain
         await _executor.InitializeAsync(_host!, _serviceId, CancellationToken.None);
         await RefreshPositionFromRegistryAsync(CancellationToken.None);
         await StartSubscriptionAsync();
-        await CatchUpAndDrainAsync(CancellationToken.None);
 
-        _catchUpTimer ??= this.RegisterGrainTimer(
-            _ => PeriodicBufferedApplyAsync(),
-            _options.PollInterval,
-            _options.PollInterval);
+        _isCatchUpActive = true;
+        _needsImmediateCatchUp = true;
+        _consecutiveEmptyBatches = 0;
+        _lastError = null;
+        _lastCatchUpStartedAt = DateTimeOffset.UtcNow;
+        _statusMarkedCatchingUp = false;
+        StartCatchUpTimer();
         _started = true;
     }
 
     public async Task RefreshAsync()
     {
         await EnsureStartedAsync();
-        await CatchUpAndDrainAsync(CancellationToken.None);
+
+        // Activate catch-up for any callers that explicitly request a refresh.
+        if (!_isCatchUpActive)
+        {
+            _isCatchUpActive = true;
+            _needsImmediateCatchUp = true;
+            _consecutiveEmptyBatches = 0;
+            _statusMarkedCatchingUp = false;
+            _lastCatchUpStartedAt = DateTimeOffset.UtcNow;
+            StartCatchUpTimer();
+        }
+
+        // Drive catch-up to an idle/ready state synchronously for callers that
+        // expect the grain to be fully caught up on return (preserves the
+        // classic RefreshAsync semantics used by integration tests).
+        // Orleans grain single-threading guarantees the scheduled timer will
+        // not interleave with this loop inside the same grain.
+        while (_isCatchUpActive)
+        {
+            var madeProgress = await RunCatchUpTickAsync(ignoreImmediateFlag: true, CancellationToken.None);
+            if (!madeProgress && !_isCatchUpActive)
+            {
+                break;
+            }
+
+            if (!madeProgress)
+            {
+                break;
+            }
+        }
+
+        await DrainPendingStreamEventsAsync(CancellationToken.None);
     }
 
     public async Task<bool> IsSortableUniqueIdReceived(string sortableUniqueId)
@@ -122,14 +172,20 @@ public sealed class MaterializedViewGrain : Grain, IMaterializedViewGrain
                 _viewName!,
                 _viewVersion,
                 _started,
-                _catchUpInProgress,
+                _batchInFlight,
                 _streamHandle is not null,
                 _pendingStreamEvents.Count,
                 _lastAppliedSortableUniqueId,
                 _lastReceivedSortableUniqueId,
                 _lastError,
                 _lastCatchUpStartedAt,
-                _lastCatchUpCompletedAt));
+                _lastCatchUpCompletedAt,
+                _isCatchUpActive,
+                _lastCatchUpAttemptAt,
+                _consecutiveEmptyBatches,
+                _lastProgressSortableUniqueId,
+                _needsImmediateCatchUp,
+                _catchUpBatchSkipCount));
     }
 
     public Task RequestDeactivationAsync()
@@ -155,6 +211,7 @@ public sealed class MaterializedViewGrain : Grain, IMaterializedViewGrain
         var streamProvider = this.GetStreamProvider(orleansStream.ProviderName);
         _stream = streamProvider.GetStream<SerializableEvent>(
             StreamId.Create(orleansStream.StreamNamespace, orleansStream.StreamId));
+        await Task.CompletedTask;
     }
 
     private async Task StartSubscriptionAsync()
@@ -189,67 +246,212 @@ public sealed class MaterializedViewGrain : Grain, IMaterializedViewGrain
         }
     }
 
-    private async Task CatchUpAndDrainAsync(CancellationToken cancellationToken)
+    private void StartCatchUpTimer()
     {
-        if (_catchUpInProgress)
+        if (_catchUpTimer is not null)
         {
             return;
         }
 
-        ResolveHost();
-        _catchUpInProgress = true;
-        _lastCatchUpStartedAt = DateTimeOffset.UtcNow;
-        _lastError = null;
+        _catchUpTimer = this.RegisterGrainTimer(
+            _ => ProcessCatchUpTickAsync(),
+            _options.PollInterval,
+            _options.PollInterval);
+    }
+
+    private void StopCatchUpTimer()
+    {
+        _catchUpTimer?.Dispose();
+        _catchUpTimer = null;
+    }
+
+    /// <summary>
+    ///     Timer-driven tick. Runs at most one catch-up batch under the global
+    ///     concurrency gate, then drains due buffered stream events.
+    /// </summary>
+    private async Task ProcessCatchUpTickAsync()
+    {
+        try
+        {
+            if (_isCatchUpActive)
+            {
+                RecoverStaleCatchUpIfNeeded();
+                await RunCatchUpTickAsync(ignoreImmediateFlag: false, CancellationToken.None);
+            }
+            else
+            {
+                // Catch-up is idle: still drain buffered stream events whose
+                // reorder window has elapsed.
+                await DrainPendingStreamEventsAsync(CancellationToken.None);
+            }
+        }
+        catch (Exception ex)
+        {
+            _lastError = ex.Message;
+            _logger.LogWarning(
+                ex,
+                "Materialized view grain catch-up tick failed for {ViewName}/{ViewVersion}.",
+                _viewName,
+                _viewVersion);
+        }
+    }
+
+    /// <summary>
+    ///     Runs at most one catch-up batch. Returns true if the batch made any
+    ///     progress (AppliedEvents &gt; 0), false if the batch was empty, skipped
+    ///     due to the global gate, or catch-up is no longer active.
+    /// </summary>
+    private async Task<bool> RunCatchUpTickAsync(bool ignoreImmediateFlag, CancellationToken cancellationToken)
+    {
+        if (!_isCatchUpActive)
+        {
+            StopCatchUpTimer();
+            return false;
+        }
+
+        if (_batchInFlight)
+        {
+            return false;
+        }
+
+        // Honour the immediate-catch-up flag only on the first tick after start;
+        // subsequent ticks always run when the gate is available.
+        if (!ignoreImmediateFlag && !_needsImmediateCatchUp && _lastCatchUpAttemptAt is { } lastAttempt &&
+            DateTimeOffset.UtcNow - lastAttempt < _options.PollInterval.Divide(2))
+        {
+            // Not yet time for the next batch.
+            return false;
+        }
+
+        var acquired = await CatchUpBatchSemaphore.WaitAsync(TimeSpan.Zero, cancellationToken);
+        if (!acquired)
+        {
+            _catchUpBatchSkipCount++;
+            _logger.LogInformation(
+                "Materialized view catch-up batch skipped due to global concurrency limit. View={ViewName}/{ViewVersion}, SkipCount={SkipCount}, PendingStreamEvents={PendingStreamEvents}, CurrentPosition={CurrentPosition}.",
+                _viewName,
+                _viewVersion,
+                _catchUpBatchSkipCount,
+                _pendingStreamEvents.Count,
+                _lastAppliedSortableUniqueId ?? "beginning");
+            return false;
+        }
+
+        _batchInFlight = true;
+        _needsImmediateCatchUp = false;
+        _lastCatchUpAttemptAt = DateTimeOffset.UtcNow;
+        var madeProgress = false;
 
         try
         {
-            await _registryStore.UpdateStatusAsync(
+            if (!_statusMarkedCatchingUp)
+            {
+                await _registryStore.UpdateStatusAsync(
                     _serviceId!,
                     _host!.ViewName,
                     _host.ViewVersion,
                     MvStatus.CatchingUp,
-                    cancellationToken: cancellationToken)
-                ;
-
-            while (true)
-            {
-                var result = await _executor.CatchUpOnceAsync(_host, _serviceId, cancellationToken);
-                if (!string.IsNullOrWhiteSpace(result.LastAppliedSortableUniqueId))
-                {
-                    _lastAppliedSortableUniqueId = result.LastAppliedSortableUniqueId;
-                }
-
-                if (result.AppliedEvents == 0 || result.ReachedUnsafeWindow)
-                {
-                    break;
-                }
+                    cancellationToken: cancellationToken);
+                _statusMarkedCatchingUp = true;
             }
 
-            await DrainPendingStreamEventsAsync(cancellationToken);
-            await RefreshPositionFromRegistryAsync(cancellationToken);
-            await _registryStore.UpdateStatusAsync(
-                    _serviceId!,
-                    _host.ViewName,
-                    _host.ViewVersion,
-                    MvStatus.Ready,
-                    cancellationToken: cancellationToken)
-                ;
-            _lastCatchUpCompletedAt = DateTimeOffset.UtcNow;
+            var result = await _executor.CatchUpOnceAsync(_host!, _serviceId, cancellationToken);
+
+            if (!string.IsNullOrWhiteSpace(result.LastAppliedSortableUniqueId))
+            {
+                _lastAppliedSortableUniqueId = result.LastAppliedSortableUniqueId;
+                _lastProgressSortableUniqueId = result.LastAppliedSortableUniqueId;
+            }
+
+            if (result.AppliedEvents > 0)
+            {
+                _consecutiveEmptyBatches = 0;
+                madeProgress = true;
+            }
+            else
+            {
+                _consecutiveEmptyBatches++;
+            }
+
+            var shouldSettle =
+                result.ReachedUnsafeWindow ||
+                _consecutiveEmptyBatches >= Math.Max(1, _options.MaxConsecutiveEmptyBatches);
+
+            if (shouldSettle)
+            {
+                await CompleteCatchUpAsync(cancellationToken);
+            }
         }
         catch (Exception ex)
         {
             _lastError = ex.Message;
             _logger.LogError(
                 ex,
-                "Materialized view grain catch-up failed for {ViewName}/{ViewVersion}.",
+                "Materialized view catch-up batch failed for {ViewName}/{ViewVersion}.",
                 _viewName,
                 _viewVersion);
             throw;
         }
         finally
         {
-            _catchUpInProgress = false;
+            _batchInFlight = false;
+            CatchUpBatchSemaphore.Release();
         }
+
+        // Regardless of catch-up result, drain due buffered stream events now
+        // that the gate is released. Orleans grain single-threading keeps this
+        // coordinated with subsequent ticks.
+        await DrainPendingStreamEventsAsync(cancellationToken);
+
+        return madeProgress;
+    }
+
+    private async Task CompleteCatchUpAsync(CancellationToken cancellationToken)
+    {
+        await RefreshPositionFromRegistryAsync(cancellationToken);
+        await _registryStore.UpdateStatusAsync(
+            _serviceId!,
+            _host!.ViewName,
+            _host.ViewVersion,
+            MvStatus.Ready,
+            cancellationToken: cancellationToken);
+        _isCatchUpActive = false;
+        _needsImmediateCatchUp = false;
+        _consecutiveEmptyBatches = 0;
+        _lastCatchUpCompletedAt = DateTimeOffset.UtcNow;
+    }
+
+    private void RecoverStaleCatchUpIfNeeded()
+    {
+        if (!_isCatchUpActive)
+        {
+            return;
+        }
+
+        var lastAttempt = _lastCatchUpAttemptAt ?? _lastCatchUpStartedAt;
+        if (lastAttempt is null)
+        {
+            return;
+        }
+
+        if (DateTimeOffset.UtcNow - lastAttempt.Value <= _options.CatchUpStallThreshold)
+        {
+            return;
+        }
+
+        _logger.LogWarning(
+            "Recovering stale materialized view catch-up state for {ViewName}/{ViewVersion}. LastAttemptAt={LastAttempt}, BatchInFlight={BatchInFlight}, PendingStreamEvents={PendingStreamEvents}.",
+            _viewName,
+            _viewVersion,
+            lastAttempt,
+            _batchInFlight,
+            _pendingStreamEvents.Count);
+
+        // Reset orchestration-only state. Registry state stays authoritative.
+        _batchInFlight = false;
+        _consecutiveEmptyBatches = 0;
+        _needsImmediateCatchUp = true;
+        _lastCatchUpAttemptAt = DateTimeOffset.UtcNow;
     }
 
     private async Task DrainPendingStreamEventsAsync(CancellationToken cancellationToken)
@@ -338,7 +540,10 @@ public sealed class MaterializedViewGrain : Grain, IMaterializedViewGrain
             _pendingStreamEvents.Add(serializableEvent);
         }
 
-        if (_catchUpInProgress || !_started)
+        // Do not apply while a catch-up batch is executing or before the grain
+        // is operational. The scheduled tick will drain buffered events once
+        // the batch completes.
+        if (_batchInFlight || !_started)
         {
             return;
         }
@@ -354,8 +559,7 @@ public sealed class MaterializedViewGrain : Grain, IMaterializedViewGrain
         }
 
         ResolveHost();
-        var applied = await _executor.ApplySerializableEventsAsync(_host!, events, _serviceId, cancellationToken)
-            ;
+        var applied = await _executor.ApplySerializableEventsAsync(_host!, events, _serviceId, cancellationToken);
         if (applied > 0)
         {
             await RefreshPositionFromRegistryAsync(cancellationToken);
@@ -367,8 +571,7 @@ public sealed class MaterializedViewGrain : Grain, IMaterializedViewGrain
     private async Task RefreshPositionFromRegistryAsync(CancellationToken cancellationToken)
     {
         ResolveHost();
-        var entries = await _registryStore.GetEntriesAsync(_serviceId!, _host!.ViewName, _host.ViewVersion, cancellationToken)
-            ;
+        var entries = await _registryStore.GetEntriesAsync(_serviceId!, _host!.ViewName, _host.ViewVersion, cancellationToken);
         var currentPosition = entries
             .Select(entry => entry.CurrentPosition)
             .Where(position => !string.IsNullOrWhiteSpace(position))
@@ -389,28 +592,6 @@ public sealed class MaterializedViewGrain : Grain, IMaterializedViewGrain
         }
 
         return sortableUniqueId.GetDateTime() <= thresholdUtc;
-    }
-
-    private async Task PeriodicBufferedApplyAsync()
-    {
-        if (_catchUpInProgress)
-        {
-            return;
-        }
-
-        try
-        {
-            await DrainPendingStreamEventsAsync(CancellationToken.None);
-        }
-        catch (Exception ex)
-        {
-            _lastError = ex.Message;
-            _logger.LogWarning(
-                ex,
-                "Materialized view grain periodic buffered apply failed for {ViewName}/{ViewVersion}.",
-                _viewName,
-                _viewVersion);
-        }
     }
 
     private void ResolveIdentity()
@@ -436,6 +617,26 @@ public sealed class MaterializedViewGrain : Grain, IMaterializedViewGrain
         }
 
         _host = _hostFactory.Create(_viewName!, _viewVersion);
+    }
+
+    private static void ReconfigureCatchUpSemaphore(int desiredConcurrency)
+    {
+        var target = Math.Max(1, desiredConcurrency);
+        var current = Volatile.Read(ref s_catchUpMaxConcurrentBatches);
+        if (target == current)
+        {
+            return;
+        }
+
+        // The concurrency limit is process-wide. We only raise it here; the
+        // effective bound is 1 by default, which matches the documented goal
+        // of protecting the event store / relational store during backlog.
+        if (target > current)
+        {
+            var delta = target - current;
+            Interlocked.Exchange(ref s_catchUpMaxConcurrentBatches, target);
+            CatchUpBatchSemaphore.Release(delta);
+        }
     }
 
     private sealed class StreamBatchObserver : IAsyncBatchObserver<SerializableEvent>

--- a/dcb/src/Sekiban.Dcb.MaterializedView.Orleans/MaterializedViewGrain.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.Orleans/MaterializedViewGrain.cs
@@ -340,8 +340,8 @@ public sealed class MaterializedViewGrain : Grain, IMaterializedViewGrain
             return false;
         }
 
-        // Honour the immediate-catch-up flag only on the first tick after start;
-        // subsequent ticks always run when the gate is available.
+        // The immediate-catch-up flag is honoured only on the first tick after
+        // startup. On later ticks we run whenever the gate is available.
         if (!ignoreImmediateFlag && !_needsImmediateCatchUp && _lastCatchUpAttemptAt is { } lastAttempt &&
             DateTimeOffset.UtcNow - lastAttempt < _options.PollInterval.Divide(2))
         {

--- a/dcb/src/Sekiban.Dcb.MaterializedView.Orleans/MaterializedViewGrainStatus.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.Orleans/MaterializedViewGrainStatus.cs
@@ -25,4 +25,16 @@ public sealed record MaterializedViewGrainStatus(
     [property: Id(10)]
     DateTimeOffset? LastCatchUpStartedAt,
     [property: Id(11)]
-    DateTimeOffset? LastCatchUpCompletedAt);
+    DateTimeOffset? LastCatchUpCompletedAt,
+    [property: Id(12)]
+    bool IsCatchUpActive = false,
+    [property: Id(13)]
+    DateTimeOffset? LastCatchUpAttemptAt = null,
+    [property: Id(14)]
+    int ConsecutiveEmptyBatches = 0,
+    [property: Id(15)]
+    string? LastProgressSortableUniqueId = null,
+    [property: Id(16)]
+    bool NeedsImmediateCatchUp = false,
+    [property: Id(17)]
+    long CatchUpBatchSkipCount = 0);

--- a/dcb/src/Sekiban.Dcb.MaterializedView/MvOptions.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView/MvOptions.cs
@@ -14,6 +14,28 @@ public sealed class MvOptions
     public int MaxConsecutiveFailuresBeforeStop { get; set; } = 3;
     public string TablePrefix { get; set; } = DefaultTablePrefix;
     public PhysicalNameResolver? PhysicalNameResolver { get; set; }
+
+    /// <summary>
+    ///     Number of consecutive empty catch-up batches that will cause the grain
+    ///     to mark catch-up as ready and stop the per-tick batch execution.
+    ///     The default (1) preserves the original "loop until AppliedEvents == 0"
+    ///     semantics so that background catch-up does not race with fresh stream
+    ///     deliveries once the initial backlog is drained.
+    /// </summary>
+    public int MaxConsecutiveEmptyBatches { get; set; } = 1;
+
+    /// <summary>
+    ///     Duration without catch-up progress after which the orchestration state
+    ///     is considered stale and reset so the next scheduled cycle can retry.
+    /// </summary>
+    public TimeSpan CatchUpStallThreshold { get; set; } = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    ///     Maximum number of MV catch-up batches that may execute concurrently
+    ///     inside the same process/silo. When the limit is busy, a grain will
+    ///     skip its scheduled cycle and retry on the next tick.
+    /// </summary>
+    public int CatchUpMaxConcurrentBatches { get; set; } = 1;
 }
 
 public static class MvSchemaHelper

--- a/dcb/tests/Sekiban.Dcb.MaterializedView.Postgres.Tests/MaterializedViewPostgresOrleansTests.cs
+++ b/dcb/tests/Sekiban.Dcb.MaterializedView.Postgres.Tests/MaterializedViewPostgresOrleansTests.cs
@@ -58,7 +58,10 @@ public sealed class MaterializedViewPostgresOrleansTests(MaterializedViewPostgre
             AddedAt = DateTimeOffset.UtcNow.AddMinutes(-1)
         });
 
-        await grain.EnsureStartedAsync();
+        // Drive initial catch-up to idle so subsequent direct writes do not
+        // race with the background catch-up tick. Startup itself is now
+        // non-blocking; RefreshAsync() explicitly waits for catch-up settle.
+        await grain.RefreshAsync();
 
         var latestBeforeStream = await GetLatestSortableUniqueIdAsync();
         await WaitUntilAsync(async () =>
@@ -176,7 +179,10 @@ public sealed class MaterializedViewPostgresOrleansTests(MaterializedViewPostgre
         }
 
         await fixture.ResetAsync();
-        await grain.EnsureStartedAsync();
+        // Drive initial catch-up to idle so subsequent direct writes do not
+        // race with the background catch-up tick. Startup itself is now
+        // non-blocking; RefreshAsync() explicitly waits for catch-up settle.
+        await grain.RefreshAsync();
 
         var executor = fixture.CreateExecutor(publishToStream: false);
         const int forecastCount = 64;
@@ -321,7 +327,10 @@ public sealed class MaterializedViewPostgresOrleansTests(MaterializedViewPostgre
         }
 
         await fixture.ResetAsync();
-        await grain.EnsureStartedAsync();
+        // Drive initial catch-up to idle so subsequent direct writes do not
+        // race with the background catch-up tick. Startup itself is now
+        // non-blocking; RefreshAsync() explicitly waits for catch-up settle.
+        await grain.RefreshAsync();
 
         var executor = fixture.CreateExecutor(publishToStream: false);
         var forecastId = Guid.CreateVersion7();
@@ -457,7 +466,10 @@ public sealed class MaterializedViewPostgresOrleansTests(MaterializedViewPostgre
         }
 
         await fixture.ResetAsync();
-        await grain.EnsureStartedAsync();
+        // Drive initial catch-up to idle so subsequent direct writes do not
+        // race with the background catch-up tick. Startup itself is now
+        // non-blocking; RefreshAsync() explicitly waits for catch-up settle.
+        await grain.RefreshAsync();
 
         var executor = fixture.CreateExecutor(publishToStream: false);
         var forecastId = Guid.CreateVersion7();
@@ -563,7 +575,10 @@ public sealed class MaterializedViewPostgresOrleansTests(MaterializedViewPostgre
         }
 
         await fixture.ResetAsync();
-        await grain.EnsureStartedAsync();
+        // Drive initial catch-up to idle so subsequent direct writes do not
+        // race with the background catch-up tick. Startup itself is now
+        // non-blocking; RefreshAsync() explicitly waits for catch-up settle.
+        await grain.RefreshAsync();
 
         var executor = fixture.CreateExecutor(publishToStream: false);
         var delayedForecastId = Guid.CreateVersion7();


### PR DESCRIPTION
## Summary

Closes #1036.

Refactors `MaterializedViewGrain` catch-up orchestration so that grain activation is no longer blocked by a full catch-up loop and catch-up advances in bounded batches under a process-wide concurrency gate.

## Changes

- **Non-blocking startup** — `EnsureStartedAsync()` now: resolve host → init executor/registry → refresh position → start stream subscription → arm catch-up timer → return. The previous `while (AppliedEvents > 0 && !ReachedUnsafeWindow)` loop is gone from the startup path.
- **Batch-driven catch-up** — a grain timer invokes `ProcessCatchUpTickAsync()` every `MvOptions.PollInterval`. Each tick runs at most one `IMvExecutor.CatchUpOnceAsync(...)` under a static `SemaphoreSlim` that bounds concurrent MV batches per process/silo. After each batch, due buffered stream events are drained. The classic while-loop semantics are preserved for callers that explicitly request them via `RefreshAsync()`, which drives catch-up to idle synchronously (Orleans grain single-threading makes this safe).
- **Stale recovery** — `RecoverStaleCatchUpIfNeeded()` resets orchestration state (never registry state) when no progress has been made within `MvOptions.CatchUpStallThreshold` (default 30s).
- **Observability** — `MaterializedViewGrainStatus` gains `IsCatchUpActive`, `LastCatchUpAttemptAt`, `ConsecutiveEmptyBatches`, `LastProgressSortableUniqueId`, `NeedsImmediateCatchUp`, `CatchUpBatchSkipCount` for operators.
- **New `MvOptions`** — `MaxConsecutiveEmptyBatches` (default 1), `CatchUpStallThreshold` (30s), `CatchUpMaxConcurrentBatches` (1).

## Architectural boundaries preserved

- No provider-specific logic in the grain or MV database providers.
- No Hybrid/Cold-Event branching introduced in the MV layer.
- `IMvExecutor` remains the execution boundary for catch-up/apply.
- `IEventStore` remains the event-read boundary (Hybrid benefits still flow through transparently).

## Test updates

Postgres Orleans integration tests switched from `EnsureStartedAsync()` to `RefreshAsync()` in 5 test setups where the test explicitly needs catch-up to be settled before proceeding (e.g. direct writes followed by stream publish). `RefreshAsync()` composes `EnsureStartedAsync()` + a synchronous drive-to-idle loop, matching the semantics the tests originally relied on.

## Validation

- `dotnet build dcb/Sekiban.Dcb.slnx -c Release` → Build succeeded (0 errors).
- `dotnet test dcb/tests/Sekiban.Dcb.MaterializedView.Tests -c Release` → 21/21 passed (net9.0 + net10.0).
- `dotnet test dcb/tests/Sekiban.Dcb.MaterializedView.Postgres.Tests -c Release -f net9.0` → 11/11 passed (Orleans + raw Postgres integration, Testcontainers).
- `dotnet test dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests -c Release -f net9.0` → 6/6 passed (SqlServer + MySQL + SQLite registrations + integration).

## Notes

- Follow-up ideas (not required for acceptance): expose `MvOptions.CatchUpMaxConcurrentBatches` in DI configuration helpers; add dedicated unit tests for the stall-recovery path; add telemetry metric for `CatchUpBatchSkipCount`.
- The concurrency gate is currently `SemaphoreSlim(1,1)` by default. `ReconfigureCatchUpSemaphore` only raises the bound (we can't safely narrow a busy semaphore), which matches the documented goal of preventing overload at scale-out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)