### PR TITLE
Add unsafe-window materialized view support for SQL Server, MySQL, and SQLite

### DIFF
--- a/dcb/src/Sekiban.Dcb.MaterializedView.MySql/UnsafeWindowMvMySqlRegistration.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.MySql/UnsafeWindowMvMySqlRegistration.cs
@@ -1,0 +1,108 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Sekiban.Dcb.Domains;
+using Sekiban.Dcb.Storage;
+
+namespace Sekiban.Dcb.MaterializedView.MySql;
+
+public static class UnsafeWindowMvMySqlRegistration
+{
+    public static string ConnectionStringKey<TProjector>() =>
+        "UnsafeWindowMvMySql:" + (typeof(TProjector).FullName ?? typeof(TProjector).Name);
+
+    public static string SchemaResolverKey<TProjector>() =>
+        "UnsafeWindowMvMySqlResolver:" + (typeof(TProjector).FullName ?? typeof(TProjector).Name);
+
+    public static IServiceCollection AddSekibanDcbUnsafeWindowMvMySql<TProjector, TRow>(
+        this IServiceCollection services,
+        IConfiguration configuration,
+        string connectionStringName = "DcbMaterializedViewMySql",
+        TimeSpan? idleDelay = null,
+        int catchUpBatchSize = 256,
+        int promotionBatchSize = 32)
+        where TProjector : class, IUnsafeWindowMvProjector<TRow>
+        where TRow : class, new()
+    {
+        if (string.IsNullOrWhiteSpace(connectionStringName))
+        {
+            throw new ArgumentException("Connection string name must be non-empty.", nameof(connectionStringName));
+        }
+
+        var connectionString = configuration.GetConnectionString(connectionStringName)
+            ?? configuration[$"ConnectionStrings:{connectionStringName}"]
+            ?? throw new InvalidOperationException(
+                $"Connection string '{connectionStringName}' not found — unsafe window MV (MySQL) requires a MySQL database.");
+
+        return services.AddSekibanDcbUnsafeWindowMvMySql<TProjector, TRow>(
+            connectionString,
+            idleDelay,
+            catchUpBatchSize,
+            promotionBatchSize);
+    }
+
+    public static IServiceCollection AddSekibanDcbUnsafeWindowMvMySql<TProjector, TRow>(
+        this IServiceCollection services,
+        string connectionString,
+        TimeSpan? idleDelay = null,
+        int catchUpBatchSize = 256,
+        int promotionBatchSize = 32)
+        where TProjector : class, IUnsafeWindowMvProjector<TRow>
+        where TRow : class, new()
+    {
+        if (string.IsNullOrWhiteSpace(connectionString))
+        {
+            throw new ArgumentException("Connection string must be non-empty.", nameof(connectionString));
+        }
+
+        services.AddSingleton<TProjector>();
+        services.AddSingleton<IUnsafeWindowMvProjector<TRow>>(sp => sp.GetRequiredService<TProjector>());
+
+        services.AddKeyedSingleton(SchemaResolverKey<TProjector>(), (sp, _) =>
+        {
+            var projector = sp.GetRequiredService<TProjector>();
+            return new UnsafeWindowMvMySqlSchemaResolver(projector.ViewName, projector.ViewVersion, projector.Schema);
+        });
+        services.AddKeyedSingleton(ConnectionStringKey<TProjector>(), (_, _) => connectionString);
+
+        services.AddSingleton(sp =>
+        {
+            var resolver = sp.GetRequiredKeyedService<UnsafeWindowMvMySqlSchemaResolver>(SchemaResolverKey<TProjector>());
+            var logger = sp.GetRequiredService<ILogger<UnsafeWindowMvMySqlInitializer>>();
+            return new UnsafeWindowMvMySqlInitializer(resolver, connectionString, logger);
+        });
+
+        services.AddSingleton<UnsafeWindowMvMySqlCatchUpWorker<TRow>>(sp =>
+        {
+            var resolver = sp.GetRequiredKeyedService<UnsafeWindowMvMySqlSchemaResolver>(SchemaResolverKey<TProjector>());
+            var projector = sp.GetRequiredService<IUnsafeWindowMvProjector<TRow>>();
+            var eventStore = sp.GetRequiredService<IEventStore>();
+            var eventTypes = sp.GetRequiredService<IEventTypes>();
+            var logger = sp.GetRequiredService<ILogger<UnsafeWindowMvMySqlCatchUpWorker<TRow>>>();
+            return new UnsafeWindowMvMySqlCatchUpWorker<TRow>(resolver, projector, eventStore, eventTypes, connectionString, logger, catchUpBatchSize);
+        });
+
+        services.AddSingleton<UnsafeWindowMvMySqlPromoter<TRow>>(sp =>
+        {
+            var resolver = sp.GetRequiredKeyedService<UnsafeWindowMvMySqlSchemaResolver>(SchemaResolverKey<TProjector>());
+            var projector = sp.GetRequiredService<IUnsafeWindowMvProjector<TRow>>();
+            var eventStore = sp.GetRequiredService<IEventStore>();
+            var eventTypes = sp.GetRequiredService<IEventTypes>();
+            var logger = sp.GetRequiredService<ILogger<UnsafeWindowMvMySqlPromoter<TRow>>>();
+            return new UnsafeWindowMvMySqlPromoter<TRow>(resolver, projector, eventStore, eventTypes, connectionString, logger, promotionBatchSize);
+        });
+
+        services.AddHostedService(sp =>
+        {
+            var projector = sp.GetRequiredService<IUnsafeWindowMvProjector<TRow>>();
+            var initializer = sp.GetRequiredService<UnsafeWindowMvMySqlInitializer>();
+            var catchUp = sp.GetRequiredService<UnsafeWindowMvMySqlCatchUpWorker<TRow>>();
+            var promoter = sp.GetRequiredService<UnsafeWindowMvMySqlPromoter<TRow>>();
+            var logger = sp.GetRequiredService<ILogger<UnsafeWindowMvHostedService>>();
+            return new UnsafeWindowMvHostedService(initializer, catchUp, promoter, projector.ViewName, logger, idleDelay);
+        });
+
+        return services;
+    }
+}

--- a/dcb/src/Sekiban.Dcb.MaterializedView.MySql/UnsafeWindowMvMySqlRuntime.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.MySql/UnsafeWindowMvMySqlRuntime.cs
@@ -191,8 +191,6 @@ internal static class UnsafeWindowMvMySqlDdl
             );
             """;
 
-        var businessSelect = string.Join(", ", resolver.Schema.Columns.Select(c => c.Name));
-
         // CREATE OR REPLACE VIEW is supported by MySQL 5.x+.
         var currentView = $"""
             CREATE OR REPLACE VIEW {resolver.CurrentView} AS

--- a/dcb/src/Sekiban.Dcb.MaterializedView.MySql/UnsafeWindowMvMySqlRuntime.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.MySql/UnsafeWindowMvMySqlRuntime.cs
@@ -1,0 +1,897 @@
+using System.Data;
+using Dapper;
+using Microsoft.Extensions.Logging;
+using MySqlConnector;
+using Sekiban.Dcb.Common;
+using Sekiban.Dcb.Domains;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.Storage;
+using Sekiban.Dcb.Tags;
+
+namespace Sekiban.Dcb.MaterializedView.MySql;
+
+// ============================================================================
+// Unsafe Window Materialized View — MySQL runtime (issue #1035).
+//
+// Dialect notes:
+//   - VARCHAR(191) for _projection_key PK so utf8mb4 indexes stay within the
+//     767/3072-byte InnoDB key limit regardless of server configuration.
+//   - BOOLEAN (TINYINT(1)) / DATETIME(6) / VARCHAR(64) / JSON-free plain types.
+//   - ON DUPLICATE KEY UPDATE for upserts.
+//   - FOR UPDATE / FOR UPDATE SKIP LOCKED (MySQL 8.0+ is required).
+//   - information_schema.columns with table_schema = DATABASE() for validation.
+// ============================================================================
+
+public sealed class UnsafeWindowMvMySqlSchemaResolver
+{
+    // MySQL identifier limit is 64 chars, and InnoDB table name internally
+    // reserves a little headroom. We pick 63 (same as Postgres) so projector
+    // definitions that validated on Postgres keep working here.
+    private const int MaxSharedPrefixLength = 63 - 13;
+
+    public UnsafeWindowMvMySqlSchemaResolver(string viewName, int viewVersion, UnsafeWindowMvSchema schema)
+    {
+        if (string.IsNullOrWhiteSpace(viewName))
+        {
+            throw new ArgumentException("View name must be non-empty.", nameof(viewName));
+        }
+        if (viewVersion <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(viewVersion), "View version must be positive.");
+        }
+        if (schema.Columns.Count == 0)
+        {
+            throw new ArgumentException("Unsafe window MV schema must declare at least one business column.", nameof(schema));
+        }
+
+        var reserved = new HashSet<string>(UnsafeWindowMvReservedColumns.AllReservedNames, StringComparer.OrdinalIgnoreCase);
+        foreach (var column in schema.Columns)
+        {
+            if (reserved.Contains(column.Name))
+            {
+                throw new InvalidOperationException(
+                    $"Unsafe window MV '{viewName}' declares a business column '{column.Name}' that clashes with a framework-managed metadata column. Rename the business column.");
+            }
+
+            MvPhysicalName.ValidateIdentifier(column.Name);
+            ValidateSqlType(column.Name, column.SqlType);
+        }
+
+        var sanitized = MvPhysicalName.SanitizeSegment(viewName);
+        var rawPrefix = $"sekiban_uwmv_{sanitized}_v{viewVersion}";
+        var prefix = rawPrefix.Length <= MaxSharedPrefixLength
+            ? rawPrefix
+            : BuildBoundedPrefix(sanitized, viewVersion);
+
+        SafeTable = $"{prefix}_safe";
+        UnsafeTable = $"{prefix}_unsafe";
+        CurrentView = $"{prefix}_current";
+        CurrentLiveView = $"{prefix}_current_live";
+
+        foreach (var identifier in new[] { SafeTable, UnsafeTable, CurrentView, CurrentLiveView })
+        {
+            MvPhysicalName.ValidateIdentifier(identifier);
+        }
+
+        Schema = schema;
+        ViewName = viewName;
+        ViewVersion = viewVersion;
+    }
+
+    public string ViewName { get; }
+    public int ViewVersion { get; }
+    public string SafeTable { get; }
+    public string UnsafeTable { get; }
+    public string CurrentView { get; }
+    public string CurrentLiveView { get; }
+    public UnsafeWindowMvSchema Schema { get; }
+
+    private static string BuildBoundedPrefix(string sanitized, int viewVersion)
+    {
+        var versionSuffix = $"_v{viewVersion}";
+        var hash = Convert.ToHexString(
+                System.Security.Cryptography.SHA1.HashData(System.Text.Encoding.UTF8.GetBytes(sanitized)))
+            .Substring(0, 8)
+            .ToLowerInvariant();
+
+        var headroom = MaxSharedPrefixLength - ("sekiban_uwmv__".Length + hash.Length + versionSuffix.Length);
+        if (headroom < 1)
+        {
+            headroom = 1;
+        }
+        var head = sanitized.Substring(0, Math.Min(headroom, sanitized.Length));
+        return $"sekiban_uwmv_{head}_{hash}{versionSuffix}";
+    }
+
+    private static void ValidateSqlType(string columnName, string sqlType)
+    {
+        if (string.IsNullOrWhiteSpace(sqlType))
+        {
+            throw new ArgumentException($"Business column '{columnName}' has an empty SQL type.");
+        }
+        foreach (var ch in sqlType)
+        {
+            if (ch == ';' || ch == '\r' || ch == '\n')
+            {
+                throw new ArgumentException(
+                    $"Business column '{columnName}' declares a SQL type containing illegal characters (semicolon / newline). Type: '{sqlType}'.");
+            }
+        }
+        if (sqlType.Contains("--", StringComparison.Ordinal) || sqlType.Contains("/*", StringComparison.Ordinal))
+        {
+            throw new ArgumentException(
+                $"Business column '{columnName}' declares a SQL type containing SQL comment markers. Type: '{sqlType}'.");
+        }
+    }
+}
+
+internal static class UnsafeWindowMvMySqlTypes
+{
+    private static readonly IReadOnlyDictionary<string, string> Map = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+    {
+        ["TEXT"] = "TEXT",
+        ["BOOLEAN"] = "TINYINT(1)",
+        ["BOOL"] = "TINYINT(1)",
+        ["UUID"] = "CHAR(36)",
+        ["TIMESTAMPTZ"] = "DATETIME(6)",
+        ["TIMESTAMP"] = "DATETIME(6)",
+        ["BIGINT"] = "BIGINT",
+        ["INT"] = "INT",
+        ["INTEGER"] = "INT",
+        ["DATE"] = "DATE",
+        ["REAL"] = "FLOAT",
+        ["DOUBLE"] = "DOUBLE",
+        ["SMALLINT"] = "SMALLINT"
+    };
+
+    public static string Translate(string declaredType) =>
+        UnsafeWindowMvLogicalTypes.Translate(declaredType, Map);
+}
+
+internal static class UnsafeWindowMvMySqlDdl
+{
+    public static IReadOnlyList<string> BuildInitializeStatements(UnsafeWindowMvMySqlSchemaResolver resolver)
+    {
+        var businessDdl = string.Join(
+            ",\n    ",
+            resolver.Schema.Columns.Select(c => $"{c.Name} {UnsafeWindowMvMySqlTypes.Translate(c.SqlType)}"));
+
+        // VARCHAR(191) lets utf8mb4 indexes fit within 767 bytes on older
+        // InnoDB configurations too. Modern MySQL 8.0+ supports longer keys
+        // but we stay on the safe floor for compatibility.
+        var safeTable = $"""
+            CREATE TABLE IF NOT EXISTS {resolver.SafeTable} (
+                {UnsafeWindowMvReservedColumns.ProjectionKey} VARCHAR(191) NOT NULL,
+                {businessDdl},
+                {UnsafeWindowMvReservedColumns.IsDeleted} TINYINT(1) NOT NULL DEFAULT 0,
+                {UnsafeWindowMvReservedColumns.LastSortableUniqueId} VARCHAR(64) NOT NULL,
+                {UnsafeWindowMvReservedColumns.LastEventVersion} BIGINT NOT NULL DEFAULT 0,
+                {UnsafeWindowMvReservedColumns.LastAppliedAt} DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+                {UnsafeWindowMvReservedColumns.SafeConfirmedAt} DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+                PRIMARY KEY ({UnsafeWindowMvReservedColumns.ProjectionKey})
+            );
+            """;
+
+        // MySQL identifiers are capped at 64 chars. The obvious index name
+        // "idx_<unsafe-table>_safe_due_at" can overflow once the view name is
+        // more than a few characters long, so we use a shorter suffix form.
+        var unsafeTable = $"""
+            CREATE TABLE IF NOT EXISTS {resolver.UnsafeTable} (
+                {UnsafeWindowMvReservedColumns.ProjectionKey} VARCHAR(191) NOT NULL,
+                {businessDdl},
+                {UnsafeWindowMvReservedColumns.IsDeleted} TINYINT(1) NOT NULL DEFAULT 0,
+                {UnsafeWindowMvReservedColumns.LastSortableUniqueId} VARCHAR(64) NOT NULL,
+                {UnsafeWindowMvReservedColumns.LastEventVersion} BIGINT NOT NULL DEFAULT 0,
+                {UnsafeWindowMvReservedColumns.LastAppliedAt} DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+                {UnsafeWindowMvReservedColumns.UnsafeSince} DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+                {UnsafeWindowMvReservedColumns.SafeDueAt} DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+                {UnsafeWindowMvReservedColumns.NeedsRebuild} TINYINT(1) NOT NULL DEFAULT 0,
+                PRIMARY KEY ({UnsafeWindowMvReservedColumns.ProjectionKey}),
+                INDEX {resolver.UnsafeTable}_sd ({UnsafeWindowMvReservedColumns.SafeDueAt})
+            );
+            """;
+
+        var businessSelect = string.Join(", ", resolver.Schema.Columns.Select(c => c.Name));
+
+        // CREATE OR REPLACE VIEW is supported by MySQL 5.x+.
+        var currentView = $"""
+            CREATE OR REPLACE VIEW {resolver.CurrentView} AS
+            SELECT
+                u.{UnsafeWindowMvReservedColumns.ProjectionKey},
+                {string.Join(", ", resolver.Schema.Columns.Select(c => $"u.{c.Name}"))},
+                u.{UnsafeWindowMvReservedColumns.IsDeleted},
+                u.{UnsafeWindowMvReservedColumns.LastSortableUniqueId},
+                u.{UnsafeWindowMvReservedColumns.LastEventVersion},
+                u.{UnsafeWindowMvReservedColumns.LastAppliedAt}
+            FROM {resolver.UnsafeTable} u
+            UNION ALL
+            SELECT
+                s.{UnsafeWindowMvReservedColumns.ProjectionKey},
+                {string.Join(", ", resolver.Schema.Columns.Select(c => $"s.{c.Name}"))},
+                s.{UnsafeWindowMvReservedColumns.IsDeleted},
+                s.{UnsafeWindowMvReservedColumns.LastSortableUniqueId},
+                s.{UnsafeWindowMvReservedColumns.LastEventVersion},
+                s.{UnsafeWindowMvReservedColumns.LastAppliedAt}
+            FROM {resolver.SafeTable} s
+            WHERE NOT EXISTS (
+                SELECT 1 FROM {resolver.UnsafeTable} u2
+                WHERE u2.{UnsafeWindowMvReservedColumns.ProjectionKey} = s.{UnsafeWindowMvReservedColumns.ProjectionKey}
+            )
+            """;
+
+        var currentLiveView = $"""
+            CREATE OR REPLACE VIEW {resolver.CurrentLiveView} AS
+            SELECT *
+            FROM {resolver.CurrentView}
+            WHERE {UnsafeWindowMvReservedColumns.IsDeleted} = 0
+            """;
+
+        return [safeTable, unsafeTable, currentView, currentLiveView];
+    }
+}
+
+internal static class UnsafeWindowMvMySqlValidator
+{
+    public static async Task ValidateAsync(
+        UnsafeWindowMvMySqlSchemaResolver resolver,
+        MySqlConnection connection,
+        CancellationToken ct)
+    {
+        foreach (var table in new[] { resolver.SafeTable, resolver.UnsafeTable })
+        {
+            var columns = (await connection.QueryAsync<(string column_name, string data_type)>(
+                new CommandDefinition(
+                    """
+                    SELECT column_name, data_type
+                    FROM information_schema.columns
+                    WHERE table_schema = DATABASE()
+                      AND table_name = @Table
+                    """,
+                    new { Table = table },
+                    cancellationToken: ct))).ToList();
+
+            if (columns.Count == 0)
+            {
+                throw new InvalidOperationException($"Unsafe window MV table '{table}' was not created by initialization.");
+            }
+
+            var columnSet = new HashSet<string>(columns.Select(c => c.column_name), StringComparer.OrdinalIgnoreCase);
+
+            foreach (var required in UnsafeWindowMvReservedColumns.CommonMetadata)
+            {
+                if (!columnSet.Contains(required))
+                {
+                    throw new InvalidOperationException($"Unsafe window MV table '{table}' is missing required metadata column '{required}'.");
+                }
+            }
+
+            var tableSpecific = table == resolver.SafeTable
+                ? UnsafeWindowMvReservedColumns.SafeOnlyMetadata
+                : UnsafeWindowMvReservedColumns.UnsafeOnlyMetadata;
+            foreach (var required in tableSpecific)
+            {
+                if (!columnSet.Contains(required))
+                {
+                    throw new InvalidOperationException($"Unsafe window MV table '{table}' is missing required metadata column '{required}'.");
+                }
+            }
+
+            foreach (var business in resolver.Schema.Columns)
+            {
+                if (!columnSet.Contains(business.Name))
+                {
+                    throw new InvalidOperationException(
+                        $"Unsafe window MV table '{table}' is missing declared business column '{business.Name}'. Drop the table or bump the view version to reshape the schema.");
+                }
+            }
+        }
+    }
+}
+
+public sealed class UnsafeWindowMvMySqlInitializer : IUnsafeWindowMvInitializer
+{
+    private readonly UnsafeWindowMvMySqlSchemaResolver _resolver;
+    private readonly string _connectionString;
+    private readonly ILogger _logger;
+
+    public UnsafeWindowMvMySqlInitializer(UnsafeWindowMvMySqlSchemaResolver resolver, string connectionString, ILogger logger)
+    {
+        _resolver = resolver;
+        _connectionString = connectionString;
+        _logger = logger;
+    }
+
+    public async Task InitializeAsync(CancellationToken cancellationToken)
+    {
+        await using var connection = new MySqlConnection(_connectionString);
+        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+        foreach (var statement in UnsafeWindowMvMySqlDdl.BuildInitializeStatements(_resolver))
+        {
+            await connection.ExecuteAsync(new CommandDefinition(statement, cancellationToken: cancellationToken))
+                .ConfigureAwait(false);
+        }
+
+        await UnsafeWindowMvMySqlValidator.ValidateAsync(_resolver, connection, cancellationToken).ConfigureAwait(false);
+
+        _logger.LogInformation(
+            "Unsafe window MV '{View}' v{Version} initialized on MySQL (safe={Safe}, unsafe={Unsafe}, view={Current}, view_live={CurrentLive}).",
+            _resolver.ViewName,
+            _resolver.ViewVersion,
+            _resolver.SafeTable,
+            _resolver.UnsafeTable,
+            _resolver.CurrentView,
+            _resolver.CurrentLiveView);
+    }
+}
+
+public sealed class UnsafeWindowMvMySqlStreamApplier<TRow> where TRow : class, new()
+{
+    private readonly UnsafeWindowMvMySqlSchemaResolver _resolver;
+    private readonly IUnsafeWindowMvProjector<TRow> _projector;
+    private readonly TimeSpan _safeWindow;
+
+    public UnsafeWindowMvMySqlStreamApplier(
+        UnsafeWindowMvMySqlSchemaResolver resolver,
+        IUnsafeWindowMvProjector<TRow> projector)
+    {
+        _resolver = resolver;
+        _projector = projector;
+        _safeWindow = projector.SafeWindow;
+    }
+
+    public async Task ApplyEventAsync(
+        MySqlConnection connection,
+        IDbTransaction transaction,
+        Event ev,
+        CancellationToken ct)
+    {
+        var projectionKey = _projector.GetProjectionKey(ev);
+        if (projectionKey is null)
+        {
+            return;
+        }
+
+        var existingRow = await connection.QueryFirstOrDefaultAsync(new CommandDefinition(
+            $"SELECT * FROM {_resolver.UnsafeTable} WHERE {UnsafeWindowMvReservedColumns.ProjectionKey} = @Key FOR UPDATE",
+            new { Key = projectionKey },
+            transaction: transaction,
+            cancellationToken: ct)).ConfigureAwait(false);
+
+        if (existingRow is IDictionary<string, object> existingDict)
+        {
+            var existingSuid = (string)existingDict[UnsafeWindowMvReservedColumns.LastSortableUniqueId];
+            if (string.CompareOrdinal(ev.SortableUniqueIdValue, existingSuid) <= 0)
+            {
+                await connection.ExecuteAsync(new CommandDefinition(
+                    $"UPDATE {_resolver.UnsafeTable} SET {UnsafeWindowMvReservedColumns.NeedsRebuild} = 1 WHERE {UnsafeWindowMvReservedColumns.ProjectionKey} = @Key",
+                    new { Key = projectionKey },
+                    transaction: transaction,
+                    cancellationToken: ct)).ConfigureAwait(false);
+                return;
+            }
+        }
+
+        TRow? current = null;
+        IDictionary<string, object>? fallbackBusinessValues = null;
+        long existingEventVersion = 0;
+        if (existingRow is IDictionary<string, object> existing)
+        {
+            current = UnsafeWindowMvRowHydrator<TRow>.Hydrate(_projector.Schema, existing);
+            existingEventVersion = Convert.ToInt64(existing[UnsafeWindowMvReservedColumns.LastEventVersion]);
+        }
+        else
+        {
+            var safeRow = await connection.QueryFirstOrDefaultAsync(new CommandDefinition(
+                $"SELECT * FROM {_resolver.SafeTable} WHERE {UnsafeWindowMvReservedColumns.ProjectionKey} = @Key FOR UPDATE",
+                new { Key = projectionKey },
+                transaction: transaction,
+                cancellationToken: ct)).ConfigureAwait(false);
+            if (safeRow is IDictionary<string, object> safeDict)
+            {
+                var safeSuid = (string)safeDict[UnsafeWindowMvReservedColumns.LastSortableUniqueId];
+                existingEventVersion = Convert.ToInt64(safeDict[UnsafeWindowMvReservedColumns.LastEventVersion]);
+                if (string.CompareOrdinal(ev.SortableUniqueIdValue, safeSuid) <= 0)
+                {
+                    await MirrorSafeIntoUnsafeForRebuildAsync(connection, transaction, projectionKey, safeDict, ct)
+                        .ConfigureAwait(false);
+                    return;
+                }
+
+                current = UnsafeWindowMvRowHydrator<TRow>.Hydrate(_projector.Schema, safeDict);
+                fallbackBusinessValues = safeDict;
+            }
+        }
+
+        var outcome = _projector.Apply(current, ev);
+        var newEventVersion = existingEventVersion + 1;
+        switch (outcome)
+        {
+            case UnsafeWindowMvApplyOutcome.NoChange:
+                return;
+            case UnsafeWindowMvApplyOutcome.Upsert up:
+                if (!string.Equals(up.ProjectionKey, projectionKey, StringComparison.Ordinal))
+                {
+                    throw new InvalidOperationException(
+                        $"Projector '{_projector.ViewName}' returned a different projection key from Apply ('{up.ProjectionKey}') than GetProjectionKey ('{projectionKey}').");
+                }
+                await UpsertUnsafeAsync(connection, transaction, projectionKey, up.Row, isDeleted: false, ev, newEventVersion, ct).ConfigureAwait(false);
+                break;
+            case UnsafeWindowMvApplyOutcome.Delete del:
+                if (!string.Equals(del.ProjectionKey, projectionKey, StringComparison.Ordinal))
+                {
+                    throw new InvalidOperationException(
+                        $"Projector '{_projector.ViewName}' returned a different projection key from Apply ('{del.ProjectionKey}') than GetProjectionKey ('{projectionKey}').");
+                }
+                await UpsertDeletionAsync(connection, transaction, projectionKey, current, fallbackBusinessValues, ev, newEventVersion, ct).ConfigureAwait(false);
+                break;
+        }
+    }
+
+    private async Task MirrorSafeIntoUnsafeForRebuildAsync(
+        MySqlConnection connection,
+        IDbTransaction transaction,
+        string projectionKey,
+        IDictionary<string, object> safeDict,
+        CancellationToken ct)
+    {
+        var businessCols = _projector.Schema.Columns.Select(c => c.Name).ToList();
+        var businessValueParams = string.Join(", ", businessCols.Select(c => "@" + c));
+
+        var sql = $"""
+            INSERT INTO {_resolver.UnsafeTable}
+                ({UnsafeWindowMvReservedColumns.ProjectionKey},
+                 {string.Join(", ", businessCols)},
+                 {UnsafeWindowMvReservedColumns.IsDeleted},
+                 {UnsafeWindowMvReservedColumns.LastSortableUniqueId},
+                 {UnsafeWindowMvReservedColumns.LastEventVersion},
+                 {UnsafeWindowMvReservedColumns.LastAppliedAt},
+                 {UnsafeWindowMvReservedColumns.UnsafeSince},
+                 {UnsafeWindowMvReservedColumns.SafeDueAt},
+                 {UnsafeWindowMvReservedColumns.NeedsRebuild})
+            VALUES (@__projectionKey, {businessValueParams}, @__isDeleted, @__suid, @__eventVersion, CURRENT_TIMESTAMP(6), CURRENT_TIMESTAMP(6), CURRENT_TIMESTAMP(6), 1)
+            ON DUPLICATE KEY UPDATE
+                {UnsafeWindowMvReservedColumns.NeedsRebuild} = 1;
+            """;
+
+        var parameters = new DynamicParameters();
+        parameters.Add("__projectionKey", projectionKey);
+        parameters.Add("__isDeleted", Convert.ToBoolean(safeDict[UnsafeWindowMvReservedColumns.IsDeleted]));
+        parameters.Add("__suid", safeDict[UnsafeWindowMvReservedColumns.LastSortableUniqueId]);
+        parameters.Add("__eventVersion", Convert.ToInt64(safeDict[UnsafeWindowMvReservedColumns.LastEventVersion]));
+        foreach (var column in _projector.Schema.Columns)
+        {
+            parameters.Add(column.Name, safeDict.TryGetValue(column.Name, out var v) ? (v ?? DBNull.Value) : DBNull.Value);
+        }
+
+        await connection.ExecuteAsync(new CommandDefinition(sql, parameters, transaction: transaction, cancellationToken: ct))
+            .ConfigureAwait(false);
+    }
+
+    private async Task UpsertUnsafeAsync(
+        MySqlConnection connection,
+        IDbTransaction transaction,
+        string projectionKey,
+        object row,
+        bool isDeleted,
+        Event ev,
+        long eventVersion,
+        CancellationToken ct)
+    {
+        var businessCols = _projector.Schema.Columns.Select(c => c.Name).ToList();
+        var safeDueAt = DateTime.UtcNow.Add(_safeWindow);
+        var businessValueParams = string.Join(", ", businessCols.Select(c => "@" + c));
+        var businessUpdates = string.Join(", ", businessCols.Select(c => $"{c} = VALUES({c})"));
+
+        var sql = $"""
+            INSERT INTO {_resolver.UnsafeTable}
+                ({UnsafeWindowMvReservedColumns.ProjectionKey},
+                 {string.Join(", ", businessCols)},
+                 {UnsafeWindowMvReservedColumns.IsDeleted},
+                 {UnsafeWindowMvReservedColumns.LastSortableUniqueId},
+                 {UnsafeWindowMvReservedColumns.LastEventVersion},
+                 {UnsafeWindowMvReservedColumns.LastAppliedAt},
+                 {UnsafeWindowMvReservedColumns.UnsafeSince},
+                 {UnsafeWindowMvReservedColumns.SafeDueAt},
+                 {UnsafeWindowMvReservedColumns.NeedsRebuild})
+            VALUES (@__projectionKey, {businessValueParams}, @__isDeleted, @__suid, @__eventVersion, CURRENT_TIMESTAMP(6), CURRENT_TIMESTAMP(6), @__safeDueAt, 0)
+            ON DUPLICATE KEY UPDATE
+                {businessUpdates},
+                {UnsafeWindowMvReservedColumns.IsDeleted} = VALUES({UnsafeWindowMvReservedColumns.IsDeleted}),
+                {UnsafeWindowMvReservedColumns.LastSortableUniqueId} = VALUES({UnsafeWindowMvReservedColumns.LastSortableUniqueId}),
+                {UnsafeWindowMvReservedColumns.LastEventVersion} = VALUES({UnsafeWindowMvReservedColumns.LastEventVersion}),
+                {UnsafeWindowMvReservedColumns.LastAppliedAt} = CURRENT_TIMESTAMP(6),
+                {UnsafeWindowMvReservedColumns.SafeDueAt} = VALUES({UnsafeWindowMvReservedColumns.SafeDueAt}),
+                {UnsafeWindowMvReservedColumns.NeedsRebuild} = 0;
+            """;
+
+        var parameters = new DynamicParameters();
+        parameters.Add("__projectionKey", projectionKey);
+        parameters.Add("__isDeleted", isDeleted);
+        parameters.Add("__suid", ev.SortableUniqueIdValue);
+        parameters.Add("__eventVersion", eventVersion);
+        parameters.Add("__safeDueAt", safeDueAt);
+
+        foreach (var column in _projector.Schema.Columns)
+        {
+            parameters.Add(column.Name, column.Getter(row) ?? DBNull.Value);
+        }
+
+        await connection.ExecuteAsync(new CommandDefinition(sql, parameters, transaction: transaction, cancellationToken: ct))
+            .ConfigureAwait(false);
+    }
+
+    private async Task UpsertDeletionAsync(
+        MySqlConnection connection,
+        IDbTransaction transaction,
+        string projectionKey,
+        TRow? currentRow,
+        IDictionary<string, object>? fallbackBusinessValues,
+        Event ev,
+        long eventVersion,
+        CancellationToken ct)
+    {
+        if (currentRow is null && fallbackBusinessValues is null)
+        {
+            return;
+        }
+
+        var safeDueAt = DateTime.UtcNow.Add(_safeWindow);
+        var businessCols = _projector.Schema.Columns.Select(c => c.Name).ToList();
+        var businessValueParams = string.Join(", ", businessCols.Select(c => "@" + c));
+        var businessUpdates = string.Join(", ", businessCols.Select(c => $"{c} = VALUES({c})"));
+
+        var sql = $"""
+            INSERT INTO {_resolver.UnsafeTable}
+                ({UnsafeWindowMvReservedColumns.ProjectionKey},
+                 {string.Join(", ", businessCols)},
+                 {UnsafeWindowMvReservedColumns.IsDeleted},
+                 {UnsafeWindowMvReservedColumns.LastSortableUniqueId},
+                 {UnsafeWindowMvReservedColumns.LastEventVersion},
+                 {UnsafeWindowMvReservedColumns.LastAppliedAt},
+                 {UnsafeWindowMvReservedColumns.UnsafeSince},
+                 {UnsafeWindowMvReservedColumns.SafeDueAt},
+                 {UnsafeWindowMvReservedColumns.NeedsRebuild})
+            VALUES (@__projectionKey, {businessValueParams}, 1, @__suid, @__eventVersion, CURRENT_TIMESTAMP(6), CURRENT_TIMESTAMP(6), @__safeDueAt, 0)
+            ON DUPLICATE KEY UPDATE
+                {businessUpdates},
+                {UnsafeWindowMvReservedColumns.IsDeleted} = 1,
+                {UnsafeWindowMvReservedColumns.LastSortableUniqueId} = VALUES({UnsafeWindowMvReservedColumns.LastSortableUniqueId}),
+                {UnsafeWindowMvReservedColumns.LastEventVersion} = VALUES({UnsafeWindowMvReservedColumns.LastEventVersion}),
+                {UnsafeWindowMvReservedColumns.LastAppliedAt} = CURRENT_TIMESTAMP(6),
+                {UnsafeWindowMvReservedColumns.SafeDueAt} = VALUES({UnsafeWindowMvReservedColumns.SafeDueAt}),
+                {UnsafeWindowMvReservedColumns.NeedsRebuild} = 0;
+            """;
+
+        var parameters = new DynamicParameters();
+        parameters.Add("__projectionKey", projectionKey);
+        parameters.Add("__suid", ev.SortableUniqueIdValue);
+        parameters.Add("__eventVersion", eventVersion);
+        parameters.Add("__safeDueAt", safeDueAt);
+
+        foreach (var column in _projector.Schema.Columns)
+        {
+            object? value;
+            if (currentRow is not null)
+            {
+                value = column.Getter(currentRow);
+            }
+            else if (fallbackBusinessValues is not null && fallbackBusinessValues.TryGetValue(column.Name, out var v))
+            {
+                value = v;
+            }
+            else
+            {
+                value = null;
+            }
+            parameters.Add(column.Name, value ?? DBNull.Value);
+        }
+
+        await connection.ExecuteAsync(new CommandDefinition(sql, parameters, transaction: transaction, cancellationToken: ct))
+            .ConfigureAwait(false);
+    }
+}
+
+public sealed class UnsafeWindowMvMySqlCatchUpWorker<TRow> : IUnsafeWindowMvCatchUpRunner where TRow : class, new()
+{
+    private readonly UnsafeWindowMvMySqlSchemaResolver _resolver;
+    private readonly IUnsafeWindowMvProjector<TRow> _projector;
+    private readonly UnsafeWindowMvMySqlStreamApplier<TRow> _applier;
+    private readonly IEventStore _eventStore;
+    private readonly IEventTypes _eventTypes;
+    private readonly string _connectionString;
+    private readonly ILogger _logger;
+    private readonly int _batchSize;
+
+    public UnsafeWindowMvMySqlCatchUpWorker(
+        UnsafeWindowMvMySqlSchemaResolver resolver,
+        IUnsafeWindowMvProjector<TRow> projector,
+        IEventStore eventStore,
+        IEventTypes eventTypes,
+        string connectionString,
+        ILogger logger,
+        int batchSize = 256)
+    {
+        _resolver = resolver;
+        _projector = projector;
+        _applier = new UnsafeWindowMvMySqlStreamApplier<TRow>(resolver, projector);
+        _eventStore = eventStore;
+        _eventTypes = eventTypes;
+        _connectionString = connectionString;
+        _logger = logger;
+        _batchSize = batchSize;
+    }
+
+    public async Task<int> CatchUpOnceAsync(CancellationToken cancellationToken)
+    {
+        await using var connection = new MySqlConnection(_connectionString);
+        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+        var lastSuid = await connection.QuerySingleOrDefaultAsync<string?>(new CommandDefinition(
+            $"""
+             SELECT COALESCE(MAX(x.suid), '')
+             FROM (
+                 SELECT {UnsafeWindowMvReservedColumns.LastSortableUniqueId} AS suid FROM {_resolver.SafeTable}
+                 UNION ALL
+                 SELECT {UnsafeWindowMvReservedColumns.LastSortableUniqueId} AS suid FROM {_resolver.UnsafeTable}
+             ) x
+             """,
+            cancellationToken: cancellationToken)).ConfigureAwait(false);
+
+        var since = string.IsNullOrEmpty(lastSuid) ? null : new SortableUniqueId(lastSuid);
+        var result = await _eventStore.ReadAllSerializableEventsAsync(since).ConfigureAwait(false);
+        if (!result.IsSuccess)
+        {
+            throw result.GetException();
+        }
+
+        var events = result.GetValue().Take(_batchSize).ToList();
+        if (events.Count == 0)
+        {
+            return 0;
+        }
+
+        await using var transaction = await connection.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
+        foreach (var serialized in events)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var evResult = serialized.ToEvent(_eventTypes);
+            if (!evResult.IsSuccess)
+            {
+                throw evResult.GetException();
+            }
+
+            await _applier.ApplyEventAsync(connection, transaction, evResult.GetValue(), cancellationToken).ConfigureAwait(false);
+        }
+        await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+        _logger.LogDebug("Unsafe window MV '{View}' caught up {Count} event(s) on MySQL.", _projector.ViewName, events.Count);
+        return events.Count;
+    }
+}
+
+public sealed class UnsafeWindowMvMySqlPromoter<TRow> : IUnsafeWindowMvPromoter where TRow : class, new()
+{
+    private readonly UnsafeWindowMvMySqlSchemaResolver _resolver;
+    private readonly IUnsafeWindowMvProjector<TRow> _projector;
+    private readonly IEventStore _eventStore;
+    private readonly IEventTypes _eventTypes;
+    private readonly string _connectionString;
+    private readonly ILogger _logger;
+    private readonly int _batchSize;
+
+    public UnsafeWindowMvMySqlPromoter(
+        UnsafeWindowMvMySqlSchemaResolver resolver,
+        IUnsafeWindowMvProjector<TRow> projector,
+        IEventStore eventStore,
+        IEventTypes eventTypes,
+        string connectionString,
+        ILogger logger,
+        int batchSize = 32)
+    {
+        _resolver = resolver;
+        _projector = projector;
+        _eventStore = eventStore;
+        _eventTypes = eventTypes;
+        _connectionString = connectionString;
+        _logger = logger;
+        _batchSize = batchSize;
+    }
+
+    public async Task<int> PromoteOnceAsync(CancellationToken cancellationToken)
+    {
+        await using var connection = new MySqlConnection(_connectionString);
+        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+        await using var transaction = await connection.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
+
+        // MySQL 8.0+ supports FOR UPDATE SKIP LOCKED.
+        var dueRows = (await connection.QueryAsync<(string key, bool needs_rebuild)>(new CommandDefinition(
+            $"""
+             SELECT {UnsafeWindowMvReservedColumns.ProjectionKey} AS `key`,
+                    {UnsafeWindowMvReservedColumns.NeedsRebuild} AS needs_rebuild
+             FROM {_resolver.UnsafeTable}
+             WHERE {UnsafeWindowMvReservedColumns.SafeDueAt} <= CURRENT_TIMESTAMP(6)
+             ORDER BY {UnsafeWindowMvReservedColumns.SafeDueAt}
+             LIMIT @Limit
+             FOR UPDATE SKIP LOCKED
+             """,
+            new { Limit = _batchSize },
+            transaction: transaction,
+            cancellationToken: cancellationToken))).ToList();
+
+        if (dueRows.Count == 0)
+        {
+            await transaction.RollbackAsync(cancellationToken).ConfigureAwait(false);
+            return 0;
+        }
+
+        foreach (var (projectionKey, needsRebuild) in dueRows)
+        {
+            await PromoteKeyAsync(connection, transaction, projectionKey, needsRebuild, cancellationToken).ConfigureAwait(false);
+        }
+
+        await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+        _logger.LogDebug("Unsafe window MV '{View}' promoted {Count} key(s) on MySQL.", _projector.ViewName, dueRows.Count);
+        return dueRows.Count;
+    }
+
+    private async Task PromoteKeyAsync(
+        MySqlConnection connection,
+        IDbTransaction transaction,
+        string projectionKey,
+        bool needsRebuild,
+        CancellationToken ct)
+    {
+        var safeRow = await connection.QueryFirstOrDefaultAsync(new CommandDefinition(
+            $"SELECT * FROM {_resolver.SafeTable} WHERE {UnsafeWindowMvReservedColumns.ProjectionKey} = @Key",
+            new { Key = projectionKey },
+            transaction: transaction,
+            cancellationToken: ct)).ConfigureAwait(false);
+
+        TRow? current = null;
+        string? startSuid = null;
+        long startVersion = 0;
+        var isDeleted = false;
+
+        if (!needsRebuild && safeRow is IDictionary<string, object> safeDict)
+        {
+            current = UnsafeWindowMvRowHydrator<TRow>.Hydrate(_projector.Schema, safeDict);
+            startSuid = (string)safeDict[UnsafeWindowMvReservedColumns.LastSortableUniqueId];
+            startVersion = Convert.ToInt64(safeDict[UnsafeWindowMvReservedColumns.LastEventVersion]);
+            isDeleted = Convert.ToBoolean(safeDict[UnsafeWindowMvReservedColumns.IsDeleted]);
+        }
+
+        var events = await FetchReplayEventsAsync(projectionKey, startSuid, ct).ConfigureAwait(false);
+
+        var lastSuid = startSuid;
+        var lastEventVersion = startVersion;
+
+        foreach (var ev in events)
+        {
+            var outcome = _projector.Apply(current, ev);
+            switch (outcome)
+            {
+                case UnsafeWindowMvApplyOutcome.NoChange:
+                    break;
+                case UnsafeWindowMvApplyOutcome.Upsert up:
+                    current = (TRow)up.Row;
+                    isDeleted = false;
+                    break;
+                case UnsafeWindowMvApplyOutcome.Delete:
+                    isDeleted = true;
+                    break;
+            }
+
+            lastSuid = ev.SortableUniqueIdValue;
+            lastEventVersion++;
+        }
+
+        if (lastSuid is null)
+        {
+            await connection.ExecuteAsync(new CommandDefinition(
+                $"DELETE FROM {_resolver.UnsafeTable} WHERE {UnsafeWindowMvReservedColumns.ProjectionKey} = @Key",
+                new { Key = projectionKey },
+                transaction: transaction,
+                cancellationToken: ct)).ConfigureAwait(false);
+            return;
+        }
+
+        await UpsertSafeAsync(connection, transaction, projectionKey, current, isDeleted, lastSuid, lastEventVersion, ct).ConfigureAwait(false);
+
+        await connection.ExecuteAsync(new CommandDefinition(
+            $"DELETE FROM {_resolver.UnsafeTable} WHERE {UnsafeWindowMvReservedColumns.ProjectionKey} = @Key",
+            new { Key = projectionKey },
+            transaction: transaction,
+            cancellationToken: ct)).ConfigureAwait(false);
+    }
+
+    private async Task<IReadOnlyList<Event>> FetchReplayEventsAsync(string projectionKey, string? sinceSuid, CancellationToken ct)
+    {
+        var since = string.IsNullOrEmpty(sinceSuid) ? null : new SortableUniqueId(sinceSuid);
+        var combined = new Dictionary<string, Event>(StringComparer.Ordinal);
+
+        var tags = _projector.TagsForProjectionKey(projectionKey);
+        if (tags.Count == 0)
+        {
+            return [];
+        }
+
+        foreach (var tag in tags)
+        {
+            ct.ThrowIfCancellationRequested();
+            var result = await _eventStore.ReadSerializableEventsByTagAsync(tag, since).ConfigureAwait(false);
+            if (!result.IsSuccess)
+            {
+                throw result.GetException();
+            }
+
+            foreach (var serialized in result.GetValue())
+            {
+                var key = serialized.Id.ToString();
+                if (combined.ContainsKey(key))
+                {
+                    continue;
+                }
+
+                var evResult = serialized.ToEvent(_eventTypes);
+                if (!evResult.IsSuccess)
+                {
+                    throw evResult.GetException();
+                }
+                combined[key] = evResult.GetValue();
+            }
+        }
+
+        return combined.Values
+            .Where(e => sinceSuid is null || string.CompareOrdinal(e.SortableUniqueIdValue, sinceSuid) > 0)
+            .OrderBy(e => e.SortableUniqueIdValue, StringComparer.Ordinal)
+            .ToArray();
+    }
+
+    private async Task UpsertSafeAsync(
+        MySqlConnection connection,
+        IDbTransaction transaction,
+        string projectionKey,
+        TRow? row,
+        bool isDeleted,
+        string sortableUniqueId,
+        long eventVersion,
+        CancellationToken ct)
+    {
+        var businessCols = _projector.Schema.Columns.Select(c => c.Name).ToList();
+        var businessValueParams = string.Join(", ", businessCols.Select(c => "@" + c));
+        var businessUpdates = string.Join(", ", businessCols.Select(c => $"{c} = VALUES({c})"));
+
+        var sql = $"""
+            INSERT INTO {_resolver.SafeTable}
+                ({UnsafeWindowMvReservedColumns.ProjectionKey},
+                 {string.Join(", ", businessCols)},
+                 {UnsafeWindowMvReservedColumns.IsDeleted},
+                 {UnsafeWindowMvReservedColumns.LastSortableUniqueId},
+                 {UnsafeWindowMvReservedColumns.LastEventVersion},
+                 {UnsafeWindowMvReservedColumns.LastAppliedAt},
+                 {UnsafeWindowMvReservedColumns.SafeConfirmedAt})
+            VALUES (@__projectionKey, {businessValueParams}, @__isDeleted, @__suid, @__eventVersion, CURRENT_TIMESTAMP(6), CURRENT_TIMESTAMP(6))
+            ON DUPLICATE KEY UPDATE
+                {businessUpdates},
+                {UnsafeWindowMvReservedColumns.IsDeleted} = VALUES({UnsafeWindowMvReservedColumns.IsDeleted}),
+                {UnsafeWindowMvReservedColumns.LastSortableUniqueId} = VALUES({UnsafeWindowMvReservedColumns.LastSortableUniqueId}),
+                {UnsafeWindowMvReservedColumns.LastEventVersion} = VALUES({UnsafeWindowMvReservedColumns.LastEventVersion}),
+                {UnsafeWindowMvReservedColumns.LastAppliedAt} = CURRENT_TIMESTAMP(6),
+                {UnsafeWindowMvReservedColumns.SafeConfirmedAt} = CURRENT_TIMESTAMP(6);
+            """;
+
+        var parameters = new DynamicParameters();
+        parameters.Add("__projectionKey", projectionKey);
+        parameters.Add("__isDeleted", isDeleted);
+        parameters.Add("__suid", sortableUniqueId);
+        parameters.Add("__eventVersion", eventVersion);
+
+        foreach (var column in _projector.Schema.Columns)
+        {
+            parameters.Add(column.Name, row is null ? DBNull.Value : (column.Getter(row) ?? DBNull.Value));
+        }
+
+        await connection.ExecuteAsync(new CommandDefinition(sql, parameters, transaction: transaction, cancellationToken: ct))
+            .ConfigureAwait(false);
+    }
+}

--- a/dcb/src/Sekiban.Dcb.MaterializedView.SqlServer/UnsafeWindowMvSqlServerRegistration.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.SqlServer/UnsafeWindowMvSqlServerRegistration.cs
@@ -1,0 +1,108 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Sekiban.Dcb.Domains;
+using Sekiban.Dcb.Storage;
+
+namespace Sekiban.Dcb.MaterializedView.SqlServer;
+
+public static class UnsafeWindowMvSqlServerRegistration
+{
+    public static string ConnectionStringKey<TProjector>() =>
+        "UnsafeWindowMvSqlServer:" + (typeof(TProjector).FullName ?? typeof(TProjector).Name);
+
+    public static string SchemaResolverKey<TProjector>() =>
+        "UnsafeWindowMvSqlServerResolver:" + (typeof(TProjector).FullName ?? typeof(TProjector).Name);
+
+    public static IServiceCollection AddSekibanDcbUnsafeWindowMvSqlServer<TProjector, TRow>(
+        this IServiceCollection services,
+        IConfiguration configuration,
+        string connectionStringName = "DcbMaterializedViewSqlServer",
+        TimeSpan? idleDelay = null,
+        int catchUpBatchSize = 256,
+        int promotionBatchSize = 32)
+        where TProjector : class, IUnsafeWindowMvProjector<TRow>
+        where TRow : class, new()
+    {
+        if (string.IsNullOrWhiteSpace(connectionStringName))
+        {
+            throw new ArgumentException("Connection string name must be non-empty.", nameof(connectionStringName));
+        }
+
+        var connectionString = configuration.GetConnectionString(connectionStringName)
+            ?? configuration[$"ConnectionStrings:{connectionStringName}"]
+            ?? throw new InvalidOperationException(
+                $"Connection string '{connectionStringName}' not found — unsafe window MV (SQL Server) requires a SQL Server database.");
+
+        return services.AddSekibanDcbUnsafeWindowMvSqlServer<TProjector, TRow>(
+            connectionString,
+            idleDelay,
+            catchUpBatchSize,
+            promotionBatchSize);
+    }
+
+    public static IServiceCollection AddSekibanDcbUnsafeWindowMvSqlServer<TProjector, TRow>(
+        this IServiceCollection services,
+        string connectionString,
+        TimeSpan? idleDelay = null,
+        int catchUpBatchSize = 256,
+        int promotionBatchSize = 32)
+        where TProjector : class, IUnsafeWindowMvProjector<TRow>
+        where TRow : class, new()
+    {
+        if (string.IsNullOrWhiteSpace(connectionString))
+        {
+            throw new ArgumentException("Connection string must be non-empty.", nameof(connectionString));
+        }
+
+        services.AddSingleton<TProjector>();
+        services.AddSingleton<IUnsafeWindowMvProjector<TRow>>(sp => sp.GetRequiredService<TProjector>());
+
+        services.AddKeyedSingleton(SchemaResolverKey<TProjector>(), (sp, _) =>
+        {
+            var projector = sp.GetRequiredService<TProjector>();
+            return new UnsafeWindowMvSqlServerSchemaResolver(projector.ViewName, projector.ViewVersion, projector.Schema);
+        });
+        services.AddKeyedSingleton(ConnectionStringKey<TProjector>(), (_, _) => connectionString);
+
+        services.AddSingleton(sp =>
+        {
+            var resolver = sp.GetRequiredKeyedService<UnsafeWindowMvSqlServerSchemaResolver>(SchemaResolverKey<TProjector>());
+            var logger = sp.GetRequiredService<ILogger<UnsafeWindowMvSqlServerInitializer>>();
+            return new UnsafeWindowMvSqlServerInitializer(resolver, connectionString, logger);
+        });
+
+        services.AddSingleton<UnsafeWindowMvSqlServerCatchUpWorker<TRow>>(sp =>
+        {
+            var resolver = sp.GetRequiredKeyedService<UnsafeWindowMvSqlServerSchemaResolver>(SchemaResolverKey<TProjector>());
+            var projector = sp.GetRequiredService<IUnsafeWindowMvProjector<TRow>>();
+            var eventStore = sp.GetRequiredService<IEventStore>();
+            var eventTypes = sp.GetRequiredService<IEventTypes>();
+            var logger = sp.GetRequiredService<ILogger<UnsafeWindowMvSqlServerCatchUpWorker<TRow>>>();
+            return new UnsafeWindowMvSqlServerCatchUpWorker<TRow>(resolver, projector, eventStore, eventTypes, connectionString, logger, catchUpBatchSize);
+        });
+
+        services.AddSingleton<UnsafeWindowMvSqlServerPromoter<TRow>>(sp =>
+        {
+            var resolver = sp.GetRequiredKeyedService<UnsafeWindowMvSqlServerSchemaResolver>(SchemaResolverKey<TProjector>());
+            var projector = sp.GetRequiredService<IUnsafeWindowMvProjector<TRow>>();
+            var eventStore = sp.GetRequiredService<IEventStore>();
+            var eventTypes = sp.GetRequiredService<IEventTypes>();
+            var logger = sp.GetRequiredService<ILogger<UnsafeWindowMvSqlServerPromoter<TRow>>>();
+            return new UnsafeWindowMvSqlServerPromoter<TRow>(resolver, projector, eventStore, eventTypes, connectionString, logger, promotionBatchSize);
+        });
+
+        services.AddHostedService(sp =>
+        {
+            var projector = sp.GetRequiredService<IUnsafeWindowMvProjector<TRow>>();
+            var initializer = sp.GetRequiredService<UnsafeWindowMvSqlServerInitializer>();
+            var catchUp = sp.GetRequiredService<UnsafeWindowMvSqlServerCatchUpWorker<TRow>>();
+            var promoter = sp.GetRequiredService<UnsafeWindowMvSqlServerPromoter<TRow>>();
+            var logger = sp.GetRequiredService<ILogger<UnsafeWindowMvHostedService>>();
+            return new UnsafeWindowMvHostedService(initializer, catchUp, promoter, projector.ViewName, logger, idleDelay);
+        });
+
+        return services;
+    }
+}

--- a/dcb/src/Sekiban.Dcb.MaterializedView.SqlServer/UnsafeWindowMvSqlServerRuntime.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.SqlServer/UnsafeWindowMvSqlServerRuntime.cs
@@ -205,8 +205,6 @@ internal static class UnsafeWindowMvSqlServerDdl
             END;
             """;
 
-        var businessSelect = string.Join(", ", resolver.Schema.Columns.Select(c => c.Name));
-
         var dropCurrentView = $"IF OBJECT_ID(N'{resolver.CurrentView}', N'V') IS NOT NULL DROP VIEW {resolver.CurrentView};";
         var createCurrentView = $"""
             EXEC(N'CREATE VIEW {resolver.CurrentView} AS

--- a/dcb/src/Sekiban.Dcb.MaterializedView.SqlServer/UnsafeWindowMvSqlServerRuntime.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.SqlServer/UnsafeWindowMvSqlServerRuntime.cs
@@ -1,0 +1,955 @@
+using System.Data;
+using Dapper;
+using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.Logging;
+using Sekiban.Dcb.Common;
+using Sekiban.Dcb.Domains;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.Storage;
+using Sekiban.Dcb.Tags;
+
+namespace Sekiban.Dcb.MaterializedView.SqlServer;
+
+// ============================================================================
+// Unsafe Window Materialized View — SQL Server runtime (issue #1035).
+//
+// Mirrors the Postgres runtime shape (UnsafeWindowMvPostgresRuntime.cs) but
+// uses SQL Server SQL dialect:
+//   - NVARCHAR(MAX) for TEXT, NVARCHAR(450) for PRIMARY KEY columns so
+//     the index stays within SQL Server's 900-byte key limit.
+//   - BIT for BOOLEAN.
+//   - DATETIMEOFFSET for TIMESTAMPTZ, SYSUTCDATETIME() for NOW().
+//   - UNIQUEIDENTIFIER for UUID.
+//   - UPDATE … WITH (UPDLOCK, HOLDLOCK) + conditional INSERT in place of
+//     ON CONFLICT (same upsert pattern as the classic SQL Server MV
+//     registry; avoids MERGE's concurrency pitfalls).
+//   - WITH (UPDLOCK, HOLDLOCK, ROWLOCK) for FOR UPDATE, WITH (UPDLOCK,
+//     READPAST, ROWLOCK) for FOR UPDATE SKIP LOCKED.
+// ============================================================================
+
+public sealed class UnsafeWindowMvSqlServerSchemaResolver
+{
+    // SQL Server object names allow up to 128 Unicode chars, but we stay within
+    // 63 bytes to keep identifiers portable with Postgres and MySQL. The 13-byte
+    // "_current_live" suffix still needs to fit within the bound.
+    private const int MaxSharedPrefixLength = 63 - 13;
+
+    public UnsafeWindowMvSqlServerSchemaResolver(string viewName, int viewVersion, UnsafeWindowMvSchema schema)
+    {
+        if (string.IsNullOrWhiteSpace(viewName))
+        {
+            throw new ArgumentException("View name must be non-empty.", nameof(viewName));
+        }
+        if (viewVersion <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(viewVersion), "View version must be positive.");
+        }
+        if (schema.Columns.Count == 0)
+        {
+            throw new ArgumentException("Unsafe window MV schema must declare at least one business column.", nameof(schema));
+        }
+
+        var reserved = new HashSet<string>(UnsafeWindowMvReservedColumns.AllReservedNames, StringComparer.OrdinalIgnoreCase);
+        foreach (var column in schema.Columns)
+        {
+            if (reserved.Contains(column.Name))
+            {
+                throw new InvalidOperationException(
+                    $"Unsafe window MV '{viewName}' declares a business column '{column.Name}' that clashes with a framework-managed metadata column. Rename the business column.");
+            }
+
+            MvPhysicalName.ValidateIdentifier(column.Name);
+            ValidateSqlType(column.Name, column.SqlType);
+        }
+
+        var sanitized = MvPhysicalName.SanitizeSegment(viewName);
+        var rawPrefix = $"sekiban_uwmv_{sanitized}_v{viewVersion}";
+        var prefix = rawPrefix.Length <= MaxSharedPrefixLength
+            ? rawPrefix
+            : BuildBoundedPrefix(sanitized, viewVersion);
+
+        SafeTable = $"{prefix}_safe";
+        UnsafeTable = $"{prefix}_unsafe";
+        CurrentView = $"{prefix}_current";
+        CurrentLiveView = $"{prefix}_current_live";
+
+        foreach (var identifier in new[] { SafeTable, UnsafeTable, CurrentView, CurrentLiveView })
+        {
+            MvPhysicalName.ValidateIdentifier(identifier);
+        }
+
+        Schema = schema;
+        ViewName = viewName;
+        ViewVersion = viewVersion;
+    }
+
+    public string ViewName { get; }
+    public int ViewVersion { get; }
+    public string SafeTable { get; }
+    public string UnsafeTable { get; }
+    public string CurrentView { get; }
+    public string CurrentLiveView { get; }
+    public UnsafeWindowMvSchema Schema { get; }
+
+    private static string BuildBoundedPrefix(string sanitized, int viewVersion)
+    {
+        var versionSuffix = $"_v{viewVersion}";
+        var hash = Convert.ToHexString(
+                System.Security.Cryptography.SHA1.HashData(System.Text.Encoding.UTF8.GetBytes(sanitized)))
+            .Substring(0, 8)
+            .ToLowerInvariant();
+
+        var headroom = MaxSharedPrefixLength - ("sekiban_uwmv__".Length + hash.Length + versionSuffix.Length);
+        if (headroom < 1)
+        {
+            headroom = 1;
+        }
+        var head = sanitized.Substring(0, Math.Min(headroom, sanitized.Length));
+        return $"sekiban_uwmv_{head}_{hash}{versionSuffix}";
+    }
+
+    private static void ValidateSqlType(string columnName, string sqlType)
+    {
+        if (string.IsNullOrWhiteSpace(sqlType))
+        {
+            throw new ArgumentException($"Business column '{columnName}' has an empty SQL type.");
+        }
+        foreach (var ch in sqlType)
+        {
+            if (ch == ';' || ch == '\r' || ch == '\n')
+            {
+                throw new ArgumentException(
+                    $"Business column '{columnName}' declares a SQL type containing illegal characters (semicolon / newline). Type: '{sqlType}'.");
+            }
+        }
+        if (sqlType.Contains("--", StringComparison.Ordinal) || sqlType.Contains("/*", StringComparison.Ordinal))
+        {
+            throw new ArgumentException(
+                $"Business column '{columnName}' declares a SQL type containing SQL comment markers. Type: '{sqlType}'.");
+        }
+    }
+}
+
+internal static class UnsafeWindowMvSqlServerTypes
+{
+    // Portable Postgres-style keywords a projector can use in SqlType are
+    // translated to their SQL Server equivalents when emitting DDL so the
+    // same projector definition works on every supported provider.
+    private static readonly IReadOnlyDictionary<string, string> Map = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+    {
+        ["TEXT"] = "NVARCHAR(MAX)",
+        ["BOOLEAN"] = "BIT",
+        ["BOOL"] = "BIT",
+        ["UUID"] = "UNIQUEIDENTIFIER",
+        ["TIMESTAMPTZ"] = "DATETIMEOFFSET",
+        ["TIMESTAMP"] = "DATETIME2",
+        ["BIGINT"] = "BIGINT",
+        ["INT"] = "INT",
+        ["INTEGER"] = "INT",
+        ["DATE"] = "DATE",
+        ["REAL"] = "REAL",
+        ["DOUBLE"] = "FLOAT",
+        ["DOUBLE PRECISION"] = "FLOAT",
+        ["SMALLINT"] = "SMALLINT"
+    };
+
+    public static string Translate(string declaredType) =>
+        UnsafeWindowMvLogicalTypes.Translate(declaredType, Map);
+}
+
+internal static class UnsafeWindowMvSqlServerDdl
+{
+    public static IReadOnlyList<string> BuildInitializeStatements(UnsafeWindowMvSqlServerSchemaResolver resolver)
+    {
+        var businessDdl = string.Join(
+            ",\n    ",
+            resolver.Schema.Columns.Select(c => $"{c.Name} {UnsafeWindowMvSqlServerTypes.Translate(c.SqlType)}"));
+
+        var safeTable = $"""
+            IF OBJECT_ID(N'{resolver.SafeTable}', N'U') IS NULL
+            BEGIN
+                CREATE TABLE {resolver.SafeTable} (
+                    {UnsafeWindowMvReservedColumns.ProjectionKey} NVARCHAR(450) NOT NULL PRIMARY KEY,
+                    {businessDdl},
+                    {UnsafeWindowMvReservedColumns.IsDeleted} BIT NOT NULL CONSTRAINT DF_{resolver.SafeTable}_is_deleted DEFAULT 0,
+                    {UnsafeWindowMvReservedColumns.LastSortableUniqueId} NVARCHAR(64) NOT NULL,
+                    {UnsafeWindowMvReservedColumns.LastEventVersion} BIGINT NOT NULL CONSTRAINT DF_{resolver.SafeTable}_last_event_version DEFAULT 0,
+                    {UnsafeWindowMvReservedColumns.LastAppliedAt} DATETIMEOFFSET NOT NULL CONSTRAINT DF_{resolver.SafeTable}_last_applied_at DEFAULT SYSUTCDATETIME(),
+                    {UnsafeWindowMvReservedColumns.SafeConfirmedAt} DATETIMEOFFSET NOT NULL CONSTRAINT DF_{resolver.SafeTable}_safe_confirmed_at DEFAULT SYSUTCDATETIME()
+                );
+            END;
+            """;
+
+        var unsafeTable = $"""
+            IF OBJECT_ID(N'{resolver.UnsafeTable}', N'U') IS NULL
+            BEGIN
+                CREATE TABLE {resolver.UnsafeTable} (
+                    {UnsafeWindowMvReservedColumns.ProjectionKey} NVARCHAR(450) NOT NULL PRIMARY KEY,
+                    {businessDdl},
+                    {UnsafeWindowMvReservedColumns.IsDeleted} BIT NOT NULL CONSTRAINT DF_{resolver.UnsafeTable}_is_deleted DEFAULT 0,
+                    {UnsafeWindowMvReservedColumns.LastSortableUniqueId} NVARCHAR(64) NOT NULL,
+                    {UnsafeWindowMvReservedColumns.LastEventVersion} BIGINT NOT NULL CONSTRAINT DF_{resolver.UnsafeTable}_last_event_version DEFAULT 0,
+                    {UnsafeWindowMvReservedColumns.LastAppliedAt} DATETIMEOFFSET NOT NULL CONSTRAINT DF_{resolver.UnsafeTable}_last_applied_at DEFAULT SYSUTCDATETIME(),
+                    {UnsafeWindowMvReservedColumns.UnsafeSince} DATETIMEOFFSET NOT NULL CONSTRAINT DF_{resolver.UnsafeTable}_unsafe_since DEFAULT SYSUTCDATETIME(),
+                    {UnsafeWindowMvReservedColumns.SafeDueAt} DATETIMEOFFSET NOT NULL CONSTRAINT DF_{resolver.UnsafeTable}_safe_due_at DEFAULT SYSUTCDATETIME(),
+                    {UnsafeWindowMvReservedColumns.NeedsRebuild} BIT NOT NULL CONSTRAINT DF_{resolver.UnsafeTable}_needs_rebuild DEFAULT 0
+                );
+            END;
+            """;
+
+        var indexName = $"idx_{resolver.UnsafeTable}_safe_due_at";
+        var unsafeDueIdx = $"""
+            IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name = '{indexName}' AND object_id = OBJECT_ID(N'{resolver.UnsafeTable}'))
+            BEGIN
+                CREATE INDEX {indexName} ON {resolver.UnsafeTable} ({UnsafeWindowMvReservedColumns.SafeDueAt});
+            END;
+            """;
+
+        var businessSelect = string.Join(", ", resolver.Schema.Columns.Select(c => c.Name));
+
+        var dropCurrentView = $"IF OBJECT_ID(N'{resolver.CurrentView}', N'V') IS NOT NULL DROP VIEW {resolver.CurrentView};";
+        var createCurrentView = $"""
+            EXEC(N'CREATE VIEW {resolver.CurrentView} AS
+            SELECT
+                u.{UnsafeWindowMvReservedColumns.ProjectionKey},
+                {string.Join(", ", resolver.Schema.Columns.Select(c => $"u.{c.Name}"))},
+                u.{UnsafeWindowMvReservedColumns.IsDeleted},
+                u.{UnsafeWindowMvReservedColumns.LastSortableUniqueId},
+                u.{UnsafeWindowMvReservedColumns.LastEventVersion},
+                u.{UnsafeWindowMvReservedColumns.LastAppliedAt}
+            FROM {resolver.UnsafeTable} u
+            UNION ALL
+            SELECT
+                s.{UnsafeWindowMvReservedColumns.ProjectionKey},
+                {string.Join(", ", resolver.Schema.Columns.Select(c => $"s.{c.Name}"))},
+                s.{UnsafeWindowMvReservedColumns.IsDeleted},
+                s.{UnsafeWindowMvReservedColumns.LastSortableUniqueId},
+                s.{UnsafeWindowMvReservedColumns.LastEventVersion},
+                s.{UnsafeWindowMvReservedColumns.LastAppliedAt}
+            FROM {resolver.SafeTable} s
+            WHERE NOT EXISTS (
+                SELECT 1 FROM {resolver.UnsafeTable} u2
+                WHERE u2.{UnsafeWindowMvReservedColumns.ProjectionKey} = s.{UnsafeWindowMvReservedColumns.ProjectionKey}
+            );');
+            """;
+
+        var dropCurrentLiveView = $"IF OBJECT_ID(N'{resolver.CurrentLiveView}', N'V') IS NOT NULL DROP VIEW {resolver.CurrentLiveView};";
+        var createCurrentLiveView = $"""
+            EXEC(N'CREATE VIEW {resolver.CurrentLiveView} AS
+            SELECT * FROM {resolver.CurrentView} WHERE {UnsafeWindowMvReservedColumns.IsDeleted} = 0;');
+            """;
+
+        return
+        [
+            safeTable,
+            unsafeTable,
+            unsafeDueIdx,
+            dropCurrentView,
+            createCurrentView,
+            dropCurrentLiveView,
+            createCurrentLiveView
+        ];
+    }
+}
+
+internal static class UnsafeWindowMvSqlServerValidator
+{
+    public static async Task ValidateAsync(
+        UnsafeWindowMvSqlServerSchemaResolver resolver,
+        SqlConnection connection,
+        CancellationToken ct)
+    {
+        foreach (var table in new[] { resolver.SafeTable, resolver.UnsafeTable })
+        {
+            var columns = (await connection.QueryAsync<(string column_name, string data_type)>(
+                new CommandDefinition(
+                    """
+                    SELECT column_name, data_type
+                    FROM information_schema.columns
+                    WHERE table_schema = SCHEMA_NAME()
+                      AND table_name = @Table
+                    """,
+                    new { Table = table },
+                    cancellationToken: ct))).ToList();
+
+            if (columns.Count == 0)
+            {
+                throw new InvalidOperationException($"Unsafe window MV table '{table}' was not created by initialization.");
+            }
+
+            var columnSet = new HashSet<string>(columns.Select(c => c.column_name), StringComparer.OrdinalIgnoreCase);
+
+            foreach (var required in UnsafeWindowMvReservedColumns.CommonMetadata)
+            {
+                if (!columnSet.Contains(required))
+                {
+                    throw new InvalidOperationException($"Unsafe window MV table '{table}' is missing required metadata column '{required}'.");
+                }
+            }
+
+            var tableSpecific = table == resolver.SafeTable
+                ? UnsafeWindowMvReservedColumns.SafeOnlyMetadata
+                : UnsafeWindowMvReservedColumns.UnsafeOnlyMetadata;
+            foreach (var required in tableSpecific)
+            {
+                if (!columnSet.Contains(required))
+                {
+                    throw new InvalidOperationException($"Unsafe window MV table '{table}' is missing required metadata column '{required}'.");
+                }
+            }
+
+            foreach (var business in resolver.Schema.Columns)
+            {
+                if (!columnSet.Contains(business.Name))
+                {
+                    throw new InvalidOperationException(
+                        $"Unsafe window MV table '{table}' is missing declared business column '{business.Name}'. Drop the table or bump the view version to reshape the schema.");
+                }
+            }
+        }
+    }
+}
+
+public sealed class UnsafeWindowMvSqlServerInitializer : IUnsafeWindowMvInitializer
+{
+    private readonly UnsafeWindowMvSqlServerSchemaResolver _resolver;
+    private readonly string _connectionString;
+    private readonly ILogger _logger;
+
+    public UnsafeWindowMvSqlServerInitializer(UnsafeWindowMvSqlServerSchemaResolver resolver, string connectionString, ILogger logger)
+    {
+        _resolver = resolver;
+        _connectionString = connectionString;
+        _logger = logger;
+    }
+
+    public async Task InitializeAsync(CancellationToken cancellationToken)
+    {
+        await using var connection = new SqlConnection(_connectionString);
+        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+        foreach (var statement in UnsafeWindowMvSqlServerDdl.BuildInitializeStatements(_resolver))
+        {
+            await connection.ExecuteAsync(new CommandDefinition(statement, cancellationToken: cancellationToken))
+                .ConfigureAwait(false);
+        }
+
+        await UnsafeWindowMvSqlServerValidator.ValidateAsync(_resolver, connection, cancellationToken).ConfigureAwait(false);
+
+        _logger.LogInformation(
+            "Unsafe window MV '{View}' v{Version} initialized on SQL Server (safe={Safe}, unsafe={Unsafe}, view={Current}, view_live={CurrentLive}).",
+            _resolver.ViewName,
+            _resolver.ViewVersion,
+            _resolver.SafeTable,
+            _resolver.UnsafeTable,
+            _resolver.CurrentView,
+            _resolver.CurrentLiveView);
+    }
+}
+
+public sealed class UnsafeWindowMvSqlServerStreamApplier<TRow> where TRow : class, new()
+{
+    private readonly UnsafeWindowMvSqlServerSchemaResolver _resolver;
+    private readonly IUnsafeWindowMvProjector<TRow> _projector;
+    private readonly TimeSpan _safeWindow;
+
+    public UnsafeWindowMvSqlServerStreamApplier(
+        UnsafeWindowMvSqlServerSchemaResolver resolver,
+        IUnsafeWindowMvProjector<TRow> projector)
+    {
+        _resolver = resolver;
+        _projector = projector;
+        _safeWindow = projector.SafeWindow;
+    }
+
+    public async Task ApplyEventAsync(
+        SqlConnection connection,
+        IDbTransaction transaction,
+        Event ev,
+        CancellationToken ct)
+    {
+        var projectionKey = _projector.GetProjectionKey(ev);
+        if (projectionKey is null)
+        {
+            return;
+        }
+
+        // FOR UPDATE equivalent on SQL Server: WITH (UPDLOCK, HOLDLOCK, ROWLOCK)
+        // HOLDLOCK upgrades to SERIALIZABLE for the key range, which keeps the
+        // upsert correct under concurrent stream writes.
+        var existingRow = await connection.QueryFirstOrDefaultAsync(new CommandDefinition(
+            $"SELECT * FROM {_resolver.UnsafeTable} WITH (UPDLOCK, HOLDLOCK, ROWLOCK) WHERE {UnsafeWindowMvReservedColumns.ProjectionKey} = @Key",
+            new { Key = projectionKey },
+            transaction: transaction,
+            cancellationToken: ct)).ConfigureAwait(false);
+
+        if (existingRow is IDictionary<string, object> existingDict)
+        {
+            var existingSuid = (string)existingDict[UnsafeWindowMvReservedColumns.LastSortableUniqueId];
+            if (string.CompareOrdinal(ev.SortableUniqueIdValue, existingSuid) <= 0)
+            {
+                await connection.ExecuteAsync(new CommandDefinition(
+                    $"UPDATE {_resolver.UnsafeTable} SET {UnsafeWindowMvReservedColumns.NeedsRebuild} = 1 WHERE {UnsafeWindowMvReservedColumns.ProjectionKey} = @Key",
+                    new { Key = projectionKey },
+                    transaction: transaction,
+                    cancellationToken: ct)).ConfigureAwait(false);
+                return;
+            }
+        }
+
+        TRow? current = null;
+        IDictionary<string, object>? fallbackBusinessValues = null;
+        long existingEventVersion = 0;
+        if (existingRow is IDictionary<string, object> existing)
+        {
+            current = UnsafeWindowMvRowHydrator<TRow>.Hydrate(_projector.Schema, existing);
+            existingEventVersion = Convert.ToInt64(existing[UnsafeWindowMvReservedColumns.LastEventVersion]);
+        }
+        else
+        {
+            var safeRow = await connection.QueryFirstOrDefaultAsync(new CommandDefinition(
+                $"SELECT * FROM {_resolver.SafeTable} WITH (UPDLOCK, HOLDLOCK, ROWLOCK) WHERE {UnsafeWindowMvReservedColumns.ProjectionKey} = @Key",
+                new { Key = projectionKey },
+                transaction: transaction,
+                cancellationToken: ct)).ConfigureAwait(false);
+            if (safeRow is IDictionary<string, object> safeDict)
+            {
+                var safeSuid = (string)safeDict[UnsafeWindowMvReservedColumns.LastSortableUniqueId];
+                existingEventVersion = Convert.ToInt64(safeDict[UnsafeWindowMvReservedColumns.LastEventVersion]);
+                if (string.CompareOrdinal(ev.SortableUniqueIdValue, safeSuid) <= 0)
+                {
+                    await MirrorSafeIntoUnsafeForRebuildAsync(
+                            connection,
+                            transaction,
+                            projectionKey,
+                            safeDict,
+                            ct)
+                        .ConfigureAwait(false);
+                    return;
+                }
+
+                current = UnsafeWindowMvRowHydrator<TRow>.Hydrate(_projector.Schema, safeDict);
+                fallbackBusinessValues = safeDict;
+            }
+        }
+
+        var outcome = _projector.Apply(current, ev);
+        var newEventVersion = existingEventVersion + 1;
+        switch (outcome)
+        {
+            case UnsafeWindowMvApplyOutcome.NoChange:
+                return;
+            case UnsafeWindowMvApplyOutcome.Upsert up:
+                if (!string.Equals(up.ProjectionKey, projectionKey, StringComparison.Ordinal))
+                {
+                    throw new InvalidOperationException(
+                        $"Projector '{_projector.ViewName}' returned a different projection key from Apply ('{up.ProjectionKey}') than GetProjectionKey ('{projectionKey}'). The two must agree.");
+                }
+                await UpsertUnsafeAsync(connection, transaction, projectionKey, up.Row, isDeleted: false, ev, newEventVersion, ct).ConfigureAwait(false);
+                break;
+            case UnsafeWindowMvApplyOutcome.Delete del:
+                if (!string.Equals(del.ProjectionKey, projectionKey, StringComparison.Ordinal))
+                {
+                    throw new InvalidOperationException(
+                        $"Projector '{_projector.ViewName}' returned a different projection key from Apply ('{del.ProjectionKey}') than GetProjectionKey ('{projectionKey}'). The two must agree.");
+                }
+                await UpsertDeletionAsync(connection, transaction, projectionKey, current, fallbackBusinessValues, ev, newEventVersion, ct).ConfigureAwait(false);
+                break;
+        }
+    }
+
+    private async Task MirrorSafeIntoUnsafeForRebuildAsync(
+        SqlConnection connection,
+        IDbTransaction transaction,
+        string projectionKey,
+        IDictionary<string, object> safeDict,
+        CancellationToken ct)
+    {
+        var businessCols = _projector.Schema.Columns.Select(c => c.Name).ToList();
+        var parameters = new DynamicParameters();
+        parameters.Add("__projectionKey", projectionKey);
+        parameters.Add("__isDeleted", safeDict[UnsafeWindowMvReservedColumns.IsDeleted]);
+        parameters.Add("__suid", safeDict[UnsafeWindowMvReservedColumns.LastSortableUniqueId]);
+        parameters.Add("__eventVersion", Convert.ToInt64(safeDict[UnsafeWindowMvReservedColumns.LastEventVersion]));
+        foreach (var column in _projector.Schema.Columns)
+        {
+            parameters.Add(column.Name, safeDict.TryGetValue(column.Name, out var v) ? (v ?? DBNull.Value) : DBNull.Value);
+        }
+
+        // SQL Server upsert: UPDATE (HOLDLOCK) then INSERT when no row was
+        // updated. HOLDLOCK keeps the key range locked for the branch, so a
+        // concurrent caller cannot race an INSERT into the same key.
+        var businessValueParams = string.Join(", ", businessCols.Select(c => "@" + c));
+        var sql = $"""
+            UPDATE {_resolver.UnsafeTable} WITH (UPDLOCK, HOLDLOCK)
+            SET {UnsafeWindowMvReservedColumns.NeedsRebuild} = 1
+            WHERE {UnsafeWindowMvReservedColumns.ProjectionKey} = @__projectionKey;
+
+            IF @@ROWCOUNT = 0
+            BEGIN
+                INSERT INTO {_resolver.UnsafeTable}
+                    ({UnsafeWindowMvReservedColumns.ProjectionKey},
+                     {string.Join(", ", businessCols)},
+                     {UnsafeWindowMvReservedColumns.IsDeleted},
+                     {UnsafeWindowMvReservedColumns.LastSortableUniqueId},
+                     {UnsafeWindowMvReservedColumns.LastEventVersion},
+                     {UnsafeWindowMvReservedColumns.LastAppliedAt},
+                     {UnsafeWindowMvReservedColumns.UnsafeSince},
+                     {UnsafeWindowMvReservedColumns.SafeDueAt},
+                     {UnsafeWindowMvReservedColumns.NeedsRebuild})
+                VALUES (@__projectionKey, {businessValueParams}, @__isDeleted, @__suid, @__eventVersion, SYSUTCDATETIME(), SYSUTCDATETIME(), SYSUTCDATETIME(), 1);
+            END;
+            """;
+
+        await connection.ExecuteAsync(new CommandDefinition(sql, parameters, transaction: transaction, cancellationToken: ct))
+            .ConfigureAwait(false);
+    }
+
+    private async Task UpsertUnsafeAsync(
+        SqlConnection connection,
+        IDbTransaction transaction,
+        string projectionKey,
+        object row,
+        bool isDeleted,
+        Event ev,
+        long eventVersion,
+        CancellationToken ct)
+    {
+        var businessCols = _projector.Schema.Columns.Select(c => c.Name).ToList();
+        var safeDueAt = DateTimeOffset.UtcNow.Add(_safeWindow);
+
+        var parameters = new DynamicParameters();
+        parameters.Add("__projectionKey", projectionKey);
+        parameters.Add("__isDeleted", isDeleted);
+        parameters.Add("__suid", ev.SortableUniqueIdValue);
+        parameters.Add("__eventVersion", eventVersion);
+        parameters.Add("__safeDueAt", safeDueAt);
+        foreach (var column in _projector.Schema.Columns)
+        {
+            parameters.Add(column.Name, column.Getter(row) ?? DBNull.Value);
+        }
+
+        var businessUpdates = string.Join(", ", businessCols.Select(c => $"{c} = @{c}"));
+        var businessInsertCols = string.Join(", ", businessCols);
+        var businessInsertValues = string.Join(", ", businessCols.Select(c => "@" + c));
+
+        var sql = $"""
+            UPDATE {_resolver.UnsafeTable} WITH (UPDLOCK, HOLDLOCK)
+            SET {businessUpdates},
+                {UnsafeWindowMvReservedColumns.IsDeleted} = @__isDeleted,
+                {UnsafeWindowMvReservedColumns.LastSortableUniqueId} = @__suid,
+                {UnsafeWindowMvReservedColumns.LastEventVersion} = @__eventVersion,
+                {UnsafeWindowMvReservedColumns.LastAppliedAt} = SYSUTCDATETIME(),
+                {UnsafeWindowMvReservedColumns.SafeDueAt} = @__safeDueAt,
+                {UnsafeWindowMvReservedColumns.NeedsRebuild} = 0
+            WHERE {UnsafeWindowMvReservedColumns.ProjectionKey} = @__projectionKey;
+
+            IF @@ROWCOUNT = 0
+            BEGIN
+                INSERT INTO {_resolver.UnsafeTable}
+                    ({UnsafeWindowMvReservedColumns.ProjectionKey},
+                     {businessInsertCols},
+                     {UnsafeWindowMvReservedColumns.IsDeleted},
+                     {UnsafeWindowMvReservedColumns.LastSortableUniqueId},
+                     {UnsafeWindowMvReservedColumns.LastEventVersion},
+                     {UnsafeWindowMvReservedColumns.LastAppliedAt},
+                     {UnsafeWindowMvReservedColumns.UnsafeSince},
+                     {UnsafeWindowMvReservedColumns.SafeDueAt},
+                     {UnsafeWindowMvReservedColumns.NeedsRebuild})
+                VALUES (@__projectionKey, {businessInsertValues}, @__isDeleted, @__suid, @__eventVersion, SYSUTCDATETIME(), SYSUTCDATETIME(), @__safeDueAt, 0);
+            END;
+            """;
+
+        await connection.ExecuteAsync(new CommandDefinition(sql, parameters, transaction: transaction, cancellationToken: ct))
+            .ConfigureAwait(false);
+    }
+
+    private async Task UpsertDeletionAsync(
+        SqlConnection connection,
+        IDbTransaction transaction,
+        string projectionKey,
+        TRow? currentRow,
+        IDictionary<string, object>? fallbackBusinessValues,
+        Event ev,
+        long eventVersion,
+        CancellationToken ct)
+    {
+        if (currentRow is null && fallbackBusinessValues is null)
+        {
+            return;
+        }
+
+        var safeDueAt = DateTimeOffset.UtcNow.Add(_safeWindow);
+        var businessCols = _projector.Schema.Columns.Select(c => c.Name).ToList();
+
+        var parameters = new DynamicParameters();
+        parameters.Add("__projectionKey", projectionKey);
+        parameters.Add("__suid", ev.SortableUniqueIdValue);
+        parameters.Add("__eventVersion", eventVersion);
+        parameters.Add("__safeDueAt", safeDueAt);
+
+        foreach (var column in _projector.Schema.Columns)
+        {
+            object? value;
+            if (currentRow is not null)
+            {
+                value = column.Getter(currentRow);
+            }
+            else if (fallbackBusinessValues is not null && fallbackBusinessValues.TryGetValue(column.Name, out var v))
+            {
+                value = v;
+            }
+            else
+            {
+                value = null;
+            }
+            parameters.Add(column.Name, value ?? DBNull.Value);
+        }
+
+        var businessUpdates = string.Join(", ", businessCols.Select(c => $"{c} = @{c}"));
+        var businessInsertCols = string.Join(", ", businessCols);
+        var businessInsertValues = string.Join(", ", businessCols.Select(c => "@" + c));
+
+        var sql = $"""
+            UPDATE {_resolver.UnsafeTable} WITH (UPDLOCK, HOLDLOCK)
+            SET {businessUpdates},
+                {UnsafeWindowMvReservedColumns.IsDeleted} = 1,
+                {UnsafeWindowMvReservedColumns.LastSortableUniqueId} = @__suid,
+                {UnsafeWindowMvReservedColumns.LastEventVersion} = @__eventVersion,
+                {UnsafeWindowMvReservedColumns.LastAppliedAt} = SYSUTCDATETIME(),
+                {UnsafeWindowMvReservedColumns.SafeDueAt} = @__safeDueAt,
+                {UnsafeWindowMvReservedColumns.NeedsRebuild} = 0
+            WHERE {UnsafeWindowMvReservedColumns.ProjectionKey} = @__projectionKey;
+
+            IF @@ROWCOUNT = 0
+            BEGIN
+                INSERT INTO {_resolver.UnsafeTable}
+                    ({UnsafeWindowMvReservedColumns.ProjectionKey},
+                     {businessInsertCols},
+                     {UnsafeWindowMvReservedColumns.IsDeleted},
+                     {UnsafeWindowMvReservedColumns.LastSortableUniqueId},
+                     {UnsafeWindowMvReservedColumns.LastEventVersion},
+                     {UnsafeWindowMvReservedColumns.LastAppliedAt},
+                     {UnsafeWindowMvReservedColumns.UnsafeSince},
+                     {UnsafeWindowMvReservedColumns.SafeDueAt},
+                     {UnsafeWindowMvReservedColumns.NeedsRebuild})
+                VALUES (@__projectionKey, {businessInsertValues}, 1, @__suid, @__eventVersion, SYSUTCDATETIME(), SYSUTCDATETIME(), @__safeDueAt, 0);
+            END;
+            """;
+
+        await connection.ExecuteAsync(new CommandDefinition(sql, parameters, transaction: transaction, cancellationToken: ct))
+            .ConfigureAwait(false);
+    }
+}
+
+public sealed class UnsafeWindowMvSqlServerCatchUpWorker<TRow> : IUnsafeWindowMvCatchUpRunner where TRow : class, new()
+{
+    private readonly UnsafeWindowMvSqlServerSchemaResolver _resolver;
+    private readonly IUnsafeWindowMvProjector<TRow> _projector;
+    private readonly UnsafeWindowMvSqlServerStreamApplier<TRow> _applier;
+    private readonly IEventStore _eventStore;
+    private readonly IEventTypes _eventTypes;
+    private readonly string _connectionString;
+    private readonly ILogger _logger;
+    private readonly int _batchSize;
+
+    public UnsafeWindowMvSqlServerCatchUpWorker(
+        UnsafeWindowMvSqlServerSchemaResolver resolver,
+        IUnsafeWindowMvProjector<TRow> projector,
+        IEventStore eventStore,
+        IEventTypes eventTypes,
+        string connectionString,
+        ILogger logger,
+        int batchSize = 256)
+    {
+        _resolver = resolver;
+        _projector = projector;
+        _applier = new UnsafeWindowMvSqlServerStreamApplier<TRow>(resolver, projector);
+        _eventStore = eventStore;
+        _eventTypes = eventTypes;
+        _connectionString = connectionString;
+        _logger = logger;
+        _batchSize = batchSize;
+    }
+
+    public async Task<int> CatchUpOnceAsync(CancellationToken cancellationToken)
+    {
+        await using var connection = new SqlConnection(_connectionString);
+        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+        var lastSuid = await connection.QuerySingleOrDefaultAsync<string?>(new CommandDefinition(
+            $"""
+             SELECT COALESCE(MAX(x.suid), '')
+             FROM (
+                 SELECT {UnsafeWindowMvReservedColumns.LastSortableUniqueId} AS suid FROM {_resolver.SafeTable}
+                 UNION ALL
+                 SELECT {UnsafeWindowMvReservedColumns.LastSortableUniqueId} AS suid FROM {_resolver.UnsafeTable}
+             ) x
+             """,
+            cancellationToken: cancellationToken)).ConfigureAwait(false);
+
+        var since = string.IsNullOrEmpty(lastSuid) ? null : new SortableUniqueId(lastSuid);
+        var result = await _eventStore.ReadAllSerializableEventsAsync(since).ConfigureAwait(false);
+        if (!result.IsSuccess)
+        {
+            throw result.GetException();
+        }
+
+        var events = result.GetValue().Take(_batchSize).ToList();
+        if (events.Count == 0)
+        {
+            return 0;
+        }
+
+        await using var transaction = await connection.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
+        foreach (var serialized in events)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var evResult = serialized.ToEvent(_eventTypes);
+            if (!evResult.IsSuccess)
+            {
+                throw evResult.GetException();
+            }
+
+            await _applier.ApplyEventAsync(connection, transaction, evResult.GetValue(), cancellationToken).ConfigureAwait(false);
+        }
+        await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+        _logger.LogDebug("Unsafe window MV '{View}' caught up {Count} event(s) on SQL Server.", _projector.ViewName, events.Count);
+        return events.Count;
+    }
+}
+
+public sealed class UnsafeWindowMvSqlServerPromoter<TRow> : IUnsafeWindowMvPromoter where TRow : class, new()
+{
+    private readonly UnsafeWindowMvSqlServerSchemaResolver _resolver;
+    private readonly IUnsafeWindowMvProjector<TRow> _projector;
+    private readonly IEventStore _eventStore;
+    private readonly IEventTypes _eventTypes;
+    private readonly string _connectionString;
+    private readonly ILogger _logger;
+    private readonly int _batchSize;
+
+    public UnsafeWindowMvSqlServerPromoter(
+        UnsafeWindowMvSqlServerSchemaResolver resolver,
+        IUnsafeWindowMvProjector<TRow> projector,
+        IEventStore eventStore,
+        IEventTypes eventTypes,
+        string connectionString,
+        ILogger logger,
+        int batchSize = 32)
+    {
+        _resolver = resolver;
+        _projector = projector;
+        _eventStore = eventStore;
+        _eventTypes = eventTypes;
+        _connectionString = connectionString;
+        _logger = logger;
+        _batchSize = batchSize;
+    }
+
+    public async Task<int> PromoteOnceAsync(CancellationToken cancellationToken)
+    {
+        await using var connection = new SqlConnection(_connectionString);
+        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+        await using var transaction = await connection.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
+
+        // FOR UPDATE SKIP LOCKED equivalent: READPAST + UPDLOCK + ROWLOCK lets
+        // concurrent promoters across the silo each grab a different set of due
+        // keys without blocking on each other.
+        var dueRows = (await connection.QueryAsync<(string key, bool needs_rebuild)>(new CommandDefinition(
+            $"""
+             SELECT TOP (@Limit)
+                    {UnsafeWindowMvReservedColumns.ProjectionKey} AS [key],
+                    {UnsafeWindowMvReservedColumns.NeedsRebuild} AS needs_rebuild
+             FROM {_resolver.UnsafeTable} WITH (UPDLOCK, READPAST, ROWLOCK)
+             WHERE {UnsafeWindowMvReservedColumns.SafeDueAt} <= SYSUTCDATETIME()
+             ORDER BY {UnsafeWindowMvReservedColumns.SafeDueAt}
+             """,
+            new { Limit = _batchSize },
+            transaction: transaction,
+            cancellationToken: cancellationToken))).ToList();
+
+        if (dueRows.Count == 0)
+        {
+            await transaction.RollbackAsync(cancellationToken).ConfigureAwait(false);
+            return 0;
+        }
+
+        foreach (var (projectionKey, needsRebuild) in dueRows)
+        {
+            await PromoteKeyAsync(connection, transaction, projectionKey, needsRebuild, cancellationToken).ConfigureAwait(false);
+        }
+
+        await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+        _logger.LogDebug("Unsafe window MV '{View}' promoted {Count} key(s) on SQL Server.", _projector.ViewName, dueRows.Count);
+        return dueRows.Count;
+    }
+
+    private async Task PromoteKeyAsync(
+        SqlConnection connection,
+        IDbTransaction transaction,
+        string projectionKey,
+        bool needsRebuild,
+        CancellationToken ct)
+    {
+        var safeRow = await connection.QueryFirstOrDefaultAsync(new CommandDefinition(
+            $"SELECT * FROM {_resolver.SafeTable} WHERE {UnsafeWindowMvReservedColumns.ProjectionKey} = @Key",
+            new { Key = projectionKey },
+            transaction: transaction,
+            cancellationToken: ct)).ConfigureAwait(false);
+
+        TRow? current = null;
+        string? startSuid = null;
+        long startVersion = 0;
+        var isDeleted = false;
+
+        if (!needsRebuild && safeRow is IDictionary<string, object> safeDict)
+        {
+            current = UnsafeWindowMvRowHydrator<TRow>.Hydrate(_projector.Schema, safeDict);
+            startSuid = (string)safeDict[UnsafeWindowMvReservedColumns.LastSortableUniqueId];
+            startVersion = Convert.ToInt64(safeDict[UnsafeWindowMvReservedColumns.LastEventVersion]);
+            isDeleted = Convert.ToBoolean(safeDict[UnsafeWindowMvReservedColumns.IsDeleted]);
+        }
+
+        var events = await FetchReplayEventsAsync(projectionKey, startSuid, ct).ConfigureAwait(false);
+
+        var lastSuid = startSuid;
+        var lastEventVersion = startVersion;
+
+        foreach (var ev in events)
+        {
+            var outcome = _projector.Apply(current, ev);
+            switch (outcome)
+            {
+                case UnsafeWindowMvApplyOutcome.NoChange:
+                    break;
+                case UnsafeWindowMvApplyOutcome.Upsert up:
+                    current = (TRow)up.Row;
+                    isDeleted = false;
+                    break;
+                case UnsafeWindowMvApplyOutcome.Delete:
+                    isDeleted = true;
+                    break;
+            }
+
+            lastSuid = ev.SortableUniqueIdValue;
+            lastEventVersion++;
+        }
+
+        if (lastSuid is null)
+        {
+            await connection.ExecuteAsync(new CommandDefinition(
+                $"DELETE FROM {_resolver.UnsafeTable} WHERE {UnsafeWindowMvReservedColumns.ProjectionKey} = @Key",
+                new { Key = projectionKey },
+                transaction: transaction,
+                cancellationToken: ct)).ConfigureAwait(false);
+            return;
+        }
+
+        await UpsertSafeAsync(connection, transaction, projectionKey, current, isDeleted, lastSuid, lastEventVersion, ct).ConfigureAwait(false);
+
+        await connection.ExecuteAsync(new CommandDefinition(
+            $"DELETE FROM {_resolver.UnsafeTable} WHERE {UnsafeWindowMvReservedColumns.ProjectionKey} = @Key",
+            new { Key = projectionKey },
+            transaction: transaction,
+            cancellationToken: ct)).ConfigureAwait(false);
+    }
+
+    private async Task<IReadOnlyList<Event>> FetchReplayEventsAsync(string projectionKey, string? sinceSuid, CancellationToken ct)
+    {
+        var since = string.IsNullOrEmpty(sinceSuid) ? null : new SortableUniqueId(sinceSuid);
+        var combined = new Dictionary<string, Event>(StringComparer.Ordinal);
+
+        var tags = _projector.TagsForProjectionKey(projectionKey);
+        if (tags.Count == 0)
+        {
+            return [];
+        }
+
+        foreach (var tag in tags)
+        {
+            ct.ThrowIfCancellationRequested();
+            var result = await _eventStore.ReadSerializableEventsByTagAsync(tag, since).ConfigureAwait(false);
+            if (!result.IsSuccess)
+            {
+                throw result.GetException();
+            }
+
+            foreach (var serialized in result.GetValue())
+            {
+                var key = serialized.Id.ToString();
+                if (combined.ContainsKey(key))
+                {
+                    continue;
+                }
+
+                var evResult = serialized.ToEvent(_eventTypes);
+                if (!evResult.IsSuccess)
+                {
+                    throw evResult.GetException();
+                }
+                combined[key] = evResult.GetValue();
+            }
+        }
+
+        return combined.Values
+            .Where(e => sinceSuid is null || string.CompareOrdinal(e.SortableUniqueIdValue, sinceSuid) > 0)
+            .OrderBy(e => e.SortableUniqueIdValue, StringComparer.Ordinal)
+            .ToArray();
+    }
+
+    private async Task UpsertSafeAsync(
+        SqlConnection connection,
+        IDbTransaction transaction,
+        string projectionKey,
+        TRow? row,
+        bool isDeleted,
+        string sortableUniqueId,
+        long eventVersion,
+        CancellationToken ct)
+    {
+        var businessCols = _projector.Schema.Columns.Select(c => c.Name).ToList();
+
+        var parameters = new DynamicParameters();
+        parameters.Add("__projectionKey", projectionKey);
+        parameters.Add("__isDeleted", isDeleted);
+        parameters.Add("__suid", sortableUniqueId);
+        parameters.Add("__eventVersion", eventVersion);
+
+        foreach (var column in _projector.Schema.Columns)
+        {
+            parameters.Add(column.Name, row is null ? DBNull.Value : (column.Getter(row) ?? DBNull.Value));
+        }
+
+        var businessUpdates = string.Join(", ", businessCols.Select(c => $"{c} = @{c}"));
+        var businessInsertCols = string.Join(", ", businessCols);
+        var businessInsertValues = string.Join(", ", businessCols.Select(c => "@" + c));
+
+        var sql = $"""
+            UPDATE {_resolver.SafeTable} WITH (UPDLOCK, HOLDLOCK)
+            SET {businessUpdates},
+                {UnsafeWindowMvReservedColumns.IsDeleted} = @__isDeleted,
+                {UnsafeWindowMvReservedColumns.LastSortableUniqueId} = @__suid,
+                {UnsafeWindowMvReservedColumns.LastEventVersion} = @__eventVersion,
+                {UnsafeWindowMvReservedColumns.LastAppliedAt} = SYSUTCDATETIME(),
+                {UnsafeWindowMvReservedColumns.SafeConfirmedAt} = SYSUTCDATETIME()
+            WHERE {UnsafeWindowMvReservedColumns.ProjectionKey} = @__projectionKey;
+
+            IF @@ROWCOUNT = 0
+            BEGIN
+                INSERT INTO {_resolver.SafeTable}
+                    ({UnsafeWindowMvReservedColumns.ProjectionKey},
+                     {businessInsertCols},
+                     {UnsafeWindowMvReservedColumns.IsDeleted},
+                     {UnsafeWindowMvReservedColumns.LastSortableUniqueId},
+                     {UnsafeWindowMvReservedColumns.LastEventVersion},
+                     {UnsafeWindowMvReservedColumns.LastAppliedAt},
+                     {UnsafeWindowMvReservedColumns.SafeConfirmedAt})
+                VALUES (@__projectionKey, {businessInsertValues}, @__isDeleted, @__suid, @__eventVersion, SYSUTCDATETIME(), SYSUTCDATETIME());
+            END;
+            """;
+
+        await connection.ExecuteAsync(new CommandDefinition(sql, parameters, transaction: transaction, cancellationToken: ct))
+            .ConfigureAwait(false);
+    }
+}

--- a/dcb/src/Sekiban.Dcb.MaterializedView.Sqlite/UnsafeWindowMvSqliteRegistration.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.Sqlite/UnsafeWindowMvSqliteRegistration.cs
@@ -1,0 +1,108 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Sekiban.Dcb.Domains;
+using Sekiban.Dcb.Storage;
+
+namespace Sekiban.Dcb.MaterializedView.Sqlite;
+
+public static class UnsafeWindowMvSqliteRegistration
+{
+    public static string ConnectionStringKey<TProjector>() =>
+        "UnsafeWindowMvSqlite:" + (typeof(TProjector).FullName ?? typeof(TProjector).Name);
+
+    public static string SchemaResolverKey<TProjector>() =>
+        "UnsafeWindowMvSqliteResolver:" + (typeof(TProjector).FullName ?? typeof(TProjector).Name);
+
+    public static IServiceCollection AddSekibanDcbUnsafeWindowMvSqlite<TProjector, TRow>(
+        this IServiceCollection services,
+        IConfiguration configuration,
+        string connectionStringName = "DcbMaterializedViewSqlite",
+        TimeSpan? idleDelay = null,
+        int catchUpBatchSize = 256,
+        int promotionBatchSize = 32)
+        where TProjector : class, IUnsafeWindowMvProjector<TRow>
+        where TRow : class, new()
+    {
+        if (string.IsNullOrWhiteSpace(connectionStringName))
+        {
+            throw new ArgumentException("Connection string name must be non-empty.", nameof(connectionStringName));
+        }
+
+        var connectionString = configuration.GetConnectionString(connectionStringName)
+            ?? configuration[$"ConnectionStrings:{connectionStringName}"]
+            ?? throw new InvalidOperationException(
+                $"Connection string '{connectionStringName}' not found — unsafe window MV (SQLite) requires a SQLite connection string.");
+
+        return services.AddSekibanDcbUnsafeWindowMvSqlite<TProjector, TRow>(
+            connectionString,
+            idleDelay,
+            catchUpBatchSize,
+            promotionBatchSize);
+    }
+
+    public static IServiceCollection AddSekibanDcbUnsafeWindowMvSqlite<TProjector, TRow>(
+        this IServiceCollection services,
+        string connectionString,
+        TimeSpan? idleDelay = null,
+        int catchUpBatchSize = 256,
+        int promotionBatchSize = 32)
+        where TProjector : class, IUnsafeWindowMvProjector<TRow>
+        where TRow : class, new()
+    {
+        if (string.IsNullOrWhiteSpace(connectionString))
+        {
+            throw new ArgumentException("Connection string must be non-empty.", nameof(connectionString));
+        }
+
+        services.AddSingleton<TProjector>();
+        services.AddSingleton<IUnsafeWindowMvProjector<TRow>>(sp => sp.GetRequiredService<TProjector>());
+
+        services.AddKeyedSingleton(SchemaResolverKey<TProjector>(), (sp, _) =>
+        {
+            var projector = sp.GetRequiredService<TProjector>();
+            return new UnsafeWindowMvSqliteSchemaResolver(projector.ViewName, projector.ViewVersion, projector.Schema);
+        });
+        services.AddKeyedSingleton(ConnectionStringKey<TProjector>(), (_, _) => connectionString);
+
+        services.AddSingleton(sp =>
+        {
+            var resolver = sp.GetRequiredKeyedService<UnsafeWindowMvSqliteSchemaResolver>(SchemaResolverKey<TProjector>());
+            var logger = sp.GetRequiredService<ILogger<UnsafeWindowMvSqliteInitializer>>();
+            return new UnsafeWindowMvSqliteInitializer(resolver, connectionString, logger);
+        });
+
+        services.AddSingleton<UnsafeWindowMvSqliteCatchUpWorker<TRow>>(sp =>
+        {
+            var resolver = sp.GetRequiredKeyedService<UnsafeWindowMvSqliteSchemaResolver>(SchemaResolverKey<TProjector>());
+            var projector = sp.GetRequiredService<IUnsafeWindowMvProjector<TRow>>();
+            var eventStore = sp.GetRequiredService<IEventStore>();
+            var eventTypes = sp.GetRequiredService<IEventTypes>();
+            var logger = sp.GetRequiredService<ILogger<UnsafeWindowMvSqliteCatchUpWorker<TRow>>>();
+            return new UnsafeWindowMvSqliteCatchUpWorker<TRow>(resolver, projector, eventStore, eventTypes, connectionString, logger, catchUpBatchSize);
+        });
+
+        services.AddSingleton<UnsafeWindowMvSqlitePromoter<TRow>>(sp =>
+        {
+            var resolver = sp.GetRequiredKeyedService<UnsafeWindowMvSqliteSchemaResolver>(SchemaResolverKey<TProjector>());
+            var projector = sp.GetRequiredService<IUnsafeWindowMvProjector<TRow>>();
+            var eventStore = sp.GetRequiredService<IEventStore>();
+            var eventTypes = sp.GetRequiredService<IEventTypes>();
+            var logger = sp.GetRequiredService<ILogger<UnsafeWindowMvSqlitePromoter<TRow>>>();
+            return new UnsafeWindowMvSqlitePromoter<TRow>(resolver, projector, eventStore, eventTypes, connectionString, logger, promotionBatchSize);
+        });
+
+        services.AddHostedService(sp =>
+        {
+            var projector = sp.GetRequiredService<IUnsafeWindowMvProjector<TRow>>();
+            var initializer = sp.GetRequiredService<UnsafeWindowMvSqliteInitializer>();
+            var catchUp = sp.GetRequiredService<UnsafeWindowMvSqliteCatchUpWorker<TRow>>();
+            var promoter = sp.GetRequiredService<UnsafeWindowMvSqlitePromoter<TRow>>();
+            var logger = sp.GetRequiredService<ILogger<UnsafeWindowMvHostedService>>();
+            return new UnsafeWindowMvHostedService(initializer, catchUp, promoter, projector.ViewName, logger, idleDelay);
+        });
+
+        return services;
+    }
+}

--- a/dcb/src/Sekiban.Dcb.MaterializedView.Sqlite/UnsafeWindowMvSqliteRuntime.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.Sqlite/UnsafeWindowMvSqliteRuntime.cs
@@ -1,0 +1,912 @@
+using System.Data;
+using Dapper;
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Logging;
+using Sekiban.Dcb.Common;
+using Sekiban.Dcb.Domains;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.Storage;
+using Sekiban.Dcb.Tags;
+
+namespace Sekiban.Dcb.MaterializedView.Sqlite;
+
+// ============================================================================
+// Unsafe Window Materialized View — SQLite runtime (issue #1035).
+//
+// Dialect notes:
+//   - TEXT for keys / business strings, INTEGER for booleans, DATETIME values
+//     stored as ISO 8601 TEXT.
+//   - CURRENT_TIMESTAMP returns UTC ISO 8601 text by default.
+//   - ON CONFLICT (col) DO UPDATE SET is supported since SQLite 3.24 (2018).
+//   - No FOR UPDATE / SKIP LOCKED: SQLite serialises writers globally, so
+//     the promoter naturally never races another writer on the same file.
+//   - Schema validation via pragma_table_info(table).
+// ============================================================================
+
+public sealed class UnsafeWindowMvSqliteSchemaResolver
+{
+    private const int MaxSharedPrefixLength = 63 - 13;
+
+    public UnsafeWindowMvSqliteSchemaResolver(string viewName, int viewVersion, UnsafeWindowMvSchema schema)
+    {
+        if (string.IsNullOrWhiteSpace(viewName))
+        {
+            throw new ArgumentException("View name must be non-empty.", nameof(viewName));
+        }
+        if (viewVersion <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(viewVersion), "View version must be positive.");
+        }
+        if (schema.Columns.Count == 0)
+        {
+            throw new ArgumentException("Unsafe window MV schema must declare at least one business column.", nameof(schema));
+        }
+
+        var reserved = new HashSet<string>(UnsafeWindowMvReservedColumns.AllReservedNames, StringComparer.OrdinalIgnoreCase);
+        foreach (var column in schema.Columns)
+        {
+            if (reserved.Contains(column.Name))
+            {
+                throw new InvalidOperationException(
+                    $"Unsafe window MV '{viewName}' declares a business column '{column.Name}' that clashes with a framework-managed metadata column. Rename the business column.");
+            }
+
+            MvPhysicalName.ValidateIdentifier(column.Name);
+            ValidateSqlType(column.Name, column.SqlType);
+        }
+
+        var sanitized = MvPhysicalName.SanitizeSegment(viewName);
+        var rawPrefix = $"sekiban_uwmv_{sanitized}_v{viewVersion}";
+        var prefix = rawPrefix.Length <= MaxSharedPrefixLength
+            ? rawPrefix
+            : BuildBoundedPrefix(sanitized, viewVersion);
+
+        SafeTable = $"{prefix}_safe";
+        UnsafeTable = $"{prefix}_unsafe";
+        CurrentView = $"{prefix}_current";
+        CurrentLiveView = $"{prefix}_current_live";
+
+        foreach (var identifier in new[] { SafeTable, UnsafeTable, CurrentView, CurrentLiveView })
+        {
+            MvPhysicalName.ValidateIdentifier(identifier);
+        }
+
+        Schema = schema;
+        ViewName = viewName;
+        ViewVersion = viewVersion;
+    }
+
+    public string ViewName { get; }
+    public int ViewVersion { get; }
+    public string SafeTable { get; }
+    public string UnsafeTable { get; }
+    public string CurrentView { get; }
+    public string CurrentLiveView { get; }
+    public UnsafeWindowMvSchema Schema { get; }
+
+    private static string BuildBoundedPrefix(string sanitized, int viewVersion)
+    {
+        var versionSuffix = $"_v{viewVersion}";
+        var hash = Convert.ToHexString(
+                System.Security.Cryptography.SHA1.HashData(System.Text.Encoding.UTF8.GetBytes(sanitized)))
+            .Substring(0, 8)
+            .ToLowerInvariant();
+
+        var headroom = MaxSharedPrefixLength - ("sekiban_uwmv__".Length + hash.Length + versionSuffix.Length);
+        if (headroom < 1)
+        {
+            headroom = 1;
+        }
+        var head = sanitized.Substring(0, Math.Min(headroom, sanitized.Length));
+        return $"sekiban_uwmv_{head}_{hash}{versionSuffix}";
+    }
+
+    private static void ValidateSqlType(string columnName, string sqlType)
+    {
+        if (string.IsNullOrWhiteSpace(sqlType))
+        {
+            throw new ArgumentException($"Business column '{columnName}' has an empty SQL type.");
+        }
+        foreach (var ch in sqlType)
+        {
+            if (ch == ';' || ch == '\r' || ch == '\n')
+            {
+                throw new ArgumentException(
+                    $"Business column '{columnName}' declares a SQL type containing illegal characters (semicolon / newline). Type: '{sqlType}'.");
+            }
+        }
+        if (sqlType.Contains("--", StringComparison.Ordinal) || sqlType.Contains("/*", StringComparison.Ordinal))
+        {
+            throw new ArgumentException(
+                $"Business column '{columnName}' declares a SQL type containing SQL comment markers. Type: '{sqlType}'.");
+        }
+    }
+}
+
+internal static class UnsafeWindowMvSqliteTypes
+{
+    // SQLite's type system is dynamic / affinity-based so most declarations
+    // are informational. We still translate common logical keywords so the
+    // declared types stay consistent with the other providers.
+    private static readonly IReadOnlyDictionary<string, string> Map = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+    {
+        ["TEXT"] = "TEXT",
+        ["BOOLEAN"] = "INTEGER",
+        ["BOOL"] = "INTEGER",
+        ["UUID"] = "TEXT",
+        ["TIMESTAMPTZ"] = "TEXT",
+        ["TIMESTAMP"] = "TEXT",
+        ["BIGINT"] = "INTEGER",
+        ["INT"] = "INTEGER",
+        ["INTEGER"] = "INTEGER",
+        ["DATE"] = "TEXT",
+        ["REAL"] = "REAL",
+        ["DOUBLE"] = "REAL",
+        ["DOUBLE PRECISION"] = "REAL",
+        ["SMALLINT"] = "INTEGER"
+    };
+
+    public static string Translate(string declaredType) =>
+        UnsafeWindowMvLogicalTypes.Translate(declaredType, Map);
+}
+
+internal static class UnsafeWindowMvSqliteDdl
+{
+    public static IReadOnlyList<string> BuildInitializeStatements(UnsafeWindowMvSqliteSchemaResolver resolver)
+    {
+        var businessDdl = string.Join(
+            ",\n    ",
+            resolver.Schema.Columns.Select(c => $"{c.Name} {UnsafeWindowMvSqliteTypes.Translate(c.SqlType)}"));
+
+        var safeTable = $"""
+            CREATE TABLE IF NOT EXISTS {resolver.SafeTable} (
+                {UnsafeWindowMvReservedColumns.ProjectionKey} TEXT PRIMARY KEY,
+                {businessDdl},
+                {UnsafeWindowMvReservedColumns.IsDeleted} INTEGER NOT NULL DEFAULT 0,
+                {UnsafeWindowMvReservedColumns.LastSortableUniqueId} TEXT NOT NULL,
+                {UnsafeWindowMvReservedColumns.LastEventVersion} INTEGER NOT NULL DEFAULT 0,
+                {UnsafeWindowMvReservedColumns.LastAppliedAt} TEXT NOT NULL DEFAULT (CURRENT_TIMESTAMP),
+                {UnsafeWindowMvReservedColumns.SafeConfirmedAt} TEXT NOT NULL DEFAULT (CURRENT_TIMESTAMP)
+            );
+            """;
+
+        var unsafeTable = $"""
+            CREATE TABLE IF NOT EXISTS {resolver.UnsafeTable} (
+                {UnsafeWindowMvReservedColumns.ProjectionKey} TEXT PRIMARY KEY,
+                {businessDdl},
+                {UnsafeWindowMvReservedColumns.IsDeleted} INTEGER NOT NULL DEFAULT 0,
+                {UnsafeWindowMvReservedColumns.LastSortableUniqueId} TEXT NOT NULL,
+                {UnsafeWindowMvReservedColumns.LastEventVersion} INTEGER NOT NULL DEFAULT 0,
+                {UnsafeWindowMvReservedColumns.LastAppliedAt} TEXT NOT NULL DEFAULT (CURRENT_TIMESTAMP),
+                {UnsafeWindowMvReservedColumns.UnsafeSince} TEXT NOT NULL DEFAULT (CURRENT_TIMESTAMP),
+                {UnsafeWindowMvReservedColumns.SafeDueAt} TEXT NOT NULL DEFAULT (CURRENT_TIMESTAMP),
+                {UnsafeWindowMvReservedColumns.NeedsRebuild} INTEGER NOT NULL DEFAULT 0
+            );
+            """;
+
+        var unsafeDueIdx = $"CREATE INDEX IF NOT EXISTS idx_{resolver.UnsafeTable}_safe_due_at ON {resolver.UnsafeTable} ({UnsafeWindowMvReservedColumns.SafeDueAt});";
+
+        // SQLite doesn't support CREATE OR REPLACE VIEW. Recreate with drop+create.
+        var dropCurrentView = $"DROP VIEW IF EXISTS {resolver.CurrentView};";
+        var createCurrentView = $"""
+            CREATE VIEW {resolver.CurrentView} AS
+            SELECT
+                u.{UnsafeWindowMvReservedColumns.ProjectionKey},
+                {string.Join(", ", resolver.Schema.Columns.Select(c => $"u.{c.Name}"))},
+                u.{UnsafeWindowMvReservedColumns.IsDeleted},
+                u.{UnsafeWindowMvReservedColumns.LastSortableUniqueId},
+                u.{UnsafeWindowMvReservedColumns.LastEventVersion},
+                u.{UnsafeWindowMvReservedColumns.LastAppliedAt}
+            FROM {resolver.UnsafeTable} u
+            UNION ALL
+            SELECT
+                s.{UnsafeWindowMvReservedColumns.ProjectionKey},
+                {string.Join(", ", resolver.Schema.Columns.Select(c => $"s.{c.Name}"))},
+                s.{UnsafeWindowMvReservedColumns.IsDeleted},
+                s.{UnsafeWindowMvReservedColumns.LastSortableUniqueId},
+                s.{UnsafeWindowMvReservedColumns.LastEventVersion},
+                s.{UnsafeWindowMvReservedColumns.LastAppliedAt}
+            FROM {resolver.SafeTable} s
+            WHERE NOT EXISTS (
+                SELECT 1 FROM {resolver.UnsafeTable} u2
+                WHERE u2.{UnsafeWindowMvReservedColumns.ProjectionKey} = s.{UnsafeWindowMvReservedColumns.ProjectionKey}
+            );
+            """;
+
+        var dropCurrentLiveView = $"DROP VIEW IF EXISTS {resolver.CurrentLiveView};";
+        var createCurrentLiveView = $"""
+            CREATE VIEW {resolver.CurrentLiveView} AS
+            SELECT *
+            FROM {resolver.CurrentView}
+            WHERE {UnsafeWindowMvReservedColumns.IsDeleted} = 0;
+            """;
+
+        return
+        [
+            safeTable,
+            unsafeTable,
+            unsafeDueIdx,
+            dropCurrentView,
+            createCurrentView,
+            dropCurrentLiveView,
+            createCurrentLiveView
+        ];
+    }
+}
+
+internal static class UnsafeWindowMvSqliteValidator
+{
+    public static async Task ValidateAsync(
+        UnsafeWindowMvSqliteSchemaResolver resolver,
+        SqliteConnection connection,
+        CancellationToken ct)
+    {
+        foreach (var table in new[] { resolver.SafeTable, resolver.UnsafeTable })
+        {
+            // pragma_table_info is SQLite's introspection source.
+            var columns = (await connection.QueryAsync<(string name, string type)>(
+                new CommandDefinition(
+                    $"SELECT name, type FROM pragma_table_info('{table}')",
+                    cancellationToken: ct))).ToList();
+
+            if (columns.Count == 0)
+            {
+                throw new InvalidOperationException($"Unsafe window MV table '{table}' was not created by initialization.");
+            }
+
+            var columnSet = new HashSet<string>(columns.Select(c => c.name), StringComparer.OrdinalIgnoreCase);
+
+            foreach (var required in UnsafeWindowMvReservedColumns.CommonMetadata)
+            {
+                if (!columnSet.Contains(required))
+                {
+                    throw new InvalidOperationException($"Unsafe window MV table '{table}' is missing required metadata column '{required}'.");
+                }
+            }
+
+            var tableSpecific = table == resolver.SafeTable
+                ? UnsafeWindowMvReservedColumns.SafeOnlyMetadata
+                : UnsafeWindowMvReservedColumns.UnsafeOnlyMetadata;
+            foreach (var required in tableSpecific)
+            {
+                if (!columnSet.Contains(required))
+                {
+                    throw new InvalidOperationException($"Unsafe window MV table '{table}' is missing required metadata column '{required}'.");
+                }
+            }
+
+            foreach (var business in resolver.Schema.Columns)
+            {
+                if (!columnSet.Contains(business.Name))
+                {
+                    throw new InvalidOperationException(
+                        $"Unsafe window MV table '{table}' is missing declared business column '{business.Name}'. Drop the table or bump the view version to reshape the schema.");
+                }
+            }
+        }
+    }
+}
+
+public sealed class UnsafeWindowMvSqliteInitializer : IUnsafeWindowMvInitializer
+{
+    private readonly UnsafeWindowMvSqliteSchemaResolver _resolver;
+    private readonly string _connectionString;
+    private readonly ILogger _logger;
+
+    public UnsafeWindowMvSqliteInitializer(UnsafeWindowMvSqliteSchemaResolver resolver, string connectionString, ILogger logger)
+    {
+        _resolver = resolver;
+        _connectionString = connectionString;
+        _logger = logger;
+    }
+
+    public async Task InitializeAsync(CancellationToken cancellationToken)
+    {
+        await using var connection = new SqliteConnection(_connectionString);
+        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+        // Enable WAL + NORMAL synchronous up front so that subsequent writes
+        // (catch-up + promotion) don't block readers. journal_mode survives
+        // the connection; synchronous is per-connection.
+        await connection.ExecuteAsync(new CommandDefinition(
+            "PRAGMA journal_mode=WAL; PRAGMA synchronous=NORMAL;",
+            cancellationToken: cancellationToken)).ConfigureAwait(false);
+
+        foreach (var statement in UnsafeWindowMvSqliteDdl.BuildInitializeStatements(_resolver))
+        {
+            await connection.ExecuteAsync(new CommandDefinition(statement, cancellationToken: cancellationToken))
+                .ConfigureAwait(false);
+        }
+
+        await UnsafeWindowMvSqliteValidator.ValidateAsync(_resolver, connection, cancellationToken).ConfigureAwait(false);
+
+        _logger.LogInformation(
+            "Unsafe window MV '{View}' v{Version} initialized on SQLite (safe={Safe}, unsafe={Unsafe}, view={Current}, view_live={CurrentLive}).",
+            _resolver.ViewName,
+            _resolver.ViewVersion,
+            _resolver.SafeTable,
+            _resolver.UnsafeTable,
+            _resolver.CurrentView,
+            _resolver.CurrentLiveView);
+    }
+}
+
+public sealed class UnsafeWindowMvSqliteStreamApplier<TRow> where TRow : class, new()
+{
+    private readonly UnsafeWindowMvSqliteSchemaResolver _resolver;
+    private readonly IUnsafeWindowMvProjector<TRow> _projector;
+    private readonly TimeSpan _safeWindow;
+
+    public UnsafeWindowMvSqliteStreamApplier(
+        UnsafeWindowMvSqliteSchemaResolver resolver,
+        IUnsafeWindowMvProjector<TRow> projector)
+    {
+        _resolver = resolver;
+        _projector = projector;
+        _safeWindow = projector.SafeWindow;
+    }
+
+    public async Task ApplyEventAsync(
+        SqliteConnection connection,
+        IDbTransaction transaction,
+        Event ev,
+        CancellationToken ct)
+    {
+        var projectionKey = _projector.GetProjectionKey(ev);
+        if (projectionKey is null)
+        {
+            return;
+        }
+
+        // SQLite serializes writers; no row-level SELECT FOR UPDATE is needed
+        // or available. The surrounding transaction is enough.
+        var existingRow = await connection.QueryFirstOrDefaultAsync(new CommandDefinition(
+            $"SELECT * FROM {_resolver.UnsafeTable} WHERE {UnsafeWindowMvReservedColumns.ProjectionKey} = @Key",
+            new { Key = projectionKey },
+            transaction: transaction,
+            cancellationToken: ct)).ConfigureAwait(false);
+
+        if (existingRow is IDictionary<string, object> existingDict)
+        {
+            var existingSuid = (string)existingDict[UnsafeWindowMvReservedColumns.LastSortableUniqueId];
+            if (string.CompareOrdinal(ev.SortableUniqueIdValue, existingSuid) <= 0)
+            {
+                await connection.ExecuteAsync(new CommandDefinition(
+                    $"UPDATE {_resolver.UnsafeTable} SET {UnsafeWindowMvReservedColumns.NeedsRebuild} = 1 WHERE {UnsafeWindowMvReservedColumns.ProjectionKey} = @Key",
+                    new { Key = projectionKey },
+                    transaction: transaction,
+                    cancellationToken: ct)).ConfigureAwait(false);
+                return;
+            }
+        }
+
+        TRow? current = null;
+        IDictionary<string, object>? fallbackBusinessValues = null;
+        long existingEventVersion = 0;
+        if (existingRow is IDictionary<string, object> existing)
+        {
+            current = UnsafeWindowMvRowHydrator<TRow>.Hydrate(_projector.Schema, existing);
+            existingEventVersion = Convert.ToInt64(existing[UnsafeWindowMvReservedColumns.LastEventVersion]);
+        }
+        else
+        {
+            var safeRow = await connection.QueryFirstOrDefaultAsync(new CommandDefinition(
+                $"SELECT * FROM {_resolver.SafeTable} WHERE {UnsafeWindowMvReservedColumns.ProjectionKey} = @Key",
+                new { Key = projectionKey },
+                transaction: transaction,
+                cancellationToken: ct)).ConfigureAwait(false);
+            if (safeRow is IDictionary<string, object> safeDict)
+            {
+                var safeSuid = (string)safeDict[UnsafeWindowMvReservedColumns.LastSortableUniqueId];
+                existingEventVersion = Convert.ToInt64(safeDict[UnsafeWindowMvReservedColumns.LastEventVersion]);
+                if (string.CompareOrdinal(ev.SortableUniqueIdValue, safeSuid) <= 0)
+                {
+                    await MirrorSafeIntoUnsafeForRebuildAsync(connection, transaction, projectionKey, safeDict, ct)
+                        .ConfigureAwait(false);
+                    return;
+                }
+
+                current = UnsafeWindowMvRowHydrator<TRow>.Hydrate(_projector.Schema, safeDict);
+                fallbackBusinessValues = safeDict;
+            }
+        }
+
+        var outcome = _projector.Apply(current, ev);
+        var newEventVersion = existingEventVersion + 1;
+        switch (outcome)
+        {
+            case UnsafeWindowMvApplyOutcome.NoChange:
+                return;
+            case UnsafeWindowMvApplyOutcome.Upsert up:
+                if (!string.Equals(up.ProjectionKey, projectionKey, StringComparison.Ordinal))
+                {
+                    throw new InvalidOperationException(
+                        $"Projector '{_projector.ViewName}' returned a different projection key from Apply ('{up.ProjectionKey}') than GetProjectionKey ('{projectionKey}').");
+                }
+                await UpsertUnsafeAsync(connection, transaction, projectionKey, up.Row, isDeleted: false, ev, newEventVersion, ct).ConfigureAwait(false);
+                break;
+            case UnsafeWindowMvApplyOutcome.Delete del:
+                if (!string.Equals(del.ProjectionKey, projectionKey, StringComparison.Ordinal))
+                {
+                    throw new InvalidOperationException(
+                        $"Projector '{_projector.ViewName}' returned a different projection key from Apply ('{del.ProjectionKey}') than GetProjectionKey ('{projectionKey}').");
+                }
+                await UpsertDeletionAsync(connection, transaction, projectionKey, current, fallbackBusinessValues, ev, newEventVersion, ct).ConfigureAwait(false);
+                break;
+        }
+    }
+
+    private async Task MirrorSafeIntoUnsafeForRebuildAsync(
+        SqliteConnection connection,
+        IDbTransaction transaction,
+        string projectionKey,
+        IDictionary<string, object> safeDict,
+        CancellationToken ct)
+    {
+        var businessCols = _projector.Schema.Columns.Select(c => c.Name).ToList();
+        var businessValueParams = string.Join(", ", businessCols.Select(c => "@" + c));
+
+        var sql = $"""
+            INSERT INTO {_resolver.UnsafeTable}
+                ({UnsafeWindowMvReservedColumns.ProjectionKey},
+                 {string.Join(", ", businessCols)},
+                 {UnsafeWindowMvReservedColumns.IsDeleted},
+                 {UnsafeWindowMvReservedColumns.LastSortableUniqueId},
+                 {UnsafeWindowMvReservedColumns.LastEventVersion},
+                 {UnsafeWindowMvReservedColumns.LastAppliedAt},
+                 {UnsafeWindowMvReservedColumns.UnsafeSince},
+                 {UnsafeWindowMvReservedColumns.SafeDueAt},
+                 {UnsafeWindowMvReservedColumns.NeedsRebuild})
+            VALUES (@__projectionKey, {businessValueParams}, @__isDeleted, @__suid, @__eventVersion, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 1)
+            ON CONFLICT ({UnsafeWindowMvReservedColumns.ProjectionKey}) DO UPDATE SET
+                {UnsafeWindowMvReservedColumns.NeedsRebuild} = 1;
+            """;
+
+        var parameters = new DynamicParameters();
+        parameters.Add("__projectionKey", projectionKey);
+        parameters.Add("__isDeleted", Convert.ToInt64(safeDict[UnsafeWindowMvReservedColumns.IsDeleted]));
+        parameters.Add("__suid", safeDict[UnsafeWindowMvReservedColumns.LastSortableUniqueId]);
+        parameters.Add("__eventVersion", Convert.ToInt64(safeDict[UnsafeWindowMvReservedColumns.LastEventVersion]));
+        foreach (var column in _projector.Schema.Columns)
+        {
+            parameters.Add(column.Name, safeDict.TryGetValue(column.Name, out var v) ? (v ?? DBNull.Value) : DBNull.Value);
+        }
+
+        await connection.ExecuteAsync(new CommandDefinition(sql, parameters, transaction: transaction, cancellationToken: ct))
+            .ConfigureAwait(false);
+    }
+
+    private async Task UpsertUnsafeAsync(
+        SqliteConnection connection,
+        IDbTransaction transaction,
+        string projectionKey,
+        object row,
+        bool isDeleted,
+        Event ev,
+        long eventVersion,
+        CancellationToken ct)
+    {
+        var businessCols = _projector.Schema.Columns.Select(c => c.Name).ToList();
+        // SQLite stores CURRENT_TIMESTAMP as UTC ISO text; compare safe_due_at as text ordering.
+        var safeDueAt = DateTime.UtcNow.Add(_safeWindow).ToString("yyyy-MM-dd HH:mm:ss");
+        var businessValueParams = string.Join(", ", businessCols.Select(c => "@" + c));
+        var businessUpdates = string.Join(", ", businessCols.Select(c => $"{c} = excluded.{c}"));
+
+        var sql = $"""
+            INSERT INTO {_resolver.UnsafeTable}
+                ({UnsafeWindowMvReservedColumns.ProjectionKey},
+                 {string.Join(", ", businessCols)},
+                 {UnsafeWindowMvReservedColumns.IsDeleted},
+                 {UnsafeWindowMvReservedColumns.LastSortableUniqueId},
+                 {UnsafeWindowMvReservedColumns.LastEventVersion},
+                 {UnsafeWindowMvReservedColumns.LastAppliedAt},
+                 {UnsafeWindowMvReservedColumns.UnsafeSince},
+                 {UnsafeWindowMvReservedColumns.SafeDueAt},
+                 {UnsafeWindowMvReservedColumns.NeedsRebuild})
+            VALUES (@__projectionKey, {businessValueParams}, @__isDeleted, @__suid, @__eventVersion, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, @__safeDueAt, 0)
+            ON CONFLICT ({UnsafeWindowMvReservedColumns.ProjectionKey}) DO UPDATE SET
+                {businessUpdates},
+                {UnsafeWindowMvReservedColumns.IsDeleted} = excluded.{UnsafeWindowMvReservedColumns.IsDeleted},
+                {UnsafeWindowMvReservedColumns.LastSortableUniqueId} = excluded.{UnsafeWindowMvReservedColumns.LastSortableUniqueId},
+                {UnsafeWindowMvReservedColumns.LastEventVersion} = excluded.{UnsafeWindowMvReservedColumns.LastEventVersion},
+                {UnsafeWindowMvReservedColumns.LastAppliedAt} = CURRENT_TIMESTAMP,
+                {UnsafeWindowMvReservedColumns.SafeDueAt} = excluded.{UnsafeWindowMvReservedColumns.SafeDueAt},
+                {UnsafeWindowMvReservedColumns.NeedsRebuild} = 0;
+            """;
+
+        var parameters = new DynamicParameters();
+        parameters.Add("__projectionKey", projectionKey);
+        parameters.Add("__isDeleted", isDeleted ? 1 : 0);
+        parameters.Add("__suid", ev.SortableUniqueIdValue);
+        parameters.Add("__eventVersion", eventVersion);
+        parameters.Add("__safeDueAt", safeDueAt);
+
+        foreach (var column in _projector.Schema.Columns)
+        {
+            parameters.Add(column.Name, column.Getter(row) ?? DBNull.Value);
+        }
+
+        await connection.ExecuteAsync(new CommandDefinition(sql, parameters, transaction: transaction, cancellationToken: ct))
+            .ConfigureAwait(false);
+    }
+
+    private async Task UpsertDeletionAsync(
+        SqliteConnection connection,
+        IDbTransaction transaction,
+        string projectionKey,
+        TRow? currentRow,
+        IDictionary<string, object>? fallbackBusinessValues,
+        Event ev,
+        long eventVersion,
+        CancellationToken ct)
+    {
+        if (currentRow is null && fallbackBusinessValues is null)
+        {
+            return;
+        }
+
+        var safeDueAt = DateTime.UtcNow.Add(_safeWindow).ToString("yyyy-MM-dd HH:mm:ss");
+        var businessCols = _projector.Schema.Columns.Select(c => c.Name).ToList();
+        var businessValueParams = string.Join(", ", businessCols.Select(c => "@" + c));
+        var businessUpdates = string.Join(", ", businessCols.Select(c => $"{c} = excluded.{c}"));
+
+        var sql = $"""
+            INSERT INTO {_resolver.UnsafeTable}
+                ({UnsafeWindowMvReservedColumns.ProjectionKey},
+                 {string.Join(", ", businessCols)},
+                 {UnsafeWindowMvReservedColumns.IsDeleted},
+                 {UnsafeWindowMvReservedColumns.LastSortableUniqueId},
+                 {UnsafeWindowMvReservedColumns.LastEventVersion},
+                 {UnsafeWindowMvReservedColumns.LastAppliedAt},
+                 {UnsafeWindowMvReservedColumns.UnsafeSince},
+                 {UnsafeWindowMvReservedColumns.SafeDueAt},
+                 {UnsafeWindowMvReservedColumns.NeedsRebuild})
+            VALUES (@__projectionKey, {businessValueParams}, 1, @__suid, @__eventVersion, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, @__safeDueAt, 0)
+            ON CONFLICT ({UnsafeWindowMvReservedColumns.ProjectionKey}) DO UPDATE SET
+                {businessUpdates},
+                {UnsafeWindowMvReservedColumns.IsDeleted} = 1,
+                {UnsafeWindowMvReservedColumns.LastSortableUniqueId} = excluded.{UnsafeWindowMvReservedColumns.LastSortableUniqueId},
+                {UnsafeWindowMvReservedColumns.LastEventVersion} = excluded.{UnsafeWindowMvReservedColumns.LastEventVersion},
+                {UnsafeWindowMvReservedColumns.LastAppliedAt} = CURRENT_TIMESTAMP,
+                {UnsafeWindowMvReservedColumns.SafeDueAt} = excluded.{UnsafeWindowMvReservedColumns.SafeDueAt},
+                {UnsafeWindowMvReservedColumns.NeedsRebuild} = 0;
+            """;
+
+        var parameters = new DynamicParameters();
+        parameters.Add("__projectionKey", projectionKey);
+        parameters.Add("__suid", ev.SortableUniqueIdValue);
+        parameters.Add("__eventVersion", eventVersion);
+        parameters.Add("__safeDueAt", safeDueAt);
+
+        foreach (var column in _projector.Schema.Columns)
+        {
+            object? value;
+            if (currentRow is not null)
+            {
+                value = column.Getter(currentRow);
+            }
+            else if (fallbackBusinessValues is not null && fallbackBusinessValues.TryGetValue(column.Name, out var v))
+            {
+                value = v;
+            }
+            else
+            {
+                value = null;
+            }
+            parameters.Add(column.Name, value ?? DBNull.Value);
+        }
+
+        await connection.ExecuteAsync(new CommandDefinition(sql, parameters, transaction: transaction, cancellationToken: ct))
+            .ConfigureAwait(false);
+    }
+}
+
+public sealed class UnsafeWindowMvSqliteCatchUpWorker<TRow> : IUnsafeWindowMvCatchUpRunner where TRow : class, new()
+{
+    private readonly UnsafeWindowMvSqliteSchemaResolver _resolver;
+    private readonly IUnsafeWindowMvProjector<TRow> _projector;
+    private readonly UnsafeWindowMvSqliteStreamApplier<TRow> _applier;
+    private readonly IEventStore _eventStore;
+    private readonly IEventTypes _eventTypes;
+    private readonly string _connectionString;
+    private readonly ILogger _logger;
+    private readonly int _batchSize;
+
+    public UnsafeWindowMvSqliteCatchUpWorker(
+        UnsafeWindowMvSqliteSchemaResolver resolver,
+        IUnsafeWindowMvProjector<TRow> projector,
+        IEventStore eventStore,
+        IEventTypes eventTypes,
+        string connectionString,
+        ILogger logger,
+        int batchSize = 256)
+    {
+        _resolver = resolver;
+        _projector = projector;
+        _applier = new UnsafeWindowMvSqliteStreamApplier<TRow>(resolver, projector);
+        _eventStore = eventStore;
+        _eventTypes = eventTypes;
+        _connectionString = connectionString;
+        _logger = logger;
+        _batchSize = batchSize;
+    }
+
+    public async Task<int> CatchUpOnceAsync(CancellationToken cancellationToken)
+    {
+        await using var connection = new SqliteConnection(_connectionString);
+        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+        await connection.ExecuteAsync(new CommandDefinition(
+            "PRAGMA synchronous=NORMAL;",
+            cancellationToken: cancellationToken)).ConfigureAwait(false);
+
+        var lastSuid = await connection.QuerySingleOrDefaultAsync<string?>(new CommandDefinition(
+            $"""
+             SELECT COALESCE(MAX(x.suid), '')
+             FROM (
+                 SELECT {UnsafeWindowMvReservedColumns.LastSortableUniqueId} AS suid FROM {_resolver.SafeTable}
+                 UNION ALL
+                 SELECT {UnsafeWindowMvReservedColumns.LastSortableUniqueId} AS suid FROM {_resolver.UnsafeTable}
+             ) x
+             """,
+            cancellationToken: cancellationToken)).ConfigureAwait(false);
+
+        var since = string.IsNullOrEmpty(lastSuid) ? null : new SortableUniqueId(lastSuid);
+        var result = await _eventStore.ReadAllSerializableEventsAsync(since).ConfigureAwait(false);
+        if (!result.IsSuccess)
+        {
+            throw result.GetException();
+        }
+
+        var events = result.GetValue().Take(_batchSize).ToList();
+        if (events.Count == 0)
+        {
+            return 0;
+        }
+
+        await using var transaction = await connection.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
+        foreach (var serialized in events)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var evResult = serialized.ToEvent(_eventTypes);
+            if (!evResult.IsSuccess)
+            {
+                throw evResult.GetException();
+            }
+
+            await _applier.ApplyEventAsync(connection, transaction, evResult.GetValue(), cancellationToken).ConfigureAwait(false);
+        }
+        await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+        _logger.LogDebug("Unsafe window MV '{View}' caught up {Count} event(s) on SQLite.", _projector.ViewName, events.Count);
+        return events.Count;
+    }
+}
+
+public sealed class UnsafeWindowMvSqlitePromoter<TRow> : IUnsafeWindowMvPromoter where TRow : class, new()
+{
+    private readonly UnsafeWindowMvSqliteSchemaResolver _resolver;
+    private readonly IUnsafeWindowMvProjector<TRow> _projector;
+    private readonly IEventStore _eventStore;
+    private readonly IEventTypes _eventTypes;
+    private readonly string _connectionString;
+    private readonly ILogger _logger;
+    private readonly int _batchSize;
+
+    public UnsafeWindowMvSqlitePromoter(
+        UnsafeWindowMvSqliteSchemaResolver resolver,
+        IUnsafeWindowMvProjector<TRow> projector,
+        IEventStore eventStore,
+        IEventTypes eventTypes,
+        string connectionString,
+        ILogger logger,
+        int batchSize = 32)
+    {
+        _resolver = resolver;
+        _projector = projector;
+        _eventStore = eventStore;
+        _eventTypes = eventTypes;
+        _connectionString = connectionString;
+        _logger = logger;
+        _batchSize = batchSize;
+    }
+
+    public async Task<int> PromoteOnceAsync(CancellationToken cancellationToken)
+    {
+        await using var connection = new SqliteConnection(_connectionString);
+        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+        await connection.ExecuteAsync(new CommandDefinition(
+            "PRAGMA synchronous=NORMAL;",
+            cancellationToken: cancellationToken)).ConfigureAwait(false);
+        await using var transaction = await connection.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
+
+        // SQLite has no FOR UPDATE SKIP LOCKED; the file-wide writer lock
+        // serialises promoters across processes naturally.
+        var dueRows = (await connection.QueryAsync<(string key, long needs_rebuild)>(new CommandDefinition(
+            $"""
+             SELECT {UnsafeWindowMvReservedColumns.ProjectionKey} AS key,
+                    {UnsafeWindowMvReservedColumns.NeedsRebuild} AS needs_rebuild
+             FROM {_resolver.UnsafeTable}
+             WHERE {UnsafeWindowMvReservedColumns.SafeDueAt} <= CURRENT_TIMESTAMP
+             ORDER BY {UnsafeWindowMvReservedColumns.SafeDueAt}
+             LIMIT @Limit
+             """,
+            new { Limit = _batchSize },
+            transaction: transaction,
+            cancellationToken: cancellationToken))).ToList();
+
+        if (dueRows.Count == 0)
+        {
+            await transaction.RollbackAsync(cancellationToken).ConfigureAwait(false);
+            return 0;
+        }
+
+        foreach (var (projectionKey, needsRebuildInt) in dueRows)
+        {
+            await PromoteKeyAsync(connection, transaction, projectionKey, needsRebuildInt != 0, cancellationToken).ConfigureAwait(false);
+        }
+
+        await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+        _logger.LogDebug("Unsafe window MV '{View}' promoted {Count} key(s) on SQLite.", _projector.ViewName, dueRows.Count);
+        return dueRows.Count;
+    }
+
+    private async Task PromoteKeyAsync(
+        SqliteConnection connection,
+        IDbTransaction transaction,
+        string projectionKey,
+        bool needsRebuild,
+        CancellationToken ct)
+    {
+        var safeRow = await connection.QueryFirstOrDefaultAsync(new CommandDefinition(
+            $"SELECT * FROM {_resolver.SafeTable} WHERE {UnsafeWindowMvReservedColumns.ProjectionKey} = @Key",
+            new { Key = projectionKey },
+            transaction: transaction,
+            cancellationToken: ct)).ConfigureAwait(false);
+
+        TRow? current = null;
+        string? startSuid = null;
+        long startVersion = 0;
+        var isDeleted = false;
+
+        if (!needsRebuild && safeRow is IDictionary<string, object> safeDict)
+        {
+            current = UnsafeWindowMvRowHydrator<TRow>.Hydrate(_projector.Schema, safeDict);
+            startSuid = (string)safeDict[UnsafeWindowMvReservedColumns.LastSortableUniqueId];
+            startVersion = Convert.ToInt64(safeDict[UnsafeWindowMvReservedColumns.LastEventVersion]);
+            isDeleted = Convert.ToInt64(safeDict[UnsafeWindowMvReservedColumns.IsDeleted]) != 0;
+        }
+
+        var events = await FetchReplayEventsAsync(projectionKey, startSuid, ct).ConfigureAwait(false);
+
+        var lastSuid = startSuid;
+        var lastEventVersion = startVersion;
+
+        foreach (var ev in events)
+        {
+            var outcome = _projector.Apply(current, ev);
+            switch (outcome)
+            {
+                case UnsafeWindowMvApplyOutcome.NoChange:
+                    break;
+                case UnsafeWindowMvApplyOutcome.Upsert up:
+                    current = (TRow)up.Row;
+                    isDeleted = false;
+                    break;
+                case UnsafeWindowMvApplyOutcome.Delete:
+                    isDeleted = true;
+                    break;
+            }
+
+            lastSuid = ev.SortableUniqueIdValue;
+            lastEventVersion++;
+        }
+
+        if (lastSuid is null)
+        {
+            await connection.ExecuteAsync(new CommandDefinition(
+                $"DELETE FROM {_resolver.UnsafeTable} WHERE {UnsafeWindowMvReservedColumns.ProjectionKey} = @Key",
+                new { Key = projectionKey },
+                transaction: transaction,
+                cancellationToken: ct)).ConfigureAwait(false);
+            return;
+        }
+
+        await UpsertSafeAsync(connection, transaction, projectionKey, current, isDeleted, lastSuid, lastEventVersion, ct).ConfigureAwait(false);
+
+        await connection.ExecuteAsync(new CommandDefinition(
+            $"DELETE FROM {_resolver.UnsafeTable} WHERE {UnsafeWindowMvReservedColumns.ProjectionKey} = @Key",
+            new { Key = projectionKey },
+            transaction: transaction,
+            cancellationToken: ct)).ConfigureAwait(false);
+    }
+
+    private async Task<IReadOnlyList<Event>> FetchReplayEventsAsync(string projectionKey, string? sinceSuid, CancellationToken ct)
+    {
+        var since = string.IsNullOrEmpty(sinceSuid) ? null : new SortableUniqueId(sinceSuid);
+        var combined = new Dictionary<string, Event>(StringComparer.Ordinal);
+
+        var tags = _projector.TagsForProjectionKey(projectionKey);
+        if (tags.Count == 0)
+        {
+            return [];
+        }
+
+        foreach (var tag in tags)
+        {
+            ct.ThrowIfCancellationRequested();
+            var result = await _eventStore.ReadSerializableEventsByTagAsync(tag, since).ConfigureAwait(false);
+            if (!result.IsSuccess)
+            {
+                throw result.GetException();
+            }
+
+            foreach (var serialized in result.GetValue())
+            {
+                var key = serialized.Id.ToString();
+                if (combined.ContainsKey(key))
+                {
+                    continue;
+                }
+
+                var evResult = serialized.ToEvent(_eventTypes);
+                if (!evResult.IsSuccess)
+                {
+                    throw evResult.GetException();
+                }
+                combined[key] = evResult.GetValue();
+            }
+        }
+
+        return combined.Values
+            .Where(e => sinceSuid is null || string.CompareOrdinal(e.SortableUniqueIdValue, sinceSuid) > 0)
+            .OrderBy(e => e.SortableUniqueIdValue, StringComparer.Ordinal)
+            .ToArray();
+    }
+
+    private async Task UpsertSafeAsync(
+        SqliteConnection connection,
+        IDbTransaction transaction,
+        string projectionKey,
+        TRow? row,
+        bool isDeleted,
+        string sortableUniqueId,
+        long eventVersion,
+        CancellationToken ct)
+    {
+        var businessCols = _projector.Schema.Columns.Select(c => c.Name).ToList();
+        var businessValueParams = string.Join(", ", businessCols.Select(c => "@" + c));
+        var businessUpdates = string.Join(", ", businessCols.Select(c => $"{c} = excluded.{c}"));
+
+        var sql = $"""
+            INSERT INTO {_resolver.SafeTable}
+                ({UnsafeWindowMvReservedColumns.ProjectionKey},
+                 {string.Join(", ", businessCols)},
+                 {UnsafeWindowMvReservedColumns.IsDeleted},
+                 {UnsafeWindowMvReservedColumns.LastSortableUniqueId},
+                 {UnsafeWindowMvReservedColumns.LastEventVersion},
+                 {UnsafeWindowMvReservedColumns.LastAppliedAt},
+                 {UnsafeWindowMvReservedColumns.SafeConfirmedAt})
+            VALUES (@__projectionKey, {businessValueParams}, @__isDeleted, @__suid, @__eventVersion, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+            ON CONFLICT ({UnsafeWindowMvReservedColumns.ProjectionKey}) DO UPDATE SET
+                {businessUpdates},
+                {UnsafeWindowMvReservedColumns.IsDeleted} = excluded.{UnsafeWindowMvReservedColumns.IsDeleted},
+                {UnsafeWindowMvReservedColumns.LastSortableUniqueId} = excluded.{UnsafeWindowMvReservedColumns.LastSortableUniqueId},
+                {UnsafeWindowMvReservedColumns.LastEventVersion} = excluded.{UnsafeWindowMvReservedColumns.LastEventVersion},
+                {UnsafeWindowMvReservedColumns.LastAppliedAt} = CURRENT_TIMESTAMP,
+                {UnsafeWindowMvReservedColumns.SafeConfirmedAt} = CURRENT_TIMESTAMP;
+            """;
+
+        var parameters = new DynamicParameters();
+        parameters.Add("__projectionKey", projectionKey);
+        parameters.Add("__isDeleted", isDeleted ? 1 : 0);
+        parameters.Add("__suid", sortableUniqueId);
+        parameters.Add("__eventVersion", eventVersion);
+
+        foreach (var column in _projector.Schema.Columns)
+        {
+            parameters.Add(column.Name, row is null ? DBNull.Value : (column.Getter(row) ?? DBNull.Value));
+        }
+
+        await connection.ExecuteAsync(new CommandDefinition(sql, parameters, transaction: transaction, cancellationToken: ct))
+            .ConfigureAwait(false);
+    }
+}

--- a/dcb/src/Sekiban.Dcb.MaterializedView/UnsafeWindowMvRuntime.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView/UnsafeWindowMvRuntime.cs
@@ -1,0 +1,341 @@
+using System.Globalization;
+using System.Reflection;
+using System.Text;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Sekiban.Dcb.MaterializedView;
+
+// ============================================================================
+// Unsafe Window Materialized View — provider-neutral runtime pieces (issue #1035).
+//
+// Each relational provider (Postgres / SQL Server / MySQL / SQLite) owns its
+// own SQL dialect, connection type, and DDL/upsert statements. The pieces in
+// this file are purely provider-agnostic:
+//
+//   UnsafeWindowMvReservedColumns — metadata column name constants shared by
+//                                   every provider.
+//   UnsafeWindowMvLogicalType     — neutral logical SQL types a projector can
+//                                   declare; each provider maps them to its
+//                                   native dialect when generating DDL.
+//   UnsafeWindowMvRowHydrator<T>  — reflection-based POCO hydration from a
+//                                   DB row dictionary; uses only projector
+//                                   schema + dictionary access, so there is
+//                                   no reason to duplicate per provider.
+//   IUnsafeWindowMv{Initializer,
+//                   CatchUpRunner,
+//                   Promoter}     — provider-neutral contracts the hosted
+//                                   service depends on. Concrete types in
+//                                   each provider package implement these.
+//   UnsafeWindowMvHostedService   — the catch-up + promotion loop. Identical
+//                                   across providers, so it lives here.
+// ============================================================================
+
+/// <summary>
+///     Framework-managed metadata column names used by every unsafe-window
+///     materialized view, regardless of database provider. Business column
+///     names must not collide with any name in here.
+/// </summary>
+public static class UnsafeWindowMvReservedColumns
+{
+    public const string ProjectionKey = "_projection_key";
+    public const string IsDeleted = "_is_deleted";
+    public const string LastSortableUniqueId = "_last_sortable_unique_id";
+    public const string LastEventVersion = "_last_event_version";
+    public const string LastAppliedAt = "_last_applied_at";
+    public const string SafeConfirmedAt = "_safe_confirmed_at";
+    public const string UnsafeSince = "_unsafe_since";
+    public const string SafeDueAt = "_safe_due_at";
+    public const string NeedsRebuild = "_needs_rebuild";
+
+    public static readonly string[] CommonMetadata =
+    [
+        ProjectionKey,
+        IsDeleted,
+        LastSortableUniqueId,
+        LastEventVersion,
+        LastAppliedAt
+    ];
+
+    public static readonly string[] SafeOnlyMetadata = [SafeConfirmedAt];
+
+    public static readonly string[] UnsafeOnlyMetadata =
+    [
+        UnsafeSince,
+        SafeDueAt,
+        NeedsRebuild
+    ];
+
+    public static IEnumerable<string> AllReservedNames =>
+        CommonMetadata.Concat(SafeOnlyMetadata).Concat(UnsafeOnlyMetadata);
+}
+
+/// <summary>
+///     Reflection-based hydrator that rebuilds a TRow POCO from a dictionary
+///     of column name -&gt; value pairs (the typical shape a micro-ORM returns
+///     for dynamic rows). The hydrator only looks at the projector's declared
+///     schema and does not know about database providers, so the same logic
+///     can be reused unchanged across every unsafe-window runtime.
+/// </summary>
+public static class UnsafeWindowMvRowHydrator<TRow> where TRow : class, new()
+{
+    public static TRow Hydrate(UnsafeWindowMvSchema schema, IDictionary<string, object> dbRow)
+    {
+        var ctor = typeof(TRow).GetConstructors().FirstOrDefault(c => c.GetParameters().Length == 0)
+            ?? throw new InvalidOperationException(
+                $"Row type '{typeof(TRow).FullName}' must expose a parameterless constructor so the runtime can rebuild rows read from the unsafe/safe tables.");
+
+        var instance = (TRow)ctor.Invoke(null);
+        foreach (var column in schema.Columns)
+        {
+            if (!dbRow.TryGetValue(column.Name, out var value) || value is null || value is DBNull)
+            {
+                continue;
+            }
+
+            var property = typeof(TRow).GetProperty(PascalCaseFromSnake(column.Name), BindingFlags.Public | BindingFlags.Instance);
+            if (property is null || !property.CanWrite)
+            {
+                continue;
+            }
+
+            property.SetValue(instance, CoerceValue(value, property.PropertyType));
+        }
+
+        return instance;
+    }
+
+    private static object? CoerceValue(object value, Type targetType)
+    {
+        var underlying = Nullable.GetUnderlyingType(targetType) ?? targetType;
+        if (underlying.IsInstanceOfType(value))
+        {
+            return value;
+        }
+
+        if (underlying == typeof(DateOnly))
+        {
+            return value switch
+            {
+                DateTime dt => DateOnly.FromDateTime(dt),
+                DateTimeOffset dto => DateOnly.FromDateTime(dto.UtcDateTime),
+                string s when DateTime.TryParse(s, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out var parsedDate)
+                    => DateOnly.FromDateTime(parsedDate),
+                _ => value
+            };
+        }
+        if (underlying == typeof(Guid) && value is string str && Guid.TryParse(str, out var g))
+        {
+            return g;
+        }
+        if (underlying == typeof(bool))
+        {
+            return value switch
+            {
+                long l => l != 0,
+                int i => i != 0,
+                short s => s != 0,
+                byte b => b != 0,
+                sbyte sb => sb != 0,
+                _ => value
+            };
+        }
+
+        try
+        {
+            return Convert.ChangeType(value, underlying, CultureInfo.InvariantCulture);
+        }
+        catch
+        {
+            return value;
+        }
+    }
+
+    private static string PascalCaseFromSnake(string name)
+    {
+        var parts = name.Split('_', StringSplitOptions.RemoveEmptyEntries);
+        var sb = new StringBuilder();
+        foreach (var part in parts)
+        {
+            sb.Append(char.ToUpperInvariant(part[0]));
+            if (part.Length > 1)
+            {
+                sb.Append(part[1..]);
+            }
+        }
+        return sb.ToString();
+    }
+}
+
+/// <summary>
+///     Provider-neutral "create tables, views and indices for this unsafe
+///     window MV" contract. The concrete provider package (Postgres, SQL
+///     Server, MySQL, SQLite) implements this with dialect-specific DDL.
+/// </summary>
+public interface IUnsafeWindowMvInitializer
+{
+    Task InitializeAsync(CancellationToken cancellationToken);
+}
+
+/// <summary>
+///     Runs one pass of "read events from the event store and apply them to
+///     unsafe" for a single projector. Returns the number of events applied
+///     in that pass.
+/// </summary>
+public interface IUnsafeWindowMvCatchUpRunner
+{
+    Task<int> CatchUpOnceAsync(CancellationToken cancellationToken);
+}
+
+/// <summary>
+///     Runs one pass of "promote due unsafe rows into safe" for a single
+///     projector. Returns the number of keys promoted.
+/// </summary>
+public interface IUnsafeWindowMvPromoter
+{
+    Task<int> PromoteOnceAsync(CancellationToken cancellationToken);
+}
+
+/// <summary>
+///     Provider-neutral BackgroundService that drives the catch-up +
+///     promotion loop for a single unsafe-window projector. Providers only
+///     need to supply their concrete initializer / catch-up / promoter
+///     implementations; the orchestration is identical everywhere.
+/// </summary>
+public sealed class UnsafeWindowMvHostedService : BackgroundService
+{
+    private readonly IUnsafeWindowMvInitializer _initializer;
+    private readonly IUnsafeWindowMvCatchUpRunner _catchUp;
+    private readonly IUnsafeWindowMvPromoter _promoter;
+    private readonly TimeSpan _idleDelay;
+    private readonly ILogger<UnsafeWindowMvHostedService> _logger;
+    private readonly string _viewName;
+
+    public UnsafeWindowMvHostedService(
+        IUnsafeWindowMvInitializer initializer,
+        IUnsafeWindowMvCatchUpRunner catchUp,
+        IUnsafeWindowMvPromoter promoter,
+        string viewName,
+        ILogger<UnsafeWindowMvHostedService> logger,
+        TimeSpan? idleDelay = null)
+    {
+        _initializer = initializer;
+        _catchUp = catchUp;
+        _promoter = promoter;
+        _viewName = viewName;
+        _logger = logger;
+        _idleDelay = idleDelay ?? TimeSpan.FromSeconds(1);
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        var initialized = false;
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            if (!initialized)
+            {
+                // Initialization can fail if the database is not yet reachable
+                // at boot. Retry on the loop cadence instead of bailing out so
+                // the service recovers as soon as the DB comes up, without
+                // requiring the entire host to be restarted.
+                try
+                {
+                    await _initializer.InitializeAsync(stoppingToken).ConfigureAwait(false);
+                    initialized = true;
+                }
+                catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+                {
+                    break;
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Unsafe window MV '{View}' initialization failed; retrying after {Delay}.", _viewName, _idleDelay);
+                    try
+                    {
+                        await Task.Delay(_idleDelay, stoppingToken).ConfigureAwait(false);
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        break;
+                    }
+                    continue;
+                }
+            }
+
+            var did = 0;
+            try
+            {
+                did += await _catchUp.CatchUpOnceAsync(stoppingToken).ConfigureAwait(false);
+                did += await _promoter.PromoteOnceAsync(stoppingToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Unsafe window MV '{View}' iteration failed; retrying after {Delay}.", _viewName, _idleDelay);
+            }
+
+            if (did == 0)
+            {
+                try
+                {
+                    await Task.Delay(_idleDelay, stoppingToken).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                    break;
+                }
+            }
+        }
+    }
+}
+
+/// <summary>
+///     Maps the small, portable set of business-column type names we accept
+///     in <see cref="UnsafeWindowMvColumn.SqlType" /> to a concrete dialect.
+///     The goal is that the same projector definition can be used against
+///     any supported provider by writing types in a canonical Postgres-style
+///     form (<c>UUID NOT NULL</c>, <c>TEXT</c>, <c>TIMESTAMPTZ</c>, …) and
+///     letting each provider translate them when generating DDL.
+/// </summary>
+public static class UnsafeWindowMvLogicalTypes
+{
+    /// <summary>
+    ///     Replace the type keyword at the head of a projector-supplied
+    ///     <c>SqlType</c> with its provider-specific equivalent. Constraint
+    ///     tail (e.g. <c>NOT NULL</c>, <c>DEFAULT 0</c>) is preserved.
+    /// </summary>
+    public static string Translate(string declaredType, IReadOnlyDictionary<string, string> keywordMap)
+    {
+        if (string.IsNullOrWhiteSpace(declaredType))
+        {
+            return declaredType;
+        }
+
+        var trimmed = declaredType.TrimStart();
+        // Find the first whitespace boundary after the type keyword (if any).
+        var end = 0;
+        while (end < trimmed.Length && !char.IsWhiteSpace(trimmed[end]))
+        {
+            end++;
+        }
+
+        if (end == 0)
+        {
+            return declaredType;
+        }
+
+        var keyword = trimmed[..end];
+        var rest = trimmed[end..];
+        if (keywordMap.TryGetValue(keyword.ToUpperInvariant(), out var replacement))
+        {
+            var leadingWhitespace = declaredType[..(declaredType.Length - trimmed.Length)];
+            return $"{leadingWhitespace}{replacement}{rest}";
+        }
+
+        return declaredType;
+    }
+}

--- a/dcb/src/Sekiban.Dcb.MaterializedView/UnsafeWindowMvRuntime.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView/UnsafeWindowMvRuntime.cs
@@ -316,24 +316,26 @@ public static class UnsafeWindowMvLogicalTypes
         }
 
         var trimmed = declaredType.TrimStart();
-        // Find the first whitespace boundary after the type keyword (if any).
-        var end = 0;
-        while (end < trimmed.Length && !char.IsWhiteSpace(trimmed[end]))
-        {
-            end++;
-        }
+        var leadingWhitespace = declaredType[..(declaredType.Length - trimmed.Length)];
 
-        if (end == 0)
+        // Match against the longest keyword in the map first so multi-word
+        // logical types like "DOUBLE PRECISION" are translated ahead of the
+        // shorter "DOUBLE" form. A trailing word-boundary check keeps
+        // "INTEGER_SOMETHING" from matching "INTEGER".
+        foreach (var keyword in keywordMap.Keys.OrderByDescending(static key => key.Length))
         {
-            return declaredType;
-        }
+            if (!trimmed.StartsWith(keyword, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
 
-        var keyword = trimmed[..end];
-        var rest = trimmed[end..];
-        if (keywordMap.TryGetValue(keyword.ToUpperInvariant(), out var replacement))
-        {
-            var leadingWhitespace = declaredType[..(declaredType.Length - trimmed.Length)];
-            return $"{leadingWhitespace}{replacement}{rest}";
+            if (trimmed.Length > keyword.Length && !char.IsWhiteSpace(trimmed[keyword.Length]))
+            {
+                continue;
+            }
+
+            var rest = trimmed[keyword.Length..];
+            return $"{leadingWhitespace}{keywordMap[keyword]}{rest}";
         }
 
         return declaredType;

--- a/dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/MultiProviderFixtures.cs
+++ b/dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/MultiProviderFixtures.cs
@@ -244,6 +244,11 @@ public abstract class MultiProviderFixtureBase : IAsyncLifetime
     public string? AvailabilityMessage => _skipReason;
     protected string ConnectionString => _connectionString ?? throw new InvalidOperationException("Fixture not initialized.");
 
+    // Public alias exposed to sibling test files that need the raw connection
+    // string (the unsafe-window MV harnesses wire their own initializer /
+    // catch-up / promoter rather than going through IMvExecutor).
+    public string ConnectionStringForTests => ConnectionString;
+
     protected abstract MvDbType DatabaseType { get; }
     protected abstract Task<string> CreateConnectionStringAsync();
     protected abstract void RegisterProvider(IServiceCollection services, string connectionString);

--- a/dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/UnsafeWindowMvMultiProviderTests.cs
+++ b/dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/UnsafeWindowMvMultiProviderTests.cs
@@ -1,0 +1,341 @@
+using System.Data.Common;
+using Dapper;
+using Dcb.Domain.WithoutResult;
+using Dcb.Domain.WithoutResult.MaterializedViews;
+using Dcb.Domain.WithoutResult.Weather;
+using Microsoft.Data.SqlClient;
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Logging.Abstractions;
+using MySqlConnector;
+using Sekiban.Dcb.Actors;
+using Sekiban.Dcb.Domains;
+using Sekiban.Dcb.InMemory;
+using Sekiban.Dcb.MaterializedView;
+using Sekiban.Dcb.MaterializedView.MySql;
+using Sekiban.Dcb.MaterializedView.Sqlite;
+using Sekiban.Dcb.MaterializedView.SqlServer;
+using Sekiban.Dcb.Storage;
+using Xunit;
+
+namespace Sekiban.Dcb.MaterializedView.MultiProvider.Tests;
+
+// ============================================================================
+// Unsafe Window Materialized View — provider parity integration tests
+// (issue #1035).
+//
+// Each provider fixture already spins up a Testcontainers-backed MySQL / SQL
+// Server instance or a file-backed SQLite database. We reuse those fixtures
+// here so the tests run automatically on the same CI pipeline as the classic
+// MV multi-provider tests. The event-source side is driven by a command
+// executor against the fixture's in-memory event store; the UWMV side is
+// driven directly by each provider's initializer / catch-up worker / promoter.
+// The same WeatherForecast projector definition is used for every provider
+// so any dialect mistakes surface immediately as a DDL or SQL error.
+// ============================================================================
+
+[Collection(nameof(SqlServerMvCollection))]
+public sealed class UnsafeWindowMvSqlServerIntegrationTests(SqlServerMvFixture fixture)
+{
+    [SkippableFact]
+    public Task InitializeCatchUpAndPromote_ProducesExpectedSafeAndDeleteBehavior() =>
+        UnsafeWindowMultiProviderAssertions.AssertAsync(
+            fixture,
+            new SqlServerUnsafeWindowHarness(fixture.ConnectionStringForTests, fixture));
+}
+
+[Collection(nameof(MySqlMvCollection))]
+public sealed class UnsafeWindowMvMySqlIntegrationTests(MySqlMvFixture fixture)
+{
+    [SkippableFact]
+    public Task InitializeCatchUpAndPromote_ProducesExpectedSafeAndDeleteBehavior() =>
+        UnsafeWindowMultiProviderAssertions.AssertAsync(
+            fixture,
+            new MySqlUnsafeWindowHarness(fixture.ConnectionStringForTests, fixture));
+}
+
+[Collection(nameof(SqliteMvCollection))]
+public sealed class UnsafeWindowMvSqliteIntegrationTests(SqliteMvFixture fixture)
+{
+    [SkippableFact]
+    public Task InitializeCatchUpAndPromote_ProducesExpectedSafeAndDeleteBehavior() =>
+        UnsafeWindowMultiProviderAssertions.AssertAsync(
+            fixture,
+            new SqliteUnsafeWindowHarness(fixture.ConnectionStringForTests, fixture));
+}
+
+internal interface IUnsafeWindowTestHarness : IAsyncDisposable
+{
+    Task InitializeAsync(CancellationToken ct);
+    Task<int> CatchUpOnceAsync(CancellationToken ct);
+    Task<int> PromoteOnceAsync(CancellationToken ct);
+    string SafeTable { get; }
+    string UnsafeTable { get; }
+    string CurrentLiveView { get; }
+    Task<DbConnection> OpenConnectionAsync();
+    Task ResetTablesAsync();
+}
+
+internal static class UnsafeWindowMultiProviderAssertions
+{
+    public static async Task AssertAsync(MultiProviderFixtureBase fixture, IUnsafeWindowTestHarness harness)
+    {
+        Skip.IfNot(fixture.IsAvailable, fixture.AvailabilityMessage ?? "Provider fixture is unavailable.");
+
+        await using (harness)
+        {
+            fixture.EventStore.Clear();
+            await harness.InitializeAsync(CancellationToken.None);
+            await harness.ResetTablesAsync();
+
+            var executor = new GeneralSekibanExecutor(fixture.EventStore, fixture.ActorAccessor, fixture.DomainTypes);
+            var forecastId = Guid.CreateVersion7();
+
+            await executor.ExecuteAsync(new CreateWeatherForecast
+            {
+                ForecastId = forecastId,
+                Location = "Tokyo",
+                Date = new DateOnly(2026, 4, 18),
+                TemperatureC = 20,
+                Summary = "Sunny"
+            });
+            await executor.ExecuteAsync(new ChangeLocationName
+            {
+                ForecastId = forecastId,
+                NewLocationName = "Tokyo-Shinjuku"
+            });
+
+            // Catch up both events into unsafe.
+            var applied = await harness.CatchUpOnceAsync(CancellationToken.None);
+            Assert.Equal(2, applied);
+
+            await using (var connection = await harness.OpenConnectionAsync())
+            {
+                var unsafeLocation = await connection.ExecuteScalarAsync<string>(
+                    $"SELECT location FROM {harness.UnsafeTable} WHERE _projection_key = @Key;",
+                    new { Key = forecastId.ToString() });
+                Assert.Equal("Tokyo-Shinjuku", unsafeLocation);
+
+                var safeCount = await connection.ExecuteScalarAsync<long>(
+                    $"SELECT COUNT(*) FROM {harness.SafeTable};");
+                Assert.Equal(0, safeCount);
+
+                var liveLocation = await connection.ExecuteScalarAsync<string>(
+                    $"SELECT location FROM {harness.CurrentLiveView} WHERE _projection_key = @Key;",
+                    new { Key = forecastId.ToString() });
+                Assert.Equal("Tokyo-Shinjuku", liveLocation);
+            }
+
+            // Wait for the projector's 2-second safe window, then promote.
+            await Task.Delay(TimeSpan.FromMilliseconds(2200));
+            var promoted = await harness.PromoteOnceAsync(CancellationToken.None);
+            Assert.Equal(1, promoted);
+
+            await using (var connection = await harness.OpenConnectionAsync())
+            {
+                var safeLocation = await connection.ExecuteScalarAsync<string>(
+                    $"SELECT location FROM {harness.SafeTable} WHERE _projection_key = @Key;",
+                    new { Key = forecastId.ToString() });
+                Assert.Equal("Tokyo-Shinjuku", safeLocation);
+
+                var unsafeCount = await connection.ExecuteScalarAsync<long>(
+                    $"SELECT COUNT(*) FROM {harness.UnsafeTable};");
+                Assert.Equal(0, unsafeCount);
+
+                var liveCount = await connection.ExecuteScalarAsync<long>(
+                    $"SELECT COUNT(*) FROM {harness.CurrentLiveView} WHERE _projection_key = @Key;",
+                    new { Key = forecastId.ToString() });
+                Assert.Equal(1, liveCount);
+            }
+
+            // Delete the forecast; it reappears in unsafe as a tombstone.
+            await executor.ExecuteAsync(new DeleteWeatherForecast { ForecastId = forecastId });
+            var appliedDelete = await harness.CatchUpOnceAsync(CancellationToken.None);
+            Assert.Equal(1, appliedDelete);
+
+            await using (var connection = await harness.OpenConnectionAsync())
+            {
+                var isDeleted = ToBool(await connection.ExecuteScalarAsync<object>(
+                    $"SELECT _is_deleted FROM {harness.UnsafeTable} WHERE _projection_key = @Key;",
+                    new { Key = forecastId.ToString() }));
+                Assert.True(isDeleted);
+
+                var liveCount = await connection.ExecuteScalarAsync<long>(
+                    $"SELECT COUNT(*) FROM {harness.CurrentLiveView} WHERE _projection_key = @Key;",
+                    new { Key = forecastId.ToString() });
+                Assert.Equal(0, liveCount);
+            }
+
+            await Task.Delay(TimeSpan.FromMilliseconds(2200));
+            var promoted2 = await harness.PromoteOnceAsync(CancellationToken.None);
+            Assert.Equal(1, promoted2);
+
+            await using (var connection = await harness.OpenConnectionAsync())
+            {
+                var isDeletedSafe = ToBool(await connection.ExecuteScalarAsync<object>(
+                    $"SELECT _is_deleted FROM {harness.SafeTable} WHERE _projection_key = @Key;",
+                    new { Key = forecastId.ToString() }));
+                Assert.True(isDeletedSafe);
+
+                var liveCount = await connection.ExecuteScalarAsync<long>(
+                    $"SELECT COUNT(*) FROM {harness.CurrentLiveView} WHERE _projection_key = @Key;",
+                    new { Key = forecastId.ToString() });
+                Assert.Equal(0, liveCount);
+            }
+        }
+    }
+
+    private static bool ToBool(object? value) => value switch
+    {
+        null => false,
+        bool b => b,
+        long l => l != 0,
+        int i => i != 0,
+        short s => s != 0,
+        byte b8 => b8 != 0,
+        sbyte sb => sb != 0,
+        _ => Convert.ToBoolean(value)
+    };
+}
+
+// -- Provider test harnesses --
+
+internal sealed class SqlServerUnsafeWindowHarness : IUnsafeWindowTestHarness
+{
+    private readonly WeatherForecastUnsafeWindowMvV1 _projector = new();
+    private readonly string _connectionString;
+    private readonly UnsafeWindowMvSqlServerSchemaResolver _resolver;
+    private readonly UnsafeWindowMvSqlServerInitializer _initializer;
+    private readonly UnsafeWindowMvSqlServerCatchUpWorker<WeatherForecastUnsafeRow> _catchUp;
+    private readonly UnsafeWindowMvSqlServerPromoter<WeatherForecastUnsafeRow> _promoter;
+
+    public SqlServerUnsafeWindowHarness(string connectionString, MultiProviderFixtureBase fixture)
+    {
+        _connectionString = connectionString;
+        _resolver = new UnsafeWindowMvSqlServerSchemaResolver(_projector.ViewName, _projector.ViewVersion, _projector.Schema);
+        _initializer = new UnsafeWindowMvSqlServerInitializer(_resolver, connectionString, NullLogger.Instance);
+        _catchUp = new UnsafeWindowMvSqlServerCatchUpWorker<WeatherForecastUnsafeRow>(_resolver, _projector, fixture.EventStore, fixture.DomainTypes.EventTypes, connectionString, NullLogger.Instance);
+        _promoter = new UnsafeWindowMvSqlServerPromoter<WeatherForecastUnsafeRow>(_resolver, _projector, fixture.EventStore, fixture.DomainTypes.EventTypes, connectionString, NullLogger.Instance);
+    }
+
+    public Task InitializeAsync(CancellationToken ct) => _initializer.InitializeAsync(ct);
+    public Task<int> CatchUpOnceAsync(CancellationToken ct) => _catchUp.CatchUpOnceAsync(ct);
+    public Task<int> PromoteOnceAsync(CancellationToken ct) => _promoter.PromoteOnceAsync(ct);
+    public string SafeTable => _resolver.SafeTable;
+    public string UnsafeTable => _resolver.UnsafeTable;
+    public string CurrentLiveView => _resolver.CurrentLiveView;
+
+    public async Task<DbConnection> OpenConnectionAsync()
+    {
+        var connection = new SqlConnection(_connectionString);
+        await connection.OpenAsync();
+        return connection;
+    }
+
+    public async Task ResetTablesAsync()
+    {
+        await using var connection = await OpenConnectionAsync();
+        await connection.ExecuteAsync($"""
+            IF OBJECT_ID(N'{_resolver.CurrentLiveView}', N'V') IS NOT NULL DROP VIEW {_resolver.CurrentLiveView};
+            IF OBJECT_ID(N'{_resolver.CurrentView}', N'V') IS NOT NULL DROP VIEW {_resolver.CurrentView};
+            IF OBJECT_ID(N'{_resolver.UnsafeTable}', N'U') IS NOT NULL DROP TABLE {_resolver.UnsafeTable};
+            IF OBJECT_ID(N'{_resolver.SafeTable}', N'U') IS NOT NULL DROP TABLE {_resolver.SafeTable};
+            """);
+        await _initializer.InitializeAsync(CancellationToken.None);
+    }
+
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+}
+
+internal sealed class MySqlUnsafeWindowHarness : IUnsafeWindowTestHarness
+{
+    private readonly WeatherForecastUnsafeWindowMvV1 _projector = new();
+    private readonly string _connectionString;
+    private readonly UnsafeWindowMvMySqlSchemaResolver _resolver;
+    private readonly UnsafeWindowMvMySqlInitializer _initializer;
+    private readonly UnsafeWindowMvMySqlCatchUpWorker<WeatherForecastUnsafeRow> _catchUp;
+    private readonly UnsafeWindowMvMySqlPromoter<WeatherForecastUnsafeRow> _promoter;
+
+    public MySqlUnsafeWindowHarness(string connectionString, MultiProviderFixtureBase fixture)
+    {
+        _connectionString = connectionString;
+        _resolver = new UnsafeWindowMvMySqlSchemaResolver(_projector.ViewName, _projector.ViewVersion, _projector.Schema);
+        _initializer = new UnsafeWindowMvMySqlInitializer(_resolver, connectionString, NullLogger.Instance);
+        _catchUp = new UnsafeWindowMvMySqlCatchUpWorker<WeatherForecastUnsafeRow>(_resolver, _projector, fixture.EventStore, fixture.DomainTypes.EventTypes, connectionString, NullLogger.Instance);
+        _promoter = new UnsafeWindowMvMySqlPromoter<WeatherForecastUnsafeRow>(_resolver, _projector, fixture.EventStore, fixture.DomainTypes.EventTypes, connectionString, NullLogger.Instance);
+    }
+
+    public Task InitializeAsync(CancellationToken ct) => _initializer.InitializeAsync(ct);
+    public Task<int> CatchUpOnceAsync(CancellationToken ct) => _catchUp.CatchUpOnceAsync(ct);
+    public Task<int> PromoteOnceAsync(CancellationToken ct) => _promoter.PromoteOnceAsync(ct);
+    public string SafeTable => _resolver.SafeTable;
+    public string UnsafeTable => _resolver.UnsafeTable;
+    public string CurrentLiveView => _resolver.CurrentLiveView;
+
+    public async Task<DbConnection> OpenConnectionAsync()
+    {
+        var connection = new MySqlConnection(_connectionString);
+        await connection.OpenAsync();
+        return connection;
+    }
+
+    public async Task ResetTablesAsync()
+    {
+        await using var connection = await OpenConnectionAsync();
+        await connection.ExecuteAsync($"""
+            DROP VIEW IF EXISTS {_resolver.CurrentLiveView};
+            DROP VIEW IF EXISTS {_resolver.CurrentView};
+            DROP TABLE IF EXISTS {_resolver.UnsafeTable};
+            DROP TABLE IF EXISTS {_resolver.SafeTable};
+            """);
+        await _initializer.InitializeAsync(CancellationToken.None);
+    }
+
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+}
+
+internal sealed class SqliteUnsafeWindowHarness : IUnsafeWindowTestHarness
+{
+    private readonly WeatherForecastUnsafeWindowMvV1 _projector = new();
+    private readonly string _connectionString;
+    private readonly UnsafeWindowMvSqliteSchemaResolver _resolver;
+    private readonly UnsafeWindowMvSqliteInitializer _initializer;
+    private readonly UnsafeWindowMvSqliteCatchUpWorker<WeatherForecastUnsafeRow> _catchUp;
+    private readonly UnsafeWindowMvSqlitePromoter<WeatherForecastUnsafeRow> _promoter;
+
+    public SqliteUnsafeWindowHarness(string connectionString, MultiProviderFixtureBase fixture)
+    {
+        _connectionString = connectionString;
+        _resolver = new UnsafeWindowMvSqliteSchemaResolver(_projector.ViewName, _projector.ViewVersion, _projector.Schema);
+        _initializer = new UnsafeWindowMvSqliteInitializer(_resolver, connectionString, NullLogger.Instance);
+        _catchUp = new UnsafeWindowMvSqliteCatchUpWorker<WeatherForecastUnsafeRow>(_resolver, _projector, fixture.EventStore, fixture.DomainTypes.EventTypes, connectionString, NullLogger.Instance);
+        _promoter = new UnsafeWindowMvSqlitePromoter<WeatherForecastUnsafeRow>(_resolver, _projector, fixture.EventStore, fixture.DomainTypes.EventTypes, connectionString, NullLogger.Instance);
+    }
+
+    public Task InitializeAsync(CancellationToken ct) => _initializer.InitializeAsync(ct);
+    public Task<int> CatchUpOnceAsync(CancellationToken ct) => _catchUp.CatchUpOnceAsync(ct);
+    public Task<int> PromoteOnceAsync(CancellationToken ct) => _promoter.PromoteOnceAsync(ct);
+    public string SafeTable => _resolver.SafeTable;
+    public string UnsafeTable => _resolver.UnsafeTable;
+    public string CurrentLiveView => _resolver.CurrentLiveView;
+
+    public async Task<DbConnection> OpenConnectionAsync()
+    {
+        var connection = new SqliteConnection(_connectionString);
+        await connection.OpenAsync();
+        return connection;
+    }
+
+    public async Task ResetTablesAsync()
+    {
+        await using var connection = await OpenConnectionAsync();
+        await connection.ExecuteAsync($"""
+            DROP VIEW IF EXISTS {_resolver.CurrentLiveView};
+            DROP VIEW IF EXISTS {_resolver.CurrentView};
+            DROP TABLE IF EXISTS {_resolver.UnsafeTable};
+            DROP TABLE IF EXISTS {_resolver.SafeTable};
+            """);
+        await _initializer.InitializeAsync(CancellationToken.None);
+    }
+
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+}


### PR DESCRIPTION
## Summary

Closes #1035.

Ports the unsafe-window materialized view runtime from Postgres to **SQL Server**, **MySQL**, and **SQLite**, achieving provider parity for the unsafe-window model. Teams can now validate the unsafe-window concept against any supported relational store.

## Scope

- Shared core additions (Sekiban.Dcb.MaterializedView):
  - `UnsafeWindowMvReservedColumns` — metadata column name constants.
  - `UnsafeWindowMvRowHydrator<TRow>` — reflection-based POCO hydration shared across providers.
  - `IUnsafeWindowMvInitializer` / `IUnsafeWindowMvCatchUpRunner` / `IUnsafeWindowMvPromoter` — provider-neutral contracts.
  - `UnsafeWindowMvHostedService` — provider-neutral BackgroundService for the init + catch-up + promote loop.
  - `UnsafeWindowMvLogicalTypes.Translate` — keyword translator so `UUID`/`TIMESTAMPTZ`/`BOOLEAN`/`TEXT` projector declarations work on every provider.

- New provider runtimes (full parity with Postgres implementation):
  - `Sekiban.Dcb.MaterializedView.SqlServer/UnsafeWindowMvSqlServerRuntime.cs` + registration
  - `Sekiban.Dcb.MaterializedView.MySql/UnsafeWindowMvMySqlRuntime.cs` + registration
  - `Sekiban.Dcb.MaterializedView.Sqlite/UnsafeWindowMvSqliteRuntime.cs` + registration

Each provider implements schema resolution, DDL generation, schema validation, initializer, stream applier (safe / unsafe upsert with reorder guards), catch-up worker, and promoter. Registration follows the existing `AddSekibanDcbUnsafeWindowMv` DI pattern.

## Dialect highlights

| Feature | SQL Server | MySQL | SQLite |
|---|---|---|---|
| Upsert | `UPDATE WITH (UPDLOCK, HOLDLOCK)` + conditional `INSERT` | `ON DUPLICATE KEY UPDATE` | `ON CONFLICT DO UPDATE` |
| FOR UPDATE | `WITH (UPDLOCK, HOLDLOCK, ROWLOCK)` | `FOR UPDATE` | (serialised writer, N/A) |
| SKIP LOCKED | `WITH (UPDLOCK, READPAST, ROWLOCK)` | `FOR UPDATE SKIP LOCKED` | (serialised writer, N/A) |
| PK for `_projection_key` | `NVARCHAR(450)` | `VARCHAR(191)` | `TEXT PRIMARY KEY` |
| Booleans | `BIT` | `TINYINT(1)` | `INTEGER` |
| Timestamps | `DATETIMEOFFSET` | `DATETIME(6)` | `TEXT` (ISO 8601) |
| `CREATE OR REPLACE VIEW` | `DROP VIEW IF EXISTS` + `EXEC('CREATE VIEW …')` | native | `DROP VIEW IF EXISTS` + `CREATE VIEW` |

## Design constraints preserved

- Event read path remains provider-agnostic — UWMV reads events via `IEventStore`, no Hybrid-specific logic in any MV provider layer.
- Safe table / unsafe table / merged view (`_current`) / live view (`_current_live`) semantics match the Postgres runtime:
  - Safe holds the committed row (with `_is_deleted` tombstone after delete).
  - Unsafe holds the latest mutable row per key until the safe window elapses.
  - `_current` unions unsafe-first-preferred rows; `_current_live` filters out `_is_deleted`.
  - Reorder inside the unsafe window still sets `_needs_rebuild = true` and triggers a full replay at promotion time.
- `IUnsafeWindowMvProjector<TRow>` contract is unchanged — the same projector code compiles against every provider.

## Tests

- Shared MV unit tests continue to pass (21/21 net9.0 + net10.0).
- Postgres integration tests continue to pass (11/11).
- New `UnsafeWindowMvMultiProviderTests` adds per-provider integration coverage that reuses the existing Testcontainers-backed fixtures:
  - catch-up lands rows in unsafe, safe stays empty
  - safe-window elapse → promotion moves the merged row into safe, empties unsafe
  - delete event → tombstone in safe, hidden from `_current_live`
- Full multi-provider suite passes 9/9 (`dotnet test ... MultiProvider.Tests -c Release -f net9.0`).

## Validation

- `dotnet build dcb/Sekiban.Dcb.slnx -c Release` → Build succeeded (0 errors).
- `dotnet test dcb/tests/Sekiban.Dcb.MaterializedView.Tests -c Release -f net9.0` → 21/21 passed.
- `dotnet test dcb/tests/Sekiban.Dcb.MaterializedView.Postgres.Tests -c Release -f net9.0` → 11/11 passed.
- `dotnet test dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests -c Release -f net9.0` → 9/9 passed (SqlServer + MySQL + SQLite + registrations, including new UWMV integration tests).

## Follow-ups (not in this PR)

- The per-provider runtime files share a lot of structural similarity. A future refactor could extract a generic base with provider-specific `IUnsafeWindowMvDialect` to trim the duplication, similar to the Copilot feedback on #1034 for the classic MV executors. Kept duplicated here to match the pattern already established by the classic MV provider PRs and keep this PR reviewable.
- `UnsafeWindowMvSchemaResolver` is duplicated per provider (only the identifier-length budget differs). Could also be unified behind a `MaxLength` parameter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)