### PR TITLE
Make Cosmos DCB tag writes deterministic and idempotent

### DIFF
--- a/dcb/src/Sekiban.Dcb.CosmosDb/CosmosDbEventStore.cs
+++ b/dcb/src/Sekiban.Dcb.CosmosDb/CosmosDbEventStore.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Logging;
 using ResultBoxes;
 using Sekiban.Dcb.Common;
 using Sekiban.Dcb.CosmosDb.Models;
+using Sekiban.Dcb.CosmosDb.Tags;
 using Sekiban.Dcb.Domains;
 using Sekiban.Dcb.Events;
 using Sekiban.Dcb.ServiceId;
@@ -43,6 +44,12 @@ public partial class CosmosDbEventStore : IHotEventStore
         _containerResolver = containerResolver ?? throw new ArgumentNullException(nameof(containerResolver));
         _logger = logger;
     }
+
+    /// <summary>
+    ///     Test-only hook to fail the tag-write stage deterministically after a given number of batches.
+    ///     Always null in production; the public construction paths cannot set it.
+    /// </summary>
+    internal ICosmosTagWriteFaultInjector? TagWriteFaultInjector { get; set; }
 
     private string CurrentServiceId => _serviceIdProvider.GetCurrentServiceId();
 
@@ -547,110 +554,30 @@ public partial class CosmosDbEventStore : IHotEventStore
     }
 
     /// <summary>
-    ///     Writes tags using TransactionalBatch for efficiency.
-    ///     Tags with the same partition key (tag string) are batched together.
+    ///     Writes tags idempotently, batched per tag partition.
+    ///     See <see cref="CosmosTagWriteStage" /> — re-executing this for the same events is safe.
     /// </summary>
-    private static async Task<List<TagWriteResult>> WriteTagsWithBatchAsync(
+    private async Task<List<TagWriteResult>> WriteTagsWithBatchAsync(
         List<Event> writtenEvents,
         Container tagsContainer,
         CosmosDbEventStoreOptions options,
         string serviceId,
         CosmosContainerSettings settings)
     {
-        var tagWriteResults = new List<TagWriteResult>();
+        var sources = writtenEvents
+            .SelectMany(ev => ev.Tags.Select(tagString => new CosmosTagRowSource(
+                tagString,
+                ev.Id,
+                ev.SortableUniqueIdValue,
+                ev.EventType)))
+            .ToList();
 
-        // Group all tag entries by tag string (partition key)
-        var tagEntries = writtenEvents
-            .SelectMany(ev => ev.Tags.Select(tagString => (TagString: tagString, Event: ev)))
-            .GroupBy(x => $"{serviceId}|{x.TagString}");
-
-        foreach (var group in tagEntries)
-        {
-            var tagPk = group.Key;
-            var tagString = group.First().TagString;
-            var tagGroup = tagString.Contains(':', StringComparison.Ordinal)
-                ? tagString.Split(':')[0]
-                : tagString;
-            var items = group.ToList();
-
-            if (options.UseTransactionalBatchForTags && items.Count <= options.MaxBatchOperations)
-            {
-                // Use TransactionalBatch for same-partition writes
-                var batch = tagsContainer.CreateTransactionalBatch(new PartitionKey(tagPk));
-
-                foreach (var item in items)
-                {
-                    var cosmosTag = CosmosTag.FromEventTag(
-                        tagString,
-                        tagGroup,
-                        item.Event.SortableUniqueIdValue,
-                        item.Event.Id,
-                        item.Event.EventType,
-                        serviceId);
-
-                    batch.CreateItem(cosmosTag);
-                }
-
-                var response = await batch.ExecuteAsync().ConfigureAwait(false);
-
-                if (!response.IsSuccessStatusCode)
-                {
-                    throw new CosmosException(
-                        $"TransactionalBatch failed for tag '{tagString}' with status {response.StatusCode}",
-                        response.StatusCode,
-                        (int)response.StatusCode,
-                        response.ActivityId,
-                        response.RequestCharge);
-                }
-
-                // Add results for all items in batch
-                foreach (var item in items)
-                {
-                    tagWriteResults.Add(new TagWriteResult(tagString, 1, DateTimeOffset.UtcNow));
-                }
-            }
-            else
-            {
-                // Fallback: Split into multiple batches if exceeding limit
-                for (var i = 0; i < items.Count; i += options.MaxBatchOperations)
-                {
-                    var batchItems = items.Skip(i).Take(options.MaxBatchOperations).ToList();
-                    var batch = tagsContainer.CreateTransactionalBatch(new PartitionKey(tagPk));
-
-                    foreach (var item in batchItems)
-                    {
-                        var cosmosTag = CosmosTag.FromEventTag(
-                            tagString,
-                            tagGroup,
-                            item.Event.SortableUniqueIdValue,
-                            item.Event.Id,
-                            item.Event.EventType,
-                            serviceId);
-
-                        batch.CreateItem(cosmosTag);
-                    }
-
-                    var response = await batch.ExecuteAsync().ConfigureAwait(false);
-
-                    if (!response.IsSuccessStatusCode)
-                    {
-                        throw new CosmosException(
-                            $"TransactionalBatch failed for tag '{tagString}' (batch {i / options.MaxBatchOperations + 1}) with status {response.StatusCode}",
-                            response.StatusCode,
-                            (int)response.StatusCode,
-                            response.ActivityId,
-                            response.RequestCharge);
-                    }
-
-                    foreach (var item in batchItems)
-                    {
-                        tagWriteResults.Add(new TagWriteResult(tagString, 1, DateTimeOffset.UtcNow));
-                    }
-                }
-            }
-        }
-
-        return tagWriteResults;
+        return await CosmosTagWriteStage.WriteAsync(
+            sources,
+            new CosmosContainerTagRowStore(tagsContainer),
+            options,
+            serviceId,
+            TagWriteFaultInjector).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -1360,106 +1287,30 @@ public partial class CosmosDbEventStore : IHotEventStore
     }
 
     /// <summary>
-    ///     Writes tags for serializable events using TransactionalBatch.
+    ///     Writes tags for serializable events idempotently, batched per tag partition.
+    ///     See <see cref="CosmosTagWriteStage" /> — re-executing this for the same events is safe.
     /// </summary>
-    private static async Task<List<TagWriteResult>> WriteSerializableTagsWithBatchAsync(
+    private async Task<List<TagWriteResult>> WriteSerializableTagsWithBatchAsync(
         List<SerializableEvent> writtenEvents,
         Container tagsContainer,
         CosmosDbEventStoreOptions options,
         string serviceId,
         CosmosContainerSettings settings)
     {
-        var tagWriteResults = new List<TagWriteResult>();
+        var sources = writtenEvents
+            .SelectMany(se => se.Tags.Select(tagString => new CosmosTagRowSource(
+                tagString,
+                se.Id,
+                se.SortableUniqueIdValue,
+                se.EventPayloadName)))
+            .ToList();
 
-        // Group all tag entries by tag string (partition key)
-        var tagEntries = writtenEvents
-            .SelectMany(se => se.Tags.Select(tagString => (TagString: tagString, Event: se)))
-            .GroupBy(x => $"{serviceId}|{x.TagString}");
-
-        foreach (var group in tagEntries)
-        {
-            var tagPk = group.Key;
-            var tagString = group.First().TagString;
-            var tagGroup = tagString.Contains(':', StringComparison.Ordinal)
-                ? tagString.Split(':')[0]
-                : tagString;
-            var items = group.ToList();
-
-            if (options.UseTransactionalBatchForTags && items.Count <= options.MaxBatchOperations)
-            {
-                var batch = tagsContainer.CreateTransactionalBatch(new PartitionKey(tagPk));
-
-                foreach (var item in items)
-                {
-                    var cosmosTag = CosmosTag.FromEventTag(
-                        tagString,
-                        tagGroup,
-                        item.Event.SortableUniqueIdValue,
-                        item.Event.Id,
-                        item.Event.EventPayloadName,
-                        serviceId);
-
-                    batch.CreateItem(cosmosTag);
-                }
-
-                var response = await batch.ExecuteAsync().ConfigureAwait(false);
-
-                if (!response.IsSuccessStatusCode)
-                {
-                    throw new CosmosException(
-                        $"TransactionalBatch failed for tag '{tagString}' with status {response.StatusCode}",
-                        response.StatusCode,
-                        (int)response.StatusCode,
-                        response.ActivityId,
-                        response.RequestCharge);
-                }
-
-                foreach (var item in items)
-                {
-                    tagWriteResults.Add(new TagWriteResult(tagString, 1, DateTimeOffset.UtcNow));
-                }
-            }
-            else
-            {
-                for (var i = 0; i < items.Count; i += options.MaxBatchOperations)
-                {
-                    var batchItems = items.Skip(i).Take(options.MaxBatchOperations).ToList();
-                    var batch = tagsContainer.CreateTransactionalBatch(new PartitionKey(tagPk));
-
-                    foreach (var item in batchItems)
-                    {
-                        var cosmosTag = CosmosTag.FromEventTag(
-                            tagString,
-                            tagGroup,
-                            item.Event.SortableUniqueIdValue,
-                            item.Event.Id,
-                            item.Event.EventPayloadName,
-                            serviceId);
-
-                        batch.CreateItem(cosmosTag);
-                    }
-
-                    var response = await batch.ExecuteAsync().ConfigureAwait(false);
-
-                    if (!response.IsSuccessStatusCode)
-                    {
-                        throw new CosmosException(
-                            $"TransactionalBatch failed for tag '{tagString}' (batch {i / options.MaxBatchOperations + 1}) with status {response.StatusCode}",
-                            response.StatusCode,
-                            (int)response.StatusCode,
-                            response.ActivityId,
-                            response.RequestCharge);
-                    }
-
-                    foreach (var item in batchItems)
-                    {
-                        tagWriteResults.Add(new TagWriteResult(tagString, 1, DateTimeOffset.UtcNow));
-                    }
-                }
-            }
-        }
-
-        return tagWriteResults;
+        return await CosmosTagWriteStage.WriteAsync(
+            sources,
+            new CosmosContainerTagRowStore(tagsContainer),
+            options,
+            serviceId,
+            TagWriteFaultInjector).ConfigureAwait(false);
     }
 
     /// <summary>

--- a/dcb/src/Sekiban.Dcb.CosmosDb/Models/CosmosTag.cs
+++ b/dcb/src/Sekiban.Dcb.CosmosDb/Models/CosmosTag.cs
@@ -69,6 +69,10 @@ public class CosmosTag
 
     /// <summary>
     ///     Creates a tag document from event metadata.
+    ///     Every field is derived from the (event, tag) pair, so the same pair always produces the same
+    ///     document — see <see cref="Tags.CosmosTagIdentity" /> for the derivation rule. The
+    ///     <paramref name="tagGroup" /> argument is accepted for source compatibility but the group is
+    ///     derived from <paramref name="tag" />, so it cannot drift from the tag it belongs to.
     /// </summary>
     public static CosmosTag FromEventTag(
         string tag,
@@ -77,16 +81,5 @@ public class CosmosTag
         Guid eventId,
         string eventType,
         string serviceId) =>
-        new()
-        {
-            Pk = $"{serviceId}|{tag}",
-            ServiceId = serviceId,
-            Id = Guid.NewGuid().ToString(), // Generate unique ID for the document
-            Tag = tag,
-            TagGroup = tagGroup,
-            EventType = eventType,
-            SortableUniqueId = sortableUniqueId,
-            EventId = eventId.ToString(),
-            CreatedAt = DateTime.UtcNow
-        };
+        Tags.CosmosTagIdentity.DeriveRow(serviceId, tag, eventId, sortableUniqueId, eventType);
 }

--- a/dcb/src/Sekiban.Dcb.CosmosDb/Sekiban.Dcb.CosmosDb.csproj
+++ b/dcb/src/Sekiban.Dcb.CosmosDb/Sekiban.Dcb.CosmosDb.csproj
@@ -49,4 +49,10 @@
         <ProjectReference Include="..\Sekiban.Dcb.Core\Sekiban.Dcb.Core.csproj"/>
     </ItemGroup>
 
+    <ItemGroup>
+        <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+            <_Parameter1>Sekiban.Dcb.WithResult.Tests</_Parameter1>
+        </AssemblyAttribute>
+    </ItemGroup>
+
 </Project>

--- a/dcb/src/Sekiban.Dcb.CosmosDb/Tags/CosmosContainerTagRowStore.cs
+++ b/dcb/src/Sekiban.Dcb.CosmosDb/Tags/CosmosContainerTagRowStore.cs
@@ -1,0 +1,92 @@
+using Microsoft.Azure.Cosmos;
+using Sekiban.Dcb.CosmosDb.Models;
+using System.Net;
+namespace Sekiban.Dcb.CosmosDb.Tags;
+
+/// <summary>
+///     The production <see cref="ICosmosTagRowStore" />: the tag-write stage's operations against a real
+///     Cosmos tags container.
+/// </summary>
+internal sealed class CosmosContainerTagRowStore : ICosmosTagRowStore
+{
+    private readonly Container _container;
+
+    public CosmosContainerTagRowStore(Container container) => _container = container;
+
+    public async Task<CosmosTagBatchOutcome> CreateBatchAsync(string partitionKey, IReadOnlyList<CosmosTag> rows)
+    {
+        var batch = _container.CreateTransactionalBatch(new PartitionKey(partitionKey));
+        foreach (var row in rows)
+        {
+            batch.CreateItem(row);
+        }
+
+        using var response = await batch.ExecuteAsync().ConfigureAwait(false);
+        if (response.IsSuccessStatusCode)
+        {
+            return CosmosTagBatchOutcome.Created;
+        }
+
+        // A batch is all-or-nothing: a row that already exists fails the whole batch and creates nothing.
+        // That is the re-execution path, not an error — the caller settles the chunk row by row.
+        if (ContainsConflict(response))
+        {
+            return CosmosTagBatchOutcome.Conflict;
+        }
+
+        throw new CosmosException(
+            $"TransactionalBatch failed for tag partition '{partitionKey}' with status {response.StatusCode}",
+            response.StatusCode,
+            (int)response.StatusCode,
+            response.ActivityId,
+            response.RequestCharge);
+    }
+
+    public async Task<bool> TryCreateRowAsync(string partitionKey, CosmosTag row)
+    {
+        try
+        {
+            await _container.CreateItemAsync(row, new PartitionKey(partitionKey)).ConfigureAwait(false);
+            return true;
+        }
+        catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.Conflict)
+        {
+            return false;
+        }
+    }
+
+    public async Task<CosmosTag?> TryReadRowAsync(string partitionKey, string id)
+    {
+        try
+        {
+            var response = await _container
+                .ReadItemAsync<CosmosTag>(id, new PartitionKey(partitionKey))
+                .ConfigureAwait(false);
+            return response.Resource;
+        }
+        catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
+        {
+            return null;
+        }
+    }
+
+    private static bool ContainsConflict(TransactionalBatchResponse response)
+    {
+        if (response.StatusCode == HttpStatusCode.Conflict)
+        {
+            return true;
+        }
+
+        // When one operation conflicts, the batch reports 424 Failed Dependency for the others, so the
+        // conflict has to be found among the per-operation results.
+        for (var i = 0; i < response.Count; i++)
+        {
+            if (response[i].StatusCode == HttpStatusCode.Conflict)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/dcb/src/Sekiban.Dcb.CosmosDb/Tags/CosmosTagIdentity.cs
+++ b/dcb/src/Sekiban.Dcb.CosmosDb/Tags/CosmosTagIdentity.cs
@@ -1,0 +1,139 @@
+using Sekiban.Dcb.Common;
+using Sekiban.Dcb.CosmosDb.Models;
+namespace Sekiban.Dcb.CosmosDb.Tags;
+
+/// <summary>
+///     Deterministic derivation rule for Cosmos tag rows.
+///     A tag row is a projection of an (event, tag) pair: given the event document — which carries the
+///     complete <c>tags</c> array — and one tag from it, every field of the tag row is fully derivable.
+///     Re-deriving a row for the same (event, tag) pair always yields the same document id, partition key,
+///     and content, which is what makes the tag-write stage safely re-executable and the tags container a
+///     rebuildable index over the events container.
+///     Derivation rule (v1):
+///     <list type="bullet">
+///         <item>
+///             <description><c>pk</c> = <c>{serviceId}|{tag}</c></description>
+///         </item>
+///         <item>
+///             <description>
+///                 <c>id</c> = the event id. A tag row is unique per (service, tag, event), and the
+///                 partition key already pins service and tag, so the event id alone is a unique — and
+///                 trivially re-derivable — document id inside that partition.
+///             </description>
+///         </item>
+///         <item>
+///             <description>
+///                 <c>tagGroup</c> = the segment before the first <c>:</c> of the tag, or the whole tag
+///                 when it has no <c>:</c>.
+///             </description>
+///         </item>
+///         <item>
+///             <description>
+///                 <c>createdAt</c> = the timestamp encoded in the event's SortableUniqueId (UTC). It is
+///                 derived from the event rather than read from the wall clock so that re-execution
+///                 produces byte-identical content.
+///             </description>
+///         </item>
+///     </list>
+/// </summary>
+public static class CosmosTagIdentity
+{
+    /// <summary>
+    ///     Derives the partition key of the tag row for a (service, tag) pair.
+    /// </summary>
+    public static string DerivePartitionKey(string serviceId, string tag) => $"{serviceId}|{tag}";
+
+    /// <summary>
+    ///     Derives the document id of the tag row for an (event, tag) pair.
+    /// </summary>
+    public static string DeriveId(Guid eventId) => eventId.ToString();
+
+    /// <summary>
+    ///     Derives the tag group of a tag string.
+    /// </summary>
+    public static string DeriveTagGroup(string tag)
+    {
+        ArgumentNullException.ThrowIfNull(tag);
+        return tag.Contains(':', StringComparison.Ordinal) ? tag.Split(':')[0] : tag;
+    }
+
+    /// <summary>
+    ///     Derives the creation timestamp of the tag row from the event's SortableUniqueId.
+    /// </summary>
+    public static DateTime DeriveCreatedAt(string sortableUniqueId)
+    {
+        ArgumentNullException.ThrowIfNull(sortableUniqueId);
+        return DateTime.SpecifyKind(new SortableUniqueId(sortableUniqueId).GetDateTime(), DateTimeKind.Utc);
+    }
+
+    /// <summary>
+    ///     Derives the complete tag row for an (event, tag) pair.
+    /// </summary>
+    public static CosmosTag DeriveRow(
+        string serviceId,
+        string tag,
+        Guid eventId,
+        string sortableUniqueId,
+        string eventType)
+    {
+        ArgumentNullException.ThrowIfNull(serviceId);
+        ArgumentNullException.ThrowIfNull(tag);
+        ArgumentNullException.ThrowIfNull(sortableUniqueId);
+        ArgumentNullException.ThrowIfNull(eventType);
+
+        return new CosmosTag
+        {
+            Pk = DerivePartitionKey(serviceId, tag),
+            ServiceId = serviceId,
+            Id = DeriveId(eventId),
+            Tag = tag,
+            TagGroup = DeriveTagGroup(tag),
+            EventType = eventType,
+            SortableUniqueId = sortableUniqueId,
+            EventId = eventId.ToString(),
+            CreatedAt = DeriveCreatedAt(sortableUniqueId)
+        };
+    }
+
+    /// <summary>
+    ///     Compares two tag rows by their derived content, ignoring Cosmos-managed fields such as
+    ///     <c>_etag</c> and <c>_ts</c>. Timestamps are normalized to UTC before comparison so that a
+    ///     serializer round-trip which changes only <see cref="DateTimeKind" /> is not reported as a mismatch.
+    ///     Used to decide whether an already-existing tag row is the row we intended to write (idempotent
+    ///     re-execution) or a different row occupying the same identity (index corruption).
+    /// </summary>
+    public static bool ContentEquals(CosmosTag left, CosmosTag right)
+    {
+        ArgumentNullException.ThrowIfNull(left);
+        ArgumentNullException.ThrowIfNull(right);
+
+        return string.Equals(left.Pk, right.Pk, StringComparison.Ordinal) &&
+            string.Equals(left.ServiceId, right.ServiceId, StringComparison.Ordinal) &&
+            string.Equals(left.Id, right.Id, StringComparison.Ordinal) &&
+            string.Equals(left.Tag, right.Tag, StringComparison.Ordinal) &&
+            string.Equals(left.TagGroup, right.TagGroup, StringComparison.Ordinal) &&
+            string.Equals(left.EventType, right.EventType, StringComparison.Ordinal) &&
+            string.Equals(left.SortableUniqueId, right.SortableUniqueId, StringComparison.Ordinal) &&
+            string.Equals(left.EventId, right.EventId, StringComparison.Ordinal) &&
+            NormalizeToUtc(left.CreatedAt) == NormalizeToUtc(right.CreatedAt);
+    }
+
+    /// <summary>
+    ///     Describes the content of a tag row for diagnostics. Used in corruption error messages.
+    /// </summary>
+    public static string Describe(CosmosTag row)
+    {
+        ArgumentNullException.ThrowIfNull(row);
+        return $"pk={row.Pk}, id={row.Id}, tag={row.Tag}, tagGroup={row.TagGroup}, eventId={row.EventId}, " +
+            $"eventType={row.EventType}, sortableUniqueId={row.SortableUniqueId}, " +
+            $"createdAt={NormalizeToUtc(row.CreatedAt):O}";
+    }
+
+    private static DateTime NormalizeToUtc(DateTime value) =>
+        value.Kind switch
+        {
+            DateTimeKind.Utc => value,
+            DateTimeKind.Local => value.ToUniversalTime(),
+            _ => DateTime.SpecifyKind(value, DateTimeKind.Utc)
+        };
+}

--- a/dcb/src/Sekiban.Dcb.CosmosDb/Tags/CosmosTagIndexCorruptionException.cs
+++ b/dcb/src/Sekiban.Dcb.CosmosDb/Tags/CosmosTagIndexCorruptionException.cs
@@ -1,0 +1,90 @@
+namespace Sekiban.Dcb.CosmosDb.Tags;
+
+/// <summary>
+///     Raised when a tag row already exists at the identity a write derives for an (event, tag) pair, but
+///     its content differs from what that pair derives. Because a tag row is a pure projection of the event
+///     document (see <see cref="CosmosTagIdentity" />), this can only mean the tags container disagrees with
+///     the events container — the index is corrupt, or something outside Sekiban wrote to it.
+///     This exception is NOT retryable. Re-executing the write will derive exactly the same content and hit
+///     exactly the same mismatch, so retry/backoff logic will spin without making progress. Consumers with
+///     broad catch-and-retry policies should treat it as terminal, surface it, and repair the index rather
+///     than retry. The write never silently overwrites the existing row.
+/// </summary>
+public class CosmosTagIndexCorruptionException : Exception
+{
+    /// <summary>
+    ///     Creates a corruption exception.
+    /// </summary>
+    public CosmosTagIndexCorruptionException()
+    {
+    }
+
+    /// <summary>
+    ///     Creates a corruption exception with a message.
+    /// </summary>
+    public CosmosTagIndexCorruptionException(string message) : base(message)
+    {
+    }
+
+    /// <summary>
+    ///     Creates a corruption exception with a message and inner exception.
+    /// </summary>
+    public CosmosTagIndexCorruptionException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+
+    /// <summary>
+    ///     Creates a corruption exception describing the conflicting tag row.
+    /// </summary>
+    public CosmosTagIndexCorruptionException(
+        string serviceId,
+        string tag,
+        string partitionKey,
+        string documentId,
+        string expectedContent,
+        string actualContent)
+        : base(
+            $"Tag index corruption detected for service '{serviceId}', tag '{tag}'. " +
+            $"An existing tag row at pk='{partitionKey}', id='{documentId}' does not match the row derived " +
+            $"from the event. The existing row was left untouched. This is not retryable — the same content " +
+            $"is derived on every attempt. Expected: [{expectedContent}]. Actual: [{actualContent}].")
+    {
+        ServiceId = serviceId;
+        Tag = tag;
+        PartitionKey = partitionKey;
+        DocumentId = documentId;
+        ExpectedContent = expectedContent;
+        ActualContent = actualContent;
+    }
+
+    /// <summary>
+    ///     Service id the write was scoped to.
+    /// </summary>
+    public string? ServiceId { get; }
+
+    /// <summary>
+    ///     Tag whose row conflicts.
+    /// </summary>
+    public string? Tag { get; }
+
+    /// <summary>
+    ///     Partition key of the conflicting tag row.
+    /// </summary>
+    public string? PartitionKey { get; }
+
+    /// <summary>
+    ///     Document id of the conflicting tag row.
+    /// </summary>
+    public string? DocumentId { get; }
+
+    /// <summary>
+    ///     Content derived from the event for this (event, tag) pair.
+    /// </summary>
+    public string? ExpectedContent { get; }
+
+    /// <summary>
+    ///     Content of the tag row currently stored.
+    /// </summary>
+    public string? ActualContent { get; }
+}

--- a/dcb/src/Sekiban.Dcb.CosmosDb/Tags/CosmosTagWriteStage.cs
+++ b/dcb/src/Sekiban.Dcb.CosmosDb/Tags/CosmosTagWriteStage.cs
@@ -1,0 +1,143 @@
+using Sekiban.Dcb.CosmosDb.Models;
+using Sekiban.Dcb.Tags;
+namespace Sekiban.Dcb.CosmosDb.Tags;
+
+/// <summary>
+///     One (event, tag) pair to index, reduced to the fields a tag row derives from.
+///     Both the typed and the pre-serialized write paths project onto this.
+/// </summary>
+internal readonly record struct CosmosTagRowSource(
+    string Tag,
+    Guid EventId,
+    string SortableUniqueId,
+    string EventType);
+
+/// <summary>
+///     Writes tag rows idempotently.
+///     Rows are derived deterministically (see <see cref="CosmosTagIdentity" />), so re-executing this stage
+///     for the same events is always safe: a row that already exists with the derived content counts as
+///     success, and no row is ever overwritten. A row that exists with different content means the tags
+///     container disagrees with the events container, which surfaces as
+///     <see cref="CosmosTagIndexCorruptionException" /> rather than being papered over with an upsert.
+///     This is the primitive that roll-forward retry and tag-index repair build on.
+/// </summary>
+internal static class CosmosTagWriteStage
+{
+    public static async Task<List<TagWriteResult>> WriteAsync(
+        IReadOnlyList<CosmosTagRowSource> sources,
+        ICosmosTagRowStore store,
+        CosmosDbEventStoreOptions options,
+        string serviceId,
+        ICosmosTagWriteFaultInjector? faultInjector = null)
+    {
+        var results = new List<TagWriteResult>();
+        if (sources.Count == 0)
+        {
+            return results;
+        }
+
+        var maxBatchOperations = options.MaxBatchOperations > 0 ? options.MaxBatchOperations : 1;
+        var batchIndex = 0;
+
+        // An (event, tag) pair maps to exactly one row, so a tag repeated within one event is one row, not two.
+        var partitions = sources
+            .Distinct()
+            .GroupBy(source => CosmosTagIdentity.DerivePartitionKey(serviceId, source.Tag));
+
+        foreach (var partition in partitions)
+        {
+            var partitionKey = partition.Key;
+            var rows = partition
+                .Select(source => CosmosTagIdentity.DeriveRow(
+                    serviceId,
+                    source.Tag,
+                    source.EventId,
+                    source.SortableUniqueId,
+                    source.EventType))
+                .ToList();
+
+            for (var offset = 0; offset < rows.Count; offset += maxBatchOperations)
+            {
+                var chunk = rows.Skip(offset).Take(maxBatchOperations).ToList();
+
+                if (faultInjector != null)
+                {
+                    await faultInjector.OnBeforeBatchAsync(batchIndex, partitionKey, chunk).ConfigureAwait(false);
+                }
+
+                batchIndex++;
+
+                var created = false;
+                if (options.UseTransactionalBatchForTags)
+                {
+                    var outcome = await store.CreateBatchAsync(partitionKey, chunk).ConfigureAwait(false);
+                    created = outcome == CosmosTagBatchOutcome.Created;
+                }
+
+                // A conflicting batch creates nothing (it is all-or-nothing), so settle the chunk row by row.
+                if (!created)
+                {
+                    foreach (var row in chunk)
+                    {
+                        await EnsureRowAsync(store, partitionKey, row, serviceId).ConfigureAwait(false);
+                    }
+                }
+
+                foreach (var row in chunk)
+                {
+                    results.Add(new TagWriteResult(row.Tag, 1, DateTimeOffset.UtcNow));
+                }
+            }
+        }
+
+        return results;
+    }
+
+    /// <summary>
+    ///     Ensures a single row exists with exactly the derived content — creating it, accepting an identical
+    ///     existing row, or reporting corruption. Never overwrites.
+    /// </summary>
+    private static async Task EnsureRowAsync(
+        ICosmosTagRowStore store,
+        string partitionKey,
+        CosmosTag row,
+        string serviceId)
+    {
+        if (await store.TryCreateRowAsync(partitionKey, row).ConfigureAwait(false))
+        {
+            return;
+        }
+
+        var existing = await store.TryReadRowAsync(partitionKey, row.Id).ConfigureAwait(false);
+        if (existing == null)
+        {
+            // Created and then removed between our create and our read: one more create settles it.
+            if (await store.TryCreateRowAsync(partitionKey, row).ConfigureAwait(false))
+            {
+                return;
+            }
+
+            existing = await store.TryReadRowAsync(partitionKey, row.Id).ConfigureAwait(false);
+            if (existing == null)
+            {
+                throw new InvalidOperationException(
+                    $"Tag row pk='{partitionKey}', id='{row.Id}' could neither be created nor read back. " +
+                    "The tags container is being modified concurrently by another writer.");
+            }
+        }
+
+        if (CosmosTagIdentity.ContentEquals(row, existing))
+        {
+            // Already indexed by an earlier attempt of this same write — idempotent success.
+            return;
+        }
+
+        throw new CosmosTagIndexCorruptionException(
+            serviceId,
+            row.Tag,
+            partitionKey,
+            row.Id,
+            CosmosTagIdentity.Describe(row),
+            CosmosTagIdentity.Describe(existing));
+    }
+}

--- a/dcb/src/Sekiban.Dcb.CosmosDb/Tags/ICosmosTagRowStore.cs
+++ b/dcb/src/Sekiban.Dcb.CosmosDb/Tags/ICosmosTagRowStore.cs
@@ -1,0 +1,52 @@
+using Sekiban.Dcb.CosmosDb.Models;
+namespace Sekiban.Dcb.CosmosDb.Tags;
+
+/// <summary>
+///     Result of attempting to create a batch of tag rows in one partition.
+/// </summary>
+internal enum CosmosTagBatchOutcome
+{
+    /// <summary>All rows in the batch were created.</summary>
+    Created,
+
+    /// <summary>At least one row already existed, so the (all-or-nothing) batch created none of them.</summary>
+    Conflict
+}
+
+/// <summary>
+///     The storage operations the tag-write stage needs, narrowed to a seam.
+///     The production implementation talks to a Cosmos <c>Container</c>; tests substitute an in-memory
+///     implementation so the stage's idempotency and corruption-detection logic can be exercised
+///     deterministically — including failing after a given number of batches — without a Cosmos endpoint.
+/// </summary>
+internal interface ICosmosTagRowStore
+{
+    /// <summary>
+    ///     Creates every row of one partition in a single all-or-nothing batch.
+    ///     Returns <see cref="CosmosTagBatchOutcome.Conflict" /> if any row already exists.
+    /// </summary>
+    Task<CosmosTagBatchOutcome> CreateBatchAsync(string partitionKey, IReadOnlyList<CosmosTag> rows);
+
+    /// <summary>
+    ///     Creates a single row. Returns false if a row already exists at that identity.
+    /// </summary>
+    Task<bool> TryCreateRowAsync(string partitionKey, CosmosTag row);
+
+    /// <summary>
+    ///     Reads a single row, or null when it does not exist.
+    /// </summary>
+    Task<CosmosTag?> TryReadRowAsync(string partitionKey, string id);
+}
+
+/// <summary>
+///     Deterministic fault-injection hook for the tag-write stage. Called once before each batch is sent,
+///     with the zero-based index of that batch, so a test can fail the stage after exactly N batches
+///     without relying on timing. Never registered in production.
+/// </summary>
+internal interface ICosmosTagWriteFaultInjector
+{
+    /// <summary>
+    ///     Called before batch <paramref name="batchIndex" /> is written. Throw to fail the stage there.
+    /// </summary>
+    Task OnBeforeBatchAsync(int batchIndex, string partitionKey, IReadOnlyList<CosmosTag> rows);
+}

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/CosmosTagWriteStageTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/CosmosTagWriteStageTests.cs
@@ -1,0 +1,306 @@
+using Sekiban.Dcb.Common;
+using Sekiban.Dcb.CosmosDb;
+using Sekiban.Dcb.CosmosDb.Models;
+using Sekiban.Dcb.CosmosDb.Tags;
+
+namespace Sekiban.Dcb.Tests;
+
+/// <summary>
+///     Covers the Cosmos tag-write stage: deterministic row identity, idempotent re-execution,
+///     convergence after a partial write, and detection of a corrupt tag index.
+/// </summary>
+public class CosmosTagWriteStageTests
+{
+    private const string ServiceId = "svc";
+
+    /// <summary>
+    ///     In-memory stand-in for the tags container. Batches are all-or-nothing, and a create against an
+    ///     existing identity conflicts, exactly as Cosmos behaves.
+    /// </summary>
+    private sealed class FakeTagRowStore : ICosmosTagRowStore
+    {
+        private readonly Dictionary<(string PartitionKey, string Id), CosmosTag> _rows = new();
+
+        public int BatchAttempts { get; private set; }
+        public int RowCreateAttempts { get; private set; }
+        public IReadOnlyCollection<CosmosTag> Rows => _rows.Values;
+
+        public void Seed(CosmosTag row) => _rows[(row.Pk, row.Id)] = row;
+
+        public Task<CosmosTagBatchOutcome> CreateBatchAsync(string partitionKey, IReadOnlyList<CosmosTag> rows)
+        {
+            BatchAttempts++;
+
+            if (rows.Any(row => _rows.ContainsKey((partitionKey, row.Id))))
+            {
+                return Task.FromResult(CosmosTagBatchOutcome.Conflict);
+            }
+
+            foreach (var row in rows)
+            {
+                _rows[(partitionKey, row.Id)] = row;
+            }
+
+            return Task.FromResult(CosmosTagBatchOutcome.Created);
+        }
+
+        public Task<bool> TryCreateRowAsync(string partitionKey, CosmosTag row)
+        {
+            RowCreateAttempts++;
+
+            if (_rows.ContainsKey((partitionKey, row.Id)))
+            {
+                return Task.FromResult(false);
+            }
+
+            _rows[(partitionKey, row.Id)] = row;
+            return Task.FromResult(true);
+        }
+
+        public Task<CosmosTag?> TryReadRowAsync(string partitionKey, string id) =>
+            Task.FromResult(_rows.GetValueOrDefault((partitionKey, id)));
+    }
+
+    /// <summary>
+    ///     Fails the stage before batch number <c>failBeforeBatchIndex</c> — deterministic, no timing.
+    /// </summary>
+    private sealed class FailBeforeBatchFaultInjector : ICosmosTagWriteFaultInjector
+    {
+        private readonly int _failBeforeBatchIndex;
+
+        public FailBeforeBatchFaultInjector(int failBeforeBatchIndex) => _failBeforeBatchIndex = failBeforeBatchIndex;
+
+        public Task OnBeforeBatchAsync(int batchIndex, string partitionKey, IReadOnlyList<CosmosTag> rows)
+        {
+            if (batchIndex >= _failBeforeBatchIndex)
+            {
+                throw new InvalidOperationException($"Injected tag-write failure at batch {batchIndex}");
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+
+    private static CosmosTagRowSource Source(string tag, Guid eventId, string sortableUniqueId) =>
+        new(tag, eventId, sortableUniqueId, "TestEvent");
+
+    private static string NewSortableUniqueId() => SortableUniqueId.GenerateNew();
+
+    private static Task<List<Sekiban.Dcb.Tags.TagWriteResult>> WriteAsync(
+        IReadOnlyList<CosmosTagRowSource> sources,
+        ICosmosTagRowStore store,
+        CosmosDbEventStoreOptions? options = null,
+        ICosmosTagWriteFaultInjector? faultInjector = null) =>
+        CosmosTagWriteStage.WriteAsync(
+            sources,
+            store,
+            options ?? new CosmosDbEventStoreOptions(),
+            ServiceId,
+            faultInjector);
+
+    [Fact]
+    public void DeriveRow_Should_Be_Deterministic_For_The_Same_Event_And_Tag()
+    {
+        var eventId = Guid.NewGuid();
+        var sortableUniqueId = NewSortableUniqueId();
+
+        var first = CosmosTagIdentity.DeriveRow(ServiceId, "Student:1", eventId, sortableUniqueId, "TestEvent");
+        var second = CosmosTagIdentity.DeriveRow(ServiceId, "Student:1", eventId, sortableUniqueId, "TestEvent");
+
+        Assert.Equal(first.Id, second.Id);
+        Assert.Equal(first.Pk, second.Pk);
+        Assert.True(CosmosTagIdentity.ContentEquals(first, second));
+
+        Assert.Equal(eventId.ToString(), first.Id);
+        Assert.Equal($"{ServiceId}|Student:1", first.Pk);
+        Assert.Equal("Student", first.TagGroup);
+        Assert.Equal(new SortableUniqueId(sortableUniqueId).GetDateTime(), first.CreatedAt);
+    }
+
+    [Fact]
+    public void DeriveRow_Should_Distinguish_Different_Events_And_Tags()
+    {
+        var sortableUniqueId = NewSortableUniqueId();
+        var eventA = Guid.NewGuid();
+        var eventB = Guid.NewGuid();
+
+        var rowA = CosmosTagIdentity.DeriveRow(ServiceId, "Student:1", eventA, sortableUniqueId, "TestEvent");
+        var rowB = CosmosTagIdentity.DeriveRow(ServiceId, "Student:1", eventB, sortableUniqueId, "TestEvent");
+        var rowC = CosmosTagIdentity.DeriveRow(ServiceId, "Student:2", eventA, sortableUniqueId, "TestEvent");
+
+        Assert.NotEqual(rowA.Id, rowB.Id);
+        Assert.Equal(rowA.Pk, rowB.Pk);
+        Assert.Equal(rowA.Id, rowC.Id);
+        Assert.NotEqual(rowA.Pk, rowC.Pk);
+    }
+
+    [Fact]
+    public async Task Re_Executing_A_Completed_Write_Should_Not_Duplicate_Rows()
+    {
+        var store = new FakeTagRowStore();
+        var sources = new[]
+        {
+            Source("Student:1", Guid.NewGuid(), NewSortableUniqueId()),
+            Source("Student:2", Guid.NewGuid(), NewSortableUniqueId())
+        };
+
+        var first = await WriteAsync(sources, store);
+        var second = await WriteAsync(sources, store);
+
+        Assert.Equal(2, first.Count);
+        Assert.Equal(2, second.Count);
+        Assert.Equal(2, store.Rows.Count);
+    }
+
+    [Fact]
+    public async Task Re_Execution_After_A_Partial_Write_Should_Converge()
+    {
+        var store = new FakeTagRowStore();
+        var sources = new[]
+        {
+            Source("Student:1", Guid.NewGuid(), NewSortableUniqueId()),
+            Source("Student:2", Guid.NewGuid(), NewSortableUniqueId()),
+            Source("Student:3", Guid.NewGuid(), NewSortableUniqueId())
+        };
+
+        // Each tag is its own partition, so each is its own batch: fail once two have been written.
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => WriteAsync(sources, store, faultInjector: new FailBeforeBatchFaultInjector(2)));
+
+        Assert.Equal(2, store.Rows.Count);
+
+        var replay = await WriteAsync(sources, store);
+
+        Assert.Equal(3, replay.Count);
+        Assert.Equal(3, store.Rows.Count);
+        Assert.Equal(
+            sources.Select(source => source.EventId.ToString()).OrderBy(id => id, StringComparer.Ordinal),
+            store.Rows.Select(row => row.Id).OrderBy(id => id, StringComparer.Ordinal));
+    }
+
+    [Fact]
+    public async Task Existing_Row_With_Different_Content_Should_Raise_Corruption_And_Not_Overwrite()
+    {
+        var store = new FakeTagRowStore();
+        var eventId = Guid.NewGuid();
+        var sortableUniqueId = NewSortableUniqueId();
+
+        var corrupt = CosmosTagIdentity.DeriveRow(ServiceId, "Student:1", eventId, sortableUniqueId, "TestEvent");
+        corrupt.EventType = "SomethingElse";
+        store.Seed(corrupt);
+
+        var exception = await Assert.ThrowsAsync<CosmosTagIndexCorruptionException>(
+            () => WriteAsync(new[] { Source("Student:1", eventId, sortableUniqueId) }, store));
+
+        Assert.Equal(ServiceId, exception.ServiceId);
+        Assert.Equal("Student:1", exception.Tag);
+        Assert.Equal($"{ServiceId}|Student:1", exception.PartitionKey);
+        Assert.Equal(eventId.ToString(), exception.DocumentId);
+
+        // The existing row is left exactly as it was — never silently overwritten.
+        var stored = Assert.Single(store.Rows);
+        Assert.Equal("SomethingElse", stored.EventType);
+    }
+
+    [Fact]
+    public async Task Identical_Existing_Row_Should_Count_As_Success()
+    {
+        var store = new FakeTagRowStore();
+        var eventId = Guid.NewGuid();
+        var sortableUniqueId = NewSortableUniqueId();
+
+        store.Seed(CosmosTagIdentity.DeriveRow(ServiceId, "Student:1", eventId, sortableUniqueId, "TestEvent"));
+
+        var results = await WriteAsync(new[] { Source("Student:1", eventId, sortableUniqueId) }, store);
+
+        Assert.Single(results);
+        Assert.Single(store.Rows);
+    }
+
+    [Fact]
+    public async Task A_Tag_Repeated_Within_One_Event_Should_Produce_One_Row()
+    {
+        var store = new FakeTagRowStore();
+        var eventId = Guid.NewGuid();
+        var sortableUniqueId = NewSortableUniqueId();
+
+        var results = await WriteAsync(
+            new[]
+            {
+                Source("Student:1", eventId, sortableUniqueId),
+                Source("Student:1", eventId, sortableUniqueId)
+            },
+            store);
+
+        Assert.Single(results);
+        Assert.Single(store.Rows);
+    }
+
+    [Fact]
+    public async Task Rows_Beyond_MaxBatchOperations_Should_Be_Chunked_And_Stay_Idempotent()
+    {
+        var store = new FakeTagRowStore();
+        var options = new CosmosDbEventStoreOptions { MaxBatchOperations = 2 };
+        var sortableUniqueId = NewSortableUniqueId();
+
+        // One partition (one tag), five rows -> three batches of at most two.
+        var sources = Enumerable
+            .Range(0, 5)
+            .Select(_ => Source("Student:1", Guid.NewGuid(), sortableUniqueId))
+            .ToList();
+
+        var first = await WriteAsync(sources, store, options);
+        Assert.Equal(5, first.Count);
+        Assert.Equal(5, store.Rows.Count);
+        Assert.Equal(3, store.BatchAttempts);
+
+        var second = await WriteAsync(sources, store, options);
+        Assert.Equal(5, second.Count);
+        Assert.Equal(5, store.Rows.Count);
+    }
+
+    [Fact]
+    public async Task Writes_Should_Stay_Idempotent_Without_TransactionalBatch()
+    {
+        var store = new FakeTagRowStore();
+        var options = new CosmosDbEventStoreOptions { UseTransactionalBatchForTags = false };
+        var sources = new[]
+        {
+            Source("Student:1", Guid.NewGuid(), NewSortableUniqueId()),
+            Source("Student:2", Guid.NewGuid(), NewSortableUniqueId())
+        };
+
+        await WriteAsync(sources, store, options);
+        await WriteAsync(sources, store, options);
+
+        Assert.Equal(0, store.BatchAttempts);
+        Assert.Equal(2, store.Rows.Count);
+    }
+
+    [Fact]
+    public async Task A_Conflicting_Batch_Should_Settle_Row_By_Row()
+    {
+        var store = new FakeTagRowStore();
+        var options = new CosmosDbEventStoreOptions { MaxBatchOperations = 10 };
+        var sortableUniqueId = NewSortableUniqueId();
+        var existing = Guid.NewGuid();
+        var missing = Guid.NewGuid();
+
+        // The state a crash between batches leaves behind: one row of the partition present, one absent.
+        store.Seed(CosmosTagIdentity.DeriveRow(ServiceId, "Student:1", existing, sortableUniqueId, "TestEvent"));
+
+        var results = await WriteAsync(
+            new[]
+            {
+                Source("Student:1", existing, sortableUniqueId),
+                Source("Student:1", missing, sortableUniqueId)
+            },
+            store,
+            options);
+
+        Assert.Equal(2, results.Count);
+        Assert.Equal(2, store.Rows.Count);
+        Assert.Equal(1, store.BatchAttempts);
+        Assert.Equal(2, store.RowCreateAttempts);
+    }
+}


### PR DESCRIPTION
## Summary

Makes the Cosmos tag-write stage a deterministic, idempotent primitive with corruption detection, plus a fault-injection seam and tests — the prerequisite for roll-forward retry and tag-index repair (#1046).

Closes #1049

## Root cause found

The issue described re-execution failing with 409 Conflict. The actual behavior was **worse**: `CosmosTag.FromEventTag` derived `id` with `Guid.NewGuid()` and `createdAt` with `DateTime.UtcNow`, so a re-executed tag write did **not** conflict — it silently created **duplicate tag rows** for the same (event, tag) pair. Either way the remedy is the same: a deterministic identity. Fixing it removes the duplicate-row failure mode as well.

## Tag row identity derivation rule (v1) — for the repair API slice

Reported here so the repair/sweep slice derives rows identically. A tag row is a pure projection of an (event, tag) pair; the event document carries the complete `tags` array, so every field is derivable from the events container alone. Implemented in `Tags/CosmosTagIdentity.cs`:

| Field | Derivation |
|---|---|
| `pk` | `{serviceId}\|{tag}` |
| `id` | the **event id**. The partition key already pins service and tag, so the event id alone is unique — and trivially re-derivable — within that partition |
| `tag` | the tag |
| `tagGroup` | segment before the first `:`, or the whole tag when it has none |
| `eventId` | the event id |
| `eventType` | event type name |
| `sortableUniqueId` | the event's SortableUniqueId |
| `createdAt` | the timestamp **encoded in the event's SortableUniqueId** (UTC) — derived from the event, not the wall clock, so re-execution produces identical content |

An (event, tag) pair maps to exactly one row, so a tag repeated within one event yields one row, not two.

## Idempotency and corruption

- Rows are created, never blind-upserted.
- A `TransactionalBatch` is all-or-nothing, so a conflicting batch creates nothing; the chunk is then settled row by row.
- Existing row with **identical** derived content → idempotent success.
- Existing row with **differing** content → `CosmosTagIndexCorruptionException` (additive; documented as **non-retryable** — the same content is derived on every attempt, so retry/backoff logic would spin without progress). The existing row is never overwritten.

## Compatibility

- No public constructor or options signature changed (`CosmosDbEventStore`, `CosmosDbEventStoreOptions` construct exactly as before — downstream repos construct these directly).
- `CosmosTag.FromEventTag` keeps its signature; the `tagGroup` argument is now derived from the tag so it cannot drift.
- The fault-injection seam (`ICosmosTagRowStore`, `ICosmosTagWriteFaultInjector`, `CosmosDbEventStore.TagWriteFaultInjector`) is `internal`, exposed to tests via `InternalsVisibleTo`. It is always null in production and unreachable from public construction paths.
- New public surface is additive only: `CosmosTagIdentity`, `CosmosTagIndexCorruptionException`.
- Two-phase write design unchanged; retry policy / repair API remain follow-up slices.

**Note for reviewers:** rows written by earlier versions carry random ids. A re-execution over such rows derives the new id and creates a row alongside the legacy one rather than matching it. That only matters once roll-forward retry (a later slice) is enabled over pre-existing data, and is worth folding into the repair-slice design.

## Test plan

- [x] 10 new tests in `dcb/tests/Sekiban.Dcb.WithResult.Tests/CosmosTagWriteStageTests.cs`: identity determinism, distinct events/tags, no duplicates on re-execution, convergence after a fault-injected partial write, corruption detected and not overwritten, identical row counts as success, repeated tag → one row, chunking beyond `MaxBatchOperations`, idempotency without TransactionalBatch, conflicting batch settles row-by-row
- [x] `Sekiban.Dcb.WithResult.Tests` 503 passed / 0 failed
- [x] `Sekiban.Dcb.WithoutResult.Tests` 30 passed, `Sekiban.Dcb.Orleans.Tests` 80 passed / 1 skipped — no regressions
- [x] `DcbOrleans.ApiService` (downstream Cosmos consumer) builds
- [x] `git diff --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017KAPyZPCMZzurEZTt1k8LX