### PR TITLE
Support DCB docs in Sekiban MCP

### DIFF
--- a/tools/SekibanDocumentMcpSse/AzureOpenAIService.cs
+++ b/tools/SekibanDocumentMcpSse/AzureOpenAIService.cs
@@ -60,37 +60,10 @@ public class AzureOpenAIService
 
         try
         {
-            // Search for relevant documents
-            var searchResults = await _documentService.SearchAsync(question, documentSet);
-
-            // Prepare context from search results
-            var context = new StringBuilder();
-            foreach (var result in searchResults.Take(3))
+            var context = await BuildQuestionContextAsync(question, documentSet);
+            if (context == null)
             {
-                var document = await _documentService.GetDocumentAsync(result.FileName, documentSet);
-                if (document != null)
-                {
-                    context.AppendLine($"# {document.Title}");
-                    foreach (var section in result.MatchedSections.Take(2))
-                    {
-                        var sectionContent = document.GetSectionContent(section);
-                        context.AppendLine($"## {section}");
-                        context.AppendLine(sectionContent);
-                    }
-                }
-            }
-
-            // If no search results, include basic information
-            if (searchResults.Count == 0)
-            {
-                var firstDocument = await _documentService.GetDocumentByIndexAsync(0, documentSet);
-                if (firstDocument != null)
-                {
-                    context.AppendLine(firstDocument.Content);
-                } else
-                {
-                    return $"Document set '{documentSet}' was not found or has no documents.";
-                }
+                return $"Document set '{documentSet}' was not found or has no documents.";
             }
 
             // Get the chat client
@@ -106,30 +79,60 @@ public class AzureOpenAIService
             // Complete chat
             var response = await chatClient.CompleteChatAsync(messages);
 
-            try
-            {
-                var contentProperty = response.Value.GetType().GetProperty("Content");
-                if (contentProperty != null)
-                {
-                    var content = response.Value.Content.FirstOrDefault()?.Text;
-                    if (!string.IsNullOrEmpty(content))
-                    {
-                        return content;
-                    }
-                }
-
-                return response.Value.Content.FirstOrDefault()?.Text ?? "No response content";
-            }
-            catch (Exception ex)
-            {
-                _logger.LogWarning(ex, "Error extracting content from Azure OpenAI response");
-                return "Error processing response from Azure OpenAI";
-            }
+            return ExtractResponseContent(response.Value);
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error answering question");
             return $"I'm sorry, but an error occurred when trying to answer your question: {ex.Message}";
+        }
+    }
+
+    private async Task<StringBuilder?> BuildQuestionContextAsync(string question, string documentSet)
+    {
+        var searchResults = await _documentService.SearchAsync(question, documentSet);
+        if (searchResults.Count == 0)
+        {
+            var firstDocument = await _documentService.GetDocumentByIndexAsync(0, documentSet);
+            return firstDocument == null ? null : new StringBuilder(firstDocument.Content);
+        }
+
+        var context = new StringBuilder();
+        foreach (var result in searchResults.Take(3))
+        {
+            await AppendSearchResultContextAsync(context, result, documentSet);
+        }
+
+        return context;
+    }
+
+    private async Task AppendSearchResultContextAsync(StringBuilder context, SearchResult result, string documentSet)
+    {
+        var document = await _documentService.GetDocumentAsync(result.FileName, documentSet);
+        if (document == null)
+        {
+            return;
+        }
+
+        context.AppendLine($"# {document.Title}");
+        foreach (var section in result.MatchedSections.Take(2))
+        {
+            var sectionContent = document.GetSectionContent(section);
+            context.AppendLine($"## {section}");
+            context.AppendLine(sectionContent);
+        }
+    }
+
+    private string ExtractResponseContent(ChatCompletion response)
+    {
+        try
+        {
+            return response.Content.FirstOrDefault()?.Text ?? "No response content";
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Error extracting content from Azure OpenAI response");
+            return "Error processing response from Azure OpenAI";
         }
     }
 }

--- a/tools/SekibanDocumentMcpSse/AzureOpenAIService.cs
+++ b/tools/SekibanDocumentMcpSse/AzureOpenAIService.cs
@@ -50,7 +50,7 @@ public class AzureOpenAIService
     /// <summary>
     ///     Answer a question about Sekiban using Azure OpenAI
     /// </summary>
-    public async Task<string> AnswerQuestionAsync(string question)
+    public async Task<string> AnswerQuestionAsync(string question, string documentSet)
     {
         if (_client == null || string.IsNullOrEmpty(_options.DeploymentName))
         {
@@ -61,13 +61,13 @@ public class AzureOpenAIService
         try
         {
             // Search for relevant documents
-            var searchResults = await _documentService.SearchAsync(question);
+            var searchResults = await _documentService.SearchAsync(question, documentSet);
 
             // Prepare context from search results
             var context = new StringBuilder();
             foreach (var result in searchResults.Take(3))
             {
-                var document = await _documentService.GetDocumentAsync(result.FileName);
+                var document = await _documentService.GetDocumentAsync(result.FileName, documentSet);
                 if (document != null)
                 {
                     context.AppendLine($"# {document.Title}");
@@ -83,10 +83,13 @@ public class AzureOpenAIService
             // If no search results, include basic information
             if (searchResults.Count == 0)
             {
-                var firstDocument = await _documentService.GetDocumentByIndexAsync(0);
+                var firstDocument = await _documentService.GetDocumentByIndexAsync(0, documentSet);
                 if (firstDocument != null)
                 {
                     context.AppendLine(firstDocument.Content);
+                } else
+                {
+                    return $"Document set '{documentSet}' was not found or has no documents.";
                 }
             }
 

--- a/tools/SekibanDocumentMcpSse/DocumentationOptions.cs
+++ b/tools/SekibanDocumentMcpSse/DocumentationOptions.cs
@@ -8,9 +8,15 @@ public class DocumentationOptions
     public const string SectionName = "Documentation";
 
     /// <summary>
-    ///     Base path for documents
+    ///     Legacy single base path for documents.
     /// </summary>
-    public string BasePath { get; set; } = "./docs/llm";
+    public string BasePath { get; set; } = "docs/dcb_llm";
+
+    /// <summary>
+    ///     Base paths for document sets. Each path is exposed under its directory name
+    ///     (for example, docs/dcb_llm/01_core_concepts.md becomes dcb_llm/01_core_concepts.md).
+    /// </summary>
+    public List<string> BasePaths { get; set; } = ["docs/dcb_llm", "docs/dcb_llm_ja", "docs/llm", "docs/llm_ja"];
 
     /// <summary>
     ///     Enable file watcher to automatically reload docs when changed

--- a/tools/SekibanDocumentMcpSse/DocumentationOptions.cs
+++ b/tools/SekibanDocumentMcpSse/DocumentationOptions.cs
@@ -16,7 +16,7 @@ public class DocumentationOptions
     ///     Base paths for document sets. Each path is exposed under its directory name
     ///     (for example, docs/dcb_llm/01_core_concepts.md becomes dcb_llm/01_core_concepts.md).
     /// </summary>
-    public List<string> BasePaths { get; set; } = ["docs/dcb_llm", "docs/dcb_llm_ja", "docs/llm", "docs/llm_ja"];
+    public List<string> BasePaths { get; set; } = [];
 
     /// <summary>
     ///     Enable file watcher to automatically reload docs when changed

--- a/tools/SekibanDocumentMcpSse/MarkdownReader.cs
+++ b/tools/SekibanDocumentMcpSse/MarkdownReader.cs
@@ -7,12 +7,14 @@ namespace SekibanDocumentMcpSse;
 public class MarkdownReader
 {
     public readonly string _docsBasePath;
+    private readonly string _documentSet;
     private readonly ILogger<MarkdownReader> _logger;
 
-    public MarkdownReader(ILogger<MarkdownReader> logger, string docsBasePath)
+    public MarkdownReader(ILogger<MarkdownReader> logger, string docsBasePath, string documentSet)
     {
         _logger = logger;
         _docsBasePath = docsBasePath;
+        _documentSet = documentSet;
     }
 
     /// <summary>
@@ -32,7 +34,7 @@ public class MarkdownReader
             var files = Directory.GetFiles(_docsBasePath, "*.md", SearchOption.TopDirectoryOnly);
             foreach (var file in files)
             {
-                var fileName = Path.GetFileName(file);
+                var fileName = GetExposedFileName(Path.GetFileName(file));
                 var content = await File.ReadAllTextAsync(file);
                 var doc = ParseDocument(fileName, content);
                 documents.Add(doc);
@@ -138,7 +140,14 @@ public class MarkdownReader
     {
         try
         {
-            var filePath = Path.Combine(_docsBasePath, fileName);
+            var requestedFileName = fileName;
+            if (!string.IsNullOrWhiteSpace(_documentSet) &&
+                requestedFileName.StartsWith($"{_documentSet}/", StringComparison.OrdinalIgnoreCase))
+            {
+                requestedFileName = requestedFileName[(_documentSet.Length + 1)..];
+            }
+
+            var filePath = Path.Combine(_docsBasePath, Path.GetFileName(requestedFileName));
             if (!File.Exists(filePath))
             {
                 _logger.LogWarning("Document not found: {FilePath}", filePath);
@@ -154,4 +163,7 @@ public class MarkdownReader
             return null;
         }
     }
+
+    private string GetExposedFileName(string fileName) =>
+        string.IsNullOrWhiteSpace(_documentSet) ? fileName : $"{_documentSet}/{fileName}";
 }

--- a/tools/SekibanDocumentMcpSse/SekibanDocumentMcpSse.csproj
+++ b/tools/SekibanDocumentMcpSse/SekibanDocumentMcpSse.csproj
@@ -9,15 +9,24 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Azure.AI.OpenAI" Version="2.2.0-beta.4"/>
-        <PackageReference Include="OpenAI" Version="2.3.0"/>
+        <PackageReference Include="Azure.AI.OpenAI" Version="2.2.0-beta.5"/>
+        <PackageReference Include="OpenAI" Version="2.2.0"/>
         <PackageReference Include="Markdig" Version="0.41.3"/>
         <PackageReference Include="ModelContextProtocol.AspNetCore" Version="0.2.0-preview.1"/>
         <PackageReference Include="System.Text.Json" Version="9.0.8"/>
     </ItemGroup>
 
     <ItemGroup>
-        <Content Include="../../docs/llm/*.md">
+        <Content Include="../../docs/dcb_llm/*.md" Link="docs/dcb_llm/%(Filename)%(Extension)">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </Content>
+        <Content Include="../../docs/dcb_llm_ja/*.md" Link="docs/dcb_llm_ja/%(Filename)%(Extension)">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </Content>
+        <Content Include="../../docs/llm/*.md" Link="docs/llm/%(Filename)%(Extension)">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </Content>
+        <Content Include="../../docs/llm_ja/*.md" Link="docs/llm_ja/%(Filename)%(Extension)">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </Content>
     </ItemGroup>

--- a/tools/SekibanDocumentMcpSse/SekibanDocumentService.cs
+++ b/tools/SekibanDocumentMcpSse/SekibanDocumentService.cs
@@ -369,7 +369,7 @@ public class SekibanDocumentService : IDisposable
 
         return prefixes
             .Select(prefix => $"{prefix}/{Path.GetFileName(normalizedFileName)}")
-            .FirstOrDefault();
+            .First();
     }
 
     private static IReadOnlyList<string> GetDocumentSetPrefixes(string documentSet)

--- a/tools/SekibanDocumentMcpSse/SekibanDocumentService.cs
+++ b/tools/SekibanDocumentMcpSse/SekibanDocumentService.cs
@@ -6,6 +6,13 @@ namespace SekibanDocumentMcpSse;
 /// </summary>
 public class SekibanDocumentService : IDisposable
 {
+    private static readonly Dictionary<string, string[]> DocumentSetPrefixes =
+        new(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Dcb"] = ["dcb_llm", "dcb_llm_ja"],
+            ["Pure"] = ["llm", "llm_ja"]
+        };
+
     private readonly IWebHostEnvironment _environment;
     private readonly ILogger<SekibanDocumentService> _logger;
     private readonly ILoggerFactory _loggerFactory;
@@ -173,7 +180,8 @@ public class SekibanDocumentService : IDisposable
             return null;
         }
 
-        return _documents.FirstOrDefault(d => d.FileName.Equals(normalizedFileName, StringComparison.OrdinalIgnoreCase));
+        return GetDocumentsForSet(documentSet)
+            .FirstOrDefault(d => d.FileName.Equals(normalizedFileName, StringComparison.OrdinalIgnoreCase));
     }
 
     /// <summary>
@@ -333,20 +341,20 @@ public class SekibanDocumentService : IDisposable
 
     private IEnumerable<MarkdownDocument> GetDocumentsForSet(string documentSet)
     {
-        var normalizedDocumentSet = NormalizeDocumentSet(documentSet);
-        if (string.IsNullOrWhiteSpace(normalizedDocumentSet))
+        var prefixes = GetDocumentSetPrefixes(documentSet);
+        if (prefixes.Count == 0)
         {
             return [];
         }
 
         return _documents.Where(
-            d => d.FileName.StartsWith($"{normalizedDocumentSet}/", StringComparison.OrdinalIgnoreCase));
+            d => prefixes.Any(prefix => d.FileName.StartsWith($"{prefix}/", StringComparison.OrdinalIgnoreCase)));
     }
 
     private static string? NormalizeFileNameForSet(string fileName, string documentSet)
     {
-        var normalizedDocumentSet = NormalizeDocumentSet(documentSet);
-        if (string.IsNullOrWhiteSpace(normalizedDocumentSet) || string.IsNullOrWhiteSpace(fileName))
+        var prefixes = GetDocumentSetPrefixes(documentSet);
+        if (prefixes.Count == 0 || string.IsNullOrWhiteSpace(fileName))
         {
             return null;
         }
@@ -354,16 +362,21 @@ public class SekibanDocumentService : IDisposable
         var normalizedFileName = fileName.Replace('\\', '/').TrimStart('/');
         if (normalizedFileName.Contains('/'))
         {
-            return normalizedFileName.StartsWith($"{normalizedDocumentSet}/", StringComparison.OrdinalIgnoreCase)
+            return prefixes.Any(prefix => normalizedFileName.StartsWith($"{prefix}/", StringComparison.OrdinalIgnoreCase))
                 ? normalizedFileName
                 : null;
         }
 
-        return $"{normalizedDocumentSet}/{Path.GetFileName(normalizedFileName)}";
+        return prefixes
+            .Select(prefix => $"{prefix}/{Path.GetFileName(normalizedFileName)}")
+            .FirstOrDefault();
     }
 
-    private static string NormalizeDocumentSet(string documentSet) =>
-        documentSet?.Trim().Trim('/', '\\') ?? string.Empty;
+    private static IReadOnlyList<string> GetDocumentSetPrefixes(string documentSet)
+    {
+        var normalized = documentSet?.Trim() ?? string.Empty;
+        return DocumentSetPrefixes.TryGetValue(normalized, out var prefixes) ? prefixes : [];
+    }
 
     private static string ResolveDocsBasePath(string configuredPath) =>
         Path.IsPathRooted(configuredPath)

--- a/tools/SekibanDocumentMcpSse/SekibanDocumentService.cs
+++ b/tools/SekibanDocumentMcpSse/SekibanDocumentService.cs
@@ -148,10 +148,10 @@ public class SekibanDocumentService : IDisposable
     /// <summary>
     ///     Get all document titles
     /// </summary>
-    public async Task<List<DocumentInfo>> GetAllDocumentsAsync()
+    public async Task<List<DocumentInfo>> GetAllDocumentsAsync(string documentSet)
     {
         await InitializeAsync();
-        return _documents
+        return GetDocumentsForSet(documentSet)
             .Select(d => new DocumentInfo
             {
                 FileName = d.FileName,
@@ -164,28 +164,28 @@ public class SekibanDocumentService : IDisposable
     /// <summary>
     ///     Get a document by filename
     /// </summary>
-    public async Task<MarkdownDocument?> GetDocumentAsync(string fileName)
+    public async Task<MarkdownDocument?> GetDocumentAsync(string fileName, string documentSet)
     {
         await InitializeAsync();
-        var exact = _documents.FirstOrDefault(d => d.FileName.Equals(fileName, StringComparison.OrdinalIgnoreCase));
-        if (exact != null)
+        var normalizedFileName = NormalizeFileNameForSet(fileName, documentSet);
+        if (normalizedFileName == null)
         {
-            return exact;
+            return null;
         }
 
-        return _documents.FirstOrDefault(
-            d => Path.GetFileName(d.FileName).Equals(fileName, StringComparison.OrdinalIgnoreCase));
+        return _documents.FirstOrDefault(d => d.FileName.Equals(normalizedFileName, StringComparison.OrdinalIgnoreCase));
     }
 
     /// <summary>
     ///     Get a document by index
     /// </summary>
-    public async Task<MarkdownDocument?> GetDocumentByIndexAsync(int index)
+    public async Task<MarkdownDocument?> GetDocumentByIndexAsync(int index, string documentSet)
     {
         await InitializeAsync();
-        if (index >= 0 && index < _documents.Count)
+        var documents = GetDocumentsForSet(documentSet).ToList();
+        if (index >= 0 && index < documents.Count)
         {
-            return _documents[index];
+            return documents[index];
         }
         return null;
     }
@@ -193,12 +193,12 @@ public class SekibanDocumentService : IDisposable
     /// <summary>
     ///     Get the navigation structure
     /// </summary>
-    public async Task<List<NavigationItem>> GetNavigationAsync()
+    public async Task<List<NavigationItem>> GetNavigationAsync(string documentSet)
     {
         await InitializeAsync();
         var navigation = new List<NavigationItem>();
 
-        foreach (var doc in _documents)
+        foreach (var doc in GetDocumentsForSet(documentSet))
         {
             navigation.Add(
                 new NavigationItem
@@ -221,10 +221,10 @@ public class SekibanDocumentService : IDisposable
     /// <summary>
     ///     Get a specific section from a document
     /// </summary>
-    public async Task<SectionContent?> GetSectionContentAsync(string fileName, string sectionTitle)
+    public async Task<SectionContent?> GetSectionContentAsync(string fileName, string sectionTitle, string documentSet)
     {
         await InitializeAsync();
-        var document = _documents.FirstOrDefault(d => d.FileName.Equals(fileName, StringComparison.OrdinalIgnoreCase));
+        var document = await GetDocumentAsync(fileName, documentSet);
         if (document == null) return null;
 
         var content = document.GetSectionContent(sectionTitle);
@@ -241,13 +241,13 @@ public class SekibanDocumentService : IDisposable
     /// <summary>
     ///     Search across all documents
     /// </summary>
-    public async Task<List<SearchResult>> SearchAsync(string query)
+    public async Task<List<SearchResult>> SearchAsync(string query, string documentSet)
     {
         await InitializeAsync();
         var results = new List<SearchResult>();
         var searchTerms = query.ToLower().Split(' ', StringSplitOptions.RemoveEmptyEntries);
 
-        foreach (var document in _documents)
+        foreach (var document in GetDocumentsForSet(documentSet))
         {
             // Search in title
             var titleMatched = searchTerms.All(term => document.Title.ToLower().Contains(term));
@@ -330,6 +330,40 @@ public class SekibanDocumentService : IDisposable
 
     private static IReadOnlyList<string> GetConfiguredBasePaths(DocumentationOptions options) =>
         options.BasePaths.Count > 0 ? options.BasePaths : [options.BasePath];
+
+    private IEnumerable<MarkdownDocument> GetDocumentsForSet(string documentSet)
+    {
+        var normalizedDocumentSet = NormalizeDocumentSet(documentSet);
+        if (string.IsNullOrWhiteSpace(normalizedDocumentSet))
+        {
+            return [];
+        }
+
+        return _documents.Where(
+            d => d.FileName.StartsWith($"{normalizedDocumentSet}/", StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static string? NormalizeFileNameForSet(string fileName, string documentSet)
+    {
+        var normalizedDocumentSet = NormalizeDocumentSet(documentSet);
+        if (string.IsNullOrWhiteSpace(normalizedDocumentSet) || string.IsNullOrWhiteSpace(fileName))
+        {
+            return null;
+        }
+
+        var normalizedFileName = fileName.Replace('\\', '/').TrimStart('/');
+        if (normalizedFileName.Contains('/'))
+        {
+            return normalizedFileName.StartsWith($"{normalizedDocumentSet}/", StringComparison.OrdinalIgnoreCase)
+                ? normalizedFileName
+                : null;
+        }
+
+        return $"{normalizedDocumentSet}/{Path.GetFileName(normalizedFileName)}";
+    }
+
+    private static string NormalizeDocumentSet(string documentSet) =>
+        documentSet?.Trim().Trim('/', '\\') ?? string.Empty;
 
     private static string ResolveDocsBasePath(string configuredPath) =>
         Path.IsPathRooted(configuredPath)

--- a/tools/SekibanDocumentMcpSse/SekibanDocumentService.cs
+++ b/tools/SekibanDocumentMcpSse/SekibanDocumentService.cs
@@ -9,10 +9,10 @@ public class SekibanDocumentService : IDisposable
     private readonly IWebHostEnvironment _environment;
     private readonly ILogger<SekibanDocumentService> _logger;
     private readonly ILoggerFactory _loggerFactory;
-    private readonly MarkdownReader _markdownReader;
+    private readonly List<MarkdownReader> _markdownReaders = [];
     private readonly DocumentationOptions _options;
     private List<MarkdownDocument> _documents = new();
-    private FileSystemWatcher? _fileWatcher;
+    private readonly List<FileSystemWatcher> _fileWatchers = [];
     private bool _isInitialized;
 
     /// <summary>
@@ -29,17 +29,17 @@ public class SekibanDocumentService : IDisposable
         _options = options.Value;
         _environment = environment;
 
-        // Resolve base path - use absolute path if provided, otherwise combine with content root
-        var docsBasePath = _options.BasePath;
-        if (!Path.IsPathRooted(docsBasePath))
+        foreach (var configuredPath in GetConfiguredBasePaths(_options))
         {
-            // For Azure deployment, use WebRootPath first, then fall back to ContentRootPath
-            var basePath = AppContext.BaseDirectory;
-            logger.LogInformation("AppContext.BaseDirectory: {BasePath}", basePath);
-            docsBasePath = Path.Combine(basePath, docsBasePath);
+            var docsBasePath = ResolveDocsBasePath(configuredPath);
+            var documentSet = GetDocumentSetName(configuredPath);
+            logger.LogInformation(
+                "Registering documentation path {DocsBasePath} as document set {DocumentSet}",
+                docsBasePath,
+                documentSet);
+            _markdownReaders.Add(
+                new MarkdownReader(_loggerFactory.CreateLogger<MarkdownReader>(), docsBasePath, documentSet));
         }
-
-        _markdownReader = new MarkdownReader(_loggerFactory.CreateLogger<MarkdownReader>(), docsBasePath);
     }
 
     /// <summary>
@@ -47,14 +47,16 @@ public class SekibanDocumentService : IDisposable
     /// </summary>
     public void Dispose()
     {
-        if (_fileWatcher != null)
+        foreach (var fileWatcher in _fileWatchers)
         {
-            _fileWatcher.Changed -= OnFileChanged;
-            _fileWatcher.Created -= OnFileChanged;
-            _fileWatcher.Deleted -= OnFileChanged;
-            _fileWatcher.Renamed -= OnFileChanged;
-            _fileWatcher.Dispose();
+            fileWatcher.Changed -= OnFileChanged;
+            fileWatcher.Created -= OnFileChanged;
+            fileWatcher.Deleted -= OnFileChanged;
+            fileWatcher.Renamed -= OnFileChanged;
+            fileWatcher.Dispose();
         }
+
+        _fileWatchers.Clear();
     }
 
     /// <summary>
@@ -66,12 +68,18 @@ public class SekibanDocumentService : IDisposable
 
         try
         {
-            _documents = await _markdownReader.ReadAllDocumentsAsync();
+            var documents = new List<MarkdownDocument>();
+            foreach (var reader in _markdownReaders)
+            {
+                documents.AddRange(await reader.ReadAllDocumentsAsync());
+            }
+
+            _documents = documents.OrderBy(d => d.FileName, StringComparer.OrdinalIgnoreCase).ToList();
             _logger.LogInformation("Loaded {Count} Markdown documents", _documents.Count);
 
             if (_options.EnableFileWatcher)
             {
-                SetupFileWatcher();
+                SetupFileWatchers();
             }
 
             _isInitialized = true;
@@ -86,29 +94,33 @@ public class SekibanDocumentService : IDisposable
     /// <summary>
     ///     Setup file watcher to reload documents when they change
     /// </summary>
-    private void SetupFileWatcher()
+    private void SetupFileWatchers()
     {
-        try
+        foreach (var reader in _markdownReaders)
         {
-            var directory = Path.GetDirectoryName(_markdownReader._docsBasePath) ?? _markdownReader._docsBasePath;
-
-            _fileWatcher = new FileSystemWatcher(directory)
+            try
             {
-                Filter = "*.md",
-                NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.FileName,
-                EnableRaisingEvents = true
-            };
+                var directory = reader._docsBasePath;
 
-            _fileWatcher.Changed += OnFileChanged;
-            _fileWatcher.Created += OnFileChanged;
-            _fileWatcher.Deleted += OnFileChanged;
-            _fileWatcher.Renamed += OnFileChanged;
+                var fileWatcher = new FileSystemWatcher(directory)
+                {
+                    Filter = "*.md",
+                    NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.FileName,
+                    EnableRaisingEvents = true
+                };
 
-            _logger.LogInformation("File watcher set up for directory: {Directory}", directory);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Failed to set up file watcher");
+                fileWatcher.Changed += OnFileChanged;
+                fileWatcher.Created += OnFileChanged;
+                fileWatcher.Deleted += OnFileChanged;
+                fileWatcher.Renamed += OnFileChanged;
+                _fileWatchers.Add(fileWatcher);
+
+                _logger.LogInformation("File watcher set up for directory: {Directory}", directory);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to set up file watcher");
+            }
         }
     }
 
@@ -121,7 +133,13 @@ public class SekibanDocumentService : IDisposable
         {
             _logger.LogInformation("Document file changed: {FullPath}, reloading documents", e.FullPath);
             await Task.Delay(500); // Small delay to ensure file is fully written
-            _documents = await _markdownReader.ReadAllDocumentsAsync();
+            var documents = new List<MarkdownDocument>();
+            foreach (var reader in _markdownReaders)
+            {
+                documents.AddRange(await reader.ReadAllDocumentsAsync());
+            }
+
+            _documents = documents.OrderBy(d => d.FileName, StringComparer.OrdinalIgnoreCase).ToList();
         }
         catch (Exception ex)
         {
@@ -151,7 +169,14 @@ public class SekibanDocumentService : IDisposable
     public async Task<MarkdownDocument?> GetDocumentAsync(string fileName)
     {
         await InitializeAsync();
-        return _documents.FirstOrDefault(d => d.FileName.Equals(fileName, StringComparison.OrdinalIgnoreCase));
+        var exact = _documents.FirstOrDefault(d => d.FileName.Equals(fileName, StringComparison.OrdinalIgnoreCase));
+        if (exact != null)
+        {
+            return exact;
+        }
+
+        return _documents.FirstOrDefault(
+            d => Path.GetFileName(d.FileName).Equals(fileName, StringComparison.OrdinalIgnoreCase));
     }
 
     /// <summary>
@@ -303,5 +328,24 @@ public class SekibanDocumentService : IDisposable
         return allSamples
             .Where(s => searchTerms.All(term => s.Title.ToLower().Contains(term) || s.Code.ToLower().Contains(term)))
             .ToList();
+    }
+
+    private static IReadOnlyList<string> GetConfiguredBasePaths(DocumentationOptions options) =>
+        options.BasePaths.Count > 0 ? options.BasePaths : [options.BasePath];
+
+    private static string ResolveDocsBasePath(string configuredPath) =>
+        Path.IsPathRooted(configuredPath)
+            ? configuredPath
+            : Path.Combine(AppContext.BaseDirectory, configuredPath);
+
+    private static string GetDocumentSetName(string configuredPath)
+    {
+        var normalized = configuredPath.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        if (string.IsNullOrWhiteSpace(normalized))
+        {
+            return string.Empty;
+        }
+
+        return Path.GetFileName(normalized);
     }
 }

--- a/tools/SekibanDocumentMcpSse/SekibanDocumentService.cs
+++ b/tools/SekibanDocumentMcpSse/SekibanDocumentService.cs
@@ -96,12 +96,10 @@ public class SekibanDocumentService : IDisposable
     /// </summary>
     private void SetupFileWatchers()
     {
-        foreach (var reader in _markdownReaders)
+        foreach (var directory in _markdownReaders.Select(reader => reader._docsBasePath))
         {
             try
             {
-                var directory = reader._docsBasePath;
-
                 var fileWatcher = new FileSystemWatcher(directory)
                 {
                     Filter = "*.md",

--- a/tools/SekibanDocumentMcpSse/SekibanDocumentTools.cs
+++ b/tools/SekibanDocumentMcpSse/SekibanDocumentTools.cs
@@ -26,9 +26,10 @@ public sealed class SekibanDocumentTools
     /// </summary>
     [McpServerTool]
     [Description("Get the navigation structure of Sekiban documentation.")]
-    public async Task<string> GetDocumentNavigation()
+    public async Task<string> GetDocumentNavigation(
+        [Description("The document set to use: dcb_llm, dcb_llm_ja, llm, or llm_ja")] string documentSet)
     {
-        var navigation = await _documentService.GetNavigationAsync();
+        var navigation = await _documentService.GetNavigationAsync(documentSet);
         return JsonSerializer.Serialize(navigation, SekibanContext.Default.ListNavigationItem);
     }
 
@@ -37,9 +38,10 @@ public sealed class SekibanDocumentTools
     /// </summary>
     [McpServerTool]
     [Description("Get a list of all available Sekiban documents.")]
-    public async Task<string> GetAllDocuments()
+    public async Task<string> GetAllDocuments(
+        [Description("The document set to use: dcb_llm, dcb_llm_ja, llm, or llm_ja")] string documentSet)
     {
-        var documents = await _documentService.GetAllDocumentsAsync();
+        var documents = await _documentService.GetAllDocumentsAsync(documentSet);
         return JsonSerializer.Serialize(documents, SekibanContext.Default.ListDocumentInfo);
     }
 
@@ -49,12 +51,13 @@ public sealed class SekibanDocumentTools
     [McpServerTool]
     [Description("Get a specific Sekiban document by filename.")]
     public async Task<string> GetDocument(
+        [Description("The document set to use: dcb_llm, dcb_llm_ja, llm, or llm_ja")] string documentSet,
         [Description("The filename of the document (e.g., '01_core_concepts.md')")] string fileName)
     {
-        var document = await _documentService.GetDocumentAsync(fileName);
+        var document = await _documentService.GetDocumentAsync(fileName, documentSet);
         if (document == null)
         {
-            return JsonSerializer.Serialize(new { error = $"Document '{fileName}' not found" });
+            return JsonSerializer.Serialize(new { error = $"Document '{fileName}' not found in document set '{documentSet}'" });
         }
 
         return JsonSerializer.Serialize(
@@ -72,14 +75,15 @@ public sealed class SekibanDocumentTools
     [McpServerTool]
     [Description("Get a specific section from a Sekiban document.")]
     public async Task<string> GetDocumentSection(
+        [Description("The document set to use: dcb_llm, dcb_llm_ja, llm, or llm_ja")] string documentSet,
         [Description("The filename of the document (e.g., '01_core_concepts.md')")] string fileName,
         [Description("The title of the section")] string sectionTitle)
     {
-        var section = await _documentService.GetSectionContentAsync(fileName, sectionTitle);
+        var section = await _documentService.GetSectionContentAsync(fileName, sectionTitle, documentSet);
         if (section == null)
         {
             return JsonSerializer.Serialize(
-                new { error = $"Section '{sectionTitle}' not found in document '{fileName}'" });
+                new { error = $"Section '{sectionTitle}' not found in document '{fileName}' for document set '{documentSet}'" });
         }
 
         return JsonSerializer.Serialize(section, SekibanContext.Default.SectionContent);
@@ -90,9 +94,11 @@ public sealed class SekibanDocumentTools
     /// </summary>
     [McpServerTool]
     [Description("Search Sekiban documentation by keyword.")]
-    public async Task<string> SearchDocumentation([Description("The search keyword or phrase")] string query)
+    public async Task<string> SearchDocumentation(
+        [Description("The document set to use: dcb_llm, dcb_llm_ja, llm, or llm_ja")] string documentSet,
+        [Description("The search keyword or phrase")] string query)
     {
-        var results = await _documentService.SearchAsync(query);
+        var results = await _documentService.SearchAsync(query, documentSet);
         return JsonSerializer.Serialize(results, SekibanContext.Default.ListSearchResult);
     }
 
@@ -132,9 +138,11 @@ public sealed class SekibanDocumentTools
     /// </summary>
     [McpServerTool]
     [Description("Ask a question about Sekiban and get an answer using AI.")]
-    public async Task<string> AskQuestion([Description("Your question about Sekiban")] string question)
+    public async Task<string> AskQuestion(
+        [Description("The document set to use: dcb_llm, dcb_llm_ja, llm, or llm_ja")] string documentSet,
+        [Description("Your question about Sekiban")] string question)
     {
-        var answer = await _openAiService.AnswerQuestionAsync(question);
-        return JsonSerializer.Serialize(new { question, answer });
+        var answer = await _openAiService.AnswerQuestionAsync(question, documentSet);
+        return JsonSerializer.Serialize(new { documentSet, question, answer });
     }
 }

--- a/tools/SekibanDocumentMcpSse/SekibanDocumentTools.cs
+++ b/tools/SekibanDocumentMcpSse/SekibanDocumentTools.cs
@@ -27,7 +27,7 @@ public sealed class SekibanDocumentTools
     [McpServerTool]
     [Description("Get the navigation structure of Sekiban documentation.")]
     public async Task<string> GetDocumentNavigation(
-        [Description("The document set to use: dcb_llm, dcb_llm_ja, llm, or llm_ja")] string documentSet)
+        [Description("The document set to use. Required value: Dcb or Pure.")] string documentSet)
     {
         var navigation = await _documentService.GetNavigationAsync(documentSet);
         return JsonSerializer.Serialize(navigation, SekibanContext.Default.ListNavigationItem);
@@ -39,7 +39,7 @@ public sealed class SekibanDocumentTools
     [McpServerTool]
     [Description("Get a list of all available Sekiban documents.")]
     public async Task<string> GetAllDocuments(
-        [Description("The document set to use: dcb_llm, dcb_llm_ja, llm, or llm_ja")] string documentSet)
+        [Description("The document set to use. Required value: Dcb or Pure.")] string documentSet)
     {
         var documents = await _documentService.GetAllDocumentsAsync(documentSet);
         return JsonSerializer.Serialize(documents, SekibanContext.Default.ListDocumentInfo);
@@ -51,7 +51,7 @@ public sealed class SekibanDocumentTools
     [McpServerTool]
     [Description("Get a specific Sekiban document by filename.")]
     public async Task<string> GetDocument(
-        [Description("The document set to use: dcb_llm, dcb_llm_ja, llm, or llm_ja")] string documentSet,
+        [Description("The document set to use. Required value: Dcb or Pure.")] string documentSet,
         [Description("The filename of the document (e.g., '01_core_concepts.md')")] string fileName)
     {
         var document = await _documentService.GetDocumentAsync(fileName, documentSet);
@@ -75,7 +75,7 @@ public sealed class SekibanDocumentTools
     [McpServerTool]
     [Description("Get a specific section from a Sekiban document.")]
     public async Task<string> GetDocumentSection(
-        [Description("The document set to use: dcb_llm, dcb_llm_ja, llm, or llm_ja")] string documentSet,
+        [Description("The document set to use. Required value: Dcb or Pure.")] string documentSet,
         [Description("The filename of the document (e.g., '01_core_concepts.md')")] string fileName,
         [Description("The title of the section")] string sectionTitle)
     {
@@ -95,7 +95,7 @@ public sealed class SekibanDocumentTools
     [McpServerTool]
     [Description("Search Sekiban documentation by keyword.")]
     public async Task<string> SearchDocumentation(
-        [Description("The document set to use: dcb_llm, dcb_llm_ja, llm, or llm_ja")] string documentSet,
+        [Description("The document set to use. Required value: Dcb or Pure.")] string documentSet,
         [Description("The search keyword or phrase")] string query)
     {
         var results = await _documentService.SearchAsync(query, documentSet);
@@ -139,7 +139,7 @@ public sealed class SekibanDocumentTools
     [McpServerTool]
     [Description("Ask a question about Sekiban and get an answer using AI.")]
     public async Task<string> AskQuestion(
-        [Description("The document set to use: dcb_llm, dcb_llm_ja, llm, or llm_ja")] string documentSet,
+        [Description("The document set to use. Required value: Dcb or Pure.")] string documentSet,
         [Description("Your question about Sekiban")] string question)
     {
         var answer = await _openAiService.AnswerQuestionAsync(question, documentSet);

--- a/tools/SekibanDocumentMcpSse/appsettings.Development.json
+++ b/tools/SekibanDocumentMcpSse/appsettings.Development.json
@@ -6,7 +6,13 @@
     }
   },
   "Documentation": {
-    "BasePath": "",
+    "BasePath": "docs/dcb_llm",
+    "BasePaths": [
+      "docs/dcb_llm",
+      "docs/dcb_llm_ja",
+      "docs/llm",
+      "docs/llm_ja"
+    ],
     "EnableFileWatcher": true
   }
 }

--- a/tools/SekibanDocumentMcpSse/appsettings.json
+++ b/tools/SekibanDocumentMcpSse/appsettings.json
@@ -7,7 +7,13 @@
   },
   "AllowedHosts": "*",
   "Documentation": {
-    "BasePath": "",
+    "BasePath": "docs/dcb_llm",
+    "BasePaths": [
+      "docs/dcb_llm",
+      "docs/dcb_llm_ja",
+      "docs/llm",
+      "docs/llm_ja"
+    ],
     "EnableFileWatcher": false
   },
   "AzureOpenAI": {


### PR DESCRIPTION
## Context

The hosted Sekiban documentation MCP server was not usable for DCB-specific questions. Its document index only exposed the legacy aggregate/Pure-oriented `docs/llm` corpus, so searches for DCB concepts such as `IsConsistencyTag` returned no results. The `AskQuestion` tool also failed at runtime with an OpenAI SDK type-load error.

## Summary

Updates the MCP server so it can serve the DCB documentation set alongside the existing aggregate/Pure docs.

## Details

- Copies `docs/dcb_llm`, `docs/dcb_llm_ja`, `docs/llm`, and `docs/llm_ja` into stable output subdirectories.
- Loads multiple documentation base paths and exposes filenames with document-set prefixes such as `dcb_llm/01_core_concepts.md`.
- Keeps legacy single-`BasePath` configuration as a fallback.
- Updates `Azure.AI.OpenAI` from `2.2.0-beta.4` to `2.2.0-beta.5` and aligns `OpenAI` to `2.2.0` to avoid the observed `AskQuestion` runtime type mismatch.

## Validation

- `dotnet build tools/SekibanDocumentMcpSse/SekibanDocumentMcpSse.csproj`
- Verified build output contains 73 Markdown files under `bin/Debug/net8.0/docs`.
- `git diff --check`
