### PR TITLE
Tell the truth about the migration CLI, and route the #1046 symptom to the fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Learn more at [dcb.events](https://dcb.events)
 - **Website**: [sekiban.dev](https://www.sekiban.dev/)
 - **DCB Documentation**: [docs/dcb_llm](./docs/dcb_llm/) (English) | [docs/dcb_llm_ja](./docs/dcb_llm_ja/) (日本語)
 - **Pure Documentation**: [docs/llm](./docs/llm/) (English) | [docs/llm_ja](./docs/llm_ja/) (日本語)
+- **Storage consistency contract (DCB)** — what each event store guarantees, and what it does not: [English](./docs/dcb_llm/11_storage_providers.md#consistency-contract) | [日本語](./docs/dcb_llm_ja/11_storage_providers.md#整合性契約). Read this before choosing Cosmos DB for a workload that needs atomic event/tag visibility.
 
 ## MCP (Model Context Protocol)
 

--- a/dcb/README.md
+++ b/dcb/README.md
@@ -35,6 +35,8 @@ dotnet new sekiban-orleans-aspire -n YourProjectName
 | DynamoDB | `Sekiban.Dcb.DynamoDB` | AWS |
 | SQLite | `Sekiban.Dcb.Sqlite` | Local/Dev |
 
+**Cosmos DB — read the consistency contract first** ([English](https://github.com/J-Tech-Japan/Sekiban/blob/main/docs/dcb_llm/11_storage_providers.md#consistency-contract) | [日本語](https://github.com/J-Tech-Japan/Sekiban/blob/main/docs/dcb_llm_ja/11_storage_providers.md#整合性契約)). Postgres writes events and tag rows in one transaction; Cosmos writes them in two phases, so a crash can leave an event visible to all-events reads but missing from tag-scoped ones. The defaults are unchanged on upgrade (`WriteFailurePolicy = Compatible`); `RollForward` is an opt-in that retries the tag write instead of deleting events, and the tag-index repair service and automatic sweep are both opt-in registrations. If you need atomic event/tag visibility — money-sensitive workflows above all — use Postgres.
+
 ## Snapshot Storage
 
 | Storage | Package | Cloud |

--- a/docs/dcb_llm/11_storage_providers.md
+++ b/docs/dcb_llm/11_storage_providers.md
@@ -296,27 +296,41 @@ It is not registered by `AddSekibanDcbCosmosDb`, it is **not reachable from the 
 
 **The service API** ships in the `Sekiban.Dcb.CosmosDb` package: register the factory with `AddSekibanDcbCosmosDbLegacyTagMigration()`, then call `PlanAsync` and `ApplyAsync(plan, options)`.
 
-**The CLI is not distributed.** `tools/SekibanDcbTagMigration` is not packaged, not published, and not a `dotnet tool` — no release produces an executable you can install. It is a thin front-end over the same service (no destructive logic of its own, and it could not have any: the seam that expresses a tag-row delete is `internal` to `Sekiban.Dcb.CosmosDb`, so no other assembly can issue one). To use it, **run it from source**, from a checkout of the release tag whose packages you are running:
+**The CLI is not distributed.** `tools/SekibanDcbTagMigration` is not packaged, not published, and not a `dotnet tool` — no release produces an executable you can install. It is a thin front-end over the same service (no destructive logic of its own, and it could not have any: the seam that expresses a tag-row delete is `internal` to `Sekiban.Dcb.CosmosDb`, so no other assembly can issue one). To use it, **run it from source**.
+
+Run it from the release tag whose packages you actually deploy. A tool built from a different revision than the code that wrote your rows will happily produce a plan describing a world you do not have — and this plan authorizes deletions. So find the tag, do not guess it:
 
 ```bash
+# 1. Which Sekiban.Dcb.CosmosDb version is your service running?
+dotnet list package | grep Sekiban.Dcb.CosmosDb
+#   > Sekiban.Dcb.CosmosDb      10.2.2   10.2.2
+
+# 2. Release tags are dcb-v<version>. List them and pick the one that matches.
 git clone https://github.com/J-Tech-Japan/Sekiban.git
 cd Sekiban
-git checkout dcb-v10.3.0        # the release tag matching your Sekiban.Dcb.CosmosDb version
+git tag --list 'dcb-v*' | sort -V | tail -20
 
-# 1. Plan. Read-only. Writes an artifact naming exactly which rows would die.
+# 3. Check it out, and VERIFY the source agrees with the package you deploy.
+git checkout dcb-v10.2.2        # ← substitute the version from step 1
+grep PackageVersion dcb/src/Sekiban.Dcb.CosmosDb/Sekiban.Dcb.CosmosDb.csproj
+#   > <PackageVersion>10.2.2</PackageVersion>   ← must match step 1
+```
+
+With a verified checkout, the two-step flow is:
+
+```bash
+# Plan. Read-only. Writes an artifact naming exactly which rows would die.
 dotnet run --project tools/SekibanDcbTagMigration -- plan \
   --connection "<cs>" --database SekibanDcb --service-id <id> \
   --plan tag-migration-plan.json
 
-# 2. READ IT. This is the point of the two-step flow.
+# READ IT. This is the point of the two-step flow.
 
-# 3. Apply. Refuses without --confirm and --backup.
+# Apply. Refuses without --confirm and --backup.
 dotnet run --project tools/SekibanDcbTagMigration -- apply \
   --connection "<cs>" --database SekibanDcb --service-id <id> \
   --plan tag-migration-plan.json --backup removed-rows.json --confirm
 ```
-
-Check out the tag that matches the package version you deploy. Running the tool from a different revision than the code that wrote your rows is asking for a plan that describes a world you do not have.
 
 If running from source is not practical, drive the service API directly — it is the same two calls, behind the same gates.
 

--- a/docs/dcb_llm/11_storage_providers.md
+++ b/docs/dcb_llm/11_storage_providers.md
@@ -296,27 +296,30 @@ It is not registered by `AddSekibanDcbCosmosDb`, it is **not reachable from the 
 
 **The service API** ships in the `Sekiban.Dcb.CosmosDb` package: register the factory with `AddSekibanDcbCosmosDbLegacyTagMigration()`, then call `PlanAsync` and `ApplyAsync(plan, options)`.
 
-**The CLI is not distributed.** `tools/SekibanDcbTagMigration` is not packaged, not published, and not a `dotnet tool` — no release produces an executable you can install. It is a thin front-end over the same service (no destructive logic of its own, and it could not have any: the seam that expresses a tag-row delete is `internal` to `Sekiban.Dcb.CosmosDb`, so no other assembly can issue one). To use it, **run it from source**.
+**Use the service API.** It is the supported path, it ships in the package you already reference, and it is what the CLI calls anyway.
 
-Run it from the release tag whose packages you actually deploy. A tool built from a different revision than the code that wrote your rows will happily produce a plan describing a world you do not have — and this plan authorizes deletions. So find the tag, do not guess it:
+**The CLI is not distributed, and no released tag contains it yet.** `tools/SekibanDcbTagMigration` is not packaged, not published, and not a `dotnet tool` — no release produces an executable you can install. It was added *after* the most recent release tag, so checking out any published `dcb-v*` tag gives you a tree in which the tool does not exist and `dotnet run --project tools/SekibanDcbTagMigration` cannot work. It is a thin front-end over the same service (no destructive logic of its own, and it could not have any: the seam that expresses a tag-row delete is `internal` to `Sekiban.Dcb.CosmosDb`, so no other assembly can issue one).
+
+If you nonetheless want to run it, **run it from a source revision you have explicitly reviewed** — and check that the revision actually contains it *before* you check it out:
 
 ```bash
-# 1. Which Sekiban.Dcb.CosmosDb version is your service running?
-dotnet list package | grep Sekiban.Dcb.CosmosDb
-#   > Sekiban.Dcb.CosmosDb      10.2.2   10.2.2
-
-# 2. Release tags are dcb-v<version>. List them and pick the one that matches.
 git clone https://github.com/J-Tech-Japan/Sekiban.git
 cd Sekiban
-git tag --list 'dcb-v*' | sort -V | tail -20
 
-# 3. Check it out, and VERIFY the source agrees with the package you deploy.
-git checkout dcb-v10.2.2        # ← substitute the version from step 1
-grep PackageVersion dcb/src/Sekiban.Dcb.CosmosDb/Sekiban.Dcb.CosmosDb.csproj
-#   > <PackageVersion>10.2.2</PackageVersion>   ← must match step 1
+# Does this ref contain the tool at all? (Substitute the ref you intend to use.)
+REF=main
+git cat-file -e "$REF:tools/SekibanDcbTagMigration/SekibanDcbTagMigration.csproj" \
+  && echo "tool present at $REF" \
+  || echo "tool ABSENT at $REF — do not use this ref"
+
+git checkout "$REF"
 ```
 
-With a verified checkout, the two-step flow is:
+Once a release tag does contain the tool, prefer that tag over a branch, and use the same existence check to confirm it before you trust it. **Do not verify a release by grepping `<PackageVersion>` out of the csproj** — the value in the tagged source is a build-time placeholder, not the version that was published.
+
+Why any of this care: a tool built from a revision other than the code that wrote your rows will happily produce a plan describing a world you do not have — and that plan authorizes deletions.
+
+With a reviewed checkout, the two-step flow is:
 
 ```bash
 # Plan. Read-only. Writes an artifact naming exactly which rows would die.
@@ -331,8 +334,6 @@ dotnet run --project tools/SekibanDcbTagMigration -- apply \
   --connection "<cs>" --database SekibanDcb --service-id <id> \
   --plan tag-migration-plan.json --backup removed-rows.json --confirm
 ```
-
-If running from source is not practical, drive the service API directly — it is the same two calls, behind the same gates.
 
 **What stops a mistake.** Every one of these refuses *before* touching a document:
 

--- a/docs/dcb_llm/11_storage_providers.md
+++ b/docs/dcb_llm/11_storage_providers.md
@@ -294,23 +294,31 @@ Rows written before the deterministic-id scheme sit at a random document id. **T
 
 It is not registered by `AddSekibanDcbCosmosDb`, it is **not reachable from the automatic sweep**, and it never runs by itself.
 
-**The CLI** (`tools/SekibanDcbTagMigration`) is a thin front-end over the same service — no destructive logic of its own, and it could not have any: the seam that expresses a tag-row delete is `internal` to `Sekiban.Dcb.CosmosDb`, so no other assembly can issue one.
+**The service API** ships in the `Sekiban.Dcb.CosmosDb` package: register the factory with `AddSekibanDcbCosmosDbLegacyTagMigration()`, then call `PlanAsync` and `ApplyAsync(plan, options)`.
+
+**The CLI is not distributed.** `tools/SekibanDcbTagMigration` is not packaged, not published, and not a `dotnet tool` — no release produces an executable you can install. It is a thin front-end over the same service (no destructive logic of its own, and it could not have any: the seam that expresses a tag-row delete is `internal` to `Sekiban.Dcb.CosmosDb`, so no other assembly can issue one). To use it, **run it from source**, from a checkout of the release tag whose packages you are running:
 
 ```bash
+git clone https://github.com/J-Tech-Japan/Sekiban.git
+cd Sekiban
+git checkout dcb-v10.3.0        # the release tag matching your Sekiban.Dcb.CosmosDb version
+
 # 1. Plan. Read-only. Writes an artifact naming exactly which rows would die.
-sekiban-dcb-tag-migration plan \
+dotnet run --project tools/SekibanDcbTagMigration -- plan \
   --connection "<cs>" --database SekibanDcb --service-id <id> \
   --plan tag-migration-plan.json
 
 # 2. READ IT. This is the point of the two-step flow.
 
 # 3. Apply. Refuses without --confirm and --backup.
-sekiban-dcb-tag-migration apply \
+dotnet run --project tools/SekibanDcbTagMigration -- apply \
   --connection "<cs>" --database SekibanDcb --service-id <id> \
   --plan tag-migration-plan.json --backup removed-rows.json --confirm
 ```
 
-The service API is the same two calls: `PlanAsync` then `ApplyAsync(plan, options)` (`AddSekibanDcbCosmosDbLegacyTagMigration()` to register the factory).
+Check out the tag that matches the package version you deploy. Running the tool from a different revision than the code that wrote your rows is asking for a plan that describes a world you do not have.
+
+If running from source is not practical, drive the service API directly — it is the same two calls, behind the same gates.
 
 **What stops a mistake.** Every one of these refuses *before* touching a document:
 

--- a/docs/dcb_llm/13_common_issues.md
+++ b/docs/dcb_llm/13_common_issues.md
@@ -68,6 +68,81 @@ Remember to register query types when introducing new projections.
 - Increase RU/s on the `events` and `tags` containers.
 - Use `WaitForSortableUniqueId` sparingly in read-heavy scenarios to reduce polling frequency.
 
+## Cosmos: an event is visible globally but missing from tag-scoped reads
+
+**Symptoms**: `ReadAllEventsAsync` returns the event, but `ReadEventsByTagAsync` does not. `TagExistsAsync` says false, tag projectors never see it, and `GetLatestTagAsync` — which feeds `GeneralTagConsistentActor`'s optimistic-concurrency baseline — reports a value older than the event you just wrote.
+
+This is the symptom [issue #1046](https://github.com/J-Tech-Japan/Sekiban/issues/1046) reported. Only Cosmos does this; Postgres writes events and tag rows in one transaction and cannot.
+
+### First: is it lag, or is it residue?
+
+They look identical for a few seconds and need completely different responses.
+
+- **Transient lag** — the write is still in flight, or the account's consistency level is letting a reader see a stale replica. **Wait and re-read.** If the tag read catches up on its own, nothing is wrong.
+- **Durable residue** — the tag rows never landed. The Cosmos write is two-phase (events first, then tag rows), so a crash between the phases leaves the event durable with no tag rows, and **no amount of waiting fixes it.**
+
+If the event is minutes old and still invisible to tag reads, it is residue.
+
+### Then: check the telemetry
+
+The `Sekiban.Dcb.CosmosDb` meter says whether a write actually failed:
+
+- `sekiban.dcb.cosmos.tag_write.failures` / `.retry_outcomes{outcome=exhausted}` — a tag write gave up. The structured logs and `CosmosTagWriteExhaustedException` name the affected event ids.
+- `sekiban.dcb.cosmos.event_write.partial_failures` — a multi-event write landed some events and not others.
+
+A crash leaves no in-process trace at all, so **an empty metric does not mean an empty tags container.** Confirm with a dry run.
+
+### Fix: repair the tag index
+
+The tags container is a **derivable index** — every event document carries its complete `tags` array — so missing rows can be rebuilt from the events. Register the repair service and **always dry-run first**:
+
+```csharp
+services.AddSekibanDcbCosmosDb(configuration);
+services.AddSekibanDcbCosmosDbTagRepair();   // opt-in; not registered by AddSekibanDcbCosmosDb alone
+
+var repair = await factory.CreateAsync(serviceId);
+
+// Look before you write. DryRun is the default.
+var report = await repair.RepairAsync(new CosmosTagRepairOptions
+{
+    DryRun = true,
+    ToSortableUniqueIdInclusive = lastSettledSortableUniqueId,  // pin the upper bound
+});
+```
+
+**Pin `ToSortableUniqueIdInclusive`** to an event you know is settled. Without it the scan runs to the end and races your live traffic, which the write path is already handling — the repair is for crash residue, not for events that are still being written.
+
+Read the report, then repair with `DryRun = false`. The counts tell you what you are looking at:
+
+| Category | Meaning | Does repair write? |
+|---|---|---|
+| `Missing` | Nothing indexes this `(event, tag)`. | **Yes — the only category it writes.** |
+| `Present` | The derived row exists and matches the event. | No |
+| `LegacyPresent` | A row from before the deterministic-id scheme indexes it. It works; migration is optional. | No |
+| `Duplicate` | Several legacy rows index it. | No — reported only |
+| `Corrupt` | A row indexes it but disagrees with the event. | **No — never overwritten.** Investigate before doing anything. |
+| `Overflow` | More rows than the per-key cap. | No — raise `MaxRowsPerKey` to look deeper |
+
+A `Corrupt` or `Duplicate` count is not something the repair will resolve for you, by design.
+
+### Prevent the recurrence you *can* prevent
+
+Set `WriteFailurePolicy = CosmosWriteFailurePolicy.RollForward`:
+
+```csharp
+services.AddSekibanDcbCosmosDb(
+    configuration,
+    options => options.WriteFailurePolicy = CosmosWriteFailurePolicy.RollForward);
+```
+
+The default is `Compatible`, which does not retry the tag write and — via the now-obsolete `TryRollbackOnFailure` — **deletes the events it already wrote**, which multi-projections may already have read. `RollForward` retries the tag write instead and never deletes an event.
+
+**The caveat that matters**: `RollForward` only helps when the process survives to retry. **A crash is not an in-process failure**, so it leaves residue no policy can prevent — only a repair pass closes that window. An [opt-in sweep](11_storage_providers.md) can run the repair automatically over a recent window, but it is *eventual* repair: it does not gate tag readers, and the window stays open until a run reaches it.
+
+If your workload cannot tolerate that window at all — money-sensitive workflows above all — **use the Postgres provider**, which has none of these gaps.
+
+**See**: [Consistency Contract](11_storage_providers.md#consistency-contract) for the full per-provider guarantees, the repair service, the sweep, and what none of them promise.
+
 ## Serialization Exceptions
 
 **Symptoms**: `JsonException` during event replay or API responses.

--- a/docs/dcb_llm_ja/11_storage_providers.md
+++ b/docs/dcb_llm_ja/11_storage_providers.md
@@ -320,27 +320,30 @@ services.AddSekibanDcbCosmosDbTagSweep(sweep =>
 
 **サービスAPI** は `Sekiban.Dcb.CosmosDb` パッケージに含まれます。`AddSekibanDcbCosmosDbLegacyTagMigration()` でファクトリを登録し、`PlanAsync` → `ApplyAsync(plan, options)` を呼び出します。
 
-**CLI は配布されていません。** `tools/SekibanDcbTagMigration` はパッケージ化も公開もされておらず、`dotnet tool` でもありません。インストール可能な実行ファイルを生成するリリースは存在しません。CLI は同一サービスへの薄いフロントエンドで、独自の破壊的ロジックを持ちません(持ちようがありません — タグ行の削除を表現するシームは `Sekiban.Dcb.CosmosDb` に対して `internal` であり、他のアセンブリからは削除を発行できないためです)。使用するには、**ソースから実行**してください。
+**サービスAPI を使用してください。** これがサポートされる経路であり、すでに参照しているパッケージに含まれています。CLI が呼び出しているのも、結局これと同じものです。
 
-実際にデプロイしているパッケージに対応するリリースタグから実行してください。行を書き込んだコードとは別のリビジョンでビルドしたツールは、手元に存在しない世界を記述した計画を平然と出力します。そしてその計画は**削除を承認するもの**です。タグは推測せず、必ず特定してください。
+**CLI は配布されておらず、それを含むリリースタグも現時点では存在しません。** `tools/SekibanDcbTagMigration` はパッケージ化も公開もされておらず、`dotnet tool` でもありません。インストール可能な実行ファイルを生成するリリースは存在しません。さらに、この CLI は**最新のリリースタグより後に**追加されたため、公開済みの `dcb-v*` タグをチェックアウトしても、そのツリーにツールは存在せず、`dotnet run --project tools/SekibanDcbTagMigration` は動作しません。CLI は同一サービスへの薄いフロントエンドで、独自の破壊的ロジックを持ちません(持ちようがありません — タグ行の削除を表現するシームは `Sekiban.Dcb.CosmosDb` に対して `internal` であり、他のアセンブリからは削除を発行できないためです)。
+
+それでも CLI を実行したい場合は、**自分で明示的にレビューしたソースリビジョンから実行**してください。そして**チェックアウトする前に**、そのリビジョンに実際にツールが含まれているかを確認してください。
 
 ```bash
-# 1. サービスが使用している Sekiban.Dcb.CosmosDb のバージョンを確認する。
-dotnet list package | grep Sekiban.Dcb.CosmosDb
-#   > Sekiban.Dcb.CosmosDb      10.2.2   10.2.2
-
-# 2. リリースタグは dcb-v<version> 形式。一覧から一致するものを選ぶ。
 git clone https://github.com/J-Tech-Japan/Sekiban.git
 cd Sekiban
-git tag --list 'dcb-v*' | sort -V | tail -20
 
-# 3. チェックアウトし、ソースがデプロイ中のパッケージと一致することを検証する。
-git checkout dcb-v10.2.2        # ← 手順1で確認したバージョンに置き換える
-grep PackageVersion dcb/src/Sekiban.Dcb.CosmosDb/Sekiban.Dcb.CosmosDb.csproj
-#   > <PackageVersion>10.2.2</PackageVersion>   ← 手順1と一致していること
+# この ref にツールは存在するか?(使用したい ref に置き換えてください)
+REF=main
+git cat-file -e "$REF:tools/SekibanDcbTagMigration/SekibanDcbTagMigration.csproj" \
+  && echo "tool present at $REF" \
+  || echo "tool ABSENT at $REF — この ref は使わないこと"
+
+git checkout "$REF"
 ```
 
-検証済みのチェックアウトができたら、2段階フローは次のとおりです。
+将来 CLI を含むリリースタグが出たら、ブランチよりそのタグを優先し、信頼する前に同じ存在チェックで確認してください。**csproj の `<PackageVersion>` を grep してリリースを検証してはいけません** — タグ付きソース内のその値はビルド時のプレースホルダであり、公開されたバージョンではありません。
+
+これだけ慎重になる理由は単純です。行を書き込んだコードとは別のリビジョンでビルドしたツールは、手元に存在しない世界を記述した計画を平然と出力します。そしてその計画は**削除を承認するもの**です。
+
+レビュー済みのチェックアウトができたら、2段階フローは次のとおりです。
 
 ```bash
 # 計画。読み取り専用。どの行が削除されるかを正確に記した artifact を出力する。
@@ -355,8 +358,6 @@ dotnet run --project tools/SekibanDcbTagMigration -- apply \
   --connection "<cs>" --database SekibanDcb --service-id <id> \
   --plan tag-migration-plan.json --backup removed-rows.json --confirm
 ```
-
-ソースからの実行が現実的でない場合は、サービスAPIを直接呼び出してください。同じ2つの呼び出しであり、同じゲートに守られています。
 
 **事故を防ぐもの**。以下はすべて、ドキュメントに触れる **前に** 拒否します。
 

--- a/docs/dcb_llm_ja/11_storage_providers.md
+++ b/docs/dcb_llm_ja/11_storage_providers.md
@@ -320,27 +320,41 @@ services.AddSekibanDcbCosmosDbTagSweep(sweep =>
 
 **サービスAPI** は `Sekiban.Dcb.CosmosDb` パッケージに含まれます。`AddSekibanDcbCosmosDbLegacyTagMigration()` でファクトリを登録し、`PlanAsync` → `ApplyAsync(plan, options)` を呼び出します。
 
-**CLI は配布されていません。** `tools/SekibanDcbTagMigration` はパッケージ化も公開もされておらず、`dotnet tool` でもありません。インストール可能な実行ファイルを生成するリリースは存在しません。CLI は同一サービスへの薄いフロントエンドで、独自の破壊的ロジックを持ちません(持ちようがありません — タグ行の削除を表現するシームは `Sekiban.Dcb.CosmosDb` に対して `internal` であり、他のアセンブリからは削除を発行できないためです)。使用するには、**実行中のパッケージに対応するリリースタグをチェックアウトし、ソースから実行**してください。
+**CLI は配布されていません。** `tools/SekibanDcbTagMigration` はパッケージ化も公開もされておらず、`dotnet tool` でもありません。インストール可能な実行ファイルを生成するリリースは存在しません。CLI は同一サービスへの薄いフロントエンドで、独自の破壊的ロジックを持ちません(持ちようがありません — タグ行の削除を表現するシームは `Sekiban.Dcb.CosmosDb` に対して `internal` であり、他のアセンブリからは削除を発行できないためです)。使用するには、**ソースから実行**してください。
+
+実際にデプロイしているパッケージに対応するリリースタグから実行してください。行を書き込んだコードとは別のリビジョンでビルドしたツールは、手元に存在しない世界を記述した計画を平然と出力します。そしてその計画は**削除を承認するもの**です。タグは推測せず、必ず特定してください。
 
 ```bash
+# 1. サービスが使用している Sekiban.Dcb.CosmosDb のバージョンを確認する。
+dotnet list package | grep Sekiban.Dcb.CosmosDb
+#   > Sekiban.Dcb.CosmosDb      10.2.2   10.2.2
+
+# 2. リリースタグは dcb-v<version> 形式。一覧から一致するものを選ぶ。
 git clone https://github.com/J-Tech-Japan/Sekiban.git
 cd Sekiban
-git checkout dcb-v10.3.0        # 使用中の Sekiban.Dcb.CosmosDb のバージョンに対応するリリースタグ
+git tag --list 'dcb-v*' | sort -V | tail -20
 
-# 1. 計画。読み取り専用。どの行が削除されるかを正確に記した artifact を出力する。
+# 3. チェックアウトし、ソースがデプロイ中のパッケージと一致することを検証する。
+git checkout dcb-v10.2.2        # ← 手順1で確認したバージョンに置き換える
+grep PackageVersion dcb/src/Sekiban.Dcb.CosmosDb/Sekiban.Dcb.CosmosDb.csproj
+#   > <PackageVersion>10.2.2</PackageVersion>   ← 手順1と一致していること
+```
+
+検証済みのチェックアウトができたら、2段階フローは次のとおりです。
+
+```bash
+# 計画。読み取り専用。どの行が削除されるかを正確に記した artifact を出力する。
 dotnet run --project tools/SekibanDcbTagMigration -- plan \
   --connection "<cs>" --database SekibanDcb --service-id <id> \
   --plan tag-migration-plan.json
 
-# 2. それを読む。この2段階フローの要点はここにある。
+# それを読む。この2段階フローの要点はここにある。
 
-# 3. 適用。--confirm と --backup がなければ拒否される。
+# 適用。--confirm と --backup がなければ拒否される。
 dotnet run --project tools/SekibanDcbTagMigration -- apply \
   --connection "<cs>" --database SekibanDcb --service-id <id> \
   --plan tag-migration-plan.json --backup removed-rows.json --confirm
 ```
-
-デプロイしているパッケージのバージョンと一致するタグをチェックアウトしてください。行を書き込んだコードとは別のリビジョンからツールを実行することは、手元に存在しない世界を記述した計画を作りにいくようなものです。
 
 ソースからの実行が現実的でない場合は、サービスAPIを直接呼び出してください。同じ2つの呼び出しであり、同じゲートに守られています。
 

--- a/docs/dcb_llm_ja/11_storage_providers.md
+++ b/docs/dcb_llm_ja/11_storage_providers.md
@@ -318,23 +318,31 @@ services.AddSekibanDcbCosmosDbTagSweep(sweep =>
 
 `AddSekibanDcbCosmosDb` では登録されず、**自動スイープからは到達不能**で、決して自動実行されません。
 
-**CLI**(`tools/SekibanDcbTagMigration`)は同一サービスへの薄いフロントエンドで、独自の破壊的ロジックを持ちません。持ちようがありません — タグ行の削除を表現するシームは `Sekiban.Dcb.CosmosDb` に対して `internal` であり、他のアセンブリからは削除を発行できないためです。
+**サービスAPI** は `Sekiban.Dcb.CosmosDb` パッケージに含まれます。`AddSekibanDcbCosmosDbLegacyTagMigration()` でファクトリを登録し、`PlanAsync` → `ApplyAsync(plan, options)` を呼び出します。
+
+**CLI は配布されていません。** `tools/SekibanDcbTagMigration` はパッケージ化も公開もされておらず、`dotnet tool` でもありません。インストール可能な実行ファイルを生成するリリースは存在しません。CLI は同一サービスへの薄いフロントエンドで、独自の破壊的ロジックを持ちません(持ちようがありません — タグ行の削除を表現するシームは `Sekiban.Dcb.CosmosDb` に対して `internal` であり、他のアセンブリからは削除を発行できないためです)。使用するには、**実行中のパッケージに対応するリリースタグをチェックアウトし、ソースから実行**してください。
 
 ```bash
+git clone https://github.com/J-Tech-Japan/Sekiban.git
+cd Sekiban
+git checkout dcb-v10.3.0        # 使用中の Sekiban.Dcb.CosmosDb のバージョンに対応するリリースタグ
+
 # 1. 計画。読み取り専用。どの行が削除されるかを正確に記した artifact を出力する。
-sekiban-dcb-tag-migration plan \
+dotnet run --project tools/SekibanDcbTagMigration -- plan \
   --connection "<cs>" --database SekibanDcb --service-id <id> \
   --plan tag-migration-plan.json
 
 # 2. それを読む。この2段階フローの要点はここにある。
 
 # 3. 適用。--confirm と --backup がなければ拒否される。
-sekiban-dcb-tag-migration apply \
+dotnet run --project tools/SekibanDcbTagMigration -- apply \
   --connection "<cs>" --database SekibanDcb --service-id <id> \
   --plan tag-migration-plan.json --backup removed-rows.json --confirm
 ```
 
-サービスAPIも同じ2つの呼び出しです(`PlanAsync` → `ApplyAsync(plan, options)`。ファクトリの登録は `AddSekibanDcbCosmosDbLegacyTagMigration()`)。
+デプロイしているパッケージのバージョンと一致するタグをチェックアウトしてください。行を書き込んだコードとは別のリビジョンからツールを実行することは、手元に存在しない世界を記述した計画を作りにいくようなものです。
+
+ソースからの実行が現実的でない場合は、サービスAPIを直接呼び出してください。同じ2つの呼び出しであり、同じゲートに守られています。
 
 **事故を防ぐもの**。以下はすべて、ドキュメントに触れる **前に** 拒否します。
 

--- a/docs/dcb_llm_ja/13_common_issues.md
+++ b/docs/dcb_llm_ja/13_common_issues.md
@@ -57,6 +57,81 @@
 
 **対処**: RU を増やす、`waitForSortableUniqueId` の利用頻度を減らす。
 
+## Cosmos でイベントがタグスコープ読み取りに現れない
+
+**症状**: `ReadAllEventsAsync` ではイベントが返るのに、`ReadEventsByTagAsync` では返らない。`TagExistsAsync` は false、タグプロジェクターも認識せず、(`GeneralTagConsistentActor` の楽観的並行性制御のベースラインにも使われる)`GetLatestTagAsync` が、書き込んだばかりのイベントより古い値を返す。
+
+これは [issue #1046](https://github.com/J-Tech-Japan/Sekiban/issues/1046) で報告された症状です。この現象は Cosmos だけで起こります。Postgres はイベント行とタグ行を単一トランザクションで書くため、原理的に発生しません。
+
+### まず: 遅延なのか、残骸なのか
+
+最初の数秒間は見分けがつきませんが、必要な対応はまったく異なります。
+
+- **一時的な遅延** — 書き込みがまだ進行中であるか、アカウントの整合性レベルによって読み手が古いレプリカを見ている。**待って読み直してください。** 自然に追いつくなら、何も問題はありません。
+- **永続的な残骸** — タグ行がそもそも書かれていない。Cosmos の書き込みは2段階(イベント → タグ行)なので、その間にクラッシュするとイベントだけが永続化され、タグ行が存在しない状態になります。**いくら待っても直りません。**
+
+イベントが書かれてから数分経ってもタグ読み取りに現れないなら、それは残骸です。
+
+### 次に: テレメトリを確認する
+
+`Sekiban.Dcb.CosmosDb` メーターは、書き込みが実際に失敗したかどうかを教えてくれます。
+
+- `sekiban.dcb.cosmos.tag_write.failures` / `.retry_outcomes{outcome=exhausted}` — タグ書き込みが諦めた。構造化ログと `CosmosTagWriteExhaustedException` が該当イベントIDを通知します。
+- `sekiban.dcb.cosmos.event_write.partial_failures` — 複数イベント書き込みで一部だけが着地した。
+
+ただし **クラッシュはプロセス内に痕跡を残しません**。したがって **メトリクスが空でも、tags コンテナーが健全だとは限りません**。dry run で確認してください。
+
+### 対処: タグインデックスを修復する
+
+`tags` コンテナーは **派生可能なインデックス** です(すべてのイベントドキュメントが完全な `tags` 配列を保持しています)。したがって欠けた行はイベントから再構築できます。修復サービスを登録し、**必ず dry run から始めてください**。
+
+```csharp
+services.AddSekibanDcbCosmosDb(configuration);
+services.AddSekibanDcbCosmosDbTagRepair();   // opt-in。AddSekibanDcbCosmosDb だけでは登録されない
+
+var repair = await factory.CreateAsync(serviceId);
+
+// 書き込む前に必ず確認する。DryRun が既定値。
+var report = await repair.RepairAsync(new CosmosTagRepairOptions
+{
+    DryRun = true,
+    ToSortableUniqueIdInclusive = lastSettledSortableUniqueId,  // 上限を固定する
+});
+```
+
+**`ToSortableUniqueIdInclusive` には、確定済みと分かっているイベントを指定してください。** 指定しないとスキャンが末尾まで走り、稼働中のトラフィックと競合します。それらは書き込みパス自身が処理するものです。修復はクラッシュの残骸のためのものであり、いま書き込まれつつあるイベントのためのものではありません。
+
+レポートを読んだ上で、`DryRun = false` で修復します。分類が、いま何を見ているのかを教えてくれます。
+
+| 分類 | 意味 | 修復は書き込む? |
+|---|---|---|
+| `Missing` | この (イベント, タグ) を索引する行が存在しない。 | **はい — 書き込むのはこれだけ。** |
+| `Present` | 導出された行が存在し、イベントと一致している。 | いいえ |
+| `LegacyPresent` | 決定論的ID方式より前の行が索引している。**正常に機能します**。移行は任意。 | いいえ |
+| `Duplicate` | 複数のレガシー行が索引している。 | いいえ — 報告のみ |
+| `Corrupt` | 行は存在するがイベントと矛盾している。 | **いいえ — 決して上書きしません。** 何かする前に調査してください。 |
+| `Overflow` | 1キーあたりの上限を超える行数。 | いいえ — `MaxRowsPerKey` を上げて再確認 |
+
+`Corrupt` や `Duplicate` は、修復サービスが勝手に解決するものではありません。これは意図的な設計です。
+
+### 防げる再発は防ぐ
+
+`WriteFailurePolicy = CosmosWriteFailurePolicy.RollForward` を設定してください。
+
+```csharp
+services.AddSekibanDcbCosmosDb(
+    configuration,
+    options => options.WriteFailurePolicy = CosmosWriteFailurePolicy.RollForward);
+```
+
+既定値は `Compatible` で、タグ書き込みをリトライせず、(現在は非推奨の)`TryRollbackOnFailure` を通じて **書き込み済みのイベントを削除します**。マルチプロジェクションが既に読み取っているかもしれないイベントをです。`RollForward` は代わりにタグ書き込みをリトライし、イベントを削除することは決してありません。
+
+**重要な注意点**: `RollForward` が効くのは、プロセスが生き残ってリトライできる場合だけです。**クラッシュはプロセス内の失敗ではありません**。したがって、どのポリシーでも防げない残骸が残ります。この窓を閉じられるのは修復パスだけです。[opt-in のスイープ](11_storage_providers.md)は直近のウィンドウに対して修復を自動実行できますが、あくまで *最終的な* 修復です。タグ読み取りをガードせず、スイープが到達するまで窓は開いたままです。
+
+この窓を一切許容できないワークロード(とりわけ金銭に関わるもの)では、**Postgres プロバイダーを使用してください**。ここで述べたギャップはいずれも存在しません。
+
+**参照**: [整合性契約](11_storage_providers.md#整合性契約) — プロバイダーごとの完全な保証、修復サービス、スイープ、そしてそれらが **保証しないこと**。
+
 ## JSON シリアライズ例外
 
 **対処**: イベントペイロードの変更は後方互換にする。`EventMetadata.EventType` をログに出し問題のイベントを特定。


### PR DESCRIPTION
## Summary

Documentation-only release prep. **No code, project, or workflow files touched** — the diff is six docs files.

Closes #1061

## 1. The CLI docs described a tool nobody can get

`11_storage_providers.md` showed bare `sekiban-dcb-tag-migration plan|apply` commands as if the tool were installed. It is not, and the situation is worse than "not packaged":

- `tools/SekibanDcbTagMigration` is `IsPackable=false`, no workflow builds or publishes it, and it is not a `dotnet tool`.
- **No released tag contains it at all.** It was added in `c3a0867` (PR #1060), which landed *after* the newest tag (`dcb-v10.2.2`). Checking out any published `dcb-v*` tag gives a tree where `dotnet run --project tools/SekibanDcbTagMigration` cannot work — verified with `git cat-file -e` across every `dcb-v*` tag.

So there is currently **no released way to obtain or run the CLI**. The docs now say exactly that instead of inventing an acquisition path.

**What the docs say now:**

- **The service API is named first, as the supported path.** It ships in `Sekiban.Dcb.CosmosDb`, which the reader already references, and it is what the CLI calls anyway.
- The CLI is stated to be **unpublished, not a `dotnet tool`, and absent from every released tag** — with the reason.
- Anyone who still wants to run it is directed to a **source revision they have explicitly reviewed**, with an existence check to run **before** checkout:

```bash
REF=main
git cat-file -e "$REF:tools/SekibanDcbTagMigration/SekibanDcbTagMigration.csproj" \
  && echo "tool present at $REF" \
  || echo "tool ABSENT at $REF — do not use this ref"
```

  This check works today (`main`: present; `dcb-v10.2.2`: absent — both executed) and keeps working once a tag does contain the tool, which the docs say to prefer over a branch when that happens.

- Readers are explicitly **warned off verifying a release by grepping `<PackageVersion>`** from the csproj: the value in tagged source is a build-time placeholder (`10.0.2-preview03` at `dcb-v10.2.2`), not the published version.

Why the care: a tool built from a revision other than the code that wrote your rows will produce a plan describing a world you do not have — **and that plan authorizes deletions.**

## 2. The #1046 symptom had no troubleshooting entry

A reader hitting the exact thing issue #1046 reported — **an event visible to all-events reads but missing from tag-scoped ones** — had no path in `13_common_issues.md` to the repair service that exists to fix it.

New entry (EN + JA):

- **Lag vs. residue** — identical for a few seconds, opposite responses. Transient lag catches up; durable residue never will, because the Cosmos write is two-phase and a crash between the phases leaves the event without its tag rows.
- **Telemetry**, and the trap: **a crash leaves no in-process trace, so an empty metric does not mean an empty tags container.** Confirm with a dry run.
- **Dry-run first, with a pinned `ToSortableUniqueIdInclusive`** — the repair is for crash residue, not for events still being written.
- **What each category means**, and that **only `Missing` is ever written**. `Corrupt` and `Duplicate` are reported and left alone, by design.
- **`RollForward`** as prevention — with the caveat that it only helps when the process survives to retry, so **it cannot help across a crash**. Only a repair pass closes that window; the sweep is *eventual* repair that does not gate readers.
- Postgres for workloads that cannot tolerate the window at all.

## 3. Landing pages

`README.md` and `dcb/README.md` link the consistency contract directly (EN/JA), with the Cosmos two-phase caveat in one sentence and Postgres named for atomic event/tag visibility. The destructive migration is **not** given quick-start prominence.

## Preserved

Untouched: the DI registrations (`AddSekibanDcbCosmosDbTagRepair` / `TagSweep` / `LegacyTagMigration`), the `RollForward` opt-in, the `Compatible` default, and the package-upgrade-changes-nothing text.

## Verification

- [x] Docs-only diff — six files, zero `.cs` / `.csproj` / `.slnx` / workflow files
- [x] No bare `sekiban-dcb-tag-migration` invocation left in `docs/`, and no instruction anywhere in `docs/` to check out a `dcb-v*` tag in order to run the CLI
- [x] Every claim executed, not assumed: no `dcb-v*` tag contains the CLI; the `git cat-file -e` check behaves as documented on both `main` and `dcb-v10.2.2`
- [x] EN/JA coverage equivalent
- [x] Anchor targets verified to exist: `## Consistency Contract` (EN) / `## 整合性契約` (JA)
- [x] `git diff --check` clean

## Review history worth recording

This PR needed three rounds on the same section, and the first two of my fixes were themselves untrue:

1. Original docs implied an installed executable that does not exist.
2. My first fix pointed operators at the tag `dcb-v10.3.0` — **which does not exist**; this slice is the prep *for* that release. (Recorded here as a past error, not as an instruction.)
3. My second fix used `dcb-v10.2.2` — a tag that exists but **does not contain the CLI** — and invented a `<PackageVersion>` grep as "verification", when that value is a placeholder.

Each time I asserted a fact about a git ref without checking the ref. The current version checks.

## Closeout note

**A CLI-distribution packet is warranted.** Today the only way to run the CLI is an unreleased source revision, which is not a reasonable ask of an operator performing a destructive migration. Either publish it (pack / `dotnet tool`) or drop it and keep the service API as the sole surface. The current halfway state — a tool that exists in the repo but in no release — is precisely what produced three rounds of untrue documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017KAPyZPCMZzurEZTt1k8LX
