### PR TITLE
Templates: onto 10.4.0, Testing packages in the Unit projects, production guard on by default

### DIFF
--- a/templates/Sekiban.Dcb.Templates/README.md
+++ b/templates/Sekiban.Dcb.Templates/README.md
@@ -2,7 +2,7 @@
 
 Sekiban DCB (Dynamic Consistency Boundary) 向けの .NET Aspire + Orleans スターターテンプレートです。
 
-生成されるプロジェクトはすべて **.NET 10.0** / **Aspire 13.x** / **Sekiban.Dcb 10.3.0** です。
+生成されるプロジェクトはすべて **.NET 10.0** / **Aspire 13.x** / **Sekiban.Dcb 10.4.0** です。
 
 ## インストール
 
@@ -43,11 +43,24 @@ dotnet new sekiban-dcb-orleans -n YourProjectName
 
 詳細は [ストレージプロバイダーの整合性契約](https://github.com/J-Tech-Japan/Sekiban/blob/main/docs/dcb_llm_ja/11_storage_providers.md#整合性契約) と [トラブルシューティング](https://github.com/J-Tech-Japan/Sekiban/blob/main/docs/dcb_llm_ja/13_common_issues.md) を参照してください。
 
+## 本番ガード (10.4.0 以降、既定で有効)
+
+生成される ApiService は、Sekiban の登録の後に **`AddSekibanDcbProductionGuard()`** を呼びます。起動時にコンテナーが**実際に構築したもの**(エグゼキューターと両ストア)を解決して自己申告を問い合わせ、Production 環境では次の場合にホストの起動を拒否します。
+
+- エグゼキューターがインプロセス(テスト用)、またはランタイムを申告しない → **常に拒否。オーバーライドはありません。**
+- ストアが `Volatile`、または耐久性を申告しない(`Unknown`)→ 既定で拒否。**`Volatile` のみ**、ストレージ専用の `AllowVolatileStorageInProduction` で運用者が明示的に許可できます(`Unknown` は許可できません)。
+
+**Development の挙動は変わりません。** Production 以外では検証を行わず、起動バナー(環境、エグゼキューターのランタイム、ストアのプロバイダーと耐久性、有効なオーバーライド)を出力するだけです。ローカル実行はこれまでどおり動きます。
+
+詳細: [ストレージプロバイダーと本番ガード](https://github.com/J-Tech-Japan/Sekiban/blob/main/docs/dcb_llm_ja/11_storage_providers.md)
+
 ## ローカル開発 / ユニットテスト
 
-生成されるプロジェクトはローカルでも **Orleans**(単一サイロ、localhost クラスタリング)で動きます。インメモリエグゼキューターはユニットテスト専用であり、`*.Unit` プロジェクトだけが `Sekiban.Dcb.*.Testing` パッケージを参照します。ランタイムプロジェクトからは参照しないでください。
+生成されるプロジェクトはローカルでも **Orleans**(単一サイロ、localhost クラスタリング)で動きます。インメモリエグゼキューターはユニットテスト専用です。
 
-分類と、CLI / Worker / Web それぞれの localhost 構成は [localhost Orleans ガイド](https://github.com/J-Tech-Japan/Sekiban/blob/main/docs/dcb_llm_ja/22_localhost_orleans.md) を参照してください。
+`*.Unit` プロジェクトだけが `Sekiban.Dcb.Core.Testing` と、ファサードに対応する `Sekiban.Dcb.WithResult.Testing` / `Sekiban.Dcb.WithoutResult.Testing` を参照し、`InMemoryDcbExecutorForTesting` と `InMemoryEventStore`(名前空間 `Sekiban.Dcb.Testing`)を使います。**ランタイムプロジェクトからは参照しないでください** — この 2 つは自分が `TestingInProcess` / `Volatile` であることを申告するため、本番ホストで解決されれば上のガードが起動を拒否します。
+
+分類(実環境 / ローカル開発 / ユニットテスト)と、CLI / Worker / Web それぞれの localhost 構成は [localhost Orleans ガイド](https://github.com/J-Tech-Japan/Sekiban/blob/main/docs/dcb_llm_ja/22_localhost_orleans.md) を参照してください。
 
 ## 生成後の手順
 

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.ApiService/Program.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.ApiService/Program.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Logging;
 using Orleans.Runtime;
 using Orleans.Storage;
 using Scalar.AspNetCore;
+using Sekiban.Dcb.Capabilities;
 using Sekiban.Dcb;
 using Sekiban.Dcb.Actors;
 using Sekiban.Dcb.Orleans;
@@ -320,6 +321,18 @@ if (builder.Environment.IsDevelopment())
         });
     });
 }
+// Fail closed in Production. The guard resolves what the container ACTUALLY built — the executor and both stores —
+// and refuses to start the host if what it finds would lose data: an in-process (testing) executor, which is never
+// allowed in Production and has no override, or a store that is Volatile or will not say what it is. Volatile storage
+// alone can be authorised deliberately, by name, with AllowVolatileStorageInProduction — storage only; it can never
+// authorise a testing executor.
+//
+// Development is unaffected: outside Production this only logs the startup banner (environment, executor runtime,
+// store providers and durability, overrides in use). Register it AFTER the Sekiban registrations above.
+//
+// https://github.com/J-Tech-Japan/Sekiban/blob/main/docs/dcb_llm/11_storage_providers.md
+builder.Services.AddSekibanDcbProductionGuard();
+
 var app = builder.Build();
 
 // Log startup configuration

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.ApiService/Program.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.ApiService/Program.cs
@@ -321,15 +321,9 @@ if (builder.Environment.IsDevelopment())
         });
     });
 }
-// Fail closed in Production. The guard resolves what the container ACTUALLY built — the executor and both stores —
-// and refuses to start the host if what it finds would lose data: an in-process (testing) executor, which is never
-// allowed in Production and has no override, or a store that is Volatile or will not say what it is. Volatile storage
-// alone can be authorised deliberately, by name, with AllowVolatileStorageInProduction — storage only; it can never
-// authorise a testing executor.
-//
-// Development is unaffected: outside Production this only logs the startup banner (environment, executor runtime,
-// store providers and durability, overrides in use). Register it AFTER the Sekiban registrations above.
-//
+// Fail-closed startup guard: in Production, refuses to start on a testing executor (always — no override) or a
+// Volatile/Unknown store (Volatile authorisable by name via AllowVolatileStorageInProduction, storage only).
+// Development only logs the banner. Must come AFTER the Sekiban registrations. Contract:
 // https://github.com/J-Tech-Japan/Sekiban/blob/main/docs/dcb_llm/11_storage_providers.md
 builder.Services.AddSekibanDcbProductionGuard();
 

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.ApiService/SekibanDcbDeciderAws.ApiService.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.ApiService/SekibanDcbDeciderAws.ApiService.csproj
@@ -33,13 +33,13 @@
 
         <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.3" />
         <PackageReference Include="Scalar.AspNetCore" Version="2.12.50" />
-        <PackageReference Include="Sekiban.Dcb.Orleans.WithoutResult" Version="10.3.0" />
-        <PackageReference Include="Sekiban.Dcb.DynamoDB" Version="10.3.0" />
-        <PackageReference Include="Sekiban.Dcb.BlobStorage.S3" Version="10.3.0" />
-        <PackageReference Include="Sekiban.Dcb.Postgres" Version="10.3.0" />
-        <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.3.0" />
-        <PackageReference Include="Sekiban.Dcb.MaterializedView.Postgres" Version="10.3.0" />
-        <PackageReference Include="Sekiban.Dcb.MaterializedView.Orleans" Version="10.3.0" />
+        <PackageReference Include="Sekiban.Dcb.Orleans.WithoutResult" Version="10.4.0" />
+        <PackageReference Include="Sekiban.Dcb.DynamoDB" Version="10.4.0" />
+        <PackageReference Include="Sekiban.Dcb.BlobStorage.S3" Version="10.4.0" />
+        <PackageReference Include="Sekiban.Dcb.Postgres" Version="10.4.0" />
+        <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.4.0" />
+        <PackageReference Include="Sekiban.Dcb.MaterializedView.Postgres" Version="10.4.0" />
+        <PackageReference Include="Sekiban.Dcb.MaterializedView.Orleans" Version="10.4.0" />
         <PackageReference Include="Dapper" Version="2.1.66" />
         <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />
     </ItemGroup>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.EventSource/SekibanDcbDeciderAws.EventSource.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.EventSource/SekibanDcbDeciderAws.EventSource.csproj
@@ -11,8 +11,8 @@
     <ProjectReference Include="..\SekibanDcbDeciderAws.MeetingRoomModels\SekibanDcbDeciderAws.MeetingRoomModels.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.3.0" />
-    <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.3.0" />
+    <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.4.0" />
+    <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.4.0" />
     <PackageReference Include="ResultBoxes" Version="0.4.0" />
     <PackageReference Include="Microsoft.Orleans.Serialization" Version="10.0.1" />
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.ImmutableModels/SekibanDcbDeciderAws.ImmutableModels.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.ImmutableModels/SekibanDcbDeciderAws.ImmutableModels.csproj
@@ -7,7 +7,7 @@
     <IsPackable>true</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Sekiban.Dcb.Core.Model" Version="10.3.0" />
+    <PackageReference Include="Sekiban.Dcb.Core.Model" Version="10.4.0" />
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />
   </ItemGroup>
 </Project>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.Interactions.Unit/SekibanDcbDeciderAws.Interactions.Unit.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.Interactions.Unit/SekibanDcbDeciderAws.Interactions.Unit.csproj
@@ -28,9 +28,9 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.3.0" />
-    <PackageReference Include="Sekiban.Dcb.Core.Testing" Version="10.3.0" />
-    <PackageReference Include="Sekiban.Dcb.WithoutResult.Testing" Version="10.3.0" />
+      <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.4.0" />
+    <PackageReference Include="Sekiban.Dcb.Core.Testing" Version="10.4.0" />
+    <PackageReference Include="Sekiban.Dcb.WithoutResult.Testing" Version="10.4.0" />
     </ItemGroup>
 
 </Project>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.Interactions/SekibanDcbDeciderAws.Interactions.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.Interactions/SekibanDcbDeciderAws.Interactions.csproj
@@ -10,7 +10,7 @@
     <ProjectReference Include="..\SekibanDcbDeciderAws.EventSource\SekibanDcbDeciderAws.EventSource.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.3.0" />
+    <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.4.0" />
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />
   </ItemGroup>
 </Project>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.MeetingRoomModels/SekibanDcbDeciderAws.MeetingRoomModels.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.MeetingRoomModels/SekibanDcbDeciderAws.MeetingRoomModels.csproj
@@ -7,7 +7,7 @@
     <IsPackable>true</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Sekiban.Dcb.Core.Model" Version="10.3.0" />
+    <PackageReference Include="Sekiban.Dcb.Core.Model" Version="10.4.0" />
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />
   </ItemGroup>
 </Project>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.Unit/SekibanDcbDeciderAws.Unit.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.Unit/SekibanDcbDeciderAws.Unit.csproj
@@ -15,9 +15,9 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.3.0" />
-    <PackageReference Include="Sekiban.Dcb.Core.Testing" Version="10.3.0" />
-    <PackageReference Include="Sekiban.Dcb.WithoutResult.Testing" Version="10.3.0" />
+    <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.4.0" />
+    <PackageReference Include="Sekiban.Dcb.Core.Testing" Version="10.4.0" />
+    <PackageReference Include="Sekiban.Dcb.WithoutResult.Testing" Version="10.4.0" />
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />
   </ItemGroup>
   <ItemGroup>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/.template.config/template.json
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/.template.config/template.json
@@ -35,7 +35,10 @@
         {
           "condition": "(!IncludeTests)",
           "exclude": [
-            "SekibanDcbDecider.Unit/**/*"
+            "SekibanDcbDecider.Unit/**/*",
+            "SekibanDcbDecider.ImmutableModels.Unit/**/*",
+            "SekibanDcbDecider.Interactions.Unit/**/*",
+            "SekibanDcbDecider.MeetingRoomModels.Unit/**/*"
           ]
         }
       ]

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.ApiService/Program.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.ApiService/Program.cs
@@ -12,6 +12,7 @@ using Orleans.Runtime.Hosting;
 using Orleans.Storage;
 using Npgsql;
 using Scalar.AspNetCore;
+using Sekiban.Dcb.Capabilities;
 using Sekiban.Dcb;
 using Sekiban.Dcb.Actors;
 using Sekiban.Dcb.Orleans;
@@ -253,6 +254,18 @@ builder.Services.AddCors(options =>
         policy.AllowAnyOrigin().AllowAnyHeader().AllowAnyMethod();
     });
 });
+
+// Fail closed in Production. The guard resolves what the container ACTUALLY built — the executor and both stores —
+// and refuses to start the host if what it finds would lose data: an in-process (testing) executor, which is never
+// allowed in Production and has no override, or a store that is Volatile or will not say what it is. Volatile storage
+// alone can be authorised deliberately, by name, with AllowVolatileStorageInProduction — storage only; it can never
+// authorise a testing executor.
+//
+// Development is unaffected: outside Production this only logs the startup banner (environment, executor runtime,
+// store providers and durability, overrides in use). Register it AFTER the Sekiban registrations above.
+//
+// https://github.com/J-Tech-Japan/Sekiban/blob/main/docs/dcb_llm/11_storage_providers.md
+builder.Services.AddSekibanDcbProductionGuard();
 
 var app = builder.Build();
 

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.ApiService/Program.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.ApiService/Program.cs
@@ -255,15 +255,9 @@ builder.Services.AddCors(options =>
     });
 });
 
-// Fail closed in Production. The guard resolves what the container ACTUALLY built — the executor and both stores —
-// and refuses to start the host if what it finds would lose data: an in-process (testing) executor, which is never
-// allowed in Production and has no override, or a store that is Volatile or will not say what it is. Volatile storage
-// alone can be authorised deliberately, by name, with AllowVolatileStorageInProduction — storage only; it can never
-// authorise a testing executor.
-//
-// Development is unaffected: outside Production this only logs the startup banner (environment, executor runtime,
-// store providers and durability, overrides in use). Register it AFTER the Sekiban registrations above.
-//
+// Fail-closed startup guard: in Production, refuses to start on a testing executor (always — no override) or a
+// Volatile/Unknown store (Volatile authorisable by name via AllowVolatileStorageInProduction, storage only).
+// Development only logs the banner. Must come AFTER the Sekiban registrations. Contract:
 // https://github.com/J-Tech-Japan/Sekiban/blob/main/docs/dcb_llm/11_storage_providers.md
 builder.Services.AddSekibanDcbProductionGuard();
 

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.ApiService/SekibanDcbDecider.ApiService.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.ApiService/SekibanDcbDecider.ApiService.csproj
@@ -44,14 +44,14 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Sekiban.Dcb.BlobStorage.AzureStorage" Version="10.3.0" />
-        <PackageReference Include="Sekiban.Dcb.Orleans.WithoutResult" Version="10.3.0" />
-        <PackageReference Include="Sekiban.Dcb.Postgres" Version="10.3.0" />
-        <PackageReference Include="Sekiban.Dcb.CosmosDb" Version="10.3.0" />
-        <PackageReference Include="Sekiban.Dcb.Sqlite" Version="10.3.0" />
-        <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.3.0" />
-        <PackageReference Include="Sekiban.Dcb.MaterializedView.Postgres" Version="10.3.0" />
-        <PackageReference Include="Sekiban.Dcb.MaterializedView.Orleans" Version="10.3.0" />
+        <PackageReference Include="Sekiban.Dcb.BlobStorage.AzureStorage" Version="10.4.0" />
+        <PackageReference Include="Sekiban.Dcb.Orleans.WithoutResult" Version="10.4.0" />
+        <PackageReference Include="Sekiban.Dcb.Postgres" Version="10.4.0" />
+        <PackageReference Include="Sekiban.Dcb.CosmosDb" Version="10.4.0" />
+        <PackageReference Include="Sekiban.Dcb.Sqlite" Version="10.4.0" />
+        <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.4.0" />
+        <PackageReference Include="Sekiban.Dcb.MaterializedView.Postgres" Version="10.4.0" />
+        <PackageReference Include="Sekiban.Dcb.MaterializedView.Orleans" Version="10.4.0" />
         <PackageReference Include="Dapper" Version="2.1.66" />
     </ItemGroup>
 </Project>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.Cli/SekibanDcbDecider.Cli.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.Cli/SekibanDcbDecider.Cli.csproj
@@ -14,10 +14,10 @@
         <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.3" />
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.3" />
         <PackageReference Include="System.CommandLine" Version="2.0.2" />
-        <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.3.0" />
-        <PackageReference Include="Sekiban.Dcb.Postgres" Version="10.3.0" />
-        <PackageReference Include="Sekiban.Dcb.CosmosDb" Version="10.3.0" />
-        <PackageReference Include="Sekiban.Dcb.Sqlite" Version="10.3.0" />
+        <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.4.0" />
+        <PackageReference Include="Sekiban.Dcb.Postgres" Version="10.4.0" />
+        <PackageReference Include="Sekiban.Dcb.CosmosDb" Version="10.4.0" />
+        <PackageReference Include="Sekiban.Dcb.Sqlite" Version="10.4.0" />
         <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />
     </ItemGroup>
 

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.EventSource/SekibanDcbDecider.EventSource.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.EventSource/SekibanDcbDecider.EventSource.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="ResultBoxes" Version="0.4.0" />
     <PackageReference Include="Microsoft.Orleans.Serialization" Version="10.0.1" />
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />
-    <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.3.0" />
-    <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.3.0" />
+    <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.4.0" />
+    <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.4.0" />
   </ItemGroup>
 </Project>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.ImmutableModels/SekibanDcbDecider.ImmutableModels.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.ImmutableModels/SekibanDcbDecider.ImmutableModels.csproj
@@ -10,6 +10,6 @@
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Sekiban.Dcb.Core.Model" Version="10.3.0" />
+    <PackageReference Include="Sekiban.Dcb.Core.Model" Version="10.4.0" />
   </ItemGroup>
 </Project>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.Interactions.Unit/SekibanDcbDecider.Interactions.Unit.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.Interactions.Unit/SekibanDcbDecider.Interactions.Unit.csproj
@@ -28,9 +28,9 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.3.0" />
-    <PackageReference Include="Sekiban.Dcb.Core.Testing" Version="10.3.0" />
-    <PackageReference Include="Sekiban.Dcb.WithoutResult.Testing" Version="10.3.0" />
+      <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.4.0" />
+    <PackageReference Include="Sekiban.Dcb.Core.Testing" Version="10.4.0" />
+    <PackageReference Include="Sekiban.Dcb.WithoutResult.Testing" Version="10.4.0" />
     </ItemGroup>
 
 </Project>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.Interactions/SekibanDcbDecider.Interactions.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.Interactions/SekibanDcbDecider.Interactions.csproj
@@ -11,6 +11,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />
-    <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.3.0" />
+    <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.4.0" />
   </ItemGroup>
 </Project>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.MeetingRoomModels/SekibanDcbDecider.MeetingRoomModels.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.MeetingRoomModels/SekibanDcbDecider.MeetingRoomModels.csproj
@@ -10,6 +10,6 @@
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Sekiban.Dcb.Core.Model" Version="10.3.0" />
+    <PackageReference Include="Sekiban.Dcb.Core.Model" Version="10.4.0" />
   </ItemGroup>
 </Project>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.Unit/SekibanDcbDecider.Unit.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.Unit/SekibanDcbDecider.Unit.csproj
@@ -15,9 +15,9 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.3.0" />
-    <PackageReference Include="Sekiban.Dcb.Core.Testing" Version="10.3.0" />
-    <PackageReference Include="Sekiban.Dcb.WithoutResult.Testing" Version="10.3.0" />
+    <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.4.0" />
+    <PackageReference Include="Sekiban.Dcb.Core.Testing" Version="10.4.0" />
+    <PackageReference Include="Sekiban.Dcb.WithoutResult.Testing" Version="10.4.0" />
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />
   </ItemGroup>
   <ItemGroup>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult.Aws/SekibanDcbOrleansAws.ApiService/Program.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult.Aws/SekibanDcbOrleansAws.ApiService/Program.cs
@@ -9,6 +9,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Orleans.Storage;
 using Scalar.AspNetCore;
+using Sekiban.Dcb.Capabilities;
 using Sekiban.Dcb;
 using Sekiban.Dcb.Actors;
 using Sekiban.Dcb.BlobStorage.S3;
@@ -330,6 +331,18 @@ if (builder.Environment.IsDevelopment())
         });
     });
 }
+// Fail closed in Production. The guard resolves what the container ACTUALLY built — the executor and both stores —
+// and refuses to start the host if what it finds would lose data: an in-process (testing) executor, which is never
+// allowed in Production and has no override, or a store that is Volatile or will not say what it is. Volatile storage
+// alone can be authorised deliberately, by name, with AllowVolatileStorageInProduction — storage only; it can never
+// authorise a testing executor.
+//
+// Development is unaffected: outside Production this only logs the startup banner (environment, executor runtime,
+// store providers and durability, overrides in use). Register it AFTER the Sekiban registrations above.
+//
+// https://github.com/J-Tech-Japan/Sekiban/blob/main/docs/dcb_llm/11_storage_providers.md
+builder.Services.AddSekibanDcbProductionGuard();
+
 var app = builder.Build();
 
 // DynamoDB tables will be created automatically by DynamoDbInitializer

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult.Aws/SekibanDcbOrleansAws.ApiService/Program.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult.Aws/SekibanDcbOrleansAws.ApiService/Program.cs
@@ -331,15 +331,9 @@ if (builder.Environment.IsDevelopment())
         });
     });
 }
-// Fail closed in Production. The guard resolves what the container ACTUALLY built — the executor and both stores —
-// and refuses to start the host if what it finds would lose data: an in-process (testing) executor, which is never
-// allowed in Production and has no override, or a store that is Volatile or will not say what it is. Volatile storage
-// alone can be authorised deliberately, by name, with AllowVolatileStorageInProduction — storage only; it can never
-// authorise a testing executor.
-//
-// Development is unaffected: outside Production this only logs the startup banner (environment, executor runtime,
-// store providers and durability, overrides in use). Register it AFTER the Sekiban registrations above.
-//
+// Fail-closed startup guard: in Production, refuses to start on a testing executor (always — no override) or a
+// Volatile/Unknown store (Volatile authorisable by name via AllowVolatileStorageInProduction, storage only).
+// Development only logs the banner. Must come AFTER the Sekiban registrations. Contract:
 // https://github.com/J-Tech-Japan/Sekiban/blob/main/docs/dcb_llm/11_storage_providers.md
 builder.Services.AddSekibanDcbProductionGuard();
 

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult.Aws/SekibanDcbOrleansAws.ApiService/SekibanDcbOrleansAws.ApiService.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult.Aws/SekibanDcbOrleansAws.ApiService/SekibanDcbOrleansAws.ApiService.csproj
@@ -27,13 +27,13 @@
         <!-- SQS streaming will be added when Orleans SQS package supports AWS SDK v4 -->
         <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.3" />
         <PackageReference Include="Scalar.AspNetCore" Version="2.12.50" />
-        <PackageReference Include="Sekiban.Dcb.Orleans.WithoutResult" Version="10.3.0" />
-        <PackageReference Include="Sekiban.Dcb.DynamoDB" Version="10.3.0" />
-        <PackageReference Include="Sekiban.Dcb.BlobStorage.S3" Version="10.3.0" />
-        <PackageReference Include="Sekiban.Dcb.Postgres" Version="10.3.0" />
-        <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.3.0" />
-        <PackageReference Include="Sekiban.Dcb.MaterializedView.Postgres" Version="10.3.0" />
-        <PackageReference Include="Sekiban.Dcb.MaterializedView.Orleans" Version="10.3.0" />
+        <PackageReference Include="Sekiban.Dcb.Orleans.WithoutResult" Version="10.4.0" />
+        <PackageReference Include="Sekiban.Dcb.DynamoDB" Version="10.4.0" />
+        <PackageReference Include="Sekiban.Dcb.BlobStorage.S3" Version="10.4.0" />
+        <PackageReference Include="Sekiban.Dcb.Postgres" Version="10.4.0" />
+        <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.4.0" />
+        <PackageReference Include="Sekiban.Dcb.MaterializedView.Postgres" Version="10.4.0" />
+        <PackageReference Include="Sekiban.Dcb.MaterializedView.Orleans" Version="10.4.0" />
         <PackageReference Include="Dapper" Version="2.1.66" />
         <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />
     </ItemGroup>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult.Aws/SekibanDcbOrleansAws.Domain/SekibanDcbOrleansAws.Domain.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult.Aws/SekibanDcbOrleansAws.Domain/SekibanDcbOrleansAws.Domain.csproj
@@ -7,8 +7,8 @@
     <IsPackable>true</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.3.0" />
-    <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.3.0" />
+    <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.4.0" />
+    <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.4.0" />
     <PackageReference Include="ResultBoxes" Version="0.4.0" />
     <PackageReference Include="Microsoft.Orleans.Serialization" Version="10.0.1" />
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult.Aws/SekibanDcbOrleansAws.Unit/SampleTests.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult.Aws/SekibanDcbOrleansAws.Unit/SampleTests.cs
@@ -1,9 +1,37 @@
+using Dcb.Domain.WithoutResult;
+using Dcb.Domain.WithoutResult.Student;
 using NUnit.Framework;
+using Sekiban.Dcb;
+using Sekiban.Dcb.Testing;
 
 namespace SekibanDcbOrleansAws.Unit;
 
 public class SampleTests
 {
     [Test]
-    public void SimplePass() => Assert.Pass();
+    public void DomainType_GetDomainTypes_ReturnsNonNull()
+    {
+        Assert.That(DomainType.GetDomainTypes(), Is.Not.Null);
+    }
+
+    [Test]
+    public async Task CreateStudent_ThenReadItBack()
+    {
+        // The unit-test composition, and the only place it belongs: an in-process executor over a volatile store.
+        // Both come from the Testing packages, and both say what they are — the executor reports TestingInProcess and
+        // the store reports Volatile, so if this composition ever turned up in a Production host with
+        // AddSekibanDcbProductionGuard() registered, that host would refuse to start. Which is the intent.
+        var domainTypes = DomainType.GetDomainTypes();
+        ISekibanExecutor executor = new InMemoryDcbExecutorForTesting(
+            domainTypes,
+            new InMemoryEventStore(domainTypes.EventTypes));
+
+        var studentId = Guid.CreateVersion7();
+
+        var executed = await executor.ExecuteAsync(new CreateStudent(studentId, "Alice", 3));
+        Assert.That(executed.Events, Is.Not.Empty);
+
+        var state = await executor.GetTagStateAsync<StudentProjector>(new StudentTag(studentId));
+        Assert.That(state.Payload, Is.TypeOf<StudentState>());
+    }
 }

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult.Aws/SekibanDcbOrleansAws.Unit/SekibanDcbOrleansAws.Unit.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult.Aws/SekibanDcbOrleansAws.Unit/SekibanDcbOrleansAws.Unit.csproj
@@ -14,6 +14,12 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.4.0" />
+    <PackageReference Include="Sekiban.Dcb.Core.Testing" Version="10.4.0" />
+    <PackageReference Include="Sekiban.Dcb.WithoutResult.Testing" Version="10.4.0" />
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\SekibanDcbOrleansAws.Domain\SekibanDcbOrleansAws.Domain.csproj" />
   </ItemGroup>
 </Project>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.ApiService/Program.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.ApiService/Program.cs
@@ -14,6 +14,7 @@ using Orleans.Configuration;
 using Microsoft.Extensions.Logging;
 using Orleans.Storage;
 using Scalar.AspNetCore;
+using Sekiban.Dcb.Capabilities;
 using Sekiban.Dcb;
 using Sekiban.Dcb.Actors;
 using Sekiban.Dcb.Orleans;
@@ -459,6 +460,18 @@ if (builder.Environment.IsDevelopment())
         });
     });
 }
+// Fail closed in Production. The guard resolves what the container ACTUALLY built — the executor and both stores —
+// and refuses to start the host if what it finds would lose data: an in-process (testing) executor, which is never
+// allowed in Production and has no override, or a store that is Volatile or will not say what it is. Volatile storage
+// alone can be authorised deliberately, by name, with AllowVolatileStorageInProduction — storage only; it can never
+// authorise a testing executor.
+//
+// Development is unaffected: outside Production this only logs the startup banner (environment, executor runtime,
+// store providers and durability, overrides in use). Register it AFTER the Sekiban registrations above.
+//
+// https://github.com/J-Tech-Japan/Sekiban/blob/main/docs/dcb_llm/11_storage_providers.md
+builder.Services.AddSekibanDcbProductionGuard();
+
 var app = builder.Build();
 
 // Log startup configuration

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.ApiService/Program.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.ApiService/Program.cs
@@ -460,15 +460,9 @@ if (builder.Environment.IsDevelopment())
         });
     });
 }
-// Fail closed in Production. The guard resolves what the container ACTUALLY built — the executor and both stores —
-// and refuses to start the host if what it finds would lose data: an in-process (testing) executor, which is never
-// allowed in Production and has no override, or a store that is Volatile or will not say what it is. Volatile storage
-// alone can be authorised deliberately, by name, with AllowVolatileStorageInProduction — storage only; it can never
-// authorise a testing executor.
-//
-// Development is unaffected: outside Production this only logs the startup banner (environment, executor runtime,
-// store providers and durability, overrides in use). Register it AFTER the Sekiban registrations above.
-//
+// Fail-closed startup guard: in Production, refuses to start on a testing executor (always — no override) or a
+// Volatile/Unknown store (Volatile authorisable by name via AllowVolatileStorageInProduction, storage only).
+// Development only logs the banner. Must come AFTER the Sekiban registrations. Contract:
 // https://github.com/J-Tech-Japan/Sekiban/blob/main/docs/dcb_llm/11_storage_providers.md
 builder.Services.AddSekibanDcbProductionGuard();
 

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.ApiService/SekibanDcbOrleans.ApiService.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.ApiService/SekibanDcbOrleans.ApiService.csproj
@@ -30,14 +30,14 @@
         <PackageReference Include="Microsoft.Orleans.Streaming" Version="10.0.1" />
         <PackageReference Include="Microsoft.Orleans.Streaming.AzureStorage" Version="10.0.1" />
         <PackageReference Include="Scalar.AspNetCore" Version="2.12.50" />
-        <PackageReference Include="Sekiban.Dcb.BlobStorage.AzureStorage" Version="10.3.0" />
-        <PackageReference Include="Sekiban.Dcb.Orleans.WithoutResult" Version="10.3.0" />
-        <PackageReference Include="Sekiban.Dcb.Postgres" Version="10.3.0" />
-        <PackageReference Include="Sekiban.Dcb.CosmosDb" Version="10.3.0" />
-        <PackageReference Include="Sekiban.Dcb.Sqlite" Version="10.3.0" />
-        <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.3.0" />
-        <PackageReference Include="Sekiban.Dcb.MaterializedView.Postgres" Version="10.3.0" />
-        <PackageReference Include="Sekiban.Dcb.MaterializedView.Orleans" Version="10.3.0" />
+        <PackageReference Include="Sekiban.Dcb.BlobStorage.AzureStorage" Version="10.4.0" />
+        <PackageReference Include="Sekiban.Dcb.Orleans.WithoutResult" Version="10.4.0" />
+        <PackageReference Include="Sekiban.Dcb.Postgres" Version="10.4.0" />
+        <PackageReference Include="Sekiban.Dcb.CosmosDb" Version="10.4.0" />
+        <PackageReference Include="Sekiban.Dcb.Sqlite" Version="10.4.0" />
+        <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.4.0" />
+        <PackageReference Include="Sekiban.Dcb.MaterializedView.Postgres" Version="10.4.0" />
+        <PackageReference Include="Sekiban.Dcb.MaterializedView.Orleans" Version="10.4.0" />
         <PackageReference Include="Dapper" Version="2.1.66" />
         <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />
     </ItemGroup>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.Cli/SekibanDcbOrleans.Cli.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.Cli/SekibanDcbOrleans.Cli.csproj
@@ -14,10 +14,10 @@
         <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.3" />
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.3" />
         <PackageReference Include="System.CommandLine" Version="2.0.2" />
-        <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.3.0" />
-        <PackageReference Include="Sekiban.Dcb.Postgres" Version="10.3.0" />
-        <PackageReference Include="Sekiban.Dcb.CosmosDb" Version="10.3.0" />
-        <PackageReference Include="Sekiban.Dcb.Sqlite" Version="10.3.0" />
+        <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.4.0" />
+        <PackageReference Include="Sekiban.Dcb.Postgres" Version="10.4.0" />
+        <PackageReference Include="Sekiban.Dcb.CosmosDb" Version="10.4.0" />
+        <PackageReference Include="Sekiban.Dcb.Sqlite" Version="10.4.0" />
         <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />
     </ItemGroup>
 

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.Domain/SekibanDcbOrleans.Domain.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.Domain/SekibanDcbOrleans.Domain.csproj
@@ -7,8 +7,8 @@
     <IsPackable>true</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.3.0" />
-    <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.3.0" />
+    <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.4.0" />
+    <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.4.0" />
     <PackageReference Include="ResultBoxes" Version="0.4.0" />
     <PackageReference Include="Microsoft.Orleans.Serialization" Version="10.0.1" />
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.Unit/SampleTests.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.Unit/SampleTests.cs
@@ -1,9 +1,37 @@
+using Dcb.Domain.WithoutResult;
+using Dcb.Domain.WithoutResult.Student;
 using NUnit.Framework;
+using Sekiban.Dcb;
+using Sekiban.Dcb.Testing;
 
 namespace SekibanDcbOrleans.Unit;
 
 public class SampleTests
 {
     [Test]
-    public void SimplePass() => Assert.Pass();
+    public void DomainType_GetDomainTypes_ReturnsNonNull()
+    {
+        Assert.That(DomainType.GetDomainTypes(), Is.Not.Null);
+    }
+
+    [Test]
+    public async Task CreateStudent_ThenReadItBack()
+    {
+        // The unit-test composition, and the only place it belongs: an in-process executor over a volatile store.
+        // Both come from the Testing packages, and both say what they are — the executor reports TestingInProcess and
+        // the store reports Volatile, so if this composition ever turned up in a Production host with
+        // AddSekibanDcbProductionGuard() registered, that host would refuse to start. Which is the intent.
+        var domainTypes = DomainType.GetDomainTypes();
+        ISekibanExecutor executor = new InMemoryDcbExecutorForTesting(
+            domainTypes,
+            new InMemoryEventStore(domainTypes.EventTypes));
+
+        var studentId = Guid.CreateVersion7();
+
+        var executed = await executor.ExecuteAsync(new CreateStudent(studentId, "Alice", 3));
+        Assert.That(executed.Events, Is.Not.Empty);
+
+        var state = await executor.GetTagStateAsync<StudentProjector>(new StudentTag(studentId));
+        Assert.That(state.Payload, Is.TypeOf<StudentState>());
+    }
 }

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.Unit/SekibanDcbOrleans.Unit.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.Unit/SekibanDcbOrleans.Unit.csproj
@@ -14,6 +14,12 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.4.0" />
+    <PackageReference Include="Sekiban.Dcb.Core.Testing" Version="10.4.0" />
+    <PackageReference Include="Sekiban.Dcb.WithoutResult.Testing" Version="10.4.0" />
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\SekibanDcbOrleans.Domain\SekibanDcbOrleans.Domain.csproj" />
   </ItemGroup>
 </Project>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans/SekibanDcbOrleans.ApiService/Program.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans/SekibanDcbOrleans.ApiService/Program.cs
@@ -527,15 +527,9 @@ if (builder.Environment.IsDevelopment())
     {
         options.AddPolicy("AllowAll", policy => { policy.AllowAnyOrigin().AllowAnyHeader().AllowAnyMethod(); });
     });
-// Fail closed in Production. The guard resolves what the container ACTUALLY built — the executor and both stores —
-// and refuses to start the host if what it finds would lose data: an in-process (testing) executor, which is never
-// allowed in Production and has no override, or a store that is Volatile or will not say what it is. Volatile storage
-// alone can be authorised deliberately, by name, with AllowVolatileStorageInProduction — storage only; it can never
-// authorise a testing executor.
-//
-// Development is unaffected: outside Production this only logs the startup banner (environment, executor runtime,
-// store providers and durability, overrides in use). Register it AFTER the Sekiban registrations above.
-//
+// Fail-closed startup guard: in Production, refuses to start on a testing executor (always — no override) or a
+// Volatile/Unknown store (Volatile authorisable by name via AllowVolatileStorageInProduction, storage only).
+// Development only logs the banner. Must come AFTER the Sekiban registrations. Contract:
 // https://github.com/J-Tech-Japan/Sekiban/blob/main/docs/dcb_llm/11_storage_providers.md
 builder.Services.AddSekibanDcbProductionGuard();
 

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans/SekibanDcbOrleans.ApiService/Program.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans/SekibanDcbOrleans.ApiService/Program.cs
@@ -14,6 +14,7 @@ using Microsoft.AspNetCore.Mvc;
 using Orleans.Configuration;
 using Orleans.Storage;
 using Scalar.AspNetCore;
+using Sekiban.Dcb.Capabilities;
 using Sekiban.Dcb;
 using Sekiban.Dcb.Actors;
 using Sekiban.Dcb.BlobStorage.AzureStorage;
@@ -526,6 +527,18 @@ if (builder.Environment.IsDevelopment())
     {
         options.AddPolicy("AllowAll", policy => { policy.AllowAnyOrigin().AllowAnyHeader().AllowAnyMethod(); });
     });
+// Fail closed in Production. The guard resolves what the container ACTUALLY built — the executor and both stores —
+// and refuses to start the host if what it finds would lose data: an in-process (testing) executor, which is never
+// allowed in Production and has no override, or a store that is Volatile or will not say what it is. Volatile storage
+// alone can be authorised deliberately, by name, with AllowVolatileStorageInProduction — storage only; it can never
+// authorise a testing executor.
+//
+// Development is unaffected: outside Production this only logs the startup banner (environment, executor runtime,
+// store providers and durability, overrides in use). Register it AFTER the Sekiban registrations above.
+//
+// https://github.com/J-Tech-Japan/Sekiban/blob/main/docs/dcb_llm/11_storage_providers.md
+builder.Services.AddSekibanDcbProductionGuard();
+
 var app = builder.Build();
 
 // Log startup configuration

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans/SekibanDcbOrleans.ApiService/SekibanDcbOrleans.ApiService.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans/SekibanDcbOrleans.ApiService/SekibanDcbOrleans.ApiService.csproj
@@ -28,14 +28,14 @@
     <PackageReference Include="Microsoft.Orleans.Streaming.AzureStorage" Version="10.0.1" />
     <PackageReference Include="Microsoft.Orleans.Streaming.EventHubs" Version="10.0.1" />
     <PackageReference Include="Scalar.AspNetCore" Version="2.12.50" />
-    <PackageReference Include="Sekiban.Dcb.BlobStorage.AzureStorage" Version="10.3.0" />
-    <PackageReference Include="Sekiban.Dcb.Orleans.WithResult" Version="10.3.0" />
-    <PackageReference Include="Sekiban.Dcb.Postgres" Version="10.3.0" />
-    <PackageReference Include="Sekiban.Dcb.CosmosDb" Version="10.3.0" />
-    <PackageReference Include="Sekiban.Dcb.Sqlite" Version="10.3.0" />
-    <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.3.0" />
-    <PackageReference Include="Sekiban.Dcb.MaterializedView.Postgres" Version="10.3.0" />
-    <PackageReference Include="Sekiban.Dcb.MaterializedView.Orleans" Version="10.3.0" />
+    <PackageReference Include="Sekiban.Dcb.BlobStorage.AzureStorage" Version="10.4.0" />
+    <PackageReference Include="Sekiban.Dcb.Orleans.WithResult" Version="10.4.0" />
+    <PackageReference Include="Sekiban.Dcb.Postgres" Version="10.4.0" />
+    <PackageReference Include="Sekiban.Dcb.CosmosDb" Version="10.4.0" />
+    <PackageReference Include="Sekiban.Dcb.Sqlite" Version="10.4.0" />
+    <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.4.0" />
+    <PackageReference Include="Sekiban.Dcb.MaterializedView.Postgres" Version="10.4.0" />
+    <PackageReference Include="Sekiban.Dcb.MaterializedView.Orleans" Version="10.4.0" />
     <PackageReference Include="Dapper" Version="2.1.66" />
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />
   </ItemGroup>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans/SekibanDcbOrleans.Cli/SekibanDcbOrleans.Cli.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans/SekibanDcbOrleans.Cli/SekibanDcbOrleans.Cli.csproj
@@ -14,10 +14,10 @@
         <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.3" />
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.3" />
         <PackageReference Include="System.CommandLine" Version="2.0.2" />
-        <PackageReference Include="Sekiban.Dcb.WithResult" Version="10.3.0" />
-        <PackageReference Include="Sekiban.Dcb.Postgres" Version="10.3.0" />
-        <PackageReference Include="Sekiban.Dcb.CosmosDb" Version="10.3.0" />
-        <PackageReference Include="Sekiban.Dcb.Sqlite" Version="10.3.0" />
+        <PackageReference Include="Sekiban.Dcb.WithResult" Version="10.4.0" />
+        <PackageReference Include="Sekiban.Dcb.Postgres" Version="10.4.0" />
+        <PackageReference Include="Sekiban.Dcb.CosmosDb" Version="10.4.0" />
+        <PackageReference Include="Sekiban.Dcb.Sqlite" Version="10.4.0" />
         <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />
     </ItemGroup>
 

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans/SekibanDcbOrleans.Domain/SekibanDcbOrleans.Domain.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans/SekibanDcbOrleans.Domain/SekibanDcbOrleans.Domain.csproj
@@ -7,8 +7,8 @@
     <IsPackable>true</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Sekiban.Dcb.WithResult" Version="10.3.0" />
-    <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.3.0" />
+    <PackageReference Include="Sekiban.Dcb.WithResult" Version="10.4.0" />
+    <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.4.0" />
     <PackageReference Include="ResultBoxes" Version="0.4.0" />
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />
   </ItemGroup>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans/SekibanDcbOrleans.Unit/SampleTests.cs
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans/SekibanDcbOrleans.Unit/SampleTests.cs
@@ -1,9 +1,38 @@
+using Dcb.Domain;
+using Dcb.Domain.Student;
 using NUnit.Framework;
+using Sekiban.Dcb;
+using Sekiban.Dcb.Testing;
 
 namespace SekibanDcbOrleans.Unit;
 
 public class SampleTests
 {
     [Test]
-    public void SimplePass() => Assert.Pass();
+    public void DomainType_GetDomainTypes_ReturnsNonNull()
+    {
+        Assert.That(DomainType.GetDomainTypes(), Is.Not.Null);
+    }
+
+    [Test]
+    public async Task CreateStudent_ThenReadItBack()
+    {
+        // The unit-test composition, and the only place it belongs: an in-process executor over a volatile store.
+        // Both come from the Testing packages, and both say what they are — the executor reports TestingInProcess and
+        // the store reports Volatile, so if this composition ever turned up in a Production host with
+        // AddSekibanDcbProductionGuard() registered, that host would refuse to start. Which is the intent.
+        var domainTypes = DomainType.GetDomainTypes();
+        ISekibanExecutor executor = new InMemoryDcbExecutorForTesting(
+            domainTypes,
+            new InMemoryEventStore(domainTypes.EventTypes));
+
+        var studentId = Guid.CreateVersion7();
+
+        var executed = await executor.ExecuteAsync(new CreateStudent(studentId, "Alice", 3));
+        Assert.That(executed.IsSuccess, Is.True);
+
+        var state = await executor.GetTagStateAsync<StudentProjector>(new StudentTag(studentId));
+        Assert.That(state.IsSuccess, Is.True);
+        Assert.That(state.GetValue().Payload, Is.TypeOf<StudentState>());
+    }
 }

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans/SekibanDcbOrleans.Unit/SekibanDcbOrleans.Unit.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans/SekibanDcbOrleans.Unit/SekibanDcbOrleans.Unit.csproj
@@ -14,6 +14,12 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Sekiban.Dcb.WithResult" Version="10.4.0" />
+    <PackageReference Include="Sekiban.Dcb.Core.Testing" Version="10.4.0" />
+    <PackageReference Include="Sekiban.Dcb.WithResult.Testing" Version="10.4.0" />
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\SekibanDcbOrleans.Domain\SekibanDcbOrleans.Domain.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Closes #1072

## First, the repair — and it was mine

SEK-G11 added `Sekiban.Dcb.Core.Testing` / `Sekiban.Dcb.WithoutResult.Testing` references to four Unit projects at `Version="10.3.0"`. Those packages have never had a 10.3.0 — they first exist at **10.4.0**. My migration script copied the version from the `Sekiban.Dcb.WithoutResult` reference sitting next to it, and nothing in CI generates a template project, so it merged. Two templates have been generating a project that **cannot restore** since then.

Every `Sekiban.Dcb.*` reference in all five templates is now **10.4.0**, and no stale version remains anywhere under `templates/`. There are **87** such references (an earlier draft of this body said 78 — that was the count my bump step *touched*, i.e. the 10.3.0→10.4.0 replacements; the nine-reference difference is the Testing-package set added to the Unit projects). Reproducible:

```bash
# total Sekiban.Dcb.* PackageReferences under the templates -> 87
grep -rhoE '<PackageReference Include="Sekiban\.Dcb\.[^"]*" Version="[^"]*"' templates/Sekiban.Dcb.Templates | wc -l
# how many are NOT 10.4.0 -> 0
grep -rhoE '<PackageReference Include="Sekiban\.Dcb\.[^"]*" Version="[^"]*"' templates/Sekiban.Dcb.Templates | grep -vc 10.4.0
```

## Unit projects

The three Orleans templates' Unit projects were placeholders: a single `Assert.Pass()`. Adding Testing package references to a project that uses nothing would have satisfied the letter of the acceptance criterion and taught nobody anything, so they now hold a **real sample** instead:

```csharp
var domainTypes = DomainType.GetDomainTypes();
ISekibanExecutor executor = new InMemoryDcbExecutorForTesting(
    domainTypes,
    new InMemoryEventStore(domainTypes.EventTypes));

await executor.ExecuteAsync(new CreateStudent(studentId, "Alice", 3));
var state = await executor.GetTagStateAsync<StudentProjector>(new StudentTag(studentId));
```

That is the composition a unit test is supposed to have, written where a user will actually look for it — and both halves declare what they are (`TestingInProcess`, `Volatile`), so if this composition ever turned up in a Production host, the guard below would refuse to start it. The comment in the generated file says exactly that.

The Decider templates' Unit projects were already on the Testing packages and needed only the version repair.

**Generated projects build with zero obsolete warnings** — nothing in a generated solution touches the `[Obsolete]` in-package volatile surfaces any more.

## Production guard, on by default

All five ApiServices call `AddSekibanDcbProductionGuard()` after their Sekiban registrations. The comment states the contract *accurately*, not approximately — this distinction cost two review rounds on SEK-G11, so it is worth getting right in the code new users read first:

- an **in-process (testing) executor is always rejected in Production**, and has **no override**;
- a **Volatile or Unknown store is rejected by default**, and only `Volatile` can be authorised — deliberately, by name, with the storage-only `AllowVolatileStorageInProduction`, which can never authorise a testing executor.

**Development is unaffected**: outside Production the guard only logs the startup banner (environment, executor runtime, store providers + durability, overrides in use). Local runs are unchanged.

## A pre-existing bug this slice could not leave alone

`sekiban-dcb-decider`'s `template.json` excluded **one of its four** Unit projects on `--IncludeTests false`. (Its `.slnx` already guarded all four, and `decider-aws` already excluded all four — so this was an inconsistency, not a design.) The result: "give me no tests" left three orphaned test-project directories on disk. Harmless before; as of this PR those directories carry Testing package references into a project that asked for no tests. Fixed — all five templates now leave **zero** test-project directories with `--IncludeTests false`.

## Verification — every line of this was run

| step | result |
|---|---|
| `dotnet pack` → `10.4.0-local` → `dotnet new install` | ok, 5 templates registered |
| instantiate all five | 5/5 |
| `dotnet build` each | **5/5, 0 errors** |
| obsolete warnings (`CS0618`/`CS0612`, clean `--no-incremental`) | **0 in all five** |
| `dotnet test` each | **5/5 pass** — 11 / 8 / 2 / 2 / 2 (the new samples really execute commands) |
| `--IncludeTests false` on all five | **5/5 build, 0 leftover `*Unit*` directories** |
| grep: `Sekiban.Dcb.*` versions in generated output | all `10.4.0` |
| grep: `*.Testing` referenced by a non-Unit project | **none** — only `*.Unit` |
| grep: `AddSekibanDcbProductionGuard` in generated ApiServices | **5/5** |
| diff scope | confined to `templates/Sekiban.Dcb.Templates`; `git diff --check` clean |

## SonarCloud duplication gate

The review flags `new_duplicated_lines_density` red (reliability, security, maintainability and hotspots all pass; the issue API reports no individual issues). It is duplication on new code, and this PR is, by definition, adding near-identical files to five parallel templates — the same by-design template-scaffolding duplication that blocked [SEK-G8 / #1064](https://github.com/J-Tech-Japan/Sekiban/pull/1064).

What I did about it: the largest identical new block was the ~10-line guard comment, copied verbatim into five standalone `Program.cs` files that cannot share code. I shrank it to a four-line comment that keeps the one distinction that matters and links the full contract. The guard call and its behaviour are unchanged.

What I did **not** do: fabricate differences between the three sample tests to move the number. Three templates that each "create a student and read it back" produce near-identical files because the templates are near-identical. Faking a diff to satisfy a duplication metric would be lying to the tool. If the gate is still red after the comment reduction, this needs an explicit operator exception for intentional template duplication — the SEK-G8 decision — not a doctored diff.

## Closeout note

This is the second time a templates defect has shipped because **`templates/` matches no workflow path filter** — CI does not pack, instantiate or build a single template, so both the broken 10.3.0 reference and the incomplete `--IncludeTests` exclusion merged green. The verification table above is a human running commands, and it will keep being a human until a template-CI packet exists. I have raised this in every closeout since SEK-G8; it is now the direct cause of a shipped restore failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017KAPyZPCMZzurEZTt1k8LX
