### PR TITLE
SEK-G24: add passive projection status registry

### DIFF
--- a/dcb/src/Sekiban.Dcb.Core/Actors/IProjectionStatusReader.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Actors/IProjectionStatusReader.cs
@@ -1,0 +1,35 @@
+using ResultBoxes;
+
+namespace Sekiban.Dcb.Actors;
+
+/// <summary>
+///     Passive projection status reader.  Implementations compose registry rows with event-store counts and must never
+///     resolve or invoke a projection grain.
+/// </summary>
+public interface IProjectionStatusReader
+{
+    Task<ResultBox<IReadOnlyList<ProjectionStatusSnapshot>>> ReadAsync(
+        ProjectionStatusReadRequest? request = null,
+        CancellationToken cancellationToken = default);
+
+    Task<ResultBox<IReadOnlyList<ProjectionStatusSnapshot>>> GetSnapshotsAsync(
+        ProjectionStatusReadRequest? request = null,
+        CancellationToken cancellationToken = default) =>
+        ReadAsync(request, cancellationToken);
+}
+
+/// <summary>
+///     Additive serialized boundary for passive projection status.  It is deliberately separate from
+///     <see cref="ISerializedSekibanDcbExecutor"/> so existing WASM implementors remain source and binary compatible.
+/// </summary>
+public interface ISerializedProjectionStatusReader
+{
+    Task<ResultBox<byte[]>> ReadSerializedAsync(
+        ProjectionStatusReadRequest? request = null,
+        CancellationToken cancellationToken = default);
+
+    Task<ResultBox<byte[]>> GetSerializedSnapshotsAsync(
+        ProjectionStatusReadRequest? request = null,
+        CancellationToken cancellationToken = default) =>
+        ReadSerializedAsync(request, cancellationToken);
+}

--- a/dcb/src/Sekiban.Dcb.Core/Actors/IProjectionStatusReader.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Actors/IProjectionStatusReader.cs
@@ -24,6 +24,14 @@ public interface IProjectionStatusReader
 /// </summary>
 public interface ISerializedProjectionStatusReader
 {
+    /// <summary>
+    ///     Accepts a raw V1 request envelope. The version discriminator and request shape are validated before the
+    ///     underlying reader is invoked, so rejected input performs zero status-store or event-store reads.
+    /// </summary>
+    Task<ResultBox<byte[]>> AcceptAsync(
+        ReadOnlyMemory<byte> utf8Json,
+        CancellationToken cancellationToken = default);
+
     Task<ResultBox<byte[]>> ReadSerializedAsync(
         ProjectionStatusReadRequest? request = null,
         CancellationToken cancellationToken = default);

--- a/dcb/src/Sekiban.Dcb.Core/Actors/ProjectionStatusReadWindowCache.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Actors/ProjectionStatusReadWindowCache.cs
@@ -1,0 +1,75 @@
+using System.Collections.Concurrent;
+using ResultBoxes;
+
+namespace Sekiban.Dcb.Actors;
+
+/// <summary>
+///     Small service-scoped cache for the passive reader's event-store denominator. The key is intentionally only the
+///     bound service ID: all projector filters share one head-count sample during a read window.
+/// </summary>
+public sealed class ProjectionStatusReadWindowCache
+{
+    private sealed record Sample(long TotalEventCount, DateTimeOffset SampledAtUtc);
+
+    private readonly ConcurrentDictionary<string, Sample> _samples = new(StringComparer.Ordinal);
+    private readonly ConcurrentDictionary<string, SemaphoreSlim> _sampleGates = new(StringComparer.Ordinal);
+
+    public async Task<(long TotalEventCount, DateTimeOffset SampledAtUtc)> GetOrSampleAsync(
+        string serviceId,
+        TimeSpan samplingWindow,
+        Func<Task<ResultBox<long>>> sampler,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(serviceId);
+        ArgumentNullException.ThrowIfNull(sampler);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var now = DateTimeOffset.UtcNow;
+        if (samplingWindow > TimeSpan.Zero &&
+            _samples.TryGetValue(serviceId, out var cached) &&
+            now - cached.SampledAtUtc < samplingWindow)
+        {
+            return (cached.TotalEventCount, cached.SampledAtUtc);
+        }
+
+        var gate = _sampleGates.GetOrAdd(serviceId, static _ => new SemaphoreSlim(1, 1));
+        await gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            now = DateTimeOffset.UtcNow;
+            if (samplingWindow > TimeSpan.Zero &&
+                _samples.TryGetValue(serviceId, out cached) &&
+                now - cached.SampledAtUtc < samplingWindow)
+            {
+                return (cached.TotalEventCount, cached.SampledAtUtc);
+            }
+
+            var sampled = await sampler().ConfigureAwait(false);
+            if (!sampled.IsSuccess)
+            {
+                throw sampled.GetException();
+            }
+
+            var sample = new Sample(Math.Max(0, sampled.GetValue()), DateTimeOffset.UtcNow);
+            if (samplingWindow > TimeSpan.Zero)
+            {
+                _samples[serviceId] = sample;
+            }
+
+            return (sample.TotalEventCount, sample.SampledAtUtc);
+        }
+        finally
+        {
+            gate.Release();
+        }
+    }
+
+    /// <summary>Clears a service sample; useful for deterministic provider tests and host lifecycle boundaries.</summary>
+    public void Invalidate(string serviceId)
+    {
+        if (!string.IsNullOrWhiteSpace(serviceId))
+        {
+            _samples.TryRemove(serviceId, out _);
+        }
+    }
+}

--- a/dcb/src/Sekiban.Dcb.Core/Actors/ProjectionStatusReader.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Actors/ProjectionStatusReader.cs
@@ -18,17 +18,34 @@ public sealed class ProjectionStatusReader : IProjectionStatusReader
     private readonly IEventStore _eventStore;
     private readonly IServiceIdProvider _serviceIdProvider;
     private readonly ProjectionStatusOptions _options;
+    private readonly ProjectionStatusReadWindowCache _readWindowCache;
 
     public ProjectionStatusReader(
         IProjectionStatusStore statusStore,
         IEventStore eventStore,
         IServiceIdProvider? serviceIdProvider = null,
         ProjectionStatusOptions? options = null)
+        : this(
+            statusStore,
+            eventStore,
+            serviceIdProvider,
+            options,
+            new ProjectionStatusReadWindowCache())
+    {
+    }
+
+    public ProjectionStatusReader(
+        IProjectionStatusStore statusStore,
+        IEventStore eventStore,
+        IServiceIdProvider? serviceIdProvider,
+        ProjectionStatusOptions? options,
+        ProjectionStatusReadWindowCache? readWindowCache)
     {
         _statusStore = statusStore ?? throw new ArgumentNullException(nameof(statusStore));
         _eventStore = eventStore ?? throw new ArgumentNullException(nameof(eventStore));
         _serviceIdProvider = serviceIdProvider ?? new DefaultServiceIdProvider();
         _options = options ?? new ProjectionStatusOptions();
+        _readWindowCache = readWindowCache ?? new ProjectionStatusReadWindowCache();
     }
 
     public async Task<ResultBox<IReadOnlyList<ProjectionStatusSnapshot>>> ReadAsync(
@@ -54,17 +71,16 @@ public sealed class ProjectionStatusReader : IProjectionStatusReader
                 return ResultBox.Error<IReadOnlyList<ProjectionStatusSnapshot>>(rowsResult.GetException());
             }
 
-            // This is intentionally one call, even when the registry is empty: it defines the sample window's global
-            // denominator and keeps the counting contract observable to provider tests.
-            var totalResult = await _eventStore.GetEventCountAsync().ConfigureAwait(false);
-            if (!totalResult.IsSuccess)
-            {
-                return ResultBox.Error<IReadOnlyList<ProjectionStatusSnapshot>>(totalResult.GetException());
-            }
-
             var rows = rowsResult.GetValue();
-            var total = Math.Max(0, totalResult.GetValue());
-            var sampledAt = DateTimeOffset.UtcNow;
+            // The denominator is sampled once per service/read window and shared by all projector filters. It is
+            // deliberately read-side only; heartbeat writes never call this path.
+            var sample = await _readWindowCache.GetOrSampleAsync(
+                serviceId,
+                _options.SamplingWindow,
+                () => _eventStore.GetEventCountAsync(),
+                cancellationToken).ConfigureAwait(false);
+            var total = sample.TotalEventCount;
+            var sampledAt = sample.SampledAtUtc;
             var remainingByCursor = new ConcurrentDictionary<string, long>(StringComparer.Ordinal);
             var cursors = rows
                 .Select(row => row.LastTraversedSortableUniqueId)
@@ -98,15 +114,25 @@ public sealed class ProjectionStatusReader : IProjectionStatusReader
                 ? _options.FreshnessWindow
                 : TimeSpan.FromMinutes(2));
             var conflicts = rows
-                .GroupBy(row => (row.ProjectorName, row.ProjectorVersion, row.ClusterId))
+                // A cluster is the CAS row identity, but conflict is a fleet-level signal: two fresh writers from
+                // distinct clusters for one projector/version must remain visible as a conflict.
+                .GroupBy(row => (row.ProjectorName, row.ProjectorVersion))
                 .ToDictionary(
                     group => group.Key,
-                    group => group
-                        .Where(row => row.RecordedAtUtc >= freshSince)
-                        .Select(row => row.ActivationId)
-                        .Distinct(StringComparer.Ordinal)
-                        .OrderBy(id => id, StringComparer.Ordinal)
-                        .ToArray());
+                    group =>
+                    {
+                        var freshRows = group.Where(row =>
+                                row.RecordedAtUtc >= freshSince &&
+                                (!row.LeaseExpiresAtUtc.HasValue || row.LeaseExpiresAtUtc.Value >= sampledAt))
+                            .ToArray();
+                        return (
+                            HasConflict: freshRows.Length > 1,
+                            ActivationIds: freshRows
+                                .Select(row => row.ActivationId)
+                                .Distinct(StringComparer.Ordinal)
+                                .OrderBy(id => id, StringComparer.Ordinal)
+                                .ToArray());
+                    });
 
             var snapshots = rows
                 .Select(row =>
@@ -114,8 +140,14 @@ public sealed class ProjectionStatusReader : IProjectionStatusReader
                     var remaining = string.IsNullOrWhiteSpace(row.LastTraversedSortableUniqueId)
                         ? total
                         : remainingByCursor[row.LastTraversedSortableUniqueId!];
-                    var activationIds = conflicts[(row.ProjectorName, row.ProjectorVersion, row.ClusterId)];
-                    var hasConflict = activationIds.Length > 1;
+                    var conflict = conflicts[(row.ProjectorName, row.ProjectorVersion)];
+                    var activationIds = conflict.ActivationIds;
+                    var hasConflict = conflict.HasConflict;
+                    var leaseFresh = !row.LeaseExpiresAtUtc.HasValue || row.LeaseExpiresAtUtc.Value >= sampledAt;
+                    var rowFresh = row.RecordedAtUtc >= freshSince && leaseFresh;
+                    var faulted = row.IsFaulted ||
+                        !string.IsNullOrWhiteSpace(row.FaultMessage) ||
+                        string.Equals(row.Phase, ProjectionStatusPhases.Faulted, StringComparison.Ordinal);
                     return new ProjectionStatusSnapshot(
                         row.ProjectorName,
                         row.ProjectorVersion,
@@ -129,9 +161,16 @@ public sealed class ProjectionStatusReader : IProjectionStatusReader
                         remaining,
                         sampledAt,
                         ProjectionStatusSnapshot.BestEffortConsistency,
-                        total == 0 || remaining == 0,
+                        remaining == 0 && rowFresh && !faulted && !hasConflict,
                         hasConflict,
-                        hasConflict ? activationIds : Array.Empty<string>());
+                        hasConflict ? activationIds : Array.Empty<string>())
+                    {
+                        Phase = row.Phase,
+                        LeaseExpiresAtUtc = row.LeaseExpiresAtUtc,
+                        IsFaulted = faulted,
+                        FaultMessage = row.FaultMessage,
+                        IsFresh = rowFresh
+                    };
                 })
                 .OrderBy(snapshot => snapshot.ProjectorName, StringComparer.Ordinal)
                 .ThenBy(snapshot => snapshot.ProjectorVersion, StringComparer.Ordinal)
@@ -164,6 +203,14 @@ public sealed class SerializedProjectionStatusReader : ISerializedProjectionStat
         WriteIndented = false
     };
 
+    private static readonly JsonSerializerOptions RequestJsonOptions = new(JsonSerializerDefaults.Web)
+    {
+        DefaultIgnoreCondition = JsonIgnoreCondition.Never,
+        PropertyNameCaseInsensitive = false,
+        UnmappedMemberHandling = JsonUnmappedMemberHandling.Disallow,
+        WriteIndented = false
+    };
+
     private readonly IProjectionStatusReader _reader;
     private readonly IServiceIdProvider _serviceIdProvider;
 
@@ -173,6 +220,52 @@ public sealed class SerializedProjectionStatusReader : ISerializedProjectionStat
     {
         _reader = reader ?? throw new ArgumentNullException(nameof(reader));
         _serviceIdProvider = serviceIdProvider ?? new DefaultServiceIdProvider();
+    }
+
+    public async Task<ResultBox<byte[]>> AcceptAsync(
+        ReadOnlyMemory<byte> utf8Json,
+        CancellationToken cancellationToken = default)
+    {
+        // Phase 1: inspect only the raw discriminator. This must happen before request DTO binding and before the
+        // underlying reader is reachable, so malformed/unsupported input has zero registry/event-store reads.
+        var discriminator = ReadVersion(utf8Json.Span);
+        if (!discriminator.IsSuccess)
+        {
+            return ResultBox.Error<byte[]>(discriminator.GetException());
+        }
+
+        var version = discriminator.GetValue();
+        if (version != SerializedProjectionStatusRequestEnvelopeV1.CurrentVersion)
+        {
+            return ResultBox.Error<byte[]>(
+                new UnsupportedSerializedProjectionStatusVersionException(version));
+        }
+
+        try
+        {
+            // Phase 2: bind only the already-discriminated V1 shape. Unknown fields, wrong-typed filters, and null
+            // roots are shape errors, never version errors.
+            var envelope = JsonSerializer.Deserialize<SerializedProjectionStatusRequestEnvelopeV1>(
+                utf8Json.Span,
+                RequestJsonOptions);
+            if (envelope is null)
+            {
+                return ResultBox.Error<byte[]>(
+                    new SerializedProjectionStatusShapeException("Projection status request envelope is null."));
+            }
+
+            return await ReadSerializedAsync(envelope.ToRequest(), cancellationToken).ConfigureAwait(false);
+        }
+        catch (JsonException ex)
+        {
+            return ResultBox.Error<byte[]>(
+                new SerializedProjectionStatusShapeException(ex.Message));
+        }
+        catch (Exception ex) when (ex is InvalidOperationException or NotSupportedException or OverflowException)
+        {
+            return ResultBox.Error<byte[]>(
+                new SerializedProjectionStatusShapeException(ex.Message));
+        }
     }
 
     public async Task<ResultBox<byte[]>> ReadSerializedAsync(
@@ -191,6 +284,12 @@ public sealed class SerializedProjectionStatusReader : ISerializedProjectionStat
         return ResultBox.FromValue(JsonSerializer.SerializeToUtf8Bytes(envelope, JsonOptions));
     }
 
+    /// <summary>Serializes the canonical V1 request vector used by endpoints and wire-contract tests.</summary>
+    public static byte[] SerializeRequest(ProjectionStatusReadRequest? request = null) =>
+        JsonSerializer.SerializeToUtf8Bytes(
+            SerializedProjectionStatusRequestEnvelopeV1.Create(request),
+            RequestJsonOptions);
+
     public static ResultBox<SerializedProjectionStatusEnvelopeV1> Deserialize(ReadOnlySpan<byte> payload)
     {
         try
@@ -202,27 +301,13 @@ public sealed class SerializedProjectionStatusReader : ISerializedProjectionStat
                     new SerializedProjectionStatusShapeException("Projection status envelope root must be an object."));
             }
 
-            var versionProperties = document.RootElement
-                .EnumerateObject()
-                .Where(property => property.Name.Equals("version", StringComparison.OrdinalIgnoreCase))
-                .ToArray();
-            var exactVersionProperties = versionProperties
-                .Where(property => property.Name.Equals("version", StringComparison.Ordinal))
-                .ToArray();
-            if (versionProperties.Any(property => !property.Name.Equals("version", StringComparison.Ordinal)) ||
-                exactVersionProperties.Length != 1)
+            var versionResult = ReadVersion(document.RootElement);
+            if (!versionResult.IsSuccess)
             {
-                return ResultBox.Error<SerializedProjectionStatusEnvelopeV1>(
-                    new SerializedProjectionStatusShapeException("Projection status envelope requires one exact version property."));
+                return ResultBox.Error<SerializedProjectionStatusEnvelopeV1>(versionResult.GetException());
             }
 
-            var versionElement = exactVersionProperties[0].Value;
-            if (versionElement.ValueKind != JsonValueKind.Number ||
-                !versionElement.TryGetInt32(out var version))
-            {
-                return ResultBox.Error<SerializedProjectionStatusEnvelopeV1>(
-                    new SerializedProjectionStatusShapeException("Projection status envelope requires integer version."));
-            }
+            var version = versionResult.GetValue();
 
             if (version != SerializedProjectionStatusEnvelopeV1.CurrentVersion)
             {
@@ -259,5 +344,54 @@ public sealed class SerializedProjectionStatusReader : ISerializedProjectionStat
             return ResultBox.Error<SerializedProjectionStatusEnvelopeV1>(
                 new SerializedProjectionStatusShapeException(ex.Message));
         }
+    }
+
+    private static ResultBox<int> ReadVersion(ReadOnlySpan<byte> payload)
+    {
+        try
+        {
+            using var document = JsonDocument.Parse(payload.ToArray());
+            if (document.RootElement.ValueKind != JsonValueKind.Object)
+            {
+                return ResultBox.Error<int>(
+                    new SerializedProjectionStatusShapeException(
+                        "Projection status request envelope root must be an object."));
+            }
+
+            return ReadVersion(document.RootElement);
+        }
+        catch (JsonException ex)
+        {
+            return ResultBox.Error<int>(new SerializedProjectionStatusShapeException(ex.Message));
+        }
+    }
+
+    private static ResultBox<int> ReadVersion(JsonElement root)
+    {
+        var versionProperties = root
+            .EnumerateObject()
+            .Where(property => property.Name.Equals("version", StringComparison.OrdinalIgnoreCase))
+            .ToArray();
+        var exactVersionProperties = versionProperties
+            .Where(property => property.Name.Equals("version", StringComparison.Ordinal))
+            .ToArray();
+        if (versionProperties.Any(property => !property.Name.Equals("version", StringComparison.Ordinal)) ||
+            exactVersionProperties.Length != 1)
+        {
+            return ResultBox.Error<int>(
+                new SerializedProjectionStatusShapeException(
+                    "Projection status envelope requires one exact version property."));
+        }
+
+        var versionElement = exactVersionProperties[0].Value;
+        if (versionElement.ValueKind != JsonValueKind.Number ||
+            !versionElement.TryGetInt32(out var version))
+        {
+            return ResultBox.Error<int>(
+                new SerializedProjectionStatusShapeException(
+                    "Projection status envelope requires integer version."));
+        }
+
+        return ResultBox.FromValue(version);
     }
 }

--- a/dcb/src/Sekiban.Dcb.Core/Actors/ProjectionStatusReader.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Actors/ProjectionStatusReader.cs
@@ -1,0 +1,263 @@
+using System.Collections.Concurrent;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using ResultBoxes;
+using Sekiban.Dcb.Common;
+using Sekiban.Dcb.ServiceId;
+using Sekiban.Dcb.Storage;
+
+namespace Sekiban.Dcb.Actors;
+
+/// <summary>
+///     Default passive reader.  It performs exactly one total-count sample per read window and at most one remaining
+///     count read for each distinct non-empty traversed cursor.
+/// </summary>
+public sealed class ProjectionStatusReader : IProjectionStatusReader
+{
+    private readonly IProjectionStatusStore _statusStore;
+    private readonly IEventStore _eventStore;
+    private readonly IServiceIdProvider _serviceIdProvider;
+    private readonly ProjectionStatusOptions _options;
+
+    public ProjectionStatusReader(
+        IProjectionStatusStore statusStore,
+        IEventStore eventStore,
+        IServiceIdProvider? serviceIdProvider = null,
+        ProjectionStatusOptions? options = null)
+    {
+        _statusStore = statusStore ?? throw new ArgumentNullException(nameof(statusStore));
+        _eventStore = eventStore ?? throw new ArgumentNullException(nameof(eventStore));
+        _serviceIdProvider = serviceIdProvider ?? new DefaultServiceIdProvider();
+        _options = options ?? new ProjectionStatusOptions();
+    }
+
+    public async Task<ResultBox<IReadOnlyList<ProjectionStatusSnapshot>>> ReadAsync(
+        ProjectionStatusReadRequest? request = null,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var serviceId = _serviceIdProvider.GetCurrentServiceId();
+            if (request?.ServiceId is { Length: > 0 } requestedServiceId &&
+                !string.Equals(requestedServiceId, serviceId, StringComparison.Ordinal))
+            {
+                return ResultBox.Error<IReadOnlyList<ProjectionStatusSnapshot>>(
+                    new UnauthorizedAccessException("Projection status ServiceId is owned by the server."));
+            }
+
+            var rowsResult = await _statusStore.ListAsync(
+                request?.ProjectorName,
+                request?.ProjectorVersion,
+                cancellationToken).ConfigureAwait(false);
+            if (!rowsResult.IsSuccess)
+            {
+                return ResultBox.Error<IReadOnlyList<ProjectionStatusSnapshot>>(rowsResult.GetException());
+            }
+
+            // This is intentionally one call, even when the registry is empty: it defines the sample window's global
+            // denominator and keeps the counting contract observable to provider tests.
+            var totalResult = await _eventStore.GetEventCountAsync().ConfigureAwait(false);
+            if (!totalResult.IsSuccess)
+            {
+                return ResultBox.Error<IReadOnlyList<ProjectionStatusSnapshot>>(totalResult.GetException());
+            }
+
+            var rows = rowsResult.GetValue();
+            var total = Math.Max(0, totalResult.GetValue());
+            var sampledAt = DateTimeOffset.UtcNow;
+            var remainingByCursor = new ConcurrentDictionary<string, long>(StringComparer.Ordinal);
+            var cursors = rows
+                .Select(row => row.LastTraversedSortableUniqueId)
+                .Where(cursor => !string.IsNullOrWhiteSpace(cursor))
+                .Distinct(StringComparer.Ordinal)
+                .ToArray();
+
+            using var limiter = new SemaphoreSlim(Math.Max(1, _options.MaxConcurrentReads));
+            var remainingTasks = cursors.Select(async cursor =>
+            {
+                await limiter.WaitAsync(cancellationToken).ConfigureAwait(false);
+                try
+                {
+                    var countResult = await _eventStore.GetEventCountAsync(
+                        new SortableUniqueId(cursor!)).ConfigureAwait(false);
+                    if (!countResult.IsSuccess)
+                    {
+                        throw countResult.GetException();
+                    }
+
+                    remainingByCursor[cursor!] = Math.Max(0, countResult.GetValue());
+                }
+                finally
+                {
+                    limiter.Release();
+                }
+            });
+            await Task.WhenAll(remainingTasks).ConfigureAwait(false);
+
+            var freshSince = sampledAt - (_options.FreshnessWindow > TimeSpan.Zero
+                ? _options.FreshnessWindow
+                : TimeSpan.FromMinutes(2));
+            var conflicts = rows
+                .GroupBy(row => (row.ProjectorName, row.ProjectorVersion, row.ClusterId))
+                .ToDictionary(
+                    group => group.Key,
+                    group => group
+                        .Where(row => row.RecordedAtUtc >= freshSince)
+                        .Select(row => row.ActivationId)
+                        .Distinct(StringComparer.Ordinal)
+                        .OrderBy(id => id, StringComparer.Ordinal)
+                        .ToArray());
+
+            var snapshots = rows
+                .Select(row =>
+                {
+                    var remaining = string.IsNullOrWhiteSpace(row.LastTraversedSortableUniqueId)
+                        ? total
+                        : remainingByCursor[row.LastTraversedSortableUniqueId!];
+                    var activationIds = conflicts[(row.ProjectorName, row.ProjectorVersion, row.ClusterId)];
+                    var hasConflict = activationIds.Length > 1;
+                    return new ProjectionStatusSnapshot(
+                        row.ProjectorName,
+                        row.ProjectorVersion,
+                        row.ClusterId,
+                        row.ActivationId,
+                        row.Sequence,
+                        row.AppliedEventCount,
+                        row.LastAppliedSortableUniqueId,
+                        row.LastTraversedSortableUniqueId,
+                        total,
+                        remaining,
+                        sampledAt,
+                        ProjectionStatusSnapshot.BestEffortConsistency,
+                        total == 0 || remaining == 0,
+                        hasConflict,
+                        hasConflict ? activationIds : Array.Empty<string>());
+                })
+                .OrderBy(snapshot => snapshot.ProjectorName, StringComparer.Ordinal)
+                .ThenBy(snapshot => snapshot.ProjectorVersion, StringComparer.Ordinal)
+                .ThenBy(snapshot => snapshot.ClusterId, StringComparer.Ordinal)
+                .ThenBy(snapshot => snapshot.ActivationId, StringComparer.Ordinal)
+                .ToArray();
+
+            return ResultBox.FromValue<IReadOnlyList<ProjectionStatusSnapshot>>(snapshots);
+        }
+        catch (OperationCanceledException ex) when (cancellationToken.IsCancellationRequested)
+        {
+            return ResultBox.Error<IReadOnlyList<ProjectionStatusSnapshot>>(ex);
+        }
+        catch (Exception ex)
+        {
+            return ResultBox.Error<IReadOnlyList<ProjectionStatusSnapshot>>(ex);
+        }
+    }
+}
+
+/// <summary>
+///     Strict V1 JSON adapter.  ServiceId is supplied by the server-side reader and is never taken from a client
+///     payload; an optional request ServiceId is only an equality guard.
+/// </summary>
+public sealed class SerializedProjectionStatusReader : ISerializedProjectionStatusReader
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web)
+    {
+        DefaultIgnoreCondition = JsonIgnoreCondition.Never,
+        WriteIndented = false
+    };
+
+    private readonly IProjectionStatusReader _reader;
+    private readonly IServiceIdProvider _serviceIdProvider;
+
+    public SerializedProjectionStatusReader(
+        IProjectionStatusReader reader,
+        IServiceIdProvider? serviceIdProvider = null)
+    {
+        _reader = reader ?? throw new ArgumentNullException(nameof(reader));
+        _serviceIdProvider = serviceIdProvider ?? new DefaultServiceIdProvider();
+    }
+
+    public async Task<ResultBox<byte[]>> ReadSerializedAsync(
+        ProjectionStatusReadRequest? request = null,
+        CancellationToken cancellationToken = default)
+    {
+        var result = await _reader.ReadAsync(request, cancellationToken).ConfigureAwait(false);
+        if (!result.IsSuccess)
+        {
+            return ResultBox.Error<byte[]>(result.GetException());
+        }
+
+        var envelope = SerializedProjectionStatusEnvelopeV1.Create(
+            _serviceIdProvider.GetCurrentServiceId(),
+            result.GetValue());
+        return ResultBox.FromValue(JsonSerializer.SerializeToUtf8Bytes(envelope, JsonOptions));
+    }
+
+    public static ResultBox<SerializedProjectionStatusEnvelopeV1> Deserialize(ReadOnlySpan<byte> payload)
+    {
+        try
+        {
+            using var document = JsonDocument.Parse(payload.ToArray());
+            if (document.RootElement.ValueKind != JsonValueKind.Object)
+            {
+                return ResultBox.Error<SerializedProjectionStatusEnvelopeV1>(
+                    new SerializedProjectionStatusShapeException("Projection status envelope root must be an object."));
+            }
+
+            var versionProperties = document.RootElement
+                .EnumerateObject()
+                .Where(property => property.Name.Equals("version", StringComparison.OrdinalIgnoreCase))
+                .ToArray();
+            var exactVersionProperties = versionProperties
+                .Where(property => property.Name.Equals("version", StringComparison.Ordinal))
+                .ToArray();
+            if (versionProperties.Any(property => !property.Name.Equals("version", StringComparison.Ordinal)) ||
+                exactVersionProperties.Length != 1)
+            {
+                return ResultBox.Error<SerializedProjectionStatusEnvelopeV1>(
+                    new SerializedProjectionStatusShapeException("Projection status envelope requires one exact version property."));
+            }
+
+            var versionElement = exactVersionProperties[0].Value;
+            if (versionElement.ValueKind != JsonValueKind.Number ||
+                !versionElement.TryGetInt32(out var version))
+            {
+                return ResultBox.Error<SerializedProjectionStatusEnvelopeV1>(
+                    new SerializedProjectionStatusShapeException("Projection status envelope requires integer version."));
+            }
+
+            if (version != SerializedProjectionStatusEnvelopeV1.CurrentVersion)
+            {
+                return ResultBox.Error<SerializedProjectionStatusEnvelopeV1>(
+                    new UnsupportedSerializedProjectionStatusVersionException(version));
+            }
+
+            var envelope = JsonSerializer.Deserialize<SerializedProjectionStatusEnvelopeV1>(payload, JsonOptions);
+            if (envelope is null || string.IsNullOrWhiteSpace(envelope.ServiceId) || envelope.Snapshots is null ||
+                envelope.Snapshots.Any(snapshot => snapshot is null ||
+                    string.IsNullOrWhiteSpace(snapshot.ProjectorName) ||
+                    string.IsNullOrWhiteSpace(snapshot.ProjectorVersion) ||
+                    string.IsNullOrWhiteSpace(snapshot.ClusterId) ||
+                    string.IsNullOrWhiteSpace(snapshot.ActivationId) ||
+                    string.IsNullOrWhiteSpace(snapshot.Consistency)))
+            {
+                return ResultBox.Error<SerializedProjectionStatusEnvelopeV1>(
+                    new SerializedProjectionStatusShapeException("Projection status envelope has an invalid V1 shape."));
+            }
+
+            return ResultBox.FromValue(envelope);
+        }
+        catch (UnsupportedSerializedProjectionStatusVersionException ex)
+        {
+            return ResultBox.Error<SerializedProjectionStatusEnvelopeV1>(ex);
+        }
+        catch (JsonException ex)
+        {
+            return ResultBox.Error<SerializedProjectionStatusEnvelopeV1>(
+                new SerializedProjectionStatusShapeException(ex.Message));
+        }
+        catch (Exception ex) when (ex is InvalidOperationException or NotSupportedException or OverflowException)
+        {
+            return ResultBox.Error<SerializedProjectionStatusEnvelopeV1>(
+                new SerializedProjectionStatusShapeException(ex.Message));
+        }
+    }
+}

--- a/dcb/src/Sekiban.Dcb.Core/Actors/ProjectionStatusServiceCollectionExtensions.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Actors/ProjectionStatusServiceCollectionExtensions.cs
@@ -1,0 +1,32 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Sekiban.Dcb.ServiceId;
+using Sekiban.Dcb.Storage;
+
+namespace Sekiban.Dcb.Actors;
+
+/// <summary>
+///     Dependency-injection registrations for the passive projection status read boundary.
+/// </summary>
+public static class ProjectionStatusServiceCollectionExtensions
+{
+    /// <summary>
+    ///     Registers the passive status readers after a provider has registered an
+    ///     <see cref="IProjectionStatusStore" /> and an <see cref="IEventStore" />.
+    /// </summary>
+    public static IServiceCollection AddSekibanDcbProjectionStatusReader(this IServiceCollection services)
+    {
+        services.TryAddSingleton<ProjectionStatusOptions>();
+        services.TryAddTransient<IProjectionStatusReader>(serviceProvider =>
+            new ProjectionStatusReader(
+                serviceProvider.GetRequiredService<IProjectionStatusStore>(),
+                serviceProvider.GetRequiredService<IEventStore>(),
+                serviceProvider.GetService<IServiceIdProvider>(),
+                serviceProvider.GetRequiredService<ProjectionStatusOptions>()));
+        services.TryAddTransient<ISerializedProjectionStatusReader>(serviceProvider =>
+            new SerializedProjectionStatusReader(
+                serviceProvider.GetRequiredService<IProjectionStatusReader>(),
+                serviceProvider.GetService<IServiceIdProvider>()));
+        return services;
+    }
+}

--- a/dcb/src/Sekiban.Dcb.Core/Actors/ProjectionStatusServiceCollectionExtensions.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Actors/ProjectionStatusServiceCollectionExtensions.cs
@@ -17,12 +17,14 @@ public static class ProjectionStatusServiceCollectionExtensions
     public static IServiceCollection AddSekibanDcbProjectionStatusReader(this IServiceCollection services)
     {
         services.TryAddSingleton<ProjectionStatusOptions>();
+        services.TryAddSingleton<ProjectionStatusReadWindowCache>();
         services.TryAddTransient<IProjectionStatusReader>(serviceProvider =>
             new ProjectionStatusReader(
                 serviceProvider.GetRequiredService<IProjectionStatusStore>(),
                 serviceProvider.GetRequiredService<IEventStore>(),
                 serviceProvider.GetService<IServiceIdProvider>(),
-                serviceProvider.GetRequiredService<ProjectionStatusOptions>()));
+                serviceProvider.GetRequiredService<ProjectionStatusOptions>(),
+                serviceProvider.GetRequiredService<ProjectionStatusReadWindowCache>()));
         services.TryAddTransient<ISerializedProjectionStatusReader>(serviceProvider =>
             new SerializedProjectionStatusReader(
                 serviceProvider.GetRequiredService<IProjectionStatusReader>(),

--- a/dcb/src/Sekiban.Dcb.Core/InMemory/InMemoryMultiProjectionStateStore.cs
+++ b/dcb/src/Sekiban.Dcb.Core/InMemory/InMemoryMultiProjectionStateStore.cs
@@ -17,11 +17,13 @@ namespace Sekiban.Dcb.InMemory;
     "Moved to Sekiban.Dcb.Core.Testing (namespace Sekiban.Dcb.Testing). This type is volatile/in-process and is for tests only; it lives in a production package for historical reasons, which is how it reached production once. Behaviour is unchanged and it will not be removed before the next major version.")]
 public class InMemoryMultiProjectionStateStore :
     IMultiProjectionStateStore,
+    IProjectionStatusStore,
     IStorageDurabilityDescriptorProvider,
     IGenerationAwareCheckpointStore
 {
     private readonly ConcurrentDictionary<(string ServiceId, string ProjectorName, string ProjectorVersion), MultiProjectionStateRecord> _states = new();
     private readonly ConcurrentDictionary<(string ServiceId, string ProjectorName, string ProjectorVersion), byte[]> _stateData = new();
+    private readonly Dictionary<(string ServiceId, string ProjectorName, string ProjectorVersion, string ClusterId, string ActivationId), ProjectionStatusHeartbeat> _statusRows = new();
 
     // SEK-G20 control plane: generation (rebuild epoch) + monotonic revision (exact-CAS token) + lifecycle. Guarded by
     // _casGate so every read-modify-write is atomic — the reference for what a native provider CAS must guarantee.
@@ -60,6 +62,84 @@ public class InMemoryMultiProjectionStateStore :
             {
                 _control.Remove(key);
             }
+
+            foreach (var key in _statusRows.Keys.Where(k => k.ServiceId == serviceId).ToList())
+            {
+                _statusRows.Remove(key);
+            }
+        }
+    }
+
+    public Task<ResultBox<ProjectionStatusWriteResult>> UpsertAsync(
+        ProjectionStatusHeartbeat heartbeat,
+        long expectedSequence,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(heartbeat);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var serviceId = CurrentServiceId;
+        if (!string.Equals(heartbeat.ServiceId, serviceId, StringComparison.Ordinal))
+        {
+            return Task.FromResult(ResultBox.Error<ProjectionStatusWriteResult>(
+                new UnauthorizedAccessException(
+                    $"Projection status heartbeat belongs to service '{heartbeat.ServiceId}', not '{serviceId}'.")));
+        }
+
+        if (string.IsNullOrWhiteSpace(heartbeat.ProjectorName) ||
+            string.IsNullOrWhiteSpace(heartbeat.ProjectorVersion) ||
+            string.IsNullOrWhiteSpace(heartbeat.ClusterId) ||
+            string.IsNullOrWhiteSpace(heartbeat.ActivationId) ||
+            heartbeat.Sequence <= 0)
+        {
+            return Task.FromResult(ResultBox.Error<ProjectionStatusWriteResult>(
+                new ArgumentException("Projection status heartbeat identity and sequence are required.")));
+        }
+
+        var key = (
+            serviceId,
+            heartbeat.ProjectorName,
+            heartbeat.ProjectorVersion,
+            heartbeat.ClusterId,
+            heartbeat.ActivationId);
+
+        lock (_casGate)
+        {
+            _statusRows.TryGetValue(key, out var current);
+            var currentSequence = current?.Sequence ?? 0;
+            if (currentSequence != expectedSequence || heartbeat.Sequence <= currentSequence)
+            {
+                return Task.FromResult(ResultBox.FromValue(
+                    ProjectionStatusWriteResult.Rejected(
+                        current,
+                        $"Heartbeat CAS rejected: expected sequence {expectedSequence}, current sequence {currentSequence}.")));
+            }
+
+            _statusRows[key] = heartbeat;
+            return Task.FromResult(ResultBox.FromValue(ProjectionStatusWriteResult.Success(heartbeat)));
+        }
+    }
+
+    public Task<ResultBox<IReadOnlyList<ProjectionStatusHeartbeat>>> ListAsync(
+        string? projectorName = null,
+        string? projectorVersion = null,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        var serviceId = CurrentServiceId;
+        lock (_casGate)
+        {
+            var rows = _statusRows
+                .Where(pair => pair.Key.ServiceId == serviceId)
+                .Select(pair => pair.Value)
+                .Where(row => projectorName is null || string.Equals(row.ProjectorName, projectorName, StringComparison.Ordinal))
+                .Where(row => projectorVersion is null || string.Equals(row.ProjectorVersion, projectorVersion, StringComparison.Ordinal))
+                .OrderBy(row => row.ProjectorName, StringComparer.Ordinal)
+                .ThenBy(row => row.ProjectorVersion, StringComparer.Ordinal)
+                .ThenBy(row => row.ClusterId, StringComparer.Ordinal)
+                .ThenBy(row => row.ActivationId, StringComparer.Ordinal)
+                .ToArray();
+            return Task.FromResult(ResultBox.FromValue<IReadOnlyList<ProjectionStatusHeartbeat>>(rows));
         }
     }
 

--- a/dcb/src/Sekiban.Dcb.Core/InMemory/InMemoryMultiProjectionStateStore.cs
+++ b/dcb/src/Sekiban.Dcb.Core/InMemory/InMemoryMultiProjectionStateStore.cs
@@ -23,7 +23,9 @@ public class InMemoryMultiProjectionStateStore :
 {
     private readonly ConcurrentDictionary<(string ServiceId, string ProjectorName, string ProjectorVersion), MultiProjectionStateRecord> _states = new();
     private readonly ConcurrentDictionary<(string ServiceId, string ProjectorName, string ProjectorVersion), byte[]> _stateData = new();
-    private readonly Dictionary<(string ServiceId, string ProjectorName, string ProjectorVersion, string ClusterId, string ActivationId), ProjectionStatusHeartbeat> _statusRows = new();
+    // One CAS row per service/projector/version/cluster. ActivationId is data in the row, not part of its identity;
+    // this is what lets a replacement activation observe and fence the previous writer.
+    private readonly Dictionary<(string ServiceId, string ProjectorName, string ProjectorVersion, string ClusterId), ProjectionStatusHeartbeat> _statusRows = new();
 
     // SEK-G20 control plane: generation (rebuild epoch) + monotonic revision (exact-CAS token) + lifecycle. Guarded by
     // _casGate so every read-modify-write is atomic — the reference for what a native provider CAS must guarantee.
@@ -100,8 +102,7 @@ public class InMemoryMultiProjectionStateStore :
             serviceId,
             heartbeat.ProjectorName,
             heartbeat.ProjectorVersion,
-            heartbeat.ClusterId,
-            heartbeat.ActivationId);
+            heartbeat.ClusterId);
 
         lock (_casGate)
         {

--- a/dcb/src/Sekiban.Dcb.Core/ProjectionStatus/ProjectionStatusModels.cs
+++ b/dcb/src/Sekiban.Dcb.Core/ProjectionStatus/ProjectionStatusModels.cs
@@ -212,6 +212,12 @@ public class ProjectionStatusOptions
     /// <summary>Minimum interval between repeated heartbeat failure/conflict log entries.</summary>
     public TimeSpan HeartbeatFailureLogInterval { get; set; } = TimeSpan.FromSeconds(30);
 
+    /// <summary>Initial delay for a failed heartbeat retry.</summary>
+    public TimeSpan HeartbeatRetryBase { get; set; } = TimeSpan.FromSeconds(1);
+
+    /// <summary>Maximum delay for exponential heartbeat retries.</summary>
+    public TimeSpan HeartbeatRetryCap { get; set; } = TimeSpan.FromSeconds(30);
+
     /// <summary>Allows a host to turn the heartbeat writer off while retaining the read surface.</summary>
     public bool Enabled { get; set; } = true;
 }

--- a/dcb/src/Sekiban.Dcb.Core/ProjectionStatus/ProjectionStatusModels.cs
+++ b/dcb/src/Sekiban.Dcb.Core/ProjectionStatus/ProjectionStatusModels.cs
@@ -28,14 +28,34 @@ public sealed record ProjectionStatusSnapshot(
     /// </summary>
     public const string BestEffortConsistency = "bestEffort";
 
+    /// <summary>Lifecycle phase reported by the activation that produced this sample.</summary>
+    public string Phase { get; init; } = ProjectionStatusPhases.Unknown;
+
+    /// <summary>Optional lease expiry for the activation heartbeat.</summary>
+    public DateTimeOffset? LeaseExpiresAtUtc { get; init; }
+
+    /// <summary>Whether the activation reported a projection fault.</summary>
+    public bool IsFaulted { get; init; }
+
+    /// <summary>A secret-free fault summary, when <see cref="IsFaulted"/> is true.</summary>
+    public string? FaultMessage { get; init; }
+
+    /// <summary>Whether this row satisfied the freshness/lease predicate at sampling time.</summary>
+    public bool IsFresh { get; init; }
+
+    /// <summary>Compatibility/readability alias for callers that call the lease boundary a lease.</summary>
+    [JsonIgnore]
+    public DateTimeOffset? LeaseUntilUtc => LeaseExpiresAtUtc;
+
     [JsonIgnore]
     public IReadOnlyList<string> ConflictActivations =>
         ConflictingActivationIds ?? Array.Empty<string>();
 }
 
 /// <summary>
-///     Internal registry row written by a projection activation.  Rows are keyed by service, projector, cluster, and
-///     activation.  <see cref="Sequence"/> is fenced by the status store so an old activation cannot silently win.
+///     Internal registry row written by a projection activation.  The physical row is keyed by service, projector,
+///     version, and cluster; <see cref="ActivationId"/> is row data so a replacement activation contends on the same
+///     CAS row. <see cref="Sequence"/> is fenced by the status store so an old activation cannot silently win.
 /// </summary>
 public sealed record ProjectionStatusHeartbeat(
     string ServiceId,
@@ -49,6 +69,22 @@ public sealed record ProjectionStatusHeartbeat(
     string? LastTraversedSortableUniqueId,
     DateTimeOffset RecordedAtUtc)
 {
+    /// <summary>Lifecycle phase reported by the activation.</summary>
+    public string Phase { get; init; } = ProjectionStatusPhases.Unknown;
+
+    /// <summary>Optional expiry of the activation's passive heartbeat lease.</summary>
+    public DateTimeOffset? LeaseExpiresAtUtc { get; init; }
+
+    /// <summary>Whether the activation is currently faulted.</summary>
+    public bool IsFaulted { get; init; }
+
+    /// <summary>A secret-free fault summary, when faulted.</summary>
+    public string? FaultMessage { get; init; }
+
+    /// <summary>Compatibility/readability alias for callers that call the lease boundary a lease.</summary>
+    [JsonIgnore]
+    public DateTimeOffset? LeaseUntilUtc => LeaseExpiresAtUtc;
+
     public ProjectionStatusHeartbeat WithSequence(long sequence, DateTimeOffset recordedAtUtc) =>
         this with { Sequence = sequence, RecordedAtUtc = recordedAtUtc };
 }
@@ -68,6 +104,11 @@ public sealed record ProjectionStatusRow(
     string? LastTraversedSortableUniqueId,
     DateTimeOffset RecordedAtUtc)
 {
+    public string Phase { get; init; } = ProjectionStatusPhases.Unknown;
+    public DateTimeOffset? LeaseExpiresAtUtc { get; init; }
+    public bool IsFaulted { get; init; }
+    public string? FaultMessage { get; init; }
+
     public ProjectionStatusHeartbeat ToHeartbeat() => new(
         ServiceId,
         ProjectorName,
@@ -78,7 +119,13 @@ public sealed record ProjectionStatusRow(
         AppliedEventCount,
         LastAppliedSortableUniqueId,
         LastTraversedSortableUniqueId,
-        RecordedAtUtc);
+        RecordedAtUtc)
+    {
+        Phase = Phase,
+        LeaseExpiresAtUtc = LeaseExpiresAtUtc,
+        IsFaulted = IsFaulted,
+        FaultMessage = FaultMessage
+    };
 
     public static ProjectionStatusRow FromHeartbeat(ProjectionStatusHeartbeat heartbeat) => new(
         heartbeat.ServiceId,
@@ -90,7 +137,25 @@ public sealed record ProjectionStatusRow(
         heartbeat.AppliedEventCount,
         heartbeat.LastAppliedSortableUniqueId,
         heartbeat.LastTraversedSortableUniqueId,
-        heartbeat.RecordedAtUtc);
+        heartbeat.RecordedAtUtc)
+    {
+        Phase = heartbeat.Phase,
+        LeaseExpiresAtUtc = heartbeat.LeaseExpiresAtUtc,
+        IsFaulted = heartbeat.IsFaulted,
+        FaultMessage = heartbeat.FaultMessage
+    };
+}
+
+/// <summary>Stable wire values for passive projection lifecycle reporting.</summary>
+public static class ProjectionStatusPhases
+{
+    public const string Unknown = "unknown";
+    public const string Starting = "starting";
+    public const string CatchingUp = "catchingUp";
+    public const string Active = "active";
+    public const string CaughtUp = "caughtUp";
+    public const string Faulted = "faulted";
+    public const string Stopped = "stopped";
 }
 
 public enum ProjectionStatusWriteOutcome
@@ -135,6 +200,18 @@ public class ProjectionStatusOptions
     /// <summary>Bounded parallelism for cursor-specific event-count samples.</summary>
     public int MaxConcurrentReads { get; set; } = 8;
 
+    /// <summary>
+    ///     Denominator sampling window.  A reader reuses one event-store head-count sample per service during this
+    ///     window; cursor-specific numerator samples remain per distinct cursor in each read.
+    /// </summary>
+    public TimeSpan SamplingWindow { get; set; } = TimeSpan.FromSeconds(5);
+
+    /// <summary>Maximum time allowed for one best-effort heartbeat upsert.</summary>
+    public TimeSpan HeartbeatWriteTimeout { get; set; } = TimeSpan.FromSeconds(5);
+
+    /// <summary>Minimum interval between repeated heartbeat failure/conflict log entries.</summary>
+    public TimeSpan HeartbeatFailureLogInterval { get; set; } = TimeSpan.FromSeconds(30);
+
     /// <summary>Allows a host to turn the heartbeat writer off while retaining the read surface.</summary>
     public bool Enabled { get; set; } = true;
 }
@@ -149,6 +226,26 @@ public sealed record ProjectionStatusReadRequest(
     string? ServiceId = null,
     string? ProjectorName = null,
     string? ProjectorVersion = null);
+
+/// <summary>Version-one request envelope for the serialized passive status boundary.</summary>
+public sealed record SerializedProjectionStatusRequestEnvelopeV1(
+    int Version,
+    string? ServiceId,
+    string? ProjectorName,
+    string? ProjectorVersion)
+{
+    public const int CurrentVersion = 1;
+
+    public static SerializedProjectionStatusRequestEnvelopeV1 Create(ProjectionStatusReadRequest? request) =>
+        new(
+            CurrentVersion,
+            request?.ServiceId,
+            request?.ProjectorName,
+            request?.ProjectorVersion);
+
+    public ProjectionStatusReadRequest ToRequest() =>
+        new(ServiceId, ProjectorName, ProjectorVersion);
+}
 
 /// <summary>Version-one envelope for the serialized passive status surface.</summary>
 public sealed record SerializedProjectionStatusEnvelopeV1(

--- a/dcb/src/Sekiban.Dcb.Core/ProjectionStatus/ProjectionStatusModels.cs
+++ b/dcb/src/Sekiban.Dcb.Core/ProjectionStatus/ProjectionStatusModels.cs
@@ -1,0 +1,182 @@
+using System.Text.Json.Serialization;
+
+namespace Sekiban.Dcb;
+
+/// <summary>
+///     A passive, best-effort projection status sample.  The sample is composed from a heartbeat registry and
+///     event-store counts; reading it never activates a projection grain.
+/// </summary>
+public sealed record ProjectionStatusSnapshot(
+    string ProjectorName,
+    string ProjectorVersion,
+    string ClusterId,
+    string ActivationId,
+    long Sequence,
+    long AppliedEventCount,
+    string? LastAppliedSortableUniqueId,
+    string? LastTraversedSortableUniqueId,
+    long TotalEventCount,
+    long RemainingEventCount,
+    DateTimeOffset SampledAtUtc,
+    string Consistency,
+    bool IsCaughtUp,
+    bool HasConflict = false,
+    IReadOnlyList<string>? ConflictingActivationIds = null)
+{
+    /// <summary>
+    ///     The only consistency claim made by this surface.  Counts are samples and are not an atomic head/count view.
+    /// </summary>
+    public const string BestEffortConsistency = "bestEffort";
+
+    [JsonIgnore]
+    public IReadOnlyList<string> ConflictActivations =>
+        ConflictingActivationIds ?? Array.Empty<string>();
+}
+
+/// <summary>
+///     Internal registry row written by a projection activation.  Rows are keyed by service, projector, cluster, and
+///     activation.  <see cref="Sequence"/> is fenced by the status store so an old activation cannot silently win.
+/// </summary>
+public sealed record ProjectionStatusHeartbeat(
+    string ServiceId,
+    string ProjectorName,
+    string ProjectorVersion,
+    string ClusterId,
+    string ActivationId,
+    long Sequence,
+    long AppliedEventCount,
+    string? LastAppliedSortableUniqueId,
+    string? LastTraversedSortableUniqueId,
+    DateTimeOffset RecordedAtUtc)
+{
+    public ProjectionStatusHeartbeat WithSequence(long sequence, DateTimeOffset recordedAtUtc) =>
+        this with { Sequence = sequence, RecordedAtUtc = recordedAtUtc };
+}
+
+/// <summary>
+///     Compatibility name for callers that describe a heartbeat as a row.
+/// </summary>
+public sealed record ProjectionStatusRow(
+    string ServiceId,
+    string ProjectorName,
+    string ProjectorVersion,
+    string ClusterId,
+    string ActivationId,
+    long Sequence,
+    long AppliedEventCount,
+    string? LastAppliedSortableUniqueId,
+    string? LastTraversedSortableUniqueId,
+    DateTimeOffset RecordedAtUtc)
+{
+    public ProjectionStatusHeartbeat ToHeartbeat() => new(
+        ServiceId,
+        ProjectorName,
+        ProjectorVersion,
+        ClusterId,
+        ActivationId,
+        Sequence,
+        AppliedEventCount,
+        LastAppliedSortableUniqueId,
+        LastTraversedSortableUniqueId,
+        RecordedAtUtc);
+
+    public static ProjectionStatusRow FromHeartbeat(ProjectionStatusHeartbeat heartbeat) => new(
+        heartbeat.ServiceId,
+        heartbeat.ProjectorName,
+        heartbeat.ProjectorVersion,
+        heartbeat.ClusterId,
+        heartbeat.ActivationId,
+        heartbeat.Sequence,
+        heartbeat.AppliedEventCount,
+        heartbeat.LastAppliedSortableUniqueId,
+        heartbeat.LastTraversedSortableUniqueId,
+        heartbeat.RecordedAtUtc);
+}
+
+public enum ProjectionStatusWriteOutcome
+{
+    Committed = 0,
+    Conflict = 1
+}
+
+/// <summary>
+///     Result of a heartbeat CAS.  A conflict is a normal stale-writer result and must be surfaced to the reader or
+///     caller; it is never converted into an unconditional last-write-wins update.
+/// </summary>
+public sealed record ProjectionStatusWriteResult(
+    ProjectionStatusWriteOutcome Outcome,
+    ProjectionStatusHeartbeat? Current,
+    string? ConflictReason = null)
+{
+    public bool Committed => Outcome == ProjectionStatusWriteOutcome.Committed;
+    public bool Conflict => Outcome == ProjectionStatusWriteOutcome.Conflict;
+
+    public static ProjectionStatusWriteResult Success(ProjectionStatusHeartbeat row) =>
+        new(ProjectionStatusWriteOutcome.Committed, row);
+
+    public static ProjectionStatusWriteResult Rejected(ProjectionStatusHeartbeat? current, string reason) =>
+        new(ProjectionStatusWriteOutcome.Conflict, current, reason);
+}
+
+/// <summary>Configuration for the passive projection status registry and read-side sampling.</summary>
+public class ProjectionStatusOptions
+{
+    public const string DefaultClusterId = "default";
+
+    /// <summary>Logical cluster/host identity.  It is part of the registry key and must be stable for a deployment.</summary>
+    public string ClusterId { get; set; } = DefaultClusterId;
+
+    /// <summary>Dedicated heartbeat period.  The production default is the contract's 30 seconds.</summary>
+    public TimeSpan HeartbeatInterval { get; set; } = TimeSpan.FromSeconds(30);
+
+    /// <summary>How long a row remains eligible for a fresh-activation conflict check.</summary>
+    public TimeSpan FreshnessWindow { get; set; } = TimeSpan.FromMinutes(2);
+
+    /// <summary>Bounded parallelism for cursor-specific event-count samples.</summary>
+    public int MaxConcurrentReads { get; set; } = 8;
+
+    /// <summary>Allows a host to turn the heartbeat writer off while retaining the read surface.</summary>
+    public bool Enabled { get; set; } = true;
+}
+
+/// <summary>Descriptive alias used by hosts that call the feature a registry.</summary>
+public class ProjectionStatusRegistryOptions : ProjectionStatusOptions
+{
+}
+
+/// <summary>Request used by the versioned serialized status boundary.</summary>
+public sealed record ProjectionStatusReadRequest(
+    string? ServiceId = null,
+    string? ProjectorName = null,
+    string? ProjectorVersion = null);
+
+/// <summary>Version-one envelope for the serialized passive status surface.</summary>
+public sealed record SerializedProjectionStatusEnvelopeV1(
+    int Version,
+    string ServiceId,
+    IReadOnlyList<ProjectionStatusSnapshot> Snapshots)
+{
+    public const int CurrentVersion = 1;
+
+    public static SerializedProjectionStatusEnvelopeV1 Create(
+        string serviceId,
+        IReadOnlyList<ProjectionStatusSnapshot> snapshots) =>
+        new(CurrentVersion, serviceId, snapshots);
+}
+
+/// <summary>Typed errors used by the serialized status boundary before any store read is attempted.</summary>
+public sealed class UnsupportedSerializedProjectionStatusVersionException : Exception
+{
+    public UnsupportedSerializedProjectionStatusVersionException(int version)
+        : base($"Serialized projection status version {version} is not supported.") => Version = version;
+
+    public int Version { get; }
+}
+
+public sealed class SerializedProjectionStatusShapeException : Exception
+{
+    public SerializedProjectionStatusShapeException(string message)
+        : base(message)
+    {
+    }
+}

--- a/dcb/src/Sekiban.Dcb.Core/Storage/IProjectionStatusStore.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Storage/IProjectionStatusStore.cs
@@ -1,0 +1,35 @@
+using ResultBoxes;
+
+namespace Sekiban.Dcb.Storage;
+
+/// <summary>
+///     Durable storage for passive projection heartbeat rows.  Implementations must enforce the expected-sequence
+///     compare-and-set atomically for a single (service, projector, version, cluster, activation) key.
+/// </summary>
+public interface IProjectionStatusStore
+{
+    Task<ResultBox<ProjectionStatusWriteResult>> UpsertAsync(
+        ProjectionStatusHeartbeat heartbeat,
+        long expectedSequence,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    ///     Convenience overload for a heartbeat whose sequence is the next sequence after the caller's last write.
+    /// </summary>
+    Task<ResultBox<ProjectionStatusWriteResult>> UpsertAsync(
+        ProjectionStatusHeartbeat heartbeat,
+        CancellationToken cancellationToken = default) =>
+        UpsertAsync(heartbeat, Math.Max(0, heartbeat.Sequence - 1), cancellationToken);
+
+    Task<ResultBox<IReadOnlyList<ProjectionStatusHeartbeat>>> ListAsync(
+        string? projectorName = null,
+        string? projectorVersion = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    ///     Compatibility alias for providers and hosts that call the read operation <c>ListAllAsync</c>.
+    /// </summary>
+    Task<ResultBox<IReadOnlyList<ProjectionStatusHeartbeat>>> ListAllAsync(
+        CancellationToken cancellationToken = default) =>
+        ListAsync(cancellationToken: cancellationToken);
+}

--- a/dcb/src/Sekiban.Dcb.Core/Storage/IProjectionStatusStore.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Storage/IProjectionStatusStore.cs
@@ -3,8 +3,9 @@ using ResultBoxes;
 namespace Sekiban.Dcb.Storage;
 
 /// <summary>
-///     Durable storage for passive projection heartbeat rows.  Implementations must enforce the expected-sequence
-///     compare-and-set atomically for a single (service, projector, version, cluster, activation) key.
+///     Durable storage for passive projection heartbeat rows. Implementations must enforce the expected-sequence
+///     compare-and-set atomically for a single (service, projector, version, cluster) row. ActivationId is data in
+///     that row, so a replacement activation cannot create a second physical row or bypass the CAS fence.
 /// </summary>
 public interface IProjectionStatusStore
 {

--- a/dcb/src/Sekiban.Dcb.CosmosDb/CosmosMultiProjectionStateStore.cs
+++ b/dcb/src/Sekiban.Dcb.CosmosDb/CosmosMultiProjectionStateStore.cs
@@ -16,8 +16,9 @@ namespace Sekiban.Dcb.CosmosDb;
 ///     surface (<see cref="IGenerationAwareCheckpointStore" />). The Cosmos <c>_etag</c> IS the exact per-mutation token
 ///     (IfMatch); generation + lifecycle are item fields (absent on pre-G20 docs → default 0 = generation 0, Active).
 /// </summary>
-public class CosmosMultiProjectionStateStore :
+public partial class CosmosMultiProjectionStateStore :
     IMultiProjectionStateStore,
+    IProjectionStatusStore,
     IStorageDurabilityDescriptorProvider,
     IGenerationAwareCheckpointStore
 {
@@ -104,8 +105,9 @@ public class CosmosMultiProjectionStateStore :
             var pk = GetPartitionKey(partitionKey, serviceId);
 
             var query = new QueryDefinition(
-                    "SELECT * FROM c WHERE c.pk = @pk ORDER BY c.eventsProcessed DESC")
-                .WithParameter("@pk", pk);
+                    "SELECT * FROM c WHERE c.pk = @pk AND (NOT IS_DEFINED(c.documentType) OR c.documentType = @projectionState) ORDER BY c.eventsProcessed DESC")
+                .WithParameter("@pk", pk)
+                .WithParameter("@projectionState", "projectionState");
 
             var iterator = container.GetItemQueryIterator<CosmosMultiProjectionState>(
                 query,
@@ -324,8 +326,10 @@ public class CosmosMultiProjectionStateStore :
             var settings = _containerResolver.ResolveStatesContainer(serviceId);
             var container = await _context.GetMultiProjectionStatesContainerAsync(settings).ConfigureAwait(false);
 
-            var query = new QueryDefinition("SELECT * FROM c WHERE c.serviceId = @serviceId")
-                .WithParameter("@serviceId", serviceId);
+            var query = new QueryDefinition(
+                    "SELECT * FROM c WHERE c.serviceId = @serviceId AND (NOT IS_DEFINED(c.documentType) OR c.documentType = @projectionState)")
+                .WithParameter("@serviceId", serviceId)
+                .WithParameter("@projectionState", "projectionState");
             var iterator = container.GetItemQueryIterator<CosmosMultiProjectionState>(query);
 
             var results = new List<ProjectorStateInfo>();
@@ -406,13 +410,17 @@ public class CosmosMultiProjectionStateStore :
             {
                 var partitionKey = $"MultiProjectionState_{projectorName}";
                 var pk = GetPartitionKey(partitionKey, serviceId);
-                query = new QueryDefinition("SELECT * FROM c WHERE c.pk = @pk")
-                    .WithParameter("@pk", pk);
+                query = new QueryDefinition(
+                        "SELECT * FROM c WHERE c.pk = @pk AND (NOT IS_DEFINED(c.documentType) OR c.documentType = @projectionState)")
+                    .WithParameter("@pk", pk)
+                    .WithParameter("@projectionState", "projectionState");
             }
             else
             {
-                query = new QueryDefinition("SELECT * FROM c WHERE c.serviceId = @serviceId")
-                    .WithParameter("@serviceId", serviceId);
+                query = new QueryDefinition(
+                        "SELECT * FROM c WHERE c.serviceId = @serviceId AND (NOT IS_DEFINED(c.documentType) OR c.documentType = @projectionState)")
+                    .WithParameter("@serviceId", serviceId)
+                    .WithParameter("@projectionState", "projectionState");
             }
 
             var iterator = container.GetItemQueryIterator<CosmosMultiProjectionState>(query);

--- a/dcb/src/Sekiban.Dcb.CosmosDb/CosmosProjectionStatusStore.cs
+++ b/dcb/src/Sekiban.Dcb.CosmosDb/CosmosProjectionStatusStore.cs
@@ -152,7 +152,9 @@ public partial class CosmosMultiProjectionStateStore
 
     private static string BuildStatusId(ProjectionStatusHeartbeat heartbeat)
     {
-        var identity = string.Join("\u001f", heartbeat.ProjectorVersion, heartbeat.ClusterId, heartbeat.ActivationId);
+        // ActivationId is row data, not identity. A replacement activation must contend on the same physical row and
+        // ETag as the writer it replaces.
+        var identity = string.Join("\u001f", heartbeat.ProjectorVersion, heartbeat.ClusterId);
         var encoded = Convert.ToBase64String(Encoding.UTF8.GetBytes(identity))
             .TrimEnd('=')
             .Replace('+', '-')

--- a/dcb/src/Sekiban.Dcb.CosmosDb/CosmosProjectionStatusStore.cs
+++ b/dcb/src/Sekiban.Dcb.CosmosDb/CosmosProjectionStatusStore.cs
@@ -1,0 +1,192 @@
+using System.Net;
+using System.Text;
+using Microsoft.Azure.Cosmos;
+using ResultBoxes;
+using Sekiban.Dcb.CosmosDb.Models;
+
+namespace Sekiban.Dcb.CosmosDb;
+
+public partial class CosmosMultiProjectionStateStore
+{
+    private const string ProjectionStatusDocumentType = "projectionStatus";
+
+    public async Task<ResultBox<ProjectionStatusWriteResult>> UpsertAsync(
+        ProjectionStatusHeartbeat heartbeat,
+        long expectedSequence,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(heartbeat);
+        try
+        {
+            var serviceId = CurrentServiceId;
+            if (!string.Equals(serviceId, heartbeat.ServiceId, StringComparison.Ordinal))
+            {
+                return ResultBox.Error<ProjectionStatusWriteResult>(
+                    new UnauthorizedAccessException("Projection status ServiceId is owned by the server."));
+            }
+
+            if (expectedSequence < 0 || heartbeat.Sequence <= 0)
+            {
+                return ResultBox.Error<ProjectionStatusWriteResult>(
+                    new ArgumentOutOfRangeException(nameof(expectedSequence), "Projection status sequences must be positive and expected sequence must not be negative."));
+            }
+
+            var (container, partitionKey, partitionValue) = await ResolveStatusContainerAsync(
+                heartbeat.ProjectorName,
+                serviceId).ConfigureAwait(false);
+            var id = BuildStatusId(heartbeat);
+            var doc = CosmosMultiProjectionState.FromStatusHeartbeat(
+                heartbeat,
+                id,
+                partitionKey,
+                partitionValue);
+
+            if (expectedSequence == 0)
+            {
+                try
+                {
+                    var created = await container.CreateItemAsync(
+                        doc,
+                        new PartitionKey(partitionValue),
+                        cancellationToken: cancellationToken).ConfigureAwait(false);
+                    return ResultBox.FromValue(ProjectionStatusWriteResult.Success(created.Resource.ToStatusHeartbeat()));
+                }
+                catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.Conflict)
+                {
+                    var current = await ReadStatusAsync(container, partitionValue, id, cancellationToken).ConfigureAwait(false);
+                    return ResultBox.FromValue(ProjectionStatusWriteResult.Rejected(
+                        current,
+                        "Heartbeat CAS rejected: activation row already exists."));
+                }
+            }
+
+            var currentDoc = await ReadStatusDocumentAsync(container, partitionValue, id, cancellationToken).ConfigureAwait(false);
+            if (currentDoc is null)
+            {
+                return ResultBox.FromValue(ProjectionStatusWriteResult.Rejected(
+                    null,
+                    $"Heartbeat CAS rejected: expected sequence {expectedSequence}, row is absent."));
+            }
+
+            if (!string.Equals(currentDoc.DocumentType, ProjectionStatusDocumentType, StringComparison.Ordinal) ||
+                currentDoc.Sequence != expectedSequence || heartbeat.Sequence <= currentDoc.Sequence)
+            {
+                return ResultBox.FromValue(ProjectionStatusWriteResult.Rejected(
+                    currentDoc.ToStatusHeartbeat(),
+                    $"Heartbeat CAS rejected: expected sequence {expectedSequence}, current sequence {currentDoc.Sequence}."));
+            }
+
+            doc.ETag = currentDoc.ETag;
+            try
+            {
+                var replaced = await container.ReplaceItemAsync(
+                    doc,
+                    id,
+                    new PartitionKey(partitionValue),
+                    new ItemRequestOptions { IfMatchEtag = currentDoc.ETag },
+                    cancellationToken).ConfigureAwait(false);
+                return ResultBox.FromValue(ProjectionStatusWriteResult.Success(replaced.Resource.ToStatusHeartbeat()));
+            }
+            catch (CosmosException ex) when (ex.StatusCode is HttpStatusCode.PreconditionFailed or HttpStatusCode.NotFound)
+            {
+                var current = await ReadStatusAsync(container, partitionValue, id, cancellationToken).ConfigureAwait(false);
+                return ResultBox.FromValue(ProjectionStatusWriteResult.Rejected(
+                    current,
+                    "Heartbeat CAS rejected by provider ETag."));
+            }
+        }
+        catch (Exception ex)
+        {
+            return ResultBox.Error<ProjectionStatusWriteResult>(ex);
+        }
+    }
+
+    public async Task<ResultBox<IReadOnlyList<ProjectionStatusHeartbeat>>> ListAsync(
+        string? projectorName = null,
+        string? projectorVersion = null,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var serviceId = CurrentServiceId;
+            var settings = _containerResolver.ResolveStatesContainer(serviceId);
+            var container = await _context.GetMultiProjectionStatesContainerAsync(settings).ConfigureAwait(false);
+            var query = new QueryDefinition(
+                    "SELECT * FROM c WHERE c.serviceId = @serviceId AND c.documentType = @documentType "
+                    + "AND (@projectorName = null OR c.projectorName = @projectorName) "
+                    + "AND (@projectorVersion = null OR c.projectorVersion = @projectorVersion)")
+                .WithParameter("@serviceId", serviceId)
+                .WithParameter("@documentType", ProjectionStatusDocumentType)
+                .WithParameter("@projectorName", projectorName)
+                .WithParameter("@projectorVersion", projectorVersion);
+            var iterator = container.GetItemQueryIterator<CosmosMultiProjectionState>(query);
+            var rows = new List<ProjectionStatusHeartbeat>();
+            while (iterator.HasMoreResults)
+            {
+                var response = await iterator.ReadNextAsync(cancellationToken).ConfigureAwait(false);
+                rows.AddRange(response.Select(doc => doc.ToStatusHeartbeat()));
+            }
+
+            return ResultBox.FromValue<IReadOnlyList<ProjectionStatusHeartbeat>>(
+                rows.OrderBy(row => row.ProjectorName, StringComparer.Ordinal)
+                    .ThenBy(row => row.ProjectorVersion, StringComparer.Ordinal)
+                    .ThenBy(row => row.ClusterId, StringComparer.Ordinal)
+                    .ThenBy(row => row.ActivationId, StringComparer.Ordinal)
+                    .ToArray());
+        }
+        catch (CosmosException ex)
+        {
+            return ResultBox.Error<IReadOnlyList<ProjectionStatusHeartbeat>>(ex);
+        }
+    }
+
+    private async Task<(Container Container, string PartitionKey, string PartitionValue)> ResolveStatusContainerAsync(
+        string projectorName,
+        string serviceId)
+    {
+        var settings = _containerResolver.ResolveStatesContainer(serviceId);
+        var container = await _context.GetMultiProjectionStatesContainerAsync(settings).ConfigureAwait(false);
+        var partitionKey = $"MultiProjectionState_{projectorName}";
+        return (container, partitionKey, GetPartitionKey(partitionKey, serviceId));
+    }
+
+    private static string BuildStatusId(ProjectionStatusHeartbeat heartbeat)
+    {
+        var identity = string.Join("\u001f", heartbeat.ProjectorVersion, heartbeat.ClusterId, heartbeat.ActivationId);
+        var encoded = Convert.ToBase64String(Encoding.UTF8.GetBytes(identity))
+            .TrimEnd('=')
+            .Replace('+', '-')
+            .Replace('/', '_');
+        return $"STATUS_{encoded}";
+    }
+
+    private static async Task<CosmosMultiProjectionState?> ReadStatusDocumentAsync(
+        Container container,
+        string partitionValue,
+        string id,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var response = await container.ReadItemAsync<CosmosMultiProjectionState>(
+                id,
+                new PartitionKey(partitionValue),
+                cancellationToken: cancellationToken).ConfigureAwait(false);
+            return response.Resource;
+        }
+        catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
+        {
+            return null;
+        }
+    }
+
+    private static async Task<ProjectionStatusHeartbeat?> ReadStatusAsync(
+        Container container,
+        string partitionValue,
+        string id,
+        CancellationToken cancellationToken)
+    {
+        var document = await ReadStatusDocumentAsync(container, partitionValue, id, cancellationToken).ConfigureAwait(false);
+        return document is null ? null : document.ToStatusHeartbeat();
+    }
+}

--- a/dcb/src/Sekiban.Dcb.CosmosDb/Models/CosmosMultiProjectionState.cs
+++ b/dcb/src/Sekiban.Dcb.CosmosDb/Models/CosmosMultiProjectionState.cs
@@ -11,6 +11,13 @@ namespace Sekiban.Dcb.CosmosDb.Models;
 public class CosmosMultiProjectionState
 {
     /// <summary>
+    ///     Document discriminator.  New snapshots use <c>projectionState</c>; legacy snapshots without this property
+    ///     remain valid.  Status rows use <c>projectionStatus</c> and are excluded from snapshot scans.
+    /// </summary>
+    [JsonProperty("documentType")]
+    public string? DocumentType { get; set; }
+
+    /// <summary>
     ///     Composite partition key: "{serviceId}|{partitionKey}".
     /// </summary>
     [JsonProperty("pk")]
@@ -144,6 +151,29 @@ public class CosmosMultiProjectionState
     [JsonProperty("lifecycle")]
     public int Lifecycle { get; set; }
 
+    // Passive projection-status fields.  They intentionally share the document model because Cosmos/Dynamo status
+    // rows are co-located with snapshots and are separated by DocumentType.
+    [JsonProperty("clusterId")]
+    public string? ClusterId { get; set; }
+
+    [JsonProperty("activationId")]
+    public string? ActivationId { get; set; }
+
+    [JsonProperty("sequence")]
+    public long Sequence { get; set; }
+
+    [JsonProperty("appliedEventCount")]
+    public long AppliedEventCount { get; set; }
+
+    [JsonProperty("lastAppliedSortableUniqueId")]
+    public string? LastAppliedSortableUniqueId { get; set; }
+
+    [JsonProperty("lastTraversedSortableUniqueId")]
+    public string? LastTraversedSortableUniqueId { get; set; }
+
+    [JsonProperty("recordedAtUtc")]
+    public DateTimeOffset RecordedAtUtc { get; set; }
+
     /// <summary>
     ///     Creates a CosmosMultiProjectionState from a MultiProjectionStateRecord.
     /// </summary>
@@ -161,6 +191,7 @@ public class CosmosMultiProjectionState
         var partitionKey = record.GetPartitionKey();
         return new CosmosMultiProjectionState
         {
+            DocumentType = "projectionState",
             Pk = $"{serviceId}|{partitionKey}",
             ServiceId = serviceId,
             Id = record.ProjectorVersion,
@@ -183,6 +214,44 @@ public class CosmosMultiProjectionState
             BuildHost = record.BuildHost
         };
     }
+
+    public static CosmosMultiProjectionState FromStatusHeartbeat(
+        ProjectionStatusHeartbeat heartbeat,
+        string id,
+        string partitionKey,
+        string partitionValue)
+    {
+        ArgumentNullException.ThrowIfNull(heartbeat);
+        return new CosmosMultiProjectionState
+        {
+            DocumentType = "projectionStatus",
+            Pk = partitionValue,
+            ServiceId = heartbeat.ServiceId,
+            Id = id,
+            PartitionKey = partitionKey,
+            ProjectorName = heartbeat.ProjectorName,
+            ProjectorVersion = heartbeat.ProjectorVersion,
+            ClusterId = heartbeat.ClusterId,
+            ActivationId = heartbeat.ActivationId,
+            Sequence = heartbeat.Sequence,
+            AppliedEventCount = heartbeat.AppliedEventCount,
+            LastAppliedSortableUniqueId = heartbeat.LastAppliedSortableUniqueId,
+            LastTraversedSortableUniqueId = heartbeat.LastTraversedSortableUniqueId,
+            RecordedAtUtc = heartbeat.RecordedAtUtc
+        };
+    }
+
+    public ProjectionStatusHeartbeat ToStatusHeartbeat() => new(
+        ServiceId,
+        ProjectorName,
+        ProjectorVersion,
+        ClusterId ?? string.Empty,
+        ActivationId ?? string.Empty,
+        Sequence,
+        AppliedEventCount,
+        LastAppliedSortableUniqueId,
+        LastTraversedSortableUniqueId,
+        RecordedAtUtc);
 
     /// <summary>
     ///     Converts this CosmosMultiProjectionState to a MultiProjectionStateRecord.

--- a/dcb/src/Sekiban.Dcb.CosmosDb/Models/CosmosMultiProjectionState.cs
+++ b/dcb/src/Sekiban.Dcb.CosmosDb/Models/CosmosMultiProjectionState.cs
@@ -174,6 +174,18 @@ public class CosmosMultiProjectionState
     [JsonProperty("recordedAtUtc")]
     public DateTimeOffset RecordedAtUtc { get; set; }
 
+    [JsonProperty("phase")]
+    public string? Phase { get; set; }
+
+    [JsonProperty("leaseExpiresAtUtc")]
+    public DateTimeOffset? LeaseExpiresAtUtc { get; set; }
+
+    [JsonProperty("isFaulted")]
+    public bool IsFaulted { get; set; }
+
+    [JsonProperty("faultMessage")]
+    public string? FaultMessage { get; set; }
+
     /// <summary>
     ///     Creates a CosmosMultiProjectionState from a MultiProjectionStateRecord.
     /// </summary>
@@ -237,7 +249,11 @@ public class CosmosMultiProjectionState
             AppliedEventCount = heartbeat.AppliedEventCount,
             LastAppliedSortableUniqueId = heartbeat.LastAppliedSortableUniqueId,
             LastTraversedSortableUniqueId = heartbeat.LastTraversedSortableUniqueId,
-            RecordedAtUtc = heartbeat.RecordedAtUtc
+            RecordedAtUtc = heartbeat.RecordedAtUtc,
+            Phase = heartbeat.Phase,
+            LeaseExpiresAtUtc = heartbeat.LeaseExpiresAtUtc,
+            IsFaulted = heartbeat.IsFaulted,
+            FaultMessage = heartbeat.FaultMessage
         };
     }
 
@@ -251,7 +267,13 @@ public class CosmosMultiProjectionState
         AppliedEventCount,
         LastAppliedSortableUniqueId,
         LastTraversedSortableUniqueId,
-        RecordedAtUtc);
+        RecordedAtUtc)
+    {
+        Phase = Phase ?? ProjectionStatusPhases.Unknown,
+        LeaseExpiresAtUtc = LeaseExpiresAtUtc,
+        IsFaulted = IsFaulted,
+        FaultMessage = FaultMessage
+    };
 
     /// <summary>
     ///     Converts this CosmosMultiProjectionState to a MultiProjectionStateRecord.

--- a/dcb/src/Sekiban.Dcb.CosmosDb/SekibanDcbCosmosDbExtensions.cs
+++ b/dcb/src/Sekiban.Dcb.CosmosDb/SekibanDcbCosmosDbExtensions.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
+using Sekiban.Dcb.Actors;
 using Sekiban.Dcb.CosmosDb.Migration;
 using Sekiban.Dcb.CosmosDb.Repair;
 using Sekiban.Dcb.CosmosDb.Sweep;
@@ -69,6 +70,8 @@ public static class SekibanDcbCosmosDbExtensions
         services.AddSingleton<IEventStore>(sp => sp.GetRequiredService<IHotEventStore>());
         services.AddConditionalEventStoreCapabilities();
         services.AddSingleton<IMultiProjectionStateStore, CosmosMultiProjectionStateStore>();
+        services.AddSingleton<IProjectionStatusStore>(sp => (sp.GetService<IMultiProjectionStateStore>() as IProjectionStatusStore)!);
+        services.AddSekibanDcbProjectionStatusReader();
 
         return services;
     }
@@ -103,6 +106,8 @@ public static class SekibanDcbCosmosDbExtensions
         services.AddSingleton<IEventStore>(sp => sp.GetRequiredService<IHotEventStore>());
         services.AddConditionalEventStoreCapabilities();
         services.AddSingleton<IMultiProjectionStateStore, CosmosMultiProjectionStateStore>();
+        services.AddSingleton<IProjectionStatusStore>(sp => (sp.GetService<IMultiProjectionStateStore>() as IProjectionStatusStore)!);
+        services.AddSekibanDcbProjectionStatusReader();
 
         return services;
     }
@@ -170,6 +175,8 @@ public static class SekibanDcbCosmosDbExtensions
         services.AddSingleton<IEventStore>(sp => sp.GetRequiredService<IHotEventStore>());
         services.AddConditionalEventStoreCapabilities();
         services.AddSingleton<IMultiProjectionStateStore, CosmosMultiProjectionStateStore>();
+        services.AddSingleton<IProjectionStatusStore>(sp => (sp.GetService<IMultiProjectionStateStore>() as IProjectionStatusStore)!);
+        services.AddSekibanDcbProjectionStatusReader();
 
         // Register hosted service to ensure containers are created
         services.AddHostedService<CosmosDbInitializer>();
@@ -204,6 +211,8 @@ public static class SekibanDcbCosmosDbExtensions
         services.AddScoped<IHotEventStore>(sp => sp.GetRequiredService<CosmosDbEventStore>());
         services.AddScoped<IEventStore>(sp => sp.GetRequiredService<IHotEventStore>());
         services.AddScoped<IMultiProjectionStateStore, CosmosMultiProjectionStateStore>();
+        services.AddScoped<IProjectionStatusStore>(sp => (sp.GetService<IMultiProjectionStateStore>() as IProjectionStatusStore)!);
+        services.AddSekibanDcbProjectionStatusReader();
 
         return services;
     }
@@ -232,6 +241,8 @@ public static class SekibanDcbCosmosDbExtensions
         services.AddSingleton<IEventStore>(sp => sp.GetRequiredService<IHotEventStore>());
         services.AddConditionalEventStoreCapabilities();
         services.AddSingleton<IMultiProjectionStateStore, CosmosMultiProjectionStateStore>();
+        services.AddSingleton<IProjectionStatusStore>(sp => (sp.GetService<IMultiProjectionStateStore>() as IProjectionStatusStore)!);
+        services.AddSekibanDcbProjectionStatusReader();
 
         return services;
     }
@@ -271,6 +282,8 @@ public static class SekibanDcbCosmosDbExtensions
         services.AddScoped<IHotEventStore>(sp => sp.GetRequiredService<CosmosDbEventStore>());
         services.AddScoped<IEventStore>(sp => sp.GetRequiredService<IHotEventStore>());
         services.AddScoped<IMultiProjectionStateStore, CosmosMultiProjectionStateStore>();
+        services.AddScoped<IProjectionStatusStore>(sp => (sp.GetService<IMultiProjectionStateStore>() as IProjectionStatusStore)!);
+        services.AddSekibanDcbProjectionStatusReader();
 
         return services;
     }

--- a/dcb/src/Sekiban.Dcb.DynamoDB/DynamoMultiProjectionStateStore.cs
+++ b/dcb/src/Sekiban.Dcb.DynamoDB/DynamoMultiProjectionStateStore.cs
@@ -19,10 +19,11 @@ namespace Sekiban.Dcb.DynamoDB;
 ///     on the exact (generation, revision, lifecycle) is the version condition; the required SOURCE lifecycle is hardcoded
 ///     per op so a tombstone can never be resurrected by a normal persist.
 /// </summary>
-public class DynamoMultiProjectionStateStore :
+public partial class DynamoMultiProjectionStateStore :
     IMultiProjectionStateStore,
     IStorageDurabilityDescriptorProvider,
-    IGenerationAwareCheckpointStore
+    IGenerationAwareCheckpointStore,
+    IProjectionStatusStore
 {
     /// <summary>Projection state lands in DynamoDB.</summary>
     public StorageDurabilityDescriptor DescribeStorage() =>
@@ -262,10 +263,11 @@ public class DynamoMultiProjectionStateStore :
                 var response = await _client.ScanAsync(new ScanRequest
                 {
                     TableName = _context.ProjectionStatesTableName,
-                    FilterExpression = "serviceId = :serviceId",
+                    FilterExpression = "serviceId = :serviceId AND (attribute_not_exists(documentType) OR documentType = :projectionState)",
                     ExpressionAttributeValues = new Dictionary<string, AttributeValue>
                     {
-                        [":serviceId"] = new AttributeValue { S = serviceId }
+                        [":serviceId"] = new AttributeValue { S = serviceId },
+                        [":projectionState"] = new AttributeValue { S = "projectionState" }
                     },
                     ExclusiveStartKey = lastKey,
                     Limit = _options.QueryPageSize
@@ -416,9 +418,11 @@ public class DynamoMultiProjectionStateStore :
             {
                 TableName = _context.ProjectionStatesTableName,
                 KeyConditionExpression = "pk = :pk",
+                FilterExpression = "attribute_not_exists(documentType) OR documentType = :projectionState",
                 ExpressionAttributeValues = new Dictionary<string, AttributeValue>
                 {
-                    [":pk"] = new AttributeValue { S = pk }
+                    [":pk"] = new AttributeValue { S = pk },
+                    [":projectionState"] = new AttributeValue { S = "projectionState" }
                 },
                 ExclusiveStartKey = lastKey,
                 Limit = _options.QueryPageSize
@@ -447,10 +451,11 @@ public class DynamoMultiProjectionStateStore :
             var response = await _client.ScanAsync(new ScanRequest
             {
                 TableName = _context.ProjectionStatesTableName,
-                FilterExpression = "serviceId = :serviceId",
+                FilterExpression = "serviceId = :serviceId AND (attribute_not_exists(documentType) OR documentType = :projectionState)",
                 ExpressionAttributeValues = new Dictionary<string, AttributeValue>
                 {
-                    [":serviceId"] = new AttributeValue { S = serviceId }
+                    [":serviceId"] = new AttributeValue { S = serviceId },
+                    [":projectionState"] = new AttributeValue { S = "projectionState" }
                 },
                 ExclusiveStartKey = lastKey,
                 Limit = _options.QueryPageSize

--- a/dcb/src/Sekiban.Dcb.DynamoDB/DynamoProjectionStatusStore.cs
+++ b/dcb/src/Sekiban.Dcb.DynamoDB/DynamoProjectionStatusStore.cs
@@ -190,7 +190,9 @@ public partial class DynamoMultiProjectionStateStore
 
     private static string BuildStatusSortKey(ProjectionStatusHeartbeat heartbeat)
     {
-        var identity = string.Join("|", heartbeat.ProjectorVersion, heartbeat.ClusterId, heartbeat.ActivationId);
+        // ActivationId is retained in the item as data. The physical CAS row is one row per service/projector/version
+        // and cluster, so a replacement activation cannot silently create a second row.
+        var identity = string.Join("|", heartbeat.ProjectorVersion, heartbeat.ClusterId);
         return $"STATUS#{Base64Url(identity)}";
     }
 

--- a/dcb/src/Sekiban.Dcb.DynamoDB/DynamoProjectionStatusStore.cs
+++ b/dcb/src/Sekiban.Dcb.DynamoDB/DynamoProjectionStatusStore.cs
@@ -1,0 +1,202 @@
+using System.Text;
+using Amazon.DynamoDBv2.Model;
+using ResultBoxes;
+using Sekiban.Dcb.Storage;
+
+namespace Sekiban.Dcb.DynamoDB;
+
+#pragma warning disable CA1031
+
+/// <summary>
+///     DynamoDB implementation of the passive projection heartbeat registry. Status rows share the projection-state
+///     table, but use a distinct document type and sort-key namespace so mixed-document scans remain safe.
+/// </summary>
+public partial class DynamoMultiProjectionStateStore
+{
+    private const string ProjectionStatusDocumentType = "projectionStatus";
+
+    /// <inheritdoc />
+    public async Task<ResultBox<ProjectionStatusWriteResult>> UpsertAsync(
+        ProjectionStatusHeartbeat heartbeat,
+        long expectedSequence,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(heartbeat);
+
+        try
+        {
+            var serviceId = CurrentServiceId;
+            if (!string.Equals(heartbeat.ServiceId, serviceId, StringComparison.Ordinal))
+            {
+                return ResultBox.Error<ProjectionStatusWriteResult>(
+                    new InvalidOperationException("Projection status heartbeat service ID does not match the bound service ID."));
+            }
+
+            if (string.IsNullOrWhiteSpace(heartbeat.ProjectorName) ||
+                string.IsNullOrWhiteSpace(heartbeat.ProjectorVersion) ||
+                string.IsNullOrWhiteSpace(heartbeat.ClusterId) ||
+                string.IsNullOrWhiteSpace(heartbeat.ActivationId))
+            {
+                return ResultBox.Error<ProjectionStatusWriteResult>(
+                    new ArgumentException("Projection status heartbeat identity is required."));
+            }
+
+            if (expectedSequence < 0 || heartbeat.Sequence <= 0)
+            {
+                return ResultBox.Error<ProjectionStatusWriteResult>(
+                    new ArgumentOutOfRangeException(nameof(expectedSequence), "Projection status sequences must be positive and expected sequence must not be negative."));
+            }
+
+            await _context.EnsureTablesAsync(cancellationToken).ConfigureAwait(false);
+            var document = Models.DynamoMultiProjectionState.FromStatusHeartbeat(
+                heartbeat,
+                serviceId,
+                BuildStatusSortKey(heartbeat));
+            var request = new PutItemRequest
+            {
+                TableName = _context.ProjectionStatesTableName,
+                Item = document.ToAttributeValues()
+            };
+
+            if (expectedSequence == 0)
+            {
+                request.ConditionExpression = "attribute_not_exists(pk)";
+            }
+            else
+            {
+                request.ConditionExpression = "#statusSequence = :expectedSequence AND #statusSequence < :sequence";
+                request.ExpressionAttributeNames = new Dictionary<string, string>
+                {
+                    ["#statusSequence"] = "sequence"
+                };
+                request.ExpressionAttributeValues = new Dictionary<string, AttributeValue>
+                {
+                    [":expectedSequence"] = new AttributeValue
+                    {
+                        N = expectedSequence.ToString(System.Globalization.CultureInfo.InvariantCulture)
+                    },
+                    [":sequence"] = new AttributeValue
+                    {
+                        N = heartbeat.Sequence.ToString(System.Globalization.CultureInfo.InvariantCulture)
+                    }
+                };
+            }
+
+            try
+            {
+                await _client.PutItemAsync(request, cancellationToken).ConfigureAwait(false);
+                return ResultBox.FromValue(ProjectionStatusWriteResult.Success(heartbeat));
+            }
+            catch (ConditionalCheckFailedException)
+            {
+                var current = await ReadStatusDocumentAsync(
+                    serviceId,
+                    heartbeat,
+                    cancellationToken).ConfigureAwait(false);
+                return ResultBox.FromValue(ProjectionStatusWriteResult.Rejected(
+                    current?.ToStatusHeartbeat(),
+                    "The projection status heartbeat sequence was stale or the activation already exists."));
+            }
+        }
+        catch (Exception ex)
+        {
+            return ResultBox.Error<ProjectionStatusWriteResult>(ex);
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<ResultBox<IReadOnlyList<ProjectionStatusHeartbeat>>> ListAsync(
+        string? projectorName = null,
+        string? projectorVersion = null,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            await _context.EnsureTablesAsync(cancellationToken).ConfigureAwait(false);
+
+            var values = new Dictionary<string, AttributeValue>
+            {
+                [":serviceId"] = new() { S = CurrentServiceId },
+                [":statusType"] = new() { S = ProjectionStatusDocumentType }
+            };
+            var filters = new List<string>
+            {
+                "serviceId = :serviceId",
+                "documentType = :statusType"
+            };
+            if (projectorName is not null)
+            {
+                filters.Add("projectorName = :projectorName");
+                values[":projectorName"] = new AttributeValue { S = projectorName };
+            }
+            if (projectorVersion is not null)
+            {
+                filters.Add("projectorVersion = :projectorVersion");
+                values[":projectorVersion"] = new AttributeValue { S = projectorVersion };
+            }
+
+            var rows = new List<ProjectionStatusHeartbeat>();
+            Dictionary<string, AttributeValue>? lastKey = null;
+            do
+            {
+                var response = await _client.ScanAsync(new ScanRequest
+                {
+                    TableName = _context.ProjectionStatesTableName,
+                    FilterExpression = string.Join(" AND ", filters),
+                    ExpressionAttributeValues = values,
+                    ExclusiveStartKey = lastKey,
+                    Limit = _options.QueryPageSize
+                }, cancellationToken).ConfigureAwait(false);
+
+                rows.AddRange(response.Items.Select(Models.DynamoMultiProjectionState.FromAttributeValues)
+                    .Where(item => string.Equals(item.DocumentType, ProjectionStatusDocumentType, StringComparison.Ordinal))
+                    .Select(item => item.ToStatusHeartbeat()));
+                lastKey = response.LastEvaluatedKey;
+            } while (lastKey is { Count: > 0 });
+
+            return ResultBox.FromValue<IReadOnlyList<ProjectionStatusHeartbeat>>(
+                rows.OrderBy(row => row.ProjectorName, StringComparer.Ordinal)
+                    .ThenBy(row => row.ProjectorVersion, StringComparer.Ordinal)
+                    .ThenBy(row => row.ClusterId, StringComparer.Ordinal)
+                    .ThenBy(row => row.ActivationId, StringComparer.Ordinal)
+                    .ToArray());
+        }
+        catch (Exception ex)
+        {
+            return ResultBox.Error<IReadOnlyList<ProjectionStatusHeartbeat>>(ex);
+        }
+    }
+
+    private async Task<Models.DynamoMultiProjectionState?> ReadStatusDocumentAsync(
+        string serviceId,
+        ProjectionStatusHeartbeat heartbeat,
+        CancellationToken cancellationToken)
+    {
+        var response = await _client.GetItemAsync(new GetItemRequest
+        {
+            TableName = _context.ProjectionStatesTableName,
+            Key = new Dictionary<string, AttributeValue>
+            {
+                ["pk"] = new() { S = BuildProjectorPk(serviceId, heartbeat.ProjectorName) },
+                ["sk"] = new() { S = BuildStatusSortKey(heartbeat) }
+            },
+            ConsistentRead = true
+        }, cancellationToken).ConfigureAwait(false);
+
+        return response.Item is { Count: > 0 }
+            ? Models.DynamoMultiProjectionState.FromAttributeValues(response.Item)
+            : null;
+    }
+
+    private static string BuildStatusSortKey(ProjectionStatusHeartbeat heartbeat)
+    {
+        var identity = string.Join("|", heartbeat.ProjectorVersion, heartbeat.ClusterId, heartbeat.ActivationId);
+        return $"STATUS#{Base64Url(identity)}";
+    }
+
+    private static string Base64Url(string value) =>
+        Convert.ToBase64String(Encoding.UTF8.GetBytes(value))
+            .TrimEnd('=')
+            .Replace('+', '-')
+            .Replace('/', '_');
+}

--- a/dcb/src/Sekiban.Dcb.DynamoDB/Models/DynamoMultiProjectionState.cs
+++ b/dcb/src/Sekiban.Dcb.DynamoDB/Models/DynamoMultiProjectionState.cs
@@ -140,6 +140,18 @@ public class DynamoMultiProjectionState
     /// <summary>Status heartbeat timestamp.</summary>
     public DateTimeOffset? RecordedAtUtc { get; set; }
 
+    /// <summary>Status heartbeat lifecycle phase.</summary>
+    public string? Phase { get; set; }
+
+    /// <summary>Status heartbeat lease expiry.</summary>
+    public DateTimeOffset? LeaseExpiresAtUtc { get; set; }
+
+    /// <summary>Status heartbeat fault marker.</summary>
+    public bool IsFaulted { get; set; }
+
+    /// <summary>Secret-free status heartbeat fault summary.</summary>
+    public string? FaultMessage { get; set; }
+
     /// <summary>
     ///     Converts to DynamoDB attribute values.
     /// </summary>
@@ -185,6 +197,12 @@ public class DynamoMultiProjectionState
                 item["lastTraversedSortableUniqueId"] = new AttributeValue { S = LastTraversedSortableUniqueId };
             if (RecordedAtUtc.HasValue)
                 item["recordedAtUtc"] = new AttributeValue { S = RecordedAtUtc.Value.ToString("O") };
+            item["phase"] = new AttributeValue { S = Phase ?? ProjectionStatusPhases.Unknown };
+            if (LeaseExpiresAtUtc.HasValue)
+                item["leaseExpiresAtUtc"] = new AttributeValue { S = LeaseExpiresAtUtc.Value.ToString("O") };
+            item["isFaulted"] = new AttributeValue { BOOL = IsFaulted };
+            if (!string.IsNullOrWhiteSpace(FaultMessage))
+                item["faultMessage"] = new AttributeValue { S = FaultMessage };
         }
 
         if (!string.IsNullOrEmpty(StateData))
@@ -237,7 +255,13 @@ public class DynamoMultiProjectionState
             LastTraversedSortableUniqueId = item.GetValueOrDefault("lastTraversedSortableUniqueId")?.S,
             RecordedAtUtc = DateTimeOffset.TryParse(item.GetValueOrDefault("recordedAtUtc")?.S, out var recorded)
                 ? recorded
-                : null
+                : null,
+            Phase = item.GetValueOrDefault("phase")?.S,
+            LeaseExpiresAtUtc = DateTimeOffset.TryParse(item.GetValueOrDefault("leaseExpiresAtUtc")?.S, out var lease)
+                ? lease
+                : null,
+            IsFaulted = item.GetValueOrDefault("isFaulted")?.BOOL ?? false,
+            FaultMessage = item.GetValueOrDefault("faultMessage")?.S
         };
     }
 
@@ -298,7 +322,11 @@ public class DynamoMultiProjectionState
             AppliedEventCount = heartbeat.AppliedEventCount,
             LastAppliedSortableUniqueId = heartbeat.LastAppliedSortableUniqueId,
             LastTraversedSortableUniqueId = heartbeat.LastTraversedSortableUniqueId,
-            RecordedAtUtc = heartbeat.RecordedAtUtc
+            RecordedAtUtc = heartbeat.RecordedAtUtc,
+            Phase = heartbeat.Phase,
+            LeaseExpiresAtUtc = heartbeat.LeaseExpiresAtUtc,
+            IsFaulted = heartbeat.IsFaulted,
+            FaultMessage = heartbeat.FaultMessage
         };
     }
 
@@ -315,8 +343,14 @@ public class DynamoMultiProjectionState
             Sequence,
             AppliedEventCount,
             LastAppliedSortableUniqueId,
-            LastTraversedSortableUniqueId,
-            RecordedAtUtc ?? DateTimeOffset.UtcNow);
+        LastTraversedSortableUniqueId,
+        RecordedAtUtc ?? DateTimeOffset.UtcNow)
+    {
+        Phase = Phase ?? ProjectionStatusPhases.Unknown,
+        LeaseExpiresAtUtc = LeaseExpiresAtUtc,
+        IsFaulted = IsFaulted,
+        FaultMessage = FaultMessage
+    };
 
     /// <summary>
     ///     Converts to a MultiProjectionStateRecord.

--- a/dcb/src/Sekiban.Dcb.DynamoDB/Models/DynamoMultiProjectionState.cs
+++ b/dcb/src/Sekiban.Dcb.DynamoDB/Models/DynamoMultiProjectionState.cs
@@ -1,5 +1,6 @@
 using Amazon.DynamoDBv2.Model;
 using System.Globalization;
+using Sekiban.Dcb;
 using Sekiban.Dcb.MultiProjections;
 
 namespace Sekiban.Dcb.DynamoDB.Models;
@@ -9,6 +10,11 @@ namespace Sekiban.Dcb.DynamoDB.Models;
 /// </summary>
 public class DynamoMultiProjectionState
 {
+    /// <summary>
+    ///     Logical document kind. Legacy projection snapshots may omit this field.
+    /// </summary>
+    public string? DocumentType { get; set; }
+
     /// <summary>
     ///     Partition key: SERVICE#{serviceId}#PROJECTOR#{projectorName}
     /// </summary>
@@ -113,6 +119,27 @@ public class DynamoMultiProjectionState
     /// <summary>SEK-G20 lifecycle: 0 = Active, 1 = Tombstoned. Absent → defaults to 0 (Active).</summary>
     public int Lifecycle { get; set; }
 
+    /// <summary>Status heartbeat cluster identity.</summary>
+    public string? ClusterId { get; set; }
+
+    /// <summary>Status heartbeat activation identity.</summary>
+    public string? ActivationId { get; set; }
+
+    /// <summary>Status heartbeat sequence.</summary>
+    public long Sequence { get; set; }
+
+    /// <summary>Status heartbeat applied event count.</summary>
+    public long AppliedEventCount { get; set; }
+
+    /// <summary>Status heartbeat last applied cursor.</summary>
+    public string? LastAppliedSortableUniqueId { get; set; }
+
+    /// <summary>Status heartbeat last traversed cursor.</summary>
+    public string? LastTraversedSortableUniqueId { get; set; }
+
+    /// <summary>Status heartbeat timestamp.</summary>
+    public DateTimeOffset? RecordedAtUtc { get; set; }
+
     /// <summary>
     ///     Converts to DynamoDB attribute values.
     /// </summary>
@@ -139,6 +166,26 @@ public class DynamoMultiProjectionState
             ["revision"] = new AttributeValue { N = Revision.ToString(CultureInfo.InvariantCulture) },
             ["lifecycle"] = new AttributeValue { N = Lifecycle.ToString(CultureInfo.InvariantCulture) }
         };
+
+        if (!string.IsNullOrWhiteSpace(DocumentType))
+            item["documentType"] = new AttributeValue { S = DocumentType };
+
+        if (string.Equals(DocumentType, "projectionStatus", StringComparison.Ordinal))
+        {
+            item["clusterId"] = new AttributeValue { S = ClusterId ?? string.Empty };
+            item["activationId"] = new AttributeValue { S = ActivationId ?? string.Empty };
+            item["sequence"] = new AttributeValue { N = Sequence.ToString(CultureInfo.InvariantCulture) };
+            item["appliedEventCount"] = new AttributeValue
+            {
+                N = AppliedEventCount.ToString(CultureInfo.InvariantCulture)
+            };
+            if (!string.IsNullOrWhiteSpace(LastAppliedSortableUniqueId))
+                item["lastAppliedSortableUniqueId"] = new AttributeValue { S = LastAppliedSortableUniqueId };
+            if (!string.IsNullOrWhiteSpace(LastTraversedSortableUniqueId))
+                item["lastTraversedSortableUniqueId"] = new AttributeValue { S = LastTraversedSortableUniqueId };
+            if (RecordedAtUtc.HasValue)
+                item["recordedAtUtc"] = new AttributeValue { S = RecordedAtUtc.Value.ToString("O") };
+        }
 
         if (!string.IsNullOrEmpty(StateData))
             item["stateData"] = new AttributeValue { S = StateData };
@@ -180,7 +227,17 @@ public class DynamoMultiProjectionState
             BuildHost = item.GetValueOrDefault("buildHost")?.S,
             Generation = long.TryParse(item.GetValueOrDefault("generation")?.N, out var gen) ? gen : 0,
             Revision = long.TryParse(item.GetValueOrDefault("revision")?.N, out var rev) ? rev : 0,
-            Lifecycle = int.TryParse(item.GetValueOrDefault("lifecycle")?.N, out var lc) ? lc : 0
+            Lifecycle = int.TryParse(item.GetValueOrDefault("lifecycle")?.N, out var lc) ? lc : 0,
+            DocumentType = item.GetValueOrDefault("documentType")?.S,
+            ClusterId = item.GetValueOrDefault("clusterId")?.S,
+            ActivationId = item.GetValueOrDefault("activationId")?.S,
+            Sequence = long.TryParse(item.GetValueOrDefault("sequence")?.N, out var seq) ? seq : 0,
+            AppliedEventCount = long.TryParse(item.GetValueOrDefault("appliedEventCount")?.N, out var applied) ? applied : 0,
+            LastAppliedSortableUniqueId = item.GetValueOrDefault("lastAppliedSortableUniqueId")?.S,
+            LastTraversedSortableUniqueId = item.GetValueOrDefault("lastTraversedSortableUniqueId")?.S,
+            RecordedAtUtc = DateTimeOffset.TryParse(item.GetValueOrDefault("recordedAtUtc")?.S, out var recorded)
+                ? recorded
+                : null
         };
     }
 
@@ -195,6 +252,7 @@ public class DynamoMultiProjectionState
         ArgumentNullException.ThrowIfNull(record);
         return new DynamoMultiProjectionState
         {
+            DocumentType = "projectionState",
             Pk = $"SERVICE#{serviceId}#PROJECTOR#{record.ProjectorName}",
             Sk = $"VERSION#{record.ProjectorVersion}",
             ServiceId = serviceId,
@@ -216,6 +274,49 @@ public class DynamoMultiProjectionState
             BuildHost = record.BuildHost
         };
     }
+
+    /// <summary>
+    ///     Creates a status document from a heartbeat.
+    /// </summary>
+    public static DynamoMultiProjectionState FromStatusHeartbeat(
+        ProjectionStatusHeartbeat heartbeat,
+        string serviceId,
+        string sortKey)
+    {
+        ArgumentNullException.ThrowIfNull(heartbeat);
+        return new DynamoMultiProjectionState
+        {
+            DocumentType = "projectionStatus",
+            Pk = $"SERVICE#{serviceId}#PROJECTOR#{heartbeat.ProjectorName}",
+            Sk = sortKey,
+            ServiceId = serviceId,
+            ProjectorName = heartbeat.ProjectorName,
+            ProjectorVersion = heartbeat.ProjectorVersion,
+            ClusterId = heartbeat.ClusterId,
+            ActivationId = heartbeat.ActivationId,
+            Sequence = heartbeat.Sequence,
+            AppliedEventCount = heartbeat.AppliedEventCount,
+            LastAppliedSortableUniqueId = heartbeat.LastAppliedSortableUniqueId,
+            LastTraversedSortableUniqueId = heartbeat.LastTraversedSortableUniqueId,
+            RecordedAtUtc = heartbeat.RecordedAtUtc
+        };
+    }
+
+    /// <summary>
+    ///     Converts a status document to a heartbeat.
+    /// </summary>
+    public ProjectionStatusHeartbeat ToStatusHeartbeat() =>
+        new(
+            ServiceId,
+            ProjectorName,
+            ProjectorVersion,
+            ClusterId ?? string.Empty,
+            ActivationId ?? string.Empty,
+            Sequence,
+            AppliedEventCount,
+            LastAppliedSortableUniqueId,
+            LastTraversedSortableUniqueId,
+            RecordedAtUtc ?? DateTimeOffset.UtcNow);
 
     /// <summary>
     ///     Converts to a MultiProjectionStateRecord.

--- a/dcb/src/Sekiban.Dcb.DynamoDB/SekibanDcbDynamoDbExtensions.cs
+++ b/dcb/src/Sekiban.Dcb.DynamoDB/SekibanDcbDynamoDbExtensions.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Sekiban.Dcb;
+using Sekiban.Dcb.Actors;
 using Sekiban.Dcb.Domains;
 using Sekiban.Dcb.ServiceId;
 using Sekiban.Dcb.Storage;
@@ -40,6 +41,8 @@ public static class SekibanDcbDynamoDbExtensions
         services.AddSingleton<IEventStore>(sp => sp.GetRequiredService<IHotEventStore>());
         services.AddConditionalEventStoreCapabilities();
         services.AddSingleton<IMultiProjectionStateStore, DynamoMultiProjectionStateStore>();
+        services.AddSingleton<IProjectionStatusStore>(sp => (sp.GetService<IMultiProjectionStateStore>() as IProjectionStatusStore)!);
+        services.AddSekibanDcbProjectionStatusReader();
         services.AddHostedService<DynamoDbInitializer>();
 
         return services;
@@ -65,6 +68,8 @@ public static class SekibanDcbDynamoDbExtensions
         services.AddSingleton<IEventStore>(sp => sp.GetRequiredService<IHotEventStore>());
         services.AddConditionalEventStoreCapabilities();
         services.AddSingleton<IMultiProjectionStateStore, DynamoMultiProjectionStateStore>();
+        services.AddSingleton<IProjectionStatusStore>(sp => (sp.GetService<IMultiProjectionStateStore>() as IProjectionStatusStore)!);
+        services.AddSekibanDcbProjectionStatusReader();
         services.AddHostedService<DynamoDbInitializer>();
 
         return services;
@@ -94,6 +99,8 @@ public static class SekibanDcbDynamoDbExtensions
         services.AddSingleton<IEventStore>(sp => sp.GetRequiredService<IHotEventStore>());
         services.AddConditionalEventStoreCapabilities();
         services.AddSingleton<IMultiProjectionStateStore, DynamoMultiProjectionStateStore>();
+        services.AddSingleton<IProjectionStatusStore>(sp => (sp.GetService<IMultiProjectionStateStore>() as IProjectionStatusStore)!);
+        services.AddSekibanDcbProjectionStatusReader();
         services.AddHostedService<DynamoDbInitializer>();
 
         return services;

--- a/dcb/src/Sekiban.Dcb.Orleans.Core/Grains/CatchUpPositionContracts.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.Core/Grains/CatchUpPositionContracts.cs
@@ -87,6 +87,7 @@ internal readonly record struct CatchUpBatchResult(
 
 internal enum CatchUpProductionHookPoint
 {
+    ActivationLifecycleStarted,
     BackgroundBeforeGate,
     BackgroundEnteredGate,
     BackgroundRejectedAsSuperseded,

--- a/dcb/src/Sekiban.Dcb.Orleans.Core/Grains/MultiProjectionGrain.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.Core/Grains/MultiProjectionGrain.cs
@@ -79,6 +79,8 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
     private int _projectionStatusWriteInProgress;
     private int _projectionStatusFailureAttempt;
     private DateTimeOffset _projectionStatusNextAttemptUtc;
+    private DateTimeOffset _projectionStatusLastFailureLogUtc = DateTimeOffset.MinValue;
+    private DateTimeOffset _projectionStatusLastConflictLogUtc = DateTimeOffset.MinValue;
     private IDisposable? _projectionStatusTimer;
     private readonly object _projectionStatusCursorGate = new();
     private string? _lastAppliedSortableUniqueId;
@@ -2806,19 +2808,32 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
                 _eventsProcessed,
                 lastAppliedPosition ?? _liveLastPosition,
                 lastTraversedPosition,
-                now);
+                now)
+            {
+                Phase = ResolveProjectionStatusPhase(),
+                LeaseExpiresAtUtc = now + ResolveProjectionStatusLeaseDuration(),
+                IsFaulted = IsProjectionStatusFaulted(),
+                FaultMessage = ResolveProjectionStatusFaultMessage()
+            };
 
+            var writeTimeout = _projectionStatusOptions.HeartbeatWriteTimeout > TimeSpan.Zero
+                ? _projectionStatusOptions.HeartbeatWriteTimeout
+                : TimeSpan.FromSeconds(5);
+            using var writeTimeoutCts = new CancellationTokenSource(writeTimeout);
             var writeResult = await _projectionStatusStore.UpsertAsync(
                 heartbeat,
                 Volatile.Read(ref _projectionStatusSequence),
-                CancellationToken.None).ConfigureAwait(false);
+                writeTimeoutCts.Token).ConfigureAwait(false);
             if (!writeResult.IsSuccess)
             {
                 ScheduleProjectionStatusRetry(now);
-                _logger.LogDebug(
-                    writeResult.GetException(),
-                    "[{ProjectorName}] Projection status heartbeat failed; projection execution is unaffected",
-                    projectorName);
+                if (ShouldLogProjectionStatusFailure(now, ref _projectionStatusLastFailureLogUtc))
+                {
+                    _logger.LogDebug(
+                        writeResult.GetException(),
+                        "[{ProjectorName}] Projection status heartbeat failed; projection execution is unaffected",
+                        projectorName);
+                }
                 return;
             }
 
@@ -2840,10 +2855,13 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
                 }
 
                 ScheduleProjectionStatusRetry(now);
-                _logger.LogWarning(
-                    "[{ProjectorName}] Projection status heartbeat CAS conflict: {Reason}",
-                    projectorName,
-                    outcome.ConflictReason ?? "provider rejected stale sequence");
+                if (ShouldLogProjectionStatusFailure(now, ref _projectionStatusLastConflictLogUtc))
+                {
+                    _logger.LogWarning(
+                        "[{ProjectorName}] Projection status heartbeat CAS conflict: {Reason}",
+                        projectorName,
+                        outcome.ConflictReason ?? "provider rejected stale sequence");
+                }
             }
         }
         catch (Exception ex)
@@ -2851,10 +2869,14 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
             // Status is observability only.  Await the provider operation, but never allow an outage to fault or slow
             // the projection path.
             ScheduleProjectionStatusRetry(DateTimeOffset.UtcNow);
-            _logger.LogDebug(
-                ex,
-                "[{ProjectorName}] Projection status heartbeat exception; projection execution is unaffected",
-                GetProjectorName());
+            var now = DateTimeOffset.UtcNow;
+            if (ShouldLogProjectionStatusFailure(now, ref _projectionStatusLastFailureLogUtc))
+            {
+                _logger.LogDebug(
+                    ex,
+                    "[{ProjectorName}] Projection status heartbeat exception; projection execution is unaffected",
+                    GetProjectorName());
+            }
         }
         finally
         {
@@ -2868,6 +2890,55 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
         var delay = TimeSpan.FromSeconds(Math.Min(30, Math.Pow(2, attempt - 1)));
         _projectionStatusNextAttemptUtc = now + delay;
         Interlocked.Exchange(ref _projectionStatusDirty, 1);
+    }
+
+    private bool ShouldLogProjectionStatusFailure(DateTimeOffset now, ref DateTimeOffset lastLoggedUtc)
+    {
+        var interval = _projectionStatusOptions.HeartbeatFailureLogInterval > TimeSpan.Zero
+            ? _projectionStatusOptions.HeartbeatFailureLogInterval
+            : TimeSpan.FromSeconds(30);
+        if (now - lastLoggedUtc < interval)
+        {
+            return false;
+        }
+
+        lastLoggedUtc = now;
+        return true;
+    }
+
+    private string ResolveProjectionStatusPhase()
+    {
+        if (IsProjectionStatusFaulted())
+        {
+            return ProjectionStatusPhases.Faulted;
+        }
+
+        if (!_isInitialized)
+        {
+            return ProjectionStatusPhases.Starting;
+        }
+
+        return _catchUpProgress.IsActive
+            ? ProjectionStatusPhases.CatchingUp
+            : ProjectionStatusPhases.Active;
+    }
+
+    private bool IsProjectionStatusFaulted() =>
+        _projectionFault is not null ||
+        _stateStore.Committed.FaultEventId is not null ||
+        !_activationHealthy;
+
+    private string? ResolveProjectionStatusFaultMessage() =>
+        _projectionFault?.Message ??
+        _stateStore.Committed.FaultMessage ??
+        _activationFailureReason;
+
+    private TimeSpan ResolveProjectionStatusLeaseDuration()
+    {
+        var interval = _projectionStatusOptions.HeartbeatInterval > TimeSpan.Zero
+            ? _projectionStatusOptions.HeartbeatInterval
+            : TimeSpan.FromSeconds(30);
+        return TimeSpan.FromTicks(Math.Max(TimeSpan.FromMinutes(1).Ticks, interval.Ticks * 2));
     }
 
     private async Task EnsureInitializedAsync()

--- a/dcb/src/Sekiban.Dcb.Orleans.Core/Grains/MultiProjectionGrain.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.Core/Grains/MultiProjectionGrain.cs
@@ -1,6 +1,7 @@
 using System;
 using Sekiban.Dcb.Runtime.Native;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Orleans.Streams;
@@ -70,6 +71,18 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
 
     private readonly IEventSubscriptionResolver _subscriptionResolver;
     private readonly IMultiProjectionStateStore? _multiProjectionStateStore;
+    private readonly IProjectionStatusStore? _projectionStatusStore;
+    private readonly ProjectionStatusOptions _projectionStatusOptions;
+    private readonly string _activationId = Guid.CreateVersion7().ToString("N");
+    private long _projectionStatusSequence;
+    private int _projectionStatusDirty = 1;
+    private int _projectionStatusWriteInProgress;
+    private int _projectionStatusFailureAttempt;
+    private DateTimeOffset _projectionStatusNextAttemptUtc;
+    private IDisposable? _projectionStatusTimer;
+    private readonly object _projectionStatusCursorGate = new();
+    private string? _lastAppliedSortableUniqueId;
+    private string? _lastTraversedSortableUniqueId;
 
     // SEK-G20: the SOLE checkpoint-mutation coordinator. It — not the grain — holds the generation/tombstone CAS surface
     // and is the only type that calls any checkpoint mutation (CAS or legacy). It owns the adopted-token + rebuilt-pending
@@ -245,6 +258,9 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
         bool ExternalStoreSaved,
         long UploadElapsedMs);
 
+    // Keep the pre-SEK-G24 constructor metadata intact for existing binary consumers. Orleans uses the annotated
+    // constructor below when the optional status services are registered; direct callers can continue using this
+    // compatibility overload and receive the original no-registry behavior.
     public MultiProjectionGrain(
         [PersistentState("multiProjection", "OrleansStorage")] IPersistentState<MultiProjectionGrainState> state,
         IProjectionActorHostFactory actorHostFactory,
@@ -257,6 +273,38 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
         ILogger<MultiProjectionGrain>? logger = null,
         IEventStoreFactory? eventStoreFactory = null,
         IServiceIdProvider? serviceIdProvider = null)
+        : this(
+            state,
+            actorHostFactory,
+            eventStore,
+            subscriptionResolver,
+            multiProjectionStateStore,
+            eventStats,
+            actorOptions,
+            tempFileSnapshotManager,
+            logger,
+            eventStoreFactory,
+            serviceIdProvider,
+            projectionStatusStore: null,
+            projectionStatusOptions: null)
+    {
+    }
+
+    [ActivatorUtilitiesConstructor]
+    public MultiProjectionGrain(
+        [PersistentState("multiProjection", "OrleansStorage")] IPersistentState<MultiProjectionGrainState> state,
+        IProjectionActorHostFactory actorHostFactory,
+        IEventStore eventStore,
+        IEventSubscriptionResolver? subscriptionResolver,
+        IMultiProjectionStateStore? multiProjectionStateStore,
+        Sekiban.Dcb.MultiProjections.IMultiProjectionEventStatistics? eventStats,
+        GeneralMultiProjectionActorOptions? actorOptions,
+        TempFileSnapshotManager? tempFileSnapshotManager = null,
+        ILogger<MultiProjectionGrain>? logger = null,
+        IEventStoreFactory? eventStoreFactory = null,
+        IServiceIdProvider? serviceIdProvider = null,
+        IProjectionStatusStore? projectionStatusStore = null,
+        ProjectionStatusOptions? projectionStatusOptions = null)
     {
         // Transfer ownership of the injected persistent state to the coordinated store immediately; keep no raw
         // IPersistentState reference on the grain so writes cannot bypass the single-writer gate. The live-fault
@@ -278,6 +326,8 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
         _logger = logger ?? NullLogger<MultiProjectionGrain>.Instance;
         _eventStoreFactory = eventStoreFactory;
         _serviceIdProvider = serviceIdProvider ?? new DefaultServiceIdProvider();
+        _projectionStatusStore = projectionStatusStore;
+        _projectionStatusOptions = projectionStatusOptions ?? new ProjectionStatusOptions();
 
         if (_injectedActorOptions is not null)
         {
@@ -1033,6 +1083,12 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
         {
             await _host.AddSerializableEventsAsync(newEvents, finishedCatchUp);
             _eventsProcessed += newEvents.Count;
+
+            var lastApplied = newEvents
+                .OrderBy(e => e.SortableUniqueIdValue, StringComparer.Ordinal)
+                .Last()
+                .SortableUniqueIdValue;
+            MarkProjectionStatusDirty(lastApplied, lastApplied);
 
             // Mark events as processed
             foreach (var ev in newEvents)
@@ -1991,6 +2047,7 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
                     forceFullReplay: false,
                     GetCurrentPositionAsync);
             var currentPosition = startLease.StartPosition;
+            MarkProjectionStatusDirty(currentPosition?.Value);
             var invocationReached = currentPosition;
             _catchUpProgress = new CatchUpProgress
             {
@@ -2256,6 +2313,7 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
                             else
                             {
                                 _eventsProcessed = record.EventsProcessed;
+                                MarkProjectionStatusDirty(record.LastSortableUniqueId, record.LastSortableUniqueId);
                                 ClearProcessedEventCache();
 
                                 // SEK-G18 (#1086): take the catch-up start verbatim from the restored checkpoint record, so
@@ -2514,6 +2572,7 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
         _batchTimer?.Dispose();
         _catchUpTimer?.Dispose();
         _faultPersistRetryTimer?.Dispose();
+        _projectionStatusTimer?.Dispose();
 
         await base.OnDeactivateAsync(reason, cancellationToken);
     }
@@ -2651,6 +2710,12 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
         _pendingStreamEvents.Clear();
         CompactRetainedCollections();
         _liveLastPosition = null;
+        lock (_projectionStatusCursorGate)
+        {
+            _lastAppliedSortableUniqueId = null;
+            _lastTraversedSortableUniqueId = null;
+        }
+        Interlocked.Exchange(ref _projectionStatusDirty, 1);
         _projectionFault = null;
         _catchUpTimer?.Dispose();
         _catchUpTimer = null;
@@ -2677,6 +2742,132 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
         s.LastGoodEventsProcessed = 0;
         s.LastPersistTime = DateTime.UtcNow;
         ClearFaultFieldsOnCandidate(s);
+    }
+
+    private void MarkProjectionStatusDirty(
+        string? traversedPosition = null,
+        string? appliedPosition = null)
+    {
+        lock (_projectionStatusCursorGate)
+        {
+            if (!string.IsNullOrWhiteSpace(traversedPosition) &&
+                (string.IsNullOrWhiteSpace(_lastTraversedSortableUniqueId) ||
+                 string.Compare(traversedPosition, _lastTraversedSortableUniqueId, StringComparison.Ordinal) > 0))
+            {
+                _lastTraversedSortableUniqueId = traversedPosition;
+            }
+
+            if (!string.IsNullOrWhiteSpace(appliedPosition) &&
+                (string.IsNullOrWhiteSpace(_lastAppliedSortableUniqueId) ||
+                 string.Compare(appliedPosition, _lastAppliedSortableUniqueId, StringComparison.Ordinal) > 0))
+            {
+                _lastAppliedSortableUniqueId = appliedPosition;
+            }
+        }
+
+        Interlocked.Exchange(ref _projectionStatusDirty, 1);
+    }
+
+    private async Task WriteProjectionStatusHeartbeatAsync()
+    {
+        if (_projectionStatusStore is null || !_projectionStatusOptions.Enabled ||
+            Interlocked.Exchange(ref _projectionStatusWriteInProgress, 1) != 0)
+        {
+            return;
+        }
+
+        try
+        {
+            var now = DateTimeOffset.UtcNow;
+            if (_projectionStatusNextAttemptUtc > now)
+            {
+                return;
+            }
+
+            var projectorName = GetProjectorName();
+            var sequence = Volatile.Read(ref _projectionStatusSequence) + 1;
+            string? lastAppliedPosition;
+            string? lastTraversedPosition;
+            lock (_projectionStatusCursorGate)
+            {
+                lastAppliedPosition = _lastAppliedSortableUniqueId;
+                lastTraversedPosition = _lastTraversedSortableUniqueId;
+            }
+
+            var heartbeat = new ProjectionStatusHeartbeat(
+                _serviceId,
+                projectorName,
+                _stateStore.Committed.ProjectorVersion ?? _host?.GetProjectorVersion() ?? string.Empty,
+                string.IsNullOrWhiteSpace(_projectionStatusOptions.ClusterId)
+                    ? ProjectionStatusOptions.DefaultClusterId
+                    : _projectionStatusOptions.ClusterId,
+                _activationId,
+                sequence,
+                _eventsProcessed,
+                lastAppliedPosition ?? _liveLastPosition,
+                lastTraversedPosition,
+                now);
+
+            var writeResult = await _projectionStatusStore.UpsertAsync(
+                heartbeat,
+                Volatile.Read(ref _projectionStatusSequence),
+                CancellationToken.None).ConfigureAwait(false);
+            if (!writeResult.IsSuccess)
+            {
+                ScheduleProjectionStatusRetry(now);
+                _logger.LogDebug(
+                    writeResult.GetException(),
+                    "[{ProjectorName}] Projection status heartbeat failed; projection execution is unaffected",
+                    projectorName);
+                return;
+            }
+
+            var outcome = writeResult.GetValue();
+            if (outcome.Committed)
+            {
+                Volatile.Write(ref _projectionStatusSequence, sequence);
+                Interlocked.Exchange(ref _projectionStatusDirty, 0);
+                _projectionStatusFailureAttempt = 0;
+                _projectionStatusNextAttemptUtc = DateTimeOffset.MinValue;
+            }
+            else
+            {
+                // Another writer for this activation owns the newer sequence.  Re-base without replacing its row;
+                // the next timer tick will attempt the next sequence using the provider's observed token.
+                if (outcome.Current is { Sequence: var currentSequence } && currentSequence > sequence - 1)
+                {
+                    Volatile.Write(ref _projectionStatusSequence, currentSequence);
+                }
+
+                ScheduleProjectionStatusRetry(now);
+                _logger.LogWarning(
+                    "[{ProjectorName}] Projection status heartbeat CAS conflict: {Reason}",
+                    projectorName,
+                    outcome.ConflictReason ?? "provider rejected stale sequence");
+            }
+        }
+        catch (Exception ex)
+        {
+            // Status is observability only.  Await the provider operation, but never allow an outage to fault or slow
+            // the projection path.
+            ScheduleProjectionStatusRetry(DateTimeOffset.UtcNow);
+            _logger.LogDebug(
+                ex,
+                "[{ProjectorName}] Projection status heartbeat exception; projection execution is unaffected",
+                GetProjectorName());
+        }
+        finally
+        {
+            Volatile.Write(ref _projectionStatusWriteInProgress, 0);
+        }
+    }
+
+    private void ScheduleProjectionStatusRetry(DateTimeOffset now)
+    {
+        var attempt = Math.Min(6, ++_projectionStatusFailureAttempt);
+        var delay = TimeSpan.FromSeconds(Math.Min(30, Math.Pow(2, attempt - 1)));
+        _projectionStatusNextAttemptUtc = now + delay;
+        Interlocked.Exchange(ref _projectionStatusDirty, 1);
     }
 
     private async Task EnsureInitializedAsync()
@@ -2719,6 +2910,22 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
                 Period = _batchTimeout,
                 Interleave = true
             });
+
+        if (_projectionStatusStore is not null && _projectionStatusOptions.Enabled)
+        {
+            var interval = _projectionStatusOptions.HeartbeatInterval > TimeSpan.Zero
+                ? _projectionStatusOptions.HeartbeatInterval
+                : TimeSpan.FromSeconds(30);
+            _projectionStatusTimer = this.RegisterGrainTimer(
+                async () => await WriteProjectionStatusHeartbeatAsync(),
+                new GrainTimerCreationOptions
+                {
+                    DueTime = TimeSpan.Zero,
+                    Period = interval,
+                    Interleave = true,
+                    KeepAlive = false
+                });
+        }
     }
 
     public Task RequestDeactivationAsync()
@@ -3045,6 +3252,12 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
         }
 
         _liveLastPosition = null;
+        lock (_projectionStatusCursorGate)
+        {
+            _lastAppliedSortableUniqueId = null;
+            _lastTraversedSortableUniqueId = null;
+        }
+        Interlocked.Exchange(ref _projectionStatusDirty, 1);
     }
 
     /// <summary>Re-establishes a persisted fault into the freshly-activated host so the first query fails closed.</summary>
@@ -3300,6 +3513,7 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
             // wins over host-payload inference and is consumed exactly once.
             var startLease = await _catchUpStartPositions.AcquireAsync(forceFull, GetCurrentPositionAsync);
             var currentPosition = startLease.StartPosition;
+            MarkProjectionStatusDirty(currentPosition?.Value);
 
             // NOTE: We intentionally skip reading all events to determine target position.
             // Reading 200k+ events just to find the latest position causes activation timeout.
@@ -3620,12 +3834,16 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
         }
 
         UpdateTargetPosition(events[^1].SortableUniqueIdValue);
+        // The registry cursor is the last event fetched, including events filtered out before projector application.
+        // It is intentionally distinct from the applied-event count and checkpoint cursor.
+        MarkProjectionStatusDirty(events[^1].SortableUniqueIdValue);
 
         var filtered = FilterByPositionAndProcessed(events, e => e.Id, e => e.SortableUniqueIdValue);
         var filteredCount = Math.Max(0, events.Count - filtered.Count);
         if (filtered.Count == 0)
         {
             _catchUpProgress.CurrentPosition = new SortableUniqueId(events[^1].SortableUniqueIdValue);
+            MarkProjectionStatusDirty(events[^1].SortableUniqueIdValue);
             LogCatchUpBatchSummary(
                 projectorName,
                 new CatchUpBatchTelemetry(
@@ -3766,6 +3984,7 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
                     fetchedCount++;
                     lastFetchedSortableUniqueId = ev.SortableUniqueIdValue;
                     UpdateTargetPosition(ev.SortableUniqueIdValue);
+                    MarkProjectionStatusDirty(ev.SortableUniqueIdValue);
 
                     if (_processedEventIds.Contains(ev.Id))
                     {
@@ -3838,6 +4057,7 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
             if (appliedCount == 0)
             {
                 _catchUpProgress.CurrentPosition = new SortableUniqueId(lastFetchedSortableUniqueId!);
+                MarkProjectionStatusDirty(lastFetchedSortableUniqueId!);
                 LogCatchUpBatchSummary(
                     projectorName,
                     new CatchUpBatchTelemetry(
@@ -3995,6 +4215,7 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
         }
 
         _catchUpProgress.CurrentPosition = new SortableUniqueId(lastSortableUniqueIdValue);
+        MarkProjectionStatusDirty(lastSortableUniqueIdValue, lastSortableUniqueIdValue);
 
         var persistDecision = GetCatchUpPersistDecision(hybridCatchUpStore, hybridReadBatchMetadata);
         long persistElapsedMs = 0;
@@ -4218,6 +4439,7 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
             }
             _lastEventTime = DateTime.UtcNow;
             _liveLastPosition = allEvents.Last().SortableUniqueIdValue;
+            MarkProjectionStatusDirty(_liveLastPosition, _liveLastPosition);
         }
     }
 
@@ -4458,6 +4680,7 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
                 .Last()
                 .SortableUniqueIdValue;
             _liveLastPosition = maxSortableId;
+            MarkProjectionStatusDirty(maxSortableId, newEvents.Count > 0 ? maxSortableId : null);
 
             _logger.LogDebug(
                 "[{ProjectorName}] Processed {EventCount} events - Total: {EventsProcessed:N0} events",
@@ -4565,6 +4788,7 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
                 .Last()
                 .SortableUniqueIdValue;
             _liveLastPosition = maxSortableId;
+            MarkProjectionStatusDirty(maxSortableId, maxSortableId);
 
             _logger.LogDebug(
                 "[{ProjectorName}] Processed {EventCount} buffered events - Total: {EventsProcessed:N0} events",

--- a/dcb/src/Sekiban.Dcb.Orleans.Core/Grains/MultiProjectionGrain.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.Core/Grains/MultiProjectionGrain.cs
@@ -2887,7 +2887,15 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
     private void ScheduleProjectionStatusRetry(DateTimeOffset now)
     {
         var attempt = Math.Min(6, ++_projectionStatusFailureAttempt);
-        var delay = TimeSpan.FromSeconds(Math.Min(30, Math.Pow(2, attempt - 1)));
+        var retryBase = _projectionStatusOptions.HeartbeatRetryBase > TimeSpan.Zero
+            ? _projectionStatusOptions.HeartbeatRetryBase
+            : TimeSpan.FromSeconds(1);
+        var retryCap = _projectionStatusOptions.HeartbeatRetryCap > TimeSpan.Zero
+            ? _projectionStatusOptions.HeartbeatRetryCap
+            : TimeSpan.FromSeconds(30);
+        var candidateTicks = retryBase.Ticks * Math.Pow(2, attempt - 1);
+        var delayTicks = Math.Min(retryCap.Ticks, Math.Max(1, (long)Math.Min(long.MaxValue, candidateTicks)));
+        var delay = TimeSpan.FromTicks(delayTicks);
         _projectionStatusNextAttemptUtc = now + delay;
         Interlocked.Exchange(ref _projectionStatusDirty, 1);
     }
@@ -5008,6 +5016,9 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
     {
         var grainKey = GetGrainKey();
         var projectorName = GetProjectorName();
+        await CatchUpProductionTestHooks.PublishAsync(
+            CatchUpProductionHookPoint.ActivationLifecycleStarted,
+            new CatchUpProductionObservation(_serviceId, projectorName, null, null));
         _logger.LogDebug("[SimplifiedPureGrain-{ProjectorName}] InitStreamsAsync called in lifecycle stage", projectorName);
 
         var streamInfo = _subscriptionResolver.Resolve(grainKey);

--- a/dcb/src/Sekiban.Dcb.Postgres/PostgresMultiProjectionStateStore.cs
+++ b/dcb/src/Sekiban.Dcb.Postgres/PostgresMultiProjectionStateStore.cs
@@ -15,8 +15,9 @@ namespace Sekiban.Dcb.Postgres;
 ///     surface (<see cref="IGenerationAwareCheckpointStore" />) — the AUTHORITATIVE provider — using conditional
 ///     row-count UPDATEs on the exact (Generation, Revision, Lifecycle) token.
 /// </summary>
-public class PostgresMultiProjectionStateStore :
+public partial class PostgresMultiProjectionStateStore :
     IMultiProjectionStateStore,
+    IProjectionStatusStore,
     IStorageDurabilityDescriptorProvider,
     IGenerationAwareCheckpointStore
 {

--- a/dcb/src/Sekiban.Dcb.Postgres/PostgresProjectionStatusStore.cs
+++ b/dcb/src/Sekiban.Dcb.Postgres/PostgresProjectionStatusStore.cs
@@ -18,8 +18,12 @@ public partial class PostgresMultiProjectionStateStore
             last_applied_sortable_unique_id varchar(100) NULL,
             last_traversed_sortable_unique_id varchar(100) NULL,
             recorded_at_utc timestamp with time zone NOT NULL,
+            phase varchar(64) NULL,
+            lease_expires_at_utc timestamp with time zone NULL,
+            is_faulted boolean NOT NULL DEFAULT FALSE,
+            fault_message varchar(2048) NULL,
             CONSTRAINT pk_dcb_projection_statuses PRIMARY KEY
-                (service_id, projector_name, projector_version, cluster_id, activation_id)
+                (service_id, projector_name, projector_version, cluster_id)
         );
         CREATE INDEX IF NOT EXISTS ix_dcb_projection_statuses_projector
             ON dcb_projection_statuses (service_id, projector_name, projector_version, cluster_id);
@@ -58,22 +62,29 @@ public partial class PostgresMultiProjectionStateStore
             command.CommandText = """
                 INSERT INTO dcb_projection_statuses
                     (service_id, projector_name, projector_version, cluster_id, activation_id, sequence,
-                     applied_event_count, last_applied_sortable_unique_id, last_traversed_sortable_unique_id, recorded_at_utc)
+                     applied_event_count, last_applied_sortable_unique_id, last_traversed_sortable_unique_id, recorded_at_utc,
+                     phase, lease_expires_at_utc, is_faulted, fault_message)
                 SELECT @service_id, @projector_name, @projector_version, @cluster_id, @activation_id, @sequence,
-                       @applied_event_count, @last_applied_sortable_unique_id, @last_traversed_sortable_unique_id, @recorded_at_utc
+                       @applied_event_count, @last_applied_sortable_unique_id, @last_traversed_sortable_unique_id, @recorded_at_utc,
+                       @phase, @lease_expires_at_utc, @is_faulted, @fault_message
                 WHERE @expected_sequence = 0
-                ON CONFLICT (service_id, projector_name, projector_version, cluster_id, activation_id)
+                ON CONFLICT (service_id, projector_name, projector_version, cluster_id)
                 DO UPDATE SET
+                    activation_id = EXCLUDED.activation_id,
                     sequence = EXCLUDED.sequence,
                     applied_event_count = EXCLUDED.applied_event_count,
                     last_applied_sortable_unique_id = EXCLUDED.last_applied_sortable_unique_id,
                     last_traversed_sortable_unique_id = EXCLUDED.last_traversed_sortable_unique_id,
-                    recorded_at_utc = EXCLUDED.recorded_at_utc
+                    recorded_at_utc = EXCLUDED.recorded_at_utc,
+                    phase = EXCLUDED.phase,
+                    lease_expires_at_utc = EXCLUDED.lease_expires_at_utc,
+                    is_faulted = EXCLUDED.is_faulted,
+                    fault_message = EXCLUDED.fault_message
                 WHERE dcb_projection_statuses.sequence = @expected_sequence
                   AND EXCLUDED.sequence > dcb_projection_statuses.sequence
                 RETURNING service_id, projector_name, projector_version, cluster_id, activation_id, sequence,
                           applied_event_count, last_applied_sortable_unique_id, last_traversed_sortable_unique_id,
-                          recorded_at_utc;
+                          recorded_at_utc, phase, lease_expires_at_utc, is_faulted, fault_message;
                 """;
             AddParameter(command, "service_id", heartbeat.ServiceId);
             AddParameter(command, "projector_name", heartbeat.ProjectorName);
@@ -85,6 +96,10 @@ public partial class PostgresMultiProjectionStateStore
             AddParameter(command, "last_applied_sortable_unique_id", (object?)heartbeat.LastAppliedSortableUniqueId ?? DBNull.Value);
             AddParameter(command, "last_traversed_sortable_unique_id", (object?)heartbeat.LastTraversedSortableUniqueId ?? DBNull.Value);
             AddParameter(command, "recorded_at_utc", heartbeat.RecordedAtUtc);
+            AddParameter(command, "phase", heartbeat.Phase);
+            AddParameter(command, "lease_expires_at_utc", (object?)heartbeat.LeaseExpiresAtUtc ?? DBNull.Value);
+            AddParameter(command, "is_faulted", heartbeat.IsFaulted);
+            AddParameter(command, "fault_message", (object?)heartbeat.FaultMessage ?? DBNull.Value);
             AddParameter(command, "expected_sequence", expectedSequence);
 
             await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
@@ -100,7 +115,6 @@ public partial class PostgresMultiProjectionStateStore
                 heartbeat.ProjectorName,
                 heartbeat.ProjectorVersion,
                 heartbeat.ClusterId,
-                heartbeat.ActivationId,
                 cancellationToken).ConfigureAwait(false);
             return ResultBox.FromValue(ProjectionStatusWriteResult.Rejected(
                 current,
@@ -131,7 +145,7 @@ public partial class PostgresMultiProjectionStateStore
             command.CommandText = """
                 SELECT service_id, projector_name, projector_version, cluster_id, activation_id, sequence,
                        applied_event_count, last_applied_sortable_unique_id, last_traversed_sortable_unique_id,
-                       recorded_at_utc
+                       recorded_at_utc, phase, lease_expires_at_utc, is_faulted, fault_message
                 FROM dcb_projection_statuses
                 WHERE service_id = @service_id
                   AND (@projector_name IS NULL OR projector_name = @projector_name)
@@ -182,7 +196,13 @@ public partial class PostgresMultiProjectionStateStore
         reader.GetInt64(6),
         reader.IsDBNull(7) ? null : reader.GetString(7),
         reader.IsDBNull(8) ? null : reader.GetString(8),
-        reader.GetFieldValue<DateTimeOffset>(9));
+        reader.GetFieldValue<DateTimeOffset>(9))
+    {
+        Phase = reader.IsDBNull(10) ? ProjectionStatusPhases.Unknown : reader.GetString(10),
+        LeaseExpiresAtUtc = reader.IsDBNull(11) ? null : reader.GetFieldValue<DateTimeOffset>(11),
+        IsFaulted = !reader.IsDBNull(12) && reader.GetBoolean(12),
+        FaultMessage = reader.IsDBNull(13) ? null : reader.GetString(13)
+    };
 
     private static async Task<ProjectionStatusHeartbeat?> ReadCurrentHeartbeatAsync(
         DbConnection connection,
@@ -190,24 +210,21 @@ public partial class PostgresMultiProjectionStateStore
         string projectorName,
         string projectorVersion,
         string clusterId,
-        string activationId,
         CancellationToken cancellationToken)
     {
         await using var command = connection.CreateCommand();
         command.CommandText = """
             SELECT service_id, projector_name, projector_version, cluster_id, activation_id, sequence,
                    applied_event_count, last_applied_sortable_unique_id, last_traversed_sortable_unique_id,
-                   recorded_at_utc
+                   recorded_at_utc, phase, lease_expires_at_utc, is_faulted, fault_message
             FROM dcb_projection_statuses
             WHERE service_id = @service_id AND projector_name = @projector_name
-              AND projector_version = @projector_version AND cluster_id = @cluster_id
-              AND activation_id = @activation_id;
+              AND projector_version = @projector_version AND cluster_id = @cluster_id;
             """;
         AddParameter(command, "service_id", serviceId);
         AddParameter(command, "projector_name", projectorName);
         AddParameter(command, "projector_version", projectorVersion);
         AddParameter(command, "cluster_id", clusterId);
-        AddParameter(command, "activation_id", activationId);
         await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
         return await reader.ReadAsync(cancellationToken).ConfigureAwait(false) ? ReadHeartbeat(reader) : null;
     }

--- a/dcb/src/Sekiban.Dcb.Postgres/PostgresProjectionStatusStore.cs
+++ b/dcb/src/Sekiban.Dcb.Postgres/PostgresProjectionStatusStore.cs
@@ -1,0 +1,214 @@
+using System.Data.Common;
+using Microsoft.EntityFrameworkCore;
+using ResultBoxes;
+
+namespace Sekiban.Dcb.Postgres;
+
+public partial class PostgresMultiProjectionStateStore
+{
+    private const string ProjectionStatusSchemaSql = """
+        CREATE TABLE IF NOT EXISTS dcb_projection_statuses (
+            service_id varchar(64) NOT NULL,
+            projector_name varchar(256) NOT NULL,
+            projector_version varchar(128) NOT NULL,
+            cluster_id varchar(256) NOT NULL,
+            activation_id varchar(128) NOT NULL,
+            sequence bigint NOT NULL,
+            applied_event_count bigint NOT NULL,
+            last_applied_sortable_unique_id varchar(100) NULL,
+            last_traversed_sortable_unique_id varchar(100) NULL,
+            recorded_at_utc timestamp with time zone NOT NULL,
+            CONSTRAINT pk_dcb_projection_statuses PRIMARY KEY
+                (service_id, projector_name, projector_version, cluster_id, activation_id)
+        );
+        CREATE INDEX IF NOT EXISTS ix_dcb_projection_statuses_projector
+            ON dcb_projection_statuses (service_id, projector_name, projector_version, cluster_id);
+        """;
+
+    public async Task<ResultBox<ProjectionStatusWriteResult>> UpsertAsync(
+        ProjectionStatusHeartbeat heartbeat,
+        long expectedSequence,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(heartbeat);
+        try
+        {
+            var serviceId = CurrentServiceId;
+            if (!string.Equals(heartbeat.ServiceId, serviceId, StringComparison.Ordinal))
+            {
+                return ResultBox.Error<ProjectionStatusWriteResult>(
+                    new UnauthorizedAccessException("Projection status ServiceId is owned by the server."));
+            }
+
+            if (expectedSequence < 0 || heartbeat.Sequence <= 0)
+            {
+                return ResultBox.Error<ProjectionStatusWriteResult>(
+                    new ArgumentOutOfRangeException(nameof(expectedSequence), "Projection status sequences must be positive and expected sequence must not be negative."));
+            }
+
+            await using var context = await _contextFactory.CreateDbContextAsync(cancellationToken);
+            await EnsureProjectionStatusSchemaAsync(context, cancellationToken).ConfigureAwait(false);
+            await using var connection = context.Database.GetDbConnection();
+            if (connection.State != System.Data.ConnectionState.Open)
+            {
+                await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+            }
+
+            await using var command = connection.CreateCommand();
+            command.CommandText = """
+                INSERT INTO dcb_projection_statuses
+                    (service_id, projector_name, projector_version, cluster_id, activation_id, sequence,
+                     applied_event_count, last_applied_sortable_unique_id, last_traversed_sortable_unique_id, recorded_at_utc)
+                SELECT @service_id, @projector_name, @projector_version, @cluster_id, @activation_id, @sequence,
+                       @applied_event_count, @last_applied_sortable_unique_id, @last_traversed_sortable_unique_id, @recorded_at_utc
+                WHERE @expected_sequence = 0
+                ON CONFLICT (service_id, projector_name, projector_version, cluster_id, activation_id)
+                DO UPDATE SET
+                    sequence = EXCLUDED.sequence,
+                    applied_event_count = EXCLUDED.applied_event_count,
+                    last_applied_sortable_unique_id = EXCLUDED.last_applied_sortable_unique_id,
+                    last_traversed_sortable_unique_id = EXCLUDED.last_traversed_sortable_unique_id,
+                    recorded_at_utc = EXCLUDED.recorded_at_utc
+                WHERE dcb_projection_statuses.sequence = @expected_sequence
+                  AND EXCLUDED.sequence > dcb_projection_statuses.sequence
+                RETURNING service_id, projector_name, projector_version, cluster_id, activation_id, sequence,
+                          applied_event_count, last_applied_sortable_unique_id, last_traversed_sortable_unique_id,
+                          recorded_at_utc;
+                """;
+            AddParameter(command, "service_id", heartbeat.ServiceId);
+            AddParameter(command, "projector_name", heartbeat.ProjectorName);
+            AddParameter(command, "projector_version", heartbeat.ProjectorVersion);
+            AddParameter(command, "cluster_id", heartbeat.ClusterId);
+            AddParameter(command, "activation_id", heartbeat.ActivationId);
+            AddParameter(command, "sequence", heartbeat.Sequence);
+            AddParameter(command, "applied_event_count", heartbeat.AppliedEventCount);
+            AddParameter(command, "last_applied_sortable_unique_id", (object?)heartbeat.LastAppliedSortableUniqueId ?? DBNull.Value);
+            AddParameter(command, "last_traversed_sortable_unique_id", (object?)heartbeat.LastTraversedSortableUniqueId ?? DBNull.Value);
+            AddParameter(command, "recorded_at_utc", heartbeat.RecordedAtUtc);
+            AddParameter(command, "expected_sequence", expectedSequence);
+
+            await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+            if (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                return ResultBox.FromValue(ProjectionStatusWriteResult.Success(ReadHeartbeat(reader)));
+            }
+
+            await reader.DisposeAsync().ConfigureAwait(false);
+            var current = await ReadCurrentHeartbeatAsync(
+                connection,
+                heartbeat.ServiceId,
+                heartbeat.ProjectorName,
+                heartbeat.ProjectorVersion,
+                heartbeat.ClusterId,
+                heartbeat.ActivationId,
+                cancellationToken).ConfigureAwait(false);
+            return ResultBox.FromValue(ProjectionStatusWriteResult.Rejected(
+                current,
+                $"Heartbeat CAS rejected: expected sequence {expectedSequence}."));
+        }
+        catch (Exception ex)
+        {
+            return ResultBox.Error<ProjectionStatusWriteResult>(ex);
+        }
+    }
+
+    public async Task<ResultBox<IReadOnlyList<ProjectionStatusHeartbeat>>> ListAsync(
+        string? projectorName = null,
+        string? projectorVersion = null,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            await using var context = await _contextFactory.CreateDbContextAsync(cancellationToken);
+            await EnsureProjectionStatusSchemaAsync(context, cancellationToken).ConfigureAwait(false);
+            await using var connection = context.Database.GetDbConnection();
+            if (connection.State != System.Data.ConnectionState.Open)
+            {
+                await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+            }
+
+            await using var command = connection.CreateCommand();
+            command.CommandText = """
+                SELECT service_id, projector_name, projector_version, cluster_id, activation_id, sequence,
+                       applied_event_count, last_applied_sortable_unique_id, last_traversed_sortable_unique_id,
+                       recorded_at_utc
+                FROM dcb_projection_statuses
+                WHERE service_id = @service_id
+                  AND (@projector_name IS NULL OR projector_name = @projector_name)
+                  AND (@projector_version IS NULL OR projector_version = @projector_version)
+                ORDER BY projector_name, projector_version, cluster_id, activation_id;
+                """;
+            AddParameter(command, "service_id", CurrentServiceId);
+            AddParameter(command, "projector_name", (object?)projectorName ?? DBNull.Value);
+            AddParameter(command, "projector_version", (object?)projectorVersion ?? DBNull.Value);
+
+            var rows = new List<ProjectionStatusHeartbeat>();
+            await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+            while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                rows.Add(ReadHeartbeat(reader));
+            }
+
+            return ResultBox.FromValue<IReadOnlyList<ProjectionStatusHeartbeat>>(rows);
+        }
+        catch (Exception ex)
+        {
+            return ResultBox.Error<IReadOnlyList<ProjectionStatusHeartbeat>>(ex);
+        }
+    }
+
+    private static async Task EnsureProjectionStatusSchemaAsync(
+        SekibanDcbDbContext context,
+        CancellationToken cancellationToken)
+    {
+        await context.Database.ExecuteSqlRawAsync(ProjectionStatusSchemaSql, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static void AddParameter(DbCommand command, string name, object value)
+    {
+        var parameter = command.CreateParameter();
+        parameter.ParameterName = name;
+        parameter.Value = value;
+        command.Parameters.Add(parameter);
+    }
+
+    private static ProjectionStatusHeartbeat ReadHeartbeat(DbDataReader reader) => new(
+        reader.GetString(0),
+        reader.GetString(1),
+        reader.GetString(2),
+        reader.GetString(3),
+        reader.GetString(4),
+        reader.GetInt64(5),
+        reader.GetInt64(6),
+        reader.IsDBNull(7) ? null : reader.GetString(7),
+        reader.IsDBNull(8) ? null : reader.GetString(8),
+        reader.GetFieldValue<DateTimeOffset>(9));
+
+    private static async Task<ProjectionStatusHeartbeat?> ReadCurrentHeartbeatAsync(
+        DbConnection connection,
+        string serviceId,
+        string projectorName,
+        string projectorVersion,
+        string clusterId,
+        string activationId,
+        CancellationToken cancellationToken)
+    {
+        await using var command = connection.CreateCommand();
+        command.CommandText = """
+            SELECT service_id, projector_name, projector_version, cluster_id, activation_id, sequence,
+                   applied_event_count, last_applied_sortable_unique_id, last_traversed_sortable_unique_id,
+                   recorded_at_utc
+            FROM dcb_projection_statuses
+            WHERE service_id = @service_id AND projector_name = @projector_name
+              AND projector_version = @projector_version AND cluster_id = @cluster_id
+              AND activation_id = @activation_id;
+            """;
+        AddParameter(command, "service_id", serviceId);
+        AddParameter(command, "projector_name", projectorName);
+        AddParameter(command, "projector_version", projectorVersion);
+        AddParameter(command, "cluster_id", clusterId);
+        AddParameter(command, "activation_id", activationId);
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+        return await reader.ReadAsync(cancellationToken).ConfigureAwait(false) ? ReadHeartbeat(reader) : null;
+    }
+}

--- a/dcb/src/Sekiban.Dcb.Postgres/SekibanDcbPostgresExtensions.cs
+++ b/dcb/src/Sekiban.Dcb.Postgres/SekibanDcbPostgresExtensions.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Sekiban.Dcb.Actors;
 using Sekiban.Dcb.Domains;
 using Sekiban.Dcb.ServiceId;
 using Sekiban.Dcb.Storage;
@@ -44,6 +45,8 @@ public static class SekibanDcbPostgresExtensions
         services.AddSingleton<IEventStore>(sp => sp.GetRequiredService<IHotEventStore>());
         services.AddConditionalEventStoreCapabilities();
         services.AddSingleton<IMultiProjectionStateStore, PostgresMultiProjectionStateStore>();
+        services.AddSingleton<IProjectionStatusStore>(sp => (sp.GetService<IMultiProjectionStateStore>() as IProjectionStatusStore)!);
+        services.AddSekibanDcbProjectionStatusReader();
 
         return services;
     }
@@ -95,6 +98,8 @@ public static class SekibanDcbPostgresExtensions
         services.AddSingleton<IEventStore>(sp => sp.GetRequiredService<IHotEventStore>());
         services.AddConditionalEventStoreCapabilities();
         services.AddSingleton<IMultiProjectionStateStore, PostgresMultiProjectionStateStore>();
+        services.AddSingleton<IProjectionStatusStore>(sp => (sp.GetService<IMultiProjectionStateStore>() as IProjectionStatusStore)!);
+        services.AddSekibanDcbProjectionStatusReader();
 
         return services;
     }
@@ -129,6 +134,8 @@ public static class SekibanDcbPostgresExtensions
         services.AddSingleton<IEventStore>(sp => sp.GetRequiredService<IHotEventStore>());
         services.AddConditionalEventStoreCapabilities();
         services.AddSingleton<IMultiProjectionStateStore, PostgresMultiProjectionStateStore>();
+        services.AddSingleton<IProjectionStatusStore>(sp => (sp.GetService<IMultiProjectionStateStore>() as IProjectionStatusStore)!);
+        services.AddSekibanDcbProjectionStatusReader();
 
         return services;
     }

--- a/dcb/src/Sekiban.Dcb.Sqlite/SekibanDcbSqliteExtensions.cs
+++ b/dcb/src/Sekiban.Dcb.Sqlite/SekibanDcbSqliteExtensions.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
 using Sekiban.Dcb.Domains;
+using Sekiban.Dcb.Actors;
 using Sekiban.Dcb.ServiceId;
 using Sekiban.Dcb.Sqlite.Services;
 using Sekiban.Dcb.Storage;
@@ -48,6 +49,8 @@ public static class SekibanDcbSqliteExtensions
             var serviceIdProvider = sp.GetRequiredService<IServiceIdProvider>();
             return new SqliteMultiProjectionStateStore(databasePath, logger, serviceIdProvider);
         });
+        services.AddSingleton<IProjectionStatusStore>(sp => (sp.GetService<IMultiProjectionStateStore>() as IProjectionStatusStore)!);
+        services.AddSekibanDcbProjectionStatusReader();
 
         return services;
     }

--- a/dcb/src/Sekiban.Dcb.Sqlite/SqliteMultiProjectionStateStore.cs
+++ b/dcb/src/Sekiban.Dcb.Sqlite/SqliteMultiProjectionStateStore.cs
@@ -19,8 +19,9 @@ namespace Sekiban.Dcb.Sqlite;
 ///     never uses the legacy upsert on a capable store (it routes through the CAS methods below).
 ///     </para>
 /// </summary>
-public class SqliteMultiProjectionStateStore :
+public partial class SqliteMultiProjectionStateStore :
     IMultiProjectionStateStore,
+    IProjectionStatusStore,
     IStorageDurabilityDescriptorProvider,
     IGenerationAwareCheckpointStore
 {
@@ -83,6 +84,7 @@ public class SqliteMultiProjectionStateStore :
         connection.Open();
 
         EnsureSchema(connection);
+        EnsureProjectionStatusSchema(connection);
     }
 
     private static void EnsureSchema(SqliteConnection connection)

--- a/dcb/src/Sekiban.Dcb.Sqlite/SqliteProjectionStatusStore.cs
+++ b/dcb/src/Sekiban.Dcb.Sqlite/SqliteProjectionStatusStore.cs
@@ -1,0 +1,187 @@
+using Microsoft.Data.Sqlite;
+using ResultBoxes;
+
+namespace Sekiban.Dcb.Sqlite;
+
+public partial class SqliteMultiProjectionStateStore
+{
+    private static void EnsureProjectionStatusSchema(SqliteConnection connection)
+    {
+        using var command = connection.CreateCommand();
+        command.CommandText = """
+            CREATE TABLE IF NOT EXISTS dcb_projection_statuses (
+                ServiceId TEXT NOT NULL,
+                ProjectorName TEXT NOT NULL,
+                ProjectorVersion TEXT NOT NULL,
+                ClusterId TEXT NOT NULL,
+                ActivationId TEXT NOT NULL,
+                Sequence INTEGER NOT NULL,
+                AppliedEventCount INTEGER NOT NULL,
+                LastAppliedSortableUniqueId TEXT NULL,
+                LastTraversedSortableUniqueId TEXT NULL,
+                RecordedAtUtc TEXT NOT NULL,
+                PRIMARY KEY (ServiceId, ProjectorName, ProjectorVersion, ClusterId, ActivationId)
+            );
+            CREATE INDEX IF NOT EXISTS IX_ProjectionStatuses_Projector
+                ON dcb_projection_statuses(ServiceId, ProjectorName, ProjectorVersion, ClusterId);
+            """;
+        command.ExecuteNonQuery();
+    }
+
+    public async Task<ResultBox<ProjectionStatusWriteResult>> UpsertAsync(
+        ProjectionStatusHeartbeat heartbeat,
+        long expectedSequence,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(heartbeat);
+        try
+        {
+            var serviceId = CurrentServiceId;
+            if (!string.Equals(heartbeat.ServiceId, serviceId, StringComparison.Ordinal))
+            {
+                return ResultBox.Error<ProjectionStatusWriteResult>(
+                    new UnauthorizedAccessException("Projection status ServiceId is owned by the server."));
+            }
+
+            if (expectedSequence < 0 || heartbeat.Sequence <= 0)
+            {
+                return ResultBox.Error<ProjectionStatusWriteResult>(
+                    new ArgumentOutOfRangeException(nameof(expectedSequence), "Projection status sequences must be positive and expected sequence must not be negative."));
+            }
+
+            await using var connection = new SqliteConnection(_connectionString);
+            await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+            EnsureProjectionStatusSchema(connection);
+
+            await using var command = connection.CreateCommand();
+            command.CommandText = """
+                INSERT INTO dcb_projection_statuses
+                    (ServiceId, ProjectorName, ProjectorVersion, ClusterId, ActivationId, Sequence,
+                     AppliedEventCount, LastAppliedSortableUniqueId, LastTraversedSortableUniqueId, RecordedAtUtc)
+                SELECT @serviceId, @projectorName, @projectorVersion, @clusterId, @activationId, @sequence,
+                       @appliedEventCount, @lastAppliedSortableUniqueId, @lastTraversedSortableUniqueId, @recordedAtUtc
+                WHERE @expectedSequence = 0
+                ON CONFLICT(ServiceId, ProjectorName, ProjectorVersion, ClusterId, ActivationId)
+                DO UPDATE SET
+                    Sequence = excluded.Sequence,
+                    AppliedEventCount = excluded.AppliedEventCount,
+                    LastAppliedSortableUniqueId = excluded.LastAppliedSortableUniqueId,
+                    LastTraversedSortableUniqueId = excluded.LastTraversedSortableUniqueId,
+                    RecordedAtUtc = excluded.RecordedAtUtc
+                WHERE dcb_projection_statuses.Sequence = @expectedSequence
+                  AND excluded.Sequence > dcb_projection_statuses.Sequence
+                RETURNING ServiceId, ProjectorName, ProjectorVersion, ClusterId, ActivationId, Sequence,
+                          AppliedEventCount, LastAppliedSortableUniqueId, LastTraversedSortableUniqueId, RecordedAtUtc;
+                """;
+            AddStatusParameter(command, "@serviceId", heartbeat.ServiceId);
+            AddStatusParameter(command, "@projectorName", heartbeat.ProjectorName);
+            AddStatusParameter(command, "@projectorVersion", heartbeat.ProjectorVersion);
+            AddStatusParameter(command, "@clusterId", heartbeat.ClusterId);
+            AddStatusParameter(command, "@activationId", heartbeat.ActivationId);
+            AddStatusParameter(command, "@sequence", heartbeat.Sequence);
+            AddStatusParameter(command, "@appliedEventCount", heartbeat.AppliedEventCount);
+            AddStatusParameter(command, "@lastAppliedSortableUniqueId", (object?)heartbeat.LastAppliedSortableUniqueId ?? DBNull.Value);
+            AddStatusParameter(command, "@lastTraversedSortableUniqueId", (object?)heartbeat.LastTraversedSortableUniqueId ?? DBNull.Value);
+            AddStatusParameter(command, "@recordedAtUtc", heartbeat.RecordedAtUtc.ToString("O"));
+            AddStatusParameter(command, "@expectedSequence", expectedSequence);
+
+            await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+            if (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                return ResultBox.FromValue(ProjectionStatusWriteResult.Success(ReadHeartbeat(reader)));
+            }
+
+            var current = await ReadCurrentHeartbeatAsync(
+                connection,
+                heartbeat,
+                cancellationToken).ConfigureAwait(false);
+            return ResultBox.FromValue(ProjectionStatusWriteResult.Rejected(
+                current,
+                $"Heartbeat CAS rejected: expected sequence {expectedSequence}."));
+        }
+        catch (Exception ex)
+        {
+            return ResultBox.Error<ProjectionStatusWriteResult>(ex);
+        }
+    }
+
+    public async Task<ResultBox<IReadOnlyList<ProjectionStatusHeartbeat>>> ListAsync(
+        string? projectorName = null,
+        string? projectorVersion = null,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            await using var connection = new SqliteConnection(_connectionString);
+            await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+            EnsureProjectionStatusSchema(connection);
+
+            await using var command = connection.CreateCommand();
+            command.CommandText = """
+                SELECT ServiceId, ProjectorName, ProjectorVersion, ClusterId, ActivationId, Sequence,
+                       AppliedEventCount, LastAppliedSortableUniqueId, LastTraversedSortableUniqueId, RecordedAtUtc
+                FROM dcb_projection_statuses
+                WHERE ServiceId = @serviceId
+                  AND (@projectorName IS NULL OR ProjectorName = @projectorName)
+                  AND (@projectorVersion IS NULL OR ProjectorVersion = @projectorVersion)
+                ORDER BY ProjectorName, ProjectorVersion, ClusterId, ActivationId;
+                """;
+            AddStatusParameter(command, "@serviceId", CurrentServiceId);
+            AddStatusParameter(command, "@projectorName", (object?)projectorName ?? DBNull.Value);
+            AddStatusParameter(command, "@projectorVersion", (object?)projectorVersion ?? DBNull.Value);
+
+            var rows = new List<ProjectionStatusHeartbeat>();
+            await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+            while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                rows.Add(ReadHeartbeat(reader));
+            }
+
+            return ResultBox.FromValue<IReadOnlyList<ProjectionStatusHeartbeat>>(rows);
+        }
+        catch (Exception ex)
+        {
+            return ResultBox.Error<IReadOnlyList<ProjectionStatusHeartbeat>>(ex);
+        }
+    }
+
+    private static void AddStatusParameter(SqliteCommand command, string name, object value)
+    {
+        command.Parameters.AddWithValue(name, value);
+    }
+
+    private static ProjectionStatusHeartbeat ReadHeartbeat(SqliteDataReader reader) => new(
+        reader.GetString(0),
+        reader.GetString(1),
+        reader.GetString(2),
+        reader.GetString(3),
+        reader.GetString(4),
+        reader.GetInt64(5),
+        reader.GetInt64(6),
+        reader.IsDBNull(7) ? null : reader.GetString(7),
+        reader.IsDBNull(8) ? null : reader.GetString(8),
+        DateTimeOffset.Parse(reader.GetString(9), System.Globalization.CultureInfo.InvariantCulture));
+
+    private static async Task<ProjectionStatusHeartbeat?> ReadCurrentHeartbeatAsync(
+        SqliteConnection connection,
+        ProjectionStatusHeartbeat heartbeat,
+        CancellationToken cancellationToken)
+    {
+        await using var command = connection.CreateCommand();
+        command.CommandText = """
+            SELECT ServiceId, ProjectorName, ProjectorVersion, ClusterId, ActivationId, Sequence,
+                   AppliedEventCount, LastAppliedSortableUniqueId, LastTraversedSortableUniqueId, RecordedAtUtc
+            FROM dcb_projection_statuses
+            WHERE ServiceId = @serviceId AND ProjectorName = @projectorName
+              AND ProjectorVersion = @projectorVersion AND ClusterId = @clusterId
+              AND ActivationId = @activationId;
+            """;
+        AddStatusParameter(command, "@serviceId", heartbeat.ServiceId);
+        AddStatusParameter(command, "@projectorName", heartbeat.ProjectorName);
+        AddStatusParameter(command, "@projectorVersion", heartbeat.ProjectorVersion);
+        AddStatusParameter(command, "@clusterId", heartbeat.ClusterId);
+        AddStatusParameter(command, "@activationId", heartbeat.ActivationId);
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+        return await reader.ReadAsync(cancellationToken).ConfigureAwait(false) ? ReadHeartbeat(reader) : null;
+    }
+}

--- a/dcb/src/Sekiban.Dcb.Sqlite/SqliteProjectionStatusStore.cs
+++ b/dcb/src/Sekiban.Dcb.Sqlite/SqliteProjectionStatusStore.cs
@@ -20,7 +20,11 @@ public partial class SqliteMultiProjectionStateStore
                 LastAppliedSortableUniqueId TEXT NULL,
                 LastTraversedSortableUniqueId TEXT NULL,
                 RecordedAtUtc TEXT NOT NULL,
-                PRIMARY KEY (ServiceId, ProjectorName, ProjectorVersion, ClusterId, ActivationId)
+                Phase TEXT NULL,
+                LeaseExpiresAtUtc TEXT NULL,
+                IsFaulted INTEGER NOT NULL DEFAULT 0,
+                FaultMessage TEXT NULL,
+                PRIMARY KEY (ServiceId, ProjectorName, ProjectorVersion, ClusterId)
             );
             CREATE INDEX IF NOT EXISTS IX_ProjectionStatuses_Projector
                 ON dcb_projection_statuses(ServiceId, ProjectorName, ProjectorVersion, ClusterId);
@@ -57,21 +61,29 @@ public partial class SqliteMultiProjectionStateStore
             command.CommandText = """
                 INSERT INTO dcb_projection_statuses
                     (ServiceId, ProjectorName, ProjectorVersion, ClusterId, ActivationId, Sequence,
-                     AppliedEventCount, LastAppliedSortableUniqueId, LastTraversedSortableUniqueId, RecordedAtUtc)
+                     AppliedEventCount, LastAppliedSortableUniqueId, LastTraversedSortableUniqueId, RecordedAtUtc,
+                     Phase, LeaseExpiresAtUtc, IsFaulted, FaultMessage)
                 SELECT @serviceId, @projectorName, @projectorVersion, @clusterId, @activationId, @sequence,
-                       @appliedEventCount, @lastAppliedSortableUniqueId, @lastTraversedSortableUniqueId, @recordedAtUtc
+                       @appliedEventCount, @lastAppliedSortableUniqueId, @lastTraversedSortableUniqueId, @recordedAtUtc,
+                       @phase, @leaseExpiresAtUtc, @isFaulted, @faultMessage
                 WHERE @expectedSequence = 0
-                ON CONFLICT(ServiceId, ProjectorName, ProjectorVersion, ClusterId, ActivationId)
+                ON CONFLICT(ServiceId, ProjectorName, ProjectorVersion, ClusterId)
                 DO UPDATE SET
+                    ActivationId = excluded.ActivationId,
                     Sequence = excluded.Sequence,
                     AppliedEventCount = excluded.AppliedEventCount,
                     LastAppliedSortableUniqueId = excluded.LastAppliedSortableUniqueId,
                     LastTraversedSortableUniqueId = excluded.LastTraversedSortableUniqueId,
-                    RecordedAtUtc = excluded.RecordedAtUtc
+                    RecordedAtUtc = excluded.RecordedAtUtc,
+                    Phase = excluded.Phase,
+                    LeaseExpiresAtUtc = excluded.LeaseExpiresAtUtc,
+                    IsFaulted = excluded.IsFaulted,
+                    FaultMessage = excluded.FaultMessage
                 WHERE dcb_projection_statuses.Sequence = @expectedSequence
                   AND excluded.Sequence > dcb_projection_statuses.Sequence
                 RETURNING ServiceId, ProjectorName, ProjectorVersion, ClusterId, ActivationId, Sequence,
-                          AppliedEventCount, LastAppliedSortableUniqueId, LastTraversedSortableUniqueId, RecordedAtUtc;
+                          AppliedEventCount, LastAppliedSortableUniqueId, LastTraversedSortableUniqueId, RecordedAtUtc,
+                          Phase, LeaseExpiresAtUtc, IsFaulted, FaultMessage;
                 """;
             AddStatusParameter(command, "@serviceId", heartbeat.ServiceId);
             AddStatusParameter(command, "@projectorName", heartbeat.ProjectorName);
@@ -83,6 +95,10 @@ public partial class SqliteMultiProjectionStateStore
             AddStatusParameter(command, "@lastAppliedSortableUniqueId", (object?)heartbeat.LastAppliedSortableUniqueId ?? DBNull.Value);
             AddStatusParameter(command, "@lastTraversedSortableUniqueId", (object?)heartbeat.LastTraversedSortableUniqueId ?? DBNull.Value);
             AddStatusParameter(command, "@recordedAtUtc", heartbeat.RecordedAtUtc.ToString("O"));
+            AddStatusParameter(command, "@phase", heartbeat.Phase);
+            AddStatusParameter(command, "@leaseExpiresAtUtc", (object?)heartbeat.LeaseExpiresAtUtc?.ToString("O") ?? DBNull.Value);
+            AddStatusParameter(command, "@isFaulted", heartbeat.IsFaulted ? 1 : 0);
+            AddStatusParameter(command, "@faultMessage", (object?)heartbeat.FaultMessage ?? DBNull.Value);
             AddStatusParameter(command, "@expectedSequence", expectedSequence);
 
             await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
@@ -119,7 +135,8 @@ public partial class SqliteMultiProjectionStateStore
             await using var command = connection.CreateCommand();
             command.CommandText = """
                 SELECT ServiceId, ProjectorName, ProjectorVersion, ClusterId, ActivationId, Sequence,
-                       AppliedEventCount, LastAppliedSortableUniqueId, LastTraversedSortableUniqueId, RecordedAtUtc
+                       AppliedEventCount, LastAppliedSortableUniqueId, LastTraversedSortableUniqueId, RecordedAtUtc,
+                       Phase, LeaseExpiresAtUtc, IsFaulted, FaultMessage
                 FROM dcb_projection_statuses
                 WHERE ServiceId = @serviceId
                   AND (@projectorName IS NULL OR ProjectorName = @projectorName)
@@ -160,7 +177,15 @@ public partial class SqliteMultiProjectionStateStore
         reader.GetInt64(6),
         reader.IsDBNull(7) ? null : reader.GetString(7),
         reader.IsDBNull(8) ? null : reader.GetString(8),
-        DateTimeOffset.Parse(reader.GetString(9), System.Globalization.CultureInfo.InvariantCulture));
+        DateTimeOffset.Parse(reader.GetString(9), System.Globalization.CultureInfo.InvariantCulture))
+    {
+        Phase = reader.IsDBNull(10) ? ProjectionStatusPhases.Unknown : reader.GetString(10),
+        LeaseExpiresAtUtc = reader.IsDBNull(11)
+            ? null
+            : DateTimeOffset.Parse(reader.GetString(11), System.Globalization.CultureInfo.InvariantCulture),
+        IsFaulted = !reader.IsDBNull(12) && reader.GetInt64(12) != 0,
+        FaultMessage = reader.IsDBNull(13) ? null : reader.GetString(13)
+    };
 
     private static async Task<ProjectionStatusHeartbeat?> ReadCurrentHeartbeatAsync(
         SqliteConnection connection,
@@ -170,17 +195,16 @@ public partial class SqliteMultiProjectionStateStore
         await using var command = connection.CreateCommand();
         command.CommandText = """
             SELECT ServiceId, ProjectorName, ProjectorVersion, ClusterId, ActivationId, Sequence,
-                   AppliedEventCount, LastAppliedSortableUniqueId, LastTraversedSortableUniqueId, RecordedAtUtc
+                   AppliedEventCount, LastAppliedSortableUniqueId, LastTraversedSortableUniqueId, RecordedAtUtc,
+                   Phase, LeaseExpiresAtUtc, IsFaulted, FaultMessage
             FROM dcb_projection_statuses
             WHERE ServiceId = @serviceId AND ProjectorName = @projectorName
-              AND ProjectorVersion = @projectorVersion AND ClusterId = @clusterId
-              AND ActivationId = @activationId;
+              AND ProjectorVersion = @projectorVersion AND ClusterId = @clusterId;
             """;
         AddStatusParameter(command, "@serviceId", heartbeat.ServiceId);
         AddStatusParameter(command, "@projectorName", heartbeat.ProjectorName);
         AddStatusParameter(command, "@projectorVersion", heartbeat.ProjectorVersion);
         AddStatusParameter(command, "@clusterId", heartbeat.ClusterId);
-        AddStatusParameter(command, "@activationId", heartbeat.ActivationId);
         await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
         return await reader.ReadAsync(cancellationToken).ConfigureAwait(false) ? ReadHeartbeat(reader) : null;
     }

--- a/dcb/tests/Sekiban.Dcb.Orleans.Tests/ExecutorBinaryCompatibilityTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Orleans.Tests/ExecutorBinaryCompatibilityTests.cs
@@ -1,4 +1,6 @@
 using System.Reflection;
+using Sekiban.Dcb.Orleans.Grains;
+using Sekiban.Dcb.Storage;
 using Xunit;
 
 namespace Sekiban.Dcb.Orleans.Tests;
@@ -21,5 +23,24 @@ public class ExecutorBinaryCompatibilityTests
 
         Assert.NotNull(matching);
         Assert.True(matching.IsPublic);
+    }
+
+    [Fact]
+    public void PreSekibanG24_MultiProjectionGrain_Constructor_Is_Still_Public()
+    {
+        // The registry dependencies were added through an overload. Keep the exact pre-G24 surface available to
+        // already-compiled Orleans activation factories and direct consumers.
+        var legacy = typeof(MultiProjectionGrain)
+            .GetConstructors(BindingFlags.Instance | BindingFlags.Public)
+            .SingleOrDefault(constructor =>
+            {
+                var parameters = constructor.GetParameters();
+                return parameters.Length == 11 &&
+                    parameters[^1].ParameterType == typeof(Sekiban.Dcb.ServiceId.IServiceIdProvider) &&
+                    parameters.All(parameter => parameter.ParameterType != typeof(IProjectionStatusStore));
+            });
+
+        Assert.NotNull(legacy);
+        Assert.True(legacy!.IsPublic);
     }
 }

--- a/dcb/tests/Sekiban.Dcb.Orleans.Tests/MinimalOrleansTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Orleans.Tests/MinimalOrleansTests.cs
@@ -11,6 +11,7 @@ using Sekiban.Dcb.Orleans.Grains;
 using Sekiban.Dcb.Orleans.ServiceId;
 using Sekiban.Dcb.Orleans.Streams;
 using Sekiban.Dcb.Queries;
+using Sekiban.Dcb.ServiceId;
 using Sekiban.Dcb.Storage;
 using Sekiban.Dcb.Tags;
 using Sekiban.Dcb.Common;
@@ -26,6 +27,8 @@ namespace Sekiban.Dcb.Orleans.Tests;
 public class MinimalOrleansTests : IAsyncLifetime
 {
     private static readonly CountingInMemoryEventStore SharedEventStore = CreateSharedEventStore();
+    private static readonly Sekiban.Dcb.Testing.InMemoryMultiProjectionStateStore SharedStateStore = new();
+    private static readonly TestProjectionStatusStore SharedStatusStore = new(SharedStateStore);
     private TestCluster _cluster = null!;
     private IClusterClient _client => _cluster.Client;
 
@@ -43,6 +46,8 @@ public class MinimalOrleansTests : IAsyncLifetime
         await _cluster.DeployAsync();
         SharedEventStore.Clear();
         SharedEventStore.ClearReadAllEventsTracking();
+        SharedStateStore.Clear();
+        SharedStatusStore.Reset();
     }
 
     public async Task DisposeAsync()
@@ -75,6 +80,71 @@ public class MinimalOrleansTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task PassiveStatusReader_DoesNotActivateGrain_WhileDirectGrainCallDoes()
+    {
+        var reader = new ProjectionStatusReader(
+            SharedStateStore,
+            SharedEventStore,
+            new DefaultServiceIdProvider(),
+            new ProjectionStatusOptions { SamplingWindow = TimeSpan.Zero });
+
+        var before = await reader.ReadAsync(new ProjectionStatusReadRequest(ProjectorName: "empty-test"));
+        Assert.True(before.IsSuccess);
+        Assert.Empty(before.GetValue());
+        Assert.Empty((await SharedStateStore.ListAsync("empty-test", "1.0")).GetValue());
+
+        // This is the contrast case: obtaining and calling a grain is the operation that creates the activation and
+        // its dedicated heartbeat row.
+        var grain = _client.GetGrain<IMultiProjectionGrain>("empty-test");
+        await grain.GetStatusAsync();
+
+        var deadline = DateTime.UtcNow.AddSeconds(5);
+        IReadOnlyList<ProjectionStatusHeartbeat> rows = Array.Empty<ProjectionStatusHeartbeat>();
+        while (DateTime.UtcNow < deadline)
+        {
+            rows = (await SharedStateStore.ListAsync("empty-test", "1.0")).GetValue();
+            if (rows.Count > 0)
+            {
+                break;
+            }
+
+            await Task.Delay(50);
+        }
+
+        var heartbeat = Assert.Single(rows);
+        Assert.Contains(heartbeat.Phase, new[] { ProjectionStatusPhases.Active, ProjectionStatusPhases.CatchingUp });
+        Assert.False(heartbeat.IsFaulted);
+    }
+
+    [Fact]
+    public async Task SlowHeartbeatUpsert_IsBoundedAndDoesNotBlockGrainCalls()
+    {
+        SharedStatusStore.Delay = TimeSpan.FromSeconds(2);
+        try
+        {
+            var grain = _client.GetGrain<IMultiProjectionGrain>("slow-heartbeat");
+            var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+            var status = await grain.GetStatusAsync();
+            stopwatch.Stop();
+
+            Assert.NotNull(status);
+            Assert.True(stopwatch.Elapsed < TimeSpan.FromSeconds(1), $"grain call took {stopwatch.Elapsed}");
+
+            var deadline = DateTime.UtcNow.AddSeconds(2);
+            while (!SharedStatusStore.SawCancelableToken && DateTime.UtcNow < deadline)
+            {
+                await Task.Delay(25);
+            }
+
+            Assert.True(SharedStatusStore.SawCancelableToken);
+        }
+        finally
+        {
+            SharedStatusStore.Reset();
+        }
+    }
+
+    [Fact]
     public async Task Orleans_MultiProjectionCatchUp_Should_Read_With_BatchLimit()
     {
         var grain = _client.GetGrain<IMultiProjectionGrain>("test-projector");
@@ -103,6 +173,48 @@ public class MinimalOrleansTests : IAsyncLifetime
 
         Assert.True(SharedEventStore.ReadAllSerializableEventsCallCount > 0);
         Assert.All(SharedEventStore.ReadAllSerializableEventsMaxCounts, maxCount => Assert.Equal(500, maxCount));
+    }
+
+    [Fact]
+    public async Task ProjectionHeartbeat_RealGrainAdvancesFetchedCursorPastFilteredDuplicate()
+    {
+        var grain = _client.GetGrain<IMultiProjectionGrain>("test-projector");
+        var eventId = Guid.CreateVersion7();
+        var baseTick = DateTime.UtcNow.Ticks;
+        var metadata = new EventMetadata(Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), "test");
+        var payload = Encoding.UTF8.GetBytes(JsonSerializer.Serialize(new TestProjectionEvent(1)));
+        var positions = Enumerable.Range(0, 501)
+            .Select(index => SortableUniqueId.GetTickString(baseTick + index) + SortableUniqueId.GetIdString(Guid.Empty))
+            .ToArray();
+        var events = positions.Select((position, index) => new SerializableEvent(
+                payload,
+                position,
+                index is 0 or 500 ? eventId : Guid.CreateVersion7(),
+                metadata,
+                new List<string>(),
+                nameof(TestProjectionEvent)))
+            .ToArray();
+
+        await grain.SeedEventsAsync(events);
+        await grain.RefreshAsync();
+
+        var deadline = DateTime.UtcNow.AddSeconds(8);
+        ProjectionStatusHeartbeat? heartbeat = null;
+        while (DateTime.UtcNow < deadline)
+        {
+            heartbeat = (await SharedStateStore.ListAsync("test-projector", "1.0")).GetValue().SingleOrDefault();
+            if (heartbeat?.LastTraversedSortableUniqueId == positions[^1])
+            {
+                break;
+            }
+
+            await Task.Delay(100);
+        }
+
+        Assert.NotNull(heartbeat);
+        Assert.Equal(positions[^1], heartbeat!.LastTraversedSortableUniqueId);
+        Assert.Equal(positions[^2], heartbeat.LastAppliedSortableUniqueId);
+        Assert.Equal(500, heartbeat.AppliedEventCount);
     }
 
     [Fact]
@@ -269,7 +381,15 @@ public class MinimalOrleansTests : IAsyncLifetime
 
                     // Add storage
                     services.AddSingleton<IEventStore>(SharedEventStore);
-                    services.AddSingleton<IMultiProjectionStateStore, Sekiban.Dcb.Testing.InMemoryMultiProjectionStateStore>();
+                    services.AddSingleton(SharedStateStore);
+                    services.AddSingleton<IMultiProjectionStateStore>(provider => provider.GetRequiredService<Sekiban.Dcb.Testing.InMemoryMultiProjectionStateStore>());
+                    services.AddSingleton<IProjectionStatusStore>(SharedStatusStore);
+                    services.AddSingleton(new ProjectionStatusOptions
+                    {
+                        HeartbeatInterval = TimeSpan.FromMilliseconds(100),
+                        HeartbeatWriteTimeout = TimeSpan.FromMilliseconds(50),
+                        HeartbeatFailureLogInterval = TimeSpan.FromSeconds(1)
+                    });
                     services.AddSingleton<IEventSubscriptionResolver>(
                         new DefaultOrleansEventSubscriptionResolver("EventStreamProvider", "AllEvents", Guid.Empty));
                     services.AddSingleton<IActorObjectAccessor, OrleansActorObjectAccessor>();
@@ -491,4 +611,40 @@ public class MinimalOrleansTests : IAsyncLifetime
                 e.Tags.ToList(),
                 e.EventType))
             .ToList();
+
+    private sealed class TestProjectionStatusStore : IProjectionStatusStore
+    {
+        private readonly IProjectionStatusStore _inner;
+
+        public TestProjectionStatusStore(IProjectionStatusStore inner) => _inner = inner;
+
+        public TimeSpan Delay { get; set; }
+        public bool SawCancelableToken { get; private set; }
+
+        public async Task<ResultBox<ProjectionStatusWriteResult>> UpsertAsync(
+            ProjectionStatusHeartbeat heartbeat,
+            long expectedSequence,
+            CancellationToken cancellationToken = default)
+        {
+            SawCancelableToken |= cancellationToken.CanBeCanceled;
+            if (Delay > TimeSpan.Zero)
+            {
+                await Task.Delay(Delay, cancellationToken);
+            }
+
+            return await _inner.UpsertAsync(heartbeat, expectedSequence, cancellationToken);
+        }
+
+        public Task<ResultBox<IReadOnlyList<ProjectionStatusHeartbeat>>> ListAsync(
+            string? projectorName = null,
+            string? projectorVersion = null,
+            CancellationToken cancellationToken = default) =>
+            _inner.ListAsync(projectorName, projectorVersion, cancellationToken);
+
+        public void Reset()
+        {
+            Delay = TimeSpan.Zero;
+            SawCancelableToken = false;
+        }
+    }
 }

--- a/dcb/tests/Sekiban.Dcb.Orleans.Tests/MinimalOrleansTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Orleans.Tests/MinimalOrleansTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using Microsoft.Extensions.DependencyInjection;
 using Orleans.TestingHost;
 using ResultBoxes;
@@ -29,11 +30,13 @@ public class MinimalOrleansTests : IAsyncLifetime
     private static readonly CountingInMemoryEventStore SharedEventStore = CreateSharedEventStore();
     private static readonly Sekiban.Dcb.Testing.InMemoryMultiProjectionStateStore SharedStateStore = new();
     private static readonly TestProjectionStatusStore SharedStatusStore = new(SharedStateStore);
+    private static readonly ProjectionStatusOptions SharedStatusOptions = new();
     private TestCluster _cluster = null!;
     private IClusterClient _client => _cluster.Client;
 
     public async Task InitializeAsync()
     {
+        ResetStatusOptions();
         var builder = new TestClusterBuilder();
         builder.Options.InitialSilosCount = 1;
         var uniqueId = Guid.NewGuid().ToString("N")[..8];
@@ -82,27 +85,63 @@ public class MinimalOrleansTests : IAsyncLifetime
     [Fact]
     public async Task PassiveStatusReader_DoesNotActivateGrain_WhileDirectGrainCallDoes()
     {
+        const string projectorName = "test-projector";
+        var activationCount = 0;
+        var backgroundCatchUpCount = 0;
+        var activationStarted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var backgroundStarted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var lifecycleObserver = CatchUpProductionTestHooks.Register(
+            DefaultServiceIdProvider.DefaultServiceId,
+            projectorName,
+            (point, _) =>
+            {
+                if (point == CatchUpProductionHookPoint.ActivationLifecycleStarted)
+                {
+                    Interlocked.Increment(ref activationCount);
+                    activationStarted.TrySetResult(true);
+                }
+                else if (point == CatchUpProductionHookPoint.BackgroundBeforeGate)
+                {
+                    Interlocked.Increment(ref backgroundCatchUpCount);
+                    backgroundStarted.TrySetResult(true);
+                }
+
+                return Task.CompletedTask;
+            });
+
         var reader = new ProjectionStatusReader(
             SharedStateStore,
             SharedEventStore,
             new DefaultServiceIdProvider(),
             new ProjectionStatusOptions { SamplingWindow = TimeSpan.Zero });
 
-        var before = await reader.ReadAsync(new ProjectionStatusReadRequest(ProjectorName: "empty-test"));
+        var before = await reader.ReadAsync(new ProjectionStatusReadRequest(ProjectorName: projectorName));
         Assert.True(before.IsSuccess);
         Assert.Empty(before.GetValue());
-        Assert.Empty((await SharedStateStore.ListAsync("empty-test", "1.0")).GetValue());
+        Assert.Empty((await SharedStateStore.ListAsync(projectorName, "1.0")).GetValue());
+
+        // Wait through the lifecycle/background-start interval. A passive reader must not cause even the grain
+        // lifecycle participant to run, so this is stronger than observing an empty heartbeat table.
+        await Task.Delay(TimeSpan.FromSeconds(1));
+        Assert.False(activationStarted.Task.IsCompleted);
+        Assert.Equal(0, Volatile.Read(ref activationCount));
+        Assert.Equal(0, Volatile.Read(ref backgroundCatchUpCount));
 
         // This is the contrast case: obtaining and calling a grain is the operation that creates the activation and
         // its dedicated heartbeat row.
-        var grain = _client.GetGrain<IMultiProjectionGrain>("empty-test");
+        var grain = _client.GetGrain<IMultiProjectionGrain>(projectorName);
         await grain.GetStatusAsync();
+
+        await activationStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await backgroundStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.Equal(1, Volatile.Read(ref activationCount));
+        Assert.Equal(1, Volatile.Read(ref backgroundCatchUpCount));
 
         var deadline = DateTime.UtcNow.AddSeconds(5);
         IReadOnlyList<ProjectionStatusHeartbeat> rows = Array.Empty<ProjectionStatusHeartbeat>();
         while (DateTime.UtcNow < deadline)
         {
-            rows = (await SharedStateStore.ListAsync("empty-test", "1.0")).GetValue();
+            rows = (await SharedStateStore.ListAsync(projectorName, "1.0")).GetValue();
             if (rows.Count > 0)
             {
                 break;
@@ -137,6 +176,89 @@ public class MinimalOrleansTests : IAsyncLifetime
             }
 
             Assert.True(SharedStatusStore.SawCancelableToken);
+        }
+        finally
+        {
+            SharedStatusStore.Reset();
+        }
+    }
+
+    [Fact]
+    public async Task FailingStatusRegistry_IsolatedFromRealGrainWork_AndRetriesWithCappedBackoff()
+    {
+        SharedStatusOptions.HeartbeatRetryBase = TimeSpan.FromSeconds(2);
+        SharedStatusOptions.HeartbeatRetryCap = TimeSpan.FromSeconds(3);
+        SharedStatusStore.ThrowOnUpsert = true;
+
+        try
+        {
+            var grain = _client.GetGrain<IMultiProjectionGrain>("test-projector");
+            var initialStatus = await grain.GetStatusAsync();
+            Assert.False(initialStatus.HasError);
+
+            await WaitUntilAsync(
+                () => SharedStatusStore.UpsertCalls >= 1,
+                TimeSpan.FromSeconds(2));
+            var callsBeforeProjectionWork = SharedStatusStore.UpsertCalls;
+
+            var baseTick = DateTime.UtcNow.Ticks;
+            var position = SortableUniqueId.GetTickString(baseTick) + SortableUniqueId.GetIdString(Guid.Empty);
+            var serializableEvent = new SerializableEvent(
+                Encoding.UTF8.GetBytes(JsonSerializer.Serialize(new TestProjectionEvent(42))),
+                position,
+                Guid.CreateVersion7(),
+                new EventMetadata(Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), "registry-failure-test"),
+                new List<string>(),
+                nameof(TestProjectionEvent));
+
+            // This is a real grain event/catch-up path. It must not synchronously write the passive registry; only the
+            // dedicated heartbeat timer is allowed to call the failing store.
+            await grain.SeedEventsAsync(new[] { serializableEvent });
+            MultiProjectionHeadStatusSnapshot projectionHead = await grain.GetProjectionHeadStatusAsync();
+            var projectionDeadline = DateTime.UtcNow.AddSeconds(5);
+            while (!string.Equals(projectionHead.CurrentLastSortableUniqueId, position, StringComparison.Ordinal) &&
+                   DateTime.UtcNow < projectionDeadline)
+            {
+                await grain.RefreshAsync();
+                projectionHead = await grain.GetProjectionHeadStatusAsync();
+                if (!string.Equals(projectionHead.CurrentLastSortableUniqueId, position, StringComparison.Ordinal))
+                {
+                    await Task.Delay(50);
+                }
+            }
+
+            var afterWorkStatus = await grain.GetStatusAsync();
+            var health = await grain.GetHealthStatusAsync();
+            var snapshot = await grain.GetSnapshotJsonAsync(canGetUnsafeState: false);
+            var received = await grain.IsSortableUniqueIdReceived(position);
+
+            Assert.True(
+                string.Equals(projectionHead.CurrentLastSortableUniqueId, position, StringComparison.Ordinal),
+                $"Expected current head {position}, actual current={projectionHead.CurrentLastSortableUniqueId}, " +
+                $"consistent={projectionHead.ConsistentLastSortableUniqueId}, " +
+                $"eventReads={SharedEventStore.ReadAllSerializableEventsCallCount}.");
+            Assert.True(SharedEventStore.ReadAllSerializableEventsCallCount > 0);
+            Assert.True(afterWorkStatus.EventsProcessed >= 1);
+            Assert.False(afterWorkStatus.HasError);
+            Assert.True(health.IsHealthy);
+            Assert.Null(health.LastError);
+            Assert.True(snapshot.IsSuccess, snapshot.IsSuccess ? string.Empty : snapshot.GetException().ToString());
+            Assert.True(received);
+            Assert.Equal(callsBeforeProjectionWork, SharedStatusStore.UpsertCalls);
+
+            // The failed write leaves the dirty/retry path armed. With a 2s base and 3s cap, later timer ticks
+            // provide observable intervals of approximately 2s, then 3s, and remain capped at 3s.
+            await WaitUntilAsync(
+                () => SharedStatusStore.UpsertCalls >= 4,
+                TimeSpan.FromSeconds(12));
+            var callTimes = SharedStatusStore.UpsertCallTimes;
+            Assert.True(callTimes.Count >= 4);
+            var intervals = callTimes
+                .Zip(callTimes.Skip(1), (first, second) => second - first)
+                .ToArray();
+            Assert.InRange(intervals[0], TimeSpan.FromSeconds(1.5), TimeSpan.FromSeconds(4));
+            Assert.InRange(intervals[1], TimeSpan.FromSeconds(2.5), TimeSpan.FromSeconds(5));
+            Assert.InRange(intervals[2], TimeSpan.FromSeconds(2.5), TimeSpan.FromSeconds(5));
         }
         finally
         {
@@ -384,12 +506,7 @@ public class MinimalOrleansTests : IAsyncLifetime
                     services.AddSingleton(SharedStateStore);
                     services.AddSingleton<IMultiProjectionStateStore>(provider => provider.GetRequiredService<Sekiban.Dcb.Testing.InMemoryMultiProjectionStateStore>());
                     services.AddSingleton<IProjectionStatusStore>(SharedStatusStore);
-                    services.AddSingleton(new ProjectionStatusOptions
-                    {
-                        HeartbeatInterval = TimeSpan.FromMilliseconds(100),
-                        HeartbeatWriteTimeout = TimeSpan.FromMilliseconds(50),
-                        HeartbeatFailureLogInterval = TimeSpan.FromSeconds(1)
-                    });
+                    services.AddSingleton(SharedStatusOptions);
                     services.AddSingleton<IEventSubscriptionResolver>(
                         new DefaultOrleansEventSubscriptionResolver("EventStreamProvider", "AllEvents", Guid.Empty));
                     services.AddSingleton<IActorObjectAccessor, OrleansActorObjectAccessor>();
@@ -615,18 +732,41 @@ public class MinimalOrleansTests : IAsyncLifetime
     private sealed class TestProjectionStatusStore : IProjectionStatusStore
     {
         private readonly IProjectionStatusStore _inner;
+        private readonly ConcurrentQueue<DateTimeOffset> _upsertCallTimes = new();
+        private int _upsertCalls;
+        private int _sawCancelableToken;
+        private int _throwOnUpsert;
 
         public TestProjectionStatusStore(IProjectionStatusStore inner) => _inner = inner;
 
         public TimeSpan Delay { get; set; }
-        public bool SawCancelableToken { get; private set; }
+        public bool ThrowOnUpsert
+        {
+            get => Volatile.Read(ref _throwOnUpsert) != 0;
+            set => Volatile.Write(ref _throwOnUpsert, value ? 1 : 0);
+        }
+
+        public int UpsertCalls => Volatile.Read(ref _upsertCalls);
+        public bool SawCancelableToken => Volatile.Read(ref _sawCancelableToken) != 0;
+        public IReadOnlyList<DateTimeOffset> UpsertCallTimes => _upsertCallTimes.ToArray();
 
         public async Task<ResultBox<ProjectionStatusWriteResult>> UpsertAsync(
             ProjectionStatusHeartbeat heartbeat,
             long expectedSequence,
             CancellationToken cancellationToken = default)
         {
-            SawCancelableToken |= cancellationToken.CanBeCanceled;
+            Interlocked.Increment(ref _upsertCalls);
+            _upsertCallTimes.Enqueue(DateTimeOffset.UtcNow);
+            if (cancellationToken.CanBeCanceled)
+            {
+                Interlocked.Exchange(ref _sawCancelableToken, 1);
+            }
+
+            if (ThrowOnUpsert)
+            {
+                throw new InvalidOperationException("Injected projection status registry failure.");
+            }
+
             if (Delay > TimeSpan.Zero)
             {
                 await Task.Delay(Delay, cancellationToken);
@@ -644,7 +784,38 @@ public class MinimalOrleansTests : IAsyncLifetime
         public void Reset()
         {
             Delay = TimeSpan.Zero;
-            SawCancelableToken = false;
+            ThrowOnUpsert = false;
+            Interlocked.Exchange(ref _upsertCalls, 0);
+            Interlocked.Exchange(ref _sawCancelableToken, 0);
+            while (_upsertCallTimes.TryDequeue(out _))
+            {
+            }
         }
+    }
+
+    private static async Task WaitUntilAsync(Func<bool> predicate, TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            if (predicate())
+            {
+                return;
+            }
+
+            await Task.Delay(20);
+        }
+
+        Assert.True(predicate(), $"Condition was not met within {timeout}.");
+    }
+
+    private static void ResetStatusOptions()
+    {
+        SharedStatusOptions.HeartbeatInterval = TimeSpan.FromMilliseconds(100);
+        SharedStatusOptions.HeartbeatWriteTimeout = TimeSpan.FromMilliseconds(50);
+        SharedStatusOptions.HeartbeatFailureLogInterval = TimeSpan.FromSeconds(1);
+        SharedStatusOptions.HeartbeatRetryBase = TimeSpan.FromSeconds(1);
+        SharedStatusOptions.HeartbeatRetryCap = TimeSpan.FromSeconds(30);
+        SharedStatusOptions.Enabled = true;
     }
 }

--- a/dcb/tests/Sekiban.Dcb.TestSupport/Sekiban.Dcb.TestSupport.csproj
+++ b/dcb/tests/Sekiban.Dcb.TestSupport/Sekiban.Dcb.TestSupport.csproj
@@ -5,6 +5,7 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
+        <IsTestProject>false</IsTestProject>
         <!-- Test-support only: shared fixtures for SEK-G13 and reused by SEK-G14. Not a product package. -->
     </PropertyGroup>
 

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/Cosmos/InMemoryCosmosContainer.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/Cosmos/InMemoryCosmosContainer.cs
@@ -100,6 +100,34 @@ public sealed class InMemoryCosmosContainer : NotSupportedCosmosContainer
     private static string Id_(JObject item) => item["id"]?.Value<string>() ?? string.Empty;
     private static string? ETagOf(JObject item) => item["_etag"]?.Value<string>();
 
+    private static bool IsProjectionStateDocument(JObject item)
+    {
+        var documentType = item["documentType"]?.Value<string>();
+        return documentType is null || string.Equals(documentType, "projectionState", StringComparison.Ordinal);
+    }
+
+    private static IEnumerable<JObject> FilterDocumentKind(
+        IEnumerable<JObject> rows,
+        string text,
+        IReadOnlyDictionary<string, object> parameters)
+    {
+        if (text.Contains("c.documentType = @documentType", StringComparison.Ordinal))
+        {
+            var documentType = (string)parameters["@documentType"];
+            return rows.Where(row => string.Equals(
+                row["documentType"]?.Value<string>(),
+                documentType,
+                StringComparison.Ordinal));
+        }
+
+        if (text.Contains("@projectionState", StringComparison.Ordinal))
+        {
+            return rows.Where(IsProjectionStateDocument);
+        }
+
+        return rows;
+    }
+
     private void ThrowIfFaulted()
     {
         if (WriteFaults.Count > 0)
@@ -414,6 +442,17 @@ public sealed class InMemoryCosmosContainer : NotSupportedCosmosContainer
             var pk = (string)parameters["@pk"];
             rows = rows.Where(row => Pk(row) == pk);
 
+            if (text.Contains("documentType", StringComparison.Ordinal))
+            {
+                rows = FilterDocumentKind(rows, text, parameters);
+                if (text.Contains("eventsProcessed DESC", StringComparison.Ordinal))
+                {
+                    rows = rows.OrderByDescending(row => row["eventsProcessed"]?.Value<long>() ?? 0);
+                }
+
+                return rows.ToList();
+            }
+
             // Repair's candidate prefilter: every Guid rendering, compared case-insensitively.
             if (text.Contains("STRINGEQUALS(c.eventId", StringComparison.Ordinal))
             {
@@ -448,6 +487,22 @@ public sealed class InMemoryCosmosContainer : NotSupportedCosmosContainer
         {
             var serviceId = (string)parameters["@serviceId"];
             rows = rows.Where(row => row["serviceId"]?.Value<string>() == serviceId);
+
+            if (text.Contains("documentType", StringComparison.Ordinal))
+            {
+                rows = FilterDocumentKind(rows, text, parameters);
+                if (parameters.TryGetValue("@projectorName", out var projectorName) && projectorName is string name)
+                {
+                    rows = rows.Where(row => row["projectorName"]?.Value<string>() == name);
+                }
+
+                if (parameters.TryGetValue("@projectorVersion", out var projectorVersion) && projectorVersion is string version)
+                {
+                    rows = rows.Where(row => row["projectorVersion"]?.Value<string>() == version);
+                }
+
+                return rows.ToList();
+            }
 
             if (parameters.TryGetValue("@since", out var since))
             {

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/ProjectionStatusRegistryTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/ProjectionStatusRegistryTests.cs
@@ -1,12 +1,27 @@
+using Amazon.DynamoDBv2;
+using Amazon.DynamoDBv2.Model;
 using System.Text;
 using System.Text.Json;
+using System.Reflection;
+using Microsoft.Extensions.Options;
 using Dcb.Domain;
 using Dcb.Domain.Student;
+using ResultBoxes;
 using Sekiban.Dcb;
 using Sekiban.Dcb.Actors;
+using Sekiban.Dcb.Common;
+using Sekiban.Dcb.CosmosDb;
+using Sekiban.Dcb.CosmosDb.Models;
+using Sekiban.Dcb.DynamoDB;
+using Sekiban.Dcb.Domains;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.MultiProjections;
 using Sekiban.Dcb.ServiceId;
 using Sekiban.Dcb.Sqlite;
 using Sekiban.Dcb.Storage;
+using Sekiban.Dcb.Storage.Checkpoints;
+using Sekiban.Dcb.Tags;
+using Sekiban.Dcb.Tests.Cosmos;
 using CoreInMemoryEventStore = Sekiban.Dcb.Testing.InMemoryEventStore;
 using CoreInMemoryMultiProjectionStateStore = Sekiban.Dcb.Testing.InMemoryMultiProjectionStateStore;
 
@@ -66,10 +81,16 @@ public sealed class ProjectionStatusRegistryTests
         var statusStore = new CoreInMemoryMultiProjectionStateStore(provider);
         var now = DateTimeOffset.UtcNow;
         var first = CreateHeartbeat("activation-a", 1, now);
-        var second = CreateHeartbeat("activation-b", 1, now);
+        var second = CreateHeartbeat("activation-c", 1, now) with { ClusterId = "cluster-b" };
 
         var committed = await statusStore.UpsertAsync(first, 0);
         var stale = await statusStore.UpsertAsync(first, 0);
+        var replacement = await statusStore.UpsertAsync(
+            first with { ActivationId = "activation-b", Sequence = 2 },
+            1);
+        var staleReplacement = await statusStore.UpsertAsync(
+            first with { ActivationId = "activation-a", Sequence = 3 },
+            1);
         var secondCommitted = await statusStore.UpsertAsync(second, 0);
 
         Assert.True(committed.IsSuccess);
@@ -77,6 +98,12 @@ public sealed class ProjectionStatusRegistryTests
         Assert.True(stale.IsSuccess);
         Assert.True(stale.GetValue().Conflict);
         Assert.Equal(1, stale.GetValue().Current!.Sequence);
+        Assert.True(replacement.IsSuccess);
+        Assert.True(replacement.GetValue().Committed);
+        Assert.Equal("activation-b", replacement.GetValue().Current!.ActivationId);
+        Assert.True(staleReplacement.IsSuccess);
+        Assert.True(staleReplacement.GetValue().Conflict);
+        Assert.Equal("activation-b", staleReplacement.GetValue().Current!.ActivationId);
         Assert.True(secondCommitted.IsSuccess);
 
         var eventStore = new CoreInMemoryEventStore(DomainType.GetDomainTypes().EventTypes, provider);
@@ -93,7 +120,7 @@ public sealed class ProjectionStatusRegistryTests
         Assert.All(snapshots, snapshot =>
         {
             Assert.True(snapshot.HasConflict);
-            Assert.Equal(new[] { "activation-a", "activation-b" }, snapshot.ConflictActivations);
+            Assert.Equal(new[] { "activation-b", "activation-c" }, snapshot.ConflictActivations);
         });
     }
 
@@ -121,6 +148,170 @@ public sealed class ProjectionStatusRegistryTests
             Encoding.UTF8.GetBytes("{\"version\":99,\"serviceId\":\"client\",\"snapshots\":[]}"));
         Assert.False(unsupported.IsSuccess);
         Assert.IsType<UnsupportedSerializedProjectionStatusVersionException>(unsupported.GetException());
+    }
+
+    [Fact]
+    public async Task SerializedRequestGate_RejectsBeforeAnyStoreRead_AndSeparatesVersionAndShapeErrors()
+    {
+        var provider = new MutableServiceIdProvider("server-service");
+        var eventStore = new CountingEventStore(provider);
+        var stateStore = new CoreInMemoryMultiProjectionStateStore(provider);
+        var statusStore = new CountingStatusStore(stateStore);
+        var serialized = new SerializedProjectionStatusReader(
+            new ProjectionStatusReader(
+                statusStore,
+                eventStore,
+                provider,
+                new ProjectionStatusOptions { SamplingWindow = TimeSpan.FromMinutes(1) }),
+            provider);
+
+        var rejectedInputs = new[]
+        {
+            "{}", // missing version
+            "{\"version\":\"1\"}", // wrong-typed version
+            "{\"version\":1,\"unknown\":true}", // unknown member
+            "{\"version\":1,\"projectorName\":42}", // wrong-typed filter
+            "not-json" // malformed JSON
+        };
+
+        foreach (var input in rejectedInputs)
+        {
+            var result = await serialized.AcceptAsync(Encoding.UTF8.GetBytes(input));
+            Assert.False(result.IsSuccess);
+            Assert.IsType<SerializedProjectionStatusShapeException>(result.GetException());
+        }
+
+        var unsupported = await serialized.AcceptAsync(
+            Encoding.UTF8.GetBytes("{\"version\":99,\"unknown\":{\"malformed\":true}}"));
+        Assert.False(unsupported.IsSuccess);
+        Assert.IsType<UnsupportedSerializedProjectionStatusVersionException>(unsupported.GetException());
+        Assert.Equal(0, statusStore.ListCalls);
+        Assert.Equal(0, eventStore.TotalCountCalls);
+        Assert.Equal(0, eventStore.CursorCountCalls);
+    }
+
+    [Fact]
+    public async Task SerializedRequestAndResponse_UseFrozenV1GoldenVectors()
+    {
+        var request = new ProjectionStatusReadRequest("server-service", "students", "v1");
+        Assert.Equal(
+            "{\"version\":1,\"serviceId\":\"server-service\",\"projectorName\":\"students\",\"projectorVersion\":\"v1\"}",
+            Encoding.UTF8.GetString(SerializedProjectionStatusReader.SerializeRequest(request)));
+
+        var snapshot = new ProjectionStatusSnapshot(
+            "students",
+            "v1",
+            "cluster-a",
+            "activation-a",
+            7,
+            3,
+            "0001",
+            "0002",
+            4,
+            0,
+            DateTimeOffset.Parse("2026-01-01T00:00:00+00:00"),
+            ProjectionStatusSnapshot.BestEffortConsistency,
+            true,
+            false,
+            Array.Empty<string>())
+        {
+            Phase = ProjectionStatusPhases.Active,
+            LeaseExpiresAtUtc = DateTimeOffset.Parse("2026-01-01T00:01:00+00:00"),
+            IsFaulted = false,
+            FaultMessage = null,
+            IsFresh = true
+        };
+        var adapter = new SerializedProjectionStatusReader(new FixedStatusReader(snapshot), new MutableServiceIdProvider("server-service"));
+        var response = await adapter.ReadSerializedAsync();
+
+        Assert.True(response.IsSuccess);
+        Assert.Equal(
+            "{\"version\":1,\"serviceId\":\"server-service\",\"snapshots\":[{\"projectorName\":\"students\",\"projectorVersion\":\"v1\",\"clusterId\":\"cluster-a\",\"activationId\":\"activation-a\",\"sequence\":7,\"appliedEventCount\":3,\"lastAppliedSortableUniqueId\":\"0001\",\"lastTraversedSortableUniqueId\":\"0002\",\"totalEventCount\":4,\"remainingEventCount\":0,\"sampledAtUtc\":\"2026-01-01T00:00:00+00:00\",\"consistency\":\"bestEffort\",\"isCaughtUp\":true,\"hasConflict\":false,\"conflictingActivationIds\":[],\"phase\":\"active\",\"leaseExpiresAtUtc\":\"2026-01-01T00:01:00+00:00\",\"isFaulted\":false,\"faultMessage\":null,\"isFresh\":true}]}",
+            Encoding.UTF8.GetString(response.GetValue()));
+    }
+
+    [Fact]
+    public async Task Reader_ReusesOneDenominatorPerServiceWindow_AndAggregatesDistinctCursors()
+    {
+        var provider = new MutableServiceIdProvider("alpha");
+        var eventStore = new CountingEventStore(provider) { CursorDelay = TimeSpan.FromMilliseconds(20) };
+        var stateStore = new CoreInMemoryMultiProjectionStateStore(provider);
+        var now = DateTimeOffset.UtcNow;
+        await stateStore.UpsertAsync(CreateHeartbeat("a", 1, now) with
+        {
+            LastTraversedSortableUniqueId = "0002",
+            Phase = ProjectionStatusPhases.Active,
+            LeaseExpiresAtUtc = now.AddMinutes(1)
+        }, 0);
+        await stateStore.UpsertAsync(CreateHeartbeat("b", 1, now) with
+        {
+            ClusterId = "cluster-b",
+            LastTraversedSortableUniqueId = "0002",
+            Phase = ProjectionStatusPhases.Active,
+            LeaseExpiresAtUtc = now.AddMinutes(1)
+        }, 0);
+        await stateStore.UpsertAsync(CreateHeartbeat("c", 1, now) with
+        {
+            ClusterId = "cluster-c",
+            LastTraversedSortableUniqueId = "0003",
+            Phase = ProjectionStatusPhases.Active,
+            LeaseExpiresAtUtc = now.AddMinutes(1)
+        }, 0);
+
+        var reader = new ProjectionStatusReader(
+            new CountingStatusStore(stateStore),
+            eventStore,
+            provider,
+            new ProjectionStatusOptions { SamplingWindow = TimeSpan.FromMinutes(1), MaxConcurrentReads = 2 });
+
+        var first = await reader.ReadAsync();
+        Assert.True(first.IsSuccess);
+        Assert.Equal(2, eventStore.CursorCountCalls);
+        var second = await reader.ReadAsync();
+
+        Assert.True(second.IsSuccess);
+        Assert.Equal(1, eventStore.TotalCountCalls);
+        Assert.Equal(4, eventStore.CursorCountCalls); // 0002 is sampled once and 0003 once per read.
+        Assert.Equal(2, eventStore.MaxConcurrentCursorReads);
+        Assert.All(first.GetValue(), snapshot => Assert.True(snapshot.HasConflict));
+        Assert.All(first.GetValue(), snapshot => Assert.False(snapshot.IsCaughtUp));
+    }
+
+    [Fact]
+    public async Task Reader_CaughtUpRequiresFreshNonFaultedNonConflictRow_AndSupportsEmptyStore()
+    {
+        var provider = new MutableServiceIdProvider("alpha");
+        var eventStore = new CountingEventStore(provider);
+        var stateStore = new CoreInMemoryMultiProjectionStateStore(provider);
+        var now = DateTimeOffset.UtcNow;
+
+        await stateStore.UpsertAsync(CreateHeartbeat("fresh", 1, now) with
+        {
+            Phase = ProjectionStatusPhases.Active,
+            LeaseExpiresAtUtc = now.AddMinutes(1)
+        }, 0);
+        var reader = new ProjectionStatusReader(
+            stateStore,
+            eventStore,
+            provider,
+            new ProjectionStatusOptions { SamplingWindow = TimeSpan.Zero });
+        var empty = await reader.ReadAsync();
+        Assert.True(empty.IsSuccess);
+        Assert.True(Assert.Single(empty.GetValue()).IsCaughtUp);
+        Assert.Equal(0, Assert.Single(empty.GetValue()).TotalEventCount);
+        Assert.Equal(0, Assert.Single(empty.GetValue()).RemainingEventCount);
+
+        await stateStore.UpsertAsync(CreateHeartbeat("faulted", 2, now) with
+        {
+            ClusterId = "cluster-b",
+            Phase = ProjectionStatusPhases.Faulted,
+            IsFaulted = true,
+            FaultMessage = "fold failed",
+            LeaseExpiresAtUtc = now.AddMinutes(1)
+        }, 0);
+        var withFault = await reader.ReadAsync();
+        Assert.True(withFault.IsSuccess);
+        Assert.Contains(withFault.GetValue(), item => item.IsFaulted && !item.IsCaughtUp);
     }
 
     [Fact]
@@ -153,6 +344,180 @@ public sealed class ProjectionStatusRegistryTests
         }
     }
 
+    [Fact]
+    public void ProviderStatusRows_UseClusterIdentity_AndPreserveMixedDocumentCompatibility()
+    {
+        var now = DateTimeOffset.UtcNow;
+        var first = CreateHeartbeat("activation-a", 1, now) with { Phase = ProjectionStatusPhases.Active };
+        var replacement = first with { ActivationId = "activation-b", Sequence = 2 };
+
+        var cosmosKey = typeof(Sekiban.Dcb.CosmosDb.CosmosMultiProjectionStateStore)
+            .GetMethod("BuildStatusId", BindingFlags.Static | BindingFlags.NonPublic)!
+            .Invoke(null, new object[] { first });
+        var replacementCosmosKey = typeof(Sekiban.Dcb.CosmosDb.CosmosMultiProjectionStateStore)
+            .GetMethod("BuildStatusId", BindingFlags.Static | BindingFlags.NonPublic)!
+            .Invoke(null, new object[] { replacement });
+        Assert.Equal(cosmosKey, replacementCosmosKey);
+
+        var dynamoKey = typeof(Sekiban.Dcb.DynamoDB.DynamoMultiProjectionStateStore)
+            .GetMethod("BuildStatusSortKey", BindingFlags.Static | BindingFlags.NonPublic)!
+            .Invoke(null, new object[] { first });
+        var replacementDynamoKey = typeof(Sekiban.Dcb.DynamoDB.DynamoMultiProjectionStateStore)
+            .GetMethod("BuildStatusSortKey", BindingFlags.Static | BindingFlags.NonPublic)!
+            .Invoke(null, new object[] { replacement });
+        Assert.Equal(dynamoKey, replacementDynamoKey);
+
+        var cosmos = Sekiban.Dcb.CosmosDb.Models.CosmosMultiProjectionState.FromStatusHeartbeat(
+            first,
+            (string)cosmosKey!,
+            "MultiProjectionState_students",
+            "alpha|MultiProjectionState_students");
+        Assert.Equal(first.ActivationId, cosmos.ToStatusHeartbeat().ActivationId);
+        Assert.Equal(first.Phase, cosmos.ToStatusHeartbeat().Phase);
+
+        var dynamo = Sekiban.Dcb.DynamoDB.Models.DynamoMultiProjectionState.FromStatusHeartbeat(
+            first,
+            "alpha",
+            (string)dynamoKey!);
+        var attributes = dynamo.ToAttributeValues();
+        Assert.Equal("projectionStatus", attributes["documentType"].S);
+        Assert.Equal(first.ActivationId, Sekiban.Dcb.DynamoDB.Models.DynamoMultiProjectionState
+            .FromAttributeValues(attributes).ToStatusHeartbeat().ActivationId);
+
+        // A legacy snapshot without documentType remains a projection-state document, not a status row.
+        var legacy = new Dictionary<string, Amazon.DynamoDBv2.Model.AttributeValue>
+        {
+            ["pk"] = new() { S = "SERVICE#alpha#PROJECTOR#students" },
+            ["sk"] = new() { S = "VERSION#v1" },
+            ["serviceId"] = new() { S = "alpha" },
+            ["projectorName"] = new() { S = "students" },
+            ["projectorVersion"] = new() { S = "v1" },
+            ["lastSortableUniqueId"] = new() { S = "0001" }
+        };
+        Assert.Equal("students", Sekiban.Dcb.DynamoDB.Models.DynamoMultiProjectionState
+            .FromAttributeValues(legacy).ToRecord().ProjectorName);
+    }
+
+    [Fact]
+    public async Task CosmosMixedDocuments_KeepStatusOutOfSnapshotListRestoreDeleteAll_AndCheckpointCas()
+    {
+        var client = new InMemoryCosmosClient();
+        var store = new CosmosMultiProjectionStateStore(
+            new CosmosDbContext(
+                client,
+                "test-db",
+                options: new CosmosDbEventStoreOptions
+                {
+                    MultiProjectionStatesContainerName = "multiProjectionStates"
+                }),
+            new MutableServiceIdProvider("alpha"),
+            new DefaultCosmosContainerResolver(new CosmosDbEventStoreOptions
+            {
+                MultiProjectionStatesContainerName = "multiProjectionStates"
+            }));
+        var status = CreateHeartbeat("status-activation", 1, DateTimeOffset.UtcNow);
+
+        Assert.True((await store.UpsertAsync(status, 0)).GetValue().Committed);
+
+        var checkpoint = (IGenerationAwareCheckpointStore)store;
+        var created = await checkpoint.ConditionalUpsertAsync(
+            CreateProjectionWriteRequest(),
+            new MemoryStream(Encoding.UTF8.GetBytes("snapshot")),
+            CheckpointExpectation.Absent,
+            1_000_000);
+        Assert.Equal(CheckpointCasStatus.Committed, created.Status);
+
+        var listed = await store.ListAllAsync();
+        Assert.True(listed.IsSuccess);
+        Assert.Single(listed.GetValue());
+        Assert.Equal("students", listed.GetValue()[0].ProjectorName);
+        Assert.Single((await store.ListAsync()).GetValue());
+
+        var restored = await store.GetLatestForVersionAsync("students", "v1");
+        Assert.True(restored.IsSuccess);
+        Assert.True(restored.GetValue().HasValue);
+
+        var deleted = await store.DeleteAllAsync();
+        Assert.True(deleted.IsSuccess);
+        Assert.Equal(1, deleted.GetValue());
+        Assert.Single((await store.ListAsync()).GetValue());
+
+        // A discriminator-less pre-G24 snapshot is accepted by the restore path after status rows have been written.
+        var legacy = CosmosMultiProjectionState.FromRecord(
+            CreateProjectionWriteRequest().ToRecord(),
+            "alpha");
+        legacy.DocumentType = null;
+        client.Container("multiProjectionStates").Seed(legacy);
+        var legacyRestored = await store.GetLatestForVersionAsync("students", "v1");
+        Assert.True(legacyRestored.IsSuccess);
+        Assert.True(legacyRestored.GetValue().HasValue);
+        Assert.Equal("students", legacyRestored.GetValue().Value!.ProjectorName);
+
+        var deletedLegacy = await store.DeleteAllAsync("students");
+        Assert.True(deletedLegacy.IsSuccess);
+        Assert.Equal(1, deletedLegacy.GetValue());
+        Assert.Empty((await store.ListAllAsync()).GetValue());
+        Assert.Single((await store.ListAsync()).GetValue());
+    }
+
+    [Fact]
+    public async Task DynamoMixedDocuments_KeepStatusOutOfSnapshotListRestoreDeleteAll_AndCheckpointCas()
+    {
+        var client = DispatchProxy.Create<IAmazonDynamoDB, MixedDynamoDb>();
+        var store = new DynamoMultiProjectionStateStore(
+            new DynamoDbContext(
+                client,
+                Options.Create(new DynamoDbEventStoreOptions
+                {
+                    AutoCreateTables = false,
+                    ProjectionStatesTableName = "states"
+                })),
+            new MutableServiceIdProvider("alpha"));
+        var status = CreateHeartbeat("status-activation", 1, DateTimeOffset.UtcNow);
+
+        Assert.True((await store.UpsertAsync(status, 0)).GetValue().Committed);
+
+        var checkpoint = (IGenerationAwareCheckpointStore)store;
+        var created = await checkpoint.ConditionalUpsertAsync(
+            CreateProjectionWriteRequest(),
+            new MemoryStream(Encoding.UTF8.GetBytes("snapshot")),
+            CheckpointExpectation.Absent,
+            1_000_000);
+        Assert.Equal(CheckpointCasStatus.Committed, created.Status);
+
+        var listed = await store.ListAllAsync();
+        Assert.True(listed.IsSuccess);
+        Assert.Single(listed.GetValue());
+        Assert.Single((await store.ListAsync()).GetValue());
+
+        var restored = await store.GetLatestForVersionAsync("students", "v1");
+        Assert.True(restored.IsSuccess);
+        Assert.True(restored.GetValue().HasValue);
+
+        var deleted = await store.DeleteAllAsync();
+        Assert.True(deleted.IsSuccess);
+        Assert.Equal(1, deleted.GetValue());
+        Assert.Single((await store.ListAsync()).GetValue());
+
+        // A discriminator-less pre-G24 snapshot is accepted by Dynamo restore and snapshot cleanup paths.
+        var legacy = Sekiban.Dcb.DynamoDB.Models.DynamoMultiProjectionState
+            .FromRecord(CreateProjectionWriteRequest().ToRecord(), "alpha")
+            .ToAttributeValues();
+        legacy.Remove("documentType");
+        MixedDynamoDb.LastCreated!.Seed(legacy);
+
+        var legacyRestored = await store.GetLatestForVersionAsync("students", "v1");
+        Assert.True(legacyRestored.IsSuccess);
+        Assert.True(legacyRestored.GetValue().HasValue);
+        Assert.Equal("students", legacyRestored.GetValue().Value!.ProjectorName);
+
+        var deletedLegacy = await store.DeleteAllAsync("students");
+        Assert.True(deletedLegacy.IsSuccess);
+        Assert.Equal(1, deletedLegacy.GetValue());
+        Assert.Empty((await store.ListAllAsync()).GetValue());
+        Assert.Single((await store.ListAsync()).GetValue());
+    }
+
     private static ProjectionStatusHeartbeat CreateHeartbeat(
         string activationId,
         long sequence,
@@ -168,6 +533,323 @@ public sealed class ProjectionStatusRegistryTests
             null,
             null,
             recordedAtUtc);
+
+    private static MultiProjectionStateWriteRequest CreateProjectionWriteRequest() => new(
+        "students",
+        "v1",
+        "Payload",
+        "0001",
+        1,
+        false,
+        null,
+        null,
+        1,
+        1,
+        "0000",
+        new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+        new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+        "test",
+        null);
+
+    private sealed class FixedStatusReader : IProjectionStatusReader
+    {
+        private readonly IReadOnlyList<ProjectionStatusSnapshot> _snapshots;
+
+        public FixedStatusReader(ProjectionStatusSnapshot snapshot) => _snapshots = new[] { snapshot };
+
+        public Task<ResultBox<IReadOnlyList<ProjectionStatusSnapshot>>> ReadAsync(
+            ProjectionStatusReadRequest? request = null,
+            CancellationToken cancellationToken = default) =>
+            Task.FromResult(ResultBox.FromValue(_snapshots));
+    }
+
+    private sealed class CountingStatusStore : IProjectionStatusStore
+    {
+        private readonly IProjectionStatusStore _inner;
+
+        public CountingStatusStore(IProjectionStatusStore inner) => _inner = inner;
+
+        public int ListCalls { get; private set; }
+
+        public Task<ResultBox<ProjectionStatusWriteResult>> UpsertAsync(
+            ProjectionStatusHeartbeat heartbeat,
+            long expectedSequence,
+            CancellationToken cancellationToken = default) =>
+            _inner.UpsertAsync(heartbeat, expectedSequence, cancellationToken);
+
+        public Task<ResultBox<IReadOnlyList<ProjectionStatusHeartbeat>>> ListAsync(
+            string? projectorName = null,
+            string? projectorVersion = null,
+            CancellationToken cancellationToken = default)
+        {
+            ListCalls++;
+            return _inner.ListAsync(projectorName, projectorVersion, cancellationToken);
+        }
+    }
+
+    private sealed class CountingEventStore : IEventStore
+    {
+        private readonly CoreInMemoryEventStore _inner;
+        private int _activeCursorReads;
+
+        public CountingEventStore(IServiceIdProvider provider)
+        {
+            _inner = new CoreInMemoryEventStore(DomainType.GetDomainTypes().EventTypes, provider);
+        }
+
+        public int TotalCountCalls { get; private set; }
+        public int CursorCountCalls { get; private set; }
+        public int MaxConcurrentCursorReads { get; private set; }
+        public TimeSpan CursorDelay { get; set; }
+
+        public Task<ResultBox<IEnumerable<TagStream>>> ReadTagsAsync(ITag tag) => _inner.ReadTagsAsync(tag);
+        public Task<ResultBox<TagState>> GetLatestTagAsync(ITag tag) => _inner.GetLatestTagAsync(tag);
+        public Task<ResultBox<bool>> TagExistsAsync(ITag tag) => _inner.TagExistsAsync(tag);
+
+        public async Task<ResultBox<long>> GetEventCountAsync(SortableUniqueId? since = null)
+        {
+            if (since is null)
+            {
+                TotalCountCalls++;
+                return await _inner.GetEventCountAsync(since);
+            }
+
+            CursorCountCalls++;
+            var active = Interlocked.Increment(ref _activeCursorReads);
+            MaxConcurrentCursorReads = Math.Max(MaxConcurrentCursorReads, active);
+            try
+            {
+                if (CursorDelay > TimeSpan.Zero)
+                {
+                    await Task.Delay(CursorDelay);
+                }
+
+                return await _inner.GetEventCountAsync(since);
+            }
+            finally
+            {
+                Interlocked.Decrement(ref _activeCursorReads);
+            }
+        }
+
+        public Task<ResultBox<IEnumerable<TagInfo>>> GetAllTagsAsync(string? tagGroup = null) => _inner.GetAllTagsAsync(tagGroup);
+        public Task<ResultBox<IEnumerable<SerializableEvent>>> ReadAllSerializableEventsAsync(SortableUniqueId? since = null) => _inner.ReadAllSerializableEventsAsync(since);
+        public Task<ResultBox<IEnumerable<SerializableEvent>>> ReadAllSerializableEventsAsync(SortableUniqueId? since, int? maxCount) => _inner.ReadAllSerializableEventsAsync(since, maxCount);
+        public Task<ResultBox<SerializableEvent>> ReadSerializableEventAsync(Guid eventId) => _inner.ReadSerializableEventAsync(eventId);
+        public Task<ResultBox<IEnumerable<SerializableEvent>>> ReadSerializableEventsByTagAsync(ITag tag, SortableUniqueId? since = null) => _inner.ReadSerializableEventsByTagAsync(tag, since);
+        public Task<ResultBox<(IReadOnlyList<SerializableEvent> Events, IReadOnlyList<TagWriteResult> TagWrites)>> WriteSerializableEventsAsync(IEnumerable<SerializableEvent> events) => _inner.WriteSerializableEventsAsync(events);
+        public Task<ResultBox<string>> GetLatestSortableUniqueIdAsync() => _inner.GetLatestSortableUniqueIdAsync();
+    }
+
+    private class MixedDynamoDb : DispatchProxy
+    {
+        private readonly Dictionary<(string Pk, string Sk), Dictionary<string, AttributeValue>> _items = new();
+        private readonly object _gate = new();
+
+        public static MixedDynamoDb? LastCreated { get; private set; }
+
+        public MixedDynamoDb() => LastCreated = this;
+
+        public void Seed(Dictionary<string, AttributeValue> item)
+        {
+            lock (_gate)
+            {
+                _items[KeyOf(item)] = Clone(item);
+            }
+        }
+
+        protected override object? Invoke(MethodInfo? targetMethod, object?[]? args)
+        {
+            var name = targetMethod?.Name ?? string.Empty;
+            var request = args is { Length: > 0 } ? args[0] : null;
+            return request switch
+            {
+                GetItemRequest get when name == nameof(IAmazonDynamoDB.GetItemAsync) => Task.FromResult(Get(get)),
+                PutItemRequest put when name == nameof(IAmazonDynamoDB.PutItemAsync) => Task.FromResult(Put(put)),
+                ScanRequest scan when name == nameof(IAmazonDynamoDB.ScanAsync) => Task.FromResult(Scan(scan)),
+                QueryRequest query when name == nameof(IAmazonDynamoDB.QueryAsync) => Task.FromResult(Query(query)),
+                DeleteItemRequest delete when name == nameof(IAmazonDynamoDB.DeleteItemAsync) => Task.FromResult(Delete(delete)),
+                _ when name == "Dispose" => null,
+                _ when name.StartsWith("get_", StringComparison.Ordinal) => null,
+                _ => throw new NotSupportedException($"MixedDynamoDb does not support {name}")
+            };
+        }
+
+        private static (string Pk, string Sk) KeyOf(Dictionary<string, AttributeValue> item) =>
+            (item["pk"].S, item["sk"].S);
+
+        private static Dictionary<string, AttributeValue> Clone(Dictionary<string, AttributeValue> item) =>
+            item.ToDictionary(pair => pair.Key, pair => pair.Value, StringComparer.Ordinal);
+
+        private GetItemResponse Get(GetItemRequest request)
+        {
+            lock (_gate)
+            {
+                var key = (request.Key["pk"].S, request.Key["sk"].S);
+                return new GetItemResponse
+                {
+                    Item = _items.TryGetValue(key, out var item)
+                        ? Clone(item)
+                        : new Dictionary<string, AttributeValue>()
+                };
+            }
+        }
+
+        private PutItemResponse Put(PutItemRequest request)
+        {
+            lock (_gate)
+            {
+                var key = KeyOf(request.Item);
+                _items.TryGetValue(key, out var current);
+                if (!Evaluate(
+                        request.ConditionExpression,
+                        current,
+                        request.ExpressionAttributeNames,
+                        request.ExpressionAttributeValues))
+                {
+                    throw new ConditionalCheckFailedException("The conditional request failed");
+                }
+
+                _items[key] = Clone(request.Item);
+                return new PutItemResponse();
+            }
+        }
+
+        private ScanResponse Scan(ScanRequest request)
+        {
+            lock (_gate)
+            {
+                var rows = Filter(_items.Values, request.FilterExpression, request.ExpressionAttributeValues).ToList();
+                return new ScanResponse
+                {
+                    Items = rows.Select(Clone).ToList(),
+                    LastEvaluatedKey = new Dictionary<string, AttributeValue>()
+                };
+            }
+        }
+
+        private QueryResponse Query(QueryRequest request)
+        {
+            lock (_gate)
+            {
+                var pk = request.ExpressionAttributeValues![":pk"].S;
+                var rows = Filter(
+                    _items.Values.Where(item => item["pk"].S == pk),
+                    request.FilterExpression,
+                    request.ExpressionAttributeValues).ToList();
+                if (request.FilterExpression?.Contains("documentType", StringComparison.Ordinal) == true)
+                {
+                    rows = rows.OrderByDescending(item =>
+                        long.TryParse(item.GetValueOrDefault("eventsProcessed")?.N, out var count) ? count : 0).ToList();
+                }
+
+                return new QueryResponse
+                {
+                    Items = rows.Select(Clone).ToList(),
+                    LastEvaluatedKey = new Dictionary<string, AttributeValue>()
+                };
+            }
+        }
+
+        private DeleteItemResponse Delete(DeleteItemRequest request)
+        {
+            lock (_gate)
+            {
+                _items.Remove((request.Key["pk"].S, request.Key["sk"].S));
+                return new DeleteItemResponse();
+            }
+        }
+
+        private static IEnumerable<Dictionary<string, AttributeValue>> Filter(
+            IEnumerable<Dictionary<string, AttributeValue>> source,
+            string? expression,
+            Dictionary<string, AttributeValue>? values)
+        {
+            var rows = source;
+            if (values?.TryGetValue(":serviceId", out var serviceId) == true)
+            {
+                rows = rows.Where(item => item.GetValueOrDefault("serviceId")?.S == serviceId.S);
+            }
+
+            if (values?.TryGetValue(":projectorName", out var projectorName) == true)
+            {
+                rows = rows.Where(item => item.GetValueOrDefault("projectorName")?.S == projectorName.S);
+            }
+
+            if (values?.TryGetValue(":projectorVersion", out var projectorVersion) == true)
+            {
+                rows = rows.Where(item => item.GetValueOrDefault("projectorVersion")?.S == projectorVersion.S);
+            }
+
+            if (expression?.Contains("documentType = :statusType", StringComparison.Ordinal) == true)
+            {
+                rows = rows.Where(item => item.GetValueOrDefault("documentType")?.S == "projectionStatus");
+            }
+            else if (expression?.Contains("attribute_not_exists(documentType)", StringComparison.Ordinal) == true)
+            {
+                rows = rows.Where(item =>
+                    !item.ContainsKey("documentType") || item.GetValueOrDefault("documentType")?.S == "projectionState");
+            }
+
+            return rows;
+        }
+
+        private static bool Evaluate(
+            string? expression,
+            Dictionary<string, AttributeValue>? current,
+            Dictionary<string, string>? names,
+            Dictionary<string, AttributeValue>? values)
+        {
+            if (string.IsNullOrWhiteSpace(expression))
+            {
+                return true;
+            }
+
+            if (expression.Contains("attribute_not_exists(pk)", StringComparison.Ordinal))
+            {
+                return current is null;
+            }
+
+            if (current is null || values is null)
+            {
+                return false;
+            }
+
+            foreach (var clause in expression.Split(" AND ", StringSplitOptions.None))
+            {
+                var comparison = clause.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+                if (comparison.Length != 3)
+                {
+                    return false;
+                }
+
+                var attribute = comparison[0].StartsWith('#') && names is not null
+                    ? names[comparison[0]]
+                    : comparison[0];
+                if (!current.TryGetValue(attribute, out var actual) ||
+                    !values.TryGetValue(comparison[2], out var expected))
+                {
+                    return false;
+                }
+
+                var actualNumber = long.TryParse(actual.N, out var actualN) ? actualN : 0;
+                var expectedNumber = long.TryParse(expected.N, out var expectedN) ? expectedN : 0;
+                var matches = comparison[1] switch
+                {
+                    "=" => string.Equals(actual.N, expected.N, StringComparison.Ordinal) ||
+                        string.Equals(actual.S, expected.S, StringComparison.Ordinal),
+                    "<" => actualNumber < expectedNumber,
+                    _ => false
+                };
+                if (!matches)
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+    }
 
     private sealed class MutableServiceIdProvider : IServiceIdProvider
     {

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/ProjectionStatusRegistryTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/ProjectionStatusRegistryTests.cs
@@ -1,0 +1,180 @@
+using System.Text;
+using System.Text.Json;
+using Dcb.Domain;
+using Dcb.Domain.Student;
+using Sekiban.Dcb;
+using Sekiban.Dcb.Actors;
+using Sekiban.Dcb.ServiceId;
+using Sekiban.Dcb.Sqlite;
+using Sekiban.Dcb.Storage;
+using CoreInMemoryEventStore = Sekiban.Dcb.Testing.InMemoryEventStore;
+using CoreInMemoryMultiProjectionStateStore = Sekiban.Dcb.Testing.InMemoryMultiProjectionStateStore;
+
+namespace Sekiban.Dcb.Tests;
+
+public sealed class ProjectionStatusRegistryTests
+{
+    [Fact]
+    public async Task Reader_UsesLastTraversedCursor_AndKeepsAppliedCountDistinct()
+    {
+        var provider = new MutableServiceIdProvider("alpha");
+        var domainTypes = DomainType.GetDomainTypes();
+        var eventStore = new CoreInMemoryEventStore(domainTypes.EventTypes, provider);
+        var statusStore = new CoreInMemoryMultiProjectionStateStore(provider);
+        var events = new[]
+        {
+            EventTestHelper.CreateEvent(new StudentCreated(Guid.NewGuid(), "Alice"),
+                new StudentTag(Guid.NewGuid())),
+            EventTestHelper.CreateEvent(new StudentCreated(Guid.NewGuid(), "Bob"),
+                new StudentTag(Guid.NewGuid()))
+        }.OrderBy(item => item.SortableUniqueIdValue).ToArray();
+
+        var write = await eventStore.WriteEventsAsync(events, domainTypes.EventTypes);
+        Assert.True(write.IsSuccess);
+
+        var heartbeat = new ProjectionStatusHeartbeat(
+            "alpha",
+            "students",
+            "v1",
+            "cluster-a",
+            "activation-a",
+            1,
+            1,
+            events[0].SortableUniqueIdValue,
+            events[1].SortableUniqueIdValue,
+            DateTimeOffset.UtcNow);
+        var heartbeatWrite = await statusStore.UpsertAsync(heartbeat, 0);
+        Assert.True(heartbeatWrite.IsSuccess);
+
+        var reader = new ProjectionStatusReader(statusStore, eventStore, provider);
+        var result = await reader.ReadAsync(new ProjectionStatusReadRequest(ProjectorName: "students"));
+
+        Assert.True(result.IsSuccess);
+        var snapshot = Assert.Single(result.GetValue());
+        Assert.Equal(2, snapshot.TotalEventCount);
+        Assert.Equal(0, snapshot.RemainingEventCount);
+        Assert.Equal(1, snapshot.AppliedEventCount);
+        Assert.Equal(events[1].SortableUniqueIdValue, snapshot.LastTraversedSortableUniqueId);
+        Assert.True(snapshot.IsCaughtUp);
+        Assert.Equal(ProjectionStatusSnapshot.BestEffortConsistency, snapshot.Consistency);
+    }
+
+    [Fact]
+    public async Task Registry_CasRejectsStaleWriter_AndReaderSurfacesFreshActivationConflict()
+    {
+        var provider = new MutableServiceIdProvider("alpha");
+        var statusStore = new CoreInMemoryMultiProjectionStateStore(provider);
+        var now = DateTimeOffset.UtcNow;
+        var first = CreateHeartbeat("activation-a", 1, now);
+        var second = CreateHeartbeat("activation-b", 1, now);
+
+        var committed = await statusStore.UpsertAsync(first, 0);
+        var stale = await statusStore.UpsertAsync(first, 0);
+        var secondCommitted = await statusStore.UpsertAsync(second, 0);
+
+        Assert.True(committed.IsSuccess);
+        Assert.True(committed.GetValue().Committed);
+        Assert.True(stale.IsSuccess);
+        Assert.True(stale.GetValue().Conflict);
+        Assert.Equal(1, stale.GetValue().Current!.Sequence);
+        Assert.True(secondCommitted.IsSuccess);
+
+        var eventStore = new CoreInMemoryEventStore(DomainType.GetDomainTypes().EventTypes, provider);
+        var reader = new ProjectionStatusReader(
+            statusStore,
+            eventStore,
+            provider,
+            new ProjectionStatusOptions { FreshnessWindow = TimeSpan.FromMinutes(5) });
+        var result = await reader.ReadAsync();
+
+        Assert.True(result.IsSuccess);
+        var snapshots = result.GetValue();
+        Assert.Equal(2, snapshots.Count);
+        Assert.All(snapshots, snapshot =>
+        {
+            Assert.True(snapshot.HasConflict);
+            Assert.Equal(new[] { "activation-a", "activation-b" }, snapshot.ConflictActivations);
+        });
+    }
+
+    [Fact]
+    public async Task SerializedReader_EmitsV1Envelope_AndRejectsUnknownVersionBeforeBinding()
+    {
+        var provider = new MutableServiceIdProvider("server-service");
+        var eventStore = new CoreInMemoryEventStore(DomainType.GetDomainTypes().EventTypes, provider);
+        var statusStore = new CoreInMemoryMultiProjectionStateStore(provider);
+        var reader = new SerializedProjectionStatusReader(
+            new ProjectionStatusReader(statusStore, eventStore, provider),
+            provider);
+
+        var serialized = await reader.ReadSerializedAsync();
+        Assert.True(serialized.IsSuccess);
+        using var document = JsonDocument.Parse(serialized.GetValue());
+        Assert.Equal(1, document.RootElement.GetProperty("version").GetInt32());
+        Assert.Equal("server-service", document.RootElement.GetProperty("serviceId").GetString());
+
+        var roundTrip = SerializedProjectionStatusReader.Deserialize(serialized.GetValue());
+        Assert.True(roundTrip.IsSuccess);
+        Assert.Equal("server-service", roundTrip.GetValue().ServiceId);
+
+        var unsupported = SerializedProjectionStatusReader.Deserialize(
+            Encoding.UTF8.GetBytes("{\"version\":99,\"serviceId\":\"client\",\"snapshots\":[]}"));
+        Assert.False(unsupported.IsSuccess);
+        Assert.IsType<UnsupportedSerializedProjectionStatusVersionException>(unsupported.GetException());
+    }
+
+    [Fact]
+    public async Task SqliteStatusStore_AutoCreatesTable_AndRejectsStaleSequence()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"sekiban-projection-status-{Guid.NewGuid():N}.db");
+        try
+        {
+            var provider = new MutableServiceIdProvider("alpha");
+            var store = new SqliteMultiProjectionStateStore(path, serviceIdProvider: provider);
+            var heartbeat = CreateHeartbeat("activation-a", 1, DateTimeOffset.UtcNow);
+
+            var committed = await store.UpsertAsync(heartbeat, 0);
+            var stale = await store.UpsertAsync(heartbeat with { Sequence = 2 }, 0);
+            var rows = await store.ListAsync("students", "v1");
+
+            Assert.True(committed.IsSuccess);
+            Assert.True(committed.GetValue().Committed);
+            Assert.True(stale.IsSuccess);
+            Assert.True(stale.GetValue().Conflict);
+            Assert.True(rows.IsSuccess);
+            Assert.Single(rows.GetValue());
+        }
+        finally
+        {
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
+    }
+
+    private static ProjectionStatusHeartbeat CreateHeartbeat(
+        string activationId,
+        long sequence,
+        DateTimeOffset recordedAtUtc) =>
+        new(
+            "alpha",
+            "students",
+            "v1",
+            "cluster-a",
+            activationId,
+            sequence,
+            0,
+            null,
+            null,
+            recordedAtUtc);
+
+    private sealed class MutableServiceIdProvider : IServiceIdProvider
+    {
+        private readonly string _serviceId;
+
+        public MutableServiceIdProvider(string serviceId) => _serviceId = serviceId;
+
+        public string GetCurrentServiceId() => ServiceIdValidator.NormalizeAndValidate(_serviceId);
+    }
+}

--- a/docs/dcb_llm/04_multiple_aggregate_projector.md
+++ b/docs/dcb_llm/04_multiple_aggregate_projector.md
@@ -56,6 +56,33 @@ The sample domain registers multiple generic projectors in `internalUsages/Dcb.D
 
 `src/Sekiban.Dcb.Orleans/Grains/MultiProjectionGrain.cs` contains the orchestrator that wires these pieces together.
 
+## Passive projection status (SEK-G24 / dcb-v10.10.0)
+
+Fleet dashboards can read a catch-up sample without activating a projection grain. Provider registrations include the
+passive `IProjectionStatusReader` and `ISerializedProjectionStatusReader` surfaces:
+
+```csharp
+var reader = serviceProvider.GetRequiredService<IProjectionStatusReader>();
+var result = await reader.ReadAsync(new ProjectionStatusReadRequest(ProjectorName: "WeatherForecast"));
+```
+
+Each `MultiProjectionGrain` writes a best-effort heartbeat on a dedicated 30-second timer. The timer is interleaved,
+non-keep-alive, fenced by `(ClusterId, ActivationId, Sequence)`, and retries storage failures with bounded backoff.
+Projection execution is never blocked by a status write. The passive reader samples the event-store denominator once,
+then counts events after each distinct `LastTraversedSortableUniqueId`; this cursor includes filtered events, so
+`AppliedEventCount` may be smaller than the traversed head while `RemainingEventCount` is zero. Every sample carries
+`SampledAtUtc` and `Consistency == "bestEffort"`; it is not an atomic head/count transaction.
+
+Use the three status tiers for different operator questions: (1) the passive registry for a fleet-wide catch-up
+overview, (2) the persisted snapshot APIs for restoration/checkpoint detail, and (3) an activated grain query when an
+authoritative, current projection result is required. The existing snapshot and grain status APIs remain unchanged.
+
+For Cloud/WASM transport, use the additive `ISerializedProjectionStatusReader` and its V1 envelope. The serialized
+boundary binds `ServiceId` from the server's `IServiceIdProvider`; a client cannot select another service. Keep the
+endpoint operator-only and default-deny it at the host boundary: map it only when needed and require an explicit
+authorization policy (for example, `RequireAuthorization("ProjectionStatusOperator")`). Do not expose it with
+`AllowAnonymous`; the existing `ISerializedSekibanDcbExecutor` contract is unchanged.
+
 ## Snapshot Offloading
 
 Large projections can use `Sekiban.Dcb.BlobStorage.AzureStorage` to persist snapshots in Azure Blob Storage.

--- a/docs/dcb_llm/04_multiple_aggregate_projector.md
+++ b/docs/dcb_llm/04_multiple_aggregate_projector.md
@@ -67,11 +67,15 @@ var result = await reader.ReadAsync(new ProjectionStatusReadRequest(ProjectorNam
 ```
 
 Each `MultiProjectionGrain` writes a best-effort heartbeat on a dedicated 30-second timer. The timer is interleaved,
-non-keep-alive, fenced by `(ClusterId, ActivationId, Sequence)`, and retries storage failures with bounded backoff.
-Projection execution is never blocked by a status write. The passive reader samples the event-store denominator once,
-then counts events after each distinct `LastTraversedSortableUniqueId`; this cursor includes filtered events, so
-`AppliedEventCount` may be smaller than the traversed head while `RemainingEventCount` is zero. Every sample carries
-`SampledAtUtc` and `Consistency == "bestEffort"`; it is not an atomic head/count transaction.
+non-keep-alive, and uses one CAS row per `(ServiceId, ProjectorName, ProjectorVersion, ClusterId)`; `ActivationId` is
+data in that row, so a replacement activation cannot create a second row or bypass the sequence fence. Storage writes
+use an independent bounded timeout, retry with capped backoff, and rate-limit repeated failure logs. Projection
+execution is never blocked by a status write. The passive reader samples one event-store denominator per service per
+sampling window (five seconds by default), then counts events after each distinct `LastTraversedSortableUniqueId`
+with bounded parallelism; this cursor includes filtered events, so `AppliedEventCount` may be smaller than the
+traversed head while `RemainingEventCount` is zero. `IsCaughtUp` additionally requires a fresh leased row that is
+not faulted and has no fresh-cluster conflict. Every sample carries `SampledAtUtc` and `Consistency == "bestEffort"`;
+it is not an atomic head/count transaction.
 
 Use the three status tiers for different operator questions: (1) the passive registry for a fleet-wide catch-up
 overview, (2) the persisted snapshot APIs for restoration/checkpoint detail, and (3) an activated grain query when an

--- a/docs/dcb_llm/11_storage_providers.md
+++ b/docs/dcb_llm/11_storage_providers.md
@@ -146,9 +146,11 @@ services.AddSingleton<IBlobStorageSnapshotAccessor>(sp =>
 
 The passive `IProjectionStatusStore` is registered alongside each provider's projection-state store, and the
 `IProjectionStatusReader` composes its rows with event-store counts without resolving a grain. The sample is explicitly
-best effort: one denominator is sampled per read, remaining counts are taken after each distinct traversed cursor, and
-`SampledAtUtc` identifies the read window. A fresh row per `(ProjectorName, ProjectorVersion, ClusterId)` with more than
-one `ActivationId` is reported as a conflict; providers never silently last-write-wins a stale activation.
+best effort: one denominator is sampled per service per sampling window (five seconds by default), remaining counts are
+taken after each distinct traversed cursor with bounded parallelism, and `SampledAtUtc` identifies the sample window.
+The CAS row identity is `(ServiceId, ProjectorName, ProjectorVersion, ClusterId)`; `ActivationId` is retained as row
+data. More than one fresh row across clusters for a `(ProjectorName, ProjectorVersion)` is reported as a conflict, and
+providers reject stale activation replacements instead of silently last-write-wins updating a different row.
 
 Storage layout and upgrade behavior:
 

--- a/docs/dcb_llm/11_storage_providers.md
+++ b/docs/dcb_llm/11_storage_providers.md
@@ -142,6 +142,38 @@ services.AddSingleton<IBlobStorageSnapshotAccessor>(sp =>
 | DynamoDB | `Sekiban.Dcb.DynamoDB` | `Sekiban.Dcb.BlobStorage.S3` | Production |
 | SQLite | `Sekiban.Dcb.Sqlite` | N/A | Development |
 
+## Passive projection status registry (SEK-G24 / dcb-v10.10.0)
+
+The passive `IProjectionStatusStore` is registered alongside each provider's projection-state store, and the
+`IProjectionStatusReader` composes its rows with event-store counts without resolving a grain. The sample is explicitly
+best effort: one denominator is sampled per read, remaining counts are taken after each distinct traversed cursor, and
+`SampledAtUtc` identifies the read window. A fresh row per `(ProjectorName, ProjectorVersion, ClusterId)` with more than
+one `ActivationId` is reported as a conflict; providers never silently last-write-wins a stale activation.
+
+Storage layout and upgrade behavior:
+
+- PostgreSQL and SQLite create a dedicated `dcb_projection_statuses` table automatically, including on an existing
+  database. Heartbeats use an atomic expected-sequence CAS.
+- Cosmos DB and DynamoDB co-locate status rows with projection snapshots and mark them with
+  `documentType = "projectionStatus"`. Snapshot list, delete, scan, and latest-version queries accept legacy
+  discriminator-less snapshots but exclude status rows.
+- DynamoDB status listing intentionally uses a bounded filtered scan in this slice; add a dedicated status GSI only if
+  fleet size makes that escalation worthwhile.
+- Status reads and count sampling are read-only with respect to projection state; no grain activation is required.
+
+The serialized surface is the new `ISerializedProjectionStatusReader` with a V1 envelope. Its `ServiceId` is always
+bound from the server-side provider. Hosts should keep the endpoint absent or protected by an explicit operator policy
+by default, for example:
+
+```csharp
+app.MapGet("/ops/projection-status", async (ISerializedProjectionStatusReader reader) =>
+        Results.Bytes((await reader.ReadSerializedAsync()).GetValue(), "application/json"))
+   .RequireAuthorization("ProjectionStatusOperator");
+```
+
+Never use `AllowAnonymous` for this surface. `ISerializedSekibanDcbExecutor` remains untouched. This is the
+dcb-v10.10.0 release-note entry for SEK-G24.
+
 ## Consistency Contract
 
 This section documents the actual atomicity guarantees of `IEventStore.WriteSerializableEventsAsync` / `WriteEventsAsync` per provider. The two-phase Cosmos write design itself is unchanged; what has changed is how a failure of that write is handled.

--- a/docs/dcb_llm_ja/04_multiple_aggregate_projector.md
+++ b/docs/dcb_llm_ja/04_multiple_aggregate_projector.md
@@ -56,6 +56,35 @@ public class WeatherForecastProjection : IMultiProjector<WeatherForecastProjecti
 
 実装詳細は `src/Sekiban.Dcb.Orleans/Grains/MultiProjectionGrain.cs` を参照してください。
 
+## 受動的なプロジェクション状態 (SEK-G24 / dcb-v10.10.0)
+
+フリート監視は、プロジェクション Grain を起動せずにキャッチアップ状況をサンプルできます。プロバイダーの
+登録時に `IProjectionStatusReader` と `ISerializedProjectionStatusReader` が登録されるため、次のように読み取れます。
+
+```csharp
+var reader = serviceProvider.GetRequiredService<IProjectionStatusReader>();
+var result = await reader.ReadAsync(new ProjectionStatusReadRequest(ProjectorName: "WeatherForecast"));
+```
+
+各 `MultiProjectionGrain` は専用の 30 秒タイマーで best-effort の heartbeat を書き込みます。タイマーは
+interleave、keep-alive 無効で、`(ClusterId, ActivationId, Sequence)` の CAS で古い activation をフェンスします。
+ストレージ障害は上限付きバックオフで再試行しますが、状態書き込みによってプロジェクション処理を止めません。
+reader は読み取り窓ごとにイベント総数の分母を 1 回だけ取得し、異なる `LastTraversedSortableUniqueId` ごとに
+後続イベント数を数えます。filtered event も traversed cursor に含むため、`AppliedEventCount` が小さくても
+`RemainingEventCount` が 0 になり得ます。サンプルには `SampledAtUtc` と `Consistency == "bestEffort"` が付き、
+atomic な head/count を主張しません。
+
+運用上の status は 3 層で使い分けます。(1) フリート全体の catch-up 概要には Grain を起動しない passive
+registry、(2) restore/checkpoint の詳細には永続化 snapshot API、(3) authoritative な最新の projection 結果が
+必要な場合には Grain query を使います。既存の snapshot API と Grain の status API は変更されません。
+
+Cloud/WASM の転送には既存の `ISerializedSekibanDcbExecutor` ではなく、新しい
+`ISerializedProjectionStatusReader` の V1 envelope を使います。serialized 境界の `ServiceId` はサーバー側の
+`IServiceIdProvider` から決まり、クライアントが別サービスを選ぶことはできません。ホスト側の endpoint は
+operator 専用として既定で deny し、必要な場合だけ明示的な認可ポリシー
+(`RequireAuthorization("ProjectionStatusOperator")` など) を要求して公開してください。
+`AllowAnonymous` は使わないでください。
+
 ## スナップショット退避
 
 `Sekiban.Dcb.BlobStorage.AzureStorage` を利用すると大規模な状態を Blob Storage に退避できます。

--- a/docs/dcb_llm_ja/04_multiple_aggregate_projector.md
+++ b/docs/dcb_llm_ja/04_multiple_aggregate_projector.md
@@ -67,11 +67,14 @@ var result = await reader.ReadAsync(new ProjectionStatusReadRequest(ProjectorNam
 ```
 
 各 `MultiProjectionGrain` は専用の 30 秒タイマーで best-effort の heartbeat を書き込みます。タイマーは
-interleave、keep-alive 無効で、`(ClusterId, ActivationId, Sequence)` の CAS で古い activation をフェンスします。
-ストレージ障害は上限付きバックオフで再試行しますが、状態書き込みによってプロジェクション処理を止めません。
-reader は読み取り窓ごとにイベント総数の分母を 1 回だけ取得し、異なる `LastTraversedSortableUniqueId` ごとに
-後続イベント数を数えます。filtered event も traversed cursor に含むため、`AppliedEventCount` が小さくても
-`RemainingEventCount` が 0 になり得ます。サンプルには `SampledAtUtc` と `Consistency == "bestEffort"` が付き、
+interleave、keep-alive 無効で、物理行は `(ServiceId, ProjectorName, ProjectorVersion, ClusterId)` の 1 行です。
+`ActivationId` は行のデータとして保持するため、replacement activation が別行を作ったり sequence fence を
+迂回したりしません。ストレージ書き込みは独立した timeout と上限付きバックオフを使い、同じ失敗のログを
+レート制限します。状態書き込みによってプロジェクション処理を止めません。reader は service ごとに
+sampling window（既定 5 秒）あたりイベント総数の分母を 1 回だけ取得し、bounded parallelism で異なる
+`LastTraversedSortableUniqueId` ごとに後続イベント数を数えます。filtered event も traversed cursor に含むため、
+`AppliedEventCount` が小さくても `RemainingEventCount` が 0 になり得ます。`IsCaughtUp` はさらに fresh な lease、
+非 fault、fresh cluster conflict なしを要求します。サンプルには `SampledAtUtc` と `Consistency == "bestEffort"` が付き、
 atomic な head/count を主張しません。
 
 運用上の status は 3 層で使い分けます。(1) フリート全体の catch-up 概要には Grain を起動しない passive

--- a/docs/dcb_llm_ja/11_storage_providers.md
+++ b/docs/dcb_llm_ja/11_storage_providers.md
@@ -151,9 +151,11 @@ builder.Services.AddSekibanDcbPostgres("Host=localhost;Database=sekiban_dcb;User
 
 各プロバイダーは、プロジェクション状態ストアと同時に受動的な `IProjectionStatusStore` と reader を登録します。
 `IProjectionStatusReader` は Grain を解決せず、heartbeat とイベントストアの件数だけで状況を組み立てます。
-分母は読み取りごとに 1 回、残数は distinct な traversed cursor ごとに取得し、`SampledAtUtc` を付けた
-best-effort サンプルとして返します。同じ `(ProjectorName, ProjectorVersion, ClusterId)` に新しい
-`ActivationId` が複数ある場合は conflict として返し、古い activation の書き込みを last-write-wins で隠しません。
+分母は service ごとに sampling window（既定 5 秒）あたり 1 回、残数は bounded parallelism で distinct な
+traversed cursor ごとに取得し、`SampledAtUtc` を付けた best-effort サンプルとして返します。CAS の行 identity は
+`(ServiceId, ProjectorName, ProjectorVersion, ClusterId)` で、`ActivationId` は行データとして保持します。1 つの
+`(ProjectorName, ProjectorVersion)` に fresh な cluster 行が複数ある場合は conflict として返し、古い activation
+の replacement が別行へ書き込まれることも、last-write-wins で隠されることもありません。
 
 保存形式は次のとおりです。
 

--- a/docs/dcb_llm_ja/11_storage_providers.md
+++ b/docs/dcb_llm_ja/11_storage_providers.md
@@ -147,6 +147,29 @@ builder.Services.AddSekibanDcbPostgres("Host=localhost;Database=sekiban_dcb;User
 
 マイグレーションは `Sekiban.Dcb.Postgres.MigrationHost` から実行するか、Aspire の初期化サービスに任せます。
 
+## 受動的なプロジェクション状態レジストリ (SEK-G24 / dcb-v10.10.0)
+
+各プロバイダーは、プロジェクション状態ストアと同時に受動的な `IProjectionStatusStore` と reader を登録します。
+`IProjectionStatusReader` は Grain を解決せず、heartbeat とイベントストアの件数だけで状況を組み立てます。
+分母は読み取りごとに 1 回、残数は distinct な traversed cursor ごとに取得し、`SampledAtUtc` を付けた
+best-effort サンプルとして返します。同じ `(ProjectorName, ProjectorVersion, ClusterId)` に新しい
+`ActivationId` が複数ある場合は conflict として返し、古い activation の書き込みを last-write-wins で隠しません。
+
+保存形式は次のとおりです。
+
+- PostgreSQL と SQLite は `dcb_projection_statuses` 専用テーブルを、既存 DB に対しても自動作成します。heartbeat
+  は expected-sequence CAS で書き込みます。
+- Cosmos DB と DynamoDB は projection snapshot と同じ領域に保存し、`documentType = "projectionStatus"` を付けます。
+  snapshot の list/delete/scan/latest-version は status 行を除外し、discriminator のない旧 snapshot は読み込めます。
+- DynamoDB の status 一覧はこの slice では bounded な filtered scan を使います。フリート規模で必要になった場合だけ
+  status 専用 GSI を追加する、という escalation path です。
+- 状態の読み取りと件数サンプルは projection state への書き込みではなく、Grain の activation も必要ありません。
+
+serialized 境界は新しい `ISerializedProjectionStatusReader` の V1 envelope です。`ServiceId` は常にサーバー側
+provider から決まり、ホストの endpoint は既定で deny としてください。必要な場合のみ operator 用 policy を明示し、
+例えば `RequireAuthorization("ProjectionStatusOperator")` を指定します。`AllowAnonymous` は使わず、既存の
+`ISerializedSekibanDcbExecutor` は変更しません。これは dcb-v10.10.0 の SEK-G24 release note です。
+
 ---
 
 ## 設定のポイント


### PR DESCRIPTION
Closes #1109

## Summary
- add passive heartbeat registry and grain timer with CAS fencing and failure backoff
- add no-activation status readers with cursor-based best-effort sampling and additive V1 serialization
- add Postgres, SQLite, Cosmos DB, and DynamoDB storage paths, mixed-document filters, tests, and EN/JA docs

## Verification
- dotnet test dcb/Sekiban.Dcb.slnx --no-restore -f net10.0 --logger "console;verbosity=minimal"
- dotnet test dcb/Sekiban.Dcb.slnx --no-restore -f net9.0 --logger "console;verbosity=minimal"
- git diff --check