### PR TITLE
Document DCB storage provider consistency contract (Cosmos non-atomicity)

### DIFF
--- a/dcb/src/Sekiban.Dcb.Core/Storage/IEventStore.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Storage/IEventStore.cs
@@ -68,8 +68,11 @@ public interface IEventStore
     Task<ResultBox<IEnumerable<SerializableEvent>>> ReadSerializableEventsByTagAsync(ITag tag, SortableUniqueId? since = null);
 
     /// <summary>
-    ///     Writes multiple pre-serialized events to the event store atomically.
-    ///     Also updates tag states for all affected tags.
+    ///     Writes multiple pre-serialized events to the event store and updates tag states
+    ///     for all affected tags. Atomicity of the event write, the tag write, and the
+    ///     visibility of a multi-event batch is provider-dependent — see the
+    ///     "Consistency Contract" section in docs/dcb_llm/11_storage_providers.md for the
+    ///     guarantees of each storage provider.
     /// </summary>
     /// <returns>ResultBox containing the written serializable events and tag write results</returns>
     Task<ResultBox<(IReadOnlyList<SerializableEvent> Events, IReadOnlyList<TagWriteResult> TagWrites)>> WriteSerializableEventsAsync(

--- a/docs/dcb_llm/11_storage_providers.md
+++ b/docs/dcb_llm/11_storage_providers.md
@@ -142,6 +142,39 @@ services.AddSingleton<IBlobStorageSnapshotAccessor>(sp =>
 | DynamoDB | `Sekiban.Dcb.DynamoDB` | `Sekiban.Dcb.BlobStorage.S3` | Production |
 | SQLite | `Sekiban.Dcb.Sqlite` | N/A | Development |
 
+## Consistency Contract
+
+This section documents the actual atomicity guarantees of `IEventStore.WriteSerializableEventsAsync` / `WriteEventsAsync` per provider. Follow-up slices are planned to close the gaps described below (idempotent tag writes, roll-forward retry, a tag-index repair API, an opt-in startup sweep) — the two-phase Cosmos write design itself is not changed by this document update.
+
+### Postgres — current guarantee
+
+`PostgresEventStore.WriteEventsAsync` writes event rows and tag rows inside a single database transaction. Both **event-set atomicity** (all events in a `WriteEventsAsync` call commit, or none do) and **event/tag atomicity** (an event is never visible without its tag rows) are guaranteed.
+
+### Cosmos DB — current guarantee
+
+`CosmosDbEventStore.WriteSerializableEventsAsync` performs a two-phase write with **no transaction spanning the two phases**:
+
+1. Event documents are created in parallel (`CreateItemAsync`), one per event, partitioned by `{serviceId}|{eventId}`.
+2. Tag rows are then written via per-tag-partition `TransactionalBatch` (`{serviceId}|{tag}`).
+
+This has two consequences today:
+
+- **Event/tag crash window**: a crash or host termination between phase 1 and phase 2 (or mid-way through the phase 2 tag batches) leaves durable events without their tag rows. Those events are visible via `ReadAllEventsAsync`, but invisible to `ReadEventsByTagAsync`, tag projectors, and `GetLatestTagAsync` — which also feeds `GeneralTagConsistentActor`'s optimistic-concurrency baseline.
+- **Multi-event partial visibility**: a multi-event `WriteEventsAsync` call can fail partway through its parallel event creates. Successfully created events become immediately visible to all-events readers even though sibling events from the same call may never get written.
+
+`TryRollbackSerializableEventsAsync` only runs from an in-process `catch` block; it never runs after a crash, and there is no durable compensation record.
+
+**Planned improvements (not yet released)**: idempotent tag writes, roll-forward retry, a tag-index repair API, and an opt-in startup sweep. None of these ship in the current release — upgrading the package alone does not enable any repair or sweep behavior; they will land later as explicit opt-ins.
+
+Because Cosmos event documents carry the complete `tags` array (see `Models/CosmosEvent.cs`), the `tags` container is a **derivable index**: it can always be reconstructed from the `events` container. This is the basis for the planned repair strategy. Note that once a repair/sweep ships, reads immediately after a repair may still observe stale state depending on the configured Cosmos consistency level.
+
+### Choosing a provider
+
+Recommend **Postgres** for any workload that requires atomic event/tag visibility or event-set atomicity — for example money-sensitive workflows. Concrete examples in the Sekiban ecosystem:
+
+- [SekibanWasmRuntime](https://github.com/J-Tech-Japan/SekibanWasmRuntime) defaults to Postgres for its event store, with Cosmos as an opt-in.
+- SekibanAsAService uses separate management and runtime container lineages; each can select its provider independently, so apply the same Postgres-for-atomicity guidance per container.
+
 ## Materialized View Storage
 
 Materialized views are currently implemented for PostgreSQL:

--- a/docs/dcb_llm_ja/11_storage_providers.md
+++ b/docs/dcb_llm_ja/11_storage_providers.md
@@ -166,6 +166,39 @@ builder.Services.AddSekibanDcbPostgres("Host=localhost;Database=sekiban_dcb;User
 
 DCB の Dapr 版は開発中です。現時点では Orleans ベースの実行環境をご利用ください。
 
+## 整合性契約
+
+このセクションでは `IEventStore.WriteSerializableEventsAsync` / `WriteEventsAsync` の、プロバイダーごとの実際のアトミック性保証を説明します。以下で説明するギャップを埋めるための後続スライス(冪等なタグ書き込み、ロールフォワードリトライ、タグインデックス修復API、opt-inのスタートアップスイープ)が計画されていますが、Cosmos の二段階書き込み設計自体はこのドキュメント更新では変更していません。
+
+### Postgres — 現在の保証
+
+`PostgresEventStore.WriteEventsAsync` はイベント行とタグ行を単一のデータベーストランザクション内で書き込みます。**イベントセットのアトミック性**(`WriteEventsAsync` 呼び出し内のすべてのイベントがコミットされるか、まったくコミットされないか)と、**イベント/タグのアトミック性**(タグ行を伴わずにイベントが可視化されることはない)の両方が保証されます。
+
+### Cosmos DB — 現在の保証
+
+`CosmosDbEventStore.WriteSerializableEventsAsync` は、**2つのフェーズにまたがるトランザクションを持たない**、2段階の書き込みを行います:
+
+1. イベントドキュメントを並列に作成(`CreateItemAsync`)。イベントごとに1件、`{serviceId}|{eventId}` でパーティション分割。
+2. その後、タグ行を per-tag-partition の `TransactionalBatch`(`{serviceId}|{tag}`)で書き込み。
+
+これにより、現在次の2つの問題があります:
+
+- **イベント/タグのクラッシュウィンドウ**: フェーズ1とフェーズ2の間、またはフェーズ2のタグバッチ処理中にクラッシュやホスト終了が発生すると、タグ行を伴わない永続化済みイベントが残ります。これらのイベントは `ReadAllEventsAsync` からは可視ですが、`ReadEventsByTagAsync`、タグプロジェクター、および(`GeneralTagConsistentActor` の楽観的並行性制御のベースラインにも使われる)`GetLatestTagAsync` からは不可視です。
+- **複数イベントの部分的な可視化**: 複数イベントの `WriteEventsAsync` 呼び出しは、並列のイベント作成の途中で失敗することがあります。作成に成功したイベントは all-events リーダーに即座に可視化されますが、同じ呼び出し内の書き込みに失敗した兄弟イベントはどこにも記録されません。
+
+`TryRollbackSerializableEventsAsync` はプロセス内の `catch` ブロックからのみ実行され、クラッシュ後には実行されません。また、永続的な補償レコードもありません。
+
+**計画中の改善(未リリース)**: 冪等なタグ書き込み、ロールフォワードリトライ、タグインデックス修復API、opt-in のスタートアップスイープ。これらは現行リリースには含まれておらず、パッケージをアップグレードするだけでは修復/スイープの動作は有効になりません。今後、明示的な opt-in として提供される予定です。
+
+Cosmos のイベントドキュメントは完全な `tags` 配列を保持しているため(`Models/CosmosEvent.cs` 参照)、`tags` コンテナーは **派生可能なインデックス** であり、常に `events` コンテナーから再構築できます。これが計画中の修復戦略の基礎になっています。なお、将来的に修復/スイープがリリースされた後も、修復直後の読み取りは、設定された Cosmos の整合性レベルによっては古い状態を観測する可能性がある点に注意してください。
+
+### プロバイダーの選び方
+
+アトミックなイベント/タグの可視性やイベントセットのアトミック性を必要とするワークロード(例: 金銭に関わるワークフロー)には **Postgres** を推奨します。Sekiban エコシステムにおける具体例:
+
+- [SekibanWasmRuntime](https://github.com/J-Tech-Japan/SekibanWasmRuntime) はイベントストアのデフォルトが Postgres で、Cosmos は opt-in です。
+- SekibanAsAService は管理系(management)とランタイム系(runtime)で別系統のコンテナーを使用しており、それぞれ独立してプロバイダーを選択できます。コンテナーごとに上記と同じ「アトミック性が必要なら Postgres」というガイドラインを適用してください。
+
 ## マテリアライズドビュー用ストレージ
 
 マテリアライズドビューは現在 PostgreSQL 向けに実装されています。


### PR DESCRIPTION
## Summary
- Fix `IEventStore.WriteSerializableEventsAsync` XML doc, which claimed unconditional atomicity, to state that atomicity is provider-dependent and point to the storage provider docs.
- Add a "Consistency Contract" section (EN + JA) to `11_storage_providers.md` documenting the Postgres single-transaction guarantee vs. the Cosmos two-phase write's crash window (event/tag visibility gap) and multi-event partial-visibility gap.
- Separate CURRENT guarantees from PLANNED improvements (idempotent tag writes, roll-forward retry, tag-index repair API, opt-in startup sweep — none shipped yet).
- Recommend Postgres for atomicity-critical workloads (e.g. money-sensitive workflows), with SekibanWasmRuntime (Postgres default) and SekibanAsAService (separate management/runtime container lineages) as concrete examples.

Documentation-only change; no runtime behavior change.

Closes #1047

## Test plan
- [x] `dotnet build dcb/src/Sekiban.Dcb.Core/Sekiban.Dcb.Core.csproj` succeeds (doc-comment-only code change)
- [x] `git diff --check` clean
- [x] EN and JA sections verified equivalent in content/structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017KAPyZPCMZzurEZTt1k8LX