### PR TITLE
Bring the DCB templates onto 10.3.0, and opt new Cosmos projects into RollForward

### DIFF
--- a/templates/Sekiban.Dcb.Templates/README.md
+++ b/templates/Sekiban.Dcb.Templates/README.md
@@ -1,6 +1,8 @@
-# Sekiban Dcb Templates
+# Sekiban DCB Templates
 
-Sekiban Dcb (Distributed Consistent Bus) 向けの .NET Aspire + Orleans スターターテンプレートを提供します。
+Sekiban DCB (Dynamic Consistency Boundary) 向けの .NET Aspire + Orleans スターターテンプレートです。
+
+生成されるプロジェクトはすべて **.NET 10.0** / **Aspire 13.x** / **Sekiban.Dcb 10.3.0** です。
 
 ## インストール
 
@@ -8,47 +10,43 @@ Sekiban Dcb (Distributed Consistent Bus) 向けの .NET Aspire + Orleans スタ�
 dotnet new install Sekiban.Dcb.Templates
 ```
 
-## 利用可能なテンプレート
+## テンプレート一覧
 
-### 1. Dcb Orleans Aspire テンプレート (WithResult)
+| ショート名 | 結果モデル | イベントストア | スナップショット | クラウド |
+|---|---|---|---|---|
+| `sekiban-dcb-orleans` | WithResult (`ResultBox`) | Cosmos DB / Postgres / SQLite | Azure Blob | Azure |
+| `sekiban-dcb-orleans-withoutresult` | WithoutResult (例外ベース) | Cosmos DB / Postgres / SQLite | Azure Blob | Azure |
+| `sekiban-dcb-orleans-aws` | WithoutResult (例外ベース) | DynamoDB / Postgres | Amazon S3 | AWS |
+| `sekiban-dcb-decider` | WithoutResult (Decider パターン) | Cosmos DB / Postgres / SQLite | Azure Blob | Azure |
+| `sekiban-dcb-decider-aws` | WithoutResult (Decider パターン) | DynamoDB / Postgres | Amazon S3 | AWS |
+
+イベントストアは生成後に `Sekiban:Database` 設定で切り替えます(既定は Postgres)。
 
 ```bash
 dotnet new sekiban-dcb-orleans -n YourProjectName
 ```
 
-含まれるもの:
+各テンプレートに共通して含まれるもの:
 
-- .NET 10.0 + Aspire 9.4 AppHost
-- Orleans クラスタ (Azure Storage / Queue / Tables / Blobs)
-- PostgreSQL (PgAdmin 付き) + マイグレーション基本形
-- Sekiban Dcb Orleans/Postgres 連携 (WithResult)
-- Web フロント (Blazor Server) + API Service
-- ServiceDefaults (共通設定) / Unit Test プロジェクト
+- Orleans クラスタ + .NET Aspire AppHost
+- API Service / Web フロント (Blazor Server) / ServiceDefaults
+- ドメインモデルとマルチプロジェクション、マテリアライズドビュー
+- ユニットテストプロジェクト (`--IncludeTests false` で除外可能)
 
-### 2. Dcb Orleans Aspire テンプレート (WithoutResult)
+## Cosmos DB を使う場合
 
-```bash
-dotnet new sekiban-dcb-orleans-withoutresult -n YourProjectName
-```
+生成されるプロジェクトは **`CosmosWriteFailurePolicy.RollForward`** を明示的に選択します。新規デプロイにはこれが適切なポリシーです。ライブラリの既定値が `Compatible` のままなのは、既存デプロイの挙動をパッケージ更新だけで変えないためであり、テンプレートが生成するのは新規デプロイだからです。
 
-含まれるもの:
+ただし **RollForward はクラッシュウィンドウを閉じません**。Cosmos はイベントとタグ行を2段階で書き込むため、クラッシュするとイベントだけが永続化され、タグ行が欠落することがあります(all-events 読み取りからは見えるが、タグ検索からは見えない)。これを閉じられるのは修復パスだけです。
 
-- .NET 10.0 + Aspire 9.4 AppHost
-- Orleans クラスタ (Azure Storage / Queue / Tables / Blobs)
-- PostgreSQL (PgAdmin 付き) + マイグレーション基本形
-- Sekiban Dcb Orleans/Postgres 連携 (WithoutResult)
-- Web フロント (Blazor Server) + API Service
-- ServiceDefaults (共通設定) / Unit Test プロジェクト
+修復サービスとスイープは **どちらも opt-in** で、生成コードには**コメントとしてのみ**記載しています(テンプレートが生成したというだけで、あなたのコンテナーのスキャンを勝手に始めるべきではないため)。
+
+詳細は [ストレージプロバイダーの整合性契約](https://github.com/J-Tech-Japan/Sekiban/blob/main/docs/dcb_llm_ja/11_storage_providers.md#整合性契約) と [トラブルシューティング](https://github.com/J-Tech-Japan/Sekiban/blob/main/docs/dcb_llm_ja/13_common_issues.md) を参照してください。
 
 ## 生成後の手順
 
 ```bash
 dotnet restore
-```
-
-AppHost 実行:
-
-```bash
 dotnet run --project YourProjectName.AppHost
 ```
 

--- a/templates/Sekiban.Dcb.Templates/Sekiban.Dcb.Templates.csproj
+++ b/templates/Sekiban.Dcb.Templates/Sekiban.Dcb.Templates.csproj
@@ -3,13 +3,16 @@
     <PackageId>Sekiban.Dcb.Templates</PackageId>
     <PackageVersion>0.0.0-local</PackageVersion>
     <Version>0.0.0-local</Version>
-    <Title>Sekiban Dcb Templates</Title>
+    <Title>Sekiban DCB Templates</Title>
     <Authors>J-Tech Japan</Authors>
-    <Description>Templates for starting Sekiban Dcb (Distributed Consistent Bus) projects with Orleans and .NET Aspire</Description>
+    <Description>Templates for starting Sekiban DCB (Dynamic Consistency Boundary) projects with Orleans and .NET Aspire</Description>
     <PackageTags>Event Sourcing,CQRS,Orleans,Aspire,Sekiban,Dcb</PackageTags>
     <PackageProjectUrl>https://github.com/J-Tech-Japan/Sekiban</PackageProjectUrl>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageType>Template</PackageType>
+    <!-- net9.0 on purpose: this project only carries the template content (IncludeBuildOutput=false), and
+         the lower TFM keeps it installable on template-engine hosts that are not yet on net10.0. The
+         templates it ships generate net10.0 projects regardless. -->
     <TargetFramework>net9.0</TargetFramework>
     <IncludeContentInPack>true</IncludeContentInPack>
     <IncludeBuildOutput>false</IncludeBuildOutput>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.ApiService/SekibanDcbDeciderAws.ApiService.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.ApiService/SekibanDcbDeciderAws.ApiService.csproj
@@ -33,13 +33,13 @@
 
         <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.3" />
         <PackageReference Include="Scalar.AspNetCore" Version="2.12.50" />
-        <PackageReference Include="Sekiban.Dcb.Orleans.WithoutResult" Version="10.2.2" />
-        <PackageReference Include="Sekiban.Dcb.DynamoDB" Version="10.2.2" />
-        <PackageReference Include="Sekiban.Dcb.BlobStorage.S3" Version="10.2.2" />
-        <PackageReference Include="Sekiban.Dcb.Postgres" Version="10.2.2" />
-        <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.2.2" />
-        <PackageReference Include="Sekiban.Dcb.MaterializedView.Postgres" Version="10.2.2" />
-        <PackageReference Include="Sekiban.Dcb.MaterializedView.Orleans" Version="10.2.2" />
+        <PackageReference Include="Sekiban.Dcb.Orleans.WithoutResult" Version="10.3.0" />
+        <PackageReference Include="Sekiban.Dcb.DynamoDB" Version="10.3.0" />
+        <PackageReference Include="Sekiban.Dcb.BlobStorage.S3" Version="10.3.0" />
+        <PackageReference Include="Sekiban.Dcb.Postgres" Version="10.3.0" />
+        <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.3.0" />
+        <PackageReference Include="Sekiban.Dcb.MaterializedView.Postgres" Version="10.3.0" />
+        <PackageReference Include="Sekiban.Dcb.MaterializedView.Orleans" Version="10.3.0" />
         <PackageReference Include="Dapper" Version="2.1.66" />
         <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />
     </ItemGroup>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.EventSource/SekibanDcbDeciderAws.EventSource.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.EventSource/SekibanDcbDeciderAws.EventSource.csproj
@@ -11,8 +11,8 @@
     <ProjectReference Include="..\SekibanDcbDeciderAws.MeetingRoomModels\SekibanDcbDeciderAws.MeetingRoomModels.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.2.2" />
-    <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.2.2" />
+    <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.3.0" />
+    <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.3.0" />
     <PackageReference Include="ResultBoxes" Version="0.4.0" />
     <PackageReference Include="Microsoft.Orleans.Serialization" Version="10.0.1" />
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.ImmutableModels/SekibanDcbDeciderAws.ImmutableModels.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.ImmutableModels/SekibanDcbDeciderAws.ImmutableModels.csproj
@@ -7,7 +7,7 @@
     <IsPackable>true</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Sekiban.Dcb.Core.Model" Version="10.2.2" />
+    <PackageReference Include="Sekiban.Dcb.Core.Model" Version="10.3.0" />
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />
   </ItemGroup>
 </Project>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.Interactions.Unit/SekibanDcbDeciderAws.Interactions.Unit.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.Interactions.Unit/SekibanDcbDeciderAws.Interactions.Unit.csproj
@@ -28,7 +28,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.2.2" />
+      <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.3.0" />
     </ItemGroup>
 
 </Project>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.Interactions/SekibanDcbDeciderAws.Interactions.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.Interactions/SekibanDcbDeciderAws.Interactions.csproj
@@ -10,7 +10,7 @@
     <ProjectReference Include="..\SekibanDcbDeciderAws.EventSource\SekibanDcbDeciderAws.EventSource.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.2.2" />
+    <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.3.0" />
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />
   </ItemGroup>
 </Project>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.MeetingRoomModels/SekibanDcbDeciderAws.MeetingRoomModels.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.MeetingRoomModels/SekibanDcbDeciderAws.MeetingRoomModels.csproj
@@ -7,7 +7,7 @@
     <IsPackable>true</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Sekiban.Dcb.Core.Model" Version="10.2.2" />
+    <PackageReference Include="Sekiban.Dcb.Core.Model" Version="10.3.0" />
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />
   </ItemGroup>
 </Project>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.Unit/SekibanDcbDeciderAws.Unit.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.Unit/SekibanDcbDeciderAws.Unit.csproj
@@ -15,7 +15,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.2.2" />
+    <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.3.0" />
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />
   </ItemGroup>
   <ItemGroup>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.slnx
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.slnx
@@ -2,14 +2,22 @@
   <Project Path="SekibanDcbDeciderAws.ApiService\SekibanDcbDeciderAws.ApiService.csproj" />
   <Project Path="SekibanDcbDeciderAws.AppHost\SekibanDcbDeciderAws.AppHost.csproj" />
   <Project Path="SekibanDcbDeciderAws.Cli\SekibanDcbDeciderAws.Cli.csproj" />
+  <!--#if (IncludeTests) -->
   <Project Path="SekibanDcbDeciderAws.Interactions.Unit\SekibanDcbDeciderAws.Interactions.Unit.csproj" />
+  <!--#endif -->
   <Project Path="SekibanDcbDeciderAws.Interactions\SekibanDcbDeciderAws.Interactions.csproj" />
   <Project Path="SekibanDcbDeciderAws.EventSource\SekibanDcbDeciderAws.EventSource.csproj" />
+  <!--#if (IncludeTests) -->
   <Project Path="SekibanDcbDeciderAws.ImmutableModels.Unit\SekibanDcbDeciderAws.ImmutableModels.Unit.csproj" />
+  <!--#endif -->
   <Project Path="SekibanDcbDeciderAws.ImmutableModels\SekibanDcbDeciderAws.ImmutableModels.csproj" />
+  <!--#if (IncludeTests) -->
   <Project Path="SekibanDcbDeciderAws.MeetingRoomModels.Unit\SekibanDcbDeciderAws.MeetingRoomModels.Unit.csproj" />
+  <!--#endif -->
   <Project Path="SekibanDcbDeciderAws.MeetingRoomModels\SekibanDcbDeciderAws.MeetingRoomModels.csproj" />
   <Project Path="SekibanDcbDeciderAws.ServiceDefaults\SekibanDcbDeciderAws.ServiceDefaults.csproj" />
+  <!--#if (IncludeTests) -->
   <Project Path="SekibanDcbDeciderAws.Unit\SekibanDcbDeciderAws.Unit.csproj" />
+  <!--#endif -->
   <Project Path="SekibanDcbDeciderAws.Web\SekibanDcbDeciderAws.Web.csproj" />
 </Solution>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.ApiService/Program.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.ApiService/Program.cs
@@ -191,16 +191,12 @@ if (databaseType == "cosmos")
     builder.Services.AddSekibanDcbCosmosDbWithAspire(options =>
         options.WriteFailurePolicy = CosmosWriteFailurePolicy.RollForward);
 
-    // Recovery surfaces, both opt-in. Left commented on purpose: neither should start scanning your
-    // containers because a template generated them.
-    //
-    //   Repair — rebuilds tag rows the crash window left missing. Operator-triggered; dry-run by default.
-    //   builder.Services.AddSekibanDcbCosmosDbTagRepair();
-    //
-    //   Sweep — runs that repair automatically over a recent window. Disabled unless Enabled = true, and
-    //   it is EVENTUAL repair: it does not gate tag readers, so the missing-tag window stays open until a
-    //   run reaches it. Measure the RU cost with a manual dry run first.
-    //   builder.Services.AddSekibanDcbCosmosDbTagSweep(sweep => sweep.Enabled = true);
+    // Two recovery surfaces exist for that window, and both are opt-in registrations this template
+    // deliberately does not make: a repair service (operator-triggered, dry-run by default) that rebuilds
+    // the missing tag rows, and a sweep that runs it automatically over a recent window — eventual repair
+    // that does not gate tag readers. Nothing should start scanning your containers because a template
+    // generated it, so enable them yourself, once you have read what they do and do not promise.
+    // Registration and options: docs/dcb_llm/11_storage_providers.md (Consistency Contract).
     builder.Services.AddSingleton<IMultiProjectionStateStore, Sekiban.Dcb.CosmosDb.CosmosMultiProjectionStateStore>();
 }
 else if (databaseType == "sqlite")

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.ApiService/Program.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.ApiService/Program.cs
@@ -177,7 +177,30 @@ builder.Services.AddHostedService<OrleansStreamEventRouter>();
 string? configuredDatabasePath = null;
 if (databaseType == "cosmos")
 {
-    builder.Services.AddSekibanDcbCosmosDbWithAspire();
+    // CosmosDB settings - Aspire will automatically provide CosmosClient if configured.
+    //
+    // RollForward is the right policy for a NEW deployment. Cosmos writes events and tag rows in two
+    // phases, and when the tag phase fails in-process, RollForward retries it instead of deleting the
+    // events it already wrote (the Compatible default deletes them, and multi-projections may already
+    // have read them). The library keeps Compatible as its default only so that upgrading a package
+    // cannot change an existing deployment's behavior; a template generates a new one.
+    //
+    // It does NOT close the crash window: a crash is not an in-process failure, so it can still leave an
+    // event durable with no tag rows — visible to all-events reads, invisible to tag-scoped ones. Only a
+    // repair pass closes that. See docs/dcb_llm/11_storage_providers.md (Consistency Contract).
+    builder.Services.AddSekibanDcbCosmosDbWithAspire(options =>
+        options.WriteFailurePolicy = CosmosWriteFailurePolicy.RollForward);
+
+    // Recovery surfaces, both opt-in. Left commented on purpose: neither should start scanning your
+    // containers because a template generated them.
+    //
+    //   Repair — rebuilds tag rows the crash window left missing. Operator-triggered; dry-run by default.
+    //   builder.Services.AddSekibanDcbCosmosDbTagRepair();
+    //
+    //   Sweep — runs that repair automatically over a recent window. Disabled unless Enabled = true, and
+    //   it is EVENTUAL repair: it does not gate tag readers, so the missing-tag window stays open until a
+    //   run reaches it. Measure the RU cost with a manual dry run first.
+    //   builder.Services.AddSekibanDcbCosmosDbTagSweep(sweep => sweep.Enabled = true);
     builder.Services.AddSingleton<IMultiProjectionStateStore, Sekiban.Dcb.CosmosDb.CosmosMultiProjectionStateStore>();
 }
 else if (databaseType == "sqlite")

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.ApiService/SekibanDcbDecider.ApiService.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.ApiService/SekibanDcbDecider.ApiService.csproj
@@ -44,14 +44,14 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Sekiban.Dcb.BlobStorage.AzureStorage" Version="10.2.2" />
-        <PackageReference Include="Sekiban.Dcb.Orleans.WithoutResult" Version="10.2.2" />
-        <PackageReference Include="Sekiban.Dcb.Postgres" Version="10.2.2" />
-        <PackageReference Include="Sekiban.Dcb.CosmosDb" Version="10.2.2" />
-        <PackageReference Include="Sekiban.Dcb.Sqlite" Version="10.2.2" />
-        <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.2.2" />
-        <PackageReference Include="Sekiban.Dcb.MaterializedView.Postgres" Version="10.2.2" />
-        <PackageReference Include="Sekiban.Dcb.MaterializedView.Orleans" Version="10.2.2" />
+        <PackageReference Include="Sekiban.Dcb.BlobStorage.AzureStorage" Version="10.3.0" />
+        <PackageReference Include="Sekiban.Dcb.Orleans.WithoutResult" Version="10.3.0" />
+        <PackageReference Include="Sekiban.Dcb.Postgres" Version="10.3.0" />
+        <PackageReference Include="Sekiban.Dcb.CosmosDb" Version="10.3.0" />
+        <PackageReference Include="Sekiban.Dcb.Sqlite" Version="10.3.0" />
+        <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.3.0" />
+        <PackageReference Include="Sekiban.Dcb.MaterializedView.Postgres" Version="10.3.0" />
+        <PackageReference Include="Sekiban.Dcb.MaterializedView.Orleans" Version="10.3.0" />
         <PackageReference Include="Dapper" Version="2.1.66" />
     </ItemGroup>
 </Project>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.Cli/SekibanDcbDecider.Cli.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.Cli/SekibanDcbDecider.Cli.csproj
@@ -14,10 +14,10 @@
         <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.3" />
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.3" />
         <PackageReference Include="System.CommandLine" Version="2.0.2" />
-        <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.2.2" />
-        <PackageReference Include="Sekiban.Dcb.Postgres" Version="10.2.2" />
-        <PackageReference Include="Sekiban.Dcb.CosmosDb" Version="10.2.2" />
-        <PackageReference Include="Sekiban.Dcb.Sqlite" Version="10.2.2" />
+        <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.3.0" />
+        <PackageReference Include="Sekiban.Dcb.Postgres" Version="10.3.0" />
+        <PackageReference Include="Sekiban.Dcb.CosmosDb" Version="10.3.0" />
+        <PackageReference Include="Sekiban.Dcb.Sqlite" Version="10.3.0" />
         <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />
     </ItemGroup>
 

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.EventSource/SekibanDcbDecider.EventSource.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.EventSource/SekibanDcbDecider.EventSource.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="ResultBoxes" Version="0.4.0" />
     <PackageReference Include="Microsoft.Orleans.Serialization" Version="10.0.1" />
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />
-    <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.2.2" />
-    <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.2.2" />
+    <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.3.0" />
+    <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.3.0" />
   </ItemGroup>
 </Project>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.ImmutableModels/SekibanDcbDecider.ImmutableModels.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.ImmutableModels/SekibanDcbDecider.ImmutableModels.csproj
@@ -10,6 +10,6 @@
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Sekiban.Dcb.Core.Model" Version="10.2.2" />
+    <PackageReference Include="Sekiban.Dcb.Core.Model" Version="10.3.0" />
   </ItemGroup>
 </Project>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.Interactions.Unit/SekibanDcbDecider.Interactions.Unit.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.Interactions.Unit/SekibanDcbDecider.Interactions.Unit.csproj
@@ -28,7 +28,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.2.2" />
+      <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.3.0" />
     </ItemGroup>
 
 </Project>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.Interactions/SekibanDcbDecider.Interactions.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.Interactions/SekibanDcbDecider.Interactions.csproj
@@ -11,6 +11,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />
-    <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.2.2" />
+    <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.3.0" />
   </ItemGroup>
 </Project>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.MeetingRoomModels/SekibanDcbDecider.MeetingRoomModels.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.MeetingRoomModels/SekibanDcbDecider.MeetingRoomModels.csproj
@@ -10,6 +10,6 @@
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Sekiban.Dcb.Core.Model" Version="10.2.2" />
+    <PackageReference Include="Sekiban.Dcb.Core.Model" Version="10.3.0" />
   </ItemGroup>
 </Project>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.Unit/SekibanDcbDecider.Unit.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.Unit/SekibanDcbDecider.Unit.csproj
@@ -15,7 +15,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.2.2" />
+    <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.3.0" />
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />
   </ItemGroup>
   <ItemGroup>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.slnx
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.slnx
@@ -2,14 +2,22 @@
   <Project Path="SekibanDcbDecider.ApiService\SekibanDcbDecider.ApiService.csproj" />
   <Project Path="SekibanDcbDecider.AppHost\SekibanDcbDecider.AppHost.csproj" />
   <Project Path="SekibanDcbDecider.Cli\SekibanDcbDecider.Cli.csproj" />
+  <!--#if (IncludeTests) -->
   <Project Path="SekibanDcbDecider.Interactions.Unit\SekibanDcbDecider.Interactions.Unit.csproj" />
+  <!--#endif -->
   <Project Path="SekibanDcbDecider.Interactions\SekibanDcbDecider.Interactions.csproj" />
   <Project Path="SekibanDcbDecider.EventSource\SekibanDcbDecider.EventSource.csproj" />
+  <!--#if (IncludeTests) -->
   <Project Path="SekibanDcbDecider.ImmutableModels.Unit\SekibanDcbDecider.ImmutableModels.Unit.csproj" />
+  <!--#endif -->
   <Project Path="SekibanDcbDecider.ImmutableModels\SekibanDcbDecider.ImmutableModels.csproj" />
+  <!--#if (IncludeTests) -->
   <Project Path="SekibanDcbDecider.MeetingRoomModels.Unit\SekibanDcbDecider.MeetingRoomModels.Unit.csproj" />
+  <!--#endif -->
   <Project Path="SekibanDcbDecider.MeetingRoomModels\SekibanDcbDecider.MeetingRoomModels.csproj" />
   <Project Path="SekibanDcbDecider.ServiceDefaults\SekibanDcbDecider.ServiceDefaults.csproj" />
+  <!--#if (IncludeTests) -->
   <Project Path="SekibanDcbDecider.Unit\SekibanDcbDecider.Unit.csproj" />
+  <!--#endif -->
   <Project Path="SekibanDcbDecider.Web\SekibanDcbDecider.Web.csproj" />
 </Solution>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult.Aws/SekibanDcbOrleansAws.ApiService/SekibanDcbOrleansAws.ApiService.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult.Aws/SekibanDcbOrleansAws.ApiService/SekibanDcbOrleansAws.ApiService.csproj
@@ -27,13 +27,13 @@
         <!-- SQS streaming will be added when Orleans SQS package supports AWS SDK v4 -->
         <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.3" />
         <PackageReference Include="Scalar.AspNetCore" Version="2.12.50" />
-        <PackageReference Include="Sekiban.Dcb.Orleans.WithoutResult" Version="10.2.2" />
-        <PackageReference Include="Sekiban.Dcb.DynamoDB" Version="10.2.2" />
-        <PackageReference Include="Sekiban.Dcb.BlobStorage.S3" Version="10.2.2" />
-        <PackageReference Include="Sekiban.Dcb.Postgres" Version="10.2.2" />
-        <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.2.2" />
-        <PackageReference Include="Sekiban.Dcb.MaterializedView.Postgres" Version="10.2.2" />
-        <PackageReference Include="Sekiban.Dcb.MaterializedView.Orleans" Version="10.2.2" />
+        <PackageReference Include="Sekiban.Dcb.Orleans.WithoutResult" Version="10.3.0" />
+        <PackageReference Include="Sekiban.Dcb.DynamoDB" Version="10.3.0" />
+        <PackageReference Include="Sekiban.Dcb.BlobStorage.S3" Version="10.3.0" />
+        <PackageReference Include="Sekiban.Dcb.Postgres" Version="10.3.0" />
+        <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.3.0" />
+        <PackageReference Include="Sekiban.Dcb.MaterializedView.Postgres" Version="10.3.0" />
+        <PackageReference Include="Sekiban.Dcb.MaterializedView.Orleans" Version="10.3.0" />
         <PackageReference Include="Dapper" Version="2.1.66" />
         <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />
     </ItemGroup>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult.Aws/SekibanDcbOrleansAws.Domain/SekibanDcbOrleansAws.Domain.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult.Aws/SekibanDcbOrleansAws.Domain/SekibanDcbOrleansAws.Domain.csproj
@@ -7,8 +7,8 @@
     <IsPackable>true</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.2.2" />
-    <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.2.2" />
+    <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.3.0" />
+    <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.3.0" />
     <PackageReference Include="ResultBoxes" Version="0.4.0" />
     <PackageReference Include="Microsoft.Orleans.Serialization" Version="10.0.1" />
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult.Aws/SekibanDcbOrleansAws.slnx
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult.Aws/SekibanDcbOrleansAws.slnx
@@ -4,6 +4,8 @@
   <Project Path="SekibanDcbOrleansAws.Cli/SekibanDcbOrleansAws.Cli.csproj" />
   <Project Path="SekibanDcbOrleansAws.Domain/SekibanDcbOrleansAws.Domain.csproj" />
   <Project Path="SekibanDcbOrleansAws.ServiceDefaults/SekibanDcbOrleansAws.ServiceDefaults.csproj" />
+  <!--#if (IncludeTests) -->
   <Project Path="SekibanDcbOrleansAws.Unit/SekibanDcbOrleansAws.Unit.csproj" />
+  <!--#endif -->
   <Project Path="SekibanDcbOrleansAws.Web/SekibanDcbOrleansAws.Web.csproj" />
 </Solution>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.ApiService/Program.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.ApiService/Program.cs
@@ -371,8 +371,30 @@ DefaultTypeMap.MatchNamesWithUnderscores = true;
 string? configuredDatabasePath = null;
 if (databaseType == "cosmos")
 {
-    // CosmosDB settings - Aspire will automatically provide CosmosClient if configured
-    builder.Services.AddSekibanDcbCosmosDbWithAspire();
+    // CosmosDB settings - Aspire will automatically provide CosmosClient if configured.
+    //
+    // RollForward is the right policy for a NEW deployment. Cosmos writes events and tag rows in two
+    // phases, and when the tag phase fails in-process, RollForward retries it instead of deleting the
+    // events it already wrote (the Compatible default deletes them, and multi-projections may already
+    // have read them). The library keeps Compatible as its default only so that upgrading a package
+    // cannot change an existing deployment's behavior; a template generates a new one.
+    //
+    // It does NOT close the crash window: a crash is not an in-process failure, so it can still leave an
+    // event durable with no tag rows — visible to all-events reads, invisible to tag-scoped ones. Only a
+    // repair pass closes that. See docs/dcb_llm/11_storage_providers.md (Consistency Contract).
+    builder.Services.AddSekibanDcbCosmosDbWithAspire(options =>
+        options.WriteFailurePolicy = CosmosWriteFailurePolicy.RollForward);
+
+    // Recovery surfaces, both opt-in. Left commented on purpose: neither should start scanning your
+    // containers because a template generated them.
+    //
+    //   Repair — rebuilds tag rows the crash window left missing. Operator-triggered; dry-run by default.
+    //   builder.Services.AddSekibanDcbCosmosDbTagRepair();
+    //
+    //   Sweep — runs that repair automatically over a recent window. Disabled unless Enabled = true, and
+    //   it is EVENTUAL repair: it does not gate tag readers, so the missing-tag window stays open until a
+    //   run reaches it. Measure the RU cost with a manual dry run first.
+    //   builder.Services.AddSekibanDcbCosmosDbTagSweep(sweep => sweep.Enabled = true);
     builder.Services.AddSingleton<IMultiProjectionStateStore, Sekiban.Dcb.CosmosDb.CosmosMultiProjectionStateStore>();
 }
 else if (databaseType == "sqlite")

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.ApiService/Program.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.ApiService/Program.cs
@@ -385,16 +385,12 @@ if (databaseType == "cosmos")
     builder.Services.AddSekibanDcbCosmosDbWithAspire(options =>
         options.WriteFailurePolicy = CosmosWriteFailurePolicy.RollForward);
 
-    // Recovery surfaces, both opt-in. Left commented on purpose: neither should start scanning your
-    // containers because a template generated them.
-    //
-    //   Repair — rebuilds tag rows the crash window left missing. Operator-triggered; dry-run by default.
-    //   builder.Services.AddSekibanDcbCosmosDbTagRepair();
-    //
-    //   Sweep — runs that repair automatically over a recent window. Disabled unless Enabled = true, and
-    //   it is EVENTUAL repair: it does not gate tag readers, so the missing-tag window stays open until a
-    //   run reaches it. Measure the RU cost with a manual dry run first.
-    //   builder.Services.AddSekibanDcbCosmosDbTagSweep(sweep => sweep.Enabled = true);
+    // Two recovery surfaces exist for that window, and both are opt-in registrations this template
+    // deliberately does not make: a repair service (operator-triggered, dry-run by default) that rebuilds
+    // the missing tag rows, and a sweep that runs it automatically over a recent window — eventual repair
+    // that does not gate tag readers. Nothing should start scanning your containers because a template
+    // generated it, so enable them yourself, once you have read what they do and do not promise.
+    // Registration and options: docs/dcb_llm/11_storage_providers.md (Consistency Contract).
     builder.Services.AddSingleton<IMultiProjectionStateStore, Sekiban.Dcb.CosmosDb.CosmosMultiProjectionStateStore>();
 }
 else if (databaseType == "sqlite")

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.ApiService/SekibanDcbOrleans.ApiService.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.ApiService/SekibanDcbOrleans.ApiService.csproj
@@ -30,14 +30,14 @@
         <PackageReference Include="Microsoft.Orleans.Streaming" Version="10.0.1" />
         <PackageReference Include="Microsoft.Orleans.Streaming.AzureStorage" Version="10.0.1" />
         <PackageReference Include="Scalar.AspNetCore" Version="2.12.50" />
-        <PackageReference Include="Sekiban.Dcb.BlobStorage.AzureStorage" Version="10.2.2" />
-        <PackageReference Include="Sekiban.Dcb.Orleans.WithoutResult" Version="10.2.2" />
-        <PackageReference Include="Sekiban.Dcb.Postgres" Version="10.2.2" />
-        <PackageReference Include="Sekiban.Dcb.CosmosDb" Version="10.2.2" />
-        <PackageReference Include="Sekiban.Dcb.Sqlite" Version="10.2.2" />
-        <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.2.2" />
-        <PackageReference Include="Sekiban.Dcb.MaterializedView.Postgres" Version="10.2.2" />
-        <PackageReference Include="Sekiban.Dcb.MaterializedView.Orleans" Version="10.2.2" />
+        <PackageReference Include="Sekiban.Dcb.BlobStorage.AzureStorage" Version="10.3.0" />
+        <PackageReference Include="Sekiban.Dcb.Orleans.WithoutResult" Version="10.3.0" />
+        <PackageReference Include="Sekiban.Dcb.Postgres" Version="10.3.0" />
+        <PackageReference Include="Sekiban.Dcb.CosmosDb" Version="10.3.0" />
+        <PackageReference Include="Sekiban.Dcb.Sqlite" Version="10.3.0" />
+        <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.3.0" />
+        <PackageReference Include="Sekiban.Dcb.MaterializedView.Postgres" Version="10.3.0" />
+        <PackageReference Include="Sekiban.Dcb.MaterializedView.Orleans" Version="10.3.0" />
         <PackageReference Include="Dapper" Version="2.1.66" />
         <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />
     </ItemGroup>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.Cli/SekibanDcbOrleans.Cli.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.Cli/SekibanDcbOrleans.Cli.csproj
@@ -14,10 +14,10 @@
         <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.3" />
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.3" />
         <PackageReference Include="System.CommandLine" Version="2.0.2" />
-        <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.2.2" />
-        <PackageReference Include="Sekiban.Dcb.Postgres" Version="10.2.2" />
-        <PackageReference Include="Sekiban.Dcb.CosmosDb" Version="10.2.2" />
-        <PackageReference Include="Sekiban.Dcb.Sqlite" Version="10.2.2" />
+        <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.3.0" />
+        <PackageReference Include="Sekiban.Dcb.Postgres" Version="10.3.0" />
+        <PackageReference Include="Sekiban.Dcb.CosmosDb" Version="10.3.0" />
+        <PackageReference Include="Sekiban.Dcb.Sqlite" Version="10.3.0" />
         <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />
     </ItemGroup>
 

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.Domain/SekibanDcbOrleans.Domain.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.Domain/SekibanDcbOrleans.Domain.csproj
@@ -7,8 +7,8 @@
     <IsPackable>true</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.2.2" />
-    <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.2.2" />
+    <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.3.0" />
+    <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.3.0" />
     <PackageReference Include="ResultBoxes" Version="0.4.0" />
     <PackageReference Include="Microsoft.Orleans.Serialization" Version="10.0.1" />
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.slnx
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.slnx
@@ -4,6 +4,8 @@
   <Project Path="SekibanDcbOrleans.Cli/SekibanDcbOrleans.Cli.csproj" />
   <Project Path="SekibanDcbOrleans.Domain/SekibanDcbOrleans.Domain.csproj" />
   <Project Path="SekibanDcbOrleans.ServiceDefaults/SekibanDcbOrleans.ServiceDefaults.csproj" />
+  <!--#if (IncludeTests) -->
   <Project Path="SekibanDcbOrleans.Unit/SekibanDcbOrleans.Unit.csproj" />
+  <!--#endif -->
   <Project Path="SekibanDcbOrleans.Web/SekibanDcbOrleans.Web.csproj" />
 </Solution>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans/SekibanDcbOrleans.ApiService/Program.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans/SekibanDcbOrleans.ApiService/Program.cs
@@ -449,8 +449,30 @@ DefaultTypeMap.MatchNamesWithUnderscores = true;
 string? configuredDatabasePath = null;
 if (databaseType == "cosmos")
 {
-    // CosmosDB settings - Aspire will automatically provide CosmosClient if configured
-    builder.Services.AddSekibanDcbCosmosDbWithAspire();
+    // CosmosDB settings - Aspire will automatically provide CosmosClient if configured.
+    //
+    // RollForward is the right policy for a NEW deployment. Cosmos writes events and tag rows in two
+    // phases, and when the tag phase fails in-process, RollForward retries it instead of deleting the
+    // events it already wrote (the Compatible default deletes them, and multi-projections may already
+    // have read them). The library keeps Compatible as its default only so that upgrading a package
+    // cannot change an existing deployment's behavior; a template generates a new one.
+    //
+    // It does NOT close the crash window: a crash is not an in-process failure, so it can still leave an
+    // event durable with no tag rows — visible to all-events reads, invisible to tag-scoped ones. Only a
+    // repair pass closes that. See docs/dcb_llm/11_storage_providers.md (Consistency Contract).
+    builder.Services.AddSekibanDcbCosmosDbWithAspire(options =>
+        options.WriteFailurePolicy = CosmosWriteFailurePolicy.RollForward);
+
+    // Recovery surfaces, both opt-in. Left commented on purpose: neither should start scanning your
+    // containers because a template generated them.
+    //
+    //   Repair — rebuilds tag rows the crash window left missing. Operator-triggered; dry-run by default.
+    //   builder.Services.AddSekibanDcbCosmosDbTagRepair();
+    //
+    //   Sweep — runs that repair automatically over a recent window. Disabled unless Enabled = true, and
+    //   it is EVENTUAL repair: it does not gate tag readers, so the missing-tag window stays open until a
+    //   run reaches it. Measure the RU cost with a manual dry run first.
+    //   builder.Services.AddSekibanDcbCosmosDbTagSweep(sweep => sweep.Enabled = true);
     builder.Services.AddSingleton<IMultiProjectionStateStore, Sekiban.Dcb.CosmosDb.CosmosMultiProjectionStateStore>();
 }
 else if (databaseType == "sqlite")

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans/SekibanDcbOrleans.ApiService/Program.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans/SekibanDcbOrleans.ApiService/Program.cs
@@ -463,16 +463,12 @@ if (databaseType == "cosmos")
     builder.Services.AddSekibanDcbCosmosDbWithAspire(options =>
         options.WriteFailurePolicy = CosmosWriteFailurePolicy.RollForward);
 
-    // Recovery surfaces, both opt-in. Left commented on purpose: neither should start scanning your
-    // containers because a template generated them.
-    //
-    //   Repair — rebuilds tag rows the crash window left missing. Operator-triggered; dry-run by default.
-    //   builder.Services.AddSekibanDcbCosmosDbTagRepair();
-    //
-    //   Sweep — runs that repair automatically over a recent window. Disabled unless Enabled = true, and
-    //   it is EVENTUAL repair: it does not gate tag readers, so the missing-tag window stays open until a
-    //   run reaches it. Measure the RU cost with a manual dry run first.
-    //   builder.Services.AddSekibanDcbCosmosDbTagSweep(sweep => sweep.Enabled = true);
+    // Two recovery surfaces exist for that window, and both are opt-in registrations this template
+    // deliberately does not make: a repair service (operator-triggered, dry-run by default) that rebuilds
+    // the missing tag rows, and a sweep that runs it automatically over a recent window — eventual repair
+    // that does not gate tag readers. Nothing should start scanning your containers because a template
+    // generated it, so enable them yourself, once you have read what they do and do not promise.
+    // Registration and options: docs/dcb_llm/11_storage_providers.md (Consistency Contract).
     builder.Services.AddSingleton<IMultiProjectionStateStore, Sekiban.Dcb.CosmosDb.CosmosMultiProjectionStateStore>();
 }
 else if (databaseType == "sqlite")

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans/SekibanDcbOrleans.ApiService/SekibanDcbOrleans.ApiService.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans/SekibanDcbOrleans.ApiService/SekibanDcbOrleans.ApiService.csproj
@@ -28,14 +28,14 @@
     <PackageReference Include="Microsoft.Orleans.Streaming.AzureStorage" Version="10.0.1" />
     <PackageReference Include="Microsoft.Orleans.Streaming.EventHubs" Version="10.0.1" />
     <PackageReference Include="Scalar.AspNetCore" Version="2.12.50" />
-    <PackageReference Include="Sekiban.Dcb.BlobStorage.AzureStorage" Version="10.2.2" />
-    <PackageReference Include="Sekiban.Dcb.Orleans.WithResult" Version="10.2.2" />
-    <PackageReference Include="Sekiban.Dcb.Postgres" Version="10.2.2" />
-    <PackageReference Include="Sekiban.Dcb.CosmosDb" Version="10.2.2" />
-    <PackageReference Include="Sekiban.Dcb.Sqlite" Version="10.2.2" />
-    <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.2.2" />
-    <PackageReference Include="Sekiban.Dcb.MaterializedView.Postgres" Version="10.2.2" />
-    <PackageReference Include="Sekiban.Dcb.MaterializedView.Orleans" Version="10.2.2" />
+    <PackageReference Include="Sekiban.Dcb.BlobStorage.AzureStorage" Version="10.3.0" />
+    <PackageReference Include="Sekiban.Dcb.Orleans.WithResult" Version="10.3.0" />
+    <PackageReference Include="Sekiban.Dcb.Postgres" Version="10.3.0" />
+    <PackageReference Include="Sekiban.Dcb.CosmosDb" Version="10.3.0" />
+    <PackageReference Include="Sekiban.Dcb.Sqlite" Version="10.3.0" />
+    <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.3.0" />
+    <PackageReference Include="Sekiban.Dcb.MaterializedView.Postgres" Version="10.3.0" />
+    <PackageReference Include="Sekiban.Dcb.MaterializedView.Orleans" Version="10.3.0" />
     <PackageReference Include="Dapper" Version="2.1.66" />
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />
   </ItemGroup>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans/SekibanDcbOrleans.Cli/SekibanDcbOrleans.Cli.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans/SekibanDcbOrleans.Cli/SekibanDcbOrleans.Cli.csproj
@@ -14,10 +14,10 @@
         <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.3" />
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.3" />
         <PackageReference Include="System.CommandLine" Version="2.0.2" />
-        <PackageReference Include="Sekiban.Dcb.WithResult" Version="10.2.2" />
-        <PackageReference Include="Sekiban.Dcb.Postgres" Version="10.2.2" />
-        <PackageReference Include="Sekiban.Dcb.CosmosDb" Version="10.2.2" />
-        <PackageReference Include="Sekiban.Dcb.Sqlite" Version="10.2.2" />
+        <PackageReference Include="Sekiban.Dcb.WithResult" Version="10.3.0" />
+        <PackageReference Include="Sekiban.Dcb.Postgres" Version="10.3.0" />
+        <PackageReference Include="Sekiban.Dcb.CosmosDb" Version="10.3.0" />
+        <PackageReference Include="Sekiban.Dcb.Sqlite" Version="10.3.0" />
         <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />
     </ItemGroup>
 

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans/SekibanDcbOrleans.Domain/SekibanDcbOrleans.Domain.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans/SekibanDcbOrleans.Domain/SekibanDcbOrleans.Domain.csproj
@@ -7,8 +7,8 @@
     <IsPackable>true</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Sekiban.Dcb.WithResult" Version="10.2.2" />
-    <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.2.2" />
+    <PackageReference Include="Sekiban.Dcb.WithResult" Version="10.3.0" />
+    <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.3.0" />
     <PackageReference Include="ResultBoxes" Version="0.4.0" />
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />
   </ItemGroup>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans/SekibanDcbOrleans.slnx
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans/SekibanDcbOrleans.slnx
@@ -4,6 +4,8 @@
   <Project Path="SekibanDcbOrleans.Cli/SekibanDcbOrleans.Cli.csproj" />
   <Project Path="SekibanDcbOrleans.Domain/SekibanDcbOrleans.Domain.csproj" />
   <Project Path="SekibanDcbOrleans.ServiceDefaults/SekibanDcbOrleans.ServiceDefaults.csproj" />
+  <!--#if (IncludeTests) -->
   <Project Path="SekibanDcbOrleans.Unit/SekibanDcbOrleans.Unit.csproj" />
+  <!--#endif -->
   <Project Path="SekibanDcbOrleans.Web/SekibanDcbOrleans.Web.csproj" />
 </Solution>


### PR DESCRIPTION
## Summary

Brings all five `dotnet new` templates onto dcb-v10.3.0 and opts new Cosmos projects into `RollForward`. **Diff confined to `templates/Sekiban.Dcb.Templates`.**

Closes #1063

## RollForward for new deployments

Templates are how new users adopt Sekiban, so they should not hand people the legacy-compatible failure policy. The **three** Cosmos-capable templates now opt in explicitly, in their `ApiService/Program.cs`:

```csharp
builder.Services.AddSekibanDcbCosmosDbWithAspire(options =>
    options.WriteFailurePolicy = CosmosWriteFailurePolicy.RollForward);
```

On an in-process tag-write failure this **retries** instead of deleting the events it already wrote — which multi-projections may already have read. The library keeps `Compatible` as its default only so that a package upgrade cannot change an existing deployment's behavior; a template generates a *new* one, where that reasoning does not apply.

The comment next to it says what RollForward does **not** do: a crash is not an in-process failure, so it can still leave an event durable with no tag rows — visible to all-events reads, invisible to tag-scoped ones. Only a repair pass closes that. It links the consistency contract.

## Recovery surfaces: named, explained, not registered

The repair service and the sweep are **described in prose** next to the registration, with what they do and what they do not promise, and the docs link carries the actual registration calls. Neither is registered; the sweep is not enabled. Nothing should start scanning someone's containers because a template generated it. Legacy migration is not mentioned in startup code at all.

They were originally commented-out API calls copied into three files — SonarCloud was right to flag that (S125 + duplication), and a commented-out line is also the kind of thing someone uncomments without reading. Prose plus a docs link does the discoverability job without either problem.

## A defect the verification caught

`--IncludeTests false` excluded the test project's **files** but left it **referenced in the `.slnx`** — so every generated no-tests solution failed to build. Pre-existing, not introduced here, but the packet asks for that variant as evidence, and evidence that does not build is not evidence.

The `.slnx` now guards the reference with the same `IncludeTests` condition. Verified end-to-end: the generated file drops the line, the directive leaves no trace, and the solution builds.

## Also

- **P0** — whole `Sekiban.Dcb.*` family bumped to 10.3.0. No partial bump: **70 direct references across 14 distinct packages** in the template sources, all at 10.3.0; zero occurrences of `10.2.2` remain under `templates/`. (Confirmed `Sekiban.Dcb.CosmosDb` 10.3.0 is live on NuGet before bumping.)
- **P2** — README listed **two of five** templates, claimed **Aspire 9.4** where the projects use **13.2.2**, and expanded DCB as *"Distributed Consistent Bus"*. Now: all five with accurate providers/result models, net10.0 + Aspire 13.x, **Dynamic Consistency Boundary** — same fix in the package `Description`.
- **P2** — pack project stays `net9.0`, with a comment saying why (content-only pack; keeps it installable on template-engine hosts not yet on net10.0; the templates still generate net10.0).

## Verification evidence

All local, from the packed nupkg. Every count below is reproducible with the command shown.

```bash
# Template sources: the family bump
cd templates/Sekiban.Dcb.Templates
grep -rhoE 'Include="Sekiban\.Dcb[^"]*"[^/]*Version="10\.3\.0"' . | wc -l          # 70 references
grep -rhoE 'Include="Sekiban\.Dcb[^"]*"[^/]*Version="10\.3\.0"' . \
  | sed -E 's/Include="([^"]*)".*/\1/' | sort -u | wc -l                            # 14 packages
grep -rn "10\.2\.2" .                                                               # (no output)

# RollForward: three startup locations
grep -rl "CosmosWriteFailurePolicy.RollForward" content/*/*/Program.cs | wc -l       # 3

# No active repair/sweep registration anywhere in the templates
grep -rn "^\s*builder\.Services\.AddSekibanDcbCosmosDbTag" content/                  # (no output)
```

```bash
# Pack -> install -> instantiate -> build
dotnet pack -c Release -p:PackageVersion=10.3.0-local -o /tmp/pkg
dotnet new install /tmp/pkg/Sekiban.Dcb.Templates.10.3.0-local.nupkg                 # all five listed
```

| Generated | Release build | Tests (assemblies / passed) |
|---|---|---|
| `sekiban-dcb-orleans` | ✅ | 1 / **1** |
| `sekiban-dcb-orleans-withoutresult` | ✅ | 1 / **1** |
| `sekiban-dcb-orleans-aws` | ✅ | 1 / **1** |
| `sekiban-dcb-decider` | ✅ | 4 / **220** |
| `sekiban-dcb-decider-aws` | ✅ | 4 / **216** |
| `sekiban-dcb-orleans --IncludeTests false` | ✅ (after the `.slnx` fix) | n/a |

Zero failing assemblies across all of them.

Greps over the **generated** output:

- `dotnet list package` → every `Sekiban.Dcb.*` at **10.3.0**
- `10.2.2` / `TryRollbackOnFailure` → **none**
- `CosmosWriteFailurePolicy.RollForward` → present in every Cosmos-generated app
- active `AddSekibanDcbCosmosDbTag*` registration → **none**
- `LegacyTagMigration` in startup → **absent**

`git diff --check` clean; no changes outside `templates/Sekiban.Dcb.Templates`.

## A correction to my own earlier evidence

The first version of this PR body said "84 references" and reported the Decider suite as "49 passed". Both were wrong: 84 was the count in the *generated output* (where projects reference the packages more than once across a solution), not the 70 in the template sources this diff actually changes, and 49 was one assembly of the Decider's four. The table above is measured, and the commands to reproduce it are inline.

## Closeout note

**A template-CI packet is worth stacking.** This PR changes every template, bumps 70 package references, and rewrites three Cosmos startup paths — and triggered **zero** build or test checks, because `templates/` matches no workflow path filter. The only verification it received is the local evidence above, run by hand. If I had not run it, the `IncludeTests=false` defect would have merged unnoticed, exactly as it originally did. A PR job that packs, installs, instantiates all five short names (plus one `--IncludeTests false`) and builds them would have caught it at the commit that introduced it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017KAPyZPCMZzurEZTt1k8LX
