### PR TITLE
Add the crash-window fault-injection E2E matrix

### DIFF
--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/Cosmos/CosmosCrashWindowE2ETests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/Cosmos/CosmosCrashWindowE2ETests.cs
@@ -1,0 +1,631 @@
+using Dcb.Domain;
+using Microsoft.Extensions.DependencyInjection;
+using Sekiban.Dcb.Common;
+using Sekiban.Dcb.CosmosDb;
+using Sekiban.Dcb.CosmosDb.Models;
+using Sekiban.Dcb.CosmosDb.Repair;
+using Sekiban.Dcb.CosmosDb.Sweep;
+using Sekiban.Dcb.CosmosDb.Tags;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.ServiceId;
+using Sekiban.Dcb.Tags;
+
+namespace Sekiban.Dcb.Tests.Cosmos;
+
+/// <summary>
+///     The crash-window matrix: crash → restart → repair → convergence, driven end to end through the real
+///     <see cref="CosmosDbEventStore" />, the real <see cref="CosmosDbTagRepairService" />, and the real
+///     sweep, against in-memory Cosmos containers.
+///     The scoped tests that landed with the earlier slices check each piece in isolation. These check the
+///     thing those pieces exist for: that after a crash in the two-phase write, a tag-scoped reader
+///     eventually sees the event — and that nothing stronger than "eventually" is true, because that is all
+///     the documentation claims.
+///     Everything here is deterministic. Faults are injected through the seams; nothing sleeps, and nothing
+///     depends on timing.
+/// </summary>
+public class CosmosCrashWindowE2ETests
+{
+    private const string ServiceId = "svc";
+    private const string OtherServiceId = "other";
+
+    /// <summary>One service's containers plus the store that writes to them.</summary>
+    private sealed class Lineage
+    {
+        public Lineage(string serviceId, InMemoryCosmosClient client, CosmosDbEventStoreOptions options)
+        {
+            ServiceId = serviceId;
+            Client = client;
+            Options = options;
+
+            var context = new CosmosDbContext(client, "test-db", null, options);
+            var resolver = new DefaultCosmosContainerResolver(options);
+            Store = new CosmosDbEventStore(
+                context,
+                DomainType.GetDomainTypes().EventTypes,
+                new FixedServiceIdProvider(serviceId),
+                resolver);
+            RepairFactory = new CosmosDbTagRepairServiceFactory(context, resolver);
+        }
+
+        public string ServiceId { get; }
+        public InMemoryCosmosClient Client { get; }
+        public CosmosDbEventStoreOptions Options { get; }
+        public CosmosDbEventStore Store { get; }
+        public CosmosDbTagRepairServiceFactory RepairFactory { get; }
+
+        public InMemoryCosmosContainer Events => Client.Container(Options.EventsContainerName);
+        public InMemoryCosmosContainer Tags => Client.Container(Options.TagsContainerName);
+
+        public Task<CosmosDbTagRepairService> RepairAsync() => RepairFactory.CreateAsync(ServiceId);
+    }
+
+    private sealed class FixedServiceIdProvider : IServiceIdProvider
+    {
+        private readonly string _serviceId;
+
+        public FixedServiceIdProvider(string serviceId) => _serviceId = serviceId;
+
+        public string GetCurrentServiceId() => _serviceId;
+    }
+
+    /// <summary>Fails the tag write before batch N, deterministically — the seam, not a race.</summary>
+    private sealed class FailBeforeBatch : ICosmosTagWriteFaultInjector
+    {
+        private readonly int _batchIndex;
+
+        public FailBeforeBatch(int batchIndex) => _batchIndex = batchIndex;
+
+        public Task OnBeforeBatchAsync(int batchIndex, string partitionKey, IReadOnlyList<CosmosTag> rows)
+        {
+            if (batchIndex >= _batchIndex)
+            {
+                throw new InvalidOperationException($"Injected crash before tag batch {batchIndex}");
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+
+    private static CosmosDbEventStoreOptions NewOptions() =>
+        new()
+        {
+            EventsContainerName = "events",
+            TagsContainerName = "tags",
+            // Roll-forward with a single attempt reproduces exactly what a crash leaves behind: the events
+            // are durable and nothing is deleted, but the tag write never completed.
+            WriteFailurePolicy = CosmosWriteFailurePolicy.RollForward,
+            TagWriteRetry = new CosmosTagWriteRetryOptions { MaxAttempts = 1, JitterRatio = 0 }
+        };
+
+    private static Lineage NewLineage(string serviceId = ServiceId, CosmosDbEventStoreOptions? options = null) =>
+        new(serviceId, new InMemoryCosmosClient(), options ?? NewOptions());
+
+    private static SerializableEvent NewEvent(params string[] tags) =>
+        new(
+            System.Text.Encoding.UTF8.GetBytes("""{"Name":"test"}"""),
+            SortableUniqueId.GenerateNew(),
+            Guid.NewGuid(),
+            new EventMetadata("causation", "correlation", "user"),
+            tags.ToList(),
+            "TestEventPayload");
+
+    private sealed record TestTag(string Value) : ITag
+    {
+        public bool IsConsistencyTag() => false;
+        public string GetTagGroup() => Value.Split(':')[0];
+        public string GetTag() => Value;
+        public string GetTagContent() => Value.Split(':')[1];
+    }
+
+    private static async Task<CosmosTagRepairReport> RunRepairAsync(Lineage lineage, bool dryRun = false)
+    {
+        var repair = await lineage.RepairAsync();
+        return await repair.RepairAsync(new CosmosTagRepairOptions { DryRun = dryRun });
+    }
+
+    // ── Scenario 1: crash before any tag batch ──────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Crash_Before_Any_Tag_Batch_Should_Converge_After_Repair()
+    {
+        var lineage = NewLineage();
+        lineage.Store.TagWriteFaultInjector = new FailBeforeBatch(0); // die before the first batch
+
+        var written = NewEvent("Student:1");
+        var result = await lineage.Store.WriteSerializableEventsAsync(new[] { written });
+
+        // The crash residue: the event is durable and was NOT deleted, but no tag row landed.
+        Assert.False(result.IsSuccess);
+        Assert.IsType<CosmosTagWriteExhaustedException>(result.GetException());
+        Assert.Single(lineage.Events.Items);
+        Assert.Empty(lineage.Tags.Items);
+        Assert.Equal(0, lineage.Events.Deletes);
+
+        // An all-events reader sees it; a tag-scoped reader does not. This is the window.
+        var all = await lineage.Store.ReadAllSerializableEventsAsync();
+        Assert.Single(all.GetValue());
+
+        var byTagBefore = await lineage.Store.ReadSerializableEventsByTagAsync(new TestTag("Student:1"));
+        Assert.Empty(byTagBefore.GetValue());
+
+        // Restart: the fault is gone, and repair runs.
+        lineage.Store.TagWriteFaultInjector = null;
+        var report = await RunRepairAsync(lineage);
+
+        Assert.Equal(1, report.Missing);
+        Assert.Equal(1, report.Repaired);
+
+        // The window is closed: the tag-scoped reader now sees the event.
+        var byTagAfter = await lineage.Store.ReadSerializableEventsByTagAsync(new TestTag("Student:1"));
+        Assert.Equal(written.Id, Assert.Single(byTagAfter.GetValue()).Id);
+    }
+
+    // ── Scenario 2: crash mid tag batches ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Crash_Between_Tag_Batches_Should_Converge_Without_Duplicates()
+    {
+        var lineage = NewLineage();
+
+        // Three tags = three tag partitions = three batches. Die before the second, so the first landed.
+        lineage.Store.TagWriteFaultInjector = new FailBeforeBatch(1);
+
+        var written = NewEvent("Student:1", "Student:2", "Student:3");
+        var result = await lineage.Store.WriteSerializableEventsAsync(new[] { written });
+
+        Assert.False(result.IsSuccess);
+        Assert.Single(lineage.Events.Items);
+        Assert.Single(lineage.Tags.Items); // exactly one of the three tag rows landed
+
+        lineage.Store.TagWriteFaultInjector = null;
+        var report = await RunRepairAsync(lineage);
+
+        // The row that landed is recognized, not rewritten; the two that did not are backfilled.
+        Assert.Equal(1, report.Present);
+        Assert.Equal(2, report.Missing);
+        Assert.Equal(2, report.Repaired);
+        Assert.Equal(3, lineage.Tags.Items.Count);
+
+        foreach (var tag in new[] { "Student:1", "Student:2", "Student:3" })
+        {
+            var byTag = await lineage.Store.ReadSerializableEventsByTagAsync(new TestTag(tag));
+            Assert.Equal(written.Id, Assert.Single(byTag.GetValue()).Id);
+        }
+    }
+
+    // ── Scenario 3: multi-event partial create ──────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task A_Partially_Failed_Multi_Event_Write_Should_Delete_Nothing_And_Name_Both_Sets()
+    {
+        var lineage = NewLineage();
+
+        // The second event's create fails. Events have distributed partition keys, so no transaction spans
+        // them: whichever ones landed are already visible.
+        lineage.Events.WriteFaults.Enqueue(CosmosFailures.Conflict());
+
+        var events = new[] { NewEvent("Student:1"), NewEvent("Student:2") };
+        var result = await lineage.Store.WriteSerializableEventsAsync(events);
+
+        Assert.False(result.IsSuccess);
+        var failure = Assert.IsType<CosmosPartialEventWriteException>(result.GetException());
+
+        Assert.Single(failure.FailedEventIds);
+        Assert.Single(failure.WrittenEventIds);
+
+        // Nothing is deleted — a multi-projection may already have read the event that landed.
+        Assert.Equal(0, lineage.Events.Deletes);
+        Assert.Single(lineage.Events.Items);
+
+        // And the event that never landed is not indexed either.
+        Assert.Empty(lineage.Tags.Items);
+    }
+
+    // ── Scenario 4: re-execution and corruption, through the real store ─────────────────────────────
+
+    /// <summary>Fails the tag write's first <c>failures</c> batch attempts, then lets it through.</summary>
+    private sealed class FailFirstAttempts : ICosmosTagWriteFaultInjector
+    {
+        private int _remaining;
+
+        public FailFirstAttempts(int failures) => _remaining = failures;
+
+        public Task OnBeforeBatchAsync(int batchIndex, string partitionKey, IReadOnlyList<CosmosTag> rows)
+        {
+            if (_remaining-- > 0)
+            {
+                throw new InvalidOperationException("Injected transient tag-write failure");
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+
+    /// <summary>Retries without waiting, so a backoff policy costs a test no wall-clock.</summary>
+    private sealed class NoWaitRetryScheduler : ICosmosRetryScheduler
+    {
+        public DateTimeOffset UtcNow => new(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        public Task WaitAsync(TimeSpan delay, CancellationToken cancellationToken) => Task.CompletedTask;
+        public double NextJitter() => 0;
+    }
+
+    [Fact]
+    public async Task Roll_Forward_Should_Converge_After_A_Transient_Tag_Failure_Without_Duplicates()
+    {
+        var options = NewOptions();
+        options.TagWriteRetry = new CosmosTagWriteRetryOptions { MaxAttempts = 3, JitterRatio = 0 };
+
+        var lineage = NewLineage(options: options);
+        lineage.Store.RetryScheduler = new NoWaitRetryScheduler();
+
+        // The first attempt dies partway through the tag batches; the retry re-executes the whole stage.
+        lineage.Store.TagWriteFaultInjector = new FailFirstAttempts(1);
+
+        var written = NewEvent("Student:1", "Student:2", "Student:3");
+        var result = await lineage.Store.WriteSerializableEventsAsync(new[] { written });
+
+        // Re-executing a tag write is safe because the rows derive deterministically: the retry re-derives
+        // identical rows, accepts the one the failed attempt already created, and fills in the rest.
+        Assert.True(result.IsSuccess);
+        Assert.Equal(3, lineage.Tags.Items.Count);
+        Assert.Equal(0, lineage.Events.Deletes);
+
+        foreach (var tag in new[] { "Student:1", "Student:2", "Student:3" })
+        {
+            var byTag = await lineage.Store.ReadSerializableEventsByTagAsync(new TestTag(tag));
+            Assert.Equal(written.Id, Assert.Single(byTag.GetValue()).Id);
+        }
+    }
+
+    [Fact]
+    public async Task Re_Executing_The_Same_Write_Should_Not_Duplicate_Tag_Rows()
+    {
+        var lineage = NewLineage();
+        var written = NewEvent("Student:1");
+
+        var first = await lineage.Store.WriteSerializableEventsAsync(new[] { written });
+        Assert.True(first.IsSuccess);
+        Assert.Single(lineage.Tags.Items);
+
+        // Replaying the same event: the event create conflicts, but the tag rows must not multiply.
+        var second = await lineage.Store.WriteSerializableEventsAsync(new[] { written });
+        Assert.False(second.IsSuccess); // the event already exists
+
+        Assert.Single(lineage.Tags.Items);
+        var byTag = await lineage.Store.ReadSerializableEventsByTagAsync(new TestTag("Student:1"));
+        Assert.Single(byTag.GetValue());
+    }
+
+    [Fact]
+    public async Task A_Tag_Row_That_Disagrees_With_Its_Event_Should_Be_Reported_As_Corruption()
+    {
+        var lineage = NewLineage();
+        var written = NewEvent("Student:1");
+        await lineage.Store.WriteSerializableEventsAsync(new[] { written });
+
+        // Something outside Sekiban rewrote the row's event type.
+        var corrupted = CosmosTagIdentity.DeriveRow(
+            ServiceId,
+            "Student:1",
+            written.Id,
+            written.SortableUniqueIdValue,
+            "SomethingElse");
+        lineage.Tags.Seed(corrupted);
+
+        var report = await RunRepairAsync(lineage);
+
+        // Reported, never overwritten.
+        Assert.Equal(1, report.Corrupt);
+        Assert.Equal(0, report.Repaired);
+        Assert.Equal("SomethingElse", Assert.Single(lineage.Tags.Items)["eventType"]!.ToString());
+    }
+
+    // ── Scenario 5: repair re-run and concurrency ───────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Repairs_Should_Be_Idempotent_When_Re_Run_And_When_Run_Concurrently()
+    {
+        var lineage = NewLineage();
+        lineage.Store.TagWriteFaultInjector = new FailBeforeBatch(0);
+        await lineage.Store.WriteSerializableEventsAsync(new[] { NewEvent("Student:1") });
+        lineage.Store.TagWriteFaultInjector = null;
+
+        // Two repairs racing each other over the same residue.
+        var concurrent = await Task.WhenAll(RunRepairAsync(lineage), RunRepairAsync(lineage));
+
+        // Exactly one of them writes the row; the other finds it already there. Between the two, the pair is
+        // accounted for exactly once, and neither reports corruption.
+        Assert.Equal(1, concurrent.Sum(report => report.Repaired));
+        Assert.Equal(1, concurrent.Sum(report => report.Present));
+        Assert.Single(lineage.Tags.Items);
+        Assert.All(concurrent, report => Assert.Equal(0, report.Corrupt));
+
+        // A third, after the fact, finds nothing to do.
+        var again = await RunRepairAsync(lineage);
+        Assert.Equal(0, again.Repaired);
+        Assert.Equal(1, again.Present);
+        Assert.Single(lineage.Tags.Items);
+    }
+
+    // ── Scenario 6: checkpoint/resume under throttling and cancellation ─────────────────────────────
+
+    [Fact]
+    public async Task A_Scan_Should_Resume_Across_Runs_And_Survive_Throttling()
+    {
+        var lineage = NewLineage();
+
+        // Six events whose tag rows never landed.
+        lineage.Store.TagWriteFaultInjector = new FailBeforeBatch(0);
+        for (var i = 0; i < 6; i++)
+        {
+            await lineage.Store.WriteSerializableEventsAsync(new[] { NewEvent($"Student:{i}") });
+        }
+
+        lineage.Store.TagWriteFaultInjector = null;
+        Assert.Empty(lineage.Tags.Items);
+
+        // The tags container throttles the first write. Retry-After is honored, not shortened.
+        lineage.Tags.WriteFaults.Enqueue(CosmosFailures.Throttled(TimeSpan.FromMilliseconds(1)));
+
+        var repair = await lineage.RepairAsync();
+
+        var first = await repair.RepairAsync(new CosmosTagRepairOptions
+        {
+            DryRun = false,
+            MaxEventsToScan = 4,
+            PageSize = 2
+        });
+
+        Assert.Equal(4, first.EventsScanned);
+        Assert.Equal(4, first.Repaired);
+        Assert.True(first.HasMore);
+        Assert.NotNull(first.Checkpoint);
+
+        var second = await repair.RepairAsync(new CosmosTagRepairOptions
+        {
+            DryRun = false,
+            Checkpoint = first.Checkpoint
+        });
+
+        // Resuming picks up exactly the two it had not reached — no gap, no re-repair.
+        Assert.Equal(2, second.EventsScanned);
+        Assert.Equal(2, second.Repaired);
+        Assert.False(second.HasMore);
+        Assert.Equal(6, lineage.Tags.Items.Count);
+    }
+
+    [Fact]
+    public async Task A_Cancelled_Scan_Should_Keep_The_Progress_It_Settled()
+    {
+        var lineage = NewLineage();
+        lineage.Store.TagWriteFaultInjector = new FailBeforeBatch(0);
+        for (var i = 0; i < 4; i++)
+        {
+            await lineage.Store.WriteSerializableEventsAsync(new[] { NewEvent($"Student:{i}") });
+        }
+
+        lineage.Store.TagWriteFaultInjector = null;
+
+        using var cts = new CancellationTokenSource();
+        var repair = await lineage.RepairAsync();
+
+        // Cancel exactly as the third tag row is about to be written, as a run budget elapsing would — at a
+        // precise point, not whenever a polling loop happens to notice.
+        lineage.Tags.OnWrite = alreadyWritten =>
+        {
+            if (alreadyWritten == 2)
+            {
+                cts.Cancel();
+            }
+        };
+
+        var exception = await Assert.ThrowsAsync<CosmosTagRepairCancelledException>(
+            () => repair.RepairAsync(
+                new CosmosTagRepairOptions { DryRun = false, PageSize = 1 },
+                cts.Token));
+
+        lineage.Tags.OnWrite = null;
+
+        // Cancelling does not abandon the row already in flight — it completes, and the run stops at the next
+        // check. So three events are settled, and the report says exactly three: the checkpoint never claims
+        // more progress than was actually made, nor less.
+        Assert.Equal(3, exception.PartialReport.Repaired);
+        Assert.Equal(3, exception.PartialReport.EventsScanned);
+        Assert.Equal(3, lineage.Tags.Items.Count);
+        Assert.NotNull(exception.PartialReport.Checkpoint);
+
+        // Resuming from the cancelled run's checkpoint finishes the one it did not reach, and redoes none of
+        // the three it did.
+        var resumed = await repair.RepairAsync(new CosmosTagRepairOptions
+        {
+            DryRun = false,
+            Checkpoint = exception.PartialReport.Checkpoint
+        });
+
+        Assert.Equal(1, resumed.EventsScanned);
+        Assert.Equal(1, resumed.Repaired);
+        Assert.Equal(0, resumed.Corrupt);
+        Assert.Equal(4, lineage.Tags.Items.Count);
+    }
+
+    // ── Scenario 7: readers racing repair — the documented non-guarantee ────────────────────────────
+
+    [Fact]
+    public async Task A_Tag_Reader_Racing_Repair_Sees_Eventual_Repair_And_Nothing_Stronger()
+    {
+        var lineage = NewLineage();
+        lineage.Store.TagWriteFaultInjector = new FailBeforeBatch(0);
+        var written = NewEvent("Student:1");
+        await lineage.Store.WriteSerializableEventsAsync(new[] { written });
+        lineage.Store.TagWriteFaultInjector = null;
+
+        var tag = new TestTag("Student:1");
+
+        // Before repair, a tag reader does NOT see the event, and the tag-consistent baseline is regressed
+        // with it. Nothing gates the reader — this is the documented window, asserted rather than wished away.
+        Assert.Empty((await lineage.Store.ReadSerializableEventsByTagAsync(tag)).GetValue());
+        Assert.False((await lineage.Store.TagExistsAsync(tag)).GetValue());
+        Assert.Equal(string.Empty, (await lineage.Store.GetLatestTagAsync(tag)).GetValue().LastSortedUniqueId);
+
+        // Meanwhile the event is durable and visible to all-events readers the whole time.
+        Assert.Single((await lineage.Store.ReadAllSerializableEventsAsync()).GetValue());
+
+        await RunRepairAsync(lineage);
+
+        // Only after repair does the tag reader converge. "Eventually" — never "before the read".
+        Assert.Single((await lineage.Store.ReadSerializableEventsByTagAsync(tag)).GetValue());
+        Assert.True((await lineage.Store.TagExistsAsync(tag)).GetValue());
+        Assert.Equal(
+            written.SortableUniqueIdValue,
+            (await lineage.Store.GetLatestTagAsync(tag)).GetValue().LastSortedUniqueId);
+    }
+
+    // ── Consumer contract: both registration styles ─────────────────────────────────────────────────
+
+    [Fact]
+    public void Both_Registration_Styles_Should_Reach_The_Same_Non_Destructive_Surface()
+    {
+        // DI style.
+        var services = new ServiceCollection();
+        services.AddSekibanDcbCosmosDb("AccountEndpoint=https://localhost:8081/;AccountKey=key==", "db");
+        services.AddSekibanDcbCosmosDbTagRepair();
+        var provider = services.BuildServiceProvider();
+
+        Assert.NotNull(provider.GetRequiredService<CosmosDbTagRepairServiceFactory>());
+
+        // Manual style: options + context + resolver, no container.
+        var options = new CosmosDbEventStoreOptions { EventsContainerName = "events", TagsContainerName = "tags" };
+        var manual = new CosmosDbTagRepairServiceFactory(
+            new CosmosDbContext(new InMemoryCosmosClient(), "db", null, options),
+            new DefaultCosmosContainerResolver(options));
+
+        Assert.NotNull(manual);
+    }
+
+    [Fact]
+    public async Task The_Manual_Construction_Path_Should_Repair_Exactly_Like_The_DI_Path()
+    {
+        // The manual path is what SekibanWasmRuntime / SekibanAsAService actually use, so it gets the same
+        // end-to-end proof, not just a smoke check that it constructs.
+        var lineage = NewLineage();
+        lineage.Store.TagWriteFaultInjector = new FailBeforeBatch(0);
+        await lineage.Store.WriteSerializableEventsAsync(new[] { NewEvent("Student:1") });
+        lineage.Store.TagWriteFaultInjector = null;
+
+        var report = await RunRepairAsync(lineage);
+
+        Assert.Equal(1, report.Repaired);
+        Assert.Single(lineage.Tags.Items);
+    }
+
+    // ── Compatibility: legacy defaults do nothing new ───────────────────────────────────────────────
+
+    [Fact]
+    public async Task Legacy_Defaults_Should_Behave_As_Before_The_Upgrade()
+    {
+        // Exactly what a downstream repo constructs today: container names, nothing else.
+        var options = new CosmosDbEventStoreOptions
+        {
+            EventsContainerName = "events",
+            TagsContainerName = "tags"
+        };
+
+        Assert.Equal(CosmosWriteFailurePolicy.Compatible, options.WriteFailurePolicy);
+
+        var lineage = NewLineage(options: options);
+        lineage.Store.TagWriteFaultInjector = new FailBeforeBatch(0);
+
+        var result = await lineage.Store.WriteSerializableEventsAsync(new[] { NewEvent("Student:1") });
+
+        // The pre-upgrade behavior, unchanged: no retry, and the legacy rollback deletes the written event.
+        Assert.False(result.IsSuccess);
+        Assert.IsType<InvalidOperationException>(result.GetException());
+        Assert.Equal(1, lineage.Events.Deletes);
+        Assert.Empty(lineage.Events.Items);
+    }
+
+    [Fact]
+    public void A_Disabled_Sweep_Should_Add_No_Background_Work()
+    {
+        var services = new ServiceCollection();
+        services.AddSekibanDcbCosmosDb("AccountEndpoint=https://localhost:8081/;AccountKey=key==", "db");
+
+        // Upgrading the package adds no sweep, no hosted service, no configuration to fill in.
+        Assert.Null(services.BuildServiceProvider().GetService<CosmosTagSweepOptions>());
+        Assert.False(new CosmosTagSweepOptions().Enabled);
+    }
+
+    // ── Two-lineage isolation ───────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Repair_Should_Not_Cross_Lineages()
+    {
+        // Two services sharing one Cosmos account but different container lineages — the management/runtime
+        // split a multi-tenant host has.
+        var client = new InMemoryCosmosClient();
+        var runtime = new Lineage(
+            ServiceId,
+            client,
+            new CosmosDbEventStoreOptions
+            {
+                EventsContainerName = "runtime-events",
+                TagsContainerName = "runtime-tags",
+                WriteFailurePolicy = CosmosWriteFailurePolicy.RollForward,
+                TagWriteRetry = new CosmosTagWriteRetryOptions { MaxAttempts = 1 }
+            });
+
+        var management = new Lineage(
+            OtherServiceId,
+            client,
+            new CosmosDbEventStoreOptions
+            {
+                EventsContainerName = "management-events",
+                TagsContainerName = "management-tags",
+                WriteFailurePolicy = CosmosWriteFailurePolicy.RollForward,
+                TagWriteRetry = new CosmosTagWriteRetryOptions { MaxAttempts = 1 }
+            });
+
+        // Both crash with residue.
+        runtime.Store.TagWriteFaultInjector = new FailBeforeBatch(0);
+        management.Store.TagWriteFaultInjector = new FailBeforeBatch(0);
+        await runtime.Store.WriteSerializableEventsAsync(new[] { NewEvent("Student:1") });
+        await management.Store.WriteSerializableEventsAsync(new[] { NewEvent("Student:1") });
+        runtime.Store.TagWriteFaultInjector = null;
+        management.Store.TagWriteFaultInjector = null;
+
+        // Repair only the runtime lineage.
+        var report = await RunRepairAsync(runtime);
+
+        Assert.Equal(1, report.Repaired);
+        Assert.Single(runtime.Tags.Items);
+
+        // The management lineage is untouched — an instance is bound to one lineage at construction, so it
+        // cannot reach across even by accident.
+        Assert.Empty(management.Tags.Items);
+        Assert.Equal(0, management.Tags.Creates);
+
+        // And repairing it separately fixes only it.
+        var managementReport = await RunRepairAsync(management);
+        Assert.Equal(1, managementReport.Repaired);
+        Assert.Single(management.Tags.Items);
+        Assert.Single(runtime.Tags.Items);
+    }
+
+    [Fact]
+    public async Task A_Dry_Run_Should_Report_The_Crash_Residue_Without_Repairing_It()
+    {
+        var lineage = NewLineage();
+        lineage.Store.TagWriteFaultInjector = new FailBeforeBatch(0);
+        await lineage.Store.WriteSerializableEventsAsync(new[] { NewEvent("Student:1") });
+        lineage.Store.TagWriteFaultInjector = null;
+
+        var report = await RunRepairAsync(lineage, dryRun: true);
+
+        // The operator's first move: look before you write.
+        Assert.True(report.DryRun);
+        Assert.Equal(1, report.Missing);
+        Assert.Equal(0, report.Repaired);
+        Assert.Empty(lineage.Tags.Items);
+        Assert.Equal(0, lineage.Tags.Creates);
+    }
+}

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/Cosmos/CosmosSweepE2ETests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/Cosmos/CosmosSweepE2ETests.cs
@@ -1,0 +1,339 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
+using Sekiban.Dcb.Common;
+using Sekiban.Dcb.CosmosDb;
+using Sekiban.Dcb.CosmosDb.Models;
+using Sekiban.Dcb.CosmosDb.Repair;
+using Sekiban.Dcb.CosmosDb.Sweep;
+using Sekiban.Dcb.CosmosDb.Tags;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.ServiceId;
+using Dcb.Domain;
+
+namespace Sekiban.Dcb.Tests.Cosmos;
+
+/// <summary>
+///     The sweep, end to end, through the types that actually run in production: the registered
+///     <see cref="CosmosTagSweepService" /> driving the real <see cref="CosmosTagRepairRunner" />, the real
+///     <see cref="CosmosDbTagRepairService" />, and the in-memory Cosmos containers.
+///     The sweep's own tests substitute a fake runner, which proves the scheduling but not that the wiring
+///     reaches storage — the same "tested the fake, not the production path" gap that hid three real defects
+///     in the earlier slices. These close it: nothing here is faked below the sweep.
+///     Deterministic throughout. Turns are driven by starting the service, not by waiting for an interval;
+///     cancellation is injected at an exact write, not polled for.
+/// </summary>
+public class CosmosSweepE2ETests
+{
+    private const string RuntimeServiceId = "runtime-svc";
+    private const string ManagementServiceId = "management-svc";
+
+    /// <summary>One service's containers, its repair factory, and the store that writes to them.</summary>
+    private sealed class SweepLineage
+    {
+        public SweepLineage(string serviceId, InMemoryCosmosClient client, string eventsContainer, string tagsContainer)
+        {
+            ServiceId = serviceId;
+            Client = client;
+
+            Options = new CosmosDbEventStoreOptions
+            {
+                EventsContainerName = eventsContainer,
+                TagsContainerName = tagsContainer,
+                // A single attempt with no rollback reproduces what a crash leaves: durable events, no tags.
+                WriteFailurePolicy = CosmosWriteFailurePolicy.RollForward,
+                TagWriteRetry = new CosmosTagWriteRetryOptions { MaxAttempts = 1, JitterRatio = 0 }
+            };
+
+            Context = new CosmosDbContext(client, "test-db", null, Options);
+            Resolver = new DefaultCosmosContainerResolver(Options);
+            Store = new CosmosDbEventStore(
+                Context,
+                DomainType.GetDomainTypes().EventTypes,
+                new FixedServiceIdProvider(serviceId),
+                Resolver);
+            Factory = new CosmosDbTagRepairServiceFactory(Context, Resolver);
+        }
+
+        public string ServiceId { get; }
+        public InMemoryCosmosClient Client { get; }
+        public CosmosDbEventStoreOptions Options { get; }
+        public CosmosDbContext Context { get; }
+        public DefaultCosmosContainerResolver Resolver { get; }
+        public CosmosDbEventStore Store { get; }
+        public CosmosDbTagRepairServiceFactory Factory { get; }
+
+        public InMemoryCosmosContainer Events => Client.Container(Options.EventsContainerName);
+        public InMemoryCosmosContainer Tags => Client.Container(Options.TagsContainerName);
+
+        /// <summary>Writes events whose tag rows never land — the residue a crash leaves behind.</summary>
+        public async Task<List<SerializableEvent>> WriteCrashResidueAsync(int count)
+        {
+            Store.TagWriteFaultInjector = new AlwaysFailTagWrite();
+
+            var written = new List<SerializableEvent>();
+            for (var i = 0; i < count; i++)
+            {
+                var serializable = NewEvent($"Student:{ServiceId}:{i}");
+                await Store.WriteSerializableEventsAsync(new[] { serializable });
+                written.Add(serializable);
+            }
+
+            Store.TagWriteFaultInjector = null;
+            return written;
+        }
+    }
+
+    private sealed class FixedServiceIdProvider : IServiceIdProvider
+    {
+        private readonly string _serviceId;
+
+        public FixedServiceIdProvider(string serviceId) => _serviceId = serviceId;
+
+        public string GetCurrentServiceId() => _serviceId;
+    }
+
+    private sealed class AlwaysFailTagWrite : ICosmosTagWriteFaultInjector
+    {
+        public Task OnBeforeBatchAsync(int batchIndex, string partitionKey, IReadOnlyList<CosmosTag> rows) =>
+            throw new InvalidOperationException("Injected crash before the tag write");
+    }
+
+    /// <summary>No waiting and no randomness: a sweep's schedule is asserted, never endured.</summary>
+    private sealed class FakeSweepClock : ISweepClock
+    {
+        public DateTime UtcNow { get; set; } = DateTime.UtcNow;
+
+        public Task DelayAsync(TimeSpan delay, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            UtcNow = UtcNow.Add(delay);
+            return Task.CompletedTask;
+        }
+
+        public double NextJitter() => 0;
+    }
+
+    private static SerializableEvent NewEvent(string tag) =>
+        new(
+            System.Text.Encoding.UTF8.GetBytes("""{"Name":"test"}"""),
+            SortableUniqueId.GenerateNew(),
+            Guid.NewGuid(),
+            new EventMetadata("causation", "correlation", "user"),
+            new List<string> { tag },
+            "TestEventPayload");
+
+    /// <summary>Starts the sweep and waits for its cycle. With no interval, that is all of its work.</summary>
+    private static async Task RunOneSweepTurnAsync(IHostedService sweep)
+    {
+        await sweep.StartAsync(CancellationToken.None);
+
+        if (sweep is CosmosTagSweepService typed && typed.Sweeping != null)
+        {
+            await typed.Sweeping;
+        }
+
+        await sweep.StopAsync(CancellationToken.None);
+    }
+
+    // ── (1) The registered DI wiring reaches production repair ──────────────────────────────────────
+
+    [Fact]
+    public async Task An_Enabled_Sweep_Registered_Through_DI_Should_Repair_Missing_Tag_Rows()
+    {
+        var client = new InMemoryCosmosClient();
+        var lineage = new SweepLineage(RuntimeServiceId, client, "events", "tags");
+        await lineage.WriteCrashResidueAsync(2);
+
+        Assert.Equal(2, lineage.Events.Items.Count);
+        Assert.Empty(lineage.Tags.Items);
+
+        // The registration a consumer actually writes — then the context is pointed at the in-memory account.
+        var services = new ServiceCollection();
+        services.AddSekibanDcbCosmosDb("AccountEndpoint=https://localhost:8081/;AccountKey=key==", "test-db");
+        services.AddSekibanDcbCosmosDbTagSweep(sweep =>
+        {
+            sweep.Enabled = true;
+            sweep.MaxStartupJitter = TimeSpan.Zero;
+            sweep.Window = TimeSpan.FromDays(365);
+        });
+
+        services.Replace(ServiceDescriptor.Singleton(lineage.Options));
+        services.Replace(ServiceDescriptor.Singleton(lineage.Context));
+        services.Replace(ServiceDescriptor.Singleton<IServiceIdProvider>(
+            new FixedServiceIdProvider(RuntimeServiceId)));
+
+        var provider = services.BuildServiceProvider();
+
+        // The hosted service the host would start — no test double anywhere below it.
+        var sweep = provider.GetServices<IHostedService>().OfType<CosmosTagSweepService>().Single();
+
+        await RunOneSweepTurnAsync(sweep);
+
+        // The real runner reached the real repair, which wrote the rows the crash left missing.
+        Assert.Equal(2, lineage.Tags.Items.Count);
+
+        // And a tag-scoped read — the thing the whole chain exists for — now sees the event.
+        var tag = $"Student:{RuntimeServiceId}:0";
+        var byTag = await lineage.Store.ReadSerializableEventsByTagAsync(new SweepTag(tag));
+        Assert.Single(byTag.GetValue());
+    }
+
+    private sealed record SweepTag(string Value) : Sekiban.Dcb.Tags.ITag
+    {
+        public bool IsConsistencyTag() => false;
+        public string GetTagGroup() => Value.Split(':')[0];
+        public string GetTag() => Value;
+        public string GetTagContent() => Value.Split(':')[1];
+    }
+
+    // ── (2) A budget-exhausted turn carries its progress into the next one ──────────────────────────
+
+    [Fact]
+    public async Task A_Budget_Exhausted_Sweep_Turn_Should_Resume_Next_Turn_And_Clear_On_Completion()
+    {
+        var client = new InMemoryCosmosClient();
+        var lineage = new SweepLineage(RuntimeServiceId, client, "events", "tags");
+        await lineage.WriteCrashResidueAsync(4);
+
+        // The real sweep, the real runner, the real repair — only the clock is substituted, so a turn costs
+        // no wall-clock.
+        var options = new CosmosTagSweepOptions
+        {
+            Enabled = true,
+            MaxStartupJitter = TimeSpan.Zero,
+            Window = TimeSpan.FromDays(365)
+        };
+        var sweep = new CosmosTagSweepService(
+            options,
+            new[] { RuntimeServiceId },
+            new CosmosTagRepairRunner(lineage.Factory),
+            new FakeSweepClock());
+
+        // Turn 1: the run is cancelled once two rows are settled — exactly what the run budget elapsing does
+        // to it, injected at a precise write rather than timed.
+        lineage.Tags.OnWrite = alreadyWritten =>
+        {
+            if (alreadyWritten == 2)
+            {
+                throw new OperationCanceledException("Injected run-budget expiry");
+            }
+        };
+
+        await RunOneSweepTurnAsync(sweep);
+
+        lineage.Tags.OnWrite = null;
+        Assert.Equal(2, lineage.Tags.Items.Count); // two settled before the budget went
+
+        // Turn 2 resumes from the checkpoint the cancelled turn kept, and finishes the two it never reached.
+        //
+        // Asserting only the final row count would NOT prove that: a turn that dropped the checkpoint would
+        // re-scan from the window, find the first two already present, repair the last two, and converge on
+        // the same four rows. So count the work instead. The repair issues exactly one tag lookup per
+        // (event, tag) key it examines, so a resumed turn examines two keys and a restarted one examines
+        // four. Two is the proof; four is the bug.
+        var lookupsBefore = lineage.Tags.Queries;
+
+        await RunOneSweepTurnAsync(sweep);
+
+        Assert.Equal(2, lineage.Tags.Queries - lookupsBefore);
+        Assert.Equal(4, lineage.Tags.Items.Count);
+
+        // Turn 3: completing the range cleared the checkpoint, so this turn starts from the window again —
+        // all four keys examined, all four already indexed, nothing created and nothing rewritten. A turn
+        // that had kept a stale checkpoint would examine none of them.
+        var createsBefore = lineage.Tags.Creates;
+        var lookupsBeforeTurn3 = lineage.Tags.Queries;
+
+        await RunOneSweepTurnAsync(sweep);
+
+        Assert.Equal(4, lineage.Tags.Queries - lookupsBeforeTurn3);
+        Assert.Equal(4, lineage.Tags.Items.Count);
+        Assert.Equal(createsBefore, lineage.Tags.Creates);
+    }
+
+    // ── (3) Lineages stay isolated through sweep execution ──────────────────────────────────────────
+
+    [Fact]
+    public async Task A_Sweep_Should_Not_Repair_Across_Lineages()
+    {
+        // Two lineages in one account — the management/runtime split a multi-tenant host has.
+        var client = new InMemoryCosmosClient();
+        var runtime = new SweepLineage(RuntimeServiceId, client, "runtime-events", "runtime-tags");
+        var management = new SweepLineage(ManagementServiceId, client, "management-events", "management-tags");
+
+        await runtime.WriteCrashResidueAsync(2);
+        await management.WriteCrashResidueAsync(2);
+
+        Assert.Empty(runtime.Tags.Items);
+        Assert.Empty(management.Tags.Items);
+
+        var options = new CosmosTagSweepOptions
+        {
+            Enabled = true,
+            MaxStartupJitter = TimeSpan.Zero,
+            Window = TimeSpan.FromDays(365)
+        };
+
+        // A sweep bound to the runtime lineage: its runner was built from the runtime factory, which resolved
+        // the runtime containers at construction. There is no configuration that points it elsewhere.
+        var runtimeSweep = new CosmosTagSweepService(
+            options,
+            new[] { RuntimeServiceId },
+            new CosmosTagRepairRunner(runtime.Factory),
+            new FakeSweepClock());
+
+        await RunOneSweepTurnAsync(runtimeSweep);
+
+        Assert.Equal(2, runtime.Tags.Items.Count);
+
+        // The management lineage is untouched — not merely unrepaired, but never written to at all.
+        Assert.Empty(management.Tags.Items);
+        Assert.Equal(0, management.Tags.Creates);
+
+        // Sweeping management repairs only management, and leaves runtime as it was.
+        var managementSweep = new CosmosTagSweepService(
+            options,
+            new[] { ManagementServiceId },
+            new CosmosTagRepairRunner(management.Factory),
+            new FakeSweepClock());
+
+        await RunOneSweepTurnAsync(managementSweep);
+
+        Assert.Equal(2, management.Tags.Items.Count);
+        Assert.Equal(2, runtime.Tags.Items.Count);
+
+        // Every row sits in its own service's partition. Neither lineage's index mentions the other.
+        Assert.All(
+            runtime.Tags.Items,
+            row => Assert.StartsWith(RuntimeServiceId, row["pk"]!.ToString(), StringComparison.Ordinal));
+        Assert.All(
+            management.Tags.Items,
+            row => Assert.StartsWith(ManagementServiceId, row["pk"]!.ToString(), StringComparison.Ordinal));
+    }
+
+    // ── The disabled default, proven against the harness rather than a fake ─────────────────────────
+
+    [Fact]
+    public async Task A_Disabled_Sweep_Should_Not_Touch_The_Containers()
+    {
+        var client = new InMemoryCosmosClient();
+        var lineage = new SweepLineage(RuntimeServiceId, client, "events", "tags");
+        await lineage.WriteCrashResidueAsync(2);
+
+        var queriesBefore = lineage.Events.Queries;
+
+        // Registered but not enabled — the default. It must not read, let alone write.
+        var sweep = new CosmosTagSweepService(
+            new CosmosTagSweepOptions(),
+            new[] { RuntimeServiceId },
+            new CosmosTagRepairRunner(lineage.Factory),
+            new FakeSweepClock());
+
+        await RunOneSweepTurnAsync(sweep);
+
+        Assert.Equal(queriesBefore, lineage.Events.Queries);
+        Assert.Empty(lineage.Tags.Items);
+        Assert.Equal(0, lineage.Tags.Creates);
+    }
+}

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/Cosmos/CosmosSweepE2ETests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/Cosmos/CosmosSweepE2ETests.cs
@@ -321,9 +321,15 @@ public class CosmosSweepE2ETests
         var lineage = new SweepLineage(RuntimeServiceId, client, "events", "tags");
         await lineage.WriteCrashResidueAsync(2);
 
-        var queriesBefore = lineage.Events.Queries;
+        // Both containers, both dimensions. A sweep that is off must not scan events, must not look a single
+        // tag key up, and must not write anywhere — so all four counters are pinned, not just the one that
+        // happened to be convenient.
+        var eventQueriesBefore = lineage.Events.Queries;
+        var tagQueriesBefore = lineage.Tags.Queries;
+        var eventCreatesBefore = lineage.Events.Creates;
+        var tagCreatesBefore = lineage.Tags.Creates;
 
-        // Registered but not enabled — the default. It must not read, let alone write.
+        // Registered but not enabled — the default.
         var sweep = new CosmosTagSweepService(
             new CosmosTagSweepOptions(),
             new[] { RuntimeServiceId },
@@ -332,8 +338,12 @@ public class CosmosSweepE2ETests
 
         await RunOneSweepTurnAsync(sweep);
 
-        Assert.Equal(queriesBefore, lineage.Events.Queries);
+        Assert.Equal(eventQueriesBefore, lineage.Events.Queries);
+        Assert.Equal(tagQueriesBefore, lineage.Tags.Queries);
+        Assert.Equal(eventCreatesBefore, lineage.Events.Creates);
+        Assert.Equal(tagCreatesBefore, lineage.Tags.Creates);
+        Assert.Equal(0, lineage.Events.Deletes);
+        Assert.Equal(0, lineage.Tags.Deletes);
         Assert.Empty(lineage.Tags.Items);
-        Assert.Equal(0, lineage.Tags.Creates);
     }
 }

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/Cosmos/InMemoryCosmosClient.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/Cosmos/InMemoryCosmosClient.cs
@@ -1,0 +1,106 @@
+using Microsoft.Azure.Cosmos;
+using System.Net;
+
+namespace Sekiban.Dcb.Tests.Cosmos;
+
+/// <summary>
+///     A CosmosClient whose database hands out <see cref="InMemoryCosmosContainer" />s, so the real
+///     <c>CosmosDbContext</c> — and therefore the real event store, repair service, and sweep — can be
+///     constructed and driven without an emulator.
+/// </summary>
+public sealed class InMemoryCosmosClient : CosmosClient
+{
+    private readonly InMemoryCosmosDatabase _database;
+
+    public InMemoryCosmosClient() => _database = new InMemoryCosmosDatabase();
+
+    /// <summary>The container by name, creating it on first ask, exactly as the context expects.</summary>
+    public InMemoryCosmosContainer Container(string name) => _database.Container(name);
+
+    public override Task<DatabaseResponse> CreateDatabaseIfNotExistsAsync(
+        string id,
+        int? throughput = null,
+        RequestOptions? requestOptions = null,
+        CancellationToken cancellationToken = default) =>
+        Task.FromResult<DatabaseResponse>(new InMemoryDatabaseResponse(_database));
+
+    public override Task<DatabaseResponse> CreateDatabaseIfNotExistsAsync(
+        string id,
+        ThroughputProperties? throughputProperties,
+        RequestOptions? requestOptions = null,
+        CancellationToken cancellationToken = default) =>
+        CreateDatabaseIfNotExistsAsync(id, (int?)null, requestOptions, cancellationToken);
+
+    public override Database GetDatabase(string id) => _database;
+
+    public override Container GetContainer(string databaseId, string containerId) => _database.Container(containerId);
+}
+
+/// <summary>
+///     The in-memory database: a name-to-container map, and nothing else the code under test needs.
+/// </summary>
+public sealed class InMemoryCosmosDatabase : NotSupportedCosmosDatabase
+{
+    private readonly Dictionary<string, InMemoryCosmosContainer> _containers = new(StringComparer.Ordinal);
+
+    public override string Id => "test-db";
+
+    public InMemoryCosmosContainer Container(string name)
+    {
+        if (!_containers.TryGetValue(name, out var container))
+        {
+            container = new InMemoryCosmosContainer(name);
+            _containers[name] = container;
+        }
+
+        return container;
+    }
+
+    public override Task<ContainerResponse> CreateContainerIfNotExistsAsync(
+        ContainerProperties containerProperties,
+        int? throughput = null,
+        RequestOptions? requestOptions = null,
+        CancellationToken cancellationToken = default) =>
+        Task.FromResult<ContainerResponse>(new InMemoryContainerResponse(Container(containerProperties.Id)));
+
+    public override Task<ContainerResponse> CreateContainerIfNotExistsAsync(
+        ContainerProperties containerProperties,
+        ThroughputProperties throughputProperties,
+        RequestOptions? requestOptions = null,
+        CancellationToken cancellationToken = default) =>
+        CreateContainerIfNotExistsAsync(containerProperties, (int?)null, requestOptions, cancellationToken);
+
+    public override Container GetContainer(string id) => Container(id);
+}
+
+internal sealed class InMemoryDatabaseResponse : DatabaseResponse
+{
+    private readonly Headers _headers = new();
+
+    public InMemoryDatabaseResponse(Database database) => Database = database;
+
+    public override Database Database { get; }
+    public override DatabaseProperties Resource => new();
+    public override HttpStatusCode StatusCode => HttpStatusCode.OK;
+    public override Headers Headers => _headers;
+    public override CosmosDiagnostics Diagnostics => null!;
+    public override double RequestCharge => 1.0;
+    public override string ActivityId => "activity";
+    public override string? ETag => null;
+}
+
+internal sealed class InMemoryContainerResponse : ContainerResponse
+{
+    private readonly Headers _headers = new();
+
+    public InMemoryContainerResponse(Container container) => Container = container;
+
+    public override Container Container { get; }
+    public override ContainerProperties Resource => new();
+    public override HttpStatusCode StatusCode => HttpStatusCode.OK;
+    public override Headers Headers => _headers;
+    public override CosmosDiagnostics Diagnostics => null!;
+    public override double RequestCharge => 1.0;
+    public override string ActivityId => "activity";
+    public override string? ETag => null;
+}

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/Cosmos/InMemoryCosmosContainer.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/Cosmos/InMemoryCosmosContainer.cs
@@ -1,0 +1,464 @@
+using Microsoft.Azure.Cosmos;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System.Collections;
+using System.Net;
+
+namespace Sekiban.Dcb.Tests.Cosmos;
+
+/// <summary>
+///     An in-memory Cosmos container: enough of one to drive the real <c>CosmosDbEventStore</c>, the real
+///     repair service, and the real sweep end to end, with no emulator and no timing.
+///     It is a test double, not a Cosmos implementation. It recognizes the handful of query shapes those
+///     types actually issue rather than interpreting SQL, and it models the two behaviors the crash-window
+///     contracts hang on: a create conflicts on an existing (partition key, id), and a transactional batch is
+///     all-or-nothing within one partition.
+/// </summary>
+public sealed class InMemoryCosmosContainer : NotSupportedCosmosContainer
+{
+    private readonly Dictionary<(string PartitionKey, string Id), JObject> _items = new();
+    private readonly string _name;
+
+    public InMemoryCosmosContainer(string name) => _name = name;
+
+    /// <summary>Fails the next N writes with this, to model a store that is throttling or a host that dies.</summary>
+    public Queue<Exception> WriteFaults { get; } = new();
+
+    /// <summary>
+    ///     Called with the running count before each document is written. Lets a test act on the Nth write —
+    ///     cancel, crash, race a concurrent writer — at an exact point, instead of polling for one.
+    /// </summary>
+    public Action<int>? OnWrite { get; set; }
+
+    /// <summary>Every document currently stored, newest last.</summary>
+    public IReadOnlyList<JObject> Items => _items.Values.ToList();
+
+    public int Creates { get; private set; }
+    public int Deletes { get; private set; }
+    public int Queries { get; private set; }
+
+    public override string Id => _name;
+
+    /// <summary>Puts a document in directly, bypassing the write path — for seeding a starting state.</summary>
+    public void Seed(object document)
+    {
+        var item = JObject.FromObject(document);
+        _items[(Pk(item), Id_(item))] = item;
+    }
+
+    public IEnumerable<JObject> ItemsIn(string partitionKey) =>
+        _items.Where(entry => entry.Key.PartitionKey == partitionKey).Select(entry => entry.Value);
+
+    private static string Pk(JObject item) => item["pk"]?.Value<string>() ?? string.Empty;
+    private static string Id_(JObject item) => item["id"]?.Value<string>() ?? string.Empty;
+
+    private void ThrowIfFaulted()
+    {
+        if (WriteFaults.Count > 0)
+        {
+            throw WriteFaults.Dequeue();
+        }
+    }
+
+    public override Task<ItemResponse<T>> CreateItemAsync<T>(
+        T item,
+        PartitionKey? partitionKey = null,
+        ItemRequestOptions? requestOptions = null,
+        CancellationToken cancellationToken = default)
+    {
+        ThrowIfFaulted();
+        OnWrite?.Invoke(Creates);
+        Creates++;
+
+        var document = JObject.FromObject(item!);
+        var key = (Pk(document), Id_(document));
+
+        if (_items.ContainsKey(key))
+        {
+            throw CosmosFailures.Conflict();
+        }
+
+        _items[key] = document;
+        return Task.FromResult<ItemResponse<T>>(new FakeItemResponse<T>(item, HttpStatusCode.Created));
+    }
+
+    public override Task<ItemResponse<T>> ReadItemAsync<T>(
+        string id,
+        PartitionKey partitionKey,
+        ItemRequestOptions? requestOptions = null,
+        CancellationToken cancellationToken = default)
+    {
+        var match = _items
+            .Where(entry => entry.Key.Id == id)
+            .Select(entry => entry.Value)
+            .FirstOrDefault();
+
+        if (match == null)
+        {
+            throw CosmosFailures.NotFound();
+        }
+
+        return Task.FromResult<ItemResponse<T>>(
+            new FakeItemResponse<T>(match.ToObject<T>()!, HttpStatusCode.OK));
+    }
+
+    public override Task<ItemResponse<T>> DeleteItemAsync<T>(
+        string id,
+        PartitionKey partitionKey,
+        ItemRequestOptions? requestOptions = null,
+        CancellationToken cancellationToken = default)
+    {
+        Deletes++;
+
+        var key = _items.Keys.FirstOrDefault(entry => entry.Id == id);
+        if (key == default)
+        {
+            throw CosmosFailures.NotFound();
+        }
+
+        _items.Remove(key);
+        return Task.FromResult<ItemResponse<T>>(new FakeItemResponse<T>(default!, HttpStatusCode.NoContent));
+    }
+
+    public override TransactionalBatch CreateTransactionalBatch(PartitionKey partitionKey) =>
+        new InMemoryTransactionalBatch(this);
+
+    /// <summary>
+    ///     All-or-nothing within one partition, exactly as Cosmos behaves: if any create conflicts, nothing
+    ///     is written. The crash-window contracts depend on this, so the double has to get it right.
+    /// </summary>
+    internal TransactionalBatchResponse ExecuteBatch(IReadOnlyList<JObject> documents)
+    {
+        ThrowIfFaulted();
+
+        var conflicted = documents.Any(document => _items.ContainsKey((Pk(document), Id_(document))));
+        if (conflicted)
+        {
+            return new FakeBatchResponse(
+                HttpStatusCode.Conflict,
+                documents.Select(_ => HttpStatusCode.Conflict).ToList());
+        }
+
+        foreach (var document in documents)
+        {
+            OnWrite?.Invoke(Creates);
+            Creates++;
+            _items[(Pk(document), Id_(document))] = document;
+        }
+
+        return new FakeBatchResponse(
+            HttpStatusCode.OK,
+            documents.Select(_ => HttpStatusCode.Created).ToList());
+    }
+
+    public override FeedIterator<T> GetItemQueryIterator<T>(
+        QueryDefinition queryDefinition,
+        string? continuationToken = null,
+        QueryRequestOptions? requestOptions = null)
+    {
+        Queries++;
+
+        var text = queryDefinition.QueryText;
+        var parameters = queryDefinition
+            .GetQueryParameters()
+            .ToDictionary(parameter => parameter.Name, parameter => parameter.Value, StringComparer.Ordinal);
+
+        var rows = Execute(text, parameters);
+
+        // A query with an item cap pages; the store and the repair both follow continuation tokens.
+        var pageSize = requestOptions?.MaxItemCount is > 0 ? requestOptions.MaxItemCount!.Value : rows.Count;
+        var offset = continuationToken == null ? 0 : int.Parse(continuationToken, null);
+        var page = rows.Skip(offset).Take(Math.Max(1, pageSize)).ToList();
+        var consumed = offset + page.Count;
+        var next = consumed < rows.Count ? consumed.ToString(null as IFormatProvider) : null;
+
+        var typed = page.Select(Materialize<T>).ToList();
+        return new FakeFeedIterator<T>(typed, next);
+    }
+
+    private static T Materialize<T>(JObject row) =>
+        typeof(T) == typeof(long)
+            ? (T)(object)row["__count"]!.Value<long>()
+            : typeof(T) == typeof(string)
+                ? (T)(object)row["__value"]!.Value<string>()!
+                : typeof(T) == typeof(object)
+                    ? (T)(object)row
+                    : row.ToObject<T>()!;
+
+    /// <summary>
+    ///     Recognizes the query shapes the production code issues. Deliberately narrow: if a new query shape
+    ///     appears, this throws rather than quietly returning nothing and turning a real bug into a green test.
+    /// </summary>
+    private List<JObject> Execute(string text, IReadOnlyDictionary<string, object> parameters)
+    {
+        var rows = _items.Values.AsEnumerable();
+
+        // --- tags container -------------------------------------------------------------------------
+        if (text.Contains("c.pk = @pk", StringComparison.Ordinal))
+        {
+            var pk = (string)parameters["@pk"];
+            rows = rows.Where(row => Pk(row) == pk);
+
+            // Repair's candidate prefilter: every Guid rendering, compared case-insensitively.
+            if (text.Contains("STRINGEQUALS(c.eventId", StringComparison.Ordinal))
+            {
+                var renderings = parameters
+                    .Where(parameter => parameter.Key.StartsWith("@eventId", StringComparison.Ordinal))
+                    .Select(parameter => (string)parameter.Value)
+                    .ToList();
+
+                rows = rows.Where(row => renderings.Any(rendering =>
+                    string.Equals(row["eventId"]?.Value<string>(), rendering, StringComparison.OrdinalIgnoreCase)));
+            }
+
+            if (parameters.TryGetValue("@since", out var since))
+            {
+                rows = rows.Where(row =>
+                    string.CompareOrdinal(row["sortableUniqueId"]!.Value<string>(), (string)since) > 0);
+            }
+
+            if (text.Contains("COUNT(1)", StringComparison.Ordinal))
+            {
+                return Count(rows);
+            }
+
+            rows = text.Contains("DESC", StringComparison.Ordinal)
+                ? rows.OrderByDescending(row => row["sortableUniqueId"]!.Value<string>(), StringComparer.Ordinal)
+                : rows.OrderBy(row => row["sortableUniqueId"]!.Value<string>(), StringComparer.Ordinal);
+
+            return rows.ToList();
+        }
+
+        // --- events container -----------------------------------------------------------------------
+        if (text.Contains("c.serviceId = @serviceId", StringComparison.Ordinal))
+        {
+            var serviceId = (string)parameters["@serviceId"];
+            rows = rows.Where(row => row["serviceId"]?.Value<string>() == serviceId);
+
+            if (parameters.TryGetValue("@since", out var since))
+            {
+                rows = rows.Where(row =>
+                    string.CompareOrdinal(row["sortableUniqueId"]!.Value<string>(), (string)since) > 0);
+            }
+
+            if (parameters.TryGetValue("@from", out var from))
+            {
+                rows = rows.Where(row =>
+                    string.CompareOrdinal(row["sortableUniqueId"]!.Value<string>(), (string)from) > 0);
+            }
+
+            if (parameters.TryGetValue("@to", out var to))
+            {
+                rows = rows.Where(row =>
+                    string.CompareOrdinal(row["sortableUniqueId"]!.Value<string>(), (string)to) <= 0);
+            }
+
+            if (text.Contains("COUNT(1)", StringComparison.Ordinal))
+            {
+                return Count(rows);
+            }
+
+            rows = text.Contains("DESC", StringComparison.Ordinal)
+                ? rows.OrderByDescending(row => row["sortableUniqueId"]!.Value<string>(), StringComparer.Ordinal)
+                : rows.OrderBy(row => row["sortableUniqueId"]!.Value<string>(), StringComparer.Ordinal);
+
+            if (text.Contains("TOP 1 VALUE c.sortableUniqueId", StringComparison.Ordinal))
+            {
+                return rows
+                    .Take(1)
+                    .Select(row => new JObject { ["__value"] = row["sortableUniqueId"] })
+                    .ToList();
+            }
+
+            return rows.ToList();
+        }
+
+        throw new NotSupportedException($"The in-memory container does not recognize this query: {text}");
+    }
+
+    private static List<JObject> Count(IEnumerable<JObject> rows) =>
+        new() { new JObject { ["__count"] = rows.Count() } };
+}
+
+/// <summary>Cosmos failures the double needs to raise, shaped the way the production code matches on them.</summary>
+public static class CosmosFailures
+{
+    public static CosmosException Conflict() =>
+        new("conflict", HttpStatusCode.Conflict, 409, "activity", 1.0);
+
+    public static CosmosException NotFound() =>
+        new("not found", HttpStatusCode.NotFound, 404, "activity", 1.0);
+
+    /// <summary>A 429 carrying the server's Retry-After, which the production code must honor in full.</summary>
+    public static CosmosException Throttled(TimeSpan retryAfter) => new ThrottledException(retryAfter);
+
+    private sealed class ThrottledException : CosmosException
+    {
+        private readonly TimeSpan _retryAfter;
+
+        public ThrottledException(TimeSpan retryAfter)
+            : base("throttled", HttpStatusCode.TooManyRequests, 429, "activity", 1.0) =>
+            _retryAfter = retryAfter;
+
+        public override TimeSpan? RetryAfter => _retryAfter;
+    }
+}
+
+internal sealed class InMemoryTransactionalBatch : TransactionalBatch
+{
+    private readonly InMemoryCosmosContainer _container;
+    private readonly List<JObject> _documents = new();
+
+    public InMemoryTransactionalBatch(InMemoryCosmosContainer container) => _container = container;
+
+    public override TransactionalBatch CreateItem<T>(T item, TransactionalBatchItemRequestOptions? requestOptions = null)
+    {
+        _documents.Add(JObject.FromObject(item!));
+        return this;
+    }
+
+    public override Task<TransactionalBatchResponse> ExecuteAsync(CancellationToken cancellationToken = default) =>
+        Task.FromResult(_container.ExecuteBatch(_documents));
+
+    public override Task<TransactionalBatchResponse> ExecuteAsync(
+        TransactionalBatchRequestOptions requestOptions,
+        CancellationToken cancellationToken = default) =>
+        ExecuteAsync(cancellationToken);
+
+    public override TransactionalBatch CreateItemStream(
+        Stream streamPayload,
+        TransactionalBatchItemRequestOptions? requestOptions = null) => throw new NotSupportedException();
+
+    public override TransactionalBatch DeleteItem(string id, TransactionalBatchItemRequestOptions? requestOptions = null) =>
+        throw new NotSupportedException("The write path never deletes through a batch.");
+
+    public override TransactionalBatch PatchItem(
+        string id,
+        IReadOnlyList<PatchOperation> patchOperations,
+        TransactionalBatchPatchItemRequestOptions? requestOptions = null) => throw new NotSupportedException();
+
+    public override TransactionalBatch ReadItem(string id, TransactionalBatchItemRequestOptions? requestOptions = null) =>
+        throw new NotSupportedException();
+
+    public override TransactionalBatch ReplaceItem<T>(
+        string id,
+        T item,
+        TransactionalBatchItemRequestOptions? requestOptions = null) =>
+        throw new NotSupportedException("The write path never replaces through a batch.");
+
+    public override TransactionalBatch ReplaceItemStream(
+        string id,
+        Stream streamPayload,
+        TransactionalBatchItemRequestOptions? requestOptions = null) => throw new NotSupportedException();
+
+    public override TransactionalBatch UpsertItem<T>(T item, TransactionalBatchItemRequestOptions? requestOptions = null) =>
+        throw new NotSupportedException("The write path never upserts.");
+
+    public override TransactionalBatch UpsertItemStream(
+        Stream streamPayload,
+        TransactionalBatchItemRequestOptions? requestOptions = null) => throw new NotSupportedException();
+}
+
+internal sealed class FakeBatchResponse : TransactionalBatchResponse
+{
+    private readonly IReadOnlyList<HttpStatusCode> _operations;
+
+    public FakeBatchResponse(HttpStatusCode statusCode, IReadOnlyList<HttpStatusCode> operations)
+    {
+        _statusCode = statusCode;
+        _operations = operations;
+    }
+
+    private readonly HttpStatusCode _statusCode;
+    public override HttpStatusCode StatusCode => _statusCode;
+    public override bool IsSuccessStatusCode => (int)_statusCode is >= 200 and <= 299;
+    public override int Count => _operations.Count;
+    public override string ActivityId => "activity";
+    public override double RequestCharge => _operations.Count;
+    public override string? ErrorMessage => IsSuccessStatusCode ? null : "batch failed";
+    private readonly Headers _headers = new();
+    public override Headers Headers => _headers;
+    public override CosmosDiagnostics Diagnostics => null!;
+    public override TimeSpan? RetryAfter => null;
+
+    public override TransactionalBatchOperationResult this[int index] => new FakeBatchOperationResult(_operations[index]);
+
+    public override TransactionalBatchOperationResult<T> GetOperationResultAtIndex<T>(int index) =>
+        throw new NotSupportedException();
+
+    public override IEnumerator<TransactionalBatchOperationResult> GetEnumerator() =>
+        _operations.Select(status => (TransactionalBatchOperationResult)new FakeBatchOperationResult(status))
+            .GetEnumerator();
+}
+
+internal sealed class FakeBatchOperationResult : TransactionalBatchOperationResult
+{
+    public FakeBatchOperationResult(HttpStatusCode statusCode) => StatusCode = statusCode;
+
+    public override HttpStatusCode StatusCode { get; }
+    public override bool IsSuccessStatusCode => (int)StatusCode is >= 200 and <= 299;
+    public override string? ETag => null;
+    public override TimeSpan RetryAfter => TimeSpan.Zero;
+}
+
+internal sealed class FakeItemResponse<T> : ItemResponse<T>
+{
+    public FakeItemResponse(T resource, HttpStatusCode statusCode)
+    {
+        Resource = resource;
+        StatusCode = statusCode;
+    }
+
+    public override T Resource { get; }
+    public override HttpStatusCode StatusCode { get; }
+    public override double RequestCharge => 1.0;
+    public override string ActivityId => "activity";
+    public override string? ETag => null;
+    public override Headers Headers { get; } = new();
+    public override CosmosDiagnostics Diagnostics => null!;
+}
+
+internal sealed class FakeFeedIterator<T> : FeedIterator<T>
+{
+    private readonly string? _continuationToken;
+    private readonly IReadOnlyList<T> _rows;
+    private bool _served;
+
+    public FakeFeedIterator(IReadOnlyList<T> rows, string? continuationToken)
+    {
+        _rows = rows;
+        _continuationToken = continuationToken;
+    }
+
+    public override bool HasMoreResults => !_served;
+
+    public override Task<FeedResponse<T>> ReadNextAsync(CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        _served = true;
+        return Task.FromResult<FeedResponse<T>>(new FakeFeedResponse<T>(_rows, _continuationToken));
+    }
+}
+
+internal sealed class FakeFeedResponse<T> : FeedResponse<T>
+{
+    private readonly IReadOnlyList<T> _rows;
+
+    public FakeFeedResponse(IReadOnlyList<T> rows, string? continuationToken)
+    {
+        _rows = rows;
+        _continuation = continuationToken;
+    }
+
+    private readonly string? _continuation;
+    public override string? ContinuationToken => _continuation;
+    public override int Count => _rows.Count;
+    public override Headers Headers { get; } = new();
+    public override IEnumerable<T> Resource => _rows;
+    public override double RequestCharge => _rows.Count;
+    public override HttpStatusCode StatusCode => HttpStatusCode.OK;
+    public override CosmosDiagnostics Diagnostics => null!;
+    public override string IndexMetrics => string.Empty;
+
+    public override IEnumerator<T> GetEnumerator() => _rows.GetEnumerator();
+}

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/Cosmos/NotSupportedCosmosDatabase.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/Cosmos/NotSupportedCosmosDatabase.cs
@@ -1,0 +1,143 @@
+using Microsoft.Azure.Cosmos;
+using Microsoft.Azure.Cosmos.Fluent;
+
+namespace Sekiban.Dcb.Tests.Cosmos;
+
+/// <summary>
+///     A <see cref="Database" /> whose every operation throws, so a test double overrides only the two the
+///     code under test may use. Anything else it reaches for fails loudly rather than silently returning a
+///     default.
+/// </summary>
+public abstract class NotSupportedCosmosDatabase : Database
+{
+    private static NotSupportedException Unsupported() => new("This database is a test double.");
+
+    public override CosmosClient Client => throw Unsupported();
+
+    public override Task<ClientEncryptionKeyResponse> CreateClientEncryptionKeyAsync(
+        ClientEncryptionKeyProperties clientEncryptionKeyProperties,
+        RequestOptions? requestOptions = null,
+        CancellationToken cancellationToken = default) => throw Unsupported();
+
+    public override Task<ContainerResponse> CreateContainerAsync(
+        ContainerProperties containerProperties,
+        int? throughput = null,
+        RequestOptions? requestOptions = null,
+        CancellationToken cancellationToken = default) => throw Unsupported();
+
+    public override Task<ContainerResponse> CreateContainerAsync(
+        ContainerProperties containerProperties,
+        ThroughputProperties throughputProperties,
+        RequestOptions? requestOptions = null,
+        CancellationToken cancellationToken = default) => throw Unsupported();
+
+    public override Task<ContainerResponse> CreateContainerAsync(
+        string id,
+        string partitionKeyPath,
+        int? throughput = null,
+        RequestOptions? requestOptions = null,
+        CancellationToken cancellationToken = default) => throw Unsupported();
+
+    public override Task<ContainerResponse> CreateContainerIfNotExistsAsync(
+        string id,
+        string partitionKeyPath,
+        int? throughput = null,
+        RequestOptions? requestOptions = null,
+        CancellationToken cancellationToken = default) => throw Unsupported();
+
+    public override Task<ResponseMessage> CreateContainerStreamAsync(
+        ContainerProperties containerProperties,
+        int? throughput = null,
+        RequestOptions? requestOptions = null,
+        CancellationToken cancellationToken = default) => throw Unsupported();
+
+    public override Task<ResponseMessage> CreateContainerStreamAsync(
+        ContainerProperties containerProperties,
+        ThroughputProperties throughputProperties,
+        RequestOptions? requestOptions = null,
+        CancellationToken cancellationToken = default) => throw Unsupported();
+
+    public override Task<UserResponse> CreateUserAsync(
+        string id,
+        RequestOptions? requestOptions = null,
+        CancellationToken cancellationToken = default) => throw Unsupported();
+
+    public override ContainerBuilder DefineContainer(string name, string partitionKeyPath) => throw Unsupported();
+
+    public override Task<DatabaseResponse> DeleteAsync(
+        RequestOptions? requestOptions = null,
+        CancellationToken cancellationToken = default) => throw Unsupported();
+
+    public override Task<ResponseMessage> DeleteStreamAsync(
+        RequestOptions? requestOptions = null,
+        CancellationToken cancellationToken = default) => throw Unsupported();
+
+    public override ClientEncryptionKey GetClientEncryptionKey(string id) => throw Unsupported();
+
+    public override FeedIterator<ClientEncryptionKeyProperties> GetClientEncryptionKeyQueryIterator(
+        QueryDefinition? queryDefinition,
+        string? continuationToken = null,
+        QueryRequestOptions? requestOptions = null) => throw Unsupported();
+
+    public override FeedIterator<T> GetContainerQueryIterator<T>(
+        QueryDefinition queryDefinition,
+        string? continuationToken = null,
+        QueryRequestOptions? requestOptions = null) => throw Unsupported();
+
+    public override FeedIterator<T> GetContainerQueryIterator<T>(
+        string? queryText = null,
+        string? continuationToken = null,
+        QueryRequestOptions? requestOptions = null) => throw Unsupported();
+
+    public override FeedIterator GetContainerQueryStreamIterator(
+        QueryDefinition queryDefinition,
+        string? continuationToken = null,
+        QueryRequestOptions? requestOptions = null) => throw Unsupported();
+
+    public override FeedIterator GetContainerQueryStreamIterator(
+        string? queryText = null,
+        string? continuationToken = null,
+        QueryRequestOptions? requestOptions = null) => throw Unsupported();
+
+    public override User GetUser(string id) => throw Unsupported();
+
+    public override FeedIterator<T> GetUserQueryIterator<T>(
+        QueryDefinition queryDefinition,
+        string? continuationToken = null,
+        QueryRequestOptions? requestOptions = null) => throw Unsupported();
+
+    public override FeedIterator<T> GetUserQueryIterator<T>(
+        string? queryText = null,
+        string? continuationToken = null,
+        QueryRequestOptions? requestOptions = null) => throw Unsupported();
+
+    public override Task<DatabaseResponse> ReadAsync(
+        RequestOptions? requestOptions = null,
+        CancellationToken cancellationToken = default) => throw Unsupported();
+
+    public override Task<ResponseMessage> ReadStreamAsync(
+        RequestOptions? requestOptions = null,
+        CancellationToken cancellationToken = default) => throw Unsupported();
+
+    public override Task<int?> ReadThroughputAsync(CancellationToken cancellationToken = default) =>
+        throw Unsupported();
+
+    public override Task<ThroughputResponse> ReadThroughputAsync(
+        RequestOptions requestOptions,
+        CancellationToken cancellationToken = default) => throw Unsupported();
+
+    public override Task<ThroughputResponse> ReplaceThroughputAsync(
+        int throughput,
+        RequestOptions? requestOptions = null,
+        CancellationToken cancellationToken = default) => throw Unsupported();
+
+    public override Task<ThroughputResponse> ReplaceThroughputAsync(
+        ThroughputProperties throughputProperties,
+        RequestOptions? requestOptions = null,
+        CancellationToken cancellationToken = default) => throw Unsupported();
+
+    public override Task<UserResponse> UpsertUserAsync(
+        string id,
+        RequestOptions? requestOptions = null,
+        CancellationToken cancellationToken = default) => throw Unsupported();
+}


### PR DESCRIPTION
## Summary

The consolidated, deterministic fault-injection matrix for the Cosmos crash window. Tests only — **no `dcb/src` changes**.

The scoped tests that landed with SEK-G2..G5 check each piece in isolation. This checks the thing those pieces exist for: after a crash in the two-phase write, **a tag-scoped reader eventually sees the event** — and nothing stronger than "eventually" is true, because that is all the documentation claims.

Closes #1057

## The harness

An in-memory Cosmos (`InMemoryCosmosClient` / `InMemoryCosmosDatabase` / `InMemoryCosmosContainer` / transactional batch) so the **real** `CosmosDbEventStore`, the **real** `CosmosDbTagRepairService`, and the **real** sweep run end to end with no emulator.

It models the two behaviors the crash contracts hang on — a create **conflicts** on an existing `(pk, id)`, and a transactional batch is **all-or-nothing** — and it **refuses to answer a query shape it does not recognize** rather than returning nothing and turning a real bug into a green test. (That failure mode is exactly what bit PR #1054: a fake that was more forgiving than Cosmos.)

Faults go through the seams (`ICosmosTagWriteFaultInjector`, injected `ICosmosRetryScheduler`, an `OnWrite` hook to act on the Nth write). **Nothing sleeps, nothing polls, nothing depends on timing.**

## Scenarios (20)

**Crash window, through the real store and the real repair (16)** — `CosmosCrashWindowE2ETests`

| Family | What it proves |
|---|---|
| Crash **before any** tag batch | Event durable, not deleted, no tag rows. All-events reader sees it; **tag reader does not**. After repair: tag reader sees it. |
| Crash **mid** tag batches | The row that landed is recognized (`Present`), the two that did not are backfilled — 3 rows, no duplicates. |
| Roll-forward retry | A transient tag failure retried through the real store converges to exactly 3 rows, deletes nothing. |
| Multi-event partial create | `CosmosPartialEventWriteException` names both sets; **zero deletes**. |
| Re-execution / corruption | Same write replayed → no duplicate rows. A row disagreeing with its event → `Corrupt`, never overwritten. |
| Repair idempotency | Two repairs raced: exactly one writes (`Repaired`=1), the other finds it (`Present`=1), neither reports corruption. A third finds nothing to do. |
| Checkpoint / resume | Bounded runs resume with no gap and no re-repair, **through a 429 whose Retry-After is honored**. A cancelled run keeps exactly the progress it settled (3 of 4), and resuming does the remaining 1. |
| **Reader racing repair** | Before repair: `ReadEventsByTag` empty, `TagExists` false, `GetLatestTag` empty — the tag-consistent baseline is regressed — while all-events readers see the event throughout. Only after repair does it converge. **Asserts the documented window, rather than wishing it away.** |
| Both registration styles | DI and manual/custom-factory both reach the same non-destructive surface; the manual path (what SekibanWasmRuntime / SekibanAsAService use) gets the same end-to-end repair proof. |
| Legacy defaults | Unchanged after upgrade: no retry, legacy rollback still deletes. |
| Two-lineage isolation | Repairing the runtime lineage leaves the management lineage **untouched** (zero creates); each repairs only itself. |
| Dry run | Reports the residue, writes nothing. |

**The sweep, through the types that actually run (4)** — `CosmosSweepE2ETests`

The sweep's own tests substitute a fake runner, which proves the scheduling and nothing about whether the wiring reaches storage. These drive the **registered `CosmosTagSweepService`** through the **real `CosmosTagRepairRunner`**, the **real repair service**, and the harness — nothing faked below the sweep. Only `ISweepClock` is substituted; turns are driven by starting the service, and the budget expiry is injected at an exact write.

| Scenario | What it proves |
|---|---|
| DI wiring reaches production repair | `AddSekibanDcbCosmosDbTagSweep(Enabled = true)` → the hosted service the host would start → real runner → real repair → the missing rows are written, and a tag-scoped read then sees the event. |
| Budget-exhausted turn resumes | Turn 1 cancelled at the 3rd tag write (2 settled); turn 2 **resumes from the kept checkpoint** and finishes the remaining 2; turn 3 starts from the window again (checkpoint cleared) and finds all 4 present, creating nothing. |
| Lineage isolation through sweep | Sweeping runtime repairs its rows and leaves management with **zero creates**; sweeping management repairs only management. Every row sits under its own `serviceId` partition prefix. |
| Disabled default | Both containers pinned on both dimensions: **no queries, no creates, no deletes**, either side. |

## Do these tests actually bite?

**Mutation-checked, and it earned its keep.**

- Disabling the repair's write → **8 of the 16** crash-window scenarios fail.
- Making the sweep's runner never reach repair → **3 of the 4** sweep scenarios fail.
- Removing the sweep's `Enabled` guard → the disabled-default test fails.
- Dropping the budget-exhausted checkpoint → the resume test fails **(only after it was fixed — see below)**.

## Defects revealed (closeout writeback)

**Zero new product defects.** All twenty scenarios pass against `main` as it stands. The contracts from SEK-G1..G5 hold end to end.

Two distinct classes of defect are worth separating in the record for #1046:

**1. Three real product defects — caught by review, not by the scoped tests.** Each slipped through because a test exercised a fake instead of the production path:
- **G3**: a Cosmos 429 `Retry-After` was capped by the client's `MaxBackoff`, so the client retried before the server was ready.
- **G4**: the production SQL matched legacy rows by the *string form* of the event id, so a row stored in another Guid rendering looked *missing* and would have been duplicated. The unit test passed because its fake parsed Guids client-side.
- **G5**: a budget-exhausted sweep turn threw its partial checkpoint away, so a tight budget re-scanned the same prefix forever and never advanced.

**2. One defect in this PR's own coverage — caught by the mutation check.** The first version of the sweep-resume test asserted only the final row count, and **passed with the checkpoint persistence deleted**: a turn that drops the checkpoint re-scans from the window, finds the first two present, repairs the last two, and converges on the same four rows. The test proved nothing. It now counts the *work* instead — the repair issues one tag lookup per key it examines, so a resumed turn examines 2 and a restarted one examines 4 — and the mutant now fails it. That is a test defect, not a product defect, and the class of mistake this matrix exists to stop.

## Test plan

- [x] 20 new E2E scenarios (16 crash-window + 4 sweep), all green, deterministic
- [x] Mutation-checked: disabling repair writes fails 8; breaking the sweep runner fails 3; removing the Enabled guard fails the disabled test; dropping the budget checkpoint fails the resume test
- [x] `Sekiban.Dcb.WithResult.Tests` 600 passed / 0 failed — no regressions
- [x] No `dcb/src` changes (tests only, per the packet)
- [x] No warnings; `git diff --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017KAPyZPCMZzurEZTt1k8LX
