### PR TITLE
DCB: durability/runtime descriptors, fail-closed production guard, startup banner

### DIFF
--- a/dcb/src/Sekiban.Dcb.Core/Capabilities/ExecutorRuntimeDescriptor.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Capabilities/ExecutorRuntimeDescriptor.cs
@@ -1,0 +1,53 @@
+namespace Sekiban.Dcb.Capabilities;
+
+/// <summary>
+///     What kind of runtime an executor actually runs on.
+/// </summary>
+public enum ExecutorRuntimeKind
+{
+    /// <summary>
+    ///     The executor did not say. Treated as unsafe: in Production the guard fails closed on it, because an executor
+    ///     that cannot state its runtime cannot be shown to be a real one.
+    /// </summary>
+    Unknown = 0,
+
+    /// <summary>
+    ///     In-process actors, no cluster, no distribution — a unit-test runtime. Nothing here survives the process or
+    ///     coordinates with another one.
+    /// </summary>
+    TestingInProcess = 1,
+
+    /// <summary>
+    ///     A real distributed runtime (Orleans today): grains placed across a cluster, state coordinated between hosts.
+    /// </summary>
+    DistributedRuntime = 2
+}
+
+/// <summary>
+///     What an executor says about itself when something asks at runtime.
+/// </summary>
+/// <param name="Runtime">The kind of runtime this executor actually uses.</param>
+/// <param name="RuntimeName">
+///     A human name for the banner and the failure message: "Orleans", "InMemory (in-process actors)". Never a
+///     connection string.
+/// </param>
+public sealed record ExecutorRuntimeDescriptor(ExecutorRuntimeKind Runtime, string RuntimeName)
+{
+    /// <summary>For an executor whose runtime cannot be determined — e.g. a generic executor over an unknown accessor.</summary>
+    public static ExecutorRuntimeDescriptor Unknown(string runtimeName) =>
+        new(ExecutorRuntimeKind.Unknown, runtimeName);
+
+    /// <summary>e.g. <c>Orleans (DistributedRuntime)</c>.</summary>
+    public override string ToString() => $"{RuntimeName} ({Runtime})";
+}
+
+/// <summary>
+///     Implemented by executors — and by the actor accessors they run on — that can state their own runtime.
+///     Executors that are generic over an accessor answer by asking the accessor, so the answer describes the runtime
+///     that will actually execute the command, not the class that was registered.
+/// </summary>
+public interface IExecutorRuntimeDescriptorProvider
+{
+    /// <summary>Describes this executor as it is actually composed, at the moment it is asked.</summary>
+    ExecutorRuntimeDescriptor DescribeRuntime();
+}

--- a/dcb/src/Sekiban.Dcb.Core/Capabilities/SekibanDcbCapabilityExtensions.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Capabilities/SekibanDcbCapabilityExtensions.cs
@@ -1,0 +1,57 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+namespace Sekiban.Dcb.Capabilities;
+
+/// <summary>
+///     Registration for the startup banner and the production guard.
+///     Both are opt-in and neither changes how anything executes. The guard is never auto-registered by a provider or
+///     a template: a library that decides on its own when your host may not start is a library that will one day be
+///     wrong about it.
+/// </summary>
+public static class SekibanDcbCapabilityExtensions
+{
+    /// <summary>
+    ///     Registers the guard. The package that knows what <c>ISekibanExecutor</c> is passes in the lookup — see
+    ///     <c>AddSekibanDcbProductionGuard</c> in Sekiban.Dcb.WithResult / Sekiban.Dcb.WithoutResult, which is what
+    ///     applications call.
+    /// </summary>
+    public static IServiceCollection AddSekibanDcbProductionGuardCore(
+        this IServiceCollection services,
+        Func<IServiceProvider, object?> resolveExecutor,
+        Action<SekibanDcbProductionGuardOptions>? configure = null) =>
+        services.AddSekibanDcbStartupValidator(resolveExecutor, configure, true);
+
+    /// <summary>
+    ///     Registers the banner alone: it reports what was resolved and warns loudly about volatile storage, and it
+    ///     never fails the host. For local development, where a volatile store is the point.
+    /// </summary>
+    public static IServiceCollection AddSekibanDcbStartupBannerCore(
+        this IServiceCollection services,
+        Func<IServiceProvider, object?> resolveExecutor,
+        Action<SekibanDcbProductionGuardOptions>? configure = null) =>
+        services.AddSekibanDcbStartupValidator(resolveExecutor, configure, false);
+
+    private static IServiceCollection AddSekibanDcbStartupValidator(
+        this IServiceCollection services,
+        Func<IServiceProvider, object?> resolveExecutor,
+        Action<SekibanDcbProductionGuardOptions>? configure,
+        bool enforce)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(resolveExecutor);
+
+        var options = new SekibanDcbProductionGuardOptions();
+        configure?.Invoke(options);
+
+        services.AddSingleton<IHostedService>(sp => new SekibanDcbStartupValidator(
+            sp,
+            sp.GetRequiredService<IHostEnvironment>(),
+            options,
+            resolveExecutor,
+            enforce,
+            sp.GetRequiredService<ILogger<SekibanDcbStartupValidator>>()));
+
+        return services;
+    }
+}

--- a/dcb/src/Sekiban.Dcb.Core/Capabilities/SekibanDcbCapabilityReport.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Capabilities/SekibanDcbCapabilityReport.cs
@@ -1,0 +1,30 @@
+namespace Sekiban.Dcb.Capabilities;
+
+/// <summary>
+///     What was actually resolved out of the container, and what it said about itself.
+///     Assembled from live instances, not from registrations: a decorator, a factory or a lambda that quietly swaps the
+///     real store for something else is visible here, because here is where we ask the thing that got built.
+/// </summary>
+/// <param name="EnvironmentName">The host environment, e.g. "Production".</param>
+/// <param name="IsProductionEnvironment">Whether the guard considers that environment a production one.</param>
+/// <param name="ExecutorTypeName">The concrete executor type that was resolved, or null if none was registered.</param>
+/// <param name="Executor">What the executor said about its runtime.</param>
+/// <param name="EventStore">What the event store said about its durability.</param>
+/// <param name="ProjectionStore">What the projection state store said about its durability.</param>
+/// <param name="UsedOverrideNames">Overrides the operator turned on, by name.</param>
+public sealed record SekibanDcbCapabilityReport(
+    string EnvironmentName,
+    bool IsProductionEnvironment,
+    string? ExecutorTypeName,
+    ExecutorRuntimeDescriptor Executor,
+    StorageDurabilityDescriptor EventStore,
+    StorageDurabilityDescriptor ProjectionStore,
+    IReadOnlyList<string> UsedOverrideNames)
+{
+    /// <summary>True when any resolved store does not durably keep what it is given.</summary>
+    public bool HasVolatileOrUnknownStorage =>
+        EventStore.Durability != StorageDurability.Durable || ProjectionStore.Durability != StorageDurability.Durable;
+
+    /// <summary>True when the resolved executor is not a real distributed runtime.</summary>
+    public bool HasTestingOrUnknownExecutor => Executor.Runtime != ExecutorRuntimeKind.DistributedRuntime;
+}

--- a/dcb/src/Sekiban.Dcb.Core/Capabilities/SekibanDcbCapabilityReport.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Capabilities/SekibanDcbCapabilityReport.cs
@@ -21,9 +21,27 @@ public sealed record SekibanDcbCapabilityReport(
     StorageDurabilityDescriptor ProjectionStore,
     IReadOnlyList<string> UsedOverrideNames)
 {
-    /// <summary>True when any resolved store does not durably keep what it is given.</summary>
-    public bool HasVolatileOrUnknownStorage =>
-        EventStore.Durability != StorageDurability.Durable || ProjectionStore.Durability != StorageDurability.Durable;
+    /// <summary>
+    ///     True when a store told us, in as many words, that it does not keep what it is given.
+    ///     This is the only thing <c>AllowVolatileStorageInProduction</c> can authorise: an operator can look at a
+    ///     store that says "Volatile" and decide they meant it.
+    /// </summary>
+    public bool HasVolatileStorage =>
+        EventStore.Durability == StorageDurability.Volatile
+        || ProjectionStore.Durability == StorageDurability.Volatile;
+
+    /// <summary>
+    ///     True when a store would not say what it is.
+    ///     Deliberately NOT the same condition as <see cref="HasVolatileStorage" />, and deliberately not overridable.
+    ///     An operator who ticks "I accept volatile storage" has accepted a store that declared itself volatile — they
+    ///     have not accepted an unidentified store that might be anything, because there is nothing there to accept.
+    /// </summary>
+    public bool HasUnknownStorage =>
+        EventStore.Durability == StorageDurability.Unknown
+        || ProjectionStore.Durability == StorageDurability.Unknown;
+
+    /// <summary>True when any resolved store does not durably keep what it is given, for the banner's warning.</summary>
+    public bool HasVolatileOrUnknownStorage => HasVolatileStorage || HasUnknownStorage;
 
     /// <summary>True when the resolved executor is not a real distributed runtime.</summary>
     public bool HasTestingOrUnknownExecutor => Executor.Runtime != ExecutorRuntimeKind.DistributedRuntime;

--- a/dcb/src/Sekiban.Dcb.Core/Capabilities/SekibanDcbCapabilityResolver.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Capabilities/SekibanDcbCapabilityResolver.cs
@@ -1,0 +1,75 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Sekiban.Dcb.Storage;
+namespace Sekiban.Dcb.Capabilities;
+
+/// <summary>
+///     Asks the container what it actually built, and asks each thing it built what it is.
+///     Everything here resolves live instances. Reading the <c>IServiceCollection</c> instead would be easier and
+///     wrong: the registration says <c>AddSekibanDcbCosmosDb</c>, and the instance is what a decorator, a factory or a
+///     later <c>AddSingleton</c> override actually handed back.
+/// </summary>
+public static class SekibanDcbCapabilityResolver
+{
+    /// <summary>
+    ///     Resolves the executor and both stores, and asks each what it is.
+    /// </summary>
+    /// <param name="services">The built container.</param>
+    /// <param name="environment">The host environment, for the Production decision.</param>
+    /// <param name="options">Which environments count as Production, and which overrides are on.</param>
+    /// <param name="resolveExecutor">
+    ///     How to get the executor. <c>ISekibanExecutor</c> is declared in the WithResult and WithoutResult packages,
+    ///     which sit above this one, so the package that knows the interface passes in the lookup.
+    /// </param>
+    public static SekibanDcbCapabilityReport Resolve(
+        IServiceProvider services,
+        IHostEnvironment environment,
+        SekibanDcbProductionGuardOptions options,
+        Func<IServiceProvider, object?> resolveExecutor)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(environment);
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(resolveExecutor);
+
+        var executor = resolveExecutor(services);
+
+        var eventStore = (object?)services.GetService<IEventStore>() ?? services.GetService<IEventStoreFactory>();
+        var projectionStore = (object?)services.GetService<IMultiProjectionStateStore>()
+            ?? services.GetService<IMultiProjectionStateStoreFactory>();
+
+        var isProduction = options
+            .ProductionEnvironmentNames
+            .Any(name => string.Equals(name, environment.EnvironmentName, StringComparison.OrdinalIgnoreCase));
+
+        return new SekibanDcbCapabilityReport(
+            environment.EnvironmentName,
+            isProduction,
+            executor?.GetType().FullName,
+            DescribeExecutor(executor),
+            DescribeStorage(eventStore, "event store"),
+            DescribeStorage(projectionStore, "projection state store"),
+            options.UsedOverrideNames());
+    }
+
+    /// <summary>
+    ///     What the executor says, or <see cref="ExecutorRuntimeKind.Unknown" /> if it says nothing. Saying nothing is
+    ///     not the same as saying "distributed", and the guard must never read it that way.
+    /// </summary>
+    public static ExecutorRuntimeDescriptor DescribeExecutor(object? executor) =>
+        executor switch
+        {
+            null => ExecutorRuntimeDescriptor.Unknown("(no ISekibanExecutor registered)"),
+            IExecutorRuntimeDescriptorProvider provider => provider.DescribeRuntime(),
+            _ => ExecutorRuntimeDescriptor.Unknown(executor.GetType().Name)
+        };
+
+    /// <summary>What a store says, or <see cref="StorageDurability.Unknown" /> if it says nothing.</summary>
+    public static StorageDurabilityDescriptor DescribeStorage(object? store, string role) =>
+        store switch
+        {
+            null => StorageDurabilityDescriptor.Unknown($"(no {role} registered)"),
+            IStorageDurabilityDescriptorProvider provider => provider.DescribeStorage(),
+            _ => StorageDurabilityDescriptor.Unknown(store.GetType().Name)
+        };
+}

--- a/dcb/src/Sekiban.Dcb.Core/Capabilities/SekibanDcbProductionGuardException.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Capabilities/SekibanDcbProductionGuardException.cs
@@ -1,0 +1,18 @@
+namespace Sekiban.Dcb.Capabilities;
+
+/// <summary>
+///     Thrown at startup when a Production host is composed in a way that would lose data, and the host is stopped
+///     before it can serve a single request.
+///     This is the whole point of the guard: the failure it describes is not a failure the running system would ever
+///     have reported. A volatile store accepts every write and answers every read; a testing executor executes every
+///     command. Nothing looks wrong. It looks wrong only later, when the process restarts and the events are gone.
+/// </summary>
+public sealed class SekibanDcbProductionGuardException : Exception
+{
+    /// <summary>Creates the exception with the message the operator will see in the crash log.</summary>
+    public SekibanDcbProductionGuardException(string message, SekibanDcbCapabilityReport report) : base(message) =>
+        Report = report;
+
+    /// <summary>Everything the guard resolved and asked, so the message never has to be the only evidence.</summary>
+    public SekibanDcbCapabilityReport Report { get; }
+}

--- a/dcb/src/Sekiban.Dcb.Core/Capabilities/SekibanDcbProductionGuardOptions.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Capabilities/SekibanDcbProductionGuardOptions.cs
@@ -10,9 +10,23 @@ namespace Sekiban.Dcb.Capabilities;
 public sealed class SekibanDcbProductionGuardOptions
 {
     /// <summary>
-    ///     Permits a <see cref="StorageDurability.Volatile" /> or <see cref="StorageDurability.Unknown" /> store in
-    ///     Production. <b>Storage only.</b> It says nothing about the executor, and the guard will not let it: an
-    ///     environment with this set and a testing executor still fails closed.
+    ///     Permits a store that declared itself <see cref="StorageDurability.Volatile" /> in Production.
+    ///     It is narrow in two directions, and both are deliberate:
+    ///     <list type="bullet">
+    ///         <item>
+    ///             <description>
+    ///                 <b>Storage only.</b> It says nothing about the executor. An environment with this set and a
+    ///                 testing executor still fails closed.
+    ///             </description>
+    ///         </item>
+    ///         <item>
+    ///             <description>
+    ///                 <b>Volatile only — never <see cref="StorageDurability.Unknown" />.</b> Setting this means "I
+    ///                 looked at a store that said it was volatile, and I meant it". A store that says nothing has not
+    ///                 given you anything to mean. Unknown stays fail-closed with this override on.
+    ///             </description>
+    ///         </item>
+    ///     </list>
     ///     Default false. If you set it, the banner says so, by name, at Warning.
     /// </summary>
     public bool AllowVolatileStorageInProduction { get; set; }

--- a/dcb/src/Sekiban.Dcb.Core/Capabilities/SekibanDcbProductionGuardOptions.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Capabilities/SekibanDcbProductionGuardOptions.cs
@@ -1,0 +1,30 @@
+namespace Sekiban.Dcb.Capabilities;
+
+/// <summary>
+///     What the production guard is allowed to let through.
+///     There is exactly one override here, and it is deliberately narrow. There is <b>no</b> override that authorises a
+///     testing executor in Production — not off by default, not hidden behind a flag: it does not exist. A volatile
+///     store in Production is a decision an operator can make (a cache-shaped service, a throwaway environment named
+///     Production). A test executor in Production is never a decision, it is an accident.
+/// </summary>
+public sealed class SekibanDcbProductionGuardOptions
+{
+    /// <summary>
+    ///     Permits a <see cref="StorageDurability.Volatile" /> or <see cref="StorageDurability.Unknown" /> store in
+    ///     Production. <b>Storage only.</b> It says nothing about the executor, and the guard will not let it: an
+    ///     environment with this set and a testing executor still fails closed.
+    ///     Default false. If you set it, the banner says so, by name, at Warning.
+    /// </summary>
+    public bool AllowVolatileStorageInProduction { get; set; }
+
+    /// <summary>
+    ///     The environment names the guard treats as Production. Defaults to ASP.NET Core's own "Production".
+    ///     Add to it if your real environments are named something else ("Staging" that is really production, "Prod").
+    ///     Names are compared case-insensitively.
+    /// </summary>
+    public IList<string> ProductionEnvironmentNames { get; } = new List<string> { "Production" };
+
+    /// <summary>The override names that were actually used, for the banner. Empty when none were.</summary>
+    internal IReadOnlyList<string> UsedOverrideNames() =>
+        AllowVolatileStorageInProduction ? [nameof(AllowVolatileStorageInProduction)] : [];
+}

--- a/dcb/src/Sekiban.Dcb.Core/Capabilities/SekibanDcbStartupValidator.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Capabilities/SekibanDcbStartupValidator.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using System.Text;
@@ -38,7 +39,17 @@ public sealed class SekibanDcbStartupValidator : IHostedService
     /// <summary>Resolves, reports, and — if enforcing — stops a Production host that would lose data.</summary>
     public Task StartAsync(CancellationToken cancellationToken)
     {
-        var report = SekibanDcbCapabilityResolver.Resolve(_services, _environment, _options, _resolveExecutor);
+        // Resolve inside a scope, not from the root provider. Sekiban's own Cosmos registrations are scoped, and
+        // asking the root provider for a scoped service throws under ValidateScopes — so a host with a perfectly
+        // supported composition could not even opt in, and the guard would fail the host it was there to protect.
+        // The scope lives exactly as long as this check: nothing resolved here is kept.
+        using var scope = _services.CreateScope();
+
+        var report = SekibanDcbCapabilityResolver.Resolve(
+            scope.ServiceProvider,
+            _environment,
+            _options,
+            _resolveExecutor);
 
         LogBanner(report);
 
@@ -71,13 +82,26 @@ public sealed class SekibanDcbStartupValidator : IHostedService
                 + "in-process testing executor in Production is not a configuration, it is an accident.");
         }
 
-        if (report.HasVolatileOrUnknownStorage && !_options.AllowVolatileStorageInProduction)
+        if (report.HasVolatileStorage && !_options.AllowVolatileStorageInProduction)
         {
             faults.Add(
-                $"storage is not durable — event store: {report.EventStore}, projection state store: "
+                $"storage is volatile — event store: {report.EventStore}, projection state store: "
                 + $"{report.ProjectionStore}. Everything written would be lost when this process ends. If that is "
                 + $"genuinely what you want, set {nameof(SekibanDcbProductionGuardOptions.AllowVolatileStorageInProduction)} "
                 + "= true; it authorises storage only, and will not authorise a testing executor.");
+        }
+
+        if (report.HasUnknownStorage)
+        {
+            // NOT covered by AllowVolatileStorageInProduction, on purpose. That override says "I looked at a store
+            // that declared itself volatile and I meant it". An unidentified store has declared nothing, so there is
+            // nothing for an operator to have meant. Making it durable, or making it say so, is the way past this.
+            faults.Add(
+                $"storage would not identify itself — event store: {report.EventStore}, projection state store: "
+                + $"{report.ProjectionStore}. Silence is not a promise of durability. "
+                + $"{nameof(SekibanDcbProductionGuardOptions.AllowVolatileStorageInProduction)} does not authorise "
+                + "this: it authorises a store that declared itself Volatile, not one that declared nothing. Have the "
+                + $"store implement {nameof(IStorageDurabilityDescriptorProvider)} so it can say what it is.");
         }
 
         if (faults.Count == 0)

--- a/dcb/src/Sekiban.Dcb.Core/Capabilities/SekibanDcbStartupValidator.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Capabilities/SekibanDcbStartupValidator.cs
@@ -1,0 +1,144 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using System.Text;
+namespace Sekiban.Dcb.Capabilities;
+
+/// <summary>
+///     Logs what Sekiban actually resolved, and — when it was registered as a guard — refuses to let a Production host
+///     start if what it resolved would lose data.
+///     It runs as a hosted service, so it happens once, at startup, after every registration has had its say, and
+///     before the host serves anything.
+/// </summary>
+public sealed class SekibanDcbStartupValidator : IHostedService
+{
+    private readonly Func<IServiceProvider, object?> _resolveExecutor;
+    private readonly bool _enforce;
+    private readonly IHostEnvironment _environment;
+    private readonly ILogger<SekibanDcbStartupValidator> _logger;
+    private readonly SekibanDcbProductionGuardOptions _options;
+    private readonly IServiceProvider _services;
+
+    /// <summary>Creates the validator. <paramref name="enforce" /> false means banner only — it never fails the host.</summary>
+    public SekibanDcbStartupValidator(
+        IServiceProvider services,
+        IHostEnvironment environment,
+        SekibanDcbProductionGuardOptions options,
+        Func<IServiceProvider, object?> resolveExecutor,
+        bool enforce,
+        ILogger<SekibanDcbStartupValidator> logger)
+    {
+        _services = services;
+        _environment = environment;
+        _options = options;
+        _resolveExecutor = resolveExecutor;
+        _enforce = enforce;
+        _logger = logger;
+    }
+
+    /// <summary>Resolves, reports, and — if enforcing — stops a Production host that would lose data.</summary>
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        var report = SekibanDcbCapabilityResolver.Resolve(_services, _environment, _options, _resolveExecutor);
+
+        LogBanner(report);
+
+        if (_enforce)
+        {
+            Enforce(report);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    /// <summary>Nothing to stop: the validator does its whole job at startup.</summary>
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    private void Enforce(SekibanDcbCapabilityReport report)
+    {
+        if (!report.IsProductionEnvironment)
+        {
+            return;
+        }
+
+        var faults = new List<string>();
+
+        if (report.HasTestingOrUnknownExecutor)
+        {
+            // Deliberately not overridable. See SekibanDcbProductionGuardOptions.
+            faults.Add(
+                $"the executor is {report.Executor} — Production requires a distributed runtime. "
+                + $"Resolved type: {report.ExecutorTypeName ?? "(none)"}. There is no override for this: an "
+                + "in-process testing executor in Production is not a configuration, it is an accident.");
+        }
+
+        if (report.HasVolatileOrUnknownStorage && !_options.AllowVolatileStorageInProduction)
+        {
+            faults.Add(
+                $"storage is not durable — event store: {report.EventStore}, projection state store: "
+                + $"{report.ProjectionStore}. Everything written would be lost when this process ends. If that is "
+                + $"genuinely what you want, set {nameof(SekibanDcbProductionGuardOptions.AllowVolatileStorageInProduction)} "
+                + "= true; it authorises storage only, and will not authorise a testing executor.");
+        }
+
+        if (faults.Count == 0)
+        {
+            return;
+        }
+
+        var message = new StringBuilder()
+            .AppendLine(
+                $"Sekiban DCB production guard refused to start the host in environment '{report.EnvironmentName}':")
+            .AppendJoin(Environment.NewLine, faults.Select(f => $"  - {f}"))
+            .ToString();
+
+        _logger.LogCritical(
+            "Sekiban DCB production guard FAILED. Environment={Environment} Executor={Executor} EventStore={EventStore} ProjectionStore={ProjectionStore}",
+            report.EnvironmentName,
+            report.Executor.ToString(),
+            report.EventStore.ToString(),
+            report.ProjectionStore.ToString());
+
+        throw new SekibanDcbProductionGuardException(message, report);
+    }
+
+    private void LogBanner(SekibanDcbCapabilityReport report)
+    {
+        // Structured, so it can be queried; and no connection strings, ever — a banner that leaks a secret into every
+        // log sink is a worse bug than the one it exists to prevent.
+        _logger.LogInformation(
+            "Sekiban DCB startup. Environment={Environment} IsProduction={IsProduction} ExecutorType={ExecutorType} ExecutorRuntime={ExecutorRuntime} ExecutorRuntimeName={ExecutorRuntimeName} EventStoreProvider={EventStoreProvider} EventStoreDurability={EventStoreDurability} ProjectionStoreProvider={ProjectionStoreProvider} ProjectionStoreDurability={ProjectionStoreDurability} Overrides={Overrides} Enforcing={Enforcing}",
+            report.EnvironmentName,
+            report.IsProductionEnvironment,
+            report.ExecutorTypeName ?? "(none)",
+            report.Executor.Runtime,
+            report.Executor.RuntimeName,
+            report.EventStore.ProviderName,
+            report.EventStore.Durability,
+            report.ProjectionStore.ProviderName,
+            report.ProjectionStore.Durability,
+            report.UsedOverrideNames.Count == 0 ? "(none)" : string.Join(",", report.UsedOverrideNames),
+            _enforce);
+
+        if (report.UsedOverrideNames.Count > 0)
+        {
+            _logger.LogWarning(
+                "Sekiban DCB safety overrides are ON: {Overrides}. They are named in the log so that nobody has to read the deployment to find out.",
+                string.Join(",", report.UsedOverrideNames));
+        }
+
+        if (report.HasVolatileOrUnknownStorage)
+        {
+            _logger.LogWarning(
+                "Sekiban DCB DATA LOSS WARNING: storage is not durable (event store: {EventStore}, projection state store: {ProjectionStore}). Everything written is lost when this process ends. This is correct for tests and for local development, and is data loss anywhere else.",
+                report.EventStore.ToString(),
+                report.ProjectionStore.ToString());
+        }
+
+        if (report.HasTestingOrUnknownExecutor)
+        {
+            _logger.LogWarning(
+                "Sekiban DCB executor is {Executor} — not a distributed runtime. Commands run in this process only. This is correct for tests, and is not a production configuration.",
+                report.Executor.ToString());
+        }
+    }
+}

--- a/dcb/src/Sekiban.Dcb.Core/Capabilities/StorageDurabilityDescriptor.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Capabilities/StorageDurabilityDescriptor.cs
@@ -1,0 +1,56 @@
+namespace Sekiban.Dcb.Capabilities;
+
+/// <summary>
+///     Whether a store keeps what it is given.
+/// </summary>
+public enum StorageDurability
+{
+    /// <summary>
+    ///     The store did not say. Treated as unsafe: a store that cannot state its own durability is not evidence of
+    ///     durability, and in Production the guard fails closed on it.
+    /// </summary>
+    Unknown = 0,
+
+    /// <summary>
+    ///     Everything written is lost when the process ends. Correct for unit tests, catastrophic in Production.
+    /// </summary>
+    Volatile = 1,
+
+    /// <summary>
+    ///     Writes survive the process — a database, a managed service, a disk.
+    /// </summary>
+    Durable = 2
+}
+
+/// <summary>
+///     What a store says about itself when something asks at runtime.
+///     The name of a type is not evidence. A production system once registered an in-memory executor whose one-argument
+///     constructor quietly created a private volatile store, and nothing at startup could tell that events were never
+///     reaching Cosmos — because nothing could ask. This is the thing that can be asked.
+/// </summary>
+/// <param name="Durability">Whether writes survive the process.</param>
+/// <param name="ProviderName">
+///     A human name for the store, for the banner and the failure message: "Postgres", "InMemory",
+///     "HybridEventStore(CosmosDb)". Never a connection string, and never anything derived from one.
+/// </param>
+public sealed record StorageDurabilityDescriptor(StorageDurability Durability, string ProviderName)
+{
+    /// <summary>For a store that has nothing to say — including one that wraps an inner store that had nothing to say.</summary>
+    public static StorageDurabilityDescriptor Unknown(string providerName) =>
+        new(StorageDurability.Unknown, providerName);
+
+    /// <summary>e.g. <c>Postgres (Durable)</c>.</summary>
+    public override string ToString() => $"{ProviderName} ({Durability})";
+}
+
+/// <summary>
+///     Implemented by event stores and projection state stores that can state their own durability.
+///     A decorator implements this by asking what it wraps — the answer must describe where the data actually lands,
+///     not the wrapper. A store that does not implement this is <see cref="StorageDurability.Unknown" />, which is a
+///     deliberate default: silence is not a promise of durability.
+/// </summary>
+public interface IStorageDurabilityDescriptorProvider
+{
+    /// <summary>Describes this store as it is actually configured, at the moment it is asked.</summary>
+    StorageDurabilityDescriptor DescribeStorage();
+}

--- a/dcb/src/Sekiban.Dcb.Core/ColdEvents/HybridEventStore.cs
+++ b/dcb/src/Sekiban.Dcb.Core/ColdEvents/HybridEventStore.cs
@@ -3,15 +3,27 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using ResultBoxes;
 using Sekiban.Dcb.Common;
+using Sekiban.Dcb.Capabilities;
 using Sekiban.Dcb.Events;
 using Sekiban.Dcb.ServiceId;
 using Sekiban.Dcb.Storage;
 using Sekiban.Dcb.Tags;
 namespace Sekiban.Dcb.ColdEvents;
 
-public sealed class HybridEventStore : IEventStore, IStreamingSerializableEventStore
+public sealed class HybridEventStore : IEventStore, IStreamingSerializableEventStore, IStorageDurabilityDescriptorProvider
 {
     private const string ReadAllSerializableEventsCall = nameof(ReadAllSerializableEventsAsync);
+
+    /// <summary>
+    ///     A wrapper is not a durability. Writes land in the hot store, so the hot store's answer is the answer — and if
+    ///     the hot store will not say, neither will we. Reporting "Durable" because a durable-sounding decorator was
+    ///     applied is precisely the mistake this whole mechanism exists to make impossible.
+    /// </summary>
+    public StorageDurabilityDescriptor DescribeStorage()
+    {
+        var hot = SekibanDcbCapabilityResolver.DescribeStorage(_hotStore, "hot event store");
+        return new StorageDurabilityDescriptor(hot.Durability, $"HybridEventStore({hot.ProviderName})");
+    }
     private readonly IEventStore _hotStore;
     private readonly IColdObjectStorage _coldStorage;
     private readonly IColdSegmentFormatHandler _segmentFormatHandler;

--- a/dcb/src/Sekiban.Dcb.Core/InMemory/InMemoryEventStore.cs
+++ b/dcb/src/Sekiban.Dcb.Core/InMemory/InMemoryEventStore.cs
@@ -1,5 +1,6 @@
 using ResultBoxes;
 using Sekiban.Dcb.Common;
+using Sekiban.Dcb.Capabilities;
 using Sekiban.Dcb.Domains;
 using Sekiban.Dcb.Events;
 using Sekiban.Dcb.ServiceId;
@@ -13,9 +14,13 @@ namespace Sekiban.Dcb.InMemory;
 ///     In-memory implementation of IEventStore for testing and development
 ///     Stores events and tag streams only - no tag state management
 /// </summary>
-public class InMemoryEventStore : IEventStore, ISerializableEventStreamReader
+public class InMemoryEventStore : IEventStore, ISerializableEventStreamReader, IStorageDurabilityDescriptorProvider
 {
     private const string EventTypesRequiredMessage = "IEventTypes is required for SerializableEvent operations";
+
+    /// <summary>Everything here is a dictionary in this process. It is gone when the process is.</summary>
+    public StorageDurabilityDescriptor DescribeStorage() =>
+        new(StorageDurability.Volatile, "InMemory");
 
     private sealed class ServiceState
     {

--- a/dcb/src/Sekiban.Dcb.Core/InMemory/InMemoryMultiProjectionStateStore.cs
+++ b/dcb/src/Sekiban.Dcb.Core/InMemory/InMemoryMultiProjectionStateStore.cs
@@ -1,6 +1,7 @@
 using System.Collections.Concurrent;
 using ResultBoxes;
 using Sekiban.Dcb.MultiProjections;
+using Sekiban.Dcb.Capabilities;
 using Sekiban.Dcb.ServiceId;
 using Sekiban.Dcb.Storage;
 
@@ -9,7 +10,7 @@ namespace Sekiban.Dcb.InMemory;
 /// <summary>
 ///     In-memory implementation for tests.
 /// </summary>
-public sealed class InMemoryMultiProjectionStateStore : IMultiProjectionStateStore
+public sealed class InMemoryMultiProjectionStateStore : IMultiProjectionStateStore, IStorageDurabilityDescriptorProvider
 {
     private readonly ConcurrentDictionary<(string ServiceId, string ProjectorName, string ProjectorVersion), MultiProjectionStateRecord> _states = new();
     private readonly ConcurrentDictionary<(string ServiceId, string ProjectorName, string ProjectorVersion), byte[]> _stateData = new();
@@ -19,6 +20,10 @@ public sealed class InMemoryMultiProjectionStateStore : IMultiProjectionStateSto
     {
         _serviceIdProvider = serviceIdProvider ?? new DefaultServiceIdProvider();
     }
+
+    /// <summary>Projection state held in this process only: rebuildable from events, but not itself durable.</summary>
+    public StorageDurabilityDescriptor DescribeStorage() =>
+        new(StorageDurability.Volatile, "InMemory");
 
     private string CurrentServiceId => _serviceIdProvider.GetCurrentServiceId();
 

--- a/dcb/src/Sekiban.Dcb.Core/InMemory/InMemoryObjectAccessor.cs
+++ b/dcb/src/Sekiban.Dcb.Core/InMemory/InMemoryObjectAccessor.cs
@@ -1,5 +1,6 @@
 using ResultBoxes;
 using Sekiban.Dcb.Actors;
+using Sekiban.Dcb.Capabilities;
 using Sekiban.Dcb.Domains;
 using Sekiban.Dcb.Events;
 using Sekiban.Dcb.Storage;
@@ -11,8 +12,15 @@ namespace Sekiban.Dcb.InMemory;
 ///     In-memory implementation of IActorObjectAccessor
 ///     Manages and provides access to actor instances
 /// </summary>
-public class InMemoryObjectAccessor : IActorObjectAccessor, IServiceProvider
+public class InMemoryObjectAccessor : IActorObjectAccessor, IServiceProvider, IExecutorRuntimeDescriptorProvider
 {
+    /// <summary>
+    ///     Actors are objects in a dictionary in this process. No cluster, no placement, no coordination with anything
+    ///     else — which is exactly what a unit test wants, and exactly what production must not have.
+    /// </summary>
+    public ExecutorRuntimeDescriptor DescribeRuntime() =>
+        new(ExecutorRuntimeKind.TestingInProcess, "InMemory (in-process actors)");
+
     private readonly ConcurrentDictionary<string, object> _actors = new();
     private readonly object _creationLock = new();
     private readonly DcbDomainTypes _domainTypes;

--- a/dcb/src/Sekiban.Dcb.CosmosDb/CosmosDbEventStore.cs
+++ b/dcb/src/Sekiban.Dcb.CosmosDb/CosmosDbEventStore.cs
@@ -9,6 +9,7 @@ using Sekiban.Dcb.Domains;
 using Sekiban.Dcb.Events;
 using Sekiban.Dcb.ServiceId;
 using Sekiban.Dcb.Storage;
+using Sekiban.Dcb.Capabilities;
 using Sekiban.Dcb.Tags;
 using System.Net;
 using System.Text;
@@ -18,8 +19,12 @@ namespace Sekiban.Dcb.CosmosDb;
 /// <summary>
 ///     CosmosDB-backed event store implementation.
 /// </summary>
-public partial class CosmosDbEventStore : IHotEventStore
+public partial class CosmosDbEventStore : IHotEventStore, IStorageDurabilityDescriptorProvider
 {
+    /// <summary>Events land in Cosmos DB.</summary>
+    public StorageDurabilityDescriptor DescribeStorage() =>
+        new(StorageDurability.Durable, "CosmosDb");
+
     private const string ParamSince = "@since";
     private const string ParamServiceId = "@serviceId";
     private readonly CosmosDbContext _context;

--- a/dcb/src/Sekiban.Dcb.CosmosDb/CosmosDbEventStoreFactory.cs
+++ b/dcb/src/Sekiban.Dcb.CosmosDb/CosmosDbEventStoreFactory.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.Logging;
 using Sekiban.Dcb.Domains;
 using Sekiban.Dcb.ServiceId;
+using Sekiban.Dcb.Capabilities;
 using Sekiban.Dcb.Storage;
 
 namespace Sekiban.Dcb.CosmosDb;
@@ -8,8 +9,12 @@ namespace Sekiban.Dcb.CosmosDb;
 /// <summary>
 ///     Factory for creating ServiceId-scoped CosmosDbEventStore instances.
 /// </summary>
-public sealed class CosmosDbEventStoreFactory : IEventStoreFactory
+public sealed class CosmosDbEventStoreFactory : IEventStoreFactory, IStorageDurabilityDescriptorProvider
 {
+    /// <summary>Every store this factory builds writes to the same durable backend.</summary>
+    public StorageDurabilityDescriptor DescribeStorage() =>
+        new(StorageDurability.Durable, "CosmosDb (per-service factory)");
+
     private readonly CosmosDbContext _context;
     private readonly IEventTypes _eventTypes;
     private readonly ICosmosContainerResolver _containerResolver;

--- a/dcb/src/Sekiban.Dcb.CosmosDb/CosmosDbMultiProjectionStateStoreFactory.cs
+++ b/dcb/src/Sekiban.Dcb.CosmosDb/CosmosDbMultiProjectionStateStoreFactory.cs
@@ -2,14 +2,19 @@ using Microsoft.Extensions.Logging;
 using Sekiban.Dcb.ServiceId;
 using Sekiban.Dcb.Snapshots;
 using Sekiban.Dcb.Storage;
+using Sekiban.Dcb.Capabilities;
 
 namespace Sekiban.Dcb.CosmosDb;
 
 /// <summary>
 ///     Factory for creating ServiceId-scoped CosmosMultiProjectionStateStore instances.
 /// </summary>
-public sealed class CosmosDbMultiProjectionStateStoreFactory : IMultiProjectionStateStoreFactory
+public sealed class CosmosDbMultiProjectionStateStoreFactory : IMultiProjectionStateStoreFactory, IStorageDurabilityDescriptorProvider
 {
+    /// <summary>Every store this factory builds is a Cosmos one.</summary>
+    public StorageDurabilityDescriptor DescribeStorage() =>
+        new(StorageDurability.Durable, "CosmosDb (per-service factory)");
+
     private readonly CosmosDbContext _context;
     private readonly ICosmosContainerResolver _containerResolver;
     private readonly IBlobStorageSnapshotAccessor? _blobAccessor;

--- a/dcb/src/Sekiban.Dcb.CosmosDb/CosmosMultiProjectionStateStore.cs
+++ b/dcb/src/Sekiban.Dcb.CosmosDb/CosmosMultiProjectionStateStore.cs
@@ -6,14 +6,19 @@ using Sekiban.Dcb.MultiProjections;
 using Sekiban.Dcb.ServiceId;
 using Sekiban.Dcb.Snapshots;
 using Sekiban.Dcb.Storage;
+using Sekiban.Dcb.Capabilities;
 
 namespace Sekiban.Dcb.CosmosDb;
 
 /// <summary>
 ///     Cosmos DB implementation of IMultiProjectionStateStore.
 /// </summary>
-public class CosmosMultiProjectionStateStore : IMultiProjectionStateStore
+public class CosmosMultiProjectionStateStore : IMultiProjectionStateStore, IStorageDurabilityDescriptorProvider
 {
+    /// <summary>Projection state lands in Cosmos DB.</summary>
+    public StorageDurabilityDescriptor DescribeStorage() =>
+        new(StorageDurability.Durable, "CosmosDb");
+
     private readonly CosmosDbContext _context;
     private readonly IBlobStorageSnapshotAccessor? _blobAccessor;
     private readonly IServiceIdProvider _serviceIdProvider;

--- a/dcb/src/Sekiban.Dcb.DynamoDB/DynamoDbEventStore.cs
+++ b/dcb/src/Sekiban.Dcb.DynamoDB/DynamoDbEventStore.cs
@@ -8,6 +8,7 @@ using Sekiban.Dcb.DynamoDB.Models;
 using Sekiban.Dcb.Events;
 using Sekiban.Dcb.ServiceId;
 using Sekiban.Dcb.Storage;
+using Sekiban.Dcb.Capabilities;
 using Sekiban.Dcb.Tags;
 using System.Security.Cryptography;
 using System.Text;
@@ -19,8 +20,12 @@ namespace Sekiban.Dcb.DynamoDB;
 /// <summary>
 ///     DynamoDB-backed event store implementation.
 /// </summary>
-public class DynamoDbEventStore : IHotEventStore
+public class DynamoDbEventStore : IHotEventStore, IStorageDurabilityDescriptorProvider
 {
+    /// <summary>Events land in DynamoDB.</summary>
+    public StorageDurabilityDescriptor DescribeStorage() =>
+        new(StorageDurability.Durable, "DynamoDB");
+
     private const string PartitionKeyConditionExpression = "gsi1pk = :pk";
     private const string PartitionKeySinceConditionExpression = "gsi1pk = :pk AND sortableUniqueId > :since";
 

--- a/dcb/src/Sekiban.Dcb.DynamoDB/DynamoMultiProjectionStateStore.cs
+++ b/dcb/src/Sekiban.Dcb.DynamoDB/DynamoMultiProjectionStateStore.cs
@@ -6,6 +6,7 @@ using Sekiban.Dcb.MultiProjections;
 using Sekiban.Dcb.ServiceId;
 using Sekiban.Dcb.Snapshots;
 using Sekiban.Dcb.Storage;
+using Sekiban.Dcb.Capabilities;
 
 namespace Sekiban.Dcb.DynamoDB;
 
@@ -14,8 +15,12 @@ namespace Sekiban.Dcb.DynamoDB;
 /// <summary>
 ///     DynamoDB implementation of IMultiProjectionStateStore.
 /// </summary>
-public class DynamoMultiProjectionStateStore : IMultiProjectionStateStore
+public class DynamoMultiProjectionStateStore : IMultiProjectionStateStore, IStorageDurabilityDescriptorProvider
 {
+    /// <summary>Projection state lands in DynamoDB.</summary>
+    public StorageDurabilityDescriptor DescribeStorage() =>
+        new(StorageDurability.Durable, "DynamoDB");
+
     private readonly DynamoDbContext _context;
     private readonly IBlobStorageSnapshotAccessor? _blobAccessor;
     private readonly DynamoDbEventStoreOptions _options;

--- a/dcb/src/Sekiban.Dcb.Orleans.Core/OrleansActorObjectAccessor.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.Core/OrleansActorObjectAccessor.cs
@@ -1,5 +1,6 @@
 using ResultBoxes;
 using Sekiban.Dcb.Actors;
+using Sekiban.Dcb.Capabilities;
 using Sekiban.Dcb.Orleans.Grains;
 using Sekiban.Dcb.Orleans.ServiceId;
 using Sekiban.Dcb.ServiceId;
@@ -11,8 +12,12 @@ namespace Sekiban.Dcb.Orleans;
 ///     Orleans-specific implementation of IActorObjectAccessor
 ///     Manages Orleans grains for tag consistency and state management
 /// </summary>
-public class OrleansActorObjectAccessor : IActorObjectAccessor
+public class OrleansActorObjectAccessor : IActorObjectAccessor, IExecutorRuntimeDescriptorProvider
 {
+    /// <summary>Actors are Orleans grains, placed and coordinated across the cluster.</summary>
+    public ExecutorRuntimeDescriptor DescribeRuntime() =>
+        new(ExecutorRuntimeKind.DistributedRuntime, "Orleans");
+
     private readonly IClusterClient _clusterClient;
     private readonly DcbDomainTypes _domainTypes;
     private readonly IEventStore _eventStore;

--- a/dcb/src/Sekiban.Dcb.Orleans.WithResult/OrleansDcbExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.WithResult/OrleansDcbExecutor.cs
@@ -1,5 +1,6 @@
 using ResultBoxes;
 using Sekiban.Dcb.Actors;
+using Sekiban.Dcb.Capabilities;
 using Sekiban.Dcb.Commands;
 using Sekiban.Dcb.Common;
 using Sekiban.Dcb.Events;
@@ -18,8 +19,12 @@ namespace Sekiban.Dcb.Orleans;
 ///     Orleans-specific implementation of ISekibanExecutor
 ///     Uses Orleans grains for distributed command execution and queries
 /// </summary>
-public class OrleansDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecutor
+public class OrleansDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecutor, IExecutorRuntimeDescriptorProvider
 {
+    /// <summary>Commands are executed by Orleans grains across the cluster.</summary>
+    public ExecutorRuntimeDescriptor DescribeRuntime() =>
+        SekibanDcbCapabilityResolver.DescribeExecutor(_actorAccessor);
+
     private readonly IActorObjectAccessor _actorAccessor;
     private readonly IClusterClient _clusterClient;
     private readonly DcbDomainTypes _domainTypes;

--- a/dcb/src/Sekiban.Dcb.Orleans.WithoutResult/OrleansDcbExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.WithoutResult/OrleansDcbExecutor.cs
@@ -1,5 +1,6 @@
 using ResultBoxes;
 using Sekiban.Dcb.Actors;
+using Sekiban.Dcb.Capabilities;
 using Sekiban.Dcb.Boundaries;
 using Sekiban.Dcb.Commands;
 using Sekiban.Dcb.Common;
@@ -19,8 +20,12 @@ namespace Sekiban.Dcb.Orleans;
 ///     Orleans-specific implementation of ISekibanExecutor (exception-based)
 ///     Uses Orleans grains for distributed command execution and queries
 /// </summary>
-public class OrleansDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecutor
+public class OrleansDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecutor, IExecutorRuntimeDescriptorProvider
 {
+    /// <summary>Commands are executed by Orleans grains across the cluster.</summary>
+    public ExecutorRuntimeDescriptor DescribeRuntime() =>
+        SekibanDcbCapabilityResolver.DescribeExecutor(_actorAccessor);
+
     private readonly IActorObjectAccessor _actorAccessor;
     private readonly IClusterClient _clusterClient;
     private readonly DcbDomainTypes _domainTypes;

--- a/dcb/src/Sekiban.Dcb.Postgres/PostgresEventStore.cs
+++ b/dcb/src/Sekiban.Dcb.Postgres/PostgresEventStore.cs
@@ -6,6 +6,7 @@ using Sekiban.Dcb.Events;
 using Sekiban.Dcb.Postgres.DbModels;
 using Sekiban.Dcb.ServiceId;
 using Sekiban.Dcb.Storage;
+using Sekiban.Dcb.Capabilities;
 using Sekiban.Dcb.Tags;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -14,8 +15,12 @@ using System.Text;
 using System.Text.Json;
 namespace Sekiban.Dcb.Postgres;
 
-public class PostgresEventStore : IHotEventStore, ISerializableEventStreamReader
+public class PostgresEventStore : IHotEventStore, ISerializableEventStreamReader, IStorageDurabilityDescriptorProvider
 {
+    /// <summary>Events land in Postgres and survive this process.</summary>
+    public StorageDurabilityDescriptor DescribeStorage() =>
+        new(StorageDurability.Durable, "Postgres");
+
     private readonly IDbContextFactory<SekibanDcbDbContext> _contextFactory;
     private readonly IEventTypes _eventTypes;
     private readonly IServiceIdProvider _serviceIdProvider;

--- a/dcb/src/Sekiban.Dcb.Postgres/PostgresEventStoreFactory.cs
+++ b/dcb/src/Sekiban.Dcb.Postgres/PostgresEventStoreFactory.cs
@@ -2,6 +2,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Sekiban.Dcb.Domains;
 using Sekiban.Dcb.ServiceId;
+using Sekiban.Dcb.Capabilities;
 using Sekiban.Dcb.Storage;
 
 namespace Sekiban.Dcb.Postgres;
@@ -9,8 +10,12 @@ namespace Sekiban.Dcb.Postgres;
 /// <summary>
 ///     Factory for creating ServiceId-scoped PostgresEventStore instances.
 /// </summary>
-public sealed class PostgresEventStoreFactory : IEventStoreFactory
+public sealed class PostgresEventStoreFactory : IEventStoreFactory, IStorageDurabilityDescriptorProvider
 {
+    /// <summary>Every store this factory builds writes to the same durable backend.</summary>
+    public StorageDurabilityDescriptor DescribeStorage() =>
+        new(StorageDurability.Durable, "Postgres (per-service factory)");
+
     private readonly IDbContextFactory<SekibanDcbDbContext> _contextFactory;
     private readonly IEventTypes _eventTypes;
     private readonly ILoggerFactory? _loggerFactory;

--- a/dcb/src/Sekiban.Dcb.Postgres/PostgresMultiProjectionStateStore.cs
+++ b/dcb/src/Sekiban.Dcb.Postgres/PostgresMultiProjectionStateStore.cs
@@ -5,14 +5,19 @@ using Sekiban.Dcb.Postgres.DbModels;
 using Sekiban.Dcb.ServiceId;
 using Sekiban.Dcb.Snapshots;
 using Sekiban.Dcb.Storage;
+using Sekiban.Dcb.Capabilities;
 
 namespace Sekiban.Dcb.Postgres;
 
 /// <summary>
 ///     Postgres implementation of IMultiProjectionStateStore.
 /// </summary>
-public class PostgresMultiProjectionStateStore : IMultiProjectionStateStore
+public class PostgresMultiProjectionStateStore : IMultiProjectionStateStore, IStorageDurabilityDescriptorProvider
 {
+    /// <summary>Projection state lands in Postgres.</summary>
+    public StorageDurabilityDescriptor DescribeStorage() =>
+        new(StorageDurability.Durable, "Postgres");
+
     private readonly IDbContextFactory<SekibanDcbDbContext> _contextFactory;
     private readonly IBlobStorageSnapshotAccessor? _blobAccessor;
     private readonly IServiceIdProvider _serviceIdProvider;

--- a/dcb/src/Sekiban.Dcb.Postgres/PostgresMultiProjectionStateStoreFactory.cs
+++ b/dcb/src/Sekiban.Dcb.Postgres/PostgresMultiProjectionStateStoreFactory.cs
@@ -2,14 +2,19 @@ using Microsoft.EntityFrameworkCore;
 using Sekiban.Dcb.ServiceId;
 using Sekiban.Dcb.Snapshots;
 using Sekiban.Dcb.Storage;
+using Sekiban.Dcb.Capabilities;
 
 namespace Sekiban.Dcb.Postgres;
 
 /// <summary>
 ///     Factory for creating ServiceId-scoped PostgresMultiProjectionStateStore instances.
 /// </summary>
-public sealed class PostgresMultiProjectionStateStoreFactory : IMultiProjectionStateStoreFactory
+public sealed class PostgresMultiProjectionStateStoreFactory : IMultiProjectionStateStoreFactory, IStorageDurabilityDescriptorProvider
 {
+    /// <summary>Every store this factory builds is a Postgres one.</summary>
+    public StorageDurabilityDescriptor DescribeStorage() =>
+        new(StorageDurability.Durable, "Postgres (per-service factory)");
+
     private readonly IDbContextFactory<SekibanDcbDbContext> _contextFactory;
     private readonly IBlobStorageSnapshotAccessor? _blobAccessor;
 

--- a/dcb/src/Sekiban.Dcb.Sqlite/SqliteEventStore.cs
+++ b/dcb/src/Sekiban.Dcb.Sqlite/SqliteEventStore.cs
@@ -8,6 +8,7 @@ using Sekiban.Dcb.Domains;
 using Sekiban.Dcb.Events;
 using Sekiban.Dcb.ServiceId;
 using Sekiban.Dcb.Storage;
+using Sekiban.Dcb.Capabilities;
 using Sekiban.Dcb.Tags;
 
 namespace Sekiban.Dcb.Sqlite;
@@ -16,8 +17,22 @@ namespace Sekiban.Dcb.Sqlite;
 ///     SQLite implementation of IEventStore.
 ///     Can be used as a standalone event store or as a local cache for remote stores.
 /// </summary>
-public class SqliteEventStore : IHotEventStore
+public class SqliteEventStore : IHotEventStore, IStorageDurabilityDescriptorProvider
 {
+    /// <summary>
+    ///     Sqlite is durable when it is a file, and volatile when it is <c>:memory:</c> — same type, same class name,
+    ///     opposite guarantee. This is the case that proves the descriptor has to be resolved from the live instance
+    ///     rather than inferred from the registration: only the instance knows which one it got.
+    /// </summary>
+    public StorageDurabilityDescriptor DescribeStorage() =>
+        IsInMemoryConnection(_connectionString)
+            ? new StorageDurabilityDescriptor(StorageDurability.Volatile, "Sqlite (in-memory)")
+            : new StorageDurabilityDescriptor(StorageDurability.Durable, "Sqlite");
+
+    private static bool IsInMemoryConnection(string connectionString) =>
+        connectionString.Contains(":memory:", StringComparison.OrdinalIgnoreCase)
+        || connectionString.Contains("Mode=Memory", StringComparison.OrdinalIgnoreCase);
+
     private const string SchemaVersion = "1.1";
     private const string SchemaVersionKey = "schemaVersion";
     private const string ParamServiceId = "@serviceId";

--- a/dcb/src/Sekiban.Dcb.Sqlite/SqliteMultiProjectionStateStore.cs
+++ b/dcb/src/Sekiban.Dcb.Sqlite/SqliteMultiProjectionStateStore.cs
@@ -4,14 +4,29 @@ using ResultBoxes;
 using Sekiban.Dcb.MultiProjections;
 using Sekiban.Dcb.ServiceId;
 using Sekiban.Dcb.Storage;
+using Sekiban.Dcb.Capabilities;
 
 namespace Sekiban.Dcb.Sqlite;
 
 /// <summary>
 ///     SQLite implementation of IMultiProjectionStateStore
 /// </summary>
-public class SqliteMultiProjectionStateStore : IMultiProjectionStateStore
+public class SqliteMultiProjectionStateStore : IMultiProjectionStateStore, IStorageDurabilityDescriptorProvider
 {
+    /// <summary>
+    ///     Sqlite is durable when it is a file, and volatile when it is <c>:memory:</c> — same type, same class name,
+    ///     opposite guarantee. This is the case that proves the descriptor has to be resolved from the live instance
+    ///     rather than inferred from the registration: only the instance knows which one it got.
+    /// </summary>
+    public StorageDurabilityDescriptor DescribeStorage() =>
+        IsInMemoryConnection(_connectionString)
+            ? new StorageDurabilityDescriptor(StorageDurability.Volatile, "Sqlite (in-memory)")
+            : new StorageDurabilityDescriptor(StorageDurability.Durable, "Sqlite");
+
+    private static bool IsInMemoryConnection(string connectionString) =>
+        connectionString.Contains(":memory:", StringComparison.OrdinalIgnoreCase)
+        || connectionString.Contains("Mode=Memory", StringComparison.OrdinalIgnoreCase);
+
     private const string ParamServiceId = "@serviceId";
     private static readonly HashSet<string> AllowedTableNames = new(StringComparer.OrdinalIgnoreCase)
     {

--- a/dcb/src/Sekiban.Dcb.WithResult/Actors/GeneralSekibanExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.WithResult/Actors/GeneralSekibanExecutor.cs
@@ -1,5 +1,6 @@
 using ResultBoxes;
 using Sekiban.Dcb.Actors;
+using Sekiban.Dcb.Capabilities;
 using Sekiban.Dcb.Commands;
 using Sekiban.Dcb.Events;
 using Sekiban.Dcb.Queries;
@@ -12,9 +13,10 @@ namespace Sekiban.Dcb.Actors;
 ///     Wraps CoreGeneralSekibanExecutor to provide the public API
 ///     This implementation uses ResultBox for all error handling
 /// </summary>
-public class GeneralSekibanExecutor : ISekibanExecutor, ISerializedSekibanDcbExecutor
+public class GeneralSekibanExecutor : ISekibanExecutor, ISerializedSekibanDcbExecutor, IExecutorRuntimeDescriptorProvider
 {
     private readonly CoreGeneralSekibanExecutor _core;
+    private readonly IActorObjectAccessor _actorAccessor;
     private static readonly AnonymousCommand NoCommandInstance = new();
 
     public GeneralSekibanExecutor(
@@ -23,8 +25,17 @@ public class GeneralSekibanExecutor : ISekibanExecutor, ISerializedSekibanDcbExe
         DcbDomainTypes domainTypes,
         IEventPublisher? eventPublisher = null)
     {
+        _actorAccessor = actorAccessor;
         _core = new CoreGeneralSekibanExecutor(eventStore, actorAccessor, domainTypes, eventPublisher);
     }
+
+    /// <summary>
+    ///     This executor is whatever its accessor is. It has no runtime of its own — commands go wherever the accessor
+    ///     sends them — so it asks, rather than claiming. An accessor that will not say leaves this Unknown, and the
+    ///     production guard treats Unknown as unsafe, which is the only safe way to treat it.
+    /// </summary>
+    public ExecutorRuntimeDescriptor DescribeRuntime() =>
+        SekibanDcbCapabilityResolver.DescribeExecutor(_actorAccessor);
 
     /// <summary>
     ///     Execute a command with its built-in handler

--- a/dcb/src/Sekiban.Dcb.WithResult/Capabilities/SekibanDcbProductionGuardExtensions.cs
+++ b/dcb/src/Sekiban.Dcb.WithResult/Capabilities/SekibanDcbProductionGuardExtensions.cs
@@ -1,0 +1,35 @@
+using Microsoft.Extensions.DependencyInjection;
+namespace Sekiban.Dcb.Capabilities;
+
+/// <summary>
+///     The registration an application calls. It is opt-in, and nothing registers it for you.
+/// </summary>
+public static class SekibanDcbProductionGuardExtensions
+{
+    /// <summary>
+    ///     Refuses to start a Production host whose resolved executor is not a distributed runtime, or whose resolved
+    ///     stores do not durably keep what they are given.
+    ///     Call it AFTER the registrations it is meant to check — it evaluates what the container actually builds, so
+    ///     a later <c>AddSingleton&lt;ISekibanExecutor&gt;</c> that replaces the executor is still caught, but only
+    ///     because the check happens at startup rather than here.
+    ///     Outside the configured Production environments it validates nothing and only logs the banner.
+    /// </summary>
+    /// <param name="services">The application's service collection.</param>
+    /// <param name="configure">
+    ///     Optional. The only override is <c>AllowVolatileStorageInProduction</c>, and it authorises storage only —
+    ///     there is no override that permits a testing executor in Production.
+    /// </param>
+    public static IServiceCollection AddSekibanDcbProductionGuard(
+        this IServiceCollection services,
+        Action<SekibanDcbProductionGuardOptions>? configure = null) =>
+        services.AddSekibanDcbProductionGuardCore(sp => sp.GetService<ISekibanExecutor>(), configure);
+
+    /// <summary>
+    ///     Logs the startup banner — environment, executor runtime, store durability, overrides in use, and a loud
+    ///     warning when storage is volatile — and never fails the host. What local development wants.
+    /// </summary>
+    public static IServiceCollection AddSekibanDcbStartupBanner(
+        this IServiceCollection services,
+        Action<SekibanDcbProductionGuardOptions>? configure = null) =>
+        services.AddSekibanDcbStartupBannerCore(sp => sp.GetService<ISekibanExecutor>(), configure);
+}

--- a/dcb/src/Sekiban.Dcb.WithResult/InMemory/InMemoryDcbExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.WithResult/InMemory/InMemoryDcbExecutor.cs
@@ -8,6 +8,7 @@ using Sekiban.Dcb.Storage;
 using Sekiban.Dcb.Tags;
 using Sekiban.Dcb.Common;
 using System.Text;
+using Sekiban.Dcb.Capabilities;
 namespace Sekiban.Dcb.InMemory;
 
 /// <summary>
@@ -16,8 +17,15 @@ namespace Sekiban.Dcb.InMemory;
 ///     to execute commands, queries and tag state retrieval without external infrastructure.
 ///     Intended for lightweight tests / prototyping; not thread-safe for high concurrency scenarios.
 /// </summary>
-public class InMemoryDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecutor
+public class InMemoryDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecutor, IExecutorRuntimeDescriptorProvider
 {
+    /// <summary>
+    ///     In-process actors, this process only. A production host that resolves this executor is a production host
+    ///     running a unit-test runtime, and the production guard will not start it.
+    /// </summary>
+    public ExecutorRuntimeDescriptor DescribeRuntime() =>
+        new(ExecutorRuntimeKind.TestingInProcess, "InMemory (in-process actors)");
+
     private readonly GeneralSekibanExecutor _inner;
     private readonly InMemoryObjectAccessor _accessor;
     private readonly IEventStore _eventStore;
@@ -36,8 +44,17 @@ public class InMemoryDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecut
     }
 
     /// <summary>
-    ///     Creates executor with built-in lightweight in-memory event store (no external dependencies)
+    ///     Creates the executor with a built-in lightweight in-memory event store (no external dependencies).
+    ///     Obsolete because it is silent about the most important thing it does. A downstream production system
+    ///     registered this executor as its <c>ISekibanExecutor</c>; this constructor created a private volatile event
+    ///     store for it, and every command succeeded, and no event ever reached the database it had configured. Pass
+    ///     the store you mean to use — <c>new InMemoryDcbExecutor(domainTypes, new InMemoryEventStore())</c> in tests
+    ///     — so that the store is a decision somebody made, and can be seen in the code that made it.
     /// </summary>
+    [Obsolete(
+        "Pass the event store explicitly: new InMemoryDcbExecutor(domainTypes, new InMemoryEventStore()). This "
+        + "constructor silently creates a private VOLATILE event store, which is invisible at the call site and has "
+        + "reached production before. Behaviour is unchanged; only the silence is deprecated.")]
     public InMemoryDcbExecutor(DcbDomainTypes domainTypes) : this(domainTypes, new InternalInMemoryEventStore(domainTypes)) { }
 
     Task<ResultBox<ExecutionResult>> ICommandExecutor.ExecuteAsync<TCommand>(

--- a/dcb/src/Sekiban.Dcb.WithoutResult/Actors/GeneralSekibanExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.WithoutResult/Actors/GeneralSekibanExecutor.cs
@@ -1,6 +1,7 @@
 using ResultBoxes;
 using Sekiban.Dcb.Boundaries;
 using Sekiban.Dcb.Actors;
+using Sekiban.Dcb.Capabilities;
 using Sekiban.Dcb.Commands;
 using Sekiban.Dcb.Events;
 using Sekiban.Dcb.Queries;
@@ -13,9 +14,10 @@ namespace Sekiban.Dcb.Actors;
 ///     Wraps CoreGeneralSekibanExecutor and unwraps ResultBox, throwing exceptions on errors
 ///     This implementation uses exceptions for all error handling
 /// </summary>
-public class GeneralSekibanExecutor : ISekibanExecutor, ISerializedSekibanDcbExecutor
+public class GeneralSekibanExecutor : ISekibanExecutor, ISerializedSekibanDcbExecutor, IExecutorRuntimeDescriptorProvider
 {
     private readonly CoreGeneralSekibanExecutor _core;
+    private readonly IActorObjectAccessor _actorAccessor;
     private static readonly AnonymousCommand NoCommandInstance = new();
 
     public GeneralSekibanExecutor(
@@ -24,8 +26,17 @@ public class GeneralSekibanExecutor : ISekibanExecutor, ISerializedSekibanDcbExe
         DcbDomainTypes domainTypes,
         IEventPublisher? eventPublisher = null)
     {
+        _actorAccessor = actorAccessor;
         _core = new CoreGeneralSekibanExecutor(eventStore, actorAccessor, domainTypes, eventPublisher);
     }
+
+    /// <summary>
+    ///     This executor is whatever its accessor is. It has no runtime of its own — commands go wherever the accessor
+    ///     sends them — so it asks, rather than claiming. An accessor that will not say leaves this Unknown, and the
+    ///     production guard treats Unknown as unsafe, which is the only safe way to treat it.
+    /// </summary>
+    public ExecutorRuntimeDescriptor DescribeRuntime() =>
+        SekibanDcbCapabilityResolver.DescribeExecutor(_actorAccessor);
 
     /// <summary>
     ///     Execute a command with its built-in handler

--- a/dcb/src/Sekiban.Dcb.WithoutResult/Capabilities/SekibanDcbProductionGuardExtensions.cs
+++ b/dcb/src/Sekiban.Dcb.WithoutResult/Capabilities/SekibanDcbProductionGuardExtensions.cs
@@ -1,0 +1,35 @@
+using Microsoft.Extensions.DependencyInjection;
+namespace Sekiban.Dcb.Capabilities;
+
+/// <summary>
+///     The registration an application calls. It is opt-in, and nothing registers it for you.
+/// </summary>
+public static class SekibanDcbProductionGuardExtensions
+{
+    /// <summary>
+    ///     Refuses to start a Production host whose resolved executor is not a distributed runtime, or whose resolved
+    ///     stores do not durably keep what they are given.
+    ///     Call it AFTER the registrations it is meant to check — it evaluates what the container actually builds, so
+    ///     a later <c>AddSingleton&lt;ISekibanExecutor&gt;</c> that replaces the executor is still caught, but only
+    ///     because the check happens at startup rather than here.
+    ///     Outside the configured Production environments it validates nothing and only logs the banner.
+    /// </summary>
+    /// <param name="services">The application's service collection.</param>
+    /// <param name="configure">
+    ///     Optional. The only override is <c>AllowVolatileStorageInProduction</c>, and it authorises storage only —
+    ///     there is no override that permits a testing executor in Production.
+    /// </param>
+    public static IServiceCollection AddSekibanDcbProductionGuard(
+        this IServiceCollection services,
+        Action<SekibanDcbProductionGuardOptions>? configure = null) =>
+        services.AddSekibanDcbProductionGuardCore(sp => sp.GetService<ISekibanExecutor>(), configure);
+
+    /// <summary>
+    ///     Logs the startup banner — environment, executor runtime, store durability, overrides in use, and a loud
+    ///     warning when storage is volatile — and never fails the host. What local development wants.
+    /// </summary>
+    public static IServiceCollection AddSekibanDcbStartupBanner(
+        this IServiceCollection services,
+        Action<SekibanDcbProductionGuardOptions>? configure = null) =>
+        services.AddSekibanDcbStartupBannerCore(sp => sp.GetService<ISekibanExecutor>(), configure);
+}

--- a/dcb/src/Sekiban.Dcb.WithoutResult/InMemory/InMemoryDcbExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.WithoutResult/InMemory/InMemoryDcbExecutor.cs
@@ -8,6 +8,7 @@ using Sekiban.Dcb.ServiceId;
 using Sekiban.Dcb.Storage;
 using Sekiban.Dcb.Tags;
 
+using Sekiban.Dcb.Capabilities;
 namespace Sekiban.Dcb.InMemory;
 
 /// <summary>
@@ -17,8 +18,15 @@ namespace Sekiban.Dcb.InMemory;
 ///     Intended for lightweight tests / prototyping; not thread-safe for high concurrency scenarios.
 ///     Throws exceptions on errors instead of returning ResultBox.
 /// </summary>
-public class InMemoryDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecutor
+public class InMemoryDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecutor, IExecutorRuntimeDescriptorProvider
 {
+    /// <summary>
+    ///     In-process actors, this process only. A production host that resolves this executor is a production host
+    ///     running a unit-test runtime, and the production guard will not start it.
+    /// </summary>
+    public ExecutorRuntimeDescriptor DescribeRuntime() =>
+        new(ExecutorRuntimeKind.TestingInProcess, "InMemory (in-process actors)");
+
     private readonly GeneralSekibanExecutor _inner;
     private readonly InMemoryObjectAccessor _accessor;
     private readonly IEventStore _eventStore;
@@ -37,8 +45,17 @@ public class InMemoryDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecut
     }
 
     /// <summary>
-    ///     Creates executor with built-in lightweight in-memory event store (no external dependencies)
+    ///     Creates the executor with a built-in lightweight in-memory event store (no external dependencies).
+    ///     Obsolete because it is silent about the most important thing it does. A downstream production system
+    ///     registered this executor as its <c>ISekibanExecutor</c>; this constructor created a private volatile event
+    ///     store for it, and every command succeeded, and no event ever reached the database it had configured. Pass
+    ///     the store you mean to use — <c>new InMemoryDcbExecutor(domainTypes, new InMemoryEventStore())</c> in tests
+    ///     — so that the store is a decision somebody made, and can be seen in the code that made it.
     /// </summary>
+    [Obsolete(
+        "Pass the event store explicitly: new InMemoryDcbExecutor(domainTypes, new InMemoryEventStore()). This "
+        + "constructor silently creates a private VOLATILE event store, which is invisible at the call site and has "
+        + "reached production before. Behaviour is unchanged; only the silence is deprecated.")]
     public InMemoryDcbExecutor(DcbDomainTypes domainTypes)
         : this(domainTypes, new InternalInMemoryEventStore(domainTypes)) { }
 

--- a/dcb/tests/Sekiban.Dcb.ColdEvents.Tests/HybridEventStoreDurabilityDescriptorTests.cs
+++ b/dcb/tests/Sekiban.Dcb.ColdEvents.Tests/HybridEventStoreDurabilityDescriptorTests.cs
@@ -1,0 +1,95 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using ResultBoxes;
+using Sekiban.Dcb.Capabilities;
+using Sekiban.Dcb.ColdEvents;
+using Sekiban.Dcb.Common;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.InMemory;
+using Sekiban.Dcb.ServiceId;
+using Sekiban.Dcb.Storage;
+using Sekiban.Dcb.Tags;
+using Xunit;
+namespace Sekiban.Dcb.ColdEvents.Tests;
+
+/// <summary>
+///     A decorator must report where the data actually lands, not what wrapped it. This is the whole reason the
+///     descriptor is resolved from the live instance: if a wrapper could claim durability on its own authority, the
+///     guard would be checking the wrapper's opinion of itself.
+/// </summary>
+public class HybridEventStoreDurabilityDescriptorTests
+{
+    private static HybridEventStore Wrap(IEventStore hot) =>
+        new(
+            hot,
+            new InMemoryColdObjectStorage(),
+            new JsonlColdSegmentFormatHandler(),
+            new DefaultServiceIdProvider(),
+            Options.Create(new ColdEventStoreOptions { Enabled = true }),
+            NullLogger<HybridEventStore>.Instance);
+
+    [Fact]
+    public void WrappingAVolatileStore_StaysVolatile()
+    {
+        var descriptor = Wrap(new InMemoryEventStore()).DescribeStorage();
+
+        // The dangerous direction: a durable-sounding decorator over a volatile store is still data loss.
+        Assert.Equal(StorageDurability.Volatile, descriptor.Durability);
+        Assert.Equal("HybridEventStore(InMemory)", descriptor.ProviderName);
+    }
+
+    [Fact]
+    public void WrappingADurableStore_StaysDurable()
+    {
+        var descriptor = Wrap(new DescribingStore(new StorageDurabilityDescriptor(StorageDurability.Durable, "TestDurable")))
+            .DescribeStorage();
+
+        Assert.Equal(StorageDurability.Durable, descriptor.Durability);
+        Assert.Equal("HybridEventStore(TestDurable)", descriptor.ProviderName);
+    }
+
+    [Fact]
+    public void WrappingAStoreThatSaysNothing_StaysUnknown()
+    {
+        // Silence does not become durability by being wrapped. Every third-party store starts out this shape.
+        var descriptor = Wrap(new SilentStore()).DescribeStorage();
+
+        Assert.Equal(StorageDurability.Unknown, descriptor.Durability);
+        Assert.Equal("HybridEventStore(SilentStore)", descriptor.ProviderName);
+    }
+
+    /// <summary>An event store that answers the durability question however the test tells it to.</summary>
+    private sealed class DescribingStore(StorageDurabilityDescriptor descriptor)
+        : SilentStore, IStorageDurabilityDescriptorProvider
+    {
+        public StorageDurabilityDescriptor DescribeStorage() => descriptor;
+    }
+
+    /// <summary>
+    ///     An event store that does not implement the descriptor at all. None of these members are ever reached:
+    ///     describing a store does not read from it.
+    /// </summary>
+    private class SilentStore : IEventStore
+    {
+        public Task<ResultBox<IEnumerable<TagStream>>> ReadTagsAsync(ITag tag) => throw new NotSupportedException();
+        public Task<ResultBox<TagState>> GetLatestTagAsync(ITag tag) => throw new NotSupportedException();
+        public Task<ResultBox<bool>> TagExistsAsync(ITag tag) => throw new NotSupportedException();
+        public Task<ResultBox<long>> GetEventCountAsync(SortableUniqueId? since = null) =>
+            throw new NotSupportedException();
+        public Task<ResultBox<IEnumerable<TagInfo>>> GetAllTagsAsync(string? tagGroup = null) =>
+            throw new NotSupportedException();
+        public Task<ResultBox<IEnumerable<SerializableEvent>>> ReadAllSerializableEventsAsync(
+            SortableUniqueId? since = null) => throw new NotSupportedException();
+        public Task<ResultBox<IEnumerable<SerializableEvent>>> ReadAllSerializableEventsAsync(
+            SortableUniqueId? since,
+            int? maxCount) => throw new NotSupportedException();
+        public Task<ResultBox<SerializableEvent>> ReadSerializableEventAsync(Guid eventId) =>
+            throw new NotSupportedException();
+        public Task<ResultBox<IEnumerable<SerializableEvent>>> ReadSerializableEventsByTagAsync(
+            ITag tag,
+            SortableUniqueId? since = null) => throw new NotSupportedException();
+        public Task<ResultBox<(IReadOnlyList<SerializableEvent> Events, IReadOnlyList<TagWriteResult> TagWrites)>>
+            WriteSerializableEventsAsync(IEnumerable<SerializableEvent> events) => throw new NotSupportedException();
+        public Task<ResultBox<string>> GetLatestSortableUniqueIdAsync() => throw new NotSupportedException();
+    }
+}

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/Capabilities/ProductionGuardTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/Capabilities/ProductionGuardTests.cs
@@ -1,0 +1,360 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using ResultBoxes;
+using Sekiban.Dcb.Capabilities;
+using Sekiban.Dcb.Common;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.InMemory;
+using Sekiban.Dcb.MultiProjections;
+using Sekiban.Dcb.Storage;
+using Sekiban.Dcb.Tags;
+using Xunit;
+namespace Sekiban.Dcb.WithResult.Tests.Capabilities;
+
+/// <summary>
+///     The matrix that matters. A downstream production system registered an in-memory executor as its
+///     <c>ISekibanExecutor</c>; its one-argument constructor created a private volatile store; every command succeeded;
+///     no event ever reached Cosmos; and nothing at startup could tell. These tests are the "could tell".
+///     Every case builds a real host and really starts it, because the guard's entire job is to stop a host from
+///     starting — asserting on a method in isolation would prove something weaker than the claim.
+/// </summary>
+public class ProductionGuardTests
+{
+    private static IHost BuildHost(
+        string environment,
+        object? executor,
+        IEventStore? eventStore,
+        IMultiProjectionStateStore? projectionStore,
+        Action<SekibanDcbProductionGuardOptions>? configure = null,
+        bool guard = true) =>
+        new HostBuilder()
+            .UseEnvironment(environment)
+            .ConfigureServices(services =>
+            {
+                if (executor is not null)
+                {
+                    services.AddSingleton(typeof(ISekibanExecutor), executor);
+                }
+
+                if (eventStore is not null)
+                {
+                    services.AddSingleton(eventStore);
+                }
+
+                if (projectionStore is not null)
+                {
+                    services.AddSingleton(projectionStore);
+                }
+
+                if (guard)
+                {
+                    services.AddSekibanDcbProductionGuard(configure);
+                }
+                else
+                {
+                    services.AddSekibanDcbStartupBanner(configure);
+                }
+            })
+            .Build();
+
+    private static async Task<SekibanDcbProductionGuardException> AssertRefusesToStart(IHost host)
+    {
+        var thrown = await Assert.ThrowsAsync<SekibanDcbProductionGuardException>(() => host.StartAsync());
+        await host.StopAsync();
+        return thrown;
+    }
+
+    private static async Task AssertStarts(IHost host)
+    {
+        await host.StartAsync();
+        await host.StopAsync();
+    }
+
+    [Fact]
+    public async Task Production_DistributedExecutor_DurableStores_Starts()
+    {
+        using var host = BuildHost(
+            Environments.Production,
+            new FakeExecutor(ExecutorRuntimeKind.DistributedRuntime, "Orleans"),
+            new FakeEventStore(StorageDurability.Durable, "Postgres"),
+            new FakeProjectionStore(StorageDurability.Durable, "Postgres"));
+
+        await AssertStarts(host);
+    }
+
+    [Fact]
+    public async Task Production_DistributedExecutor_VolatileStore_RefusesToStart()
+    {
+        using var host = BuildHost(
+            Environments.Production,
+            new FakeExecutor(ExecutorRuntimeKind.DistributedRuntime, "Orleans"),
+            new InMemoryEventStore(),
+            new InMemoryMultiProjectionStateStore());
+
+        var thrown = await AssertRefusesToStart(host);
+
+        Assert.Contains("storage is not durable", thrown.Message);
+        Assert.Equal(StorageDurability.Volatile, thrown.Report.EventStore.Durability);
+    }
+
+    [Fact]
+    public async Task Production_DistributedExecutor_VolatileStore_WithStorageOverride_Starts()
+    {
+        using var host = BuildHost(
+            Environments.Production,
+            new FakeExecutor(ExecutorRuntimeKind.DistributedRuntime, "Orleans"),
+            new InMemoryEventStore(),
+            new InMemoryMultiProjectionStateStore(),
+            options => options.AllowVolatileStorageInProduction = true);
+
+        // An operator may decide their storage is disposable. They may not decide their executor is a test double.
+        await AssertStarts(host);
+    }
+
+    [Fact]
+    public async Task Production_TestingExecutor_DurableStores_RefusesToStart()
+    {
+        // Durable storage does not redeem a testing executor: in-process actors mean no cluster coordination, whatever
+        // the events are being written to.
+        using var host = BuildHost(
+            Environments.Production,
+            new FakeExecutor(ExecutorRuntimeKind.TestingInProcess, "InMemory (in-process actors)"),
+            new FakeEventStore(StorageDurability.Durable, "Postgres"),
+            new FakeProjectionStore(StorageDurability.Durable, "Postgres"));
+
+        var thrown = await AssertRefusesToStart(host);
+
+        Assert.Contains("Production requires a distributed runtime", thrown.Message);
+    }
+
+    [Fact]
+    public async Task Production_TestingExecutor_VolatileStore_RefusesToStart()
+    {
+        // The incident, reproduced: the executor and the store are both test-shaped, and the host must not come up.
+        using var host = BuildHost(
+            Environments.Production,
+            new FakeExecutor(ExecutorRuntimeKind.TestingInProcess, "InMemory (in-process actors)"),
+            new InMemoryEventStore(),
+            new InMemoryMultiProjectionStateStore());
+
+        var thrown = await AssertRefusesToStart(host);
+
+        Assert.Contains("Production requires a distributed runtime", thrown.Message);
+        Assert.Contains("storage is not durable", thrown.Message);
+    }
+
+    /// <summary>
+    ///     The override-separation proof the whole design turns on. Storage is authorised; the executor is not; the
+    ///     host still does not start. If this ever passes, the one override we ship has quietly become the override we
+    ///     refused to ship.
+    /// </summary>
+    [Fact]
+    public async Task Production_TestingExecutor_StorageOverride_StillRefusesToStart()
+    {
+        using var host = BuildHost(
+            Environments.Production,
+            new FakeExecutor(ExecutorRuntimeKind.TestingInProcess, "InMemory (in-process actors)"),
+            new InMemoryEventStore(),
+            new InMemoryMultiProjectionStateStore(),
+            options => options.AllowVolatileStorageInProduction = true);
+
+        var thrown = await AssertRefusesToStart(host);
+
+        Assert.Contains("Production requires a distributed runtime", thrown.Message);
+        Assert.Contains("There is no override for this", thrown.Message);
+
+        // The storage complaint is gone — the override did exactly, and only, what it says.
+        Assert.DoesNotContain("storage is not durable", thrown.Message);
+    }
+
+    [Fact]
+    public async Task Production_UnknownExecutorAndUnknownStore_RefusesToStart()
+    {
+        // Silence is not a promise. A store and an executor that decline to describe themselves fail closed.
+        using var host = BuildHost(
+            Environments.Production,
+            new SilentExecutor(),
+            new FakeEventStore(null, "third-party"),
+            new FakeProjectionStore(null, "third-party"));
+
+        var thrown = await AssertRefusesToStart(host);
+
+        Assert.Equal(ExecutorRuntimeKind.Unknown, thrown.Report.Executor.Runtime);
+        Assert.Equal(StorageDurability.Unknown, thrown.Report.EventStore.Durability);
+    }
+
+    [Fact]
+    public async Task Production_NothingRegisteredAtAll_RefusesToStart()
+    {
+        using var host = BuildHost(Environments.Production, null, null, null);
+
+        var thrown = await AssertRefusesToStart(host);
+
+        Assert.Contains("(no ISekibanExecutor registered)", thrown.Report.Executor.RuntimeName);
+    }
+
+    [Fact]
+    public async Task Development_TestingExecutorAndVolatileStore_StartsUnchanged()
+    {
+        // The everyday local setup. The guard warns in the banner and gets out of the way.
+        using var host = BuildHost(
+            Environments.Development,
+            new FakeExecutor(ExecutorRuntimeKind.TestingInProcess, "InMemory (in-process actors)"),
+            new InMemoryEventStore(),
+            new InMemoryMultiProjectionStateStore());
+
+        await AssertStarts(host);
+    }
+
+    [Fact]
+    public async Task BannerOnly_InProduction_NeverFailsTheHost()
+    {
+        // AddSekibanDcbStartupBanner reports; it does not enforce. Opting into the guard is a separate act.
+        using var host = BuildHost(
+            Environments.Production,
+            new FakeExecutor(ExecutorRuntimeKind.TestingInProcess, "InMemory"),
+            new InMemoryEventStore(),
+            new InMemoryMultiProjectionStateStore(),
+            guard: false);
+
+        await AssertStarts(host);
+    }
+
+    [Fact]
+    public async Task AnEnvironmentTheOperatorCallsProduction_IsGuardedToo()
+    {
+        // Plenty of real production runs under a name ASP.NET Core does not consider Production.
+        using var host = BuildHost(
+            "prod-eu",
+            new FakeExecutor(ExecutorRuntimeKind.TestingInProcess, "InMemory"),
+            new FakeEventStore(StorageDurability.Durable, "Postgres"),
+            new FakeProjectionStore(StorageDurability.Durable, "Postgres"),
+            options => options.ProductionEnvironmentNames.Add("prod-eu"));
+
+        await AssertRefusesToStart(host);
+    }
+
+    [Fact]
+    public void NoOverrideExistsForATestingExecutor()
+    {
+        // Not "off by default" — absent. Anything named like an executor escape hatch is a bug in this PR.
+        var escapeHatches = typeof(SekibanDcbProductionGuardOptions)
+            .GetProperties()
+            .Select(p => p.Name)
+            .Where(name => name.Contains("Executor", StringComparison.OrdinalIgnoreCase)
+                || name.Contains("Testing", StringComparison.OrdinalIgnoreCase)
+                || name.Contains("InMemory", StringComparison.OrdinalIgnoreCase))
+            .ToArray();
+
+        Assert.Empty(escapeHatches);
+    }
+
+    [Fact]
+    public async Task TheGuardEvaluatesWhatWasRESOLVED_NotWhatWasRegisteredFirst()
+    {
+        // The failure mode in the field: a perfectly good registration, then something later replaces it. Reading the
+        // IServiceCollection would see Postgres here. Resolving sees what the container will actually hand out.
+        using var host = new HostBuilder()
+            .UseEnvironment(Environments.Production)
+            .ConfigureServices(services =>
+            {
+                services.AddSingleton<ISekibanExecutor>(
+                    new FakeExecutor(ExecutorRuntimeKind.DistributedRuntime, "Orleans"));
+                services.AddSingleton<IEventStore>(new FakeEventStore(StorageDurability.Durable, "Postgres"));
+                services.AddSingleton<IMultiProjectionStateStore>(
+                    new FakeProjectionStore(StorageDurability.Durable, "Postgres"));
+
+                services.AddSekibanDcbProductionGuard();
+
+                // ...and now someone "just for a moment" swaps the store. Last registration wins in DI.
+                services.AddSingleton<IEventStore>(new InMemoryEventStore());
+            })
+            .Build();
+
+        var thrown = await AssertRefusesToStart(host);
+
+        Assert.Equal(StorageDurability.Volatile, thrown.Report.EventStore.Durability);
+    }
+
+    private sealed class FakeExecutor(ExecutorRuntimeKind runtime, string name)
+        : StubExecutor, IExecutorRuntimeDescriptorProvider
+    {
+        public ExecutorRuntimeDescriptor DescribeRuntime() => new(runtime, name);
+    }
+
+    /// <summary>An executor that declines to describe itself — every third-party executor, until it opts in.</summary>
+    private sealed class SilentExecutor : StubExecutor;
+
+    private sealed class FakeEventStore(StorageDurability? durability, string provider)
+        : SilentEventStore, IStorageDurabilityDescriptorProvider
+    {
+        public StorageDurabilityDescriptor DescribeStorage() =>
+            durability is null
+                ? StorageDurabilityDescriptor.Unknown(provider)
+                : new StorageDurabilityDescriptor(durability.Value, provider);
+    }
+
+    private sealed class FakeProjectionStore(StorageDurability? durability, string provider)
+        : SilentProjectionStore, IStorageDurabilityDescriptorProvider
+    {
+        public StorageDurabilityDescriptor DescribeStorage() =>
+            durability is null
+                ? StorageDurabilityDescriptor.Unknown(provider)
+                : new StorageDurabilityDescriptor(durability.Value, provider);
+    }
+
+    /// <summary>Same idea as SilentEventStore, for the projection state store.</summary>
+    private class SilentProjectionStore : IMultiProjectionStateStore
+    {
+        public Task<ResultBox<OptionalValue<MultiProjectionStateRecord>>> GetLatestForVersionAsync(
+            string projectorName,
+            string projectorVersion,
+            CancellationToken cancellationToken = default) => throw new NotSupportedException();
+
+        public Task<ResultBox<OptionalValue<MultiProjectionStateRecord>>> GetLatestAnyVersionAsync(
+            string projectorName,
+            CancellationToken cancellationToken = default) => throw new NotSupportedException();
+
+        public Task<ResultBox<bool>> UpsertAsync(
+            MultiProjectionStateRecord record,
+            int offloadThresholdBytes = 1_000_000,
+            CancellationToken cancellationToken = default) => throw new NotSupportedException();
+
+        public Task<ResultBox<IReadOnlyList<ProjectorStateInfo>>> ListAllAsync(
+            CancellationToken cancellationToken = default) => throw new NotSupportedException();
+
+        public Task<ResultBox<bool>> DeleteAsync(
+            string projectorName,
+            string projectorVersion,
+            CancellationToken cancellationToken = default) => throw new NotSupportedException();
+
+        public Task<ResultBox<int>> DeleteAllAsync(
+            string? projectorName = null,
+            CancellationToken cancellationToken = default) => throw new NotSupportedException();
+    }
+
+    /// <summary>None of these members run: the guard describes what it resolved, it does not use it.</summary>
+    private class SilentEventStore : IEventStore
+    {
+        public Task<ResultBox<IEnumerable<TagStream>>> ReadTagsAsync(ITag tag) => throw new NotSupportedException();
+        public Task<ResultBox<TagState>> GetLatestTagAsync(ITag tag) => throw new NotSupportedException();
+        public Task<ResultBox<bool>> TagExistsAsync(ITag tag) => throw new NotSupportedException();
+        public Task<ResultBox<long>> GetEventCountAsync(SortableUniqueId? since = null) =>
+            throw new NotSupportedException();
+        public Task<ResultBox<IEnumerable<TagInfo>>> GetAllTagsAsync(string? tagGroup = null) =>
+            throw new NotSupportedException();
+        public Task<ResultBox<IEnumerable<SerializableEvent>>> ReadAllSerializableEventsAsync(
+            SortableUniqueId? since = null) => throw new NotSupportedException();
+        public Task<ResultBox<IEnumerable<SerializableEvent>>> ReadAllSerializableEventsAsync(
+            SortableUniqueId? since,
+            int? maxCount) => throw new NotSupportedException();
+        public Task<ResultBox<SerializableEvent>> ReadSerializableEventAsync(Guid eventId) =>
+            throw new NotSupportedException();
+        public Task<ResultBox<IEnumerable<SerializableEvent>>> ReadSerializableEventsByTagAsync(
+            ITag tag,
+            SortableUniqueId? since = null) => throw new NotSupportedException();
+        public Task<ResultBox<(IReadOnlyList<SerializableEvent> Events, IReadOnlyList<TagWriteResult> TagWrites)>>
+            WriteSerializableEventsAsync(IEnumerable<SerializableEvent> events) => throw new NotSupportedException();
+        public Task<ResultBox<string>> GetLatestSortableUniqueIdAsync() => throw new NotSupportedException();
+    }
+}

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/Capabilities/ProductionGuardTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/Capabilities/ProductionGuardTests.cs
@@ -93,7 +93,7 @@ public class ProductionGuardTests
 
         var thrown = await AssertRefusesToStart(host);
 
-        Assert.Contains("storage is not durable", thrown.Message);
+        Assert.Contains("storage is volatile", thrown.Message);
         Assert.Equal(StorageDurability.Volatile, thrown.Report.EventStore.Durability);
     }
 
@@ -140,7 +140,7 @@ public class ProductionGuardTests
         var thrown = await AssertRefusesToStart(host);
 
         Assert.Contains("Production requires a distributed runtime", thrown.Message);
-        Assert.Contains("storage is not durable", thrown.Message);
+        Assert.Contains("storage is volatile", thrown.Message);
     }
 
     /// <summary>
@@ -164,7 +164,99 @@ public class ProductionGuardTests
         Assert.Contains("There is no override for this", thrown.Message);
 
         // The storage complaint is gone — the override did exactly, and only, what it says.
-        Assert.DoesNotContain("storage is not durable", thrown.Message);
+        Assert.DoesNotContain("storage is volatile", thrown.Message);
+    }
+
+    /// <summary>
+    ///     The gap the review found, and it was a real one: Volatile and Unknown were one condition, so the
+    ///     volatile-only override silently authorised an unidentified store too. They are different claims. "Volatile"
+    ///     is a store telling you it loses data, and an operator can look at that and say they meant it. "Unknown" is a
+    ///     store telling you nothing — there is nothing there for an operator to have meant.
+    /// </summary>
+    [Fact]
+    public async Task Production_UnknownStorage_WithVolatileOverride_StillRefusesToStart()
+    {
+        using var host = BuildHost(
+            Environments.Production,
+            new FakeExecutor(ExecutorRuntimeKind.DistributedRuntime, "Orleans"),
+            new FakeEventStore(null, "third-party"),
+            new FakeProjectionStore(StorageDurability.Durable, "Postgres"),
+            options => options.AllowVolatileStorageInProduction = true);
+
+        var thrown = await AssertRefusesToStart(host);
+
+        Assert.Contains("would not identify itself", thrown.Message);
+        Assert.Contains("does not authorise this", thrown.Message);
+        Assert.Equal(StorageDurability.Unknown, thrown.Report.EventStore.Durability);
+    }
+
+    [Fact]
+    public async Task Production_VolatileStorage_WithVolatileOverride_Starts_ButOnlyBecauseTheStoreSaidVolatile()
+    {
+        // The pair to the test above: same override, same environment, and the only difference is that this store
+        // answered the question. That difference is the whole point of the override.
+        using var host = BuildHost(
+            Environments.Production,
+            new FakeExecutor(ExecutorRuntimeKind.DistributedRuntime, "Orleans"),
+            new FakeEventStore(StorageDurability.Volatile, "InMemory"),
+            new FakeProjectionStore(StorageDurability.Volatile, "InMemory"),
+            options => options.AllowVolatileStorageInProduction = true);
+
+        await AssertStarts(host);
+    }
+
+    /// <summary>
+    ///     Sekiban's own Cosmos registrations are scoped. A hosted service holds the ROOT provider, and asking the root
+    ///     provider for a scoped service throws under ValidateScopes — so before this fix, opting into the guard broke
+    ///     a supported composition outright, in Development too, which is the opposite of "zero behaviour change".
+    ///     ValidateScopes is on here precisely so this test fails if the guard ever resolves from the root again.
+    /// </summary>
+    [Fact]
+    public async Task AScopedComposition_IsResolvedInsideAScope_NotFromTheRootProvider()
+    {
+        using var host = new HostBuilder()
+            .UseEnvironment(Environments.Production)
+            .UseDefaultServiceProvider(options =>
+            {
+                options.ValidateScopes = true;
+                options.ValidateOnBuild = true;
+            })
+            .ConfigureServices(services =>
+            {
+                services.AddScoped<ISekibanExecutor>(
+                    _ => new FakeExecutor(ExecutorRuntimeKind.DistributedRuntime, "Orleans"));
+                services.AddScoped<IEventStore>(_ => new FakeEventStore(StorageDurability.Durable, "CosmosDb"));
+                services.AddScoped<IMultiProjectionStateStore>(
+                    _ => new FakeProjectionStore(StorageDurability.Durable, "CosmosDb"));
+                services.AddSekibanDcbProductionGuard();
+            })
+            .Build();
+
+        // The failure this guards against is not a refusal — it is an InvalidOperationException from the container
+        // before the guard can report anything at all.
+        await AssertStarts(host);
+    }
+
+    [Fact]
+    public async Task AScopedVolatileComposition_IsStillCaught()
+    {
+        // ...and resolving in a scope must not become a way to smuggle a volatile store past the guard.
+        using var host = new HostBuilder()
+            .UseEnvironment(Environments.Production)
+            .UseDefaultServiceProvider(options => options.ValidateScopes = true)
+            .ConfigureServices(services =>
+            {
+                services.AddScoped<ISekibanExecutor>(
+                    _ => new FakeExecutor(ExecutorRuntimeKind.DistributedRuntime, "Orleans"));
+                services.AddScoped<IEventStore>(_ => new InMemoryEventStore());
+                services.AddScoped<IMultiProjectionStateStore>(_ => new InMemoryMultiProjectionStateStore());
+                services.AddSekibanDcbProductionGuard();
+            })
+            .Build();
+
+        var thrown = await AssertRefusesToStart(host);
+
+        Assert.Equal(StorageDurability.Volatile, thrown.Report.EventStore.Durability);
     }
 
     [Fact]

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/Capabilities/SqliteDurabilityDescriptorTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/Capabilities/SqliteDurabilityDescriptorTests.cs
@@ -1,0 +1,38 @@
+using Dcb.Domain;
+using Sekiban.Dcb.Capabilities;
+using Sekiban.Dcb.Sqlite;
+using Xunit;
+namespace Sekiban.Dcb.WithResult.Tests.Capabilities;
+
+/// <summary>
+///     Sqlite is the case that settles the design argument. The same class, with the same name, is durable when it is a
+///     file and volatile when it is <c>:memory:</c> — so a descriptor derived from the type name, or an attribute, or
+///     the registration method that was called, would be wrong half the time. Only the live instance knows which one it
+///     got, which is why the guard asks the live instance.
+/// </summary>
+public class SqliteDurabilityDescriptorTests
+{
+    private static SqliteEventStore Store(string databasePath) =>
+        new(databasePath, DomainType.GetDomainTypes().EventTypes);
+
+    [Fact]
+    public void AFileBackedSqliteStore_IsDurable()
+    {
+        var descriptor = Store(Path.Combine(Path.GetTempPath(), $"sekiban-dcb-{Guid.NewGuid():N}.db")).DescribeStorage();
+
+        Assert.Equal(StorageDurability.Durable, descriptor.Durability);
+        Assert.Equal("Sqlite", descriptor.ProviderName);
+    }
+
+    [Theory]
+    [InlineData(":memory:")]
+    [InlineData("file:test?mode=memory&cache=shared")]
+    public void AnInMemorySqliteStore_IsVolatile_DespiteBeingCalledSqlite(string databasePath)
+    {
+        var descriptor = Store(databasePath).DescribeStorage();
+
+        // A production host pointed at an in-memory Sqlite is exactly the incident again, wearing a durable name.
+        Assert.Equal(StorageDurability.Volatile, descriptor.Durability);
+        Assert.Equal("Sqlite (in-memory)", descriptor.ProviderName);
+    }
+}

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/Capabilities/StubExecutor.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/Capabilities/StubExecutor.cs
@@ -1,0 +1,46 @@
+using ResultBoxes;
+using Sekiban.Dcb.Commands;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.MultiProjections;
+using Sekiban.Dcb.Queries;
+using Sekiban.Dcb.Tags;
+namespace Sekiban.Dcb.WithResult.Tests.Capabilities;
+
+/// <summary>
+///     An executor that executes nothing. The guard describes what it resolved; it never calls it — and this stub is
+///     how that claim is kept honest: if the guard ever did call one of these, the test would blow up rather than
+///     quietly pass.
+/// </summary>
+public class StubExecutor : ISekibanExecutor
+{
+    public Task<ResultBox<ExecutionResult>> ExecuteAsync<TCommand>(
+        TCommand command,
+        Func<TCommand, ICommandContext, Task<ResultBox<EventOrNone>>> handlerFunc,
+        CancellationToken cancellationToken = default) where TCommand : ICommand => throw new NotSupportedException();
+
+    public Task<ResultBox<ExecutionResult>> ExecuteCommandAsync(
+        Func<ICommandContext, Task<ResultBox<EventOrNone>>> handlerFunc,
+        CancellationToken cancellationToken = default) => throw new NotSupportedException();
+
+    public Task<ResultBox<ExecutionResult>> ExecuteAsync<TCommand>(
+        TCommand command,
+        CancellationToken cancellationToken = default) where TCommand : ICommandWithHandler<TCommand> =>
+        throw new NotSupportedException();
+
+    public Task<ResultBox<TagState>> GetTagStateAsync(TagStateId tagStateId) => throw new NotSupportedException();
+
+    public Task<ResultBox<TResult>> QueryAsync<TResult>(IQueryCommon<TResult> queryCommon) where TResult : notnull =>
+        throw new NotSupportedException();
+
+    public Task<ResultBox<ListQueryResult<TResult>>> QueryAsync<TResult>(IListQueryCommon<TResult> queryCommon)
+        where TResult : notnull => throw new NotSupportedException();
+
+    public Task<ResultBox<string>> GetLatestSortableUniqueIdAsync() => throw new NotSupportedException();
+
+    public Task<ResultBox<ProjectionHeadStatus>> GetProjectionHeadStatusAsync(
+        string projectorName,
+        string? expectedProjectorVersion = null) => throw new NotSupportedException();
+
+    public Task<ResultBox<EventStoreHeadStatus>> GetEventStoreHeadStatusAsync(bool includeTotalEventCount = false) =>
+        throw new NotSupportedException();
+}

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/ExecuteCommandAsyncTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/ExecuteCommandAsyncTests.cs
@@ -11,7 +11,7 @@ namespace Sekiban.Dcb.Tests;
 
 public class ExecuteCommandAsyncTests
 {
-    private readonly ISekibanExecutor _executor = new InMemoryDcbExecutor(DomainType.GetDomainTypes());
+    private readonly ISekibanExecutor _executor = new InMemoryDcbExecutor(DomainType.GetDomainTypes(), new Sekiban.Dcb.InMemory.InMemoryEventStore(DomainType.GetDomainTypes().EventTypes));
 
     [Fact]
     public async Task ExecuteCommandAsync_NoEvent_ReturnsEmptyExecutionResult()

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/GetLatestSortableUniqueIdTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/GetLatestSortableUniqueIdTests.cs
@@ -14,7 +14,7 @@ public class GetLatestSortableUniqueIdTests
     public async Task NoEvents_Should_Return_EmptyString()
     {
         var domain = DomainType.GetDomainTypes();
-        ISekibanExecutor executor = new InMemoryDcbExecutor(domain);
+        ISekibanExecutor executor = new InMemoryDcbExecutor(domain, new Sekiban.Dcb.InMemory.InMemoryEventStore(domain.EventTypes));
 
         var result = await executor.GetLatestSortableUniqueIdAsync();
 
@@ -26,7 +26,7 @@ public class GetLatestSortableUniqueIdTests
     public async Task AfterSingleCommand_Should_Return_CommandSortableUniqueId()
     {
         var domain = DomainType.GetDomainTypes();
-        ISekibanExecutor executor = new InMemoryDcbExecutor(domain);
+        ISekibanExecutor executor = new InMemoryDcbExecutor(domain, new Sekiban.Dcb.InMemory.InMemoryEventStore(domain.EventTypes));
 
         var commandResult = await executor.ExecuteAsync(new CreateStudent(Guid.NewGuid(), "Test Student", 5));
         Assert.True(commandResult.IsSuccess);
@@ -48,7 +48,7 @@ public class GetLatestSortableUniqueIdTests
     public async Task AfterMultipleCommands_Should_Return_Latest()
     {
         var domain = DomainType.GetDomainTypes();
-        ISekibanExecutor executor = new InMemoryDcbExecutor(domain);
+        ISekibanExecutor executor = new InMemoryDcbExecutor(domain, new Sekiban.Dcb.InMemory.InMemoryEventStore(domain.EventTypes));
 
         var result1 = await executor.ExecuteAsync(new CreateStudent(Guid.NewGuid(), "Student One", 3));
         Assert.True(result1.IsSuccess);

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/InMemoryDcbExecutorIntegrationTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/InMemoryDcbExecutorIntegrationTests.cs
@@ -24,7 +24,7 @@ public class InMemoryDcbExecutorIntegrationTests
     public async Task CreateStudent_Then_QueryStudentList_Should_Return_Student()
     {
         var domain = DomainType.GetDomainTypes();
-        ISekibanExecutor executor = new InMemoryDcbExecutor(domain);
+        ISekibanExecutor executor = new InMemoryDcbExecutor(domain, new Sekiban.Dcb.InMemory.InMemoryEventStore(domain.EventTypes));
 
         var studentId = Guid.NewGuid();
         var name = "Integration Test Student";
@@ -49,7 +49,7 @@ public class InMemoryDcbExecutorIntegrationTests
     public async Task CreateStudent_Command_Should_Populate_TagState()
     {
         var domain = DomainType.GetDomainTypes();
-        ISekibanExecutor executor = new InMemoryDcbExecutor(domain);
+        ISekibanExecutor executor = new InMemoryDcbExecutor(domain, new Sekiban.Dcb.InMemory.InMemoryEventStore(domain.EventTypes));
 
         var studentId = Guid.NewGuid();
         var name = "Integration TagState Student";
@@ -90,7 +90,7 @@ public class InMemoryDcbExecutorIntegrationTests
             types.TagTypes.RegisterTagGroupType<StudentTag>();
         });
 
-        ISekibanExecutor executor = new InMemoryDcbExecutor(domainTypes);
+        ISekibanExecutor executor = new InMemoryDcbExecutor(domainTypes, new Sekiban.Dcb.InMemory.InMemoryEventStore(domainTypes.EventTypes));
 
         var studentId = Guid.NewGuid();
         var command = new CreateStudent(studentId, "Test Student", 5);
@@ -110,7 +110,7 @@ public class InMemoryDcbExecutorIntegrationTests
     public async Task MultiProjection_Should_Include_AllStudents_AfterMultipleCommands()
     {
         var domain = DomainType.GetDomainTypes();
-        ISekibanExecutor executor = new InMemoryDcbExecutor(domain);
+        ISekibanExecutor executor = new InMemoryDcbExecutor(domain, new Sekiban.Dcb.InMemory.InMemoryEventStore(domain.EventTypes));
 
         var studentId1 = Guid.NewGuid();
         var studentId2 = Guid.NewGuid();

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/ProjectionHeadStatusTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/ProjectionHeadStatusTests.cs
@@ -12,7 +12,7 @@ public class ProjectionHeadStatusTests
     public async Task InMemoryExecutor_ShouldReturnProjectionHeadStatus_ForRegisteredProjector()
     {
         var domain = DomainType.GetDomainTypes();
-        ISekibanExecutor executor = new InMemoryDcbExecutor(domain);
+        ISekibanExecutor executor = new InMemoryDcbExecutor(domain, new Sekiban.Dcb.InMemory.InMemoryEventStore(domain.EventTypes));
         var studentId = Guid.NewGuid();
 
         var executionResult = await executor.ExecuteAsync(new CreateStudent(studentId, "Projection Status", 4));
@@ -48,7 +48,7 @@ public class ProjectionHeadStatusTests
     public async Task InMemoryExecutor_ShouldReturnEventStoreHeadStatus_WithOptInCount()
     {
         var domain = DomainType.GetDomainTypes();
-        ISekibanExecutor executor = new InMemoryDcbExecutor(domain);
+        ISekibanExecutor executor = new InMemoryDcbExecutor(domain, new Sekiban.Dcb.InMemory.InMemoryEventStore(domain.EventTypes));
 
         await executor.ExecuteAsync(new CreateStudent(Guid.NewGuid(), "One", 3));
         await executor.ExecuteAsync(new CreateStudent(Guid.NewGuid(), "Two", 5));

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/Sekiban.Dcb.WithResult.Tests.csproj
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/Sekiban.Dcb.WithResult.Tests.csproj
@@ -13,6 +13,7 @@
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.3" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.3" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
         <PackageReference Include="xunit" Version="2.9.3" />
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/SerializedCommitTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/SerializedCommitTests.cs
@@ -20,7 +20,7 @@ public class SerializedCommitTests
 
     private ISerializedSekibanDcbExecutor CreateExecutor()
     {
-        return (ISerializedSekibanDcbExecutor)new InMemoryDcbExecutor(_domainTypes);
+        return (ISerializedSekibanDcbExecutor)new InMemoryDcbExecutor(_domainTypes, new Sekiban.Dcb.InMemory.InMemoryEventStore(_domainTypes.EventTypes));
     }
 
     private static byte[] SerializePayload<T>(T payload)
@@ -284,7 +284,7 @@ public class SerializedCommitTests
     public async Task InMemoryDcbExecutor_Implements_ISerializedSekibanDcbExecutor()
     {
         // Given
-        var executor = new InMemoryDcbExecutor(_domainTypes);
+        var executor = new InMemoryDcbExecutor(_domainTypes, new Sekiban.Dcb.InMemory.InMemoryEventStore(_domainTypes.EventTypes));
 
         // Then
         Assert.IsAssignableFrom<ISerializedSekibanDcbExecutor>(executor);

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/TagReservationHelperTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/TagReservationHelperTests.cs
@@ -44,7 +44,7 @@ public class TagReservationHelperTests
     public async Task RequestReservationAsync_Should_Fail_With_Stale_SortableId()
     {
         // Given: commit an event via InMemoryDcbExecutor to establish real state
-        var executor = new InMemoryDcbExecutor(_domainTypes);
+        var executor = new InMemoryDcbExecutor(_domainTypes, new Sekiban.Dcb.InMemory.InMemoryEventStore(_domainTypes.EventTypes));
         var sekibanExecutor = (ISekibanExecutor)executor;
         var studentId = Guid.NewGuid();
         var tag = new ConsistencyTag(new StudentTag(studentId));

--- a/dcb/tests/Sekiban.Dcb.WithoutResult.Tests/Boundaries/ExecutorBoundaryTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithoutResult.Tests/Boundaries/ExecutorBoundaryTests.cs
@@ -14,7 +14,7 @@ namespace Sekiban.Dcb.WithoutResult.Tests.Boundaries;
 /// </summary>
 public class ExecutorBoundaryTests
 {
-    private readonly ISekibanExecutor _executor = new InMemoryDcbExecutor(DomainType.GetDomainTypes());
+    private readonly ISekibanExecutor _executor = new InMemoryDcbExecutor(DomainType.GetDomainTypes(), new InMemoryEventStore(DomainType.GetDomainTypes().EventTypes));
 
     [Fact]
     public async Task ExecuteAsync_ValidationFailure_StaysAValidationException_AndNamesTheCommand()

--- a/dcb/tests/Sekiban.Dcb.WithoutResult.Tests/Boundaries/StructQueryBoundaryTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithoutResult.Tests/Boundaries/StructQueryBoundaryTests.cs
@@ -14,7 +14,7 @@ namespace Sekiban.Dcb.WithoutResult.Tests.Boundaries;
 /// </summary>
 public class StructQueryBoundaryTests
 {
-    private readonly ISekibanExecutor _executor = new InMemoryDcbExecutor(DomainType.GetDomainTypes());
+    private readonly ISekibanExecutor _executor = new InMemoryDcbExecutor(DomainType.GetDomainTypes(), new InMemoryEventStore(DomainType.GetDomainTypes().EventTypes));
 
     [Fact]
     public async Task FailedStructQuery_Throws_InsteadOfAnsweringZero()

--- a/dcb/tests/Sekiban.Dcb.WithoutResult.Tests/Capabilities/InMemoryExecutorCapabilityTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithoutResult.Tests/Capabilities/InMemoryExecutorCapabilityTests.cs
@@ -1,0 +1,83 @@
+using Dcb.Domain.WithoutResult;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Sekiban.Dcb.Capabilities;
+using Sekiban.Dcb.InMemory;
+using Sekiban.Dcb.Storage;
+using Xunit;
+namespace Sekiban.Dcb.WithoutResult.Tests.Capabilities;
+
+/// <summary>
+///     The real executor, not a fake of it: the thing that actually reached production says what it actually is, and
+///     the WithoutResult registration of the guard actually stops it.
+/// </summary>
+public class InMemoryExecutorCapabilityTests
+{
+    [Fact]
+    public void TheRealInMemoryExecutor_DeclaresItselfTestingInProcess()
+    {
+        var executor = new InMemoryDcbExecutor(DomainType.GetDomainTypes(), new InMemoryEventStore(DomainType.GetDomainTypes().EventTypes));
+
+        var runtime = ((IExecutorRuntimeDescriptorProvider)executor).DescribeRuntime();
+
+        Assert.Equal(ExecutorRuntimeKind.TestingInProcess, runtime.Runtime);
+    }
+
+    [Fact]
+    public void TheRealInMemoryEventStore_DeclaresItselfVolatile()
+    {
+        var storage = new InMemoryEventStore().DescribeStorage();
+
+        Assert.Equal(StorageDurability.Volatile, storage.Durability);
+        Assert.Equal("InMemory", storage.ProviderName);
+    }
+
+    [Fact]
+    public async Task TheIncident_ReproducedExactly_TheHostNoLongerStarts()
+    {
+        // What the downstream system did: register the in-memory executor as ISekibanExecutor in a Production host,
+        // with a store it never looked at. Every command used to succeed and nothing reached the database.
+        var eventStore = new InMemoryEventStore();
+
+        using var host = new HostBuilder()
+            .UseEnvironment(Environments.Production)
+            .ConfigureServices(services =>
+            {
+                services.AddSingleton<IEventStore>(eventStore);
+                services.AddSingleton<IMultiProjectionStateStore>(new InMemoryMultiProjectionStateStore());
+                services.AddSingleton<ISekibanExecutor>(
+                    new InMemoryDcbExecutor(DomainType.GetDomainTypes(), eventStore));
+                services.AddSekibanDcbProductionGuard();
+            })
+            .Build();
+
+        var thrown =
+            await Assert.ThrowsAsync<SekibanDcbProductionGuardException>(() => host.StartAsync());
+        await host.StopAsync();
+
+        Assert.Equal(ExecutorRuntimeKind.TestingInProcess, thrown.Report.Executor.Runtime);
+        Assert.Equal(StorageDurability.Volatile, thrown.Report.EventStore.Durability);
+        Assert.Contains("Production requires a distributed runtime", thrown.Message);
+    }
+
+    [Fact]
+    public async Task TheSameCompositionInDevelopment_StillStarts()
+    {
+        // Zero default behaviour change is the point: this is what every test and every local run does.
+        var eventStore = new InMemoryEventStore();
+
+        using var host = new HostBuilder()
+            .UseEnvironment(Environments.Development)
+            .ConfigureServices(services =>
+            {
+                services.AddSingleton<IEventStore>(eventStore);
+                services.AddSingleton<ISekibanExecutor>(
+                    new InMemoryDcbExecutor(DomainType.GetDomainTypes(), eventStore));
+                services.AddSekibanDcbProductionGuard();
+            })
+            .Build();
+
+        await host.StartAsync();
+        await host.StopAsync();
+    }
+}

--- a/dcb/tests/Sekiban.Dcb.WithoutResult.Tests/Capabilities/InMemoryExecutorCapabilityTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithoutResult.Tests/Capabilities/InMemoryExecutorCapabilityTests.cs
@@ -1,4 +1,5 @@
 using Dcb.Domain.WithoutResult;
+using Dcb.Domain.WithoutResult.Student;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Sekiban.Dcb.Capabilities;
@@ -61,23 +62,36 @@ public class InMemoryExecutorCapabilityTests
     }
 
     [Fact]
-    public async Task TheSameCompositionInDevelopment_StillStarts()
+    public async Task TheSameCompositionInDevelopment_StillStarts_AndStillWorks()
     {
-        // Zero default behaviour change is the point: this is what every test and every local run does.
-        var eventStore = new InMemoryEventStore();
+        // Zero default behaviour change is the point: this is what every test and every local run does. "It started"
+        // is too weak a claim to leave a test on — a guard that let the host start but broke the executor on the way
+        // past would satisfy it. So the host starts, AND the executor it guarded goes on to execute a command.
+        var eventStore = new InMemoryEventStore(DomainType.GetDomainTypes().EventTypes);
+        var executor = new InMemoryDcbExecutor(DomainType.GetDomainTypes(), eventStore);
 
         using var host = new HostBuilder()
             .UseEnvironment(Environments.Development)
             .ConfigureServices(services =>
             {
                 services.AddSingleton<IEventStore>(eventStore);
-                services.AddSingleton<ISekibanExecutor>(
-                    new InMemoryDcbExecutor(DomainType.GetDomainTypes(), eventStore));
+                services.AddSingleton<ISekibanExecutor>(executor);
                 services.AddSekibanDcbProductionGuard();
             })
             .Build();
 
         await host.StartAsync();
+
+        var resolved = host.Services.GetRequiredService<ISekibanExecutor>();
+        var studentId = Guid.NewGuid();
+        var result = await resolved.ExecuteAsync(new CreateStudent(studentId, "Test Student", 2));
+
         await host.StopAsync();
+
+        Assert.Same(executor, resolved);
+        Assert.Single(result.Events);
+        Assert.Equal(
+            ExecutorRuntimeKind.TestingInProcess,
+            ((IExecutorRuntimeDescriptorProvider)resolved).DescribeRuntime().Runtime);
     }
 }

--- a/dcb/tests/Sekiban.Dcb.WithoutResult.Tests/ComprehensiveWithoutResultTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithoutResult.Tests/ComprehensiveWithoutResultTests.cs
@@ -25,7 +25,7 @@ public class ComprehensiveWithoutResultTests
     public ComprehensiveWithoutResultTests()
     {
         _domainTypes = DomainType.GetDomainTypes();
-        _executor = new InMemoryDcbExecutor(_domainTypes);
+        _executor = new InMemoryDcbExecutor(_domainTypes, new InMemoryEventStore(_domainTypes.EventTypes));
     }
 
     #region Command Tests

--- a/dcb/tests/Sekiban.Dcb.WithoutResult.Tests/ExecuteCommandAsyncTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithoutResult.Tests/ExecuteCommandAsyncTests.cs
@@ -10,7 +10,7 @@ namespace Sekiban.Dcb.WithoutResult.Tests;
 
 public class ExecuteCommandAsyncTests
 {
-    private readonly ISekibanExecutor _executor = new InMemoryDcbExecutor(DomainType.GetDomainTypes());
+    private readonly ISekibanExecutor _executor = new InMemoryDcbExecutor(DomainType.GetDomainTypes(), new InMemoryEventStore(DomainType.GetDomainTypes().EventTypes));
 
     [Fact]
     public async Task ExecuteCommandAsync_NoEvent_ReturnsEmptyExecutionResult()

--- a/dcb/tests/Sekiban.Dcb.WithoutResult.Tests/ProjectionHeadStatusTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithoutResult.Tests/ProjectionHeadStatusTests.cs
@@ -10,7 +10,7 @@ public class ProjectionHeadStatusTests
     [Fact]
     public async Task InMemoryExecutor_ShouldReturnProjectionAndEventStoreHeadStatus()
     {
-        var executor = (ISekibanExecutor)new InMemoryDcbExecutor(DomainType.GetDomainTypes());
+        var executor = (ISekibanExecutor)new InMemoryDcbExecutor(DomainType.GetDomainTypes(), new InMemoryEventStore(DomainType.GetDomainTypes().EventTypes));
         var executionResult = await executor.ExecuteAsync(new CreateStudent(Guid.NewGuid(), "WithoutResult", 2));
 
         var projectionStatus =

--- a/dcb/tests/Sekiban.Dcb.WithoutResult.Tests/Sekiban.Dcb.WithoutResult.Tests.csproj
+++ b/dcb/tests/Sekiban.Dcb.WithoutResult.Tests/Sekiban.Dcb.WithoutResult.Tests.csproj
@@ -13,6 +13,7 @@
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.3" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.3" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
         <PackageReference Include="xunit" Version="2.9.3" />
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/docs/dcb_llm/11_storage_providers.md
+++ b/docs/dcb_llm/11_storage_providers.md
@@ -373,6 +373,85 @@ Recommend **Postgres** for any workload that requires atomic event/tag visibilit
 - [SekibanWasmRuntime](https://github.com/J-Tech-Japan/SekibanWasmRuntime) defaults to Postgres for its event store, with Cosmos as an opt-in.
 - SekibanAsAService uses separate management and runtime container lineages; each can select its provider independently, so apply the same Postgres-for-atomicity guidance per container.
 
+## Durability Descriptors and the Production Guard
+
+Names are not evidence. `InMemoryDcbExecutor` reads like a test type, and a production system still registered it as its `ISekibanExecutor`; the one-argument constructor quietly created a private in-memory event store; every command succeeded; and no event ever reached the Cosmos account that was configured, sitting there, correct and empty. Nothing at startup could detect it, because nothing could *ask*.
+
+Now something can.
+
+### The two questions anything can be asked
+
+Every built-in store and executor answers these at runtime, from the live instance — not from its type name, not from an attribute, not from which `Add...` method was called:
+
+| Axis | Values | Who answers |
+|---|---|---|
+| Storage durability | `Durable` / `Volatile` / `Unknown` + provider name | event stores **and** projection state stores (and their per-service factories) |
+| Executor runtime | `DistributedRuntime` / `TestingInProcess` / `Unknown` + runtime name | executors, by asking the actor accessor they actually run on |
+
+Built-ins self-declare: Postgres, Cosmos DB, DynamoDB → `Durable`. InMemory → `Volatile`. Orleans → `DistributedRuntime`. `InMemoryDcbExecutor` → `TestingInProcess`.
+
+Two consequences worth stating, because they are the reason this is resolved at runtime rather than inferred:
+
+- **Sqlite answers `Durable` for a file and `Volatile` for `:memory:`** — same class, same name, opposite guarantee. Only the live instance knows which one it got.
+- **A decorator reports where the data actually lands.** `HybridEventStore` wrapping a volatile store is *volatile*. A wrapper cannot launder durability by being wrapped around it.
+
+`Unknown` is not a neutral value. It means the component declined to say, and the guard treats it as unsafe, because silence is not a promise of durability.
+
+### The guard
+
+```csharp
+// Opt-in. Nothing registers this for you: a library that decides on its own when your host may not start
+// is a library that will one day be wrong about it.
+builder.Services.AddSekibanDcbProductionGuard();
+```
+
+Call it after the registrations it is meant to check. At startup — after every registration has had its say, before the host serves anything — it resolves what the container *actually built*, asks each thing what it is, logs the banner, and in a Production environment refuses to start the host when:
+
+- the executor is not a `DistributedRuntime` (i.e. it is `TestingInProcess` or `Unknown`), **or**
+- either store is not `Durable` (i.e. `Volatile` or `Unknown`).
+
+Outside Production it validates nothing and only logs. Development is unchanged.
+
+### The one override, and the one that does not exist
+
+```csharp
+builder.Services.AddSekibanDcbProductionGuard(options =>
+{
+    options.AllowVolatileStorageInProduction = true;   // storage ONLY
+    options.ProductionEnvironmentNames.Add("prod-eu"); // if your real environment is not called "Production"
+});
+```
+
+`AllowVolatileStorageInProduction` authorises **storage** and nothing else. It cannot authorise a testing executor — set it and register `InMemoryDcbExecutor` in Production, and the host still refuses to start.
+
+There is **no** override that permits a testing executor in Production. Not off by default, not hidden behind a flag: it does not exist. A volatile store in Production can be a decision (a cache-shaped service, a throwaway environment). A test executor in Production is not a decision, it is an accident.
+
+Any override you do turn on is named, by name, in the startup banner at `Warning`, so nobody has to read the deployment to find out.
+
+### The banner
+
+Logged on every start (with `AddSekibanDcbStartupBanner()` if you want the report without the enforcement — sensible for local development, where a volatile store is the point):
+
+```
+Sekiban DCB startup. Environment=Production IsProduction=True
+  ExecutorType=Sekiban.Dcb.Orleans.OrleansDcbExecutor ExecutorRuntime=DistributedRuntime ExecutorRuntimeName=Orleans
+  EventStoreProvider=CosmosDb EventStoreDurability=Durable
+  ProjectionStoreProvider=CosmosDb ProjectionStoreDurability=Durable
+  Overrides=(none) Enforcing=True
+```
+
+It never logs a connection string. A banner that leaks a secret into every log sink would be a worse bug than the one it exists to prevent.
+
+### The obsolete constructor
+
+`new InMemoryDcbExecutor(domainTypes)` is `[Obsolete]`. Its behaviour is unchanged — only its silence is deprecated. Pass the store you mean to use:
+
+```csharp
+var executor = new InMemoryDcbExecutor(domainTypes, new InMemoryEventStore());
+```
+
+so that the store is a decision somebody made, visible in the code that made it.
+
 ## Materialized View Storage
 
 Materialized views are currently implemented for PostgreSQL:

--- a/docs/dcb_llm/11_storage_providers.md
+++ b/docs/dcb_llm/11_storage_providers.md
@@ -422,7 +422,10 @@ builder.Services.AddSekibanDcbProductionGuard(options =>
 });
 ```
 
-`AllowVolatileStorageInProduction` authorises **storage** and nothing else. It cannot authorise a testing executor — set it and register `InMemoryDcbExecutor` in Production, and the host still refuses to start.
+`AllowVolatileStorageInProduction` is narrow in two directions, and both are deliberate:
+
+- **Storage only.** It cannot authorise a testing executor — set it, register `InMemoryDcbExecutor` in Production, and the host still refuses to start.
+- **`Volatile` only, never `Unknown`.** Setting it means *"I looked at a store that said it was volatile, and I meant it."* A store that says nothing has not given you anything to mean, so `Unknown` stays fail-closed with the override on. The way past `Unknown` is to make the store durable, or to have it implement `IStorageDurabilityDescriptorProvider` so it can say what it is.
 
 There is **no** override that permits a testing executor in Production. Not off by default, not hidden behind a flag: it does not exist. A volatile store in Production can be a decision (a cache-shaped service, a throwaway environment). A test executor in Production is not a decision, it is an accident.
 

--- a/docs/dcb_llm_ja/11_storage_providers.md
+++ b/docs/dcb_llm_ja/11_storage_providers.md
@@ -446,7 +446,10 @@ builder.Services.AddSekibanDcbProductionGuard(options =>
 });
 ```
 
-`AllowVolatileStorageInProduction` が許可するのは**ストレージだけ**です。テスト用エグゼキューターを許可することはできません。これを設定したうえで Production に `InMemoryDcbExecutor` を登録しても、**ホストは起動を拒否します**。
+`AllowVolatileStorageInProduction` は 2 つの意味で意図的に狭く作られています。
+
+- **ストレージのみ。** テスト用エグゼキューターを許可することはできません。これを設定したうえで Production に `InMemoryDcbExecutor` を登録しても、**ホストは起動を拒否します**。
+- **`Volatile` のみ。`Unknown` は決して許可しません。** このオプションを設定するとは「volatile だと**申告した**ストアを見たうえで、それでよいと判断した」という意味です。何も申告しないストアは、判断の対象すら与えていません。したがってこのオーバーライドを有効にしても `Unknown` は fail-closed のままです。`Unknown` を解消する方法は、ストアを durable にするか、`IStorageDurabilityDescriptorProvider` を実装して自分が何であるかを申告させるかのどちらかです。
 
 **テスト用エグゼキューターを Production で許可するオーバーライドは存在しません。** 既定で無効なのではなく、フラグの奥に隠れているのでもなく、**存在しません**。volatile なストレージは判断であり得ます(キャッシュ的なサービス、使い捨て環境)。しかし本番でのテスト用エグゼキューターは判断ではなく事故です。
 

--- a/docs/dcb_llm_ja/11_storage_providers.md
+++ b/docs/dcb_llm_ja/11_storage_providers.md
@@ -397,6 +397,85 @@ dotnet run --project tools/SekibanDcbTagMigration -- apply \
 - [SekibanWasmRuntime](https://github.com/J-Tech-Japan/SekibanWasmRuntime) はイベントストアのデフォルトが Postgres で、Cosmos は opt-in です。
 - SekibanAsAService は管理系(management)とランタイム系(runtime)で別系統のコンテナーを使用しており、それぞれ独立してプロバイダーを選択できます。コンテナーごとに上記と同じ「アトミック性が必要なら Postgres」というガイドラインを適用してください。
 
+## 耐久性ディスクリプタと本番ガード
+
+**名前は根拠になりません。** `InMemoryDcbExecutor` はテスト用の型に見えますが、ある本番システムはこれを `ISekibanExecutor` として登録していました。一引数コンストラクターが黙ってプライベートなインメモリイベントストアを作り、コマンドはすべて成功し、設定済みの Cosmos アカウントには**イベントが1件も届きませんでした**。起動時に検知できなかったのは、**問い合わせる手段がなかった**からです。
+
+これからは問い合わせられます。
+
+### 実行時に問える 2 つの軸
+
+すべての組み込みストア/エグゼキューターが、**型名でも属性でも呼び出した `Add...` メソッドでもなく、生きたインスタンスから**次を申告します。
+
+| 軸 | 値 | 申告する側 |
+|---|---|---|
+| ストレージ耐久性 | `Durable` / `Volatile` / `Unknown` + プロバイダー名 | イベントストア **および** プロジェクション状態ストア(とそのサービス別ファクトリー) |
+| エグゼキューターランタイム | `DistributedRuntime` / `TestingInProcess` / `Unknown` + ランタイム名 | エグゼキューター(実際に載っているアクターアクセサーに問い合わせて回答) |
+
+組み込みの自己申告: Postgres / Cosmos DB / DynamoDB → `Durable`、InMemory → `Volatile`、Orleans → `DistributedRuntime`、`InMemoryDcbExecutor` → `TestingInProcess`。
+
+**実行時解決である理由**を示す 2 点:
+
+- **Sqlite はファイルなら `Durable`、`:memory:` なら `Volatile`** — 同じクラス、同じ名前、正反対の保証です。どちらを掴んだかを知っているのは生きたインスタンスだけです。
+- **デコレーターはデータが実際に着地する先を申告します。** volatile なストアを包んだ `HybridEventStore` は *volatile* です。包んだだけで耐久性を得ることはできません。
+
+`Unknown` は中立の値ではありません。「申告を拒んだ」という意味であり、ガードはこれを危険側として扱います。**沈黙は耐久性の約束ではないからです。**
+
+### ガード
+
+```csharp
+// opt-in。ライブラリが勝手に登録することはありません。
+// 「ホストを起動させない」判断を勝手に下すライブラリは、いつか必ずその判断を間違えます。
+builder.Services.AddSekibanDcbProductionGuard();
+```
+
+チェック対象の登録より**後**に呼び出してください。起動時(すべての登録が済み、ホストが何かを処理する前)に、コンテナーが**実際に構築したもの**を解決し、各インスタンスに問い合わせ、バナーを出力します。そして Production 環境では、次のいずれかであればホストの起動を拒否します。
+
+- エグゼキューターが `DistributedRuntime` でない(= `TestingInProcess` または `Unknown`)
+- いずれかのストアが `Durable` でない(= `Volatile` または `Unknown`)
+
+Production 以外では検証を行わず、ログ出力のみです。**Development の挙動は変わりません。**
+
+### 唯一のオーバーライドと、存在しないオーバーライド
+
+```csharp
+builder.Services.AddSekibanDcbProductionGuard(options =>
+{
+    options.AllowVolatileStorageInProduction = true;   // ストレージのみ
+    options.ProductionEnvironmentNames.Add("prod-eu"); // 本番環境名が "Production" でない場合
+});
+```
+
+`AllowVolatileStorageInProduction` が許可するのは**ストレージだけ**です。テスト用エグゼキューターを許可することはできません。これを設定したうえで Production に `InMemoryDcbExecutor` を登録しても、**ホストは起動を拒否します**。
+
+**テスト用エグゼキューターを Production で許可するオーバーライドは存在しません。** 既定で無効なのではなく、フラグの奥に隠れているのでもなく、**存在しません**。volatile なストレージは判断であり得ます(キャッシュ的なサービス、使い捨て環境)。しかし本番でのテスト用エグゼキューターは判断ではなく事故です。
+
+有効にしたオーバーライドは、起動バナーに `Warning` レベルで**名前付きで**出力されます。デプロイ設定を読まなくても分かるようにするためです。
+
+### バナー
+
+起動のたびに出力されます(強制なしで報告だけ欲しい場合は `AddSekibanDcbStartupBanner()`。volatile ストアが目的であるローカル開発に向いています)。
+
+```
+Sekiban DCB startup. Environment=Production IsProduction=True
+  ExecutorType=Sekiban.Dcb.Orleans.OrleansDcbExecutor ExecutorRuntime=DistributedRuntime ExecutorRuntimeName=Orleans
+  EventStoreProvider=CosmosDb EventStoreDurability=Durable
+  ProjectionStoreProvider=CosmosDb ProjectionStoreDurability=Durable
+  Overrides=(none) Enforcing=True
+```
+
+**接続文字列は決して出力しません。** すべてのログシンクに秘密情報を漏らすバナーは、防ごうとしている不具合よりも重大な不具合です。
+
+### 非推奨になったコンストラクター
+
+`new InMemoryDcbExecutor(domainTypes)` は `[Obsolete]` になりました。**挙動は変わりません。非推奨にしたのはその「沈黙」です。** 使うストアを明示的に渡してください。
+
+```csharp
+var executor = new InMemoryDcbExecutor(domainTypes, new InMemoryEventStore());
+```
+
+こうすれば、ストアの選択は「誰かが下した判断」となり、その判断を下したコードの中に見えるようになります。
+
 ## マテリアライズドビュー用ストレージ
 
 マテリアライズドビューは現在 PostgreSQL 向けに実装されています。

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.Interactions.Unit/Workflows/Reservation/CreateAndHoldReservationWorkflowTests.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.Interactions.Unit/Workflows/Reservation/CreateAndHoldReservationWorkflowTests.cs
@@ -13,7 +13,7 @@ namespace SekibanDcbOrleans.Interactions.Unit.Workflows.Reservation;
 
 public class CreateAndHoldReservationWorkflowTests
 {
-    private readonly ISekibanExecutor _executor = new InMemoryDcbExecutor(DomainType.GetDomainTypes());
+    private readonly ISekibanExecutor _executor = new InMemoryDcbExecutor(DomainType.GetDomainTypes(), new InMemoryEventStore(DomainType.GetDomainTypes().EventTypes));
 
     private async Task<(Guid RoomId, Guid UserId)> SetupRoomAndUserAsync(bool requiresApproval = false)
     {

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.Interactions.Unit/Workflows/Reservation/QuickReservationWorkflowTests.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.Interactions.Unit/Workflows/Reservation/QuickReservationWorkflowTests.cs
@@ -13,7 +13,7 @@ namespace SekibanDcbOrleans.Interactions.Unit.Workflows.Reservation;
 
 public class QuickReservationWorkflowTests
 {
-    private readonly ISekibanExecutor _executor = new InMemoryDcbExecutor(DomainType.GetDomainTypes());
+    private readonly ISekibanExecutor _executor = new InMemoryDcbExecutor(DomainType.GetDomainTypes(), new InMemoryEventStore(DomainType.GetDomainTypes().EventTypes));
 
     private async Task<(Guid RoomId, Guid UserId)> SetupRoomAndUserAsync(bool requiresApproval = false)
     {

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.Unit/SampleTests.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.Unit/SampleTests.cs
@@ -33,7 +33,7 @@ public class SampleTests
     [Test]
     public async Task CreateStudent_ThenGetState_ReturnsStudentState()
     {
-        ISekibanExecutor executor = new InMemoryDcbExecutor(DomainType.GetDomainTypes());
+        ISekibanExecutor executor = new InMemoryDcbExecutor(DomainType.GetDomainTypes(), new InMemoryEventStore(DomainType.GetDomainTypes().EventTypes));
         var studentId = Guid.CreateVersion7();
 
         await executor.ExecuteAsync(new CreateStudent(studentId, "Alice", 3));
@@ -49,7 +49,7 @@ public class SampleTests
     [Test]
     public async Task CreateClassRoom_ThenGetState_ReturnsClassRoomState()
     {
-        ISekibanExecutor executor = new InMemoryDcbExecutor(DomainType.GetDomainTypes());
+        ISekibanExecutor executor = new InMemoryDcbExecutor(DomainType.GetDomainTypes(), new InMemoryEventStore(DomainType.GetDomainTypes().EventTypes));
         var classRoomId = Guid.CreateVersion7();
 
         await executor.ExecuteAsync(
@@ -67,7 +67,7 @@ public class SampleTests
     [Test]
     public async Task CreateWeatherForecast_ThenGetState_ReturnsForecastState()
     {
-        ISekibanExecutor executor = new InMemoryDcbExecutor(DomainType.GetDomainTypes());
+        ISekibanExecutor executor = new InMemoryDcbExecutor(DomainType.GetDomainTypes(), new InMemoryEventStore(DomainType.GetDomainTypes().EventTypes));
         var forecastId = Guid.CreateVersion7();
 
         await executor.ExecuteAsync(new CreateWeatherForecast
@@ -90,7 +90,7 @@ public class SampleTests
     [Test]
     public async Task CreateRoom_ThenGetState_ReturnsRoomState()
     {
-        ISekibanExecutor executor = new InMemoryDcbExecutor(DomainType.GetDomainTypes());
+        ISekibanExecutor executor = new InMemoryDcbExecutor(DomainType.GetDomainTypes(), new InMemoryEventStore(DomainType.GetDomainTypes().EventTypes));
         var roomId = Guid.CreateVersion7();
 
         await executor.ExecuteAsync(new CreateRoom
@@ -114,7 +114,7 @@ public class SampleTests
     [Test]
     public async Task RegisterUser_ThenGetState_ReturnsUserState()
     {
-        ISekibanExecutor executor = new InMemoryDcbExecutor(DomainType.GetDomainTypes());
+        ISekibanExecutor executor = new InMemoryDcbExecutor(DomainType.GetDomainTypes(), new InMemoryEventStore(DomainType.GetDomainTypes().EventTypes));
         var userId = Guid.CreateVersion7();
 
         await executor.ExecuteAsync(new RegisterUser

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.Interactions.Unit/Workflows/Reservation/CreateAndHoldReservationWorkflowTests.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.Interactions.Unit/Workflows/Reservation/CreateAndHoldReservationWorkflowTests.cs
@@ -13,7 +13,7 @@ namespace SekibanDcbOrleans.Interactions.Unit.Workflows.Reservation;
 
 public class CreateAndHoldReservationWorkflowTests
 {
-    private readonly ISekibanExecutor _executor = new InMemoryDcbExecutor(DomainType.GetDomainTypes());
+    private readonly ISekibanExecutor _executor = new InMemoryDcbExecutor(DomainType.GetDomainTypes(), new InMemoryEventStore(DomainType.GetDomainTypes().EventTypes));
 
     private async Task<(Guid RoomId, Guid UserId)> SetupRoomAndUserAsync(bool requiresApproval = false)
     {

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.Interactions.Unit/Workflows/Reservation/QuickReservationWorkflowTests.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.Interactions.Unit/Workflows/Reservation/QuickReservationWorkflowTests.cs
@@ -13,7 +13,7 @@ namespace SekibanDcbOrleans.Interactions.Unit.Workflows.Reservation;
 
 public class QuickReservationWorkflowTests
 {
-    private readonly ISekibanExecutor _executor = new InMemoryDcbExecutor(DomainType.GetDomainTypes());
+    private readonly ISekibanExecutor _executor = new InMemoryDcbExecutor(DomainType.GetDomainTypes(), new InMemoryEventStore(DomainType.GetDomainTypes().EventTypes));
 
     private async Task<(Guid RoomId, Guid UserId)> SetupRoomAndUserAsync(bool requiresApproval = false)
     {

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.Unit/SampleTests.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.Unit/SampleTests.cs
@@ -33,7 +33,7 @@ public class SampleTests
     [Test]
     public async Task CreateStudent_ThenGetState_ReturnsStudentState()
     {
-        ISekibanExecutor executor = new InMemoryDcbExecutor(DomainType.GetDomainTypes());
+        ISekibanExecutor executor = new InMemoryDcbExecutor(DomainType.GetDomainTypes(), new InMemoryEventStore(DomainType.GetDomainTypes().EventTypes));
         var studentId = Guid.CreateVersion7();
 
         await executor.ExecuteAsync(new CreateStudent(studentId, "Alice", 3));
@@ -49,7 +49,7 @@ public class SampleTests
     [Test]
     public async Task CreateClassRoom_ThenGetState_ReturnsClassRoomState()
     {
-        ISekibanExecutor executor = new InMemoryDcbExecutor(DomainType.GetDomainTypes());
+        ISekibanExecutor executor = new InMemoryDcbExecutor(DomainType.GetDomainTypes(), new InMemoryEventStore(DomainType.GetDomainTypes().EventTypes));
         var classRoomId = Guid.CreateVersion7();
 
         await executor.ExecuteAsync(
@@ -67,7 +67,7 @@ public class SampleTests
     [Test]
     public async Task CreateWeatherForecast_ThenGetState_ReturnsForecastState()
     {
-        ISekibanExecutor executor = new InMemoryDcbExecutor(DomainType.GetDomainTypes());
+        ISekibanExecutor executor = new InMemoryDcbExecutor(DomainType.GetDomainTypes(), new InMemoryEventStore(DomainType.GetDomainTypes().EventTypes));
         var forecastId = Guid.CreateVersion7();
 
         await executor.ExecuteAsync(new CreateWeatherForecast
@@ -90,7 +90,7 @@ public class SampleTests
     [Test]
     public async Task CreateRoom_ThenGetState_ReturnsRoomState()
     {
-        ISekibanExecutor executor = new InMemoryDcbExecutor(DomainType.GetDomainTypes());
+        ISekibanExecutor executor = new InMemoryDcbExecutor(DomainType.GetDomainTypes(), new InMemoryEventStore(DomainType.GetDomainTypes().EventTypes));
         var roomId = Guid.CreateVersion7();
 
         await executor.ExecuteAsync(new CreateRoom
@@ -114,7 +114,7 @@ public class SampleTests
     [Test]
     public async Task RegisterUser_ThenGetState_ReturnsUserState()
     {
-        ISekibanExecutor executor = new InMemoryDcbExecutor(DomainType.GetDomainTypes());
+        ISekibanExecutor executor = new InMemoryDcbExecutor(DomainType.GetDomainTypes(), new InMemoryEventStore(DomainType.GetDomainTypes().EventTypes));
         var userId = Guid.CreateVersion7();
 
         await executor.ExecuteAsync(new RegisterUser


### PR DESCRIPTION
Closes #1068

## The thing that happened

A downstream production system registered `InMemoryDcbExecutor` as its `ISekibanExecutor`. The one-argument constructor quietly created a private in-memory event store. Every command succeeded. No event ever reached the Cosmos account that was configured — sitting there, correct, and empty. Nothing at startup could detect it, **because nothing could ask**.

Names are not evidence. This PR adds the thing that can be asked.

## Two axes, resolved from the live instance

| Axis | Values | Answered by |
|---|---|---|
| Storage durability | `Durable` / `Volatile` / `Unknown` + provider name | event stores **and** projection state stores, plus their per-service factories |
| Executor runtime | `DistributedRuntime` / `TestingInProcess` / `Unknown` + runtime name | executors — by asking the actor accessor they actually run on |

Built-ins self-declare: Postgres / Cosmos / DynamoDB → `Durable`, InMemory → `Volatile`, Orleans → `DistributedRuntime`, `InMemoryDcbExecutor` → `TestingInProcess`.

Two cases are the argument for resolving this at runtime instead of inferring it from a type name, an attribute, or which `Add…` method was called:

- **Sqlite answers `Durable` for a file and `Volatile` for `:memory:`.** Same class, same name, opposite guarantee. Only the live instance knows which one it got.
- **`HybridEventStore` reports where the data actually lands.** Wrapping a volatile store is *volatile*. A decorator cannot launder durability by being wrapped around it.

`Unknown` is not a neutral value: it means the component declined to say, and the guard treats it as unsafe. Silence is not a promise of durability.

## The guard

`AddSekibanDcbProductionGuard()` — explicit opt-in, never auto-registered by a provider or a template. At startup, after every registration has had its say and before the host serves anything, it resolves **what the container actually built**, asks each thing what it is, logs the banner, and in Production refuses to start on a non-distributed executor or a non-durable store. Outside Production it validates nothing.

It resolves rather than reading the `IServiceCollection` — so a later `AddSingleton<IEventStore>` that swaps a durable store for a volatile one is still caught. There is a test for exactly that.

### The one override, and how narrow it is

`AllowVolatileStorageInProduction` is narrow in two directions:

- **Storage only.** Set it, register `InMemoryDcbExecutor` in Production, and the host still refuses to start.
- **`Volatile` only — never `Unknown`.** Setting it means *"I looked at a store that said it was volatile, and I meant it."* A store that says nothing has not given you anything to mean, so `Unknown` stays fail-closed with the override on. (This was **wrong in the first push** — Volatile and Unknown were one condition and the override skipped both. The review caught it; it now has its own enforcement branch and its own regression.)

There is **no** override that permits a testing executor in Production. Not off by default, not behind a flag — it does not exist, and `NoOverrideExistsForATestingExecutor` fails if a property on the options type is so much as *named* like one. A volatile store in Production can be a decision (a cache-shaped service, a throwaway environment). A test executor in Production is not a decision, it is an accident.

Any override that *is* on is named, by name, in the banner at `Warning`.

### Resolved in a scope

Sekiban's own Cosmos registrations are **scoped**. A hosted service holds the *root* provider, and asking the root provider for a scoped service throws under `ValidateScopes` — so opting into the guard broke a supported composition outright, in Development too. A guard that breaks the host it is protecting is worse than no guard. It now resolves inside a scope that lives exactly as long as the check, and a `ValidateScopes=true` test fails if it ever resolves from the root again.

### The banner

Environment, executor type + runtime, both store providers + durability, overrides in use, and a loud data-loss warning when storage is volatile. Never a connection string: a banner that leaks a secret into every log sink would be a worse bug than the one it exists to prevent. `AddSekibanDcbStartupBanner()` gives the report without the enforcement, for local development.

## Test matrix (all green)

| case | result |
|---|---|
| Production + Distributed + Durable | starts |
| Production + Distributed + Volatile | **refuses** |
| …with `AllowVolatileStorageInProduction` | starts |
| Production + Testing executor + Durable | **refuses** |
| Production + Testing executor + Volatile | **refuses** |
| **Production + Testing executor + storage override** | **still refuses** — override-separation proof |
| Production + Unknown executor / Unknown store | **refuses** |
| **Production + Unknown store + storage override** | **still refuses** — the override authorises `Volatile`, not silence |
| Production + Volatile store + storage override | starts — the pair that shows what the override *does* |
| scoped executor/stores, `ValidateScopes=true` | guard reports (does not throw); a scoped volatile store is still caught |
| Production + nothing registered | **refuses** |
| Development + Testing + Volatile | starts, unchanged |
| banner-only in Production | never fails the host |
| operator-named production env (`prod-eu`) | guarded |
| store swapped *after* the guard is registered | **refuses** (resolution, not registration) |
| decorator propagation (volatile / durable / silent inner) | reports the inner |
| the incident, reproduced end to end with the real `InMemoryDcbExecutor` | **refuses** |

Every guard case builds a real host and really starts it: the guard's whole job is to stop a host from starting, and asserting on a method in isolation would prove something weaker than the claim.

**Mutation-tested — six mutations, all killed**: let the storage override excuse a testing executor (1 fail), treat `Unknown` as acceptable (2), let the decorator claim durability on its own authority (2), make Sqlite always claim `Durable` (2), **fold `Unknown` back under the volatile override** (1), **resolve from the root provider again** (2).

## Review round 2

Three blockers, all real, all fixed:

1. **`Unknown` storage was authorised by the volatile-only override.** Fixed as described above, with the regression the review asked for.
2. **The validator resolved from the root provider**, which throws under `ValidateScopes` for the scoped Cosmos registrations. Now resolved in a scope, with a `ValidateScopes=true` test.
3. **`TheSameCompositionInDevelopment_StillStarts` asserted nothing** (Sonar S2699, BLOCKER). It was also too weak a claim to leave a test on — a guard that let the host start but broke the executor on the way past would have satisfied it. It now starts the host **and executes a command through the resolved executor**. SonarCloud is green.

## The obsolete constructor, and what obsoleting it caught

`new InMemoryDcbExecutor(domainTypes)` is `[Obsolete]`. Behaviour unchanged — only its silence is deprecated.

All **33** call sites in this repo now pass the store explicitly, so the solution builds with **zero** obsolete warnings and the migration we ask users to make is one we made first. That migration then caught itself: my first pass substituted a bare `new InMemoryEventStore()`, which uses `ReflectionEventTypes` instead of the domain's registered event types, and **21 existing tests failed**. A silent store substitution changing behaviour under a green-looking build is precisely what this slice exists to prevent, so it is worth saying that it happened here, to me, and that the tests are what said so.

Template content (`templates/**`) is outside the issue's stated target paths (`dcb/src dcb/tests`), and I edited it anyway, deliberately: leaving it would have made every newly generated project emit obsolete warnings on first build. The edit is mechanical — the same explicit-store migration — and I would rather declare it than ship that.

## Evidence

- `Sekiban.slnx`: **0 errors, 0 obsolete warnings** on a clean (`--no-incremental`) build.
- WithResult 654 passed (634 pre-existing + 20 new), WithoutResult 70 (66 + 4), ColdEvents 88 (85 + 3), Orleans 80 / 1 skipped, MaterializedView 21, MaterializedView.MultiProvider 9, BlobStorage.AzureStorage 4. All pre-existing suites green **unmodified** in behaviour.
- `git diff --check` clean. No public signature removals; everything added is additive.

## Closeout notes (feeding SEK-G11)

- **Unclassified descriptor candidates**: `IBlobStorageSnapshotAccessor` (`InMemoryBlobStorageSnapshotAccessor` volatile; Azure Blob and S3 durable) is *not* covered — the issue scoped the axes to event stores and projection state stores. A snapshot accessor that is volatile in Production is a smaller but real hole, and it is the obvious next descriptor.
- **Nontrivial decorator paths**: `HybridEventStore` is the only `IEventStore` decorator in-tree and it propagates. `EventStoreCacheSync` composes two stores but is not itself an `IEventStore`, so it is invisible to the guard — worth a look if it ever becomes one.
- The multi-tenant factories (`IEventStoreFactory`, `IMultiProjectionStateStoreFactory`) self-declare, but the guard describes the *factory*, not the per-service store it builds. That is correct for the built-ins (every store a factory builds shares its backend) and would not be for a factory that mixes backends per service.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017KAPyZPCMZzurEZTt1k8LX
