### PR TITLE
fix(dcb): use invocation cursor for first-query barrier

### DIFF
--- a/dcb/src/Sekiban.Dcb.Orleans.Core/Grains/CatchUpPositionContracts.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.Core/Grains/CatchUpPositionContracts.cs
@@ -1,4 +1,5 @@
 using Sekiban.Dcb.Common;
+using System.Collections.Concurrent;
 
 namespace Sekiban.Dcb.Orleans.Grains;
 
@@ -24,12 +25,14 @@ internal enum CatchUpStartPositionSource
 internal sealed class CatchUpStartPositionLeaseResolver
 {
     private readonly object _sync = new();
+    private bool _hasPendingRestoredPosition;
     private SortableUniqueId? _pendingRestoredPosition;
 
     internal void Restore(SortableUniqueId? position)
     {
         lock (_sync)
         {
+            _hasPendingRestoredPosition = true;
             _pendingRestoredPosition = position;
         }
     }
@@ -38,6 +41,7 @@ internal sealed class CatchUpStartPositionLeaseResolver
     {
         lock (_sync)
         {
+            _hasPendingRestoredPosition = false;
             _pendingRestoredPosition = null;
         }
     }
@@ -54,8 +58,10 @@ internal sealed class CatchUpStartPositionLeaseResolver
 
         lock (_sync)
         {
-            if (_pendingRestoredPosition is { } restored)
+            if (_hasPendingRestoredPosition)
             {
+                var restored = _pendingRestoredPosition;
+                _hasPendingRestoredPosition = false;
                 _pendingRestoredPosition = null;
                 return new CatchUpStartPositionLease(restored, CatchUpStartPositionSource.RestoredCheckpoint);
             }
@@ -78,6 +84,68 @@ internal sealed record CatchUpInvocationResult(
 internal readonly record struct CatchUpBatchResult(
     int ProcessedCount,
     SortableUniqueId? AuthoritativeReadCursor);
+
+internal enum CatchUpProductionHookPoint
+{
+    BackgroundBeforeGate,
+    BackgroundEnteredGate,
+    BackgroundRejectedAsSuperseded,
+    InvocationBeforeGate,
+    InvocationEnteredGate,
+    InvocationCompleted
+}
+
+internal sealed record CatchUpProductionObservation(
+    string ServiceId,
+    string ProjectorName,
+    CatchUpStartPositionLease? Start,
+    SortableUniqueId? Cursor);
+
+/// <summary>
+///     Friend-test-only deterministic observation seam for the real grain wiring. Registrations are scoped by the
+///     activation's service/projector identity and absent in production, where the lookup is a no-op.
+/// </summary>
+internal static class CatchUpProductionTestHooks
+{
+    private static readonly ConcurrentDictionary<string, Func<CatchUpProductionHookPoint, CatchUpProductionObservation, Task>>
+        Observers = new(StringComparer.Ordinal);
+
+    internal static IDisposable Register(
+        string serviceId,
+        string projectorName,
+        Func<CatchUpProductionHookPoint, CatchUpProductionObservation, Task> observer)
+    {
+        var key = Key(serviceId, projectorName);
+        if (!Observers.TryAdd(key, observer))
+        {
+            throw new InvalidOperationException($"A catch-up test hook is already registered for '{key}'.");
+        }
+        return new Registration(key);
+    }
+
+    internal static Task PublishAsync(
+        CatchUpProductionHookPoint point,
+        CatchUpProductionObservation observation) =>
+        Observers.TryGetValue(Key(observation.ServiceId, observation.ProjectorName), out var observer)
+            ? observer(point, observation)
+            : Task.CompletedTask;
+
+    private static string Key(string serviceId, string projectorName) => $"{serviceId}\n{projectorName}";
+
+    private sealed class Registration(string key) : IDisposable
+    {
+        private string? _key = key;
+
+        public void Dispose()
+        {
+            var current = Interlocked.Exchange(ref _key, null);
+            if (current is not null)
+            {
+                Observers.TryRemove(current, out _);
+            }
+        }
+    }
+}
 
 /// <summary>
 ///     Activation-local single-writer gate for timer and in-call runs.

--- a/dcb/src/Sekiban.Dcb.Orleans.Core/Grains/CatchUpPositionContracts.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.Core/Grains/CatchUpPositionContracts.cs
@@ -1,0 +1,105 @@
+using Sekiban.Dcb.Common;
+
+namespace Sekiban.Dcb.Orleans.Grains;
+
+/// <summary>
+///     The start checkpoint for one catch-up run. A restored checkpoint is leased once and is never replaced by
+///     host-payload inference while it is pending.
+/// </summary>
+internal sealed record CatchUpStartPositionLease(
+    SortableUniqueId? StartPosition,
+    CatchUpStartPositionSource Source);
+
+internal enum CatchUpStartPositionSource
+{
+    InferredCheckpoint,
+    RestoredCheckpoint,
+    FullReplay
+}
+
+/// <summary>
+///     Single owner of the pending restored checkpoint position. Both timer and in-call catch-up paths acquire their
+///     start through this resolver so the restored record remains authoritative and is consumed exactly once.
+/// </summary>
+internal sealed class CatchUpStartPositionLeaseResolver
+{
+    private readonly object _sync = new();
+    private SortableUniqueId? _pendingRestoredPosition;
+
+    internal void Restore(SortableUniqueId? position)
+    {
+        lock (_sync)
+        {
+            _pendingRestoredPosition = position;
+        }
+    }
+
+    internal void Clear()
+    {
+        lock (_sync)
+        {
+            _pendingRestoredPosition = null;
+        }
+    }
+
+    internal async Task<CatchUpStartPositionLease> AcquireAsync(
+        bool forceFullReplay,
+        Func<Task<SortableUniqueId?>> inferCheckpointAsync)
+    {
+        if (forceFullReplay)
+        {
+            Clear();
+            return new CatchUpStartPositionLease(null, CatchUpStartPositionSource.FullReplay);
+        }
+
+        lock (_sync)
+        {
+            if (_pendingRestoredPosition is { } restored)
+            {
+                _pendingRestoredPosition = null;
+                return new CatchUpStartPositionLease(restored, CatchUpStartPositionSource.RestoredCheckpoint);
+            }
+        }
+
+        return new CatchUpStartPositionLease(
+            await inferCheckpointAsync(),
+            CatchUpStartPositionSource.InferredCheckpoint);
+    }
+}
+
+/// <summary>
+///     Invocation-owned evidence returned by one in-call refresh. The reached cursor is derived only from reads
+///     performed by that invocation; it is never inferred from the shared timer progress object.
+/// </summary>
+internal sealed record CatchUpInvocationResult(
+    CatchUpStartPositionLease Start,
+    SortableUniqueId? AuthoritativeReachedPosition);
+
+internal readonly record struct CatchUpBatchResult(
+    int ProcessedCount,
+    SortableUniqueId? AuthoritativeReadCursor);
+
+/// <summary>
+///     Activation-local single-writer gate for timer and in-call runs.
+/// </summary>
+internal sealed class CatchUpRunExecutionGate
+{
+    private readonly SemaphoreSlim _gate = new(1, 1);
+
+    internal async ValueTask<IAsyncDisposable> EnterAsync()
+    {
+        await _gate.WaitAsync();
+        return new Lease(_gate);
+    }
+
+    private sealed class Lease(SemaphoreSlim gate) : IAsyncDisposable
+    {
+        private SemaphoreSlim? _gate = gate;
+
+        public ValueTask DisposeAsync()
+        {
+            Interlocked.Exchange(ref _gate, null)?.Release();
+            return ValueTask.CompletedTask;
+        }
+    }
+}

--- a/dcb/src/Sekiban.Dcb.Orleans.Core/Grains/MultiProjectionGrain.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.Core/Grains/MultiProjectionGrain.cs
@@ -59,10 +59,9 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
     // outside the coordinator. Seeded from the committed state on activation; surfaced by status queries.
     private string? _liveLastPosition;
 
-    // SEK-G18 (#1086): the authoritative catch-up start after a checkpoint restore is the checkpoint record's own
-    // LastSortableUniqueId — taken verbatim rather than re-inferred — so the first catch-up reads strictly AFTER the
-    // durable safe position (exclusive) and never re-folds / double-counts already-reflected events. Consumed once.
-    private SortableUniqueId? _restoredCatchUpPosition;
+    // SEK-G18/G21: the sole resolver for catch-up START positions. A restored record position is leased exactly once
+    // across both the timer and in-call paths and cannot be displaced by host-payload inference while pending.
+    private readonly CatchUpStartPositionLeaseResolver _catchUpStartPositions = new();
 
     // SEK-G18 (#1086): the last SafeWindowThreshold persisted (seeded verbatim from the restored checkpoint record). While
     // the safe checkpoint position is unchanged, the persist writes THIS value verbatim rather than a fresh wall-clock
@@ -148,6 +147,7 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
     // Catch-up state management
     private class CatchUpProgress
     {
+        public CatchUpStartPositionLease? StartLease { get; set; }
         public SortableUniqueId? InitialPosition { get; set; }
         public SortableUniqueId? CurrentPosition { get; set; }
         public SortableUniqueId? TargetPosition { get; set; }
@@ -160,6 +160,9 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
     }
 
     private CatchUpProgress _catchUpProgress = new();
+    // Serialises timer and in-call catch-up writers for this activation. Interleaving timers may wait here, but a
+    // superseded timer run can never write into the progress object installed by a first-query invocation.
+    private readonly CatchUpRunExecutionGate _catchUpExecutionGate = new();
     private IDisposable? _catchUpTimer;
     private readonly Queue<SerializableEvent> _pendingStreamEvents = new();
     private const int DefaultCatchUpBatchSize = 500;
@@ -1932,13 +1935,14 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
         return await _host.IsSortableUniqueIdReceivedAsync(sortableUniqueId);
     }
 
-    public Task RefreshAsync() => RefreshAsync(forceEvenIfCatchUpActive: false);
+    public async Task RefreshAsync() =>
+        _ = await RefreshWithAuthoritativeCursorAsync(forceEvenIfCatchUpActive: false);
 
     // forceEvenIfCatchUpActive: the first-query barrier needs the in-call catch-up to RUN even when a background
     // catch-up (re)started by EnsureInitializedAsync has flipped IsActive on — otherwise the barrier would return
     // without reading and could not re-establish a fault or reach the head. Normal RefreshAsync keeps the guard so a
     // manual refresh does not fight an already-running catch-up.
-    private async Task RefreshAsync(bool forceEvenIfCatchUpActive)
+    private async Task<CatchUpInvocationResult> RefreshWithAuthoritativeCursorAsync(bool forceEvenIfCatchUpActive)
     {
         var projectorName = GetProjectorName();
         _logger.LogDebug("[{ProjectorName}] Refreshing: Re-reading events from event store", projectorName);
@@ -1946,71 +1950,95 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
         await EnsureInitializedAsync();
         if (_host == null)
         {
-            return;
+            return new CatchUpInvocationResult(
+                new CatchUpStartPositionLease(null, CatchUpStartPositionSource.InferredCheckpoint),
+                null);
         }
 
-        RecoverStaleCatchUpIfNeeded(projectorName);
-        if (_catchUpProgress.IsActive && !forceEvenIfCatchUpActive)
+        await using (await _catchUpExecutionGate.EnterAsync())
         {
-            _logger.LogDebug(
-                "[{ProjectorName}] Refresh skipped because catch-up is already active",
-                projectorName);
-            return;
-        }
-
-        // Refresh is expected to complete catch-up before returning.
-        // Use an in-call batch loop instead of timer-driven background catch-up.
-        _catchUpTimer?.Dispose();
-        _catchUpTimer = null;
-
-        var currentPosition = await GetCurrentPositionAsync();
-        _catchUpProgress = new CatchUpProgress
-        {
-            InitialPosition = currentPosition,
-            CurrentPosition = currentPosition,
-            TargetPosition = null,
-            IsActive = true,
-            HadNewEvents = false,
-            ConsecutiveEmptyBatches = 0,
-            BatchesProcessed = 0,
-            StartTime = DateTime.UtcNow,
-            LastAttempt = DateTime.MinValue
-        };
-        ResetHybridCatchUpLogging();
-        ResetCatchUpFailureTracking();
-        _catchUpBatchSkipCount = 0;
-
-        MoveBufferedStreamEventsToPending(currentPosition);
-
-        try
-        {
-            const int maxRefreshBatches = 20000;
-            for (var i = 0; i < maxRefreshBatches && _catchUpProgress.IsActive; i++)
+            var inheritedStart = forceEvenIfCatchUpActive && _catchUpProgress.IsActive
+                ? _catchUpProgress.StartLease
+                : null;
+            RecoverStaleCatchUpIfNeeded(projectorName);
+            if (_catchUpProgress.IsActive && !forceEvenIfCatchUpActive)
             {
-                var processed = await ProcessSingleCatchUpBatch();
-                if (processed == 0)
+                _logger.LogDebug(
+                    "[{ProjectorName}] Refresh skipped because catch-up is already active",
+                    projectorName);
+                return new CatchUpInvocationResult(
+                    _catchUpProgress.StartLease
+                    ?? new CatchUpStartPositionLease(
+                        _catchUpProgress.InitialPosition,
+                        CatchUpStartPositionSource.InferredCheckpoint),
+                    null);
+            }
+
+            // Refresh is expected to complete catch-up before returning. A forced first-query run inherits the active
+            // timer run's START lease before superseding it, so a restored record remains authoritative even when the
+            // background path won the one-shot lease race.
+            _catchUpTimer?.Dispose();
+            _catchUpTimer = null;
+
+            var startLease = inheritedStart
+                ?? await _catchUpStartPositions.AcquireAsync(
+                    forceFullReplay: false,
+                    GetCurrentPositionAsync);
+            var currentPosition = startLease.StartPosition;
+            var invocationReached = currentPosition;
+            _catchUpProgress = new CatchUpProgress
+            {
+                StartLease = startLease,
+                InitialPosition = currentPosition,
+                CurrentPosition = currentPosition,
+                TargetPosition = null,
+                IsActive = true,
+                HadNewEvents = false,
+                ConsecutiveEmptyBatches = 0,
+                BatchesProcessed = 0,
+                StartTime = DateTime.UtcNow,
+                LastAttempt = DateTime.MinValue
+            };
+            ResetHybridCatchUpLogging();
+            ResetCatchUpFailureTracking();
+            _catchUpBatchSkipCount = 0;
+
+            MoveBufferedStreamEventsToPending(currentPosition);
+
+            try
+            {
+                const int maxRefreshBatches = 20000;
+                for (var i = 0; i < maxRefreshBatches && _catchUpProgress.IsActive; i++)
                 {
-                    _catchUpProgress.ConsecutiveEmptyBatches++;
-                    if (_catchUpProgress.ConsecutiveEmptyBatches >= MaxConsecutiveEmptyBatches)
+                    var batch = await ProcessSingleCatchUpBatch();
+                    if (batch.AuthoritativeReadCursor is { } batchCursor &&
+                        (invocationReached is null || batchCursor.IsLaterThan(invocationReached)))
                     {
-                        await CompleteCatchUp();
+                        invocationReached = batchCursor;
+                    }
+
+                    if (batch.ProcessedCount == 0)
+                    {
+                        _catchUpProgress.ConsecutiveEmptyBatches++;
+                        if (_catchUpProgress.ConsecutiveEmptyBatches >= MaxConsecutiveEmptyBatches)
+                        {
+                            await CompleteCatchUp();
+                        }
+                    }
+                    else
+                    {
+                        _catchUpProgress.ConsecutiveEmptyBatches = 0;
                     }
                 }
-                else
-                {
-                    _catchUpProgress.ConsecutiveEmptyBatches = 0;
-                }
             }
-        }
-        finally
-        {
-            // RefreshAsync's in-call loop can fault the actor without going through the background failure handlers, and
-            // a deserialize/fold that throws propagates straight out of the loop. Capture-and-persist the fault in a
-            // finally so the descriptor is durable on THIS production path even when the loop threw — otherwise a
-            // RefreshAsync-triggered fault would only become durable at the next timer/deactivation persist.
-            // CaptureAndPersist handles its own write failures (pins + schedules a retry) and does not throw, so the
-            // original exception's identity is preserved as it propagates.
-            await CaptureAndPersistProjectionFaultIfAnyAsync();
+            finally
+            {
+                // RefreshAsync's in-call loop can fault the actor without going through the background failure handlers,
+                // so capture and persist the fault on this production path while preserving the original exception.
+                await CaptureAndPersistProjectionFaultIfAnyAsync();
+            }
+
+            return new CatchUpInvocationResult(startLease, invocationReached);
         }
     }
 
@@ -2222,9 +2250,10 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
 
                                 // SEK-G18 (#1086): take the catch-up start verbatim from the restored checkpoint record, so
                                 // catch-up reads strictly AFTER the durable safe position (exclusive) without re-folding it.
-                                _restoredCatchUpPosition = string.IsNullOrEmpty(record.LastSortableUniqueId)
-                                    ? null
-                                    : new SortableUniqueId(record.LastSortableUniqueId);
+                                _catchUpStartPositions.Restore(
+                                    string.IsNullOrEmpty(record.LastSortableUniqueId)
+                                        ? null
+                                        : new SortableUniqueId(record.LastSortableUniqueId));
 
                                 // SEK-G18 (#1086): seed the last-persisted SafeWindowThreshold verbatim so a no-progress
                                 // re-persist writes the SAME value instead of a fresh wall-clock threshold (no drift).
@@ -2770,14 +2799,12 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
 
         // Behind the head: catch up IN-CALL (not on the background timer, which a non-reentrant grain turn held by the
         // query would deadlock waiting on). RefreshAsync re-reads and re-folds the tail; a poison re-faults the actor.
-        _catchUpTimer?.Dispose();
-        _catchUpTimer = null;
-        _catchUpProgress.IsActive = false;
         _catchUpReadException = null;
 
+        CatchUpInvocationResult? invocation = null;
         try
         {
-            await RefreshAsync(forceEvenIfCatchUpActive: true);
+            invocation = await RefreshWithAuthoritativeCursorAsync(forceEvenIfCatchUpActive: true);
         }
         catch when (_host.CurrentFault is not null)
         {
@@ -2790,10 +2817,10 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
             return; // fault established and (via RefreshAsync) persisted; the query will fail closed on it.
         }
 
-        // No fault, but did catch-up actually REACH the head? Comparing the reached position with the head is the
-        // authoritative check: a read that failed was laundered into an empty batch by the resilient background path,
-        // so "catch-up completed" does not by itself prove we reached the head.
-        var reached = await GetCurrentPositionAsync();
+        // No fault, but did THIS invocation actually REACH the fixed head? Only the cursor returned by its own store
+        // reads is authoritative. The shared timer progress is observability state and may belong to a cancelled or
+        // replacement Interleave=true run, so it is deliberately never consulted for this judgment.
+        var reached = invocation?.AuthoritativeReachedPosition;
         if (reached is null || string.CompareOrdinal(reached.Value, head) < 0)
         {
             // Still behind: fail closed. Prefer the original read exception (a swallowed failed read) for context; the
@@ -3262,25 +3289,10 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
         {
             BeginCatchUpDeactivationDelay();
 
-            // Get current position (fast operation - reads from local state).
-            // SEK-G18 (#1086): immediately after a checkpoint restore, take the catch-up start verbatim from the restored
-            // record's LastSortableUniqueId (consumed once) rather than re-inferring it, so the read is strictly AFTER the
-            // durable safe position and already-reflected events are not re-folded / double-counted.
-            SortableUniqueId? currentPosition;
-            if (forceFull)
-            {
-                currentPosition = null;
-                _restoredCatchUpPosition = null;
-            }
-            else if (_restoredCatchUpPosition is { } restored)
-            {
-                currentPosition = restored;
-                _restoredCatchUpPosition = null;
-            }
-            else
-            {
-                currentPosition = await GetCurrentPositionAsync();
-            }
+            // Both background and first-query paths acquire START from the same one-shot resolver. The restored record
+            // wins over host-payload inference and is consumed exactly once.
+            var startLease = await _catchUpStartPositions.AcquireAsync(forceFull, GetCurrentPositionAsync);
+            var currentPosition = startLease.StartPosition;
 
             // NOTE: We intentionally skip reading all events to determine target position.
             // Reading 200k+ events just to find the latest position causes activation timeout.
@@ -3290,6 +3302,7 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
             // Initialize catch-up progress (TargetPosition will be set during first batch)
             _catchUpProgress = new CatchUpProgress
             {
+                StartLease = startLease,
                 InitialPosition = currentPosition,
                 CurrentPosition = currentPosition,
                 TargetPosition = null, // Will be determined during catch-up
@@ -3355,7 +3368,8 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
 
     private async Task ProcessCatchUpBatchAsync()
     {
-        if (!_catchUpProgress.IsActive)
+        var scheduledRun = _catchUpProgress;
+        if (!scheduledRun.IsActive)
         {
             _catchUpTimer?.Dispose();
             _catchUpTimer = null;
@@ -3385,11 +3399,17 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
 
         try
         {
+            await using var runLease = await _catchUpExecutionGate.EnterAsync();
+            if (!ReferenceEquals(_catchUpProgress, scheduledRun) || !scheduledRun.IsActive)
+            {
+                return;
+            }
+
             // Process one batch
-            var processed = await ProcessSingleCatchUpBatch();
+            var batch = await ProcessSingleCatchUpBatch();
             ResetCatchUpFailureTracking();
 
-            if (processed == 0)
+            if (batch.ProcessedCount == 0)
             {
                 _catchUpProgress.ConsecutiveEmptyBatches++;
                 if (_catchUpProgress.ConsecutiveEmptyBatches >= MaxConsecutiveEmptyBatches)
@@ -3415,9 +3435,9 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
         }
     }
 
-    private async Task<int> ProcessSingleCatchUpBatch()
+    private async Task<CatchUpBatchResult> ProcessSingleCatchUpBatch()
     {
-        if (_host == null) return 0;
+        if (_host == null) return new CatchUpBatchResult(0, null);
         _catchUpProgress.LastAttempt = DateTime.UtcNow;
         return await ProcessSerializableBatch();
     }
@@ -3460,7 +3480,7 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
     /// <summary>
     ///     Catch-up via ReadAllSerializableEventsAsync (cold/hot merge path).
     /// </summary>
-    private async Task<int> ProcessSerializableBatch()
+    private async Task<CatchUpBatchResult> ProcessSerializableBatch()
     {
         var projectorName = GetProjectorName();
         var catchUpStore = GetCatchUpEventStore();
@@ -3542,7 +3562,7 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
             // failure must not be lost: the first-query barrier reads this to fail closed with the original exception
             // rather than treat a failed read as "caught up to an empty tail".
             _catchUpReadException = exception;
-            return 0;
+            return new CatchUpBatchResult(0, null);
         }
 
         _logger.LogDebug(
@@ -3580,7 +3600,7 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
                     PersistTriggered: false,
                     PersistReason: "none",
                     EventTypeSummary: EmptyLogValue));
-            return 0;
+            return new CatchUpBatchResult(0, _catchUpProgress.CurrentPosition);
         }
 
         UpdateTargetPosition(events[^1].SortableUniqueIdValue);
@@ -3617,7 +3637,9 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
                     PersistTriggered: false,
                     PersistReason: "none",
                     EventTypeSummary: EmptyLogValue));
-            return 0;
+            return new CatchUpBatchResult(
+                0,
+                new SortableUniqueId(events[^1].SortableUniqueIdValue));
         }
 
         var applyStopwatch = System.Diagnostics.Stopwatch.StartNew();
@@ -3654,10 +3676,12 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
             hybridReadBatchMetadata,
             BuildCatchUpEventTypeSummary(filtered.Select(e => e.EventPayloadName)));
 
-        return filtered.Count;
+        return new CatchUpBatchResult(
+            filtered.Count,
+            new SortableUniqueId(events[^1].SortableUniqueIdValue));
     }
 
-    private async Task<int> ProcessStreamingSerializableBatch(
+    private async Task<CatchUpBatchResult> ProcessStreamingSerializableBatch(
         IStreamingSerializableEventStore streamingCatchUpStore,
         HybridEventStore? hybridCatchUpStore,
         bool isHybridCatchUp,
@@ -3667,7 +3691,7 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
     {
         if (_host == null)
         {
-            return 0;
+            return new CatchUpBatchResult(0, null);
         }
 
         var processedIds = new List<Guid>(Math.Min(batchSize, StreamingCatchUpApplyChunkSize * 2));
@@ -3756,7 +3780,7 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
                     exception,
                     "[{ProjectorName}] Failed to stream serializable events for catch-up",
                     projectorName);
-                return 0;
+                return new CatchUpBatchResult(0, null);
             }
             if (fetchedCount == 0)
             {
@@ -3787,7 +3811,7 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
                         PersistTriggered: false,
                         PersistReason: "none",
                         EventTypeSummary: EmptyLogValue));
-                return 0;
+                return new CatchUpBatchResult(0, _catchUpProgress.CurrentPosition);
             }
 
             await FlushBufferAsync();
@@ -3822,7 +3846,9 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
                         PersistTriggered: false,
                         PersistReason: "none",
                         EventTypeSummary: EmptyLogValue));
-                return 0;
+                return new CatchUpBatchResult(
+                    0,
+                    new SortableUniqueId(lastFetchedSortableUniqueId!));
             }
 
             await UpdateCatchUpProgressAfterBatch(
@@ -3850,7 +3876,11 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
             throw;
         }
 
-        return appliedCount;
+        return new CatchUpBatchResult(
+            appliedCount,
+            lastFetchedSortableUniqueId is null
+                ? _catchUpProgress.CurrentPosition
+                : new SortableUniqueId(lastFetchedSortableUniqueId));
     }
 
     private int ResolveCatchUpBatchSize(HybridEventStore? hybridCatchUpStore)

--- a/dcb/src/Sekiban.Dcb.Orleans.Core/Grains/MultiProjectionGrain.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.Core/Grains/MultiProjectionGrain.cs
@@ -1955,8 +1955,14 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
                 null);
         }
 
+        await CatchUpProductionTestHooks.PublishAsync(
+            CatchUpProductionHookPoint.InvocationBeforeGate,
+            new CatchUpProductionObservation(_serviceId, projectorName, null, null));
         await using (await _catchUpExecutionGate.EnterAsync())
         {
+            await CatchUpProductionTestHooks.PublishAsync(
+                CatchUpProductionHookPoint.InvocationEnteredGate,
+                new CatchUpProductionObservation(_serviceId, projectorName, _catchUpProgress.StartLease, null));
             var inheritedStart = forceEvenIfCatchUpActive && _catchUpProgress.IsActive
                 ? _catchUpProgress.StartLease
                 : null;
@@ -2038,7 +2044,11 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
                 await CaptureAndPersistProjectionFaultIfAnyAsync();
             }
 
-            return new CatchUpInvocationResult(startLease, invocationReached);
+            var result = new CatchUpInvocationResult(startLease, invocationReached);
+            await CatchUpProductionTestHooks.PublishAsync(
+                CatchUpProductionHookPoint.InvocationCompleted,
+                new CatchUpProductionObservation(_serviceId, projectorName, result.Start, result.AuthoritativeReachedPosition));
+            return result;
         }
     }
 
@@ -2791,14 +2801,11 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
             return; // empty store: nothing durable to be behind on.
         }
 
-        var current = await GetCurrentPositionAsync();
-        if (current is not null && string.CompareOrdinal(current.Value, head) >= 0)
-        {
-            return; // already at or past head: ordinary lag semantics resume.
-        }
-
-        // Behind the head: catch up IN-CALL (not on the background timer, which a non-reentrant grain turn held by the
-        // query would deadlock waiting on). RefreshAsync re-reads and re-folds the tail; a poison re-faults the actor.
+        // A non-empty head must be proven by this invocation's authoritative traversal. In particular, a safe-empty
+        // host may already expose a later unsafe cursor received from the stream while an earlier durable event is
+        // still missing. Shared unsafe metadata can neither skip this read nor serve as its START checkpoint.
+        // Catch up IN-CALL (not on the background timer, which a non-reentrant grain turn held by the query would
+        // deadlock waiting on). Refresh re-reads and re-folds the tail; a poison re-faults the actor.
         _catchUpReadException = null;
 
         CatchUpInvocationResult? invocation = null;
@@ -3399,9 +3406,18 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
 
         try
         {
+            await CatchUpProductionTestHooks.PublishAsync(
+                CatchUpProductionHookPoint.BackgroundBeforeGate,
+                new CatchUpProductionObservation(_serviceId, projectorName, scheduledRun.StartLease, scheduledRun.CurrentPosition));
             await using var runLease = await _catchUpExecutionGate.EnterAsync();
+            await CatchUpProductionTestHooks.PublishAsync(
+                CatchUpProductionHookPoint.BackgroundEnteredGate,
+                new CatchUpProductionObservation(_serviceId, projectorName, scheduledRun.StartLease, scheduledRun.CurrentPosition));
             if (!ReferenceEquals(_catchUpProgress, scheduledRun) || !scheduledRun.IsActive)
             {
+                await CatchUpProductionTestHooks.PublishAsync(
+                    CatchUpProductionHookPoint.BackgroundRejectedAsSuperseded,
+                    new CatchUpProductionObservation(_serviceId, projectorName, scheduledRun.StartLease, scheduledRun.CurrentPosition));
                 return;
             }
 
@@ -3780,6 +3796,9 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
                     exception,
                     "[{ProjectorName}] Failed to stream serializable events for catch-up",
                     projectorName);
+                // Match the enumerable path: the resilient background reader may retry later, but a first-query
+                // invocation must retain and rethrow this exact provider exception when its cursor did not reach head.
+                _catchUpReadException = exception;
                 return new CatchUpBatchResult(0, null);
             }
             if (fetchedCount == 0)
@@ -4206,8 +4225,10 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
     {
         if (_host == null) return null;
 
-        // Prefer the full state when available, but fall back to primitive metadata.
-        // Catch-up progress tracking should not depend on payload deserialization succeeding.
+        // START is derived only from the safe checkpoint. Unsafe metadata is observability/served-state information,
+        // not proof that every earlier durable event was traversed; using it here can skip a missing earlier event.
+        // Prefer the full safe state when available, but fall back to primitive safe metadata so catch-up progress
+        // tracking does not depend on payload deserialization succeeding.
         var currentState = await _host.GetStateAsync(canGetUnsafeState: false);
         if (currentState.IsSuccess)
         {
@@ -4222,11 +4243,6 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
         if (metadata.IsSuccess)
         {
             var value = metadata.GetValue();
-            if (!string.IsNullOrWhiteSpace(value.UnsafeLastSortableUniqueId))
-            {
-                return new SortableUniqueId(value.UnsafeLastSortableUniqueId);
-            }
-
             if (!string.IsNullOrWhiteSpace(value.SafeLastSortableUniqueId))
             {
                 return new SortableUniqueId(value.SafeLastSortableUniqueId);

--- a/dcb/tests/Sekiban.Dcb.Orleans.Tests/CatchUpPositionContractTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Orleans.Tests/CatchUpPositionContractTests.cs
@@ -62,6 +62,36 @@ public class CatchUpPositionContractTests
     }
 
     [Fact]
+    public async Task Empty_restored_record_is_present_and_leased_once_without_host_inference()
+    {
+        var resolver = new CatchUpStartPositionLeaseResolver();
+        var inferred = Position(5);
+        var inferenceCalls = 0;
+        resolver.Restore(null);
+
+        var restored = await resolver.AcquireAsync(
+            false,
+            () =>
+            {
+                inferenceCalls++;
+                return Task.FromResult<SortableUniqueId?>(inferred);
+            });
+        var next = await resolver.AcquireAsync(
+            false,
+            () =>
+            {
+                inferenceCalls++;
+                return Task.FromResult<SortableUniqueId?>(inferred);
+            });
+
+        Assert.Equal(CatchUpStartPositionSource.RestoredCheckpoint, restored.Source);
+        Assert.Null(restored.StartPosition);
+        Assert.Equal(CatchUpStartPositionSource.InferredCheckpoint, next.Source);
+        Assert.Equal(inferred.Value, next.StartPosition?.Value);
+        Assert.Equal(1, inferenceCalls);
+    }
+
+    [Fact]
     public void Reached_cursor_is_invocation_owned_and_distinct_from_start()
     {
         var start = new CatchUpStartPositionLease(Position(40), CatchUpStartPositionSource.RestoredCheckpoint);

--- a/dcb/tests/Sekiban.Dcb.Orleans.Tests/CatchUpPositionContractTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Orleans.Tests/CatchUpPositionContractTests.cs
@@ -1,0 +1,155 @@
+using Sekiban.Dcb.Common;
+using Sekiban.Dcb.Orleans.Grains;
+using Xunit;
+
+namespace Sekiban.Dcb.Orleans.Tests;
+
+/// <summary>
+///     Killing proofs for the G21 START/REACHED contract split. START has one restored-position owner; REACHED evidence
+///     is carried by the invocation result rather than obtained from mutable shared progress.
+/// </summary>
+public class CatchUpPositionContractTests
+{
+    private static SortableUniqueId Position(long tick) =>
+        new(SortableUniqueId.GetTickString(tick) + SortableUniqueId.GetIdString(Guid.Empty));
+
+    [Fact]
+    public async Task Restored_start_wins_over_host_inference_and_is_consumed_exactly_once()
+    {
+        var resolver = new CatchUpStartPositionLeaseResolver();
+        var restored = Position(20);
+        var inferred = Position(10);
+        var inferenceCalls = 0;
+        resolver.Restore(restored);
+
+        var first = await resolver.AcquireAsync(
+            forceFullReplay: false,
+            () =>
+            {
+                inferenceCalls++;
+                return Task.FromResult<SortableUniqueId?>(inferred);
+            });
+        var second = await resolver.AcquireAsync(
+            forceFullReplay: false,
+            () =>
+            {
+                inferenceCalls++;
+                return Task.FromResult<SortableUniqueId?>(inferred);
+            });
+
+        Assert.Equal(CatchUpStartPositionSource.RestoredCheckpoint, first.Source);
+        Assert.Equal(restored.Value, first.StartPosition?.Value);
+        Assert.Equal(CatchUpStartPositionSource.InferredCheckpoint, second.Source);
+        Assert.Equal(inferred.Value, second.StartPosition?.Value);
+        Assert.Equal(1, inferenceCalls);
+    }
+
+    [Fact]
+    public async Task Racing_paths_can_lease_the_restored_start_only_once()
+    {
+        var resolver = new CatchUpStartPositionLeaseResolver();
+        var restored = Position(30);
+        var inferred = Position(5);
+        resolver.Restore(restored);
+
+        var leases = await Task.WhenAll(
+            resolver.AcquireAsync(false, () => Task.FromResult<SortableUniqueId?>(inferred)),
+            resolver.AcquireAsync(false, () => Task.FromResult<SortableUniqueId?>(inferred)));
+
+        Assert.Single(leases, lease => lease.Source == CatchUpStartPositionSource.RestoredCheckpoint);
+        Assert.Single(leases, lease => lease.Source == CatchUpStartPositionSource.InferredCheckpoint);
+        Assert.Contains(leases, lease => lease.StartPosition?.Value == restored.Value);
+    }
+
+    [Fact]
+    public void Reached_cursor_is_invocation_owned_and_distinct_from_start()
+    {
+        var start = new CatchUpStartPositionLease(Position(40), CatchUpStartPositionSource.RestoredCheckpoint);
+        var reached = Position(41);
+
+        var result = new CatchUpInvocationResult(start, reached);
+
+        Assert.Equal(Position(40).Value, result.Start.StartPosition?.Value);
+        Assert.Equal(reached.Value, result.AuthoritativeReachedPosition?.Value);
+    }
+
+    [Fact]
+    public async Task Parked_timer_then_in_call_run_has_one_writer_and_preserves_in_call_cursor()
+    {
+        var gate = new CatchUpRunExecutionGate();
+        var timerEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseTimer = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var inCallEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var cursor = Position(50);
+        var writers = 0;
+        var maxWriters = 0;
+
+        var timer = RunAsync(timerEntered, releaseTimer.Task, Position(51));
+        await timerEntered.Task;
+        var inCall = RunAsync(inCallEntered, Task.CompletedTask, Position(52));
+        Assert.False(inCallEntered.Task.IsCompleted);
+
+        releaseTimer.SetResult();
+        await Task.WhenAll(timer, inCall);
+
+        Assert.Equal(1, maxWriters);
+        Assert.Equal(Position(52).Value, cursor.Value);
+
+        async Task RunAsync(TaskCompletionSource entered, Task release, SortableUniqueId write)
+        {
+            await using (await gate.EnterAsync())
+            {
+                var active = Interlocked.Increment(ref writers);
+                maxWriters = Math.Max(maxWriters, active);
+                entered.SetResult();
+                await release;
+                cursor = write;
+                Interlocked.Decrement(ref writers);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task In_call_then_superseded_timer_cannot_overwrite_the_in_call_cursor()
+    {
+        var gate = new CatchUpRunExecutionGate();
+        var invocationEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseInvocation = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var timerEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var scheduledRun = new object();
+        var currentRun = scheduledRun;
+        var cursor = Position(60);
+
+        var invocation = Task.Run(
+            async () =>
+            {
+                await using (await gate.EnterAsync())
+                {
+                    invocationEntered.SetResult();
+                    await releaseInvocation.Task;
+                    cursor = Position(62);
+                    currentRun = new object();
+                }
+            });
+        await invocationEntered.Task;
+
+        var timer = Task.Run(
+            async () =>
+            {
+                await using (await gate.EnterAsync())
+                {
+                    timerEntered.SetResult();
+                    if (ReferenceEquals(currentRun, scheduledRun))
+                    {
+                        cursor = Position(61);
+                    }
+                }
+            });
+        Assert.False(timerEntered.Task.IsCompleted);
+
+        releaseInvocation.SetResult();
+        await Task.WhenAll(invocation, timer);
+
+        Assert.Equal(Position(62).Value, cursor.Value);
+    }
+}

--- a/dcb/tests/Sekiban.Dcb.Orleans.Tests/ProjectionFaultFirstQueryBarrierTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Orleans.Tests/ProjectionFaultFirstQueryBarrierTests.cs
@@ -9,6 +9,7 @@ using Sekiban.Dcb.MultiProjections;
 using Sekiban.Dcb.Orleans;
 using Sekiban.Dcb.Orleans.Grains;
 using Sekiban.Dcb.Orleans.Streams;
+using Sekiban.Dcb.ServiceId;
 using Sekiban.Dcb.Storage;
 using Sekiban.Dcb.Tags;
 using Sekiban.Dcb.Testing;
@@ -25,6 +26,12 @@ namespace Sekiban.Dcb.Orleans.Tests;
 /// </summary>
 public class ProjectionFaultFirstQueryBarrierTests : IAsyncLifetime
 {
+    public enum InterleaveOrder
+    {
+        BackgroundFirst,
+        InvocationFirst
+    }
+
     public enum FirstQuerySurface
     {
         State,
@@ -34,6 +41,7 @@ public class ProjectionFaultFirstQueryBarrierTests : IAsyncLifetime
     }
 
     private static readonly FailableEventStore Store = new();
+    private static readonly InMemoryMultiProjectionStateStore CheckpointStore = new();
     private TestCluster _cluster = null!;
     private ISekibanExecutor _executor = null!;
     private IClusterClient Client => _cluster.Client;
@@ -41,6 +49,7 @@ public class ProjectionFaultFirstQueryBarrierTests : IAsyncLifetime
     public async Task InitializeAsync()
     {
         Store.Reset();
+        CheckpointStore.Clear();
         var builder = new TestClusterBuilder();
         builder.Options.InitialSilosCount = 1;
         var id = Guid.NewGuid().ToString("N")[..8];
@@ -155,6 +164,9 @@ public class ProjectionFaultFirstQueryBarrierTests : IAsyncLifetime
 
         var grain = Client.GetGrain<IMultiProjectionGrain>(DomainTypes.FaultTestProjector.MultiProjectorName);
 
+        var stateResult = await grain.GetStateAsync();
+        Assert.False(stateResult.IsSuccess);
+        Assert.Contains("read failure", stateResult.GetException().ToString());
         var firstState = await grain.GetSnapshotJsonAsync();
         Assert.False(firstState.IsSuccess);
         var stateEx = firstState.GetException();
@@ -173,6 +185,14 @@ public class ProjectionFaultFirstQueryBarrierTests : IAsyncLifetime
         Assert.False((await grain.GetSnapshotJsonAsync()).IsSuccess);
         Assert.False((await _executor.QueryAsync(new DomainTypes.FaultCountQuery())).IsSuccess);
         Assert.False((await _executor.QueryAsync(new DomainTypes.FaultRowListQuery())).IsSuccess);
+
+        // The streaming provider recovers. Because the failed gate attempt was not marked complete, the next call
+        // performs another authoritative traversal and all four surfaces become available.
+        Store.FailReads = false;
+        Assert.True((await grain.GetStateAsync()).IsSuccess);
+        Assert.True((await grain.GetSnapshotJsonAsync()).IsSuccess);
+        Assert.True((await _executor.QueryAsync(new DomainTypes.FaultCountQuery())).IsSuccess);
+        Assert.True((await _executor.QueryAsync(new DomainTypes.FaultRowListQuery())).IsSuccess);
     }
 
     [Fact]
@@ -239,6 +259,29 @@ public class ProjectionFaultFirstQueryBarrierTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task SafeEmptyUnsafeHead_CannotBypassAuthoritativeTraversalOfEarlierPoison()
+    {
+        var poison = DomainTypes.Event(poison: true, tick: DateTime.UtcNow.AddMilliseconds(-2).Ticks);
+        var later = DomainTypes.Event(poison: false, tick: DateTime.UtcNow.Ticks);
+        await Store.WriteSerializableEventsAsync(new List<SerializableEvent> { poison, later });
+
+        // Park the activation's background catch-up behind a provider failure, then deliver only the later event through
+        // the production stream entry point. The host is safe-empty but its unsafe max equals the durable store head.
+        Store.FailReads = true;
+        var grain = Client.GetGrain<IMultiProjectionGrain>(DomainTypes.FaultTestProjector.MultiProjectorName);
+        await grain.AddEventsAsync(new[] { later });
+        await Store.FailedStreamReadObserved.WaitAsync(TimeSpan.FromSeconds(5));
+        Store.FailReads = false;
+
+        // Raw unsafe metadata would return Count=1 here and permanently miss the earlier poison. The first-query barrier
+        // must instead start from the safe beginning, traverse the store, and re-establish the projection fault.
+        var result = await grain.GetStateAsync();
+        Assert.False(result.IsSuccess);
+        Assert.Contains(DomainTypes.FaultTestProjector.MultiProjectorName, result.GetException().ToString());
+        Assert.True(Store.SuccessfulStreamReadCount > 0);
+    }
+
+    [Fact]
     public async Task FailFirstHeadRead_ThenRecover_ReEstablishesThePoisonFaultOnALaterQuery_NeverEmpty()
     {
         // Durable POISON sits in the store. The first queries fail closed on a transient read failure; when the store
@@ -276,6 +319,115 @@ public class ProjectionFaultFirstQueryBarrierTests : IAsyncLifetime
         Assert.All(results, r => Assert.False(r.IsSuccess));
     }
 
+    [Theory]
+    [InlineData(InterleaveOrder.BackgroundFirst)]
+    [InlineData(InterleaveOrder.InvocationFirst)]
+    public async Task RestoredEmptyStart_TimerAndBarrierInterleave_UsesProductionWiringExactlyOnce(
+        InterleaveOrder order)
+    {
+        // Persist a real empty checkpoint record, then reactivate. Its nullable position is authoritative presence:
+        // background and barrier must share the restored "beginning" START instead of replacing it with host inference.
+        var seed = Client.GetGrain<IMultiProjectionGrain>(DomainTypes.FaultTestProjector.MultiProjectorName);
+        Assert.True((await seed.PersistStateAsync()).IsSuccess);
+        await seed.RequestDeactivationAsync();
+
+        var durable = DomainTypes.Event(poison: false, tick: 20_000);
+        await Store.WriteSerializableEventsAsync(new[] { durable });
+
+        var backgroundBefore = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseBackgroundBefore = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var backgroundEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseBackgroundEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var backgroundRejected = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var invocationBefore = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var invocationEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseInvocation = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var invocationResults = new List<CatchUpProductionObservation>();
+        var observationsSync = new object();
+
+        using var hook = CatchUpProductionTestHooks.Register(
+            DefaultServiceIdProvider.DefaultServiceId,
+            DomainTypes.FaultTestProjector.MultiProjectorName,
+            async (point, observation) =>
+            {
+                switch (point)
+                {
+                    case CatchUpProductionHookPoint.BackgroundBeforeGate:
+                        backgroundBefore.TrySetResult();
+                        if (order == InterleaveOrder.InvocationFirst)
+                        {
+                            await releaseBackgroundBefore.Task;
+                        }
+                        break;
+                    case CatchUpProductionHookPoint.BackgroundEnteredGate:
+                        backgroundEntered.TrySetResult();
+                        if (order == InterleaveOrder.BackgroundFirst)
+                        {
+                            await releaseBackgroundEntered.Task;
+                        }
+                        break;
+                    case CatchUpProductionHookPoint.BackgroundRejectedAsSuperseded:
+                        backgroundRejected.TrySetResult();
+                        break;
+                    case CatchUpProductionHookPoint.InvocationBeforeGate:
+                        invocationBefore.TrySetResult();
+                        break;
+                    case CatchUpProductionHookPoint.InvocationEnteredGate:
+                        invocationEntered.TrySetResult();
+                        if (order == InterleaveOrder.InvocationFirst)
+                        {
+                            await releaseInvocation.Task;
+                        }
+                        break;
+                    case CatchUpProductionHookPoint.InvocationCompleted:
+                        lock (observationsSync)
+                        {
+                            invocationResults.Add(observation);
+                        }
+                        break;
+                }
+            });
+
+        var cold = Client.GetGrain<IMultiProjectionGrain>(DomainTypes.FaultTestProjector.MultiProjectorName);
+        var stateTask = cold.GetStateAsync();
+        var snapshotTask = cold.GetSnapshotJsonAsync();
+
+        if (order == InterleaveOrder.BackgroundFirst)
+        {
+            await backgroundEntered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            await invocationBefore.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            Assert.False(stateTask.IsCompleted);
+            releaseBackgroundEntered.TrySetResult();
+        }
+        else
+        {
+            await backgroundBefore.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            await invocationEntered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            Assert.False(stateTask.IsCompleted);
+            releaseBackgroundBefore.TrySetResult();
+            releaseInvocation.TrySetResult();
+            await backgroundRejected.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        }
+
+        var state = await stateTask.WaitAsync(TimeSpan.FromSeconds(5));
+        var snapshot = await snapshotTask.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.True(state.IsSuccess, state.IsSuccess ? "" : state.GetException().ToString());
+        Assert.True(snapshot.IsSuccess, snapshot.IsSuccess ? "" : snapshot.GetException().ToString());
+        Assert.Equal(durable.SortableUniqueIdValue, state.GetValue().LastSortableUniqueId);
+
+        CatchUpProductionObservation firstInvocation;
+        lock (observationsSync)
+        {
+            firstInvocation = Assert.Single(invocationResults);
+        }
+        Assert.Equal(CatchUpStartPositionSource.RestoredCheckpoint, firstInvocation.Start?.Source);
+        Assert.Null(firstInvocation.Start?.StartPosition);
+        Assert.Equal(durable.SortableUniqueIdValue, firstInvocation.Cursor?.Value);
+
+        // The two first callers shared one production _firstQueryGate invocation. Together with the resolver's
+        // nullable-presence race proof, this demonstrates that the restored-null START is leased exactly once.
+    }
+
     private sealed class SiloConfigurator : ISiloConfigurator
     {
         public void Configure(ISiloBuilder siloBuilder)
@@ -285,7 +437,7 @@ public class ProjectionFaultFirstQueryBarrierTests : IAsyncLifetime
                 {
                     services.AddSingleton(_ => DomainTypes.CreateDomain());
                     services.AddSingleton<IEventStore>(Store);
-                    services.AddSingleton<IMultiProjectionStateStore, InMemoryMultiProjectionStateStore>();
+                    services.AddSingleton<IMultiProjectionStateStore>(CheckpointStore);
                     services.AddSingleton<IEventSubscriptionResolver>(
                         new DefaultOrleansEventSubscriptionResolver("EventStreamProvider", "AllEvents", Guid.Empty));
                     services.AddSingleton<IActorObjectAccessor, OrleansActorObjectAccessor>();
@@ -307,20 +459,28 @@ public class ProjectionFaultFirstQueryBarrierTests : IAsyncLifetime
     ///     authoritative head read fail; FailReads makes the catch-up event reads fail. Writes always succeed so durable
     ///     events can be present behind a failing read.
     /// </summary>
-    private sealed class FailableEventStore : IEventStore
+    private sealed class FailableEventStore : IEventStore, IStreamingSerializableEventStore
     {
         private readonly InMemoryEventStore _inner = new();
         public volatile bool FailReads;
         public volatile bool FailHeadReads;
         public volatile bool ShortReads;
+        private int _successfulStreamReadCount;
+        private TaskCompletionSource _failedStreamReadObserved =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
         private static readonly InvalidOperationException ReadError = new("injected event-store read failure");
         private static readonly InvalidOperationException HeadError = new("injected event-store head-read failure");
+        public Task FailedStreamReadObserved => _failedStreamReadObserved.Task;
+        public int SuccessfulStreamReadCount => Volatile.Read(ref _successfulStreamReadCount);
 
         public void Reset()
         {
             FailReads = false;
             FailHeadReads = false;
             ShortReads = false;
+            _successfulStreamReadCount = 0;
+            _failedStreamReadObserved =
+                new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
             _inner.Clear();
         }
 
@@ -353,6 +513,38 @@ public class ProjectionFaultFirstQueryBarrierTests : IAsyncLifetime
                 since is null
                     ? result.GetValue().Take(1)
                     : Enumerable.Empty<SerializableEvent>());
+        }
+
+        public async Task<ResultBox<SerializableEventStreamReadResult>> StreamAllSerializableEventsAsync(
+            SortableUniqueId? since,
+            int? maxCount,
+            Func<SerializableEvent, ValueTask> onEvent,
+            CancellationToken cancellationToken = default)
+        {
+            if (FailReads)
+            {
+                _failedStreamReadObserved.TrySetResult();
+                return ResultBox.Error<SerializableEventStreamReadResult>(ReadError);
+            }
+
+            var result = await ReadAllSerializableEventsAsync(since, maxCount);
+            if (!result.IsSuccess)
+            {
+                return ResultBox.Error<SerializableEventStreamReadResult>(result.GetException());
+            }
+
+            var events = result.GetValue().ToList();
+            foreach (var ev in events)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                await onEvent(ev);
+            }
+
+            Interlocked.Increment(ref _successfulStreamReadCount);
+            return ResultBox.FromValue(
+                new SerializableEventStreamReadResult(
+                    events.Count,
+                    events.Count == 0 ? since?.Value : events[^1].SortableUniqueIdValue));
         }
 
         public Task<ResultBox<(IReadOnlyList<SerializableEvent> Events, IReadOnlyList<TagWriteResult> TagWrites)>>

--- a/dcb/tests/Sekiban.Dcb.Orleans.Tests/ProjectionFaultFirstQueryBarrierTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Orleans.Tests/ProjectionFaultFirstQueryBarrierTests.cs
@@ -25,6 +25,14 @@ namespace Sekiban.Dcb.Orleans.Tests;
 /// </summary>
 public class ProjectionFaultFirstQueryBarrierTests : IAsyncLifetime
 {
+    public enum FirstQuerySurface
+    {
+        State,
+        Snapshot,
+        Scalar,
+        List
+    }
+
     private static readonly FailableEventStore Store = new();
     private TestCluster _cluster = null!;
     private ISekibanExecutor _executor = null!;
@@ -68,6 +76,72 @@ public class ProjectionFaultFirstQueryBarrierTests : IAsyncLifetime
         Assert.Contains("head-read failure", ex.Message);              // original message/context preserved
     }
 
+    [Theory]
+    [InlineData(FirstQuerySurface.State)]
+    [InlineData(FirstQuerySurface.Snapshot)]
+    [InlineData(FirstQuerySurface.Scalar)]
+    [InlineData(FirstQuerySurface.List)]
+    public async Task ColdFirstQuery_ReachesFixedHeadWithoutWaitingForSafeWindow(FirstQuerySurface surface)
+    {
+        var safeEvent = DomainTypes.Event(poison: false, tick: 1_000);
+        await Store.WriteSerializableEventsAsync(new List<SerializableEvent> { safeEvent });
+
+        var grain = Client.GetGrain<IMultiProjectionGrain>(DomainTypes.FaultTestProjector.MultiProjectorName);
+        var baseline = await grain.GetStateAsync();
+        Assert.True(baseline.IsSuccess);
+        Assert.True(baseline.GetValue().IsSafeState);
+        Assert.Equal(1, ((DomainTypes.FaultTestProjector)baseline.GetValue().Payload).Count);
+        Assert.True((await grain.PersistStateAsync()).IsSuccess);
+
+        await grain.RequestDeactivationAsync();
+
+        var inWindowEvent = DomainTypes.Event(poison: false, tick: DateTime.UtcNow.Ticks);
+        await Store.WriteSerializableEventsAsync(new List<SerializableEvent> { inWindowEvent });
+        var cold = Client.GetGrain<IMultiProjectionGrain>(DomainTypes.FaultTestProjector.MultiProjectorName);
+
+        var firstQuery = surface switch
+        {
+            FirstQuerySurface.State => AssertStateAsync(cold),
+            FirstQuerySurface.Snapshot => AssertSnapshotAsync(cold),
+            FirstQuerySurface.Scalar => AssertScalarAsync(),
+            FirstQuerySurface.List => AssertListAsync(),
+            _ => throw new ArgumentOutOfRangeException(nameof(surface))
+        };
+        await firstQuery.WaitAsync(TimeSpan.FromSeconds(5));
+
+        var served = await cold.GetStateAsync(canGetUnsafeState: true);
+        Assert.True(served.IsSuccess);
+        Assert.False(served.GetValue().IsSafeState);
+        Assert.Equal(2, ((DomainTypes.FaultTestProjector)served.GetValue().Payload).Count);
+        Assert.Equal(inWindowEvent.SortableUniqueIdValue, served.GetValue().LastSortableUniqueId);
+
+        var safe = await cold.GetStateAsync(canGetUnsafeState: false);
+        Assert.True(safe.IsSuccess);
+        Assert.True(safe.GetValue().IsSafeState);
+        Assert.Equal(1, ((DomainTypes.FaultTestProjector)safe.GetValue().Payload).Count);
+        Assert.Equal(safeEvent.SortableUniqueIdValue, safe.GetValue().LastSortableUniqueId);
+
+        async Task AssertStateAsync(IMultiProjectionGrain target) =>
+            Assert.True((await target.GetStateAsync()).IsSuccess);
+
+        async Task AssertSnapshotAsync(IMultiProjectionGrain target) =>
+            Assert.True((await target.GetSnapshotJsonAsync()).IsSuccess);
+
+        async Task AssertScalarAsync()
+        {
+            var result = await _executor.QueryAsync(new DomainTypes.FaultCountQuery());
+            Assert.True(result.IsSuccess);
+            Assert.Equal(2, result.GetValue().Count);
+        }
+
+        async Task AssertListAsync()
+        {
+            var result = await _executor.QueryAsync(new DomainTypes.FaultRowListQuery());
+            Assert.True(result.IsSuccess);
+            Assert.Equal(2, result.GetValue().TotalCount);
+        }
+    }
+
     [Fact]
     public async Task EventReadFailure_FailsAllFirstQuerySurfacesClosed_AndALaterQueryDoesNotBypass()
     {
@@ -99,6 +173,69 @@ public class ProjectionFaultFirstQueryBarrierTests : IAsyncLifetime
         Assert.False((await grain.GetSnapshotJsonAsync()).IsSuccess);
         Assert.False((await _executor.QueryAsync(new DomainTypes.FaultCountQuery())).IsSuccess);
         Assert.False((await _executor.QueryAsync(new DomainTypes.FaultRowListQuery())).IsSuccess);
+    }
+
+    [Fact]
+    public async Task ShortReadWithoutError_FailsAllSurfacesWithStableGuard_ThenRecoversAtHead()
+    {
+        await Store.WriteSerializableEventsAsync(new List<SerializableEvent>
+        {
+            DomainTypes.Event(poison: false, tick: 10_100),
+            DomainTypes.Event(poison: false, tick: 10_101)
+        });
+        Store.ShortReads = true;
+
+        var grain = Client.GetGrain<IMultiProjectionGrain>(DomainTypes.FaultTestProjector.MultiProjectorName);
+
+        var state = await grain.GetStateAsync();
+        Assert.False(state.IsSuccess);
+        Assert.Contains("did not reach the event-store head", state.GetException().ToString());
+
+        var snapshot = await grain.GetSnapshotJsonAsync();
+        Assert.False(snapshot.IsSuccess);
+        Assert.Contains("did not reach the event-store head", snapshot.GetException().ToString());
+
+        var scalar = await _executor.QueryAsync(new DomainTypes.FaultCountQuery());
+        Assert.False(scalar.IsSuccess);
+        Assert.Contains("did not reach the event-store head", scalar.GetException().ToString());
+
+        var list = await _executor.QueryAsync(new DomainTypes.FaultRowListQuery());
+        Assert.False(list.IsSuccess);
+        Assert.Contains("did not reach the event-store head", list.GetException().ToString());
+
+        Store.ShortReads = false;
+        Assert.True((await grain.GetStateAsync()).IsSuccess);
+        Assert.True((await grain.GetSnapshotJsonAsync()).IsSuccess);
+        Assert.True((await _executor.QueryAsync(new DomainTypes.FaultCountQuery())).IsSuccess);
+        Assert.True((await _executor.QueryAsync(new DomainTypes.FaultRowListQuery())).IsSuccess);
+    }
+
+    [Fact]
+    public async Task InWindowPoisonAfterSafeBaseline_FaultsAllSurfaces_AndFreshActivationRestoresTheFault()
+    {
+        var safeEvent = DomainTypes.Event(poison: false, tick: 2_000);
+        await Store.WriteSerializableEventsAsync(new List<SerializableEvent> { safeEvent });
+        var seed = Client.GetGrain<IMultiProjectionGrain>(DomainTypes.FaultTestProjector.MultiProjectorName);
+        Assert.True((await seed.GetStateAsync()).IsSuccess);
+        Assert.True((await seed.PersistStateAsync()).IsSuccess);
+        await seed.RequestDeactivationAsync();
+
+        var poison = DomainTypes.Event(poison: true, tick: DateTime.UtcNow.Ticks);
+        await Store.WriteSerializableEventsAsync(new List<SerializableEvent> { poison });
+        var cold = Client.GetGrain<IMultiProjectionGrain>(DomainTypes.FaultTestProjector.MultiProjectorName);
+
+        Assert.False((await cold.GetStateAsync()).IsSuccess);
+        Assert.False((await cold.GetSnapshotJsonAsync()).IsSuccess);
+        Assert.False((await _executor.QueryAsync(new DomainTypes.FaultCountQuery())).IsSuccess);
+        Assert.False((await _executor.QueryAsync(new DomainTypes.FaultRowListQuery())).IsSuccess);
+
+        await cold.RequestDeactivationAsync();
+        var fresh = Client.GetGrain<IMultiProjectionGrain>(DomainTypes.FaultTestProjector.MultiProjectorName);
+        var restored = await fresh.GetSnapshotJsonAsync();
+        Assert.False(restored.IsSuccess);
+        Assert.Contains(
+            DomainTypes.FaultTestProjector.MultiProjectorName,
+            restored.GetException().ToString());
     }
 
     [Fact]
@@ -154,7 +291,7 @@ public class ProjectionFaultFirstQueryBarrierTests : IAsyncLifetime
                     services.AddSingleton<IActorObjectAccessor, OrleansActorObjectAccessor>();
                     services.AddSingleton<Sekiban.Dcb.Snapshots.IBlobStorageSnapshotAccessor, MockBlobStorageSnapshotAccessor>();
                     services.AddTransient<IMultiProjectionEventStatistics, NoOpMultiProjectionEventStatistics>();
-                    services.AddTransient(_ => new GeneralMultiProjectionActorOptions { SafeWindowMs = 1 });
+                    services.AddTransient(_ => new GeneralMultiProjectionActorOptions { SafeWindowMs = 20_000 });
                     services.AddSekibanDcbNativeRuntime();
                 })
                 .AddMemoryGrainStorageAsDefault()
@@ -175,6 +312,7 @@ public class ProjectionFaultFirstQueryBarrierTests : IAsyncLifetime
         private readonly InMemoryEventStore _inner = new();
         public volatile bool FailReads;
         public volatile bool FailHeadReads;
+        public volatile bool ShortReads;
         private static readonly InvalidOperationException ReadError = new("injected event-store read failure");
         private static readonly InvalidOperationException HeadError = new("injected event-store head-read failure");
 
@@ -182,6 +320,7 @@ public class ProjectionFaultFirstQueryBarrierTests : IAsyncLifetime
         {
             FailReads = false;
             FailHeadReads = false;
+            ShortReads = false;
             _inner.Clear();
         }
 
@@ -193,12 +332,28 @@ public class ProjectionFaultFirstQueryBarrierTests : IAsyncLifetime
         public Task<ResultBox<IEnumerable<SerializableEvent>>> ReadAllSerializableEventsAsync(SortableUniqueId? since = null) =>
             ReadAllSerializableEventsAsync(since, null);
 
-        public Task<ResultBox<IEnumerable<SerializableEvent>>> ReadAllSerializableEventsAsync(
+        public async Task<ResultBox<IEnumerable<SerializableEvent>>> ReadAllSerializableEventsAsync(
             SortableUniqueId? since,
-            int? maxCount) =>
-            FailReads
-                ? Task.FromResult(ResultBox.Error<IEnumerable<SerializableEvent>>(ReadError))
-                : _inner.ReadAllSerializableEventsAsync(since, maxCount);
+            int? maxCount)
+        {
+            if (FailReads)
+            {
+                return ResultBox.Error<IEnumerable<SerializableEvent>>(ReadError);
+            }
+
+            var result = await _inner.ReadAllSerializableEventsAsync(since, maxCount);
+            if (!ShortReads || !result.IsSuccess)
+            {
+                return result;
+            }
+
+            // A stable, error-free lag: the first call exposes one row, then the provider keeps returning an empty
+            // short read even though the independently-read fixed head is later.
+            return ResultBox.FromValue(
+                since is null
+                    ? result.GetValue().Take(1)
+                    : Enumerable.Empty<SerializableEvent>());
+        }
 
         public Task<ResultBox<(IReadOnlyList<SerializableEvent> Events, IReadOnlyList<TagWriteResult> TagWrites)>>
             WriteSerializableEventsAsync(IEnumerable<SerializableEvent> events) =>

--- a/dcb/tests/Sekiban.Dcb.Orleans.Tests/ProjectionFaultOrleansTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Orleans.Tests/ProjectionFaultOrleansTests.cs
@@ -195,7 +195,7 @@ public class ProjectionFaultOrleansTests : IAsyncLifetime
         public static ResultBox<FaultCountResult> HandleQuery(
             FaultTestProjector projector,
             FaultCountQuery query,
-            IQueryContext context) => ResultBox.FromValue(new FaultCountResult(0));
+            IQueryContext context) => ResultBox.FromValue(new FaultCountResult(projector.Count));
     }
 
     internal record FaultRow(int Value);
@@ -210,7 +210,8 @@ public class ProjectionFaultOrleansTests : IAsyncLifetime
         public static ResultBox<IEnumerable<FaultRow>> HandleFilter(
             FaultTestProjector projector,
             FaultRowListQuery query,
-            IQueryContext context) => ResultBox.FromValue(Enumerable.Empty<FaultRow>());
+            IQueryContext context) => ResultBox.FromValue(
+                Enumerable.Range(1, projector.Count).Select(value => new FaultRow(value)));
 
         public static ResultBox<IEnumerable<FaultRow>> HandleSort(
             IEnumerable<FaultRow> filtered,
@@ -219,11 +220,14 @@ public class ProjectionFaultOrleansTests : IAsyncLifetime
     }
 
     /// <summary>A projector that folds cleanly until it meets a poison event, then throws — a fold crash, deterministically.</summary>
-    internal record FaultTestProjector : IMultiProjector<FaultTestProjector>
+    [GenerateSerializer]
+    internal record FaultTestProjector([property: Id(0)] int Count) : IMultiProjector<FaultTestProjector>
     {
+        public FaultTestProjector() : this(0) { }
+
         public static string MultiProjectorVersion => "1.0";
         public static string MultiProjectorName => "fault-test-projector";
-        public static FaultTestProjector GenerateInitialPayload() => new();
+        public static FaultTestProjector GenerateInitialPayload() => new(0);
 
         public static ResultBox<FaultTestProjector> Project(
             FaultTestProjector payload,
@@ -237,7 +241,7 @@ public class ProjectionFaultOrleansTests : IAsyncLifetime
                 throw new InvalidOperationException("poison event: this projector refuses to fold it");
             }
 
-            return ResultBox.FromValue(payload);
+            return ResultBox.FromValue(payload with { Count = payload.Count + 1 });
         }
     }
 }

--- a/dcb/tests/Sekiban.Dcb.Orleans.Tests/TwoClusterGraduationReconcileConvergenceTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Orleans.Tests/TwoClusterGraduationReconcileConvergenceTests.cs
@@ -114,6 +114,45 @@ public class TwoClusterGraduationReconcileConvergenceTests : IAsyncLifetime
         await AssertScalarAndListAsync(execB, "earlier");
     }
 
+    [Fact]
+    public async Task TwoColdReplicas_WithSafeBaseline_ReachRecentHeadBeforeSafeWindow()
+    {
+        var baseline = CreateEvent(new CreatedWithId("baseline", "safe"), DateTime.UtcNow.AddMinutes(-1));
+        await SharedStores.EventStore.WriteSerializableEventsAsync(new[] { ToSerializable(baseline) });
+
+        var seed = _clusterA.Client.GetGrain<IMultiProjectionGrain>(FirstWinsProjector.MultiProjectorName);
+        var seeded = await seed.GetStateAsync();
+        Assert.True(seeded.IsSuccess);
+        Assert.True(seeded.GetValue().IsSafeState);
+        Assert.True((await seed.PersistStateAsync()).IsSuccess);
+        await seed.RequestDeactivationAsync();
+
+        var recent = CreateEvent(new CreatedWithId("recent", "head"), DateTime.UtcNow);
+        await SharedStores.EventStore.WriteSerializableEventsAsync(new[] { ToSerializable(recent) });
+
+        var grainA = _clusterA.Client.GetGrain<IMultiProjectionGrain>(FirstWinsProjector.MultiProjectorName);
+        var grainB = _clusterB.Client.GetGrain<IMultiProjectionGrain>(FirstWinsProjector.MultiProjectorName);
+        var states = await Task.WhenAll(grainA.GetStateAsync(), grainB.GetStateAsync())
+            .WaitAsync(TimeSpan.FromSeconds(1));
+
+        Assert.All(states, state => Assert.True(state.IsSuccess, state.IsSuccess ? "" : state.GetException().ToString()));
+        Assert.All(
+            states,
+            state =>
+            {
+                Assert.False(state.GetValue().IsSafeState);
+                var payload = (FirstWinsProjector)state.GetValue().Payload;
+                Assert.Equal("safe", payload.Winners["baseline"]);
+                Assert.Equal("head", payload.Winners["recent"]);
+                Assert.Equal(recent.SortableUniqueIdValue, state.GetValue().LastSortableUniqueId);
+            });
+
+        var safeA = (await grainA.GetStateAsync(canGetUnsafeState: false)).GetValue();
+        var safeB = (await grainB.GetStateAsync(canGetUnsafeState: false)).GetValue();
+        Assert.DoesNotContain("recent", ((FirstWinsProjector)safeA.Payload).Winners.Keys);
+        Assert.DoesNotContain("recent", ((FirstWinsProjector)safeB.Payload).Winners.Keys);
+    }
+
     private static async Task AssertScalarAndListAsync(ISekibanExecutor executor, string expectedWinner)
     {
         var scalar = await executor.QueryAsync(new WinnerQuery("team-1"));

--- a/dcb/tests/Sekiban.Dcb.Orleans.Tests/TwoClusterGraduationReconcileConvergenceTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Orleans.Tests/TwoClusterGraduationReconcileConvergenceTests.cs
@@ -10,9 +10,11 @@ using Sekiban.Dcb.Events;
 using Sekiban.Dcb.MultiProjections;
 using Sekiban.Dcb.Orleans;
 using Sekiban.Dcb.Orleans.Grains;
+using Sekiban.Dcb.Orleans.ServiceId;
 using Sekiban.Dcb.Orleans.Streams;
 using Sekiban.Dcb.Queries;
 using Sekiban.Dcb.Snapshots;
+using Sekiban.Dcb.ServiceId;
 using Sekiban.Dcb.Storage;
 using Sekiban.Dcb.Tags;
 using Sekiban.Dcb.Testing;
@@ -30,27 +32,37 @@ namespace Sekiban.Dcb.Orleans.Tests;
 /// </summary>
 public class TwoClusterGraduationReconcileConvergenceTests : IAsyncLifetime
 {
+    private const string ReplicaServiceA = "replica-a";
+    private const string ReplicaServiceB = "replica-b";
     private TestCluster _clusterA = null!;
     private TestCluster _clusterB = null!;
 
     public async Task InitializeAsync()
     {
         SharedStores.Reset();
-        _clusterA = await BuildClusterAsync("A");
-        _clusterB = await BuildClusterAsync("B");
+        (_clusterA, _) = await BuildClusterAsync("A");
+        (_clusterB, _) = await BuildClusterAsync("B");
     }
 
-    private static async Task<TestCluster> BuildClusterAsync(string name)
+    private static async Task<(TestCluster Cluster, string ServiceId)> BuildClusterAsync(string name)
     {
         var builder = new TestClusterBuilder();
         builder.Options.InitialSilosCount = 1;
         var uniqueId = Guid.NewGuid().ToString("N")[..8];
-        builder.Options.ClusterId = $"G18-2cluster-{name}-{uniqueId}";
-        builder.Options.ServiceId = $"G18-2cluster-{name}-{uniqueId}";
-        builder.AddSiloBuilderConfigurator<Configurator>();
+        var serviceId = $"G18-2cluster-{name}-{uniqueId}";
+        builder.Options.ClusterId = serviceId;
+        builder.Options.ServiceId = serviceId;
+        if (name == "A")
+        {
+            builder.AddSiloBuilderConfigurator<ConfiguratorA>();
+        }
+        else
+        {
+            builder.AddSiloBuilderConfigurator<ConfiguratorB>();
+        }
         var cluster = builder.Build();
         await cluster.DeployAsync();
-        return cluster;
+        return (cluster, serviceId);
     }
 
     public async Task DisposeAsync()
@@ -130,10 +142,70 @@ public class TwoClusterGraduationReconcileConvergenceTests : IAsyncLifetime
         var recent = CreateEvent(new CreatedWithId("recent", "head"), DateTime.UtcNow);
         await SharedStores.EventStore.WriteSerializableEventsAsync(new[] { ToSerializable(recent) });
 
-        var grainA = _clusterA.Client.GetGrain<IMultiProjectionGrain>(FirstWinsProjector.MultiProjectorName);
-        var grainB = _clusterB.Client.GetGrain<IMultiProjectionGrain>(FirstWinsProjector.MultiProjectorName);
-        var states = await Task.WhenAll(grainA.GetStateAsync(), grainB.GetStateAsync())
-            .WaitAsync(TimeSpan.FromSeconds(1));
+        var grainA = _clusterA.Client.GetGrain<IMultiProjectionGrain>(
+            ServiceIdGrainKey.Build(ReplicaServiceA, FirstWinsProjector.MultiProjectorName));
+        var grainB = _clusterB.Client.GetGrain<IMultiProjectionGrain>(
+            ServiceIdGrainKey.Build(ReplicaServiceB, FirstWinsProjector.MultiProjectorName));
+        var readGateA = SharedStores.ReplicaA.ParkNextRead();
+        var readGateB = SharedStores.ReplicaB.ParkNextRead();
+        var invocationA = new TaskCompletionSource<CatchUpProductionObservation>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var invocationB = new TaskCompletionSource<CatchUpProductionObservation>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        using var hookA = CatchUpProductionTestHooks.Register(
+            ReplicaServiceA,
+            FirstWinsProjector.MultiProjectorName,
+            (point, observation) =>
+            {
+                if (point == CatchUpProductionHookPoint.InvocationCompleted &&
+                    observation.Cursor?.Value == recent.SortableUniqueIdValue)
+                {
+                    invocationA.TrySetResult(observation);
+                }
+                return Task.CompletedTask;
+            });
+        using var hookB = CatchUpProductionTestHooks.Register(
+            ReplicaServiceB,
+            FirstWinsProjector.MultiProjectorName,
+            (point, observation) =>
+            {
+                if (point == CatchUpProductionHookPoint.InvocationCompleted &&
+                    observation.Cursor?.Value == recent.SortableUniqueIdValue)
+                {
+                    invocationB.TrySetResult(observation);
+                }
+                return Task.CompletedTask;
+            });
+
+        var execA = new OrleansDcbExecutor(
+            _clusterA.Client,
+            SharedStores.ReplicaA,
+            SharedStores.Domain,
+            serviceIdProvider: new FixedServiceIdProvider(ReplicaServiceA));
+        var execB = new OrleansDcbExecutor(
+            _clusterB.Client,
+            SharedStores.ReplicaB,
+            SharedStores.Domain,
+            serviceIdProvider: new FixedServiceIdProvider(ReplicaServiceB));
+        var stateA = grainA.GetStateAsync();
+        var stateB = grainB.GetStateAsync();
+        var scalarA = execA.QueryAsync(new WinnerQuery("recent"));
+        var scalarB = execB.QueryAsync(new WinnerQuery("recent"));
+        var listA = execA.QueryAsync(new WinnerListQuery());
+        var listB = execB.QueryAsync(new WinnerListQuery());
+
+        await Task.WhenAll(readGateA.Entered, readGateB.Entered).WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.False(stateA.IsCompleted);
+        Assert.False(stateB.IsCompleted);
+
+        // Release the replicas independently. Each first-query surface remains parked until that replica's own
+        // invocation-owned traversal returns the fixed head; no SafeWindow delay or polling is part of this proof.
+        readGateB.Release();
+        var observedB = await invocationB.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        readGateA.Release();
+        var observedA = await invocationA.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        var states = await Task.WhenAll(stateA, stateB).WaitAsync(TimeSpan.FromSeconds(5));
 
         Assert.All(states, state => Assert.True(state.IsSuccess, state.IsSuccess ? "" : state.GetException().ToString()));
         Assert.All(
@@ -145,6 +217,23 @@ public class TwoClusterGraduationReconcileConvergenceTests : IAsyncLifetime
                 Assert.Equal("safe", payload.Winners["baseline"]);
                 Assert.Equal("head", payload.Winners["recent"]);
                 Assert.Equal(recent.SortableUniqueIdValue, state.GetValue().LastSortableUniqueId);
+            });
+        Assert.Equal(recent.SortableUniqueIdValue, observedA.Cursor?.Value);
+        Assert.Equal(recent.SortableUniqueIdValue, observedB.Cursor?.Value);
+
+        var scalars = await Task.WhenAll(scalarA, scalarB).WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.All(scalars, scalar => Assert.True(scalar.IsSuccess, scalar.IsSuccess ? "" : scalar.GetException().ToString()));
+        Assert.All(scalars, scalar => Assert.Equal("head", scalar.GetValue().Value));
+
+        var lists = await Task.WhenAll(listA, listB).WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.All(lists, list => Assert.True(list.IsSuccess, list.IsSuccess ? "" : list.GetException().ToString()));
+        Assert.All(
+            lists,
+            list =>
+            {
+                var rows = list.GetValue().Items.ToList();
+                Assert.Equal("safe", Assert.Single(rows, row => row.Id == "baseline").Value);
+                Assert.Equal("head", Assert.Single(rows, row => row.Id == "recent").Value);
             });
 
         var safeA = (await grainA.GetStateAsync(canGetUnsafeState: false)).GetValue();
@@ -275,12 +364,16 @@ public class TwoClusterGraduationReconcileConvergenceTests : IAsyncLifetime
     {
         public static DcbDomainTypes Domain { get; private set; } = BuildDomain();
         public static InMemoryEventStore EventStore { get; private set; } = new(Domain.EventTypes);
+        public static ReplicaEventStore ReplicaA { get; private set; } = new(EventStore);
+        public static ReplicaEventStore ReplicaB { get; private set; } = new(EventStore);
         public static InMemoryMultiProjectionStateStore StateStore { get; } = new();
 
         public static void Reset()
         {
             Domain = BuildDomain();
             EventStore = new InMemoryEventStore(Domain.EventTypes);
+            ReplicaA = new ReplicaEventStore(EventStore);
+            ReplicaB = new ReplicaEventStore(EventStore);
             StateStore.DeleteAllAsync(FirstWinsProjector.MultiProjectorName).GetAwaiter().GetResult();
         }
 
@@ -299,7 +392,68 @@ public class TwoClusterGraduationReconcileConvergenceTests : IAsyncLifetime
         }
     }
 
-    private class Configurator : ISiloConfigurator
+    internal sealed class ReplicaEventStore(InMemoryEventStore inner) : IEventStore
+    {
+        private ReadGate? _nextReadGate;
+
+        internal ReadGate ParkNextRead()
+        {
+            var gate = new ReadGate();
+            Assert.Null(Interlocked.CompareExchange(ref _nextReadGate, gate, null));
+            return gate;
+        }
+
+        public Task<ResultBox<string>> GetLatestSortableUniqueIdAsync() =>
+            inner.GetLatestSortableUniqueIdAsync();
+
+        public Task<ResultBox<IEnumerable<SerializableEvent>>> ReadAllSerializableEventsAsync(
+            SortableUniqueId? since = null) =>
+            ReadAllSerializableEventsAsync(since, null);
+
+        public async Task<ResultBox<IEnumerable<SerializableEvent>>> ReadAllSerializableEventsAsync(
+            SortableUniqueId? since,
+            int? maxCount)
+        {
+            var gate = Interlocked.Exchange(ref _nextReadGate, null);
+            if (gate is not null)
+            {
+                gate.SignalEntered();
+                await gate.WaitForReleaseAsync();
+            }
+
+            return await inner.ReadAllSerializableEventsAsync(since, maxCount);
+        }
+
+        public Task<ResultBox<(IReadOnlyList<SerializableEvent> Events, IReadOnlyList<TagWriteResult> TagWrites)>>
+            WriteSerializableEventsAsync(IEnumerable<SerializableEvent> events) =>
+            inner.WriteSerializableEventsAsync(events);
+
+        public Task<ResultBox<IEnumerable<TagStream>>> ReadTagsAsync(ITag tag) => inner.ReadTagsAsync(tag);
+        public Task<ResultBox<TagState>> GetLatestTagAsync(ITag tag) => inner.GetLatestTagAsync(tag);
+        public Task<ResultBox<bool>> TagExistsAsync(ITag tag) => inner.TagExistsAsync(tag);
+        public Task<ResultBox<long>> GetEventCountAsync(SortableUniqueId? since = null) => inner.GetEventCountAsync(since);
+        public Task<ResultBox<IEnumerable<TagInfo>>> GetAllTagsAsync(string? tagGroup = null) => inner.GetAllTagsAsync(tagGroup);
+        public Task<ResultBox<SerializableEvent>> ReadSerializableEventAsync(Guid eventId) =>
+            inner.ReadSerializableEventAsync(eventId);
+        public Task<ResultBox<IEnumerable<SerializableEvent>>> ReadSerializableEventsByTagAsync(
+            ITag tag,
+            SortableUniqueId? since = null) => inner.ReadSerializableEventsByTagAsync(tag, since);
+
+        internal sealed class ReadGate
+        {
+            private readonly TaskCompletionSource _entered =
+                new(TaskCreationOptions.RunContinuationsAsynchronously);
+            private readonly TaskCompletionSource _release =
+                new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            internal Task Entered => _entered.Task;
+            internal void SignalEntered() => _entered.TrySetResult();
+            internal void Release() => _release.TrySetResult();
+            internal Task WaitForReleaseAsync() => _release.Task;
+        }
+    }
+
+    private abstract class Configurator(ReplicaEventStore eventStore) : ISiloConfigurator
     {
         public void Configure(ISiloBuilder siloBuilder)
         {
@@ -307,7 +461,7 @@ public class TwoClusterGraduationReconcileConvergenceTests : IAsyncLifetime
                 .ConfigureServices(services =>
                 {
                     services.AddSingleton<DcbDomainTypes>(SharedStores.Domain);
-                    services.AddSingleton<IEventStore>(SharedStores.EventStore);           // SHARED authoritative events
+                    services.AddSingleton<IEventStore>(eventStore); // replica proxy over SHARED authoritative events
                     services.AddSingleton<IMultiProjectionStateStore>(SharedStores.StateStore); // SHARED external checkpoint
                     services.AddSingleton<IEventSubscriptionResolver>(
                         new DefaultOrleansEventSubscriptionResolver("EventStreamProvider", "AllEvents", Guid.Empty));
@@ -323,4 +477,7 @@ public class TwoClusterGraduationReconcileConvergenceTests : IAsyncLifetime
                 .AddMemoryGrainStorage("EventStreamProvider");
         }
     }
+
+    private sealed class ConfiguratorA() : Configurator(SharedStores.ReplicaA);
+    private sealed class ConfiguratorB() : Configurator(SharedStores.ReplicaB);
 }

--- a/docs/dcb_llm/04_multiple_aggregate_projector.md
+++ b/docs/dcb_llm/04_multiple_aggregate_projector.md
@@ -131,3 +131,20 @@ in global `SortableUniqueId` order) and a **served/unsafe** state (what queries 
 - **`EventsProcessed` is a durable safe-checkpoint count** used as an integrity signal:
   restore takes it as the baseline; a restart that writes zero new events restores exactly the
   same payload/position/threshold/count.
+
+### First-query catch-up position contract (SEK-G21 / 10.8.1)
+
+A fresh Orleans activation places a fail-closed barrier in front of its first state, snapshot,
+scalar, or list query. The barrier uses two deliberately different positions:
+
+- **START** is the safe/restored checkpoint. A restored record's `LastSortableUniqueId` is leased
+  once by a single internal resolver shared by background and in-call catch-up. This deliberately
+  re-reads the complete uncheckpointed tail, including an in-window poison event.
+- **REACHED** is the authoritative cursor returned by that specific in-call event-store read. It is
+  not the safe position and is not read from shared timer progress. This lets a cold first query
+  return the current unsafe state immediately after its own read reaches the fixed head, without
+  waiting for safe-window graduation.
+
+A short read that does not reach the fixed head still fails closed and remains retryable. A failed
+read preserves the original exception. The safe checkpoint, SafeWindow behavior, public API, and
+storage schema are unchanged.

--- a/docs/dcb_llm/13_common_issues.md
+++ b/docs/dcb_llm/13_common_issues.md
@@ -430,3 +430,17 @@ type). See [First-write reservation semantics](03_aggregate_command_events.md#fi
 Independent clusters do not coordinate through the actor — cross-cluster uniqueness is the storage layer's conditional
 unique-append (G15/G16), and convergence over durable duplicates is SEK-G18. **Behavior change**: from 10.8.0 one side of
 a racing create now fails with a consistency error. The release gate for the full fix is G18 + G19 + G20.
+
+## Cold first query waits for the full SafeWindow — CLOSED in 10.8.1 (SEK-G21)
+
+**Symptom.** Immediately after a write, the first query to a cold multi-projection activation can fail closed for almost
+one full `SafeWindow`, even though that query's catch-up logs show `CurrentPosition == TargetPosition == head`.
+
+**Cause.** The first-query barrier correctly started at the safe/restored checkpoint, but incorrectly judged completion
+using the safe position. An event inside the SafeWindow therefore could not count as reached until graduation.
+
+**Fix.** START remains the safe/restored checkpoint so G14 poison events are re-read. REACHED now comes only from the
+authoritative cursor returned by the specific in-call read; shared timer progress is never proof. Cold state, snapshot,
+scalar, and list queries can therefore return the current `IsSafeState=false` result as soon as their own catch-up reaches
+the fixed head. Genuine short reads and read failures remain fail-closed and retryable, and poison faults, G18 rebuilds,
+G20 tombstone/CAS handling, public APIs, schemas, and SafeWindow settings are unchanged.

--- a/docs/dcb_llm_ja/04_multiple_aggregate_projector.md
+++ b/docs/dcb_llm_ja/04_multiple_aggregate_projector.md
@@ -122,3 +122,18 @@ Sekiban 内部だけで完結する読み取りならマルチプロジェクシ
   インメモリ、Hybrid の cold→hot 引き継ぎ — は厳密な `SortableUniqueId > since` フィルタを使用します。)
 - **`EventsProcessed` は永続的な safe チェックポイント数**で、整合性シグナルとして使用します。復元は
   これをベースラインとし、新規イベントゼロの再起動では同一の payload/position/threshold/count を復元します。
+
+### 初回クエリ catch-up の位置契約 (SEK-G21 / 10.8.1)
+
+Orleans の fresh activation は、最初の state・snapshot・scalar・list クエリの前に fail-closed
+barrier を置きます。この barrier は意図的に異なる 2 種類の位置を使います。
+
+- **START** は safe/restored チェックポイントです。復元レコードの `LastSortableUniqueId` は、
+  background と in-call catch-up が共有する単一の内部 resolver から一度だけ lease されます。
+  これにより SafeWindow 内の poison を含む未チェックポイント tail 全体を再読します。
+- **REACHED** は、その in-call event-store read 自身が返した権威 cursor です。safe 位置でも、
+  timer と共有する進捗値でもありません。自身の read が固定 head に到達すれば、cold な初回
+  クエリは safe-window graduation を待たず、最新の unsafe state を直ちに返せます。
+
+固定 head に届かない short read は引き続き fail-closed で retryable です。read failure は元の
+例外を保持します。safe チェックポイント、SafeWindow の動作、公開 API、storage schema は変更しません。

--- a/docs/dcb_llm_ja/13_common_issues.md
+++ b/docs/dcb_llm_ja/13_common_issues.md
@@ -396,3 +396,17 @@ G18 + G19 + G20 です。
 活性化）。独立したクラスタはアクターを介して協調しません。クラスタ間の一意性はストレージ層の条件付きユニーク追加
 （G15/G16）、永続化された重複の収束は SEK-G18 が担います。**動作変更**: 10.8.0 から競合する作成の一方が整合性エラーで
 失敗します。完全な修正のリリースゲートは G18 + G19 + G20 です。
+
+## Cold な初回クエリが SafeWindow 全体を待つ — 10.8.1 で解決 (SEK-G21)
+
+**症状**。書き込み直後、cold な multi-projection activation への初回クエリが、自身の catch-up log では
+`CurrentPosition == TargetPosition == head` なのに、ほぼ `SafeWindow` 全体にわたり fail-closed になり得ました。
+
+**原因**。初回クエリ barrier は正しく safe/restored チェックポイントから開始していましたが、完了判定にも
+safe 位置を使っていました。そのため SafeWindow 内のイベントは graduation まで reached と判定されませんでした。
+
+**修正**。G14 poison を再読するため START は safe/restored チェックポイントのままです。REACHED はその in-call
+read 自身が返した権威 cursor のみを使い、共有 timer 進捗を証拠にしません。cold な state・snapshot・scalar・list
+クエリは、自身の catch-up が固定 head に到達すれば最新の `IsSafeState=false` 結果を返せます。真の short read と
+read failure は引き続き fail-closed かつ retryable で、poison fault、G18 rebuild、G20 tombstone/CAS、公開 API、
+schema、SafeWindow 設定は変更しません。


### PR DESCRIPTION
## Summary

- split catch-up START from REACHED with distinct internal contracts
- keep START on the safe/restored checkpoint through a single one-shot lease resolver shared by timer and in-call paths
- judge REACHED only from the authoritative cursor returned by the specific in-call refresh invocation
- serialize interleaving timer/in-call writers and reject superseded timer runs
- document the 10.8.1 behavior in English and Japanese

## Root cause

The first-query barrier compared the safe projection position with a fixed authoritative store head. An event inside the SafeWindow was therefore treated as unreached until graduation even after the in-call store read had reached and folded it.

## Behavior

Cold GetState, snapshot, scalar, and list queries now return promptly with the current `IsSafeState=false` state after their own catch-up reaches the fixed head. Stable short reads and failed reads remain fail-closed and retryable; failed reads preserve their original exception. In-window poison still re-establishes the durable G14 fault. G18 restored/rebuild behavior, G20 tombstone/CAS behavior, public APIs, schemas, and SafeWindow settings are unchanged.

## Verification

- focused G21 tests on net9.0 and net10.0: 24 passed per target
- G18/G20/fault reset/API regression set: 41 passed
- full DCB net10.0 test projects: Orleans 166 passed / 1 skipped; WithResult 961 passed; WithoutResult 83 passed; ColdEvents 93 passed; Postgres 39 passed; MaterializedView MultiProvider 9 passed; Azure Blob unit 4 passed
- `git diff --check`

The solution-level command also attempts to execute the non-test `Sekiban.Dcb.TestSupport` assembly and its testhost aborts because the existing `Microsoft.AspNetCore.Http.Abstractions` 2.3.9 DLL is absent; all actual test projects above completed with zero failures.

Closes #1101