### PR TITLE
SWR-G069 Add wasm-decider option to CreateSekibanDcbTemplate dnx tool

### DIFF
--- a/tools/dotnettools/CreateSekibanDcbTemplate/Program.cs
+++ b/tools/dotnettools/CreateSekibanDcbTemplate/Program.cs
@@ -58,6 +58,7 @@ internal class Program
             Console.WriteLine("  4. pure           - Sekiban Pure Orleans Aspire Template");
             Console.WriteLine("  5. decider-aws    - Sekiban Dcb Decider AWS Template (DynamoDB)");
             Console.WriteLine("  6. withoutresult-aws - Sekiban Dcb Orleans AWS Template (DynamoDB)");
+            Console.WriteLine("  7. wasm-decider   - Sekiban WASM Runtime Decider Template (public-container stack)");
             Console.Write("Enter choice [default: decider]: ");
             var input = Console.ReadLine();
             templateType = string.IsNullOrWhiteSpace(input) ? "decider" : input.Trim();
@@ -73,10 +74,11 @@ internal class Program
             "4" => "pure",
             "5" => "decider-aws",
             "6" => "withoutresult-aws",
+            "7" => "wasm-decider",
             _ => templateType
         };
 
-        var validTypes = new[] { "decider", "dcb", "withoutresult", "pure", "decider-aws", "withoutresult-aws" };
+        var validTypes = new[] { "decider", "dcb", "withoutresult", "pure", "decider-aws", "withoutresult-aws", "wasm-decider" };
         if (!validTypes.Contains(templateType))
         {
              Console.Error.WriteLine($"❌ Invalid template type: {templateType}. Allowed values are: {string.Join(", ", validTypes.Select(t => $"'{t}'"))}.");
@@ -115,6 +117,11 @@ internal class Program
              installCommand = "new install Sekiban.Dcb.Templates";
              createCommand = $"new sekiban-dcb-orleans-aws -n {projectName}";
         }
+        else if (templateType == "wasm-decider")
+        {
+             installCommand = "new install Sekiban.Dcb.WasmRuntime.Templates";
+             createCommand = $"new sekiban-wasm-decider -n {projectName}";
+        }
         else // dcb
         {
              installCommand = "new install Sekiban.Dcb.Templates";
@@ -127,6 +134,15 @@ internal class Program
         {
             Console.Error.WriteLine();
             Console.Error.WriteLine($"❌ dotnet {installCommand} failed with exit code {installExitCode}.");
+            if (templateType == "wasm-decider")
+            {
+                Console.Error.WriteLine();
+                Console.Error.WriteLine("The Sekiban.Dcb.WasmRuntime.Templates package could not be installed.");
+                Console.Error.WriteLine("It is published from the SekibanWasmRuntime repository's templates-v* release lane;");
+                Console.Error.WriteLine("if it has not been published to NuGet.org yet, this install will fail with a not-found error.");
+                Console.Error.WriteLine("See https://github.com/J-Tech-Japan/SekibanWasmRuntime for the release status, or install a");
+                Console.Error.WriteLine("locally packed nupkg with: dotnet new install <path-to-Sekiban.Dcb.WasmRuntime.Templates.nupkg>");
+            }
             return installExitCode;
         }
 
@@ -148,6 +164,19 @@ internal class Program
         Console.WriteLine($"📁 Project created: {projectName}");
         Console.WriteLine();
 
+        if (templateType == "wasm-decider")
+        {
+            Console.WriteLine("Next steps:");
+            Console.WriteLine($"  cd {projectName}");
+            Console.WriteLine("  bash scripts/build-wasm.sh          # builds the WASM module + runtime manifest");
+            Console.WriteLine($"  dotnet restore");
+            Console.WriteLine($"  dotnet build");
+            Console.WriteLine($"  dotnet run --project {projectName}.AppHost   # starts Postgres + the public runtime container");
+            Console.WriteLine("  # or run the end-to-end smoke instead (starts the AppHost itself):");
+            Console.WriteLine("  bash scripts/smoke.sh");
+            Console.WriteLine();
+        }
+
         return 0;
     }
 
@@ -168,6 +197,7 @@ internal class Program
         Console.WriteLine("                 pure             - Sekiban Pure Orleans Aspire Template");
         Console.WriteLine("                 decider-aws      - Sekiban Dcb Decider AWS Template (DynamoDB)");
         Console.WriteLine("                 withoutresult-aws - Sekiban Dcb Orleans AWS Template (DynamoDB)");
+        Console.WriteLine("                 wasm-decider     - Sekiban WASM Runtime Decider Template (public-container stack)");
         Console.WriteLine("  -h, --help   Show this help message.");
         Console.WriteLine();
         Console.WriteLine("Examples:");
@@ -178,6 +208,7 @@ internal class Program
         Console.WriteLine("  create-sekiban-dcb-template MyProject -t pure");
         Console.WriteLine("  create-sekiban-dcb-template MyProject -t decider-aws");
         Console.WriteLine("  create-sekiban-dcb-template MyProject -t withoutresult-aws");
+        Console.WriteLine("  create-sekiban-dcb-template MyProject -t wasm-decider");
     }
 
     /// <summary>

--- a/tools/dotnettools/CreateSekibanDcbTemplate/README.md
+++ b/tools/dotnettools/CreateSekibanDcbTemplate/README.md
@@ -1,0 +1,98 @@
+# CreateSekibanDcbTemplate
+
+A `dotnet` tool (distributed via `dnx`) that installs a Sekiban template
+package and generates a new project from it. It prompts for a project name
+and a template type, runs `dotnet new install` followed by `dotnet new
+<template-short-name> -n <ProjectName>`, and prints the tool's exit status.
+
+## Usage
+
+```bash
+dnx CreateSekibanDcbTemplate [ProjectName] [Options]
+# or, from a local checkout:
+dotnet run --project tools/dotnettools/CreateSekibanDcbTemplate -- [ProjectName] [Options]
+```
+
+| Option | Effect |
+| --- | --- |
+| `[ProjectName]` | Project name to generate. Prompted (default `Contoso.Dcb`) when omitted. |
+| `-t, --type <type>` | Template type. Prompted (default `decider`) when omitted. |
+| `-h, --help` | Show help. |
+
+## Template types
+
+| Type | Package | Generated template |
+| --- | --- | --- |
+| `decider` (recommended) | `Sekiban.Dcb.Templates` | `sekiban-dcb-decider` |
+| `dcb` | `Sekiban.Dcb.Templates` | `sekiban-dcb-orleans` |
+| `withoutresult` | `Sekiban.Dcb.Templates` | `sekiban-dcb-orleans-withoutresult` |
+| `pure` | `Sekiban.Pure.Templates` | `sekiban-orleans-aspire` |
+| `decider-aws` | `Sekiban.Dcb.Templates` | `sekiban-dcb-decider-aws` |
+| `withoutresult-aws` | `Sekiban.Dcb.Templates` | `sekiban-dcb-orleans-aws` |
+| `wasm-decider` | `Sekiban.Dcb.WasmRuntime.Templates` | `sekiban-wasm-decider` |
+
+Every type installs its package via `dotnet new install <package>` and then
+runs `dotnet new <short-name> -n <ProjectName>`.
+
+## `wasm-decider`
+
+Generates an Aspire solution that hosts the **public Sekiban WASM runtime
+container** (`ghcr.io/j-tech-japan/sekiban-wasm-runtime-host`) with a
+Postgres event store: a Decider-pattern domain, a NativeAOT-LLVM `wasi-wasm`
+projector module, and an Aspire AppHost wiring the container + Postgres
+through the `Sekiban.Dcb.WasmRuntime.Aspire` package. The package and
+template are maintained in the
+[SekibanWasmRuntime](https://github.com/J-Tech-Japan/SekibanWasmRuntime)
+repository (SWR-G068); see its
+[`docs/templates/sekiban-wasm-decider.md`](https://github.com/J-Tech-Japan/SekibanWasmRuntime/blob/main/docs/templates/sekiban-wasm-decider.md)
+for the template's own generation options (e.g. `--IncludeTests`).
+
+```bash
+dnx CreateSekibanDcbTemplate MyWeather -t wasm-decider
+```
+
+On success the tool prints the generated project's next steps:
+
+```bash
+cd MyWeather
+bash scripts/build-wasm.sh          # builds the WASM module + runtime manifest
+dotnet restore
+dotnet build
+dotnet run --project MyWeather.AppHost   # starts Postgres + the public runtime container
+# or run the end-to-end smoke instead (starts the AppHost itself):
+bash scripts/smoke.sh
+```
+
+### If `Sekiban.Dcb.WasmRuntime.Templates` is not yet published
+
+`Sekiban.Dcb.WasmRuntime.Templates` is published from the
+SekibanWasmRuntime repository's own `templates-v*` release lane
+(independent of this tool's release cadence). If the `dotnet new install`
+step runs before that package has published, it fails with a NuGet
+not-found error (`dotnet new` exit code 103); the tool reports this clearly,
+names the package, and points at the SekibanWasmRuntime repository, without
+touching any other installed templates:
+
+```
+❌ dotnet new install Sekiban.Dcb.WasmRuntime.Templates failed with exit code 103.
+
+The Sekiban.Dcb.WasmRuntime.Templates package could not be installed.
+It is published from the SekibanWasmRuntime repository's templates-v* release lane;
+if it has not been published to NuGet.org yet, this install will fail with a not-found error.
+See https://github.com/J-Tech-Japan/SekibanWasmRuntime for the release status, or install a
+locally packed nupkg with: dotnet new install <path-to-Sekiban.Dcb.WasmRuntime.Templates.nupkg>
+```
+
+To verify the `wasm-decider` flow before that publish happens, install a
+locally packed nupkg first (pack it from a SekibanWasmRuntime checkout, e.g.
+`dotnet pack templates/Sekiban.Dcb.WasmRuntime.Templates/...` plus its
+`Sekiban.Dcb.WasmRuntime.Aspire` dependency), and point a `NuGet.config` in
+the project's working directory at that local output directory (with
+`nuget.org` as a fallback source) before running the tool -- the tool's own
+`dotnet new install Sekiban.Dcb.WasmRuntime.Templates` then resolves from
+the local source instead of the registry. This was verified locally: with
+the packages packed and a local `NuGet.config` in place, the tool installed
+the template, generated a project named `WasmDeciderSmoke` with the
+expected layout (`*.AppHost`, `*.Domain`, `*.Domain.Tests`, `*.Wasm`,
+`scripts/`, `README.md`), and printed the next-step commands above
+unchanged.


### PR DESCRIPTION
Closes #1043

## Summary

Adds a `wasm-decider` choice to the `CreateSekibanDcbTemplate` dnx tool, wiring the `Sekiban.Dcb.WasmRuntime.Templates` package (SWR-G068, maintained in the [SekibanWasmRuntime](https://github.com/J-Tech-Japan/SekibanWasmRuntime) repository) into the tool's existing install-then-generate flow.

- `tools/dotnettools/CreateSekibanDcbTemplate/Program.cs`: adds `wasm-decider` as choice 7 in the interactive menu and to the `-t/--type` accepted values, with a one-line description naming the Sekiban WASM runtime public-container stack. Wires it to `dotnet new install Sekiban.Dcb.WasmRuntime.Templates` then `dotnet new sekiban-wasm-decider -n <ProjectName>`, reusing the tool's existing `RunDotnetCommandAsync` helper — no new argument-parsing framework, no menu redesign, and the six existing choices (`decider`, `dcb`, `withoutresult`, `pure`, `decider-aws`, `withoutresult-aws`) are unchanged.
- On successful generation, prints the generated project's next steps (`bash scripts/build-wasm.sh`, `dotnet restore`, `dotnet build`, `dotnet run --project <name>.AppHost`, or the `bash scripts/smoke.sh` shortcut), matching the `sekiban-wasm-decider` template's own docs.
- On install failure, adds a `wasm-decider`-specific message (on top of the existing generic failure message) naming `Sekiban.Dcb.WasmRuntime.Templates` and pointing at the SekibanWasmRuntime `templates-v*` release lane / a local-nupkg workaround, without touching other installed templates.
- `--help` output updated with the new type and an example.
- `tools/dotnettools/CreateSekibanDcbTemplate/README.md` created (didn't exist before) documenting all seven template types and the `wasm-decider` option in detail, including the not-yet-published behavior.

## Verification

```bash
dotnet build tools/dotnettools/CreateSekibanDcbTemplate/CreateSekibanDcbTemplate.csproj -c Release
dotnet run --project tools/dotnettools/CreateSekibanDcbTemplate -- --help
cd "$(mktemp -d)" && dotnet run --project /path/to/Sekiban-dcb/tools/dotnettools/CreateSekibanDcbTemplate -- WasmDeciderSmoke -t wasm-decider
git diff --check
```

`Sekiban.Dcb.WasmRuntime.Templates` is not published to NuGet.org yet (its own `templates-v*` release lane is separate and human-gated), so I verified both paths:

1. **Real (unpublished) package**: the literal verification command above fails cleanly at the install step with `dotnet new` exit code 103 and the new documented message:
   ```
   ❌ dotnet new install Sekiban.Dcb.WasmRuntime.Templates failed with exit code 103.

   The Sekiban.Dcb.WasmRuntime.Templates package could not be installed.
   It is published from the SekibanWasmRuntime repository's templates-v* release lane;
   if it has not been published to NuGet.org yet, this install will fail with a not-found error.
   See https://github.com/J-Tech-Japan/SekibanWasmRuntime for the release status, or install a
   locally packed nupkg with: dotnet new install <path-to-Sekiban.Dcb.WasmRuntime.Templates.nupkg>
   ```
2. **Locally packed substitution**: packed `Sekiban.Dcb.WasmRuntime.Templates` and its `Sekiban.Dcb.WasmRuntime.Aspire` dependency from a SekibanWasmRuntime checkout, added a working-directory `NuGet.config` pointing at that local output (plus `nuget.org` as fallback), and re-ran the same command. The full flow succeeded: template installed, `WasmDeciderSmoke` generated with the expected `*.AppHost`/`*.Domain`/`*.Domain.Tests`/`*.Wasm`/`scripts/`/`README.md` layout, and the documented next-step commands printed unchanged. Template uninstalled afterward, and the existing six template choices' `dotnet new list` state was left untouched.

`dotnet build`/`--help`: both pass; `git diff --check`: clean.

## Closeout learning

The dnx tool's install-then-generate flow worked completely unchanged for a template package owned by another repository (SekibanWasmRuntime) — no tool-side assumption had to be relaxed. The only asymmetry from the six existing choices is that this package isn't published yet: the tool now surfaces that as a named, actionable error (exit code 103, package name, release-lane pointer, local-nupkg workaround) rather than a bare `dotnet new` failure, so the release batch can sequence the NuGet publish independently of this PR without leaving users confused in the meantime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NPP42Xk4nshWCXVWJQSuep