### PR TITLE
chore(dcb-templates): bump Sekiban.Dcb references to 10.8.2

### DIFF
--- a/templates/Sekiban.Dcb.Templates/README.md
+++ b/templates/Sekiban.Dcb.Templates/README.md
@@ -2,7 +2,7 @@
 
 Sekiban DCB (Dynamic Consistency Boundary) 向けの .NET Aspire + Orleans スターターテンプレートです。
 
-生成されるプロジェクトはすべて **.NET 10.0** / **Aspire 13.x** / **Sekiban.Dcb 10.4.0** です。
+生成されるプロジェクトはすべて **.NET 10.0** / **Aspire 13.x** / **Sekiban.Dcb 10.8.2** です。
 
 ## インストール
 

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.ApiService/SekibanDcbDeciderAws.ApiService.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.ApiService/SekibanDcbDeciderAws.ApiService.csproj
@@ -33,13 +33,13 @@
 
         <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.3" />
         <PackageReference Include="Scalar.AspNetCore" Version="2.12.50" />
-        <PackageReference Include="Sekiban.Dcb.Orleans.WithoutResult" Version="10.4.0" />
-        <PackageReference Include="Sekiban.Dcb.DynamoDB" Version="10.4.0" />
-        <PackageReference Include="Sekiban.Dcb.BlobStorage.S3" Version="10.4.0" />
-        <PackageReference Include="Sekiban.Dcb.Postgres" Version="10.4.0" />
-        <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.4.0" />
-        <PackageReference Include="Sekiban.Dcb.MaterializedView.Postgres" Version="10.4.0" />
-        <PackageReference Include="Sekiban.Dcb.MaterializedView.Orleans" Version="10.4.0" />
+        <PackageReference Include="Sekiban.Dcb.Orleans.WithoutResult" Version="10.8.2" />
+        <PackageReference Include="Sekiban.Dcb.DynamoDB" Version="10.8.2" />
+        <PackageReference Include="Sekiban.Dcb.BlobStorage.S3" Version="10.8.2" />
+        <PackageReference Include="Sekiban.Dcb.Postgres" Version="10.8.2" />
+        <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.8.2" />
+        <PackageReference Include="Sekiban.Dcb.MaterializedView.Postgres" Version="10.8.2" />
+        <PackageReference Include="Sekiban.Dcb.MaterializedView.Orleans" Version="10.8.2" />
         <PackageReference Include="Dapper" Version="2.1.66" />
         <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />
     </ItemGroup>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.EventSource/SekibanDcbDeciderAws.EventSource.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.EventSource/SekibanDcbDeciderAws.EventSource.csproj
@@ -11,8 +11,8 @@
     <ProjectReference Include="..\SekibanDcbDeciderAws.MeetingRoomModels\SekibanDcbDeciderAws.MeetingRoomModels.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.4.0" />
-    <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.4.0" />
+    <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.8.2" />
+    <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.8.2" />
     <PackageReference Include="ResultBoxes" Version="0.4.0" />
     <PackageReference Include="Microsoft.Orleans.Serialization" Version="10.0.1" />
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.ImmutableModels/SekibanDcbDeciderAws.ImmutableModels.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.ImmutableModels/SekibanDcbDeciderAws.ImmutableModels.csproj
@@ -7,7 +7,7 @@
     <IsPackable>true</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Sekiban.Dcb.Core.Model" Version="10.4.0" />
+    <PackageReference Include="Sekiban.Dcb.Core.Model" Version="10.8.2" />
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />
   </ItemGroup>
 </Project>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.Interactions.Unit/SekibanDcbDeciderAws.Interactions.Unit.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.Interactions.Unit/SekibanDcbDeciderAws.Interactions.Unit.csproj
@@ -28,9 +28,9 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.4.0" />
-    <PackageReference Include="Sekiban.Dcb.Core.Testing" Version="10.4.0" />
-    <PackageReference Include="Sekiban.Dcb.WithoutResult.Testing" Version="10.4.0" />
+      <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.8.2" />
+    <PackageReference Include="Sekiban.Dcb.Core.Testing" Version="10.8.2" />
+    <PackageReference Include="Sekiban.Dcb.WithoutResult.Testing" Version="10.8.2" />
     </ItemGroup>
 
 </Project>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.Interactions/SekibanDcbDeciderAws.Interactions.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.Interactions/SekibanDcbDeciderAws.Interactions.csproj
@@ -10,7 +10,7 @@
     <ProjectReference Include="..\SekibanDcbDeciderAws.EventSource\SekibanDcbDeciderAws.EventSource.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.4.0" />
+    <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.8.2" />
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />
   </ItemGroup>
 </Project>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.MeetingRoomModels/SekibanDcbDeciderAws.MeetingRoomModels.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.MeetingRoomModels/SekibanDcbDeciderAws.MeetingRoomModels.csproj
@@ -7,7 +7,7 @@
     <IsPackable>true</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Sekiban.Dcb.Core.Model" Version="10.4.0" />
+    <PackageReference Include="Sekiban.Dcb.Core.Model" Version="10.8.2" />
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />
   </ItemGroup>
 </Project>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.Unit/SekibanDcbDeciderAws.Unit.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider.Aws/SekibanDcbDeciderAws.Unit/SekibanDcbDeciderAws.Unit.csproj
@@ -15,9 +15,9 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.4.0" />
-    <PackageReference Include="Sekiban.Dcb.Core.Testing" Version="10.4.0" />
-    <PackageReference Include="Sekiban.Dcb.WithoutResult.Testing" Version="10.4.0" />
+    <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.8.2" />
+    <PackageReference Include="Sekiban.Dcb.Core.Testing" Version="10.8.2" />
+    <PackageReference Include="Sekiban.Dcb.WithoutResult.Testing" Version="10.8.2" />
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />
   </ItemGroup>
   <ItemGroup>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.ApiService/SekibanDcbDecider.ApiService.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.ApiService/SekibanDcbDecider.ApiService.csproj
@@ -44,14 +44,14 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Sekiban.Dcb.BlobStorage.AzureStorage" Version="10.4.0" />
-        <PackageReference Include="Sekiban.Dcb.Orleans.WithoutResult" Version="10.4.0" />
-        <PackageReference Include="Sekiban.Dcb.Postgres" Version="10.4.0" />
-        <PackageReference Include="Sekiban.Dcb.CosmosDb" Version="10.4.0" />
-        <PackageReference Include="Sekiban.Dcb.Sqlite" Version="10.4.0" />
-        <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.4.0" />
-        <PackageReference Include="Sekiban.Dcb.MaterializedView.Postgres" Version="10.4.0" />
-        <PackageReference Include="Sekiban.Dcb.MaterializedView.Orleans" Version="10.4.0" />
+        <PackageReference Include="Sekiban.Dcb.BlobStorage.AzureStorage" Version="10.8.2" />
+        <PackageReference Include="Sekiban.Dcb.Orleans.WithoutResult" Version="10.8.2" />
+        <PackageReference Include="Sekiban.Dcb.Postgres" Version="10.8.2" />
+        <PackageReference Include="Sekiban.Dcb.CosmosDb" Version="10.8.2" />
+        <PackageReference Include="Sekiban.Dcb.Sqlite" Version="10.8.2" />
+        <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.8.2" />
+        <PackageReference Include="Sekiban.Dcb.MaterializedView.Postgres" Version="10.8.2" />
+        <PackageReference Include="Sekiban.Dcb.MaterializedView.Orleans" Version="10.8.2" />
         <PackageReference Include="Dapper" Version="2.1.66" />
     </ItemGroup>
 </Project>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.Cli/SekibanDcbDecider.Cli.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.Cli/SekibanDcbDecider.Cli.csproj
@@ -14,10 +14,10 @@
         <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.3" />
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.3" />
         <PackageReference Include="System.CommandLine" Version="2.0.2" />
-        <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.4.0" />
-        <PackageReference Include="Sekiban.Dcb.Postgres" Version="10.4.0" />
-        <PackageReference Include="Sekiban.Dcb.CosmosDb" Version="10.4.0" />
-        <PackageReference Include="Sekiban.Dcb.Sqlite" Version="10.4.0" />
+        <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.8.2" />
+        <PackageReference Include="Sekiban.Dcb.Postgres" Version="10.8.2" />
+        <PackageReference Include="Sekiban.Dcb.CosmosDb" Version="10.8.2" />
+        <PackageReference Include="Sekiban.Dcb.Sqlite" Version="10.8.2" />
         <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />
     </ItemGroup>
 

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.EventSource/SekibanDcbDecider.EventSource.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.EventSource/SekibanDcbDecider.EventSource.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="ResultBoxes" Version="0.4.0" />
     <PackageReference Include="Microsoft.Orleans.Serialization" Version="10.0.1" />
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />
-    <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.4.0" />
-    <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.4.0" />
+    <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.8.2" />
+    <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.8.2" />
   </ItemGroup>
 </Project>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.ImmutableModels/SekibanDcbDecider.ImmutableModels.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.ImmutableModels/SekibanDcbDecider.ImmutableModels.csproj
@@ -10,6 +10,6 @@
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Sekiban.Dcb.Core.Model" Version="10.4.0" />
+    <PackageReference Include="Sekiban.Dcb.Core.Model" Version="10.8.2" />
   </ItemGroup>
 </Project>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.Interactions.Unit/SekibanDcbDecider.Interactions.Unit.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.Interactions.Unit/SekibanDcbDecider.Interactions.Unit.csproj
@@ -28,9 +28,9 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.4.0" />
-    <PackageReference Include="Sekiban.Dcb.Core.Testing" Version="10.4.0" />
-    <PackageReference Include="Sekiban.Dcb.WithoutResult.Testing" Version="10.4.0" />
+      <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.8.2" />
+    <PackageReference Include="Sekiban.Dcb.Core.Testing" Version="10.8.2" />
+    <PackageReference Include="Sekiban.Dcb.WithoutResult.Testing" Version="10.8.2" />
     </ItemGroup>
 
 </Project>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.Interactions/SekibanDcbDecider.Interactions.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.Interactions/SekibanDcbDecider.Interactions.csproj
@@ -11,6 +11,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />
-    <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.4.0" />
+    <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.8.2" />
   </ItemGroup>
 </Project>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.MeetingRoomModels/SekibanDcbDecider.MeetingRoomModels.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.MeetingRoomModels/SekibanDcbDecider.MeetingRoomModels.csproj
@@ -10,6 +10,6 @@
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Sekiban.Dcb.Core.Model" Version="10.4.0" />
+    <PackageReference Include="Sekiban.Dcb.Core.Model" Version="10.8.2" />
   </ItemGroup>
 </Project>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.Unit/SekibanDcbDecider.Unit.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.Decider/SekibanDcbDecider.Unit/SekibanDcbDecider.Unit.csproj
@@ -15,9 +15,9 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.4.0" />
-    <PackageReference Include="Sekiban.Dcb.Core.Testing" Version="10.4.0" />
-    <PackageReference Include="Sekiban.Dcb.WithoutResult.Testing" Version="10.4.0" />
+    <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.8.2" />
+    <PackageReference Include="Sekiban.Dcb.Core.Testing" Version="10.8.2" />
+    <PackageReference Include="Sekiban.Dcb.WithoutResult.Testing" Version="10.8.2" />
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />
   </ItemGroup>
   <ItemGroup>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult.Aws/SekibanDcbOrleansAws.ApiService/SekibanDcbOrleansAws.ApiService.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult.Aws/SekibanDcbOrleansAws.ApiService/SekibanDcbOrleansAws.ApiService.csproj
@@ -27,13 +27,13 @@
         <!-- SQS streaming will be added when Orleans SQS package supports AWS SDK v4 -->
         <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.3" />
         <PackageReference Include="Scalar.AspNetCore" Version="2.12.50" />
-        <PackageReference Include="Sekiban.Dcb.Orleans.WithoutResult" Version="10.4.0" />
-        <PackageReference Include="Sekiban.Dcb.DynamoDB" Version="10.4.0" />
-        <PackageReference Include="Sekiban.Dcb.BlobStorage.S3" Version="10.4.0" />
-        <PackageReference Include="Sekiban.Dcb.Postgres" Version="10.4.0" />
-        <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.4.0" />
-        <PackageReference Include="Sekiban.Dcb.MaterializedView.Postgres" Version="10.4.0" />
-        <PackageReference Include="Sekiban.Dcb.MaterializedView.Orleans" Version="10.4.0" />
+        <PackageReference Include="Sekiban.Dcb.Orleans.WithoutResult" Version="10.8.2" />
+        <PackageReference Include="Sekiban.Dcb.DynamoDB" Version="10.8.2" />
+        <PackageReference Include="Sekiban.Dcb.BlobStorage.S3" Version="10.8.2" />
+        <PackageReference Include="Sekiban.Dcb.Postgres" Version="10.8.2" />
+        <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.8.2" />
+        <PackageReference Include="Sekiban.Dcb.MaterializedView.Postgres" Version="10.8.2" />
+        <PackageReference Include="Sekiban.Dcb.MaterializedView.Orleans" Version="10.8.2" />
         <PackageReference Include="Dapper" Version="2.1.66" />
         <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />
     </ItemGroup>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult.Aws/SekibanDcbOrleansAws.Domain/SekibanDcbOrleansAws.Domain.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult.Aws/SekibanDcbOrleansAws.Domain/SekibanDcbOrleansAws.Domain.csproj
@@ -7,8 +7,8 @@
     <IsPackable>true</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.4.0" />
-    <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.4.0" />
+    <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.8.2" />
+    <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.8.2" />
     <PackageReference Include="ResultBoxes" Version="0.4.0" />
     <PackageReference Include="Microsoft.Orleans.Serialization" Version="10.0.1" />
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult.Aws/SekibanDcbOrleansAws.Unit/SekibanDcbOrleansAws.Unit.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult.Aws/SekibanDcbOrleansAws.Unit/SekibanDcbOrleansAws.Unit.csproj
@@ -14,9 +14,9 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.4.0" />
-    <PackageReference Include="Sekiban.Dcb.Core.Testing" Version="10.4.0" />
-    <PackageReference Include="Sekiban.Dcb.WithoutResult.Testing" Version="10.4.0" />
+    <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.8.2" />
+    <PackageReference Include="Sekiban.Dcb.Core.Testing" Version="10.8.2" />
+    <PackageReference Include="Sekiban.Dcb.WithoutResult.Testing" Version="10.8.2" />
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />
   </ItemGroup>
   <ItemGroup>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.ApiService/SekibanDcbOrleans.ApiService.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.ApiService/SekibanDcbOrleans.ApiService.csproj
@@ -30,14 +30,14 @@
         <PackageReference Include="Microsoft.Orleans.Streaming" Version="10.0.1" />
         <PackageReference Include="Microsoft.Orleans.Streaming.AzureStorage" Version="10.0.1" />
         <PackageReference Include="Scalar.AspNetCore" Version="2.12.50" />
-        <PackageReference Include="Sekiban.Dcb.BlobStorage.AzureStorage" Version="10.4.0" />
-        <PackageReference Include="Sekiban.Dcb.Orleans.WithoutResult" Version="10.4.0" />
-        <PackageReference Include="Sekiban.Dcb.Postgres" Version="10.4.0" />
-        <PackageReference Include="Sekiban.Dcb.CosmosDb" Version="10.4.0" />
-        <PackageReference Include="Sekiban.Dcb.Sqlite" Version="10.4.0" />
-        <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.4.0" />
-        <PackageReference Include="Sekiban.Dcb.MaterializedView.Postgres" Version="10.4.0" />
-        <PackageReference Include="Sekiban.Dcb.MaterializedView.Orleans" Version="10.4.0" />
+        <PackageReference Include="Sekiban.Dcb.BlobStorage.AzureStorage" Version="10.8.2" />
+        <PackageReference Include="Sekiban.Dcb.Orleans.WithoutResult" Version="10.8.2" />
+        <PackageReference Include="Sekiban.Dcb.Postgres" Version="10.8.2" />
+        <PackageReference Include="Sekiban.Dcb.CosmosDb" Version="10.8.2" />
+        <PackageReference Include="Sekiban.Dcb.Sqlite" Version="10.8.2" />
+        <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.8.2" />
+        <PackageReference Include="Sekiban.Dcb.MaterializedView.Postgres" Version="10.8.2" />
+        <PackageReference Include="Sekiban.Dcb.MaterializedView.Orleans" Version="10.8.2" />
         <PackageReference Include="Dapper" Version="2.1.66" />
         <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />
     </ItemGroup>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.Cli/SekibanDcbOrleans.Cli.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.Cli/SekibanDcbOrleans.Cli.csproj
@@ -14,10 +14,10 @@
         <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.3" />
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.3" />
         <PackageReference Include="System.CommandLine" Version="2.0.2" />
-        <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.4.0" />
-        <PackageReference Include="Sekiban.Dcb.Postgres" Version="10.4.0" />
-        <PackageReference Include="Sekiban.Dcb.CosmosDb" Version="10.4.0" />
-        <PackageReference Include="Sekiban.Dcb.Sqlite" Version="10.4.0" />
+        <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.8.2" />
+        <PackageReference Include="Sekiban.Dcb.Postgres" Version="10.8.2" />
+        <PackageReference Include="Sekiban.Dcb.CosmosDb" Version="10.8.2" />
+        <PackageReference Include="Sekiban.Dcb.Sqlite" Version="10.8.2" />
         <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />
     </ItemGroup>
 

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.Domain/SekibanDcbOrleans.Domain.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.Domain/SekibanDcbOrleans.Domain.csproj
@@ -7,8 +7,8 @@
     <IsPackable>true</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.4.0" />
-    <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.4.0" />
+    <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.8.2" />
+    <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.8.2" />
     <PackageReference Include="ResultBoxes" Version="0.4.0" />
     <PackageReference Include="Microsoft.Orleans.Serialization" Version="10.0.1" />
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.Unit/SekibanDcbOrleans.Unit.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans.WithoutResult/SekibanDcbOrleans.Unit/SekibanDcbOrleans.Unit.csproj
@@ -14,9 +14,9 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.4.0" />
-    <PackageReference Include="Sekiban.Dcb.Core.Testing" Version="10.4.0" />
-    <PackageReference Include="Sekiban.Dcb.WithoutResult.Testing" Version="10.4.0" />
+    <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.8.2" />
+    <PackageReference Include="Sekiban.Dcb.Core.Testing" Version="10.8.2" />
+    <PackageReference Include="Sekiban.Dcb.WithoutResult.Testing" Version="10.8.2" />
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />
   </ItemGroup>
   <ItemGroup>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans/SekibanDcbOrleans.ApiService/SekibanDcbOrleans.ApiService.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans/SekibanDcbOrleans.ApiService/SekibanDcbOrleans.ApiService.csproj
@@ -28,14 +28,14 @@
     <PackageReference Include="Microsoft.Orleans.Streaming.AzureStorage" Version="10.0.1" />
     <PackageReference Include="Microsoft.Orleans.Streaming.EventHubs" Version="10.0.1" />
     <PackageReference Include="Scalar.AspNetCore" Version="2.12.50" />
-    <PackageReference Include="Sekiban.Dcb.BlobStorage.AzureStorage" Version="10.4.0" />
-    <PackageReference Include="Sekiban.Dcb.Orleans.WithResult" Version="10.4.0" />
-    <PackageReference Include="Sekiban.Dcb.Postgres" Version="10.4.0" />
-    <PackageReference Include="Sekiban.Dcb.CosmosDb" Version="10.4.0" />
-    <PackageReference Include="Sekiban.Dcb.Sqlite" Version="10.4.0" />
-    <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.4.0" />
-    <PackageReference Include="Sekiban.Dcb.MaterializedView.Postgres" Version="10.4.0" />
-    <PackageReference Include="Sekiban.Dcb.MaterializedView.Orleans" Version="10.4.0" />
+    <PackageReference Include="Sekiban.Dcb.BlobStorage.AzureStorage" Version="10.8.2" />
+    <PackageReference Include="Sekiban.Dcb.Orleans.WithResult" Version="10.8.2" />
+    <PackageReference Include="Sekiban.Dcb.Postgres" Version="10.8.2" />
+    <PackageReference Include="Sekiban.Dcb.CosmosDb" Version="10.8.2" />
+    <PackageReference Include="Sekiban.Dcb.Sqlite" Version="10.8.2" />
+    <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.8.2" />
+    <PackageReference Include="Sekiban.Dcb.MaterializedView.Postgres" Version="10.8.2" />
+    <PackageReference Include="Sekiban.Dcb.MaterializedView.Orleans" Version="10.8.2" />
     <PackageReference Include="Dapper" Version="2.1.66" />
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />
   </ItemGroup>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans/SekibanDcbOrleans.Cli/SekibanDcbOrleans.Cli.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans/SekibanDcbOrleans.Cli/SekibanDcbOrleans.Cli.csproj
@@ -14,10 +14,10 @@
         <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.3" />
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.3" />
         <PackageReference Include="System.CommandLine" Version="2.0.2" />
-        <PackageReference Include="Sekiban.Dcb.WithResult" Version="10.4.0" />
-        <PackageReference Include="Sekiban.Dcb.Postgres" Version="10.4.0" />
-        <PackageReference Include="Sekiban.Dcb.CosmosDb" Version="10.4.0" />
-        <PackageReference Include="Sekiban.Dcb.Sqlite" Version="10.4.0" />
+        <PackageReference Include="Sekiban.Dcb.WithResult" Version="10.8.2" />
+        <PackageReference Include="Sekiban.Dcb.Postgres" Version="10.8.2" />
+        <PackageReference Include="Sekiban.Dcb.CosmosDb" Version="10.8.2" />
+        <PackageReference Include="Sekiban.Dcb.Sqlite" Version="10.8.2" />
         <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />
     </ItemGroup>
 

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans/SekibanDcbOrleans.Domain/SekibanDcbOrleans.Domain.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans/SekibanDcbOrleans.Domain/SekibanDcbOrleans.Domain.csproj
@@ -7,8 +7,8 @@
     <IsPackable>true</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Sekiban.Dcb.WithResult" Version="10.4.0" />
-    <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.4.0" />
+    <PackageReference Include="Sekiban.Dcb.WithResult" Version="10.8.2" />
+    <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.8.2" />
     <PackageReference Include="ResultBoxes" Version="0.4.0" />
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />
   </ItemGroup>

--- a/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans/SekibanDcbOrleans.Unit/SekibanDcbOrleans.Unit.csproj
+++ b/templates/Sekiban.Dcb.Templates/content/Sekiban.Dcb.Orleans/SekibanDcbOrleans.Unit/SekibanDcbOrleans.Unit.csproj
@@ -14,9 +14,9 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Sekiban.Dcb.WithResult" Version="10.4.0" />
-    <PackageReference Include="Sekiban.Dcb.Core.Testing" Version="10.4.0" />
-    <PackageReference Include="Sekiban.Dcb.WithResult.Testing" Version="10.4.0" />
+    <PackageReference Include="Sekiban.Dcb.WithResult" Version="10.8.2" />
+    <PackageReference Include="Sekiban.Dcb.Core.Testing" Version="10.8.2" />
+    <PackageReference Include="Sekiban.Dcb.WithResult.Testing" Version="10.8.2" />
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.103" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Updates all 87 `Sekiban.Dcb*` package references in `templates/Sekiban.Dcb.Templates` from 10.4.0 to **10.8.2** (current latest), plus the README version line. Mechanical version bump only — no template content changes. Prepares the `dcbTemplates-v10.8.2` release so `dotnet new` projects start on the current patch line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)