### PR TITLE
Add J-Tech JAPAN OSS Discord community link to docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,12 @@ We're glad you're interested in contributing to our project! While the maintaine
 
 This document outlines how you can contribute to our project and what you can expect during this process. Please read it thoroughly before you begin.
 
+## Community
+
+Join the **J-Tech JAPAN OSS Discord** to ask questions, discuss ideas, and connect with other Sekiban users and contributors. There is a dedicated channel for the Sekiban community.
+
+👉 [Join our Discord](https://discord.gg/kMdv978X)
+
 ## Code of Conduct
 
 First and foremost, participants in this project are expected to respect our [Code of Conduct](CODE_OF_CONDUCT.md). We're committed to providing a welcoming and positive experience for all contributors, so please respect these guidelines.

--- a/README.md
+++ b/README.md
@@ -107,6 +107,12 @@ Sekiban is Apache 2.0 open source. Support us via [GitHub Sponsors](https://gith
   </a>
 </p>
 
+## Community
+
+Join the **J-Tech JAPAN OSS Discord** to ask questions, share ideas, and connect with other Sekiban users. There is a dedicated channel for the Sekiban community.
+
+👉 [Join our Discord](https://discord.gg/kMdv978X)
+
 ## Support
 
 For training or support, contact [sekibanadmin@jtechs.com](mailto:sekibanadmin@jtechs.com).

--- a/dcb/README.md
+++ b/dcb/README.md
@@ -68,6 +68,12 @@ Learn more at [dcb.events](https://dcb.events)
 - **Website**: [sekiban.dev](https://www.sekiban.dev/)
 - **DCB Docs**: [docs/dcb_llm](https://github.com/J-Tech-Japan/Sekiban/tree/main/docs/dcb_llm) (EN) | [docs/dcb_llm_ja](https://github.com/J-Tech-Japan/Sekiban/tree/main/docs/dcb_llm_ja) (JP)
 
+## Community
+
+Join the **J-Tech JAPAN OSS Discord** to ask questions and connect with other Sekiban users. There is a dedicated channel for the Sekiban community.
+
+👉 [Join our Discord](https://discord.gg/kMdv978X)
+
 ## License
 
 Apache 2.0 - Copyright (c) 2022- J-Tech Japan

--- a/pure/README.md
+++ b/pure/README.md
@@ -57,6 +57,12 @@ Learn more at [dcb.events](https://dcb.events)
 - **Pure Docs**: [docs/llm](https://github.com/J-Tech-Japan/Sekiban/tree/main/docs/llm) (EN) | [docs/llm_ja](https://github.com/J-Tech-Japan/Sekiban/tree/main/docs/llm_ja) (JP)
 - **DCB Docs**: [docs/dcb_llm](https://github.com/J-Tech-Japan/Sekiban/tree/main/docs/dcb_llm) (EN) | [docs/dcb_llm_ja](https://github.com/J-Tech-Japan/Sekiban/tree/main/docs/dcb_llm_ja) (JP)
 
+## Community
+
+Join the **J-Tech JAPAN OSS Discord** to ask questions and connect with other Sekiban users. There is a dedicated channel for the Sekiban community.
+
+👉 [Join our Discord](https://discord.gg/kMdv978X)
+
 ## License
 
 Apache 2.0 - Copyright (c) 2022- J-Tech Japan

--- a/ts/README.md
+++ b/ts/README.md
@@ -112,6 +112,12 @@ Before publishing, ensure you have:
 5. Create a changeset
 6. Submit a pull request
 
+## Community
+
+Join the **J-Tech JAPAN OSS Discord** to ask questions and connect with other Sekiban users. There is a dedicated channel for the Sekiban community.
+
+👉 [Join our Discord](https://discord.gg/kMdv978X)
+
 ## License
 
 MIT


### PR DESCRIPTION
## Summary
- Added a **Community** section linking to the J-Tech JAPAN OSS Discord (https://discord.gg/kMdv978X), which includes a dedicated channel for the Sekiban community.
- Applied consistently across the main `README.md`, `dcb/README.md`, `pure/README.md`, `ts/README.md`, and `CONTRIBUTING.md`.

## Notes
- Text is written in English per the repository's documentation language guideline.

## Test plan
- [ ] Verify the Discord invite link resolves correctly
- [ ] Confirm the Community section renders properly in GitHub markdown preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)