### PR TITLE
Add a non-destructive Cosmos tag index repair service

### DIFF
--- a/dcb/src/Sekiban.Dcb.CosmosDb/Repair/CosmosContainerRepairStores.cs
+++ b/dcb/src/Sekiban.Dcb.CosmosDb/Repair/CosmosContainerRepairStores.cs
@@ -84,10 +84,10 @@ internal sealed class CosmosContainerRepairStore : ICosmosTagRepairStore
         int maxRows,
         CancellationToken cancellationToken)
     {
-        // Partition-confined and event-scoped: rows of other events carrying the same tag are never read.
-        var query = new QueryDefinition("SELECT * FROM c WHERE c.pk = @pk AND c.eventId = @eventId")
-            .WithParameter("@pk", partitionKey)
-            .WithParameter("@eventId", eventId.ToString());
+        // The query is a superset prefilter, confined to the tag's partition. It is NOT what decides which
+        // rows index this event — a row stored with a different Guid rendering must not be able to slip past
+        // the server and be mistaken for a missing row. See CosmosRepairRowQuery.
+        var query = CosmosRepairRowQuery.BuildCandidateQuery(partitionKey, eventId);
 
         var requestOptions = new QueryRequestOptions
         {
@@ -104,7 +104,10 @@ internal sealed class CosmosContainerRepairStore : ICosmosTagRepairStore
         {
             var response = await iterator.ReadNextAsync(cancellationToken).ConfigureAwait(false);
             requestCharge += response.RequestCharge;
-            rows.AddRange(response);
+
+            // The correctness gate: canonical Guid comparison, client-side. Format and casing cannot change
+            // the answer, and anything the prefilter over-returned is rejected here.
+            rows.AddRange(response.Where(row => CosmosRepairRowQuery.IsRowForEvent(row, eventId)));
         }
 
         if (rows.Count > maxRows)

--- a/dcb/src/Sekiban.Dcb.CosmosDb/Repair/CosmosContainerRepairStores.cs
+++ b/dcb/src/Sekiban.Dcb.CosmosDb/Repair/CosmosContainerRepairStores.cs
@@ -1,0 +1,153 @@
+using Microsoft.Azure.Cosmos;
+using Sekiban.Dcb.CosmosDb.Models;
+using System.Net;
+namespace Sekiban.Dcb.CosmosDb.Repair;
+
+/// <summary>
+///     The production events reader: a bounded, continuation-token-paged, cross-partition range scan over
+///     the events container, scoped to one service id.
+/// </summary>
+internal sealed class CosmosContainerRepairEventSource : ICosmosRepairEventSource
+{
+    private readonly Container _container;
+    private readonly string _serviceId;
+
+    public CosmosContainerRepairEventSource(Container container, string serviceId)
+    {
+        _container = container;
+        _serviceId = serviceId;
+    }
+
+    public async Task<CosmosRepairEventPage> ReadEventPageAsync(
+        string? fromSortableUniqueIdExclusive,
+        string? toSortableUniqueIdInclusive,
+        int pageSize,
+        string? continuationToken,
+        CancellationToken cancellationToken)
+    {
+        var sql = "SELECT * FROM c WHERE c.serviceId = @serviceId";
+        if (fromSortableUniqueIdExclusive != null)
+        {
+            sql += " AND c.sortableUniqueId > @from";
+        }
+
+        if (toSortableUniqueIdInclusive != null)
+        {
+            sql += " AND c.sortableUniqueId <= @to";
+        }
+
+        sql += " ORDER BY c.sortableUniqueId";
+
+        var query = new QueryDefinition(sql).WithParameter("@serviceId", _serviceId);
+        if (fromSortableUniqueIdExclusive != null)
+        {
+            query = query.WithParameter("@from", fromSortableUniqueIdExclusive);
+        }
+
+        if (toSortableUniqueIdInclusive != null)
+        {
+            query = query.WithParameter("@to", toSortableUniqueIdInclusive);
+        }
+
+        using var iterator = _container.GetItemQueryIterator<CosmosEvent>(
+            query,
+            continuationToken,
+            new QueryRequestOptions { MaxItemCount = pageSize });
+
+        if (!iterator.HasMoreResults)
+        {
+            return new CosmosRepairEventPage(Array.Empty<CosmosEvent>(), null, 0);
+        }
+
+        var response = await iterator.ReadNextAsync(cancellationToken).ConfigureAwait(false);
+        return new CosmosRepairEventPage(
+            response.ToList(),
+            response.ContinuationToken,
+            response.RequestCharge);
+    }
+}
+
+/// <summary>
+///     The production tag-row store for repair. Every lookup is confined to one tag partition, so a repair
+///     can only ever see the rows of the (service, tag) it is examining.
+///     Note there is no delete or replace here — the type cannot express a destructive operation.
+/// </summary>
+internal sealed class CosmosContainerRepairStore : ICosmosTagRepairStore
+{
+    private readonly Container _container;
+
+    public CosmosContainerRepairStore(Container container) => _container = container;
+
+    public async Task<CosmosRepairRowLookup> ReadRowsForEventAsync(
+        string partitionKey,
+        Guid eventId,
+        int maxRows,
+        CancellationToken cancellationToken)
+    {
+        // Partition-confined and event-scoped: rows of other events carrying the same tag are never read.
+        var query = new QueryDefinition("SELECT * FROM c WHERE c.pk = @pk AND c.eventId = @eventId")
+            .WithParameter("@pk", partitionKey)
+            .WithParameter("@eventId", eventId.ToString());
+
+        var requestOptions = new QueryRequestOptions
+        {
+            PartitionKey = new PartitionKey(partitionKey),
+            MaxItemCount = maxRows + 1 // one over the cap, so overflow is detectable
+        };
+
+        using var iterator = _container.GetItemQueryIterator<CosmosTag>(query, requestOptions: requestOptions);
+
+        var rows = new List<CosmosTag>();
+        var requestCharge = 0.0;
+
+        while (iterator.HasMoreResults && rows.Count <= maxRows)
+        {
+            var response = await iterator.ReadNextAsync(cancellationToken).ConfigureAwait(false);
+            requestCharge += response.RequestCharge;
+            rows.AddRange(response);
+        }
+
+        if (rows.Count > maxRows)
+        {
+            return new CosmosRepairRowLookup(rows.Take(maxRows).ToList(), true, requestCharge);
+        }
+
+        return new CosmosRepairRowLookup(rows, false, requestCharge);
+    }
+
+    public async Task<(bool Created, double RequestCharge)> TryCreateRowAsync(
+        string partitionKey,
+        CosmosTag row,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var response = await _container
+                .CreateItemAsync(row, new PartitionKey(partitionKey), cancellationToken: cancellationToken)
+                .ConfigureAwait(false);
+            return (true, response.RequestCharge);
+        }
+        catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.Conflict)
+        {
+            return (false, ex.RequestCharge);
+        }
+    }
+
+    public async Task<CosmosTag?> TryReadRowAsync(
+        string partitionKey,
+        string id,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var response = await _container
+                .ReadItemAsync<CosmosTag>(id, new PartitionKey(partitionKey), cancellationToken: cancellationToken)
+                .ConfigureAwait(false);
+            return response.Resource;
+        }
+        catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
+        {
+            return null;
+        }
+    }
+}

--- a/dcb/src/Sekiban.Dcb.CosmosDb/Repair/CosmosDbTagRepairService.cs
+++ b/dcb/src/Sekiban.Dcb.CosmosDb/Repair/CosmosDbTagRepairService.cs
@@ -265,8 +265,8 @@ public sealed class CosmosDbTagRepairService
                 case LegacyRowMatch.LegacyPresent:
                     legacyRows.Add(row);
                     break;
-                case LegacyRowMatch.NotOurKey:
                 default:
+                    // NotOurKey: the row indexes a different event. Ignore it.
                     break;
             }
         }
@@ -457,8 +457,8 @@ public sealed class CosmosDbTagRepairService
                     case CosmosTagRepairCategory.Overflow:
                         _overflow++;
                         break;
-                    case CosmosTagRepairCategory.Present:
                     default:
+                        // Present.
                         _present++;
                         break;
                 }

--- a/dcb/src/Sekiban.Dcb.CosmosDb/Repair/CosmosDbTagRepairService.cs
+++ b/dcb/src/Sekiban.Dcb.CosmosDb/Repair/CosmosDbTagRepairService.cs
@@ -1,0 +1,498 @@
+using Microsoft.Extensions.Logging;
+using Sekiban.Dcb.CosmosDb.Models;
+using Sekiban.Dcb.CosmosDb.Tags;
+namespace Sekiban.Dcb.CosmosDb.Repair;
+
+/// <summary>
+///     Administrative service that rebuilds missing tag rows from the events container.
+///     A crash between the two phases of a Cosmos write can leave a durable event with no tag rows: visible
+///     to all-events readers, invisible to tag-scoped reads, tag projectors, and the tag-consistent actor's
+///     concurrency baseline. Every event document carries its complete <c>tags</c> array, so the tags
+///     container is a derivable index — this service turns that fact into a recovery surface. It scans events
+///     over a sortableUniqueId range, derives the expected row for each (event, tag) pair with the same rule
+///     the write path uses (<see cref="CosmosTagIdentity" />), and creates the ones that are missing.
+///     It is deliberately NOT part of <c>IEventStore</c>: it is an operator tool, to be run as a job, not
+///     reachable from application request paths.
+///     STRICTLY NON-DESTRUCTIVE. It only ever creates rows that do not exist. It never deletes, rewrites, or
+///     canonicalizes a row — including the pre-SEK-G2 rows that sit at a random id, which it recognizes and
+///     leaves exactly where they are. Reducing those is a separately authorized concern (SEK-G4b) and is
+///     never invoked from here.
+///     One instance is bound to one (serviceId, events container, tags container) lineage, so repairing
+///     across lineages is structurally impossible rather than merely discouraged.
+/// </summary>
+public sealed class CosmosDbTagRepairService
+{
+    private readonly ICosmosRepairEventSource _eventSource;
+    private readonly ILogger<CosmosDbTagRepairService>? _logger;
+    private readonly string _serviceId;
+    private readonly ICosmosTagRepairStore _tagStore;
+
+    internal CosmosDbTagRepairService(
+        string serviceId,
+        ICosmosRepairEventSource eventSource,
+        ICosmosTagRepairStore tagStore,
+        ILogger<CosmosDbTagRepairService>? logger = null)
+    {
+        _serviceId = serviceId ?? throw new ArgumentNullException(nameof(serviceId));
+        _eventSource = eventSource ?? throw new ArgumentNullException(nameof(eventSource));
+        _tagStore = tagStore ?? throw new ArgumentNullException(nameof(tagStore));
+        _logger = logger;
+    }
+
+    /// <summary>
+    ///     The service id this instance repairs. An instance can only ever touch this lineage.
+    /// </summary>
+    public string ServiceId => _serviceId;
+
+    /// <summary>
+    ///     Scans the configured range and, unless <see cref="CosmosTagRepairOptions.DryRun" /> is set, writes
+    ///     the tag rows that are missing.
+    ///     The run stops at <see cref="CosmosTagRepairOptions.MaxEventsToScan" /> and hands back a checkpoint,
+    ///     so a large repair is a sequence of bounded runs rather than one unbounded scan. Re-running is
+    ///     harmless: a row that already exists is recognized, not rewritten.
+    /// </summary>
+    public async Task<CosmosTagRepairReport> RepairAsync(
+        CosmosTagRepairOptions options,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        var state = new RepairState(options);
+        var checkpoint = CosmosTagRepairCheckpoint.TryDecode(options.Checkpoint);
+
+        // The query is fixed for the whole run: `from` is where this run starts and never moves, so the
+        // continuation token below stays coherent with it.
+        var from = checkpoint?.LastSortableUniqueId ?? options.FromSortableUniqueIdExclusive;
+        string? continuationToken = null;
+        var pageSize = Math.Max(1, options.PageSize);
+        var maxEvents = Math.Max(1, options.MaxEventsToScan);
+
+        while (state.EventsScanned < maxEvents)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var page = await ThrottleAware.ExecuteAsync(
+                () => _eventSource.ReadEventPageAsync(
+                    from,
+                    options.ToSortableUniqueIdInclusive,
+                    Math.Min(pageSize, maxEvents - state.EventsScanned),
+                    continuationToken,
+                    cancellationToken),
+                options.MaxThrottleRetries,
+                cancellationToken).ConfigureAwait(false);
+
+            state.AddRequestCharge(page.RequestCharge);
+
+            foreach (var cosmosEvent in page.Events)
+            {
+                await ClassifyAndRepairEventAsync(cosmosEvent, options, state, cancellationToken)
+                    .ConfigureAwait(false);
+                state.MarkEventScanned(cosmosEvent.SortableUniqueId);
+            }
+
+            continuationToken = page.ContinuationToken;
+
+            if (continuationToken == null)
+            {
+                // The range is fully scanned; there is nothing to resume from.
+                return state.ToReport(hasMore: false, checkpoint: null);
+            }
+        }
+
+        // The next run starts after the last event this one settled. Resuming by sortableUniqueId rather
+        // than by continuation token means an expired token cannot lose our place.
+        var resume = new CosmosTagRepairCheckpoint(state.LastSortableUniqueId ?? from);
+        return state.ToReport(hasMore: true, checkpoint: resume.Encode());
+    }
+
+    private async Task ClassifyAndRepairEventAsync(
+        CosmosEvent cosmosEvent,
+        CosmosTagRepairOptions options,
+        RepairState state,
+        CancellationToken cancellationToken)
+    {
+        var tags = cosmosEvent.Tags;
+        if (tags == null || tags.Count == 0)
+        {
+            return;
+        }
+
+        if (!Guid.TryParse(cosmosEvent.Id, out var eventId))
+        {
+            state.Add(
+                new CosmosTagRepairFinding(
+                    CosmosTagRepairCategory.Corrupt,
+                    Guid.Empty,
+                    string.Empty,
+                    cosmosEvent.SortableUniqueId,
+                    $"event id '{cosmosEvent.Id}' is not a Guid"));
+            return;
+        }
+
+        // An (event, tag) pair is one row, so a tag repeated within an event is one key.
+        var distinctTags = tags.Distinct(StringComparer.Ordinal).ToList();
+
+        using var semaphore = new SemaphoreSlim(Math.Max(1, options.MaxParallelism));
+        var tasks = distinctTags.Select(async tag =>
+        {
+            await semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+            try
+            {
+                await ClassifyAndRepairKeyAsync(cosmosEvent, eventId, tag, options, state, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+            finally
+            {
+                semaphore.Release();
+            }
+        });
+
+        await Task.WhenAll(tasks).ConfigureAwait(false);
+    }
+
+    private async Task ClassifyAndRepairKeyAsync(
+        CosmosEvent cosmosEvent,
+        Guid eventId,
+        string tag,
+        CosmosTagRepairOptions options,
+        RepairState state,
+        CancellationToken cancellationToken)
+    {
+        var derived = CosmosTagIdentity.DeriveRow(
+            _serviceId,
+            tag,
+            eventId,
+            cosmosEvent.SortableUniqueId,
+            cosmosEvent.EventType);
+
+        var lookup = await ThrottleAware.ExecuteAsync(
+            () => _tagStore.ReadRowsForEventAsync(
+                derived.Pk,
+                eventId,
+                Math.Max(1, options.MaxRowsPerKey),
+                cancellationToken),
+            options.MaxThrottleRetries,
+            cancellationToken).ConfigureAwait(false);
+
+        state.MarkKeyScanned();
+        state.AddRequestCharge(lookup.RequestCharge);
+
+        if (lookup.Overflowed)
+        {
+            state.Add(
+                new CosmosTagRepairFinding(
+                    CosmosTagRepairCategory.Overflow,
+                    eventId,
+                    tag,
+                    cosmosEvent.SortableUniqueId,
+                    $"more than {options.MaxRowsPerKey} rows index this key; not classified"));
+            return;
+        }
+
+        var classification = Classify(lookup.Rows, derived, eventId, tag, cosmosEvent, state);
+        if (classification != CosmosTagRepairCategory.Missing)
+        {
+            return;
+        }
+
+        if (options.DryRun)
+        {
+            return;
+        }
+
+        await RepairMissingKeyAsync(derived, eventId, tag, cosmosEvent, options, state, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    private static CosmosTagRepairCategory Classify(
+        IReadOnlyList<CosmosTag> rows,
+        CosmosTag derived,
+        Guid eventId,
+        string tag,
+        CosmosEvent cosmosEvent,
+        RepairState state)
+    {
+        if (rows.Count == 0)
+        {
+            state.Add(
+                new CosmosTagRepairFinding(
+                    CosmosTagRepairCategory.Missing,
+                    eventId,
+                    tag,
+                    cosmosEvent.SortableUniqueId));
+            return CosmosTagRepairCategory.Missing;
+        }
+
+        // A row sitting at the derived id is the row the write path meant to write, so it is held to the
+        // strict comparator — a differing createdAt there is corruption, not legacy formatting.
+        var deterministic = rows.FirstOrDefault(row => string.Equals(row.Id, derived.Id, StringComparison.Ordinal));
+        if (deterministic != null)
+        {
+            if (CosmosTagIdentity.ContentEquals(derived, deterministic))
+            {
+                state.MarkPresent();
+                return CosmosTagRepairCategory.Present;
+            }
+
+            state.Add(
+                new CosmosTagRepairFinding(
+                    CosmosTagRepairCategory.Corrupt,
+                    eventId,
+                    tag,
+                    cosmosEvent.SortableUniqueId,
+                    $"row at the derived id disagrees with the event. Expected [{CosmosTagIdentity.Describe(derived)}], " +
+                    $"actual [{CosmosTagIdentity.Describe(deterministic)}]"));
+            return CosmosTagRepairCategory.Corrupt;
+        }
+
+        // Everything else in this partition carrying our event id is a legacy row — unless it disagrees
+        // with the event, in which case it is corrupt regardless of its id.
+        var legacyRows = new List<CosmosTag>();
+        foreach (var row in rows)
+        {
+            var match = CosmosLegacyTagRowMatcher.Classify(row, derived, out var detail);
+            switch (match)
+            {
+                case LegacyRowMatch.Corrupt:
+                    state.Add(
+                        new CosmosTagRepairFinding(
+                            CosmosTagRepairCategory.Corrupt,
+                            eventId,
+                            tag,
+                            cosmosEvent.SortableUniqueId,
+                            detail));
+                    return CosmosTagRepairCategory.Corrupt;
+                case LegacyRowMatch.LegacyPresent:
+                    legacyRows.Add(row);
+                    break;
+                case LegacyRowMatch.NotOurKey:
+                default:
+                    break;
+            }
+        }
+
+        if (legacyRows.Count == 0)
+        {
+            state.Add(
+                new CosmosTagRepairFinding(
+                    CosmosTagRepairCategory.Missing,
+                    eventId,
+                    tag,
+                    cosmosEvent.SortableUniqueId));
+            return CosmosTagRepairCategory.Missing;
+        }
+
+        if (legacyRows.Count > 1)
+        {
+            // Residue of a pre-SEK-G2 re-execution, which minted a fresh id every time. Reporting is all
+            // this service may do — removing one of them is destructive, and that is SEK-G4b's call.
+            state.Add(
+                new CosmosTagRepairFinding(
+                    CosmosTagRepairCategory.Duplicate,
+                    eventId,
+                    tag,
+                    cosmosEvent.SortableUniqueId,
+                    $"{legacyRows.Count} legacy rows index this key: ids [{string.Join(", ", legacyRows.Select(row => row.Id))}]. " +
+                    "Reported only; reduction is out of scope for this service."));
+            return CosmosTagRepairCategory.Duplicate;
+        }
+
+        state.Add(
+            new CosmosTagRepairFinding(
+                CosmosTagRepairCategory.LegacyPresent,
+                eventId,
+                tag,
+                cosmosEvent.SortableUniqueId,
+                CosmosLegacyTagRowMatcher.DescribeLegacyDifferences(legacyRows[0], derived)));
+        return CosmosTagRepairCategory.LegacyPresent;
+    }
+
+    private async Task RepairMissingKeyAsync(
+        CosmosTag derived,
+        Guid eventId,
+        string tag,
+        CosmosEvent cosmosEvent,
+        CosmosTagRepairOptions options,
+        RepairState state,
+        CancellationToken cancellationToken)
+    {
+        var (created, requestCharge) = await ThrottleAware.ExecuteAsync(
+            () => _tagStore.TryCreateRowAsync(derived.Pk, derived, cancellationToken),
+            options.MaxThrottleRetries,
+            cancellationToken).ConfigureAwait(false);
+
+        state.AddRequestCharge(requestCharge);
+
+        if (created)
+        {
+            state.MarkRepaired();
+            if (_logger != null)
+                LogRepairedRow(_logger, tag, eventId, null);
+            return;
+        }
+
+        // A normal write landed between our classification and our repair. That is expected, not an error:
+        // the row it wrote is derived from the same event, so it is the row we were about to write.
+        var existing = await ThrottleAware.ExecuteAsync(
+            () => _tagStore.TryReadRowAsync(derived.Pk, derived.Id, cancellationToken),
+            options.MaxThrottleRetries,
+            cancellationToken).ConfigureAwait(false);
+
+        if (existing != null && CosmosTagIdentity.ContentEquals(derived, existing))
+        {
+            state.MarkPresentAfterRace();
+            return;
+        }
+
+        state.Add(
+            new CosmosTagRepairFinding(
+                CosmosTagRepairCategory.Corrupt,
+                eventId,
+                tag,
+                cosmosEvent.SortableUniqueId,
+                existing == null
+                    ? "the row could neither be created nor read back; the tags container is being modified concurrently"
+                    : $"a row appeared at the derived id that disagrees with the event. Expected " +
+                    $"[{CosmosTagIdentity.Describe(derived)}], actual [{CosmosTagIdentity.Describe(existing)}]"));
+    }
+
+    private static readonly Action<ILogger, string, Guid, Exception?> LogRepairedRow =
+        LoggerMessage.Define<string, Guid>(
+            LogLevel.Information,
+            new EventId(1, nameof(LogRepairedRow)),
+            "Repaired missing tag row for tag '{Tag}', event {EventId}");
+
+    /// <summary>
+    ///     Accumulates one run's counts and findings. Mutated from the per-key tasks, hence the lock.
+    /// </summary>
+    private sealed class RepairState
+    {
+        private readonly List<CosmosTagRepairFinding> _findings = new();
+        private readonly Lock _gate = new();
+        private readonly CosmosTagRepairOptions _options;
+
+        public RepairState(CosmosTagRepairOptions options) => _options = options;
+
+        public int EventsScanned { get; private set; }
+        public string? LastSortableUniqueId { get; private set; }
+
+        private int _keysScanned;
+        private int _present;
+        private int _missing;
+        private int _repaired;
+        private int _legacyPresent;
+        private int _duplicate;
+        private int _corrupt;
+        private int _overflow;
+        private double _requestCharge;
+
+        public void MarkEventScanned(string sortableUniqueId)
+        {
+            lock (_gate)
+            {
+                EventsScanned++;
+                LastSortableUniqueId = sortableUniqueId;
+            }
+        }
+
+        public void MarkKeyScanned()
+        {
+            lock (_gate)
+            {
+                _keysScanned++;
+            }
+        }
+
+        public void MarkPresent()
+        {
+            lock (_gate)
+            {
+                _present++;
+            }
+        }
+
+        /// <summary>A concurrent writer wrote the row we were about to write. It is present, not repaired.</summary>
+        public void MarkPresentAfterRace()
+        {
+            lock (_gate)
+            {
+                _present++;
+            }
+        }
+
+        public void MarkRepaired()
+        {
+            lock (_gate)
+            {
+                _repaired++;
+            }
+        }
+
+        public void AddRequestCharge(double charge)
+        {
+            lock (_gate)
+            {
+                _requestCharge += charge;
+            }
+        }
+
+        public void Add(CosmosTagRepairFinding finding)
+        {
+            lock (_gate)
+            {
+                switch (finding.Category)
+                {
+                    case CosmosTagRepairCategory.Missing:
+                        _missing++;
+                        break;
+                    case CosmosTagRepairCategory.LegacyPresent:
+                        _legacyPresent++;
+                        break;
+                    case CosmosTagRepairCategory.Duplicate:
+                        _duplicate++;
+                        break;
+                    case CosmosTagRepairCategory.Corrupt:
+                        _corrupt++;
+                        break;
+                    case CosmosTagRepairCategory.Overflow:
+                        _overflow++;
+                        break;
+                    case CosmosTagRepairCategory.Present:
+                    default:
+                        _present++;
+                        break;
+                }
+
+                // Counts are exact; only the detail list is capped.
+                if (_findings.Count < _options.MaxFindings)
+                {
+                    _findings.Add(finding);
+                }
+            }
+        }
+
+        public CosmosTagRepairReport ToReport(bool hasMore, string? checkpoint)
+        {
+            lock (_gate)
+            {
+                return new CosmosTagRepairReport
+                {
+                    EventsScanned = EventsScanned,
+                    KeysScanned = _keysScanned,
+                    Present = _present,
+                    Missing = _missing,
+                    Repaired = _repaired,
+                    LegacyPresent = _legacyPresent,
+                    Duplicate = _duplicate,
+                    Corrupt = _corrupt,
+                    Overflow = _overflow,
+                    RequestCharge = _requestCharge,
+                    DryRun = _options.DryRun,
+                    HasMore = hasMore,
+                    Checkpoint = checkpoint,
+                    Findings = _findings.ToList()
+                };
+            }
+        }
+    }
+}

--- a/dcb/src/Sekiban.Dcb.CosmosDb/Repair/CosmosDbTagRepairServiceFactory.cs
+++ b/dcb/src/Sekiban.Dcb.CosmosDb/Repair/CosmosDbTagRepairServiceFactory.cs
@@ -1,0 +1,48 @@
+using Microsoft.Extensions.Logging;
+namespace Sekiban.Dcb.CosmosDb.Repair;
+
+/// <summary>
+///     Builds a <see cref="CosmosDbTagRepairService" /> bound to one lineage.
+///     The service id is passed explicitly rather than pulled from an ambient
+///     <c>IServiceIdProvider</c>: an operator repairing tenant A's index should not be able to touch tenant
+///     B's because of what happened to be in scope. Resolving the containers here, once, per service id
+///     makes a cross-lineage repair structurally impossible rather than merely discouraged.
+/// </summary>
+public sealed class CosmosDbTagRepairServiceFactory
+{
+    private readonly ICosmosContainerResolver _containerResolver;
+    private readonly CosmosDbContext _context;
+    private readonly ILogger<CosmosDbTagRepairService>? _logger;
+
+    /// <summary>
+    ///     Creates a factory over a Cosmos context and container resolver.
+    /// </summary>
+    public CosmosDbTagRepairServiceFactory(
+        CosmosDbContext context,
+        ICosmosContainerResolver containerResolver,
+        ILogger<CosmosDbTagRepairService>? logger = null)
+    {
+        _context = context ?? throw new ArgumentNullException(nameof(context));
+        _containerResolver = containerResolver ?? throw new ArgumentNullException(nameof(containerResolver));
+        _logger = logger;
+    }
+
+    /// <summary>
+    ///     Creates a repair service for exactly one (serviceId, events container, tags container) lineage.
+    /// </summary>
+    public async Task<CosmosDbTagRepairService> CreateAsync(string serviceId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(serviceId);
+
+        var eventsSettings = _containerResolver.ResolveEventsContainer(serviceId);
+        var tagsSettings = _containerResolver.ResolveTagsContainer(serviceId);
+        var eventsContainer = await _context.GetEventsContainerAsync(eventsSettings).ConfigureAwait(false);
+        var tagsContainer = await _context.GetTagsContainerAsync(tagsSettings).ConfigureAwait(false);
+
+        return new CosmosDbTagRepairService(
+            serviceId,
+            new CosmosContainerRepairEventSource(eventsContainer, serviceId),
+            new CosmosContainerRepairStore(tagsContainer),
+            _logger);
+    }
+}

--- a/dcb/src/Sekiban.Dcb.CosmosDb/Repair/CosmosLegacyTagRowMatcher.cs
+++ b/dcb/src/Sekiban.Dcb.CosmosDb/Repair/CosmosLegacyTagRowMatcher.cs
@@ -1,0 +1,116 @@
+using Sekiban.Dcb.CosmosDb.Models;
+using Sekiban.Dcb.CosmosDb.Tags;
+namespace Sekiban.Dcb.CosmosDb.Repair;
+
+/// <summary>
+///     How an existing tag row relates to the (event, tag) key the repair derived.
+/// </summary>
+internal enum LegacyRowMatch
+{
+    /// <summary>The row indexes a different (event, tag). Not our key at all.</summary>
+    NotOurKey,
+
+    /// <summary>
+    ///     The row indexes our key and its event-derived fields agree with the event. It differs from the
+    ///     derived row only in the ways a pre-SEK-G2 row is expected to: a random id and a wall-clock
+    ///     createdAt.
+    /// </summary>
+    LegacyPresent,
+
+    /// <summary>
+    ///     The row indexes our key but an immutable event-derived field disagrees with the event.
+    /// </summary>
+    Corrupt
+}
+
+/// <summary>
+///     Recognizes tag rows written before the deterministic-id scheme (SEK-G2), which used
+///     <c>Guid.NewGuid()</c> for the row id and <c>DateTime.UtcNow</c> for createdAt. Such a row indexes an
+///     (event, tag) pair perfectly well — it just does not sit at the id the repair would derive — so
+///     treating it as "missing" would write a second row for a pair that is already indexed.
+///     This is deliberately NOT <see cref="CosmosTagIdentity.ContentEquals" />. That comparator is strict on
+///     purpose: it decides whether a row at the *derived id* is the row we meant to write, so a differing id
+///     or createdAt there really is corruption. For a legacy row those two fields are *expected* to differ,
+///     and are reported as migration metadata rather than corruption. Every other field must still agree
+///     with the event — a legacy id does not license drift in the data the row indexes.
+/// </summary>
+internal static class CosmosLegacyTagRowMatcher
+{
+    /// <summary>
+    ///     Decides whether <paramref name="row" /> indexes the same (event, tag) as
+    ///     <paramref name="derived" />, and if so whether it agrees with the event.
+    ///     The semantic key is (serviceId, tag, eventId): serviceId and tag are compared ordinally, and the
+    ///     event id is parsed to a <see cref="Guid" /> and compared canonically, so a row written with
+    ///     different Guid formatting or casing still matches. Callers must confine the lookup to the tag's
+    ///     partition (<c>pk = {serviceId}|{tag}</c>); combined with the event-id comparison, a different event
+    ///     carrying the same tag can never match — its event id differs.
+    /// </summary>
+    public static LegacyRowMatch Classify(CosmosTag row, CosmosTag derived, out string? detail)
+    {
+        detail = null;
+
+        if (!string.Equals(row.ServiceId, derived.ServiceId, StringComparison.Ordinal) ||
+            !string.Equals(row.Tag, derived.Tag, StringComparison.Ordinal) ||
+            !string.Equals(row.Pk, derived.Pk, StringComparison.Ordinal))
+        {
+            return LegacyRowMatch.NotOurKey;
+        }
+
+        if (!TryParseCanonical(row.EventId, out var rowEventId) ||
+            !TryParseCanonical(derived.EventId, out var derivedEventId) ||
+            rowEventId != derivedEventId)
+        {
+            return LegacyRowMatch.NotOurKey;
+        }
+
+        // The key matches, so this row indexes our pair. Everything the row copies from the event must
+        // therefore agree with the event — a legacy row id excuses the id and the timestamp, nothing else.
+        if (!string.Equals(row.SortableUniqueId, derived.SortableUniqueId, StringComparison.Ordinal))
+        {
+            detail =
+                $"sortableUniqueId mismatch: row has '{row.SortableUniqueId}', event has '{derived.SortableUniqueId}'";
+            return LegacyRowMatch.Corrupt;
+        }
+
+        if (!string.Equals(row.EventType, derived.EventType, StringComparison.Ordinal))
+        {
+            detail = $"eventType mismatch: row has '{row.EventType}', event has '{derived.EventType}'";
+            return LegacyRowMatch.Corrupt;
+        }
+
+        if (!string.Equals(row.TagGroup, derived.TagGroup, StringComparison.Ordinal))
+        {
+            // tagGroup is derived from the tag string, so drift here means the row disagrees with its own
+            // tag. Surfaced explicitly rather than folded into "legacy formatting".
+            detail = $"tagGroup mismatch: row has '{row.TagGroup}', tag '{row.Tag}' derives '{derived.TagGroup}'";
+            return LegacyRowMatch.Corrupt;
+        }
+
+        return LegacyRowMatch.LegacyPresent;
+    }
+
+    /// <summary>
+    ///     Describes the expected, benign differences between a legacy row and the derived row, for the
+    ///     report. Not corruption — migration metadata.
+    /// </summary>
+    public static string DescribeLegacyDifferences(CosmosTag row, CosmosTag derived)
+    {
+        var differences = new List<string>();
+
+        if (!string.Equals(row.Id, derived.Id, StringComparison.Ordinal))
+        {
+            differences.Add($"row id '{row.Id}' (deterministic id would be '{derived.Id}')");
+        }
+
+        if (row.CreatedAt != derived.CreatedAt)
+        {
+            differences.Add($"createdAt '{row.CreatedAt:O}' (event-derived would be '{derived.CreatedAt:O}')");
+        }
+
+        return differences.Count == 0
+            ? "no differences"
+            : string.Join("; ", differences);
+    }
+
+    private static bool TryParseCanonical(string? value, out Guid parsed) => Guid.TryParse(value, out parsed);
+}

--- a/dcb/src/Sekiban.Dcb.CosmosDb/Repair/CosmosRepairRowQuery.cs
+++ b/dcb/src/Sekiban.Dcb.CosmosDb/Repair/CosmosRepairRowQuery.cs
@@ -1,0 +1,69 @@
+using Microsoft.Azure.Cosmos;
+using Sekiban.Dcb.CosmosDb.Models;
+namespace Sekiban.Dcb.CosmosDb.Repair;
+
+/// <summary>
+///     Finds the tag rows that index a given event, without letting the *string form* of the event id decide
+///     correctness.
+///     A pre-SEK-G2 row stored its event id as whatever <c>Guid.ToString()</c> produced, and a row written by
+///     anything outside Sekiban could use any format at all. An equality predicate against one rendering
+///     (<c>c.eventId = "0f8f…"</c>) silently drops the others — and a legacy row that is not returned looks
+///     exactly like a missing row, so the repair would write a second row for a pair that is already indexed.
+///     That is precisely the mistake this type exists to prevent.
+///     So the split is deliberate:
+///     <list type="bullet">
+///         <item>
+///             <description>
+///                 The SQL predicate is a <b>superset prefilter</b> — it enumerates every rendering
+///                 <see cref="Guid.ToString(string)" /> can produce, compared case-insensitively, so it cannot
+///                 miss a row that <see cref="Guid.TryParse(string, out Guid)" /> would accept. It exists to
+///                 avoid dragging the whole tag partition over the wire, not to decide anything.
+///             </description>
+///         </item>
+///         <item>
+///             <description>
+///                 The <b>correctness gate</b> is <see cref="IsRowForEvent" />: every returned row's event id
+///                 is parsed to a <see cref="Guid" /> and compared canonically. Format and casing cannot
+///                 affect the outcome, and a row belonging to a different event is rejected here even if the
+///                 prefilter let it through.
+///             </description>
+///         </item>
+///     </list>
+/// </summary>
+internal static class CosmosRepairRowQuery
+{
+    /// <summary>
+    ///     Every format <see cref="Guid.ToString(string)" /> can emit. Together with case-insensitive
+    ///     comparison, these cover every string <see cref="Guid.TryParse(string, out Guid)" /> accepts.
+    /// </summary>
+    private static readonly string[] GuidFormats = { "D", "N", "B", "P", "X" };
+
+    /// <summary>
+    ///     Builds the partition-confined superset prefilter for the rows indexing <paramref name="eventId" />.
+    /// </summary>
+    public static QueryDefinition BuildCandidateQuery(string partitionKey, Guid eventId)
+    {
+        var predicates = GuidFormats
+            .Select((_, index) => $"STRINGEQUALS(c.eventId, @eventId{index}, true)")
+            .ToList();
+
+        var query = new QueryDefinition(
+                $"SELECT * FROM c WHERE c.pk = @pk AND ({string.Join(" OR ", predicates)})")
+            .WithParameter("@pk", partitionKey);
+
+        for (var index = 0; index < GuidFormats.Length; index++)
+        {
+            query = query.WithParameter($"@eventId{index}", eventId.ToString(GuidFormats[index]));
+        }
+
+        return query;
+    }
+
+    /// <summary>
+    ///     The correctness gate: does this row index this event? Decided by canonical Guid comparison, never
+    ///     by string form. A row whose event id will not parse indexes nothing we can identify, so it is not
+    ///     ours.
+    /// </summary>
+    public static bool IsRowForEvent(CosmosTag row, Guid eventId) =>
+        Guid.TryParse(row.EventId, out var rowEventId) && rowEventId == eventId;
+}

--- a/dcb/src/Sekiban.Dcb.CosmosDb/Repair/CosmosRepairRowQuery.cs
+++ b/dcb/src/Sekiban.Dcb.CosmosDb/Repair/CosmosRepairRowQuery.cs
@@ -35,21 +35,28 @@ internal static class CosmosRepairRowQuery
     /// <summary>
     ///     Every format <see cref="Guid.ToString(string)" /> can emit. Together with case-insensitive
     ///     comparison, these cover every string <see cref="Guid.TryParse(string, out Guid)" /> accepts.
+    ///     Each one gets its own parameter in <see cref="CandidateQueryText" />, in this order.
     /// </summary>
     private static readonly string[] GuidFormats = { "D", "N", "B", "P", "X" };
+
+    /// <summary>
+    ///     The prefilter, as a constant. Nothing is formatted into it — every value the query compares
+    ///     against arrives as a bound parameter.
+    /// </summary>
+    private const string CandidateQueryText =
+        "SELECT * FROM c WHERE c.pk = @pk AND (" +
+        "STRINGEQUALS(c.eventId, @eventId0, true) OR " +
+        "STRINGEQUALS(c.eventId, @eventId1, true) OR " +
+        "STRINGEQUALS(c.eventId, @eventId2, true) OR " +
+        "STRINGEQUALS(c.eventId, @eventId3, true) OR " +
+        "STRINGEQUALS(c.eventId, @eventId4, true))";
 
     /// <summary>
     ///     Builds the partition-confined superset prefilter for the rows indexing <paramref name="eventId" />.
     /// </summary>
     public static QueryDefinition BuildCandidateQuery(string partitionKey, Guid eventId)
     {
-        var predicates = GuidFormats
-            .Select((_, index) => $"STRINGEQUALS(c.eventId, @eventId{index}, true)")
-            .ToList();
-
-        var query = new QueryDefinition(
-                $"SELECT * FROM c WHERE c.pk = @pk AND ({string.Join(" OR ", predicates)})")
-            .WithParameter("@pk", partitionKey);
+        var query = new QueryDefinition(CandidateQueryText).WithParameter("@pk", partitionKey);
 
         for (var index = 0; index < GuidFormats.Length; index++)
         {

--- a/dcb/src/Sekiban.Dcb.CosmosDb/Repair/CosmosTagRepairCheckpoint.cs
+++ b/dcb/src/Sekiban.Dcb.CosmosDb/Repair/CosmosTagRepairCheckpoint.cs
@@ -1,0 +1,41 @@
+using System.Text;
+using System.Text.Json;
+namespace Sekiban.Dcb.CosmosDb.Repair;
+
+/// <summary>
+///     Where a repair run stopped, encoded as an opaque token the caller hands back to resume.
+///     It carries the last sortableUniqueId the run reached, and deliberately NOT a Cosmos continuation
+///     token. A continuation token is bound to the exact query that produced it and expires, so it cannot be
+///     handed across runs; the scan is ordered by sortableUniqueId, which is monotonic, so resuming at
+///     "everything after the last one I saw" is both exact and durable. Continuation tokens are still used
+///     for paging *within* a run, where the query is fixed.
+///     Opaque on purpose: its shape is this service's business, not the caller's.
+/// </summary>
+internal sealed record CosmosTagRepairCheckpoint(string? LastSortableUniqueId)
+{
+    private static readonly JsonSerializerOptions SerializerOptions = new();
+
+    public string Encode() =>
+        Convert.ToBase64String(Encoding.UTF8.GetBytes(JsonSerializer.Serialize(this, SerializerOptions)));
+
+    public static CosmosTagRepairCheckpoint? TryDecode(string? token)
+    {
+        if (string.IsNullOrWhiteSpace(token))
+        {
+            return null;
+        }
+
+        try
+        {
+            var json = Encoding.UTF8.GetString(Convert.FromBase64String(token));
+            return JsonSerializer.Deserialize<CosmosTagRepairCheckpoint>(json, SerializerOptions);
+        }
+        catch (Exception ex) when (ex is FormatException or JsonException or ArgumentException)
+        {
+            throw new ArgumentException(
+                "The repair checkpoint is not a token produced by a previous run.",
+                nameof(token),
+                ex);
+        }
+    }
+}

--- a/dcb/src/Sekiban.Dcb.CosmosDb/Repair/CosmosTagRepairOptions.cs
+++ b/dcb/src/Sekiban.Dcb.CosmosDb/Repair/CosmosTagRepairOptions.cs
@@ -1,0 +1,65 @@
+namespace Sekiban.Dcb.CosmosDb.Repair;
+
+/// <summary>
+///     Bounds and mode for one repair run.
+/// </summary>
+public class CosmosTagRepairOptions
+{
+    /// <summary>
+    ///     Scan events with a sortableUniqueId strictly greater than this. Null starts from the beginning.
+    /// </summary>
+    public string? FromSortableUniqueIdExclusive { get; set; }
+
+    /// <summary>
+    ///     Scan events with a sortableUniqueId less than or equal to this. Null scans to the end.
+    ///     Pin this to a value at or below the last event you know to be settled: an event written while the
+    ///     scan is running is repaired by the write path itself, not by this service.
+    /// </summary>
+    public string? ToSortableUniqueIdInclusive { get; set; }
+
+    /// <summary>
+    ///     Classify and report, but write nothing. Default: true — a repair run must be asked for explicitly.
+    /// </summary>
+    public bool DryRun { get; set; } = true;
+
+    /// <summary>
+    ///     Event documents to read per page of the cross-partition scan. Default: 100.
+    /// </summary>
+    public int PageSize { get; set; } = 100;
+
+    /// <summary>
+    ///     Event documents to examine before the run stops and hands back a checkpoint. Keeps one run's RU
+    ///     cost and duration bounded. Default: 10,000.
+    /// </summary>
+    public int MaxEventsToScan { get; set; } = 10_000;
+
+    /// <summary>
+    ///     (event, tag) keys classified concurrently. Each key costs one partition-confined query, so this is
+    ///     the main RU-rate dial. Default: 4.
+    /// </summary>
+    public int MaxParallelism { get; set; } = 4;
+
+    /// <summary>
+    ///     Rows the scan will examine for a single (event, tag) key before reporting
+    ///     <see cref="CosmosTagRepairCategory.Overflow" /> instead of classifying. Bounds the blast radius of
+    ///     a pathological partition. Default: 16.
+    /// </summary>
+    public int MaxRowsPerKey { get; set; } = 16;
+
+    /// <summary>
+    ///     Findings kept in the report. Counts are never capped; this only bounds the detail list.
+    ///     Default: 1,000.
+    /// </summary>
+    public int MaxFindings { get; set; } = 1_000;
+
+    /// <summary>
+    ///     Attempts for a throttled (429) Cosmos call before the run gives up. The server's Retry-After is
+    ///     honored in full. Default: 5.
+    /// </summary>
+    public int MaxThrottleRetries { get; set; } = 5;
+
+    /// <summary>
+    ///     Opaque checkpoint from a previous run's report. Resumes exactly where that run stopped.
+    /// </summary>
+    public string? Checkpoint { get; set; }
+}

--- a/dcb/src/Sekiban.Dcb.CosmosDb/Repair/CosmosTagRepairReport.cs
+++ b/dcb/src/Sekiban.Dcb.CosmosDb/Repair/CosmosTagRepairReport.cs
@@ -1,0 +1,110 @@
+namespace Sekiban.Dcb.CosmosDb.Repair;
+
+/// <summary>
+///     How the repair scan classified one (event, tag) key.
+/// </summary>
+public enum CosmosTagRepairCategory
+{
+    /// <summary>The derived row already exists and matches the event exactly. Nothing to do.</summary>
+    Present,
+
+    /// <summary>No row indexes this (event, tag). This is the only category the repair writes.</summary>
+    Missing,
+
+    /// <summary>
+    ///     A row written before the deterministic-id scheme indexes this (event, tag): it carries a random
+    ///     row id and a wall-clock createdAt, but its semantic key and event-derived fields agree with the
+    ///     event. The pair is already indexed, so no row is written — and the legacy row is never touched.
+    /// </summary>
+    LegacyPresent,
+
+    /// <summary>
+    ///     More than one legacy row indexes this (event, tag) — residue of a pre-SEK-G2 re-execution, which
+    ///     created a fresh random id each time. Reported only: reducing them is destructive and belongs to
+    ///     the separately authorized SEK-G4b, never to this service.
+    /// </summary>
+    Duplicate,
+
+    /// <summary>
+    ///     A row occupies this (event, tag) but disagrees with the event — a deterministic-id row whose
+    ///     content differs, or a row whose immutable event-derived fields (sortableUniqueId, eventType,
+    ///     tagGroup) do not match the source event. Reported, never overwritten.
+    /// </summary>
+    Corrupt,
+
+    /// <summary>
+    ///     More rows index this (event, tag) than the per-key cap allows the scan to examine, so it is
+    ///     reported rather than classified. Raise <see cref="CosmosTagRepairOptions.MaxRowsPerKey" /> to look
+    ///     deeper.
+    /// </summary>
+    Overflow
+}
+
+/// <summary>
+///     What the repair scan found for one (event, tag) key.
+/// </summary>
+public record CosmosTagRepairFinding(
+    CosmosTagRepairCategory Category,
+    Guid EventId,
+    string Tag,
+    string SortableUniqueId,
+    string? Detail = null);
+
+/// <summary>
+///     The auditable result of a repair run.
+///     A dry run fills in exactly the same classification counts but leaves <see cref="Repaired" /> at zero
+///     and writes nothing.
+/// </summary>
+public record CosmosTagRepairReport
+{
+    /// <summary>Event documents examined.</summary>
+    public int EventsScanned { get; init; }
+
+    /// <summary>(event, tag) keys examined — one event contributes one key per tag it carries.</summary>
+    public int KeysScanned { get; init; }
+
+    /// <summary>Keys whose derived row already existed and matched.</summary>
+    public int Present { get; init; }
+
+    /// <summary>Keys with no row indexing them.</summary>
+    public int Missing { get; init; }
+
+    /// <summary>Rows written. Always zero in a dry run.</summary>
+    public int Repaired { get; init; }
+
+    /// <summary>Keys already indexed by a pre-SEK-G2 row. Never written, never touched.</summary>
+    public int LegacyPresent { get; init; }
+
+    /// <summary>Keys indexed by more than one legacy row. Reported only — reduction is SEK-G4b.</summary>
+    public int Duplicate { get; init; }
+
+    /// <summary>Keys whose existing row disagrees with the event. Reported, never overwritten.</summary>
+    public int Corrupt { get; init; }
+
+    /// <summary>Keys with more rows than the per-key cap allowed the scan to examine.</summary>
+    public int Overflow { get; init; }
+
+    /// <summary>Request units the scan and repair consumed, as reported by Cosmos.</summary>
+    public double RequestCharge { get; init; }
+
+    /// <summary>True when the run mutated nothing.</summary>
+    public bool DryRun { get; init; }
+
+    /// <summary>
+    ///     True when the scan stopped at its event budget or was cancelled with work left. Resume from
+    ///     <see cref="Checkpoint" />.
+    /// </summary>
+    public bool HasMore { get; init; }
+
+    /// <summary>
+    ///     Opaque token to hand back to the next run to continue where this one stopped. Null once the range
+    ///     is fully scanned.
+    /// </summary>
+    public string? Checkpoint { get; init; }
+
+    /// <summary>
+    ///     Findings for everything that was not simply <see cref="CosmosTagRepairCategory.Present" />, capped
+    ///     at <see cref="CosmosTagRepairOptions.MaxFindings" />. The counts above are never capped.
+    /// </summary>
+    public IReadOnlyList<CosmosTagRepairFinding> Findings { get; init; } = Array.Empty<CosmosTagRepairFinding>();
+}

--- a/dcb/src/Sekiban.Dcb.CosmosDb/Repair/ICosmosRepairStores.cs
+++ b/dcb/src/Sekiban.Dcb.CosmosDb/Repair/ICosmosRepairStores.cs
@@ -1,0 +1,69 @@
+using Sekiban.Dcb.CosmosDb.Models;
+namespace Sekiban.Dcb.CosmosDb.Repair;
+
+/// <summary>
+///     One page of the events scan.
+/// </summary>
+internal sealed record CosmosRepairEventPage(
+    IReadOnlyList<CosmosEvent> Events,
+    string? ContinuationToken,
+    double RequestCharge);
+
+/// <summary>
+///     The bounded, resumable read over the events container the repair scan needs.
+///     Behind a seam so the scan — paging, checkpointing, classification — can be driven without Cosmos.
+/// </summary>
+internal interface ICosmosRepairEventSource
+{
+    /// <summary>
+    ///     Reads one page of events in (from, to] ordered by sortableUniqueId, resuming from
+    ///     <paramref name="continuationToken" /> when given.
+    /// </summary>
+    Task<CosmosRepairEventPage> ReadEventPageAsync(
+        string? fromSortableUniqueIdExclusive,
+        string? toSortableUniqueIdInclusive,
+        int pageSize,
+        string? continuationToken,
+        CancellationToken cancellationToken);
+}
+
+/// <summary>
+///     Rows found for one (event, tag) key, plus whether the per-key cap hid any.
+/// </summary>
+internal sealed record CosmosRepairRowLookup(
+    IReadOnlyList<CosmosTag> Rows,
+    bool Overflowed,
+    double RequestCharge);
+
+/// <summary>
+///     The tag-container operations the repair needs: find every row indexing an (event, tag) — including
+///     legacy rows sitting at a random id — and create a missing row. There is deliberately no delete or
+///     replace here: G4 is non-destructive by construction, not by discipline.
+/// </summary>
+internal interface ICosmosTagRepairStore
+{
+    /// <summary>
+    ///     Reads the rows in the tag's partition that carry <paramref name="eventId" />, up to
+    ///     <paramref name="maxRows" />. Confined to <paramref name="partitionKey" />, so a different event's
+    ///     rows are never even considered.
+    /// </summary>
+    Task<CosmosRepairRowLookup> ReadRowsForEventAsync(
+        string partitionKey,
+        Guid eventId,
+        int maxRows,
+        CancellationToken cancellationToken);
+
+    /// <summary>
+    ///     Creates a row. Returns false if one already exists at that identity — which is how a concurrent
+    ///     writer landing between classification and repair is detected.
+    /// </summary>
+    Task<(bool Created, double RequestCharge)> TryCreateRowAsync(
+        string partitionKey,
+        CosmosTag row,
+        CancellationToken cancellationToken);
+
+    /// <summary>
+    ///     Reads the row at an exact identity, or null.
+    /// </summary>
+    Task<CosmosTag?> TryReadRowAsync(string partitionKey, string id, CancellationToken cancellationToken);
+}

--- a/dcb/src/Sekiban.Dcb.CosmosDb/Repair/ThrottleAware.cs
+++ b/dcb/src/Sekiban.Dcb.CosmosDb/Repair/ThrottleAware.cs
@@ -1,0 +1,42 @@
+using Microsoft.Azure.Cosmos;
+using System.Net;
+namespace Sekiban.Dcb.CosmosDb.Repair;
+
+/// <summary>
+///     Waits out Cosmos throttling. A repair scan is a bulk reader competing with live traffic, so being
+///     told to slow down is the normal case, not an error.
+///     The server's Retry-After is honored in full — retrying earlier than it asked only earns another 429.
+///     Only 429s are retried here; any other failure is the caller's to handle.
+/// </summary>
+internal static class ThrottleAware
+{
+    private static readonly TimeSpan FallbackDelay = TimeSpan.FromMilliseconds(500);
+
+    public static async Task<T> ExecuteAsync<T>(
+        Func<Task<T>> operation,
+        int maxRetries,
+        CancellationToken cancellationToken,
+        Func<TimeSpan, CancellationToken, Task>? wait = null)
+    {
+        var attempts = Math.Max(0, maxRetries);
+        wait ??= (delay, ct) => Task.Delay(delay, ct);
+
+        for (var attempt = 0; ; attempt++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            try
+            {
+                return await operation().ConfigureAwait(false);
+            }
+            catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.TooManyRequests && attempt < attempts)
+            {
+                var delay = ex.RetryAfter is { } retryAfter && retryAfter > TimeSpan.Zero
+                    ? retryAfter
+                    : FallbackDelay;
+
+                await wait(delay, cancellationToken).ConfigureAwait(false);
+            }
+        }
+    }
+}

--- a/dcb/src/Sekiban.Dcb.CosmosDb/Repair/ThrottleAware.cs
+++ b/dcb/src/Sekiban.Dcb.CosmosDb/Repair/ThrottleAware.cs
@@ -18,10 +18,12 @@ internal static class ThrottleAware
         CancellationToken cancellationToken,
         Func<TimeSpan, CancellationToken, Task>? wait = null)
     {
-        var attempts = Math.Max(0, maxRetries);
+        var retries = Math.Max(0, maxRetries);
         wait ??= (delay, ct) => Task.Delay(delay, ct);
 
-        for (var attempt = 0; ; attempt++)
+        // The first call is not a retry, so the bound is retries + 1 attempts. The final attempt does not
+        // catch a 429 — it lets it out, which is what ends the loop.
+        for (var attempt = 0; attempt <= retries; attempt++)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -29,7 +31,7 @@ internal static class ThrottleAware
             {
                 return await operation().ConfigureAwait(false);
             }
-            catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.TooManyRequests && attempt < attempts)
+            catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.TooManyRequests && attempt < retries)
             {
                 var delay = ex.RetryAfter is { } retryAfter && retryAfter > TimeSpan.Zero
                     ? retryAfter
@@ -38,5 +40,8 @@ internal static class ThrottleAware
                 await wait(delay, cancellationToken).ConfigureAwait(false);
             }
         }
+
+        throw new InvalidOperationException(
+            "Unreachable: the final attempt either returns its result or lets its exception out.");
     }
 }

--- a/dcb/src/Sekiban.Dcb.CosmosDb/SekibanDcbCosmosDbExtensions.cs
+++ b/dcb/src/Sekiban.Dcb.CosmosDb/SekibanDcbCosmosDbExtensions.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
+using Sekiban.Dcb.CosmosDb.Repair;
 using Sekiban.Dcb.Domains;
 using Sekiban.Dcb.ServiceId;
 using Sekiban.Dcb.Storage;
@@ -265,6 +266,20 @@ public static class SekibanDcbCosmosDbExtensions
         services.AddScoped<IEventStore>(sp => sp.GetRequiredService<IHotEventStore>());
         services.AddScoped<IMultiProjectionStateStore, CosmosMultiProjectionStateStore>();
 
+        return services;
+    }
+
+    /// <summary>
+    ///     Registers the administrative tag-repair factory (<see cref="CosmosDbTagRepairServiceFactory" />)
+    ///     alongside an existing Cosmos registration.
+    ///     Kept out of <c>AddSekibanDcbCosmosDb</c> deliberately: repair is an operator tool, so an
+    ///     application only gets it if it asks. Resolve the factory in an operator-only job and create a
+    ///     service for the one service id you intend to repair — never expose it from a request path.
+    /// </summary>
+    public static IServiceCollection AddSekibanDcbCosmosDbTagRepair(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        services.AddSingleton<CosmosDbTagRepairServiceFactory>();
         return services;
     }
 

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/CosmosContainerRepairStoreTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/CosmosContainerRepairStoreTests.cs
@@ -1,0 +1,308 @@
+using Microsoft.Azure.Cosmos;
+using Sekiban.Dcb.Common;
+using Sekiban.Dcb.CosmosDb.Models;
+using Sekiban.Dcb.CosmosDb.Repair;
+using System.Collections;
+using System.Net;
+
+namespace Sekiban.Dcb.Tests;
+
+/// <summary>
+///     Drives the PRODUCTION repair store — <see cref="CosmosContainerRepairStore" />, the one that talks to
+///     a real container — rather than an in-memory stand-in.
+///     This is where the earlier bug lived: the store's SQL filtered on <c>c.eventId = eventId.ToString()</c>,
+///     the canonical lowercase "D" rendering. A legacy row stored with a different Guid format or casing was
+///     never returned by the server, so it looked exactly like a *missing* row and the repair would have
+///     written a second row for a pair that was already indexed. The service-level tests passed anyway,
+///     because their fake store parsed Guids client-side — they were testing the fake, not the query.
+///     So these tests hold the real store to the rule: the SQL is only a superset prefilter, and the row's
+///     event id is decided by canonical Guid comparison. The fake container below deliberately IGNORES the
+///     SQL and hands back everything in the partition, which is the strongest form of the claim — even a
+///     server that over-returns cannot make the store wrong, and a store that leaned on the predicate for
+///     correctness would fail here.
+/// </summary>
+public class CosmosContainerRepairStoreTests
+{
+    private const string ServiceId = "svc";
+    private const string Tag = "Student:1";
+    private static string PartitionKey => $"{ServiceId}|{Tag}";
+
+    private sealed class FakeFeedResponse : FeedResponse<CosmosTag>
+    {
+        private readonly IReadOnlyList<CosmosTag> _rows;
+
+        public FakeFeedResponse(IReadOnlyList<CosmosTag> rows) => _rows = rows;
+
+        public override string? ContinuationToken => null;
+        public override int Count => _rows.Count;
+        public override Headers Headers { get; } = new();
+        public override IEnumerable<CosmosTag> Resource => _rows;
+        public override double RequestCharge => 1.0;
+        public override HttpStatusCode StatusCode => HttpStatusCode.OK;
+        public override CosmosDiagnostics Diagnostics => null!;
+        public override string IndexMetrics => string.Empty;
+
+        public override IEnumerator<CosmosTag> GetEnumerator() => _rows.GetEnumerator();
+    }
+
+    private sealed class FakeFeedIterator : FeedIterator<CosmosTag>
+    {
+        private readonly IReadOnlyList<CosmosTag> _rows;
+        private bool _served;
+
+        public FakeFeedIterator(IReadOnlyList<CosmosTag> rows) => _rows = rows;
+
+        public override bool HasMoreResults => !_served;
+
+        public override Task<FeedResponse<CosmosTag>> ReadNextAsync(CancellationToken cancellationToken = default)
+        {
+            _served = true;
+            return Task.FromResult<FeedResponse<CosmosTag>>(new FakeFeedResponse(_rows));
+        }
+    }
+
+    /// <summary>
+    ///     A container that ignores the SQL entirely and returns every row in the requested partition.
+    ///     If the store relied on its predicate to exclude other events' rows, that would show up here.
+    /// </summary>
+    private sealed class FakePartitionContainer : NotSupportedCosmosContainer
+    {
+        private readonly List<CosmosTag> _rows;
+
+        public FakePartitionContainer(IEnumerable<CosmosTag> rows) => _rows = rows.ToList();
+
+        public QueryDefinition? LastQuery { get; private set; }
+
+        public override FeedIterator<T> GetItemQueryIterator<T>(
+            QueryDefinition queryDefinition,
+            string? continuationToken = null,
+            QueryRequestOptions? requestOptions = null)
+        {
+            LastQuery = queryDefinition;
+
+            var partitionKey = (string)queryDefinition
+                .GetQueryParameters()
+                .First(parameter => parameter.Name == "@pk")
+                .Value;
+
+            var rows = _rows
+                .Where(row => string.Equals(row.Pk, partitionKey, StringComparison.Ordinal))
+                .ToList();
+
+            return (FeedIterator<T>)(object)new FakeFeedIterator(rows);
+        }
+    }
+
+    private static string NewSortableUniqueId() => SortableUniqueId.GenerateNew();
+
+    private static CosmosTag LegacyRow(Guid eventId, string sortableUniqueId, string eventIdRendering) =>
+        new()
+        {
+            Pk = PartitionKey,
+            ServiceId = ServiceId,
+            Id = Guid.NewGuid().ToString(), // legacy: a random row id, not the event id
+            Tag = Tag,
+            TagGroup = "Student",
+            EventType = "TestEvent",
+            SortableUniqueId = sortableUniqueId,
+            EventId = eventIdRendering,
+            CreatedAt = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc)
+        };
+
+    [Theory]
+    [InlineData("D")] // canonical, but upper-cased below
+    [InlineData("N")] // no dashes
+    [InlineData("B")] // braces
+    [InlineData("P")] // parentheses
+    [InlineData("X")] // hex object
+    public async Task Should_Return_A_Legacy_Row_Whatever_Guid_Format_It_Was_Stored_In(string format)
+    {
+        var eventId = Guid.NewGuid();
+        var sortableUniqueId = NewSortableUniqueId();
+
+        // Upper-cased on purpose: casing must not decide the outcome either.
+        var rendering = eventId.ToString(format).ToUpperInvariant();
+        var container = new FakePartitionContainer(new[] { LegacyRow(eventId, sortableUniqueId, rendering) });
+        var store = new CosmosContainerRepairStore(container);
+
+        var lookup = await store.ReadRowsForEventAsync(PartitionKey, eventId, 16, CancellationToken.None);
+
+        var row = Assert.Single(lookup.Rows);
+        Assert.Equal(rendering, row.EventId);
+        Assert.False(lookup.Overflowed);
+    }
+
+    [Fact]
+    public async Task Should_Reject_Rows_Of_A_Different_Event_Even_When_The_Server_Over_Returns()
+    {
+        var ours = Guid.NewGuid();
+        var theirs = Guid.NewGuid();
+        var sortableUniqueId = NewSortableUniqueId();
+
+        // Same tag partition, different event. The fake container hands back both rows.
+        var container = new FakePartitionContainer(new[]
+        {
+            LegacyRow(ours, sortableUniqueId, ours.ToString()),
+            LegacyRow(theirs, sortableUniqueId, theirs.ToString().ToUpperInvariant())
+        });
+        var store = new CosmosContainerRepairStore(container);
+
+        var lookup = await store.ReadRowsForEventAsync(PartitionKey, ours, 16, CancellationToken.None);
+
+        // The client-side canonical comparison is what excludes the other event — not the SQL.
+        var row = Assert.Single(lookup.Rows);
+        Assert.Equal(ours, Guid.Parse(row.EventId));
+    }
+
+    [Fact]
+    public async Task Should_Ignore_A_Row_Whose_Event_Id_Is_Not_A_Guid()
+    {
+        var eventId = Guid.NewGuid();
+        var sortableUniqueId = NewSortableUniqueId();
+
+        var container = new FakePartitionContainer(new[]
+        {
+            LegacyRow(eventId, sortableUniqueId, "not-a-guid"),
+            LegacyRow(eventId, sortableUniqueId, eventId.ToString("N"))
+        });
+        var store = new CosmosContainerRepairStore(container);
+
+        var lookup = await store.ReadRowsForEventAsync(PartitionKey, eventId, 16, CancellationToken.None);
+
+        var row = Assert.Single(lookup.Rows);
+        Assert.Equal(eventId.ToString("N"), row.EventId);
+    }
+
+    [Fact]
+    public async Task Should_Report_Overflow_On_Matching_Rows_Only()
+    {
+        var ours = Guid.NewGuid();
+        var theirs = Guid.NewGuid();
+        var sortableUniqueId = NewSortableUniqueId();
+
+        // Three rows for our event (in mixed formats), plus one for another event.
+        var container = new FakePartitionContainer(new[]
+        {
+            LegacyRow(ours, sortableUniqueId, ours.ToString("D")),
+            LegacyRow(ours, sortableUniqueId, ours.ToString("N").ToUpperInvariant()),
+            LegacyRow(ours, sortableUniqueId, ours.ToString("B")),
+            LegacyRow(theirs, sortableUniqueId, theirs.ToString())
+        });
+        var store = new CosmosContainerRepairStore(container);
+
+        var lookup = await store.ReadRowsForEventAsync(PartitionKey, ours, 2, CancellationToken.None);
+
+        // The cap counts rows that index OUR event; the other event's row must not consume it.
+        Assert.True(lookup.Overflowed);
+        Assert.Equal(2, lookup.Rows.Count);
+        Assert.All(lookup.Rows, row => Assert.Equal(ours, Guid.Parse(row.EventId)));
+    }
+
+    [Theory]
+    [InlineData("D")]
+    [InlineData("N")]
+    [InlineData("B")]
+    public async Task The_Service_On_The_Production_Store_Should_Classify_An_Odd_Format_Legacy_Row_As_LegacyPresent(
+        string format)
+    {
+        var eventId = Guid.NewGuid();
+        var sortableUniqueId = NewSortableUniqueId();
+        var rendering = eventId.ToString(format).ToUpperInvariant();
+
+        var container = new FakePartitionContainer(new[] { LegacyRow(eventId, sortableUniqueId, rendering) });
+        var service = new CosmosDbTagRepairService(
+            ServiceId,
+            new SingleEventSource(eventId, sortableUniqueId),
+            new CosmosContainerRepairStore(container));
+
+        var report = await service.RepairAsync(new CosmosTagRepairOptions { DryRun = false });
+
+        // The whole point: this row must not look "missing" just because of how its event id was rendered.
+        Assert.Equal(1, report.LegacyPresent);
+        Assert.Equal(0, report.Missing);
+        Assert.Equal(0, report.Repaired);
+        Assert.Equal(0, report.Corrupt);
+
+        // Zero create attempts — proven by the fake container, whose CreateItemAsync throws.
+    }
+
+    [Theory]
+    [InlineData("D")]
+    [InlineData("N")]
+    [InlineData("B")]
+    public async Task The_Service_On_The_Production_Store_Should_Classify_Odd_Format_Legacy_Duplicates_As_Duplicate(
+        string format)
+    {
+        var eventId = Guid.NewGuid();
+        var sortableUniqueId = NewSortableUniqueId();
+
+        // Two legacy rows for the same pair, one of them in an odd rendering.
+        var container = new FakePartitionContainer(new[]
+        {
+            LegacyRow(eventId, sortableUniqueId, eventId.ToString()),
+            LegacyRow(eventId, sortableUniqueId, eventId.ToString(format).ToUpperInvariant())
+        });
+        var service = new CosmosDbTagRepairService(
+            ServiceId,
+            new SingleEventSource(eventId, sortableUniqueId),
+            new CosmosContainerRepairStore(container));
+
+        var report = await service.RepairAsync(new CosmosTagRepairOptions { DryRun = false });
+
+        Assert.Equal(1, report.Duplicate);
+        Assert.Equal(0, report.Missing);
+        Assert.Equal(0, report.Repaired);
+    }
+
+    /// <summary>Serves exactly one event, so these tests exercise the real store, not a fake one.</summary>
+    private sealed class SingleEventSource : ICosmosRepairEventSource
+    {
+        private readonly CosmosEvent _event;
+
+        public SingleEventSource(Guid eventId, string sortableUniqueId) =>
+            _event = new CosmosEvent
+            {
+                Pk = $"{ServiceId}|{eventId}",
+                ServiceId = ServiceId,
+                Id = eventId.ToString(),
+                SortableUniqueId = sortableUniqueId,
+                EventType = "TestEvent",
+                Payload = "{}",
+                Tags = new List<string> { Tag }
+            };
+
+        public Task<CosmosRepairEventPage> ReadEventPageAsync(
+            string? fromSortableUniqueIdExclusive,
+            string? toSortableUniqueIdInclusive,
+            int pageSize,
+            string? continuationToken,
+            CancellationToken cancellationToken) =>
+            Task.FromResult(new CosmosRepairEventPage(
+                continuationToken == null ? new[] { _event } : Array.Empty<CosmosEvent>(),
+                null,
+                1.0));
+    }
+
+    [Fact]
+    public async Task The_Sql_Prefilter_Should_Enumerate_Every_Guid_Rendering_Case_Insensitively()
+    {
+        var eventId = Guid.NewGuid();
+        var container = new FakePartitionContainer(Array.Empty<CosmosTag>());
+        var store = new CosmosContainerRepairStore(container);
+
+        await store.ReadRowsForEventAsync(PartitionKey, eventId, 16, CancellationToken.None);
+
+        var query = container.LastQuery!;
+        var text = query.QueryText;
+        var parameters = query.GetQueryParameters().Select(p => (string)p.Value).ToList();
+
+        // A server-side equality on one rendering would silently drop the others, so the prefilter must not
+        // be one: it enumerates every format Guid.ToString can emit, compared case-insensitively.
+        Assert.Contains("STRINGEQUALS", text, StringComparison.Ordinal);
+        Assert.DoesNotContain("c.eventId =", text, StringComparison.Ordinal);
+        foreach (var format in new[] { "D", "N", "B", "P", "X" })
+        {
+            Assert.Contains(eventId.ToString(format), parameters);
+        }
+    }
+}

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/CosmosDbTagRepairServiceTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/CosmosDbTagRepairServiceTests.cs
@@ -1,0 +1,525 @@
+using Sekiban.Dcb.Common;
+using Sekiban.Dcb.CosmosDb.Models;
+using Sekiban.Dcb.CosmosDb.Repair;
+using Sekiban.Dcb.CosmosDb.Tags;
+
+namespace Sekiban.Dcb.Tests;
+
+/// <summary>
+///     Covers the tag-repair service: repairing genuinely-missing rows, recognizing pre-SEK-G2 legacy rows
+///     without touching them, refusing to overwrite anything that disagrees with the event, dry-run,
+///     checkpoint/resume, idempotency, and a concurrent writer racing the repair.
+/// </summary>
+public class CosmosDbTagRepairServiceTests
+{
+    private const string ServiceId = "svc";
+    private const string OtherServiceId = "other-svc";
+
+    /// <summary>In-memory events container, ordered by sortableUniqueId, paged like the real scan.</summary>
+    private sealed class FakeEventSource : ICosmosRepairEventSource
+    {
+        private readonly List<CosmosEvent> _events;
+
+        public FakeEventSource(IEnumerable<CosmosEvent> events) =>
+            _events = events.OrderBy(e => e.SortableUniqueId, StringComparer.Ordinal).ToList();
+
+        public int PagesServed { get; private set; }
+
+        public Task<CosmosRepairEventPage> ReadEventPageAsync(
+            string? fromSortableUniqueIdExclusive,
+            string? toSortableUniqueIdInclusive,
+            int pageSize,
+            string? continuationToken,
+            CancellationToken cancellationToken)
+        {
+            PagesServed++;
+
+            var offset = continuationToken == null ? 0 : int.Parse(continuationToken, null);
+            var candidates = _events
+                .Where(e => fromSortableUniqueIdExclusive == null ||
+                    string.CompareOrdinal(e.SortableUniqueId, fromSortableUniqueIdExclusive) > 0)
+                .Where(e => toSortableUniqueIdInclusive == null ||
+                    string.CompareOrdinal(e.SortableUniqueId, toSortableUniqueIdInclusive) <= 0)
+                .ToList();
+
+            var page = candidates.Skip(offset).Take(pageSize).ToList();
+            var consumed = offset + page.Count;
+            var next = consumed < candidates.Count ? consumed.ToString(null as IFormatProvider) : null;
+
+            return Task.FromResult(new CosmosRepairEventPage(page, next, 1.0));
+        }
+    }
+
+    /// <summary>In-memory tags container. Records every write so "non-destructive" can be asserted, not assumed.</summary>
+    private sealed class FakeRepairStore : ICosmosTagRepairStore
+    {
+        private readonly Dictionary<(string PartitionKey, string Id), CosmosTag> _rows = new();
+
+        public int CreateAttempts { get; private set; }
+        public Func<Task>? BeforeCreate { get; set; }
+        public IReadOnlyCollection<CosmosTag> Rows => _rows.Values;
+
+        public void Seed(CosmosTag row) => _rows[(row.Pk, row.Id)] = row;
+
+        public Task<CosmosRepairRowLookup> ReadRowsForEventAsync(
+            string partitionKey,
+            Guid eventId,
+            int maxRows,
+            CancellationToken cancellationToken)
+        {
+            var matches = _rows.Values
+                .Where(row => string.Equals(row.Pk, partitionKey, StringComparison.Ordinal))
+                .Where(row => Guid.TryParse(row.EventId, out var id) && id == eventId)
+                .ToList();
+
+            return Task.FromResult(matches.Count > maxRows
+                ? new CosmosRepairRowLookup(matches.Take(maxRows).ToList(), true, 1.0)
+                : new CosmosRepairRowLookup(matches, false, 1.0));
+        }
+
+        public async Task<(bool Created, double RequestCharge)> TryCreateRowAsync(
+            string partitionKey,
+            CosmosTag row,
+            CancellationToken cancellationToken)
+        {
+            CreateAttempts++;
+
+            if (BeforeCreate != null)
+            {
+                await BeforeCreate().ConfigureAwait(false);
+            }
+
+            if (_rows.ContainsKey((partitionKey, row.Id)))
+            {
+                return (false, 1.0);
+            }
+
+            _rows[(partitionKey, row.Id)] = row;
+            return (true, 1.0);
+        }
+
+        public Task<CosmosTag?> TryReadRowAsync(string partitionKey, string id, CancellationToken cancellationToken) =>
+            Task.FromResult(_rows.GetValueOrDefault((partitionKey, id)));
+    }
+
+    private static string NewSortableUniqueId() => SortableUniqueId.GenerateNew();
+
+    private static CosmosEvent Event(Guid id, string sortableUniqueId, params string[] tags) =>
+        new()
+        {
+            Pk = $"{ServiceId}|{id}",
+            ServiceId = ServiceId,
+            Id = id.ToString(),
+            SortableUniqueId = sortableUniqueId,
+            EventType = "TestEvent",
+            Payload = "{}",
+            Tags = tags.ToList()
+        };
+
+    /// <summary>A row as the pre-SEK-G2 writer produced it: random id, wall-clock createdAt.</summary>
+    private static CosmosTag LegacyRow(Guid eventId, string tag, string sortableUniqueId, string? id = null) =>
+        new()
+        {
+            Pk = $"{ServiceId}|{tag}",
+            ServiceId = ServiceId,
+            Id = id ?? Guid.NewGuid().ToString(),
+            Tag = tag,
+            TagGroup = tag.Contains(':', StringComparison.Ordinal) ? tag.Split(':')[0] : tag,
+            EventType = "TestEvent",
+            SortableUniqueId = sortableUniqueId,
+            EventId = eventId.ToString(),
+            CreatedAt = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc)
+        };
+
+    private static CosmosDbTagRepairService Service(FakeEventSource source, FakeRepairStore store) =>
+        new(ServiceId, source, store);
+
+    private static CosmosTagRepairOptions Repair() => new() { DryRun = false };
+
+    [Fact]
+    public async Task Should_Repair_A_Missing_Tag_Row()
+    {
+        var eventId = Guid.NewGuid();
+        var sortableUniqueId = NewSortableUniqueId();
+        var store = new FakeRepairStore();
+        var service = Service(new FakeEventSource(new[] { Event(eventId, sortableUniqueId, "Student:1") }), store);
+
+        var report = await service.RepairAsync(Repair());
+
+        Assert.Equal(1, report.EventsScanned);
+        Assert.Equal(1, report.KeysScanned);
+        Assert.Equal(1, report.Missing);
+        Assert.Equal(1, report.Repaired);
+        Assert.False(report.DryRun);
+
+        var row = Assert.Single(store.Rows);
+        Assert.Equal(eventId.ToString(), row.Id);
+        Assert.Equal($"{ServiceId}|Student:1", row.Pk);
+        Assert.True(CosmosTagIdentity.ContentEquals(
+            CosmosTagIdentity.DeriveRow(ServiceId, "Student:1", eventId, sortableUniqueId, "TestEvent"),
+            row));
+    }
+
+    [Fact]
+    public async Task Dry_Run_Should_Report_Without_Writing()
+    {
+        var store = new FakeRepairStore();
+        var service = Service(
+            new FakeEventSource(new[] { Event(Guid.NewGuid(), NewSortableUniqueId(), "Student:1") }),
+            store);
+
+        var report = await service.RepairAsync(new CosmosTagRepairOptions { DryRun = true });
+
+        Assert.True(report.DryRun);
+        Assert.Equal(1, report.Missing);
+        Assert.Equal(0, report.Repaired);
+        Assert.Empty(store.Rows);
+        Assert.Equal(0, store.CreateAttempts);
+    }
+
+    [Fact]
+    public async Task Re_Running_A_Repair_Should_Be_Idempotent()
+    {
+        var store = new FakeRepairStore();
+        var source = new FakeEventSource(new[] { Event(Guid.NewGuid(), NewSortableUniqueId(), "Student:1") });
+
+        var first = await Service(source, store).RepairAsync(Repair());
+        var second = await Service(source, store).RepairAsync(Repair());
+
+        Assert.Equal(1, first.Repaired);
+        Assert.Equal(0, second.Repaired);
+        Assert.Equal(1, second.Present);
+        Assert.Single(store.Rows);
+    }
+
+    [Fact]
+    public async Task Two_Events_Sharing_A_Tag_Should_Not_Match_Each_Other()
+    {
+        // The legacy row belongs to eventA. eventB carries the same tag, so it lives in the same partition —
+        // but it is a different event and must still be seen as missing.
+        var eventA = Guid.NewGuid();
+        var eventB = Guid.NewGuid();
+        var sortableA = NewSortableUniqueId();
+        var sortableB = NewSortableUniqueId();
+
+        var store = new FakeRepairStore();
+        store.Seed(LegacyRow(eventA, "Student:1", sortableA));
+
+        var service = Service(
+            new FakeEventSource(new[]
+            {
+                Event(eventA, sortableA, "Student:1"),
+                Event(eventB, sortableB, "Student:1")
+            }),
+            store);
+
+        var report = await service.RepairAsync(Repair());
+
+        Assert.Equal(1, report.LegacyPresent);
+        Assert.Equal(1, report.Missing);
+        Assert.Equal(1, report.Repaired);
+        Assert.Equal(0, report.Corrupt);
+
+        // eventA keeps only its legacy row; eventB gets a fresh deterministic row.
+        Assert.Equal(2, store.Rows.Count);
+        Assert.Contains(store.Rows, row => row.EventId == eventA.ToString() && row.Id != eventA.ToString());
+        Assert.Contains(store.Rows, row => row.Id == eventB.ToString());
+    }
+
+    [Theory]
+    [InlineData("D")] // 00000000-0000-0000-0000-000000000000
+    [InlineData("N")] // 00000000000000000000000000000000
+    [InlineData("B")] // {00000000-...}
+    public async Task Legacy_Rows_Should_Match_Regardless_Of_Guid_Formatting(string format)
+    {
+        var eventId = Guid.NewGuid();
+        var sortableUniqueId = NewSortableUniqueId();
+
+        var legacy = LegacyRow(eventId, "Student:1", sortableUniqueId);
+        legacy.EventId = eventId.ToString(format).ToUpperInvariant();
+
+        var store = new FakeRepairStore();
+        store.Seed(legacy);
+
+        var report = await Service(
+                new FakeEventSource(new[] { Event(eventId, sortableUniqueId, "Student:1") }),
+                store)
+            .RepairAsync(Repair());
+
+        Assert.Equal(1, report.LegacyPresent);
+        Assert.Equal(0, report.Missing);
+        Assert.Equal(0, report.Repaired);
+        Assert.Single(store.Rows);
+    }
+
+    [Fact]
+    public async Task A_Legacy_Row_Should_Be_Legacy_Present_Not_Corrupt_And_Left_Untouched()
+    {
+        var eventId = Guid.NewGuid();
+        var sortableUniqueId = NewSortableUniqueId();
+        var legacy = LegacyRow(eventId, "Student:1", sortableUniqueId);
+        var legacyId = legacy.Id;
+        var legacyCreatedAt = legacy.CreatedAt;
+
+        var store = new FakeRepairStore();
+        store.Seed(legacy);
+
+        var report = await Service(
+                new FakeEventSource(new[] { Event(eventId, sortableUniqueId, "Student:1") }),
+                store)
+            .RepairAsync(Repair());
+
+        // The random id and wall-clock createdAt are exactly the differences a legacy row is expected to
+        // have. They are migration metadata, not corruption.
+        Assert.Equal(1, report.LegacyPresent);
+        Assert.Equal(0, report.Corrupt);
+        Assert.Equal(0, report.Repaired);
+        Assert.Equal(0, store.CreateAttempts);
+
+        var stored = Assert.Single(store.Rows);
+        Assert.Equal(legacyId, stored.Id);
+        Assert.Equal(legacyCreatedAt, stored.CreatedAt);
+    }
+
+    [Theory]
+    [InlineData("sortableUniqueId")]
+    [InlineData("eventType")]
+    [InlineData("tagGroup")]
+    public async Task A_Legacy_Row_Disagreeing_With_The_Event_Should_Be_Corrupt(string driftedField)
+    {
+        var eventId = Guid.NewGuid();
+        var sortableUniqueId = NewSortableUniqueId();
+        var legacy = LegacyRow(eventId, "Student:1", sortableUniqueId);
+
+        switch (driftedField)
+        {
+            case "sortableUniqueId":
+                legacy.SortableUniqueId = NewSortableUniqueId();
+                break;
+            case "eventType":
+                legacy.EventType = "SomethingElse";
+                break;
+            default:
+                legacy.TagGroup = "Teacher";
+                break;
+        }
+
+        var store = new FakeRepairStore();
+        store.Seed(legacy);
+
+        var report = await Service(
+                new FakeEventSource(new[] { Event(eventId, sortableUniqueId, "Student:1") }),
+                store)
+            .RepairAsync(Repair());
+
+        // A legacy id excuses the id and the timestamp. It does not license drift in what the row indexes.
+        Assert.Equal(1, report.Corrupt);
+        Assert.Equal(0, report.LegacyPresent);
+        Assert.Equal(0, report.Repaired);
+        Assert.Equal(0, store.CreateAttempts);
+        Assert.Single(store.Rows);
+        Assert.Contains(report.Findings, f => f.Category == CosmosTagRepairCategory.Corrupt && f.Detail != null);
+    }
+
+    [Fact]
+    public async Task A_Deterministic_Row_With_A_Drifted_CreatedAt_Should_Still_Be_Corrupt()
+    {
+        var eventId = Guid.NewGuid();
+        var sortableUniqueId = NewSortableUniqueId();
+
+        // Sits at the derived id, so it is held to the strict SEK-G2 comparator — createdAt included.
+        var deterministic = CosmosTagIdentity.DeriveRow(ServiceId, "Student:1", eventId, sortableUniqueId, "TestEvent");
+        deterministic.CreatedAt = deterministic.CreatedAt.AddDays(1);
+
+        var store = new FakeRepairStore();
+        store.Seed(deterministic);
+
+        var report = await Service(
+                new FakeEventSource(new[] { Event(eventId, sortableUniqueId, "Student:1") }),
+                store)
+            .RepairAsync(Repair());
+
+        Assert.Equal(1, report.Corrupt);
+        Assert.Equal(0, report.Present);
+        Assert.Equal(0, report.Repaired);
+        Assert.Equal(0, store.CreateAttempts);
+    }
+
+    [Fact]
+    public async Task Multiple_Legacy_Rows_Should_Be_Reported_As_Duplicate_And_Not_Mutated()
+    {
+        var eventId = Guid.NewGuid();
+        var sortableUniqueId = NewSortableUniqueId();
+
+        var store = new FakeRepairStore();
+        store.Seed(LegacyRow(eventId, "Student:1", sortableUniqueId));
+        store.Seed(LegacyRow(eventId, "Student:1", sortableUniqueId));
+
+        var report = await Service(
+                new FakeEventSource(new[] { Event(eventId, sortableUniqueId, "Student:1") }),
+                store)
+            .RepairAsync(Repair());
+
+        // Reducing duplicates is destructive. This service reports them and stops.
+        Assert.Equal(1, report.Duplicate);
+        Assert.Equal(0, report.Repaired);
+        Assert.Equal(0, store.CreateAttempts);
+        Assert.Equal(2, store.Rows.Count);
+    }
+
+    [Fact]
+    public async Task Rows_Beyond_The_Per_Key_Cap_Should_Be_Reported_As_Overflow()
+    {
+        var eventId = Guid.NewGuid();
+        var sortableUniqueId = NewSortableUniqueId();
+
+        var store = new FakeRepairStore();
+        for (var i = 0; i < 4; i++)
+        {
+            store.Seed(LegacyRow(eventId, "Student:1", sortableUniqueId));
+        }
+
+        var report = await Service(
+                new FakeEventSource(new[] { Event(eventId, sortableUniqueId, "Student:1") }),
+                store)
+            .RepairAsync(new CosmosTagRepairOptions { DryRun = false, MaxRowsPerKey = 2 });
+
+        Assert.Equal(1, report.Overflow);
+        Assert.Equal(0, report.Repaired);
+        Assert.Equal(0, store.CreateAttempts);
+        Assert.Equal(4, store.Rows.Count);
+    }
+
+    [Fact]
+    public async Task A_Concurrent_Writer_Between_Classification_And_Repair_Should_Not_Duplicate_Or_Error()
+    {
+        var eventId = Guid.NewGuid();
+        var sortableUniqueId = NewSortableUniqueId();
+        var store = new FakeRepairStore();
+
+        // The write path lands the very row we classified as missing, just before we create it.
+        store.BeforeCreate = () =>
+        {
+            store.BeforeCreate = null;
+            store.Seed(CosmosTagIdentity.DeriveRow(ServiceId, "Student:1", eventId, sortableUniqueId, "TestEvent"));
+            return Task.CompletedTask;
+        };
+
+        var report = await Service(
+                new FakeEventSource(new[] { Event(eventId, sortableUniqueId, "Student:1") }),
+                store)
+            .RepairAsync(Repair());
+
+        // The row that landed is the row we were about to write, so this is a no-op, not a conflict.
+        Assert.Equal(0, report.Corrupt);
+        Assert.Equal(0, report.Repaired);
+        Assert.Equal(1, report.Present);
+        Assert.Single(store.Rows);
+    }
+
+    [Fact]
+    public async Task A_Scan_Should_Stop_At_Its_Event_Budget_And_Resume_From_The_Checkpoint()
+    {
+        var events = Enumerable
+            .Range(0, 5)
+            .Select(_ => Event(Guid.NewGuid(), NewSortableUniqueId(), "Student:1"))
+            .ToList();
+
+        var store = new FakeRepairStore();
+        var source = new FakeEventSource(events);
+
+        var first = await Service(source, store).RepairAsync(
+            new CosmosTagRepairOptions { DryRun = false, MaxEventsToScan = 2, PageSize = 2 });
+
+        Assert.Equal(2, first.EventsScanned);
+        Assert.Equal(2, first.Repaired);
+        Assert.True(first.HasMore);
+        Assert.NotNull(first.Checkpoint);
+
+        var second = await Service(source, store).RepairAsync(
+            new CosmosTagRepairOptions
+            {
+                DryRun = false,
+                MaxEventsToScan = 100,
+                PageSize = 2,
+                Checkpoint = first.Checkpoint
+            });
+
+        // Resuming picks up exactly the events the first run did not reach — no gap, no re-repair.
+        Assert.Equal(3, second.EventsScanned);
+        Assert.Equal(3, second.Repaired);
+        Assert.False(second.HasMore);
+        Assert.Null(second.Checkpoint);
+        Assert.Equal(5, store.Rows.Count);
+    }
+
+    [Fact]
+    public async Task A_Scan_Should_Honor_Its_SortableUniqueId_Range()
+    {
+        var events = Enumerable
+            .Range(0, 4)
+            .Select(_ => Event(Guid.NewGuid(), NewSortableUniqueId(), "Student:1"))
+            .OrderBy(e => e.SortableUniqueId, StringComparer.Ordinal)
+            .ToList();
+
+        var store = new FakeRepairStore();
+
+        var report = await Service(new FakeEventSource(events), store).RepairAsync(
+            new CosmosTagRepairOptions
+            {
+                DryRun = false,
+                FromSortableUniqueIdExclusive = events[0].SortableUniqueId,
+                ToSortableUniqueIdInclusive = events[2].SortableUniqueId
+            });
+
+        Assert.Equal(2, report.EventsScanned);
+        Assert.Equal(2, report.Repaired);
+        Assert.Equal(2, store.Rows.Count);
+    }
+
+    [Fact]
+    public async Task Cancellation_Should_Stop_The_Scan()
+    {
+        using var cts = new CancellationTokenSource();
+        var store = new FakeRepairStore();
+        store.BeforeCreate = () =>
+        {
+            cts.Cancel();
+            return Task.CompletedTask;
+        };
+
+        var events = Enumerable
+            .Range(0, 5)
+            .Select(_ => Event(Guid.NewGuid(), NewSortableUniqueId(), "Student:1"))
+            .ToList();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => Service(new FakeEventSource(events), store).RepairAsync(
+                new CosmosTagRepairOptions { DryRun = false, PageSize = 1 },
+                cts.Token));
+    }
+
+    [Fact]
+    public void A_Repair_Service_Is_Bound_To_One_Service_Id()
+    {
+        var service = Service(new FakeEventSource(Array.Empty<CosmosEvent>()), new FakeRepairStore());
+
+        // The lineage is fixed at construction, so a run cannot be pointed at another tenant's containers.
+        Assert.Equal(ServiceId, service.ServiceId);
+        Assert.NotEqual(OtherServiceId, service.ServiceId);
+    }
+
+    [Fact]
+    public async Task A_Tag_Repeated_Within_One_Event_Should_Be_One_Key()
+    {
+        var eventId = Guid.NewGuid();
+        var store = new FakeRepairStore();
+        var cosmosEvent = Event(eventId, NewSortableUniqueId(), "Student:1", "Student:1");
+
+        var report = await Service(new FakeEventSource(new[] { cosmosEvent }), store).RepairAsync(Repair());
+
+        Assert.Equal(1, report.KeysScanned);
+        Assert.Equal(1, report.Repaired);
+        Assert.Single(store.Rows);
+    }
+}

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/CosmosTagRepairRegistrationTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/CosmosTagRepairRegistrationTests.cs
@@ -1,0 +1,61 @@
+using Microsoft.Extensions.DependencyInjection;
+using Sekiban.Dcb.CosmosDb;
+using Sekiban.Dcb.CosmosDb.Repair;
+
+namespace Sekiban.Dcb.Tests;
+
+/// <summary>
+///     Both registration styles must be able to reach the repair factory — and an application that does not
+///     ask for it must not get it.
+/// </summary>
+public class CosmosTagRepairRegistrationTests
+{
+    private const string ConnectionString = "AccountEndpoint=https://localhost:8081/;AccountKey=key==";
+
+    [Fact]
+    public void AddSekibanDcbCosmosDb_Alone_Should_Not_Register_The_Repair_Factory()
+    {
+        var services = new ServiceCollection();
+        services.AddSekibanDcbCosmosDb(ConnectionString, "testdb");
+
+        // Repair is an operator tool. An application only gets it if it explicitly asks.
+        Assert.Null(services.BuildServiceProvider().GetService<CosmosDbTagRepairServiceFactory>());
+    }
+
+    [Fact]
+    public void AddSekibanDcbCosmosDbTagRepair_Should_Register_The_Factory_For_The_DI_Style()
+    {
+        var services = new ServiceCollection();
+        services.AddSekibanDcbCosmosDb(ConnectionString, "testdb");
+        services.AddSekibanDcbCosmosDbTagRepair();
+
+        Assert.NotNull(services.BuildServiceProvider().GetRequiredService<CosmosDbTagRepairServiceFactory>());
+    }
+
+    [Fact]
+    public void The_Factory_Should_Be_Constructible_Manually_For_The_Custom_Factory_Style()
+    {
+        // The manual path: hand it a context and a resolver, no DI container involved.
+        var options = new CosmosDbEventStoreOptions
+        {
+            EventsContainerName = "events",
+            TagsContainerName = "tags"
+        };
+        var context = new CosmosDbContext(ConnectionString, "testdb", null, options);
+
+        var factory = new CosmosDbTagRepairServiceFactory(context, new DefaultCosmosContainerResolver(options));
+
+        Assert.NotNull(factory);
+    }
+
+    [Fact]
+    public async Task Creating_A_Service_Should_Require_A_Service_Id()
+    {
+        var options = new CosmosDbEventStoreOptions();
+        var context = new CosmosDbContext(ConnectionString, "testdb", null, options);
+        var factory = new CosmosDbTagRepairServiceFactory(context, new DefaultCosmosContainerResolver(options));
+
+        // The lineage is explicit, never ambient — repairing tenant A must not be reachable by accident.
+        await Assert.ThrowsAnyAsync<ArgumentException>(() => factory.CreateAsync(string.Empty));
+    }
+}

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/NotSupportedCosmosContainer.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/NotSupportedCosmosContainer.cs
@@ -1,0 +1,230 @@
+using Microsoft.Azure.Cosmos;
+using Microsoft.Azure.Cosmos.Scripts;
+
+namespace Sekiban.Dcb.Tests;
+
+/// <summary>
+///     A <see cref="Container" /> whose every operation throws, so a test double can override just the two or
+///     three the code under test is allowed to use. Anything else it reaches for fails loudly instead of
+///     silently returning a default.
+/// </summary>
+public abstract class NotSupportedCosmosContainer : Container
+{
+    private static NotSupportedException Unsupported() => new("This container is a test double.");
+
+    public override string Id => throw Unsupported();
+    public override Database Database => throw Unsupported();
+    public override Conflicts Conflicts => throw Unsupported();
+    public override Microsoft.Azure.Cosmos.Scripts.Scripts Scripts => throw Unsupported();
+
+    public override Task<ItemResponse<T>> CreateItemAsync<T>(
+        T item,
+        PartitionKey? partitionKey = null,
+        ItemRequestOptions? requestOptions = null,
+        CancellationToken cancellationToken = default) => throw Unsupported();
+
+    public override Task<ResponseMessage> CreateItemStreamAsync(
+        Stream streamPayload,
+        PartitionKey partitionKey,
+        ItemRequestOptions? requestOptions = null,
+        CancellationToken cancellationToken = default) => throw Unsupported();
+
+    public override TransactionalBatch CreateTransactionalBatch(PartitionKey partitionKey) => throw Unsupported();
+
+    public override Task<ContainerResponse> DeleteContainerAsync(
+        ContainerRequestOptions? requestOptions = null,
+        CancellationToken cancellationToken = default) => throw Unsupported();
+
+    public override Task<ResponseMessage> DeleteContainerStreamAsync(
+        ContainerRequestOptions? requestOptions = null,
+        CancellationToken cancellationToken = default) => throw Unsupported();
+
+    public override Task<ItemResponse<T>> DeleteItemAsync<T>(
+        string id,
+        PartitionKey partitionKey,
+        ItemRequestOptions? requestOptions = null,
+        CancellationToken cancellationToken = default) => throw Unsupported();
+
+    public override Task<ResponseMessage> DeleteItemStreamAsync(
+        string id,
+        PartitionKey partitionKey,
+        ItemRequestOptions? requestOptions = null,
+        CancellationToken cancellationToken = default) => throw Unsupported();
+
+    public override ChangeFeedEstimator GetChangeFeedEstimator(
+        string processorName,
+        Container leaseContainer) => throw Unsupported();
+
+    public override ChangeFeedProcessorBuilder GetChangeFeedEstimatorBuilder(
+        string processorName,
+        ChangesEstimationHandler estimationDelegate,
+        TimeSpan? estimationPeriod = null) => throw Unsupported();
+
+    public override FeedIterator<T> GetChangeFeedIterator<T>(
+        ChangeFeedStartFrom changeFeedStartFrom,
+        ChangeFeedMode changeFeedMode,
+        ChangeFeedRequestOptions? changeFeedRequestOptions = null) => throw Unsupported();
+
+    public override ChangeFeedProcessorBuilder GetChangeFeedProcessorBuilder(
+        string processorName,
+        ChangeFeedStreamHandler onChangesDelegate) => throw Unsupported();
+
+    public override ChangeFeedProcessorBuilder GetChangeFeedProcessorBuilder<T>(
+        string processorName,
+        ChangeFeedHandler<T> onChangesDelegate) => throw Unsupported();
+
+    public override ChangeFeedProcessorBuilder GetChangeFeedProcessorBuilder<T>(
+        string processorName,
+        ChangesHandler<T> onChangesDelegate) => throw Unsupported();
+
+    public override ChangeFeedProcessorBuilder GetChangeFeedProcessorBuilderWithManualCheckpoint(
+        string processorName,
+        ChangeFeedStreamHandlerWithManualCheckpoint onChangesDelegate) => throw Unsupported();
+
+    public override ChangeFeedProcessorBuilder GetChangeFeedProcessorBuilderWithManualCheckpoint<T>(
+        string processorName,
+        ChangeFeedHandlerWithManualCheckpoint<T> onChangesDelegate) => throw Unsupported();
+
+    public override FeedIterator GetChangeFeedStreamIterator(
+        ChangeFeedStartFrom changeFeedStartFrom,
+        ChangeFeedMode changeFeedMode,
+        ChangeFeedRequestOptions? changeFeedRequestOptions = null) => throw Unsupported();
+
+    public override Task<IReadOnlyList<FeedRange>> GetFeedRangesAsync(
+        CancellationToken cancellationToken = default) => throw Unsupported();
+
+    public override IOrderedQueryable<T> GetItemLinqQueryable<T>(
+        bool allowSynchronousQueryExecution = false,
+        string? continuationToken = null,
+        QueryRequestOptions? requestOptions = null,
+        CosmosLinqSerializerOptions? linqSerializerOptions = null) => throw Unsupported();
+
+    public override FeedIterator<T> GetItemQueryIterator<T>(
+        QueryDefinition queryDefinition,
+        string? continuationToken = null,
+        QueryRequestOptions? requestOptions = null) => throw Unsupported();
+
+    public override FeedIterator<T> GetItemQueryIterator<T>(
+        FeedRange feedRange,
+        QueryDefinition queryDefinition,
+        string? continuationToken = null,
+        QueryRequestOptions? requestOptions = null) => throw Unsupported();
+
+    public override FeedIterator<T> GetItemQueryIterator<T>(
+        string? queryText = null,
+        string? continuationToken = null,
+        QueryRequestOptions? requestOptions = null) => throw Unsupported();
+
+    public override FeedIterator GetItemQueryStreamIterator(
+        FeedRange feedRange,
+        QueryDefinition queryDefinition,
+        string? continuationToken,
+        QueryRequestOptions? requestOptions = null) => throw Unsupported();
+
+    public override FeedIterator GetItemQueryStreamIterator(
+        QueryDefinition queryDefinition,
+        string? continuationToken = null,
+        QueryRequestOptions? requestOptions = null) => throw Unsupported();
+
+    public override FeedIterator GetItemQueryStreamIterator(
+        string? queryText = null,
+        string? continuationToken = null,
+        QueryRequestOptions? requestOptions = null) => throw Unsupported();
+
+    public override Task<ItemResponse<T>> PatchItemAsync<T>(
+        string id,
+        PartitionKey partitionKey,
+        IReadOnlyList<PatchOperation> patchOperations,
+        PatchItemRequestOptions? requestOptions = null,
+        CancellationToken cancellationToken = default) => throw Unsupported();
+
+    public override Task<ResponseMessage> PatchItemStreamAsync(
+        string id,
+        PartitionKey partitionKey,
+        IReadOnlyList<PatchOperation> patchOperations,
+        PatchItemRequestOptions? requestOptions = null,
+        CancellationToken cancellationToken = default) => throw Unsupported();
+
+    public override Task<ContainerResponse> ReadContainerAsync(
+        ContainerRequestOptions? requestOptions = null,
+        CancellationToken cancellationToken = default) => throw Unsupported();
+
+    public override Task<ResponseMessage> ReadContainerStreamAsync(
+        ContainerRequestOptions? requestOptions = null,
+        CancellationToken cancellationToken = default) => throw Unsupported();
+
+    public override Task<ItemResponse<T>> ReadItemAsync<T>(
+        string id,
+        PartitionKey partitionKey,
+        ItemRequestOptions? requestOptions = null,
+        CancellationToken cancellationToken = default) => throw Unsupported();
+
+    public override Task<ResponseMessage> ReadItemStreamAsync(
+        string id,
+        PartitionKey partitionKey,
+        ItemRequestOptions? requestOptions = null,
+        CancellationToken cancellationToken = default) => throw Unsupported();
+
+    public override Task<FeedResponse<T>> ReadManyItemsAsync<T>(
+        IReadOnlyList<(string id, PartitionKey partitionKey)> items,
+        ReadManyRequestOptions? readManyRequestOptions = null,
+        CancellationToken cancellationToken = default) => throw Unsupported();
+
+    public override Task<ResponseMessage> ReadManyItemsStreamAsync(
+        IReadOnlyList<(string id, PartitionKey partitionKey)> items,
+        ReadManyRequestOptions? readManyRequestOptions = null,
+        CancellationToken cancellationToken = default) => throw Unsupported();
+
+    public override Task<int?> ReadThroughputAsync(CancellationToken cancellationToken = default) =>
+        throw Unsupported();
+
+    public override Task<ThroughputResponse> ReadThroughputAsync(
+        RequestOptions requestOptions,
+        CancellationToken cancellationToken = default) => throw Unsupported();
+
+    public override Task<ContainerResponse> ReplaceContainerAsync(
+        ContainerProperties containerProperties,
+        ContainerRequestOptions? requestOptions = null,
+        CancellationToken cancellationToken = default) => throw Unsupported();
+
+    public override Task<ResponseMessage> ReplaceContainerStreamAsync(
+        ContainerProperties containerProperties,
+        ContainerRequestOptions? requestOptions = null,
+        CancellationToken cancellationToken = default) => throw Unsupported();
+
+    public override Task<ItemResponse<T>> ReplaceItemAsync<T>(
+        T item,
+        string id,
+        PartitionKey? partitionKey = null,
+        ItemRequestOptions? requestOptions = null,
+        CancellationToken cancellationToken = default) => throw Unsupported();
+
+    public override Task<ResponseMessage> ReplaceItemStreamAsync(
+        Stream streamPayload,
+        string id,
+        PartitionKey partitionKey,
+        ItemRequestOptions? requestOptions = null,
+        CancellationToken cancellationToken = default) => throw Unsupported();
+
+    public override Task<ThroughputResponse> ReplaceThroughputAsync(
+        int throughput,
+        RequestOptions? requestOptions = null,
+        CancellationToken cancellationToken = default) => throw Unsupported();
+
+    public override Task<ThroughputResponse> ReplaceThroughputAsync(
+        ThroughputProperties throughputProperties,
+        RequestOptions? requestOptions = null,
+        CancellationToken cancellationToken = default) => throw Unsupported();
+
+    public override Task<ItemResponse<T>> UpsertItemAsync<T>(
+        T item,
+        PartitionKey? partitionKey = null,
+        ItemRequestOptions? requestOptions = null,
+        CancellationToken cancellationToken = default) => throw Unsupported();
+
+    public override Task<ResponseMessage> UpsertItemStreamAsync(
+        Stream streamPayload,
+        PartitionKey partitionKey,
+        ItemRequestOptions? requestOptions = null,
+        CancellationToken cancellationToken = default) => throw Unsupported();
+}

--- a/docs/dcb_llm/11_storage_providers.md
+++ b/docs/dcb_llm/11_storage_providers.md
@@ -189,7 +189,64 @@ The default stays `Compatible` through the current release line so that **upgrad
 
 The `Sekiban.Dcb.CosmosDb` meter (`CosmosDbTelemetry.MeterName`) publishes `tag_write.failures` (label `reason`: `transient` | `corruption`), `tag_write.retries`, `tag_write.retry_outcomes` (label `outcome`: `recovered` | `exhausted`), and `event_write.partial_failures`. Metric labels are drawn from small fixed sets; raw event ids and tag strings are unbounded and therefore appear only in the structured logs and in the exceptions above.
 
-**Still planned (not yet released)**: a tag-index repair API and an opt-in startup sweep. Upgrading the package does not enable any repair or sweep behavior; those land later as explicit opt-ins. Note that reads immediately after a future repair may observe stale state depending on the configured Cosmos consistency level.
+#### Tag index repair (`CosmosDbTagRepairService`)
+
+Because a tag row is fully derivable from its event, the tags container can be rebuilt from the events container. `CosmosDbTagRepairService` is the operator surface for that: it scans events over a `sortableUniqueId` range, derives the expected row for each `(event, tag)` pair, and creates the ones that are missing.
+
+It is **strictly non-destructive**. It only ever creates rows that do not exist — it never deletes, rewrites, or canonicalizes one. It is deliberately not part of `IEventStore`: run it as an operator job, never expose it from a request path.
+
+```csharp
+services.AddSekibanDcbCosmosDb(configuration);
+services.AddSekibanDcbCosmosDbTagRepair();   // opt-in; not registered by AddSekibanDcbCosmosDb alone
+
+// In an operator-only job:
+var repair = await factory.CreateAsync(serviceId);   // one instance == one (serviceId, events, tags) lineage
+
+// Always look before you write.
+var report = await repair.RepairAsync(new CosmosTagRepairOptions
+{
+    DryRun = true,                                    // the default
+    ToSortableUniqueIdInclusive = lastSettledId,      // pin the upper bound; live writes repair themselves
+    MaxEventsToScan = 10_000,
+});
+
+// Then repair, resuming across bounded runs.
+string? checkpoint = null;
+do
+{
+    var run = await repair.RepairAsync(new CosmosTagRepairOptions
+    {
+        DryRun = false,
+        ToSortableUniqueIdInclusive = lastSettledId,
+        Checkpoint = checkpoint,
+    }, cancellationToken);
+
+    checkpoint = run.HasMore ? run.Checkpoint : null;
+} while (checkpoint != null);
+```
+
+The service can also be constructed manually — `new CosmosDbTagRepairServiceFactory(context, containerResolver)` — for hosts that build their stores through a custom factory instead of DI. Either way, an instance is bound to one `(serviceId, events container, tags container)` lineage at construction, so repairing across lineages is structurally impossible rather than merely discouraged.
+
+**Report categories.** Every `(event, tag)` key lands in exactly one:
+
+| Category | Meaning | Does repair write? |
+|---|---|---|
+| `Present` | The derived row exists and matches the event. | No |
+| `Missing` | Nothing indexes this pair. | **Yes** — this is the only category it writes |
+| `LegacyPresent` | A row written before the deterministic-id scheme indexes this pair. Its random id and wall-clock `createdAt` are expected differences, reported as migration metadata. | No — and the legacy row is never touched |
+| `Duplicate` | More than one legacy row indexes this pair (residue of a pre-deterministic re-execution). | No — reported only; reducing them is destructive and out of scope |
+| `Corrupt` | A row occupies this pair but disagrees with the event (`sortableUniqueId`, `eventType`, or `tagGroup` drift; or a row at the derived id whose content differs). | No — never overwritten |
+| `Overflow` | More rows index this pair than `MaxRowsPerKey` allowed the scan to examine. | No — raise the cap to look deeper |
+
+**Operational guidance.**
+
+- **Least privilege**: the job needs read on the events container and *create* on the tags container. It never deletes or replaces, so a Cosmos role without `deleteItem`/`replaceItem` on the tags container is sufficient — and is the recommended way to enforce non-destructiveness at the platform level rather than trusting the code.
+- **RU cost**: the events scan is cross-partition (events are partitioned per event), and each `(event, tag)` key costs one partition-confined query against the tags container. So RU scales with *keys*, not events: roughly `events × tags-per-event` point-ish queries plus the scan itself. `MaxParallelism` (default 4) is the RU-rate dial; `MaxEventsToScan` (default 10,000) bounds one run's total cost. Throttling is expected — the service honors Cosmos `Retry-After` in full rather than retrying early.
+- **Pin the upper bound**: set `ToSortableUniqueIdInclusive` to an event you know is settled. Events written while the scan runs are indexed by the write path itself; the repair is for crash residue, not for live traffic.
+- **Concurrency**: a run is safe alongside live writes and alongside another run. If a normal write lands the very row a run classified as missing, the run recognizes it as the row it was about to write and moves on — no duplicate, no error.
+- **Consistency caveat**: reads issued immediately after a repair may still observe stale state depending on the Cosmos consistency level configured on the account. Under session or eventual consistency, a tag-scoped read from a different session can lag the repair's writes.
+
+**Still planned (not yet released)**: an opt-in startup/periodic sweep, and destructive reduction of duplicate legacy rows (a separate, separately-authorized concern). Upgrading the package does not enable any sweep behavior.
 
 ### Choosing a provider
 

--- a/docs/dcb_llm_ja/11_storage_providers.md
+++ b/docs/dcb_llm_ja/11_storage_providers.md
@@ -213,7 +213,64 @@ services.AddSekibanDcbCosmosDb(
 
 `Sekiban.Dcb.CosmosDb` メーター(`CosmosDbTelemetry.MeterName`)は、`tag_write.failures`(ラベル `reason`: `transient` | `corruption`)、`tag_write.retries`、`tag_write.retry_outcomes`(ラベル `outcome`: `recovered` | `exhausted`)、`event_write.partial_failures` を発行します。メトリクスのラベルは小さな固定集合から取られます。生のイベントIDやタグ文字列は非有界であるため、構造化ログと上記の例外にのみ含まれます。
 
-**引き続き計画中(未リリース)**: タグインデックス修復API、opt-in のスタートアップスイープ。パッケージをアップグレードするだけでは修復/スイープの動作は有効になりません。今後、明示的な opt-in として提供されます。なお、将来的に修復がリリースされた後も、修復直後の読み取りは、設定された Cosmos の整合性レベルによっては古い状態を観測する可能性がある点に注意してください。
+#### タグインデックスの修復 (`CosmosDbTagRepairService`)
+
+タグ行はイベントから完全に導出できるため、`tags` コンテナーは `events` コンテナーから再構築できます。`CosmosDbTagRepairService` はそのための運用者向けサーフェスです。`sortableUniqueId` の範囲でイベントをスキャンし、各 (イベント, タグ) ペアについて期待されるタグ行を導出し、欠けているものだけを作成します。
+
+このサービスは **厳密に非破壊** です。存在しない行を作成することしかせず、行の削除・書き換え・正規化は決して行いません。また意図的に `IEventStore` の一部にはしていません — 運用者専用のジョブとして実行し、リクエストパスから公開しないでください。
+
+```csharp
+services.AddSekibanDcbCosmosDb(configuration);
+services.AddSekibanDcbCosmosDbTagRepair();   // opt-in。AddSekibanDcbCosmosDb だけでは登録されない
+
+// 運用者専用ジョブ内で:
+var repair = await factory.CreateAsync(serviceId);   // 1インスタンス == 1つの (serviceId, events, tags) 系統
+
+// 書き込む前に必ず確認する
+var report = await repair.RepairAsync(new CosmosTagRepairOptions
+{
+    DryRun = true,                                    // デフォルト
+    ToSortableUniqueIdInclusive = lastSettledId,      // 上限を固定。稼働中の書き込みは書き込みパス自身が処理する
+    MaxEventsToScan = 10_000,
+});
+
+// その後、有界な run を再開しながら修復する
+string? checkpoint = null;
+do
+{
+    var run = await repair.RepairAsync(new CosmosTagRepairOptions
+    {
+        DryRun = false,
+        ToSortableUniqueIdInclusive = lastSettledId,
+        Checkpoint = checkpoint,
+    }, cancellationToken);
+
+    checkpoint = run.HasMore ? run.Checkpoint : null;
+} while (checkpoint != null);
+```
+
+DI ではなくカスタムファクトリでストアを組み立てるホスト向けに、手動構築も可能です(`new CosmosDbTagRepairServiceFactory(context, containerResolver)`)。いずれの場合も、インスタンスは構築時に1つの `(serviceId, events コンテナー, tags コンテナー)` 系統に束縛されるため、系統をまたぐ修復は「非推奨」ではなく **構造的に不可能** です。
+
+**レポートの分類**。すべての (イベント, タグ) キーは必ずいずれか1つに分類されます:
+
+| 分類 | 意味 | 修復は書き込む? |
+|---|---|---|
+| `Present` | 導出された行が存在し、イベントと一致している。 | いいえ |
+| `Missing` | このペアを索引する行が存在しない。 | **はい** — 書き込むのはこの分類のみ |
+| `LegacyPresent` | 決定論的ID方式より前に書かれた行がこのペアを索引している。ランダムIDと壁時計の `createdAt` は想定内の差異であり、移行メタデータとして報告される。 | いいえ — レガシー行には一切触れない |
+| `Duplicate` | 複数のレガシー行が同じペアを索引している(決定論的ID以前の再実行の残骸)。 | いいえ — 報告のみ。削減は破壊的操作でありスコープ外 |
+| `Corrupt` | 行は存在するがイベントと矛盾している(`sortableUniqueId` / `eventType` / `tagGroup` のドリフト、または導出IDの位置にある行の内容不一致)。 | いいえ — 決して上書きしない |
+| `Overflow` | `MaxRowsPerKey` の上限を超える数の行がこのペアを索引しており、分類できなかった。 | いいえ — 上限を上げて再確認する |
+
+**運用ガイダンス**
+
+- **最小権限**: ジョブに必要なのは `events` コンテナーの読み取りと、`tags` コンテナーの *作成* だけです。削除も置換も行わないため、`tags` コンテナーに対して `deleteItem` / `replaceItem` を持たない Cosmos ロールで十分です。コードを信頼するのではなく、プラットフォーム側で非破壊性を強制する方法として推奨します。
+- **RUコスト**: イベントのスキャンはクロスパーティションクエリ(イベントはイベントごとにパーティション分割されるため)で、さらに (イベント, タグ) キーごとに `tags` コンテナーへのパーティション限定クエリが1回かかります。したがって RU はイベント数ではなく **キー数** に比例します(概ね `イベント数 × 1イベントあたりのタグ数`)。`MaxParallelism`(既定 4)が RU レートの調整ダイヤル、`MaxEventsToScan`(既定 10,000)が1回の run のコスト上限です。スロットリングは想定内で、サービスは Cosmos の `Retry-After` を短縮せずそのまま尊重します。
+- **上限を固定する**: `ToSortableUniqueIdInclusive` には、確定済みと分かっているイベントを指定してください。スキャン中に書き込まれるイベントは書き込みパス自身が索引します。修復はクラッシュの残骸のためのものであり、稼働中のトラフィックのためのものではありません。
+- **並行性**: run は稼働中の書き込みとも、別の run とも同時に安全に実行できます。通常の書き込みが「missing と分類したまさにその行」を先に書き込んだ場合、run はそれを「自分が書こうとしていた行」と認識して先へ進みます — 重複も、エラーも発生しません。
+- **整合性の注意点**: 修復直後の読み取りは、アカウントに設定された Cosmos の整合性レベルによっては古い状態を観測する可能性があります。セッション整合性や結果整合性のもとでは、別セッションからのタグ検索が修復の書き込みに遅れることがあります。
+
+**引き続き計画中(未リリース)**: opt-in のスタートアップ/定期スイープ、および重複レガシー行の破壊的な削減(別途承認が必要な、独立した関心事)。パッケージをアップグレードするだけではスイープの動作は有効になりません。
 
 ### プロバイダーの選び方
 


### PR DESCRIPTION
## Summary

Adds `CosmosDbTagRepairService`: an operator tool that scans the events container over a `sortableUniqueId` range, derives each expected `(event, tag)` row with the same deterministic rule the write path uses, and creates the ones that are missing — with dry-run, checkpoint/resume, and an auditable report.

Closes #1053

## Non-destructive by construction

G4 **only ever creates rows that do not exist**. It never deletes, rewrites, or canonicalizes one, and it never invokes G4b.

That is enforced structurally, not by discipline: the repair's store seam (`ICosmosTagRepairStore`) exposes `ReadRowsForEventAsync`, `TryCreateRowAsync`, and `TryReadRowAsync` — **the type cannot express a delete or a replace**. Operators can enforce the same thing at the platform level by granting the job a Cosmos role without `deleteItem`/`replaceItem` on the tags container (documented).

## Legacy row recognition (L1/L2)

Rows written before the deterministic-id scheme sit at a random id, so treating them as "missing" would write a *second* row for a pair that is already indexed. Recognition is:

- **Partition-confined**: the lookup queries only `pk = {serviceId}|{tag}`, so another event's rows are never even read.
- **Semantic key** = (serviceId, tag, eventId): serviceId and tag compared **ordinally**; eventId **parsed to a `Guid` and compared canonically**, so Guid formatting/casing drift still matches. A different event carrying the same tag has a different eventId and can never match.
- **Post-match validation**: `sortableUniqueId`, `eventType`, and `tagGroup` must still agree with the source event. A legacy id excuses the id and the timestamp — **and nothing else**. Drift in any of those is `Corrupt`, not `LegacyPresent`, and `tagGroup` drift is classified explicitly rather than hidden.
- **Separate comparator**: `CosmosLegacyTagRowMatcher` ignores the legacy id/createdAt *only after* a semantic-key match, reporting them as migration metadata. The strict SEK-G2 `CosmosTagIdentity.ContentEquals` (id + createdAt included) still governs rows sitting at the derived id — a drifted `createdAt` there is still corruption.
- **Multiple legacy rows** → `Duplicate`, reported only, with a per-key cap (`MaxRowsPerKey`, default 16) and `Overflow` reporting beyond it.

## Report categories

`Present` / `Missing` / `LegacyPresent` / `Duplicate` / `Corrupt` / `Overflow`, plus `Repaired` in normal mode. **`Missing` is the only category that is ever written.** Counts are exact; only the findings detail list is capped.

## Wiring — both registration styles

`AddSekibanDcbCosmosDbTagRepair()` for DI, or `new CosmosDbTagRepairServiceFactory(context, containerResolver)` for hosts using a custom factory. It is **not** registered by `AddSekibanDcbCosmosDb` alone — an operator asks for it — and it is not on `IEventStore`. An instance binds to one `(serviceId, events container, tags container)` lineage at construction with the service id passed **explicitly** (never pulled from an ambient `IServiceIdProvider`), so cross-lineage repair is structurally impossible.

## RU cost characteristics (closeout writeback — input for the sweep defaults)

- The events scan is **cross-partition** (events are partitioned per event) and paged with continuation tokens; cost scales with the range width and `PageSize` (default 100).
- Each `(event, tag)` key costs **one partition-confined query** against the tags container. So **RU scales with keys, not events**: roughly `events × distinct-tags-per-event` cheap single-partition queries, plus the scan itself. A repair write costs one create.
- `MaxParallelism` (default 4) is the RU-rate dial; `MaxEventsToScan` (default 10,000) bounds one run's total cost, after which the run hands back a checkpoint. **Suggested sweep defaults**: keep `MaxParallelism` low (2–4) so a background sweep yields to live traffic, and size `MaxEventsToScan` to the RU headroom of the quietest window.
- Throttling is expected and handled: Cosmos `Retry-After` is honored **in full** (never shortened by a client cap).

## Checkpointing

The opaque checkpoint carries the **last `sortableUniqueId` reached, not a Cosmos continuation token** — a continuation token is bound to the query that produced it and expires, so it cannot be handed across runs. The scan is ordered by `sortableUniqueId`, which is monotonic, so "everything after the last one I saw" is both exact and durable. Continuation tokens are still used for paging *within* a run, where the query is fixed. (An earlier version threaded both and double-skipped on resume; the resume test caught it.)

## Test plan

- [x] 24 new tests. Per the L1/L2 review list: two events sharing one tag → **no false match** (one `LegacyPresent`, one `Missing`, repaired independently); Guid formatting/casing (`D`/`N`/`B`, upper-cased) still matches; matching key + differing id/createdAt → `LegacyPresent`, **zero create attempts**, legacy row byte-identical afterwards; matching key + drifted `sortableUniqueId` / `eventType` / `tagGroup` → `Corrupt`, no write; multiple legacy rows → `Duplicate`, non-mutating; deterministic-id row with drifted `createdAt` → still `Corrupt` under the strict comparator; concurrent writer landing between classification and repair → no duplicate, no error, counted `Present`.
- [x] Plus: missing row repaired; dry-run writes nothing; re-run idempotent; checkpoint/resume across an interrupted scan (no gap, no re-repair); range honored; overflow cap; cancellation; tag repeated within one event = one key; lineage binding; both registration styles.
- [x] `Sekiban.Dcb.WithResult.Tests` 546 passed / 0 failed
- [x] `Sekiban.Dcb.WithoutResult.Tests` 30 passed — no regressions
- [x] `DcbOrleans.ApiService` (downstream Cosmos consumer) builds
- [x] Docs updated (EN + JA): usage, dry-run, checkpointing, report categories, least-privilege + RU guidance, operator-only job example, and the post-repair consistency-level caveat
- [x] `git diff --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017KAPyZPCMZzurEZTt1k8LX