### PR TITLE
SEK-G25: scope materialized-view event sources by service

### DIFF
--- a/dcb/internalUsages/DcbOrleans.WithoutResult.ApiService/Program.cs
+++ b/dcb/internalUsages/DcbOrleans.WithoutResult.ApiService/Program.cs
@@ -406,6 +406,8 @@ builder.Services.AddSekibanDcbNativeRuntime();
 builder.Services.AddSekibanDcbColdEventDefaults();
 builder.Services.AddSekibanDcbMaterializedView(options =>
 {
+    options.ServiceId = DefaultServiceIdProvider.DefaultServiceId;
+    options.AllowDefaultServiceId = true;
     options.BatchSize = 100;
     options.PollInterval = TimeSpan.FromSeconds(1);
 });

--- a/dcb/src/Sekiban.Dcb.Core/InMemory/InMemoryEventStore.cs
+++ b/dcb/src/Sekiban.Dcb.Core/InMemory/InMemoryEventStore.cs
@@ -10,6 +10,11 @@ using System.Collections.Concurrent;
 using System.Runtime.CompilerServices;
 namespace Sekiban.Dcb.InMemory;
 
+internal sealed class InMemoryEventStoreBackend
+{
+    public ConcurrentDictionary<string, InMemoryEventStore.ServiceState> States { get; } = new(StringComparer.Ordinal);
+}
+
 /// <summary>
 ///     In-memory implementation of IEventStore for testing and development
 ///     Stores events and tag streams only - no tag state management
@@ -24,7 +29,7 @@ public class InMemoryEventStore : IEventStore, ISerializableEventStreamReader, I
     public StorageDurabilityDescriptor DescribeStorage() =>
         new(StorageDurability.Volatile, "InMemory");
 
-    private sealed class ServiceState
+    internal sealed class ServiceState
     {
         public object Lock { get; } = new();
         public List<Event> EventOrder { get; } = new();
@@ -33,26 +38,36 @@ public class InMemoryEventStore : IEventStore, ISerializableEventStreamReader, I
         public string MaxSortableUniqueId { get; set; } = string.Empty;
     }
 
-    private readonly ConcurrentDictionary<string, ServiceState> _states = new(StringComparer.Ordinal);
+    private readonly InMemoryEventStoreBackend _backend;
     private readonly IServiceIdProvider _serviceIdProvider;
     private readonly IEventTypes? _eventTypes;
 
     public InMemoryEventStore(IServiceIdProvider? serviceIdProvider = null)
+        : this(new ReflectionEventTypes(), serviceIdProvider, new InMemoryEventStoreBackend())
     {
-        _eventTypes = new ReflectionEventTypes();
-        _serviceIdProvider = serviceIdProvider ?? new DefaultServiceIdProvider();
     }
 
     public InMemoryEventStore(IEventTypes eventTypes, IServiceIdProvider? serviceIdProvider = null)
+        : this(eventTypes, serviceIdProvider, new InMemoryEventStoreBackend())
+    {
+    }
+
+    internal InMemoryEventStore(
+        IEventTypes eventTypes,
+        IServiceIdProvider? serviceIdProvider,
+        InMemoryEventStoreBackend backend)
     {
         _eventTypes = eventTypes;
         _serviceIdProvider = serviceIdProvider ?? new DefaultServiceIdProvider();
+        _backend = backend ?? throw new ArgumentNullException(nameof(backend));
     }
+
+    internal InMemoryEventStoreBackend Backend => _backend;
 
     private ServiceState GetState()
     {
         var serviceId = _serviceIdProvider.GetCurrentServiceId();
-        return _states.GetOrAdd(serviceId, _ => new ServiceState());
+        return _backend.States.GetOrAdd(serviceId, _ => new ServiceState());
     }
 
     public IEventTypes? EventTypes => _eventTypes;

--- a/dcb/src/Sekiban.Dcb.Core/InMemory/InMemoryEventStoreFactory.cs
+++ b/dcb/src/Sekiban.Dcb.Core/InMemory/InMemoryEventStoreFactory.cs
@@ -1,0 +1,43 @@
+using Sekiban.Dcb.Capabilities;
+using Sekiban.Dcb.Domains;
+using Sekiban.Dcb.ServiceId;
+using Sekiban.Dcb.Storage;
+
+namespace Sekiban.Dcb.InMemory;
+
+#pragma warning disable CS0618
+
+/// <summary>
+/// Creates service-bound in-memory event stores over one shared process-local backend.
+/// This is intended for tests and development only.
+/// </summary>
+public sealed class InMemoryEventStoreFactory : IEventStoreFactory, IStorageDurabilityDescriptorProvider
+{
+    private readonly IEventTypes _eventTypes;
+    private readonly InMemoryEventStoreBackend _backend;
+
+    public InMemoryEventStoreFactory(IEventTypes eventTypes)
+        : this(eventTypes, new InMemoryEventStoreBackend())
+    {
+    }
+
+    /// <summary>Creates a factory sharing the backend already owned by the supplied store.</summary>
+    public InMemoryEventStoreFactory(InMemoryEventStore sharedStore)
+        : this(sharedStore?.EventTypes ?? throw new ArgumentNullException(nameof(sharedStore)), sharedStore.Backend)
+    {
+    }
+
+    private InMemoryEventStoreFactory(IEventTypes eventTypes, InMemoryEventStoreBackend backend)
+    {
+        _eventTypes = eventTypes ?? throw new ArgumentNullException(nameof(eventTypes));
+        _backend = backend ?? throw new ArgumentNullException(nameof(backend));
+    }
+
+    public StorageDurabilityDescriptor DescribeStorage() =>
+        new(StorageDurability.Volatile, "InMemory (shared per-service factory)");
+
+    public IEventStore CreateForService(string serviceId) =>
+        new InMemoryEventStore(_eventTypes, new FixedServiceIdProvider(serviceId), _backend);
+}
+
+#pragma warning restore CS0618

--- a/dcb/src/Sekiban.Dcb.Core/Storage/EventStoreRegistration.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Storage/EventStoreRegistration.cs
@@ -1,0 +1,27 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Sekiban.Dcb.Storage;
+
+/// <summary>
+///     Shared DI registration mechanics for provider event-store aliases. This only wires the already-created
+///     provider store into its interface aliases; it does not resolve or cache a service-scoped event store.
+/// </summary>
+public static class EventStoreRegistration
+{
+    public static IServiceCollection AddEventStoreAliases<TEventStore>(
+        this IServiceCollection services,
+        ServiceLifetime lifetime = ServiceLifetime.Singleton)
+        where TEventStore : class, IHotEventStore
+    {
+        services.Add(ServiceDescriptor.Describe(typeof(TEventStore), typeof(TEventStore), lifetime));
+        services.Add(ServiceDescriptor.Describe(
+            typeof(IHotEventStore),
+            provider => provider.GetRequiredService<TEventStore>(),
+            lifetime));
+        services.Add(ServiceDescriptor.Describe(
+            typeof(IEventStore),
+            provider => provider.GetRequiredService<IHotEventStore>(),
+            lifetime));
+        return services;
+    }
+}

--- a/dcb/src/Sekiban.Dcb.CosmosDb/SekibanDcbCosmosDbExtensions.cs
+++ b/dcb/src/Sekiban.Dcb.CosmosDb/SekibanDcbCosmosDbExtensions.cs
@@ -64,13 +64,7 @@ public static class SekibanDcbCosmosDbExtensions
         });
 
         // Register store implementations
-        services.TryAddSingleton<IEventTypes>(sp => sp.GetRequiredService<DcbDomainTypes>().EventTypes);
-        services.TryAddSingleton<IEventStoreFactory, CosmosDbEventStoreFactory>();
-        services.AddEventStoreAliases<CosmosDbEventStore>();
-        services.AddConditionalEventStoreCapabilities();
-        services.AddSingleton<IMultiProjectionStateStore, CosmosMultiProjectionStateStore>();
-        services.AddSingleton<IProjectionStatusStore>(sp => (sp.GetService<IMultiProjectionStateStore>() as IProjectionStatusStore)!);
-        services.AddSekibanDcbProjectionStatusReader();
+        AddCosmosDbEventStoreServices(services);
 
         return services;
     }
@@ -99,13 +93,7 @@ public static class SekibanDcbCosmosDbExtensions
         });
 
         // Register store implementations
-        services.TryAddSingleton<IEventTypes>(sp => sp.GetRequiredService<DcbDomainTypes>().EventTypes);
-        services.TryAddSingleton<IEventStoreFactory, CosmosDbEventStoreFactory>();
-        services.AddEventStoreAliases<CosmosDbEventStore>();
-        services.AddConditionalEventStoreCapabilities();
-        services.AddSingleton<IMultiProjectionStateStore, CosmosMultiProjectionStateStore>();
-        services.AddSingleton<IProjectionStatusStore>(sp => (sp.GetService<IMultiProjectionStateStore>() as IProjectionStatusStore)!);
-        services.AddSekibanDcbProjectionStatusReader();
+        AddCosmosDbEventStoreServices(services);
 
         return services;
     }
@@ -349,6 +337,17 @@ public static class SekibanDcbCosmosDbExtensions
         ArgumentNullException.ThrowIfNull(services);
         services.AddSingleton<CosmosDbLegacyTagMigrationServiceFactory>();
         return services;
+    }
+
+    private static void AddCosmosDbEventStoreServices(IServiceCollection services)
+    {
+        services.TryAddSingleton<IEventTypes>(sp => sp.GetRequiredService<DcbDomainTypes>().EventTypes);
+        services.TryAddSingleton<IEventStoreFactory, CosmosDbEventStoreFactory>();
+        services.AddEventStoreAliases<CosmosDbEventStore>();
+        services.AddConditionalEventStoreCapabilities();
+        services.AddSingleton<IMultiProjectionStateStore, CosmosMultiProjectionStateStore>();
+        services.AddSingleton<IProjectionStatusStore>(sp => (sp.GetService<IMultiProjectionStateStore>() as IProjectionStatusStore)!);
+        services.AddSekibanDcbProjectionStatusReader();
     }
 
     private static void AddCosmosDbContext(IServiceCollection services, CosmosDbEventStoreOptions options)

--- a/dcb/src/Sekiban.Dcb.CosmosDb/SekibanDcbCosmosDbExtensions.cs
+++ b/dcb/src/Sekiban.Dcb.CosmosDb/SekibanDcbCosmosDbExtensions.cs
@@ -66,9 +66,7 @@ public static class SekibanDcbCosmosDbExtensions
         // Register store implementations
         services.TryAddSingleton<IEventTypes>(sp => sp.GetRequiredService<DcbDomainTypes>().EventTypes);
         services.TryAddSingleton<IEventStoreFactory, CosmosDbEventStoreFactory>();
-        services.AddSingleton<CosmosDbEventStore>();
-        services.AddSingleton<IHotEventStore>(sp => sp.GetRequiredService<CosmosDbEventStore>());
-        services.AddSingleton<IEventStore>(sp => sp.GetRequiredService<IHotEventStore>());
+        services.AddEventStoreAliases<CosmosDbEventStore>();
         services.AddConditionalEventStoreCapabilities();
         services.AddSingleton<IMultiProjectionStateStore, CosmosMultiProjectionStateStore>();
         services.AddSingleton<IProjectionStatusStore>(sp => (sp.GetService<IMultiProjectionStateStore>() as IProjectionStatusStore)!);
@@ -103,9 +101,7 @@ public static class SekibanDcbCosmosDbExtensions
         // Register store implementations
         services.TryAddSingleton<IEventTypes>(sp => sp.GetRequiredService<DcbDomainTypes>().EventTypes);
         services.TryAddSingleton<IEventStoreFactory, CosmosDbEventStoreFactory>();
-        services.AddSingleton<CosmosDbEventStore>();
-        services.AddSingleton<IHotEventStore>(sp => sp.GetRequiredService<CosmosDbEventStore>());
-        services.AddSingleton<IEventStore>(sp => sp.GetRequiredService<IHotEventStore>());
+        services.AddEventStoreAliases<CosmosDbEventStore>();
         services.AddConditionalEventStoreCapabilities();
         services.AddSingleton<IMultiProjectionStateStore, CosmosMultiProjectionStateStore>();
         services.AddSingleton<IProjectionStatusStore>(sp => (sp.GetService<IMultiProjectionStateStore>() as IProjectionStatusStore)!);
@@ -173,9 +169,7 @@ public static class SekibanDcbCosmosDbExtensions
         // Register store implementations
         services.TryAddSingleton<IEventTypes>(sp => sp.GetRequiredService<DcbDomainTypes>().EventTypes);
         services.TryAddSingleton<IEventStoreFactory, CosmosDbEventStoreFactory>();
-        services.AddSingleton<CosmosDbEventStore>();
-        services.AddSingleton<IHotEventStore>(sp => sp.GetRequiredService<CosmosDbEventStore>());
-        services.AddSingleton<IEventStore>(sp => sp.GetRequiredService<IHotEventStore>());
+        services.AddEventStoreAliases<CosmosDbEventStore>();
         services.AddConditionalEventStoreCapabilities();
         services.AddSingleton<IMultiProjectionStateStore, CosmosMultiProjectionStateStore>();
         services.AddSingleton<IProjectionStatusStore>(sp => (sp.GetService<IMultiProjectionStateStore>() as IProjectionStatusStore)!);
@@ -211,9 +205,7 @@ public static class SekibanDcbCosmosDbExtensions
         AddCosmosDbContext(services, options);
         services.TryAddSingleton<IEventTypes>(sp => sp.GetRequiredService<DcbDomainTypes>().EventTypes);
         services.TryAddSingleton<IEventStoreFactory, CosmosDbEventStoreFactory>();
-        services.AddScoped<CosmosDbEventStore>();
-        services.AddScoped<IHotEventStore>(sp => sp.GetRequiredService<CosmosDbEventStore>());
-        services.AddScoped<IEventStore>(sp => sp.GetRequiredService<IHotEventStore>());
+        services.AddEventStoreAliases<CosmosDbEventStore>(ServiceLifetime.Scoped);
         services.AddScoped<IMultiProjectionStateStore, CosmosMultiProjectionStateStore>();
         services.AddScoped<IProjectionStatusStore>(sp => (sp.GetService<IMultiProjectionStateStore>() as IProjectionStatusStore)!);
         services.AddSekibanDcbProjectionStatusReader();
@@ -240,9 +232,7 @@ public static class SekibanDcbCosmosDbExtensions
 
         services.AddSingleton<IServiceIdProvider, DefaultServiceIdProvider>();
         services.TryAddSingleton<IEventTypes>(sp => sp.GetRequiredService<DcbDomainTypes>().EventTypes);
-        services.AddSingleton<CosmosDbEventStore>();
-        services.AddSingleton<IHotEventStore>(sp => sp.GetRequiredService<CosmosDbEventStore>());
-        services.AddSingleton<IEventStore>(sp => sp.GetRequiredService<IHotEventStore>());
+        services.AddEventStoreAliases<CosmosDbEventStore>();
         services.AddConditionalEventStoreCapabilities();
         services.AddSingleton<IMultiProjectionStateStore, CosmosMultiProjectionStateStore>();
         services.AddSingleton<IProjectionStatusStore>(sp => (sp.GetService<IMultiProjectionStateStore>() as IProjectionStatusStore)!);
@@ -282,9 +272,7 @@ public static class SekibanDcbCosmosDbExtensions
         services.AddSingleton<IMultiProjectionStateStoreFactory, CosmosDbMultiProjectionStateStoreFactory>();
 
         services.TryAddSingleton<IEventTypes>(sp => sp.GetRequiredService<DcbDomainTypes>().EventTypes);
-        services.AddScoped<CosmosDbEventStore>();
-        services.AddScoped<IHotEventStore>(sp => sp.GetRequiredService<CosmosDbEventStore>());
-        services.AddScoped<IEventStore>(sp => sp.GetRequiredService<IHotEventStore>());
+        services.AddEventStoreAliases<CosmosDbEventStore>(ServiceLifetime.Scoped);
         services.AddScoped<IMultiProjectionStateStore, CosmosMultiProjectionStateStore>();
         services.AddScoped<IProjectionStatusStore>(sp => (sp.GetService<IMultiProjectionStateStore>() as IProjectionStatusStore)!);
         services.AddSekibanDcbProjectionStatusReader();

--- a/dcb/src/Sekiban.Dcb.CosmosDb/SekibanDcbCosmosDbExtensions.cs
+++ b/dcb/src/Sekiban.Dcb.CosmosDb/SekibanDcbCosmosDbExtensions.cs
@@ -65,6 +65,7 @@ public static class SekibanDcbCosmosDbExtensions
 
         // Register store implementations
         services.TryAddSingleton<IEventTypes>(sp => sp.GetRequiredService<DcbDomainTypes>().EventTypes);
+        services.TryAddSingleton<IEventStoreFactory, CosmosDbEventStoreFactory>();
         services.AddSingleton<CosmosDbEventStore>();
         services.AddSingleton<IHotEventStore>(sp => sp.GetRequiredService<CosmosDbEventStore>());
         services.AddSingleton<IEventStore>(sp => sp.GetRequiredService<IHotEventStore>());
@@ -101,6 +102,7 @@ public static class SekibanDcbCosmosDbExtensions
 
         // Register store implementations
         services.TryAddSingleton<IEventTypes>(sp => sp.GetRequiredService<DcbDomainTypes>().EventTypes);
+        services.TryAddSingleton<IEventStoreFactory, CosmosDbEventStoreFactory>();
         services.AddSingleton<CosmosDbEventStore>();
         services.AddSingleton<IHotEventStore>(sp => sp.GetRequiredService<CosmosDbEventStore>());
         services.AddSingleton<IEventStore>(sp => sp.GetRequiredService<IHotEventStore>());
@@ -170,6 +172,7 @@ public static class SekibanDcbCosmosDbExtensions
 
         // Register store implementations
         services.TryAddSingleton<IEventTypes>(sp => sp.GetRequiredService<DcbDomainTypes>().EventTypes);
+        services.TryAddSingleton<IEventStoreFactory, CosmosDbEventStoreFactory>();
         services.AddSingleton<CosmosDbEventStore>();
         services.AddSingleton<IHotEventStore>(sp => sp.GetRequiredService<CosmosDbEventStore>());
         services.AddSingleton<IEventStore>(sp => sp.GetRequiredService<IHotEventStore>());
@@ -207,6 +210,7 @@ public static class SekibanDcbCosmosDbExtensions
 
         AddCosmosDbContext(services, options);
         services.TryAddSingleton<IEventTypes>(sp => sp.GetRequiredService<DcbDomainTypes>().EventTypes);
+        services.TryAddSingleton<IEventStoreFactory, CosmosDbEventStoreFactory>();
         services.AddScoped<CosmosDbEventStore>();
         services.AddScoped<IHotEventStore>(sp => sp.GetRequiredService<CosmosDbEventStore>());
         services.AddScoped<IEventStore>(sp => sp.GetRequiredService<IHotEventStore>());

--- a/dcb/src/Sekiban.Dcb.DynamoDB/DynamoDbEventStoreFactory.cs
+++ b/dcb/src/Sekiban.Dcb.DynamoDB/DynamoDbEventStoreFactory.cs
@@ -1,0 +1,40 @@
+using Microsoft.Extensions.Logging;
+using Sekiban.Dcb.Capabilities;
+using Sekiban.Dcb.Domains;
+using Sekiban.Dcb.ServiceId;
+using Sekiban.Dcb.Storage;
+
+namespace Sekiban.Dcb.DynamoDB;
+
+/// <summary>Creates DynamoDB event stores bound to one exact ServiceId over one shared table backend.</summary>
+public sealed class DynamoDbEventStoreFactory : IEventStoreFactory, IStorageDurabilityDescriptorProvider,
+    IWriteConditionCapabilityProvider
+{
+    private readonly DynamoDbContext _context;
+    private readonly IEventTypes _eventTypes;
+    private readonly ILoggerFactory? _loggerFactory;
+
+    public DynamoDbEventStoreFactory(
+        DynamoDbContext context,
+        IEventTypes eventTypes,
+        ILoggerFactory? loggerFactory = null)
+    {
+        _context = context ?? throw new ArgumentNullException(nameof(context));
+        _eventTypes = eventTypes ?? throw new ArgumentNullException(nameof(eventTypes));
+        _loggerFactory = loggerFactory;
+    }
+
+    public StorageDurabilityDescriptor DescribeStorage() =>
+        new(StorageDurability.Durable, "DynamoDB (per-service factory)");
+
+    public WriteConditionCapabilityDescriptor DescribeWriteConditions() =>
+        WriteConditionCapabilityDescriptor.Supporting(
+            "DynamoDB (per-service factory)", WriteConditionKind.SingleEventUniqueKey);
+
+    public IEventStore CreateForService(string serviceId)
+    {
+        var provider = new FixedServiceIdProvider(serviceId);
+        var logger = _loggerFactory?.CreateLogger<DynamoDbEventStore>();
+        return new DynamoDbEventStore(_context, _eventTypes, provider, logger);
+    }
+}

--- a/dcb/src/Sekiban.Dcb.DynamoDB/SekibanDcbDynamoDbExtensions.cs
+++ b/dcb/src/Sekiban.Dcb.DynamoDB/SekibanDcbDynamoDbExtensions.cs
@@ -37,9 +37,7 @@ public static class SekibanDcbDynamoDbExtensions
         services.TryAddSingleton<IServiceIdProvider, DefaultServiceIdProvider>();
         services.TryAddSingleton<IEventTypes>(sp => sp.GetRequiredService<DcbDomainTypes>().EventTypes);
         services.TryAddSingleton<IEventStoreFactory, DynamoDbEventStoreFactory>();
-        services.AddSingleton<DynamoDbEventStore>();
-        services.AddSingleton<IHotEventStore>(sp => sp.GetRequiredService<DynamoDbEventStore>());
-        services.AddSingleton<IEventStore>(sp => sp.GetRequiredService<IHotEventStore>());
+        services.AddEventStoreAliases<DynamoDbEventStore>();
         services.AddConditionalEventStoreCapabilities();
         services.AddSingleton<IMultiProjectionStateStore, DynamoMultiProjectionStateStore>();
         services.AddSingleton<IProjectionStatusStore>(sp => (sp.GetService<IMultiProjectionStateStore>() as IProjectionStatusStore)!);
@@ -65,9 +63,7 @@ public static class SekibanDcbDynamoDbExtensions
         services.TryAddSingleton<IServiceIdProvider, DefaultServiceIdProvider>();
         services.TryAddSingleton<IEventTypes>(sp => sp.GetRequiredService<DcbDomainTypes>().EventTypes);
         services.TryAddSingleton<IEventStoreFactory, DynamoDbEventStoreFactory>();
-        services.AddSingleton<DynamoDbEventStore>();
-        services.AddSingleton<IHotEventStore>(sp => sp.GetRequiredService<DynamoDbEventStore>());
-        services.AddSingleton<IEventStore>(sp => sp.GetRequiredService<IHotEventStore>());
+        services.AddEventStoreAliases<DynamoDbEventStore>();
         services.AddConditionalEventStoreCapabilities();
         services.AddSingleton<IMultiProjectionStateStore, DynamoMultiProjectionStateStore>();
         services.AddSingleton<IProjectionStatusStore>(sp => (sp.GetService<IMultiProjectionStateStore>() as IProjectionStatusStore)!);
@@ -97,9 +93,7 @@ public static class SekibanDcbDynamoDbExtensions
         services.TryAddSingleton<IServiceIdProvider, DefaultServiceIdProvider>();
         services.TryAddSingleton<IEventTypes>(sp => sp.GetRequiredService<DcbDomainTypes>().EventTypes);
         services.TryAddSingleton<IEventStoreFactory, DynamoDbEventStoreFactory>();
-        services.AddSingleton<DynamoDbEventStore>();
-        services.AddSingleton<IHotEventStore>(sp => sp.GetRequiredService<DynamoDbEventStore>());
-        services.AddSingleton<IEventStore>(sp => sp.GetRequiredService<IHotEventStore>());
+        services.AddEventStoreAliases<DynamoDbEventStore>();
         services.AddConditionalEventStoreCapabilities();
         services.AddSingleton<IMultiProjectionStateStore, DynamoMultiProjectionStateStore>();
         services.AddSingleton<IProjectionStatusStore>(sp => (sp.GetService<IMultiProjectionStateStore>() as IProjectionStatusStore)!);

--- a/dcb/src/Sekiban.Dcb.DynamoDB/SekibanDcbDynamoDbExtensions.cs
+++ b/dcb/src/Sekiban.Dcb.DynamoDB/SekibanDcbDynamoDbExtensions.cs
@@ -33,16 +33,7 @@ public static class SekibanDcbDynamoDbExtensions
             return CreateClient(configuration, options);
         });
 
-        services.AddSingleton<DynamoDbContext>();
-        services.TryAddSingleton<IServiceIdProvider, DefaultServiceIdProvider>();
-        services.TryAddSingleton<IEventTypes>(sp => sp.GetRequiredService<DcbDomainTypes>().EventTypes);
-        services.TryAddSingleton<IEventStoreFactory, DynamoDbEventStoreFactory>();
-        services.AddEventStoreAliases<DynamoDbEventStore>();
-        services.AddConditionalEventStoreCapabilities();
-        services.AddSingleton<IMultiProjectionStateStore, DynamoMultiProjectionStateStore>();
-        services.AddSingleton<IProjectionStatusStore>(sp => (sp.GetService<IMultiProjectionStateStore>() as IProjectionStatusStore)!);
-        services.AddSekibanDcbProjectionStatusReader();
-        services.AddHostedService<DynamoDbInitializer>();
+        AddDynamoDbEventStoreServices(services);
 
         return services;
     }
@@ -59,16 +50,7 @@ public static class SekibanDcbDynamoDbExtensions
             .Configure(options => configure?.Invoke(options));
 
         services.AddSingleton(dynamoDbClient);
-        services.AddSingleton<DynamoDbContext>();
-        services.TryAddSingleton<IServiceIdProvider, DefaultServiceIdProvider>();
-        services.TryAddSingleton<IEventTypes>(sp => sp.GetRequiredService<DcbDomainTypes>().EventTypes);
-        services.TryAddSingleton<IEventStoreFactory, DynamoDbEventStoreFactory>();
-        services.AddEventStoreAliases<DynamoDbEventStore>();
-        services.AddConditionalEventStoreCapabilities();
-        services.AddSingleton<IMultiProjectionStateStore, DynamoMultiProjectionStateStore>();
-        services.AddSingleton<IProjectionStatusStore>(sp => (sp.GetService<IMultiProjectionStateStore>() as IProjectionStatusStore)!);
-        services.AddSekibanDcbProjectionStatusReader();
-        services.AddHostedService<DynamoDbInitializer>();
+        AddDynamoDbEventStoreServices(services);
 
         return services;
     }
@@ -89,6 +71,13 @@ public static class SekibanDcbDynamoDbExtensions
             return CreateClient(configuration, options);
         });
 
+        AddDynamoDbEventStoreServices(services);
+
+        return services;
+    }
+
+    private static void AddDynamoDbEventStoreServices(IServiceCollection services)
+    {
         services.AddSingleton<DynamoDbContext>();
         services.TryAddSingleton<IServiceIdProvider, DefaultServiceIdProvider>();
         services.TryAddSingleton<IEventTypes>(sp => sp.GetRequiredService<DcbDomainTypes>().EventTypes);
@@ -99,8 +88,6 @@ public static class SekibanDcbDynamoDbExtensions
         services.AddSingleton<IProjectionStatusStore>(sp => (sp.GetService<IMultiProjectionStateStore>() as IProjectionStatusStore)!);
         services.AddSekibanDcbProjectionStatusReader();
         services.AddHostedService<DynamoDbInitializer>();
-
-        return services;
     }
 
     private static IAmazonDynamoDB CreateClient(IConfiguration configuration, DynamoDbEventStoreOptions options)

--- a/dcb/src/Sekiban.Dcb.DynamoDB/SekibanDcbDynamoDbExtensions.cs
+++ b/dcb/src/Sekiban.Dcb.DynamoDB/SekibanDcbDynamoDbExtensions.cs
@@ -36,6 +36,7 @@ public static class SekibanDcbDynamoDbExtensions
         services.AddSingleton<DynamoDbContext>();
         services.TryAddSingleton<IServiceIdProvider, DefaultServiceIdProvider>();
         services.TryAddSingleton<IEventTypes>(sp => sp.GetRequiredService<DcbDomainTypes>().EventTypes);
+        services.TryAddSingleton<IEventStoreFactory, DynamoDbEventStoreFactory>();
         services.AddSingleton<DynamoDbEventStore>();
         services.AddSingleton<IHotEventStore>(sp => sp.GetRequiredService<DynamoDbEventStore>());
         services.AddSingleton<IEventStore>(sp => sp.GetRequiredService<IHotEventStore>());
@@ -63,6 +64,7 @@ public static class SekibanDcbDynamoDbExtensions
         services.AddSingleton<DynamoDbContext>();
         services.TryAddSingleton<IServiceIdProvider, DefaultServiceIdProvider>();
         services.TryAddSingleton<IEventTypes>(sp => sp.GetRequiredService<DcbDomainTypes>().EventTypes);
+        services.TryAddSingleton<IEventStoreFactory, DynamoDbEventStoreFactory>();
         services.AddSingleton<DynamoDbEventStore>();
         services.AddSingleton<IHotEventStore>(sp => sp.GetRequiredService<DynamoDbEventStore>());
         services.AddSingleton<IEventStore>(sp => sp.GetRequiredService<IHotEventStore>());
@@ -94,6 +96,7 @@ public static class SekibanDcbDynamoDbExtensions
         services.AddSingleton<DynamoDbContext>();
         services.TryAddSingleton<IServiceIdProvider, DefaultServiceIdProvider>();
         services.TryAddSingleton<IEventTypes>(sp => sp.GetRequiredService<DcbDomainTypes>().EventTypes);
+        services.TryAddSingleton<IEventStoreFactory, DynamoDbEventStoreFactory>();
         services.AddSingleton<DynamoDbEventStore>();
         services.AddSingleton<IHotEventStore>(sp => sp.GetRequiredService<DynamoDbEventStore>());
         services.AddSingleton<IEventStore>(sp => sp.GetRequiredService<IHotEventStore>());

--- a/dcb/src/Sekiban.Dcb.MaterializedView.MySql/MySqlMvExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.MySql/MySqlMvExecutor.cs
@@ -1,23 +1,21 @@
+using System.Data;
 using Dapper;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using MySqlConnector;
 using Sekiban.Dcb.Common;
 using Sekiban.Dcb.Events;
+using Sekiban.Dcb.MaterializedView;
 using Sekiban.Dcb.ServiceId;
 using Sekiban.Dcb.Storage;
 
 namespace Sekiban.Dcb.MaterializedView.MySql;
 
-public sealed class MySqlMvExecutor : IMvExecutor
+public sealed class MySqlMvExecutor : MvExecutorBase<MySqlConnection>, IMvExecutor
 {
     private readonly IEventStoreFactory? _eventStoreFactory;
     private readonly IEventStore? _legacyEventStore;
     private readonly IServiceIdProvider? _legacyServiceIdProvider;
-    private readonly ILogger<MySqlMvExecutor> _logger;
-    private readonly MvOptions _options;
-    private readonly IMvRegistryStore _registryStore;
-    private readonly string _connectionString;
 
     /// <summary>
     /// Creates the legacy single-service compatibility executor over an aggregate event store.
@@ -30,13 +28,10 @@ public sealed class MySqlMvExecutor : IMvExecutor
         IOptions<MvOptions> options,
         ILogger<MySqlMvExecutor> logger,
         string connectionString)
+        : base(registryStore, options, logger, connectionString)
     {
         _legacyEventStore = eventStore ?? throw new ArgumentNullException(nameof(eventStore));
         _legacyServiceIdProvider = serviceIdProvider ?? throw new ArgumentNullException(nameof(serviceIdProvider));
-        _registryStore = registryStore;
-        _logger = logger;
-        _connectionString = connectionString;
-        _options = options.Value;
     }
 
     /// <summary>Creates an executor whose event reads use the standard service-scoped factory.</summary>
@@ -46,64 +41,18 @@ public sealed class MySqlMvExecutor : IMvExecutor
         IOptions<MvOptions> options,
         ILogger<MySqlMvExecutor> logger,
         string connectionString)
+        : base(registryStore, options, logger, connectionString)
     {
         _eventStoreFactory = eventStoreFactory ?? throw new ArgumentNullException(nameof(eventStoreFactory));
-        _registryStore = registryStore;
-        _logger = logger;
-        _connectionString = connectionString;
-        _options = options.Value;
     }
 
-    public async Task InitializeAsync(
+    public Task InitializeAsync(
         IMvApplyHost host,
         string? serviceId = null,
         CancellationToken cancellationToken = default)
     {
-        serviceId = ResolveServiceId(serviceId);
-        await _registryStore.EnsureInfrastructureAsync(cancellationToken).ConfigureAwait(false);
-
-        await using var connection = new MySqlConnection(_connectionString);
-        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
-        await using var transaction = await connection.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
-
-        var bindings = new MvTableBindings(host.ViewName, host.ViewVersion, _options);
-        var statements = await host.InitializeAsync(bindings, cancellationToken).ConfigureAwait(false);
-        foreach (var statement in statements)
-        {
-            await connection.ExecuteAsync(
-                new CommandDefinition(
-                    statement.Sql,
-                    ToDynamicParameters(statement.Parameters),
-                    transaction,
-                    cancellationToken: cancellationToken)).ConfigureAwait(false);
-        }
-
-        foreach (var table in bindings.Tables)
-        {
-            await _registryStore.RegisterAsync(
-                new MvRegistryEntry
-                {
-                    ServiceId = serviceId,
-                    ViewName = host.ViewName,
-                    ViewVersion = host.ViewVersion,
-                    LogicalTable = table.LogicalName,
-                    PhysicalTable = table.PhysicalName,
-                    Status = MvStatus.CatchingUp,
-                    AppliedEventVersion = 0,
-                    LastUpdated = DateTimeOffset.UtcNow
-                },
-                transaction,
-                cancellationToken).ConfigureAwait(false);
-        }
-
-        var active = await _registryStore.GetActiveAsync(serviceId, host.ViewName, cancellationToken).ConfigureAwait(false);
-        if (active is null)
-        {
-            await _registryStore.SetActiveAsync(serviceId, host.ViewName, host.ViewVersion, transaction, cancellationToken)
-                .ConfigureAwait(false);
-        }
-
-        await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+        var exactServiceId = ResolveServiceId(serviceId);
+        return InitializeCoreAsync(host, exactServiceId, cancellationToken);
     }
 
     public async Task<MvCatchUpResult> CatchUpOnceAsync(
@@ -111,24 +60,13 @@ public sealed class MySqlMvExecutor : IMvExecutor
         string? serviceId = null,
         CancellationToken cancellationToken = default)
     {
-        serviceId = ResolveServiceId(serviceId);
-        var entries = await _registryStore.GetEntriesAsync(serviceId, host.ViewName, host.ViewVersion, cancellationToken)
-            .ConfigureAwait(false);
-        if (entries.Count == 0)
-        {
-            await InitializeAsync(host, serviceId, cancellationToken).ConfigureAwait(false);
-            entries = await _registryStore.GetEntriesAsync(serviceId, host.ViewName, host.ViewVersion, cancellationToken)
-                .ConfigureAwait(false);
-        }
-
-        var currentPosition = entries
-            .Select(entry => entry.CurrentPosition)
-            .FirstOrDefault(position => !string.IsNullOrWhiteSpace(position));
+        var exactServiceId = ResolveServiceId(serviceId);
+        var currentPosition = await GetCurrentPositionAsync(host, exactServiceId, cancellationToken).ConfigureAwait(false);
         IEventStore eventStore;
         if (_eventStoreFactory is not null)
         {
-            eventStore = _eventStoreFactory.CreateForService(serviceId) ??
-                throw new InvalidOperationException($"The event-store factory returned null for ServiceId '{serviceId}'.");
+            eventStore = _eventStoreFactory.CreateForService(exactServiceId) ??
+                throw new InvalidOperationException($"The event-store factory returned null for ServiceId '{exactServiceId}'.");
         }
         else
         {
@@ -137,66 +75,10 @@ public sealed class MySqlMvExecutor : IMvExecutor
         }
 
         var readResult = await eventStore.ReadAllSerializableEventsAsync(
-            SortableUniqueId.NullableValue(currentPosition),
-            _options.BatchSize).ConfigureAwait(false);
-
-        if (!readResult.IsSuccess)
-        {
-            var exception = readResult.GetException();
-            if (exception is NotSupportedException)
-            {
-                throw exception;
-            }
-
-            _logger.LogWarning(
-                exception,
-                "Failed to read events for materialized view {ViewName}/{ViewVersion}.",
-                host.ViewName,
-                host.ViewVersion);
-            return new MvCatchUpResult(0, false);
-        }
-
-        var safeThreshold = CreateSafeThreshold(_options.SafeWindowMs);
-        var reachedUnsafeWindow = false;
-        var batch = readResult.GetValue().OrderBy(serializable => serializable.SortableUniqueIdValue).ToList();
-
-        if (batch.Count == 0)
-        {
-            return new MvCatchUpResult(0, false);
-        }
-
-        var safeBatch = new List<SerializableEvent>(batch.Count);
-        foreach (var serializableEvent in batch)
-        {
-            if (!new SortableUniqueId(serializableEvent.SortableUniqueIdValue).IsEarlierThanOrEqual(safeThreshold))
-            {
-                reachedUnsafeWindow = true;
-                break;
-            }
-
-            safeBatch.Add(serializableEvent);
-        }
-
-        if (safeBatch.Count == 0)
-        {
-            return new MvCatchUpResult(0, reachedUnsafeWindow);
-        }
-
-        var appliedEvents = await ApplySerializableEventsCoreAsync(
-                host,
-                safeBatch,
-                serviceId,
-                MvApplySource.CatchUp,
-                cancellationToken)
+                SortableUniqueId.NullableValue(currentPosition),
+                Options.BatchSize)
             .ConfigureAwait(false);
-
-        var lastAppliedSortableUniqueId = appliedEvents > 0
-            ? safeBatch[appliedEvents - 1].SortableUniqueIdValue
-            : null;
-
-        reachedUnsafeWindow |= appliedEvents < safeBatch.Count;
-
-        return new MvCatchUpResult(appliedEvents, reachedUnsafeWindow, lastAppliedSortableUniqueId);
+        return await CompleteCatchUpAsync(host, exactServiceId, readResult, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<int> ApplySerializableEventsAsync(
@@ -205,206 +87,50 @@ public sealed class MySqlMvExecutor : IMvExecutor
         string? serviceId = null,
         CancellationToken cancellationToken = default)
     {
-        serviceId = ResolveServiceId(serviceId);
+        var exactServiceId = ResolveServiceId(serviceId);
         if (events.Count == 0)
         {
             return 0;
         }
 
-        return await ApplySerializableEventsCoreAsync(host, events, serviceId, MvApplySource.Stream, cancellationToken).ConfigureAwait(false);
-    }
-
-    private async Task<int> ApplySerializableEventsCoreAsync(
-        IMvApplyHost host,
-        IReadOnlyList<SerializableEvent> events,
-        string serviceId,
-        MvApplySource source,
-        CancellationToken cancellationToken)
-    {
-        var entries = await _registryStore.GetEntriesAsync(serviceId, host.ViewName, host.ViewVersion, cancellationToken)
+        return await ApplySerializableEventsCoreAsync(
+                host,
+                events,
+                exactServiceId,
+                MvApplySource.Stream,
+                cancellationToken)
             .ConfigureAwait(false);
-        if (entries.Count == 0)
-        {
-            await InitializeAsync(host, serviceId, cancellationToken).ConfigureAwait(false);
-            entries = await _registryStore.GetEntriesAsync(serviceId, host.ViewName, host.ViewVersion, cancellationToken)
-                .ConfigureAwait(false);
-        }
+    }
 
-        var currentPosition = entries
-            .Select(entry => entry.CurrentPosition)
-            .FirstOrDefault(position => !string.IsNullOrWhiteSpace(position));
-        var orderedEvents = events
-            .GroupBy(serializableEvent => serializableEvent.SortableUniqueIdValue)
-            .Select(group => group.First())
-            .Where(serializableEvent =>
-                source == MvApplySource.Stream ||
-                string.IsNullOrWhiteSpace(currentPosition) ||
-                string.Compare(serializableEvent.SortableUniqueIdValue, currentPosition, StringComparison.Ordinal) > 0)
-            .OrderBy(serializableEvent => serializableEvent.SortableUniqueIdValue, StringComparer.Ordinal)
-            .ToList();
+    private string ResolveServiceId(string? requestedServiceId) =>
+        MvServiceIdValidation.Validate(
+            requestedServiceId,
+            Options,
+            _eventStoreFactory is null ? _legacyServiceIdProvider : null,
+            nameof(MySqlMvExecutor));
 
-        if (orderedEvents.Count == 0)
-        {
-            return 0;
-        }
-
-        await using var connection = new MySqlConnection(_connectionString);
+    protected override async Task<MySqlConnection> OpenConnectionAsync(CancellationToken cancellationToken)
+    {
+        var connection = new MySqlConnection(ConnectionString);
         await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
-        var appliedEvents = 0;
-        var bindings = CreateBindings(host, entries);
-
-        foreach (var serializableEvent in orderedEvents)
-        {
-            var applied = await ApplySerializableEventAsync(
-                    connection,
-                    host,
-                    serviceId,
-                    bindings,
-                    serializableEvent,
-                    currentPosition,
-                    source,
-                    cancellationToken)
-                .ConfigureAwait(false);
-            if (!applied)
-            {
-                break;
-            }
-
-            appliedEvents += 1;
-        }
-
-        return appliedEvents;
+        return connection;
     }
 
-    private async Task<bool> ApplySerializableEventAsync(
+    protected override IMvApplyQueryPort CreateQueryPort(
         MySqlConnection connection,
-        IMvApplyHost host,
-        string serviceId,
-        MvTableBindings bindings,
-        SerializableEvent serializableEvent,
-        string? currentPosition,
-        MvApplySource source,
-        CancellationToken cancellationToken)
-    {
-        await using var transaction = await connection.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
-        var queryPort = new MySqlMvApplyQueryPort(connection, transaction);
-        var statements = await host.ApplyEventAsync(
-            serializableEvent,
-            bindings,
-            queryPort,
-            serializableEvent.SortableUniqueIdValue,
-            cancellationToken).ConfigureAwait(false);
-        var affectedRows = 0;
-        foreach (var statement in statements)
-        {
-            affectedRows += await connection.ExecuteAsync(
-                new CommandDefinition(
-                    statement.Sql,
-                    ToDynamicParameters(statement.Parameters),
-                    transaction,
-                    cancellationToken: cancellationToken)).ConfigureAwait(false);
-        }
+        IDbTransaction transaction) =>
+        new MySqlMvApplyQueryPort(connection, transaction);
 
-        if (source == MvApplySource.Stream && statements.Count > 0 && affectedRows == 0)
-        {
-            if (!string.IsNullOrWhiteSpace(currentPosition) &&
-                string.Compare(serializableEvent.SortableUniqueIdValue, currentPosition, StringComparison.Ordinal) <= 0)
-            {
-                await transaction.RollbackAsync(cancellationToken).ConfigureAwait(false);
-                return true;
-            }
-
-            await transaction.RollbackAsync(cancellationToken).ConfigureAwait(false);
-            return false;
-        }
-
-        await _registryStore.UpdatePositionAsync(
-            new MvPositionUpdate(
-                serviceId,
-                host.ViewName,
-                host.ViewVersion,
-                serializableEvent.SortableUniqueIdValue,
-                source),
-            transaction: transaction,
-            cancellationToken: cancellationToken).ConfigureAwait(false);
-
-        await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
-        return true;
-    }
-
-    private string ResolveServiceId(string? requestedServiceId)
-    {
-        var callerSuppliedServiceId = !string.IsNullOrWhiteSpace(requestedServiceId);
-        var resolvedServiceId = requestedServiceId;
-        if (string.IsNullOrWhiteSpace(resolvedServiceId))
-        {
-            resolvedServiceId = _options.ServiceId;
-        }
-
-        if (string.IsNullOrWhiteSpace(resolvedServiceId) && _eventStoreFactory is null)
-        {
-            resolvedServiceId = _legacyServiceIdProvider?.GetCurrentServiceId();
-        }
-
-        if (string.IsNullOrWhiteSpace(resolvedServiceId))
-        {
-            throw new InvalidOperationException(
-                $"{nameof(MySqlMvExecutor)} requires an explicit non-empty ServiceId. Configure MvOptions.ServiceId or pass the service id at the caller boundary.");
-        }
-
-        var normalizedServiceId = ServiceIdValidator.NormalizeAndValidate(resolvedServiceId);
-        if (string.Equals(normalizedServiceId, DefaultServiceIdProvider.DefaultServiceId, StringComparison.Ordinal) &&
-            !_options.AllowDefaultServiceId)
-        {
-            throw new InvalidOperationException(
-                $"{nameof(MySqlMvExecutor)} cannot use the implicit default ServiceId. Opt into the named single-service compatibility option AllowDefaultServiceId or provide an explicit non-default service.");
-        }
-
-        if (callerSuppliedServiceId && !string.IsNullOrWhiteSpace(_options.ServiceId))
-        {
-            var configuredServiceId = ServiceIdValidator.NormalizeAndValidate(_options.ServiceId);
-            if (!string.Equals(configuredServiceId, normalizedServiceId, StringComparison.Ordinal))
-            {
-                throw new InvalidOperationException(
-                    $"{nameof(MySqlMvExecutor)} requested ServiceId '{normalizedServiceId}', but MvOptions is bound to '{configuredServiceId}'.");
-            }
-        }
-
-        if (_legacyEventStore is not null)
-        {
-            var legacyServiceId = ServiceIdValidator.NormalizeAndValidate(_legacyServiceIdProvider!.GetCurrentServiceId());
-            if (!string.Equals(legacyServiceId, normalizedServiceId, StringComparison.Ordinal))
-            {
-                throw new InvalidOperationException(
-                    $"{nameof(MySqlMvExecutor)} requested ServiceId '{normalizedServiceId}', but the legacy aggregate event store is bound to '{legacyServiceId}'. Register IEventStoreFactory for service-scoped MV reads.");
-            }
-        }
-
-        return normalizedServiceId;
-    }
-
-    private MvTableBindings CreateBindings(IMvApplyHost host, IReadOnlyList<MvRegistryEntry> entries)
-    {
-        var bindings = new MvTableBindings(host.ViewName, host.ViewVersion, _options);
-        foreach (var entry in entries)
-        {
-            bindings.RegisterTable(entry.LogicalTable, entry.PhysicalTable);
-        }
-
-        return bindings;
-    }
-
-    private static DynamicParameters ToDynamicParameters(IReadOnlyList<MvParam> parameters)
-    {
-        var dynamicParameters = new DynamicParameters();
-        foreach (var parameter in parameters)
-        {
-            dynamicParameters.Add(parameter.Name, MvParamConverter.ToClrValue(parameter));
-        }
-
-        return dynamicParameters;
-    }
-
-    private static SortableUniqueId CreateSafeThreshold(int safeWindowMs) =>
-        new(SortableUniqueId.Generate(DateTime.UtcNow.AddMilliseconds(-safeWindowMs), Guid.Empty));
+    protected override Task<int> ExecuteSqlAsync(
+        MySqlConnection connection,
+        string sql,
+        IReadOnlyList<MvParam> parameters,
+        IDbTransaction transaction,
+        CancellationToken cancellationToken) =>
+        connection.ExecuteAsync(
+            new CommandDefinition(
+                sql,
+                ToParameterDictionary(parameters),
+                transaction,
+                cancellationToken: cancellationToken));
 }

--- a/dcb/src/Sekiban.Dcb.MaterializedView.MySql/MySqlMvExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.MySql/MySqlMvExecutor.cs
@@ -44,13 +44,7 @@ public sealed class MySqlMvExecutor : MvExecutorBase<MySqlConnection>, IMvExecut
         : base(registryStore, options, logger, connectionString) =>
         _eventStoreFactory = RequireEventStoreFactory(eventStoreFactory);
 
-    public Task InitializeAsync(
-        IMvApplyHost host,
-        string? serviceId = null,
-        CancellationToken cancellationToken = default)
-        => InitializeAtBoundaryAsync(host, serviceId, cancellationToken);
-
-    public async Task<MvCatchUpResult> CatchUpOnceAsync(
+    public override async Task<MvCatchUpResult> CatchUpOnceAsync(
         IMvApplyHost host,
         string? serviceId = null,
         CancellationToken cancellationToken = default)
@@ -65,13 +59,6 @@ public sealed class MySqlMvExecutor : MvExecutorBase<MySqlConnection>, IMvExecut
 
         return await CatchUpFromStoreAsync(host, exactServiceId, eventStore, cancellationToken).ConfigureAwait(false);
     }
-
-    public Task<int> ApplySerializableEventsAsync(
-        IMvApplyHost host,
-        IReadOnlyList<SerializableEvent> events,
-        string? serviceId = null,
-        CancellationToken cancellationToken = default)
-        => ApplySerializableEventsAtBoundaryAsync(host, events, serviceId, cancellationToken);
 
     protected override async Task<MySqlConnection> OpenConnectionAsync(CancellationToken cancellationToken)
     {

--- a/dcb/src/Sekiban.Dcb.MaterializedView.MySql/MySqlMvExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.MySql/MySqlMvExecutor.cs
@@ -28,7 +28,7 @@ public sealed class MySqlMvExecutor : MvExecutorBase<MySqlConnection>, IMvExecut
         IOptions<MvOptions> options,
         ILogger<MySqlMvExecutor> logger,
         string connectionString)
-        : base(registryStore, options, logger, connectionString)
+        : base(registryStore, options, logger, connectionString, serviceIdProvider)
     {
         (_legacyEventStore, _legacyServiceIdProvider) =
             RequireLegacyCompatibilityDependencies(eventStore, serviceIdProvider);
@@ -48,14 +48,14 @@ public sealed class MySqlMvExecutor : MvExecutorBase<MySqlConnection>, IMvExecut
         IMvApplyHost host,
         string? serviceId = null,
         CancellationToken cancellationToken = default)
-        => InitializeCoreAsync(host, ResolveServiceId(serviceId), cancellationToken);
+        => InitializeAtBoundaryAsync(host, serviceId, cancellationToken);
 
     public async Task<MvCatchUpResult> CatchUpOnceAsync(
         IMvApplyHost host,
         string? serviceId = null,
         CancellationToken cancellationToken = default)
     {
-        var exactServiceId = ResolveServiceId(serviceId);
+        var exactServiceId = ValidateServiceIdAtBoundary(serviceId);
         var eventStore = RequireSelectedEventStore(
             _eventStoreFactory is null
                 ? _legacyEventStore
@@ -71,10 +71,7 @@ public sealed class MySqlMvExecutor : MvExecutorBase<MySqlConnection>, IMvExecut
         IReadOnlyList<SerializableEvent> events,
         string? serviceId = null,
         CancellationToken cancellationToken = default)
-        => ApplyStreamEventsAtBoundaryAsync(host, events, ResolveServiceId(serviceId), cancellationToken);
-
-    private string ResolveServiceId(string? requestedServiceId) =>
-        ValidateServiceId(requestedServiceId, _eventStoreFactory is null ? _legacyServiceIdProvider : null, nameof(MySqlMvExecutor));
+        => ApplySerializableEventsAtBoundaryAsync(host, events, serviceId, cancellationToken);
 
     protected override async Task<MySqlConnection> OpenConnectionAsync(CancellationToken cancellationToken)
     {

--- a/dcb/src/Sekiban.Dcb.MaterializedView.MySql/MySqlMvExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.MySql/MySqlMvExecutor.cs
@@ -41,10 +41,8 @@ public sealed class MySqlMvExecutor : MvExecutorBase<MySqlConnection>, IMvExecut
         IOptions<MvOptions> options,
         ILogger<MySqlMvExecutor> logger,
         string connectionString)
-        : base(registryStore, options, logger, connectionString)
-    {
+        : base(registryStore, options, logger, connectionString) =>
         _eventStoreFactory = RequireEventStoreFactory(eventStoreFactory);
-    }
 
     public Task InitializeAsync(
         IMvApplyHost host,
@@ -58,17 +56,12 @@ public sealed class MySqlMvExecutor : MvExecutorBase<MySqlConnection>, IMvExecut
         CancellationToken cancellationToken = default)
     {
         var exactServiceId = ResolveServiceId(serviceId);
-        IEventStore eventStore;
-        if (_eventStoreFactory is not null)
-        {
-            eventStore = _eventStoreFactory.CreateForService(exactServiceId) ??
-                throw new InvalidOperationException($"The event-store factory returned null for ServiceId '{exactServiceId}'.");
-        }
-        else
-        {
-            eventStore = _legacyEventStore ??
-                throw new InvalidOperationException("No legacy event store is registered for materialized views.");
-        }
+        var eventStore = RequireSelectedEventStore(
+            _eventStoreFactory is null
+                ? _legacyEventStore
+                : _eventStoreFactory!.CreateForService(exactServiceId),
+            exactServiceId,
+            _eventStoreFactory is not null);
 
         return await CatchUpFromStoreAsync(host, exactServiceId, eventStore, cancellationToken).ConfigureAwait(false);
     }
@@ -81,10 +74,7 @@ public sealed class MySqlMvExecutor : MvExecutorBase<MySqlConnection>, IMvExecut
         => ApplyStreamEventsAtBoundaryAsync(host, events, ResolveServiceId(serviceId), cancellationToken);
 
     private string ResolveServiceId(string? requestedServiceId) =>
-        ValidateServiceId(
-            requestedServiceId,
-            _eventStoreFactory is null ? _legacyServiceIdProvider : null,
-            nameof(MySqlMvExecutor));
+        ValidateServiceId(requestedServiceId, _eventStoreFactory is null ? _legacyServiceIdProvider : null, nameof(MySqlMvExecutor));
 
     protected override async Task<MySqlConnection> OpenConnectionAsync(CancellationToken cancellationToken)
     {

--- a/dcb/src/Sekiban.Dcb.MaterializedView.MySql/MySqlMvExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.MySql/MySqlMvExecutor.cs
@@ -50,14 +50,13 @@ public sealed class MySqlMvExecutor : MvExecutorBase<MySqlConnection>, IMvExecut
         CancellationToken cancellationToken = default)
     {
         var exactServiceId = ValidateServiceIdAtBoundary(serviceId);
-        var eventStore = RequireSelectedEventStore(
-            _eventStoreFactory is null
-                ? _legacyEventStore
-                : _eventStoreFactory!.CreateForService(exactServiceId),
-            exactServiceId,
-            _eventStoreFactory is not null);
-
-        return await CatchUpFromStoreAsync(host, exactServiceId, eventStore, cancellationToken).ConfigureAwait(false);
+        return await CatchUpFromStoreAsync(
+                host,
+                exactServiceId,
+                _eventStoreFactory is null ? _legacyEventStore : _eventStoreFactory!.CreateForService(exactServiceId),
+                _eventStoreFactory is not null,
+                cancellationToken)
+            .ConfigureAwait(false);
     }
 
     protected override async Task<MySqlConnection> OpenConnectionAsync(CancellationToken cancellationToken)

--- a/dcb/src/Sekiban.Dcb.MaterializedView.MySql/MySqlMvExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.MySql/MySqlMvExecutor.cs
@@ -11,13 +11,18 @@ namespace Sekiban.Dcb.MaterializedView.MySql;
 
 public sealed class MySqlMvExecutor : IMvExecutor
 {
-    private readonly IEventStore _eventStore;
+    private readonly IEventStoreFactory? _eventStoreFactory;
+    private readonly IEventStore? _legacyEventStore;
+    private readonly IServiceIdProvider? _legacyServiceIdProvider;
     private readonly ILogger<MySqlMvExecutor> _logger;
     private readonly MvOptions _options;
     private readonly IMvRegistryStore _registryStore;
     private readonly string _connectionString;
-    private readonly IServiceIdProvider _serviceIdProvider;
 
+    /// <summary>
+    /// Creates the legacy single-service compatibility executor over an aggregate event store.
+    /// Multi-service hosts should use the <see cref="IEventStoreFactory"/> constructor.
+    /// </summary>
     public MySqlMvExecutor(
         IEventStore eventStore,
         IServiceIdProvider serviceIdProvider,
@@ -26,8 +31,23 @@ public sealed class MySqlMvExecutor : IMvExecutor
         ILogger<MySqlMvExecutor> logger,
         string connectionString)
     {
-        _eventStore = eventStore;
-        _serviceIdProvider = serviceIdProvider;
+        _legacyEventStore = eventStore ?? throw new ArgumentNullException(nameof(eventStore));
+        _legacyServiceIdProvider = serviceIdProvider ?? throw new ArgumentNullException(nameof(serviceIdProvider));
+        _registryStore = registryStore;
+        _logger = logger;
+        _connectionString = connectionString;
+        _options = options.Value;
+    }
+
+    /// <summary>Creates an executor whose event reads use the standard service-scoped factory.</summary>
+    public MySqlMvExecutor(
+        IEventStoreFactory eventStoreFactory,
+        IMvRegistryStore registryStore,
+        IOptions<MvOptions> options,
+        ILogger<MySqlMvExecutor> logger,
+        string connectionString)
+    {
+        _eventStoreFactory = eventStoreFactory ?? throw new ArgumentNullException(nameof(eventStoreFactory));
         _registryStore = registryStore;
         _logger = logger;
         _connectionString = connectionString;
@@ -39,8 +59,8 @@ public sealed class MySqlMvExecutor : IMvExecutor
         string? serviceId = null,
         CancellationToken cancellationToken = default)
     {
-        await _registryStore.EnsureInfrastructureAsync(cancellationToken).ConfigureAwait(false);
         serviceId = ResolveServiceId(serviceId);
+        await _registryStore.EnsureInfrastructureAsync(cancellationToken).ConfigureAwait(false);
 
         await using var connection = new MySqlConnection(_connectionString);
         await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
@@ -104,7 +124,19 @@ public sealed class MySqlMvExecutor : IMvExecutor
         var currentPosition = entries
             .Select(entry => entry.CurrentPosition)
             .FirstOrDefault(position => !string.IsNullOrWhiteSpace(position));
-        var readResult = await _eventStore.ReadAllSerializableEventsAsync(
+        IEventStore eventStore;
+        if (_eventStoreFactory is not null)
+        {
+            eventStore = _eventStoreFactory.CreateForService(serviceId) ??
+                throw new InvalidOperationException($"The event-store factory returned null for ServiceId '{serviceId}'.");
+        }
+        else
+        {
+            eventStore = _legacyEventStore ??
+                throw new InvalidOperationException("No legacy event store is registered for materialized views.");
+        }
+
+        var readResult = await eventStore.ReadAllSerializableEventsAsync(
             SortableUniqueId.NullableValue(currentPosition),
             _options.BatchSize).ConfigureAwait(false);
 
@@ -173,12 +205,12 @@ public sealed class MySqlMvExecutor : IMvExecutor
         string? serviceId = null,
         CancellationToken cancellationToken = default)
     {
+        serviceId = ResolveServiceId(serviceId);
         if (events.Count == 0)
         {
             return 0;
         }
 
-        serviceId = ResolveServiceId(serviceId);
         return await ApplySerializableEventsCoreAsync(host, events, serviceId, MvApplySource.Stream, cancellationToken).ConfigureAwait(false);
     }
 
@@ -300,10 +332,56 @@ public sealed class MySqlMvExecutor : IMvExecutor
         return true;
     }
 
-    private string ResolveServiceId(string? serviceId) =>
-        string.IsNullOrWhiteSpace(serviceId)
-            ? _serviceIdProvider.GetCurrentServiceId()
-            : serviceId;
+    private string ResolveServiceId(string? requestedServiceId)
+    {
+        var callerSuppliedServiceId = !string.IsNullOrWhiteSpace(requestedServiceId);
+        var resolvedServiceId = requestedServiceId;
+        if (string.IsNullOrWhiteSpace(resolvedServiceId))
+        {
+            resolvedServiceId = _options.ServiceId;
+        }
+
+        if (string.IsNullOrWhiteSpace(resolvedServiceId) && _eventStoreFactory is null)
+        {
+            resolvedServiceId = _legacyServiceIdProvider?.GetCurrentServiceId();
+        }
+
+        if (string.IsNullOrWhiteSpace(resolvedServiceId))
+        {
+            throw new InvalidOperationException(
+                $"{nameof(MySqlMvExecutor)} requires an explicit non-empty ServiceId. Configure MvOptions.ServiceId or pass the service id at the caller boundary.");
+        }
+
+        var normalizedServiceId = ServiceIdValidator.NormalizeAndValidate(resolvedServiceId);
+        if (string.Equals(normalizedServiceId, DefaultServiceIdProvider.DefaultServiceId, StringComparison.Ordinal) &&
+            !_options.AllowDefaultServiceId)
+        {
+            throw new InvalidOperationException(
+                $"{nameof(MySqlMvExecutor)} cannot use the implicit default ServiceId. Opt into the named single-service compatibility option AllowDefaultServiceId or provide an explicit non-default service.");
+        }
+
+        if (callerSuppliedServiceId && !string.IsNullOrWhiteSpace(_options.ServiceId))
+        {
+            var configuredServiceId = ServiceIdValidator.NormalizeAndValidate(_options.ServiceId);
+            if (!string.Equals(configuredServiceId, normalizedServiceId, StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException(
+                    $"{nameof(MySqlMvExecutor)} requested ServiceId '{normalizedServiceId}', but MvOptions is bound to '{configuredServiceId}'.");
+            }
+        }
+
+        if (_legacyEventStore is not null)
+        {
+            var legacyServiceId = ServiceIdValidator.NormalizeAndValidate(_legacyServiceIdProvider!.GetCurrentServiceId());
+            if (!string.Equals(legacyServiceId, normalizedServiceId, StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException(
+                    $"{nameof(MySqlMvExecutor)} requested ServiceId '{normalizedServiceId}', but the legacy aggregate event store is bound to '{legacyServiceId}'. Register IEventStoreFactory for service-scoped MV reads.");
+            }
+        }
+
+        return normalizedServiceId;
+    }
 
     private MvTableBindings CreateBindings(IMvApplyHost host, IReadOnlyList<MvRegistryEntry> entries)
     {

--- a/dcb/src/Sekiban.Dcb.MaterializedView.MySql/MySqlMvExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.MySql/MySqlMvExecutor.cs
@@ -30,8 +30,8 @@ public sealed class MySqlMvExecutor : MvExecutorBase<MySqlConnection>, IMvExecut
         string connectionString)
         : base(registryStore, options, logger, connectionString)
     {
-        _legacyEventStore = eventStore ?? throw new ArgumentNullException(nameof(eventStore));
-        _legacyServiceIdProvider = serviceIdProvider ?? throw new ArgumentNullException(nameof(serviceIdProvider));
+        (_legacyEventStore, _legacyServiceIdProvider) =
+            RequireLegacyCompatibilityDependencies(eventStore, serviceIdProvider);
     }
 
     /// <summary>Creates an executor whose event reads use the standard service-scoped factory.</summary>
@@ -43,17 +43,14 @@ public sealed class MySqlMvExecutor : MvExecutorBase<MySqlConnection>, IMvExecut
         string connectionString)
         : base(registryStore, options, logger, connectionString)
     {
-        _eventStoreFactory = eventStoreFactory ?? throw new ArgumentNullException(nameof(eventStoreFactory));
+        _eventStoreFactory = RequireEventStoreFactory(eventStoreFactory);
     }
 
     public Task InitializeAsync(
         IMvApplyHost host,
         string? serviceId = null,
         CancellationToken cancellationToken = default)
-    {
-        var exactServiceId = ResolveServiceId(serviceId);
-        return InitializeCoreAsync(host, exactServiceId, cancellationToken);
-    }
+        => InitializeCoreAsync(host, ResolveServiceId(serviceId), cancellationToken);
 
     public async Task<MvCatchUpResult> CatchUpOnceAsync(
         IMvApplyHost host,
@@ -61,7 +58,6 @@ public sealed class MySqlMvExecutor : MvExecutorBase<MySqlConnection>, IMvExecut
         CancellationToken cancellationToken = default)
     {
         var exactServiceId = ResolveServiceId(serviceId);
-        var currentPosition = await GetCurrentPositionAsync(host, exactServiceId, cancellationToken).ConfigureAwait(false);
         IEventStore eventStore;
         if (_eventStoreFactory is not null)
         {
@@ -74,38 +70,19 @@ public sealed class MySqlMvExecutor : MvExecutorBase<MySqlConnection>, IMvExecut
                 throw new InvalidOperationException("No legacy event store is registered for materialized views.");
         }
 
-        var readResult = await eventStore.ReadAllSerializableEventsAsync(
-                SortableUniqueId.NullableValue(currentPosition),
-                Options.BatchSize)
-            .ConfigureAwait(false);
-        return await CompleteCatchUpAsync(host, exactServiceId, readResult, cancellationToken).ConfigureAwait(false);
+        return await CatchUpFromStoreAsync(host, exactServiceId, eventStore, cancellationToken).ConfigureAwait(false);
     }
 
-    public async Task<int> ApplySerializableEventsAsync(
+    public Task<int> ApplySerializableEventsAsync(
         IMvApplyHost host,
         IReadOnlyList<SerializableEvent> events,
         string? serviceId = null,
         CancellationToken cancellationToken = default)
-    {
-        var exactServiceId = ResolveServiceId(serviceId);
-        if (events.Count == 0)
-        {
-            return 0;
-        }
-
-        return await ApplySerializableEventsCoreAsync(
-                host,
-                events,
-                exactServiceId,
-                MvApplySource.Stream,
-                cancellationToken)
-            .ConfigureAwait(false);
-    }
+        => ApplyStreamEventsAtBoundaryAsync(host, events, ResolveServiceId(serviceId), cancellationToken);
 
     private string ResolveServiceId(string? requestedServiceId) =>
-        MvServiceIdValidation.Validate(
+        ValidateServiceId(
             requestedServiceId,
-            Options,
             _eventStoreFactory is null ? _legacyServiceIdProvider : null,
             nameof(MySqlMvExecutor));
 

--- a/dcb/src/Sekiban.Dcb.MaterializedView.MySql/SekibanDcbMaterializedViewMySqlExtensions.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.MySql/SekibanDcbMaterializedViewMySqlExtensions.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Sekiban.Dcb.ServiceId;
+using Sekiban.Dcb.Storage;
 
 namespace Sekiban.Dcb.MaterializedView.MySql;
 
@@ -32,13 +33,21 @@ public static class SekibanDcbMaterializedViewMySqlExtensions
         services.TryAddSingleton<IMvStorageInfoProvider>(_ =>
             new MvStorageInfoProvider(new MvStorageInfo(MvDbType.MySql, connectionString)));
         services.TryAddSingleton<IMvExecutor>(sp =>
-            new MySqlMvExecutor(
-                sp.GetRequiredService<Sekiban.Dcb.Storage.IEventStore>(),
-                sp.GetRequiredService<IServiceIdProvider>(),
-                sp.GetRequiredService<IMvRegistryStore>(),
-                sp.GetRequiredService<IOptions<MvOptions>>(),
-                sp.GetRequiredService<ILogger<MySqlMvExecutor>>(),
-                connectionString));
+        {
+            var options = sp.GetRequiredService<IOptions<MvOptions>>();
+            var registry = sp.GetRequiredService<IMvRegistryStore>();
+            var logger = sp.GetRequiredService<ILogger<MySqlMvExecutor>>();
+            var factory = sp.GetService<IEventStoreFactory>();
+            return factory is not null
+                ? new MySqlMvExecutor(factory, registry, options, logger, connectionString)
+                : new MySqlMvExecutor(
+                    sp.GetRequiredService<IEventStore>(),
+                    sp.GetRequiredService<IServiceIdProvider>(),
+                    registry,
+                    options,
+                    logger,
+                    connectionString);
+        });
         if (registerHostedWorker)
         {
             services.TryAddEnumerable(ServiceDescriptor.Singleton<IHostedService, MvCatchUpWorker>());

--- a/dcb/src/Sekiban.Dcb.MaterializedView.MySql/SekibanDcbMaterializedViewMySqlExtensions.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.MySql/SekibanDcbMaterializedViewMySqlExtensions.cs
@@ -33,21 +33,13 @@ public static class SekibanDcbMaterializedViewMySqlExtensions
         services.TryAddSingleton<IMvStorageInfoProvider>(_ =>
             new MvStorageInfoProvider(new MvStorageInfo(MvDbType.MySql, connectionString)));
         services.TryAddSingleton<IMvExecutor>(sp =>
-        {
-            var options = sp.GetRequiredService<IOptions<MvOptions>>();
-            var registry = sp.GetRequiredService<IMvRegistryStore>();
-            var logger = sp.GetRequiredService<ILogger<MySqlMvExecutor>>();
-            var factory = sp.GetService<IEventStoreFactory>();
-            return factory is not null
-                ? new MySqlMvExecutor(factory, registry, options, logger, connectionString)
-                : new MySqlMvExecutor(
-                    sp.GetRequiredService<IEventStore>(),
-                    sp.GetRequiredService<IServiceIdProvider>(),
-                    registry,
-                    options,
-                    logger,
-                    connectionString);
-        });
+            SekibanDcbMaterializedViewExtensions.CreateMaterializedViewExecutor<MySqlMvExecutor>(
+                sp,
+                connectionString,
+                static (factory, registry, options, logger, connection) =>
+                    new MySqlMvExecutor(factory, registry, options, logger, connection),
+                static (eventStore, serviceIdProvider, registry, options, logger, connection) =>
+                    new MySqlMvExecutor(eventStore, serviceIdProvider, registry, options, logger, connection)));
         if (registerHostedWorker)
         {
             services.TryAddEnumerable(ServiceDescriptor.Singleton<IHostedService, MvCatchUpWorker>());

--- a/dcb/src/Sekiban.Dcb.MaterializedView.Orleans/MaterializedViewGrain.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.Orleans/MaterializedViewGrain.cs
@@ -5,6 +5,7 @@ using Sekiban.Dcb.Actors;
 using Sekiban.Dcb.Common;
 using Sekiban.Dcb.Events;
 using Sekiban.Dcb.Orleans.Streams;
+using Sekiban.Dcb.ServiceId;
 
 namespace Sekiban.Dcb.MaterializedView.Orleans;
 
@@ -646,7 +647,25 @@ public sealed class MaterializedViewGrain : Grain, IMaterializedViewGrain
 
         _grainKey = this.GetPrimaryKeyString();
         var (serviceId, viewName, viewVersion) = MvGrainKey.Parse(_grainKey);
-        _serviceId = serviceId;
+        var normalizedServiceId = ServiceIdValidator.NormalizeAndValidate(serviceId);
+        if (string.Equals(normalizedServiceId, DefaultServiceIdProvider.DefaultServiceId, StringComparison.Ordinal) &&
+            !_options.AllowDefaultServiceId)
+        {
+            throw new InvalidOperationException(
+                "MaterializedViewGrain cannot use the implicit default ServiceId. Set AllowDefaultServiceId only for an explicit single-service compatibility registration.");
+        }
+
+        if (!string.IsNullOrWhiteSpace(_options.ServiceId))
+        {
+            var configuredServiceId = ServiceIdValidator.NormalizeAndValidate(_options.ServiceId);
+            if (!string.Equals(configuredServiceId, normalizedServiceId, StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException(
+                    $"MaterializedViewGrain key ServiceId '{normalizedServiceId}' does not match configured ServiceId '{configuredServiceId}'.");
+            }
+        }
+
+        _serviceId = normalizedServiceId;
         _viewName = viewName;
         _viewVersion = viewVersion;
     }

--- a/dcb/src/Sekiban.Dcb.MaterializedView.Postgres/PostgresMvExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.Postgres/PostgresMvExecutor.cs
@@ -28,7 +28,7 @@ public sealed class PostgresMvExecutor : MvExecutorBase<NpgsqlConnection>, IMvEx
         IOptions<MvOptions> options,
         ILogger<PostgresMvExecutor> logger,
         string connectionString)
-        : base(registryStore, options, logger, connectionString)
+        : base(registryStore, options, logger, connectionString, serviceIdProvider)
     {
         (_legacyEventStore, _legacyServiceIdProvider) =
             RequireLegacyCompatibilityDependencies(eventStore, serviceIdProvider);
@@ -48,14 +48,14 @@ public sealed class PostgresMvExecutor : MvExecutorBase<NpgsqlConnection>, IMvEx
         IMvApplyHost host,
         string? serviceId = null,
         CancellationToken cancellationToken = default)
-        => InitializeCoreAsync(host, ResolveServiceId(serviceId), cancellationToken);
+        => InitializeAtBoundaryAsync(host, serviceId, cancellationToken);
 
     public async Task<MvCatchUpResult> CatchUpOnceAsync(
         IMvApplyHost host,
         string? serviceId = null,
         CancellationToken cancellationToken = default)
     {
-        var exactServiceId = ResolveServiceId(serviceId);
+        var exactServiceId = ValidateServiceIdAtBoundary(serviceId);
         var eventStore = RequireSelectedEventStore(
             _eventStoreFactory is null
                 ? _legacyEventStore
@@ -71,10 +71,7 @@ public sealed class PostgresMvExecutor : MvExecutorBase<NpgsqlConnection>, IMvEx
         IReadOnlyList<SerializableEvent> events,
         string? serviceId = null,
         CancellationToken cancellationToken = default)
-        => ApplyStreamEventsAtBoundaryAsync(host, events, ResolveServiceId(serviceId), cancellationToken);
-
-    private string ResolveServiceId(string? requestedServiceId) =>
-        ValidateServiceId(requestedServiceId, _eventStoreFactory is null ? _legacyServiceIdProvider : null, nameof(PostgresMvExecutor));
+        => ApplySerializableEventsAtBoundaryAsync(host, events, serviceId, cancellationToken);
 
     protected override async Task<NpgsqlConnection> OpenConnectionAsync(CancellationToken cancellationToken)
     {

--- a/dcb/src/Sekiban.Dcb.MaterializedView.Postgres/PostgresMvExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.Postgres/PostgresMvExecutor.cs
@@ -12,13 +12,18 @@ namespace Sekiban.Dcb.MaterializedView.Postgres;
 
 public sealed class PostgresMvExecutor : IMvExecutor
 {
-    private readonly IEventStore _eventStore;
+    private readonly IEventStoreFactory? _eventStoreFactory;
+    private readonly IEventStore? _legacyEventStore;
+    private readonly IServiceIdProvider? _legacyServiceIdProvider;
     private readonly ILogger<PostgresMvExecutor> _logger;
     private readonly MvOptions _options;
     private readonly IMvRegistryStore _registryStore;
     private readonly string _connectionString;
-    private readonly IServiceIdProvider _serviceIdProvider;
 
+    /// <summary>
+    /// Creates the legacy single-service compatibility executor over an aggregate event store.
+    /// Multi-service hosts should use the <see cref="IEventStoreFactory"/> constructor.
+    /// </summary>
     public PostgresMvExecutor(
         IEventStore eventStore,
         IServiceIdProvider serviceIdProvider,
@@ -27,8 +32,23 @@ public sealed class PostgresMvExecutor : IMvExecutor
         ILogger<PostgresMvExecutor> logger,
         string connectionString)
     {
-        _eventStore = eventStore;
-        _serviceIdProvider = serviceIdProvider;
+        _legacyEventStore = eventStore ?? throw new ArgumentNullException(nameof(eventStore));
+        _legacyServiceIdProvider = serviceIdProvider ?? throw new ArgumentNullException(nameof(serviceIdProvider));
+        _registryStore = registryStore;
+        _logger = logger;
+        _connectionString = connectionString;
+        _options = options.Value;
+    }
+
+    /// <summary>Creates an executor whose event reads use the standard service-scoped factory.</summary>
+    public PostgresMvExecutor(
+        IEventStoreFactory eventStoreFactory,
+        IMvRegistryStore registryStore,
+        IOptions<MvOptions> options,
+        ILogger<PostgresMvExecutor> logger,
+        string connectionString)
+    {
+        _eventStoreFactory = eventStoreFactory ?? throw new ArgumentNullException(nameof(eventStoreFactory));
         _registryStore = registryStore;
         _logger = logger;
         _connectionString = connectionString;
@@ -40,8 +60,8 @@ public sealed class PostgresMvExecutor : IMvExecutor
         string? serviceId = null,
         CancellationToken cancellationToken = default)
     {
-        await _registryStore.EnsureInfrastructureAsync(cancellationToken).ConfigureAwait(false);
         serviceId = ResolveServiceId(serviceId);
+        await _registryStore.EnsureInfrastructureAsync(cancellationToken).ConfigureAwait(false);
 
         await using var connection = new NpgsqlConnection(_connectionString);
         await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
@@ -105,7 +125,19 @@ public sealed class PostgresMvExecutor : IMvExecutor
         var currentPosition = entries
             .Select(entry => entry.CurrentPosition)
             .FirstOrDefault(position => !string.IsNullOrWhiteSpace(position));
-        var readResult = await _eventStore.ReadAllSerializableEventsAsync(
+        IEventStore eventStore;
+        if (_eventStoreFactory is not null)
+        {
+            eventStore = _eventStoreFactory.CreateForService(serviceId) ??
+                throw new InvalidOperationException($"The event-store factory returned null for ServiceId '{serviceId}'.");
+        }
+        else
+        {
+            eventStore = _legacyEventStore ??
+                throw new InvalidOperationException("No legacy event store is registered for materialized views.");
+        }
+
+        var readResult = await eventStore.ReadAllSerializableEventsAsync(
             SortableUniqueId.NullableValue(currentPosition),
             _options.BatchSize).ConfigureAwait(false);
 
@@ -174,12 +206,12 @@ public sealed class PostgresMvExecutor : IMvExecutor
         string? serviceId = null,
         CancellationToken cancellationToken = default)
     {
+        serviceId = ResolveServiceId(serviceId);
         if (events.Count == 0)
         {
             return 0;
         }
 
-        serviceId = ResolveServiceId(serviceId);
         return await ApplySerializableEventsCoreAsync(host, events, serviceId, MvApplySource.Stream, cancellationToken).ConfigureAwait(false);
     }
 
@@ -301,10 +333,56 @@ public sealed class PostgresMvExecutor : IMvExecutor
         return true;
     }
 
-    private string ResolveServiceId(string? serviceId) =>
-        string.IsNullOrWhiteSpace(serviceId)
-            ? _serviceIdProvider.GetCurrentServiceId()
-            : serviceId;
+    private string ResolveServiceId(string? requestedServiceId)
+    {
+        var callerSuppliedServiceId = !string.IsNullOrWhiteSpace(requestedServiceId);
+        var resolvedServiceId = requestedServiceId;
+        if (string.IsNullOrWhiteSpace(resolvedServiceId))
+        {
+            resolvedServiceId = _options.ServiceId;
+        }
+
+        if (string.IsNullOrWhiteSpace(resolvedServiceId) && _eventStoreFactory is null)
+        {
+            resolvedServiceId = _legacyServiceIdProvider?.GetCurrentServiceId();
+        }
+
+        if (string.IsNullOrWhiteSpace(resolvedServiceId))
+        {
+            throw new InvalidOperationException(
+                $"{nameof(PostgresMvExecutor)} requires an explicit non-empty ServiceId. Configure MvOptions.ServiceId or pass the service id at the caller boundary.");
+        }
+
+        var normalizedServiceId = ServiceIdValidator.NormalizeAndValidate(resolvedServiceId);
+        if (string.Equals(normalizedServiceId, DefaultServiceIdProvider.DefaultServiceId, StringComparison.Ordinal) &&
+            !_options.AllowDefaultServiceId)
+        {
+            throw new InvalidOperationException(
+                $"{nameof(PostgresMvExecutor)} cannot use the implicit default ServiceId. Opt into the named single-service compatibility option AllowDefaultServiceId or provide an explicit non-default service.");
+        }
+
+        if (callerSuppliedServiceId && !string.IsNullOrWhiteSpace(_options.ServiceId))
+        {
+            var configuredServiceId = ServiceIdValidator.NormalizeAndValidate(_options.ServiceId);
+            if (!string.Equals(configuredServiceId, normalizedServiceId, StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException(
+                    $"{nameof(PostgresMvExecutor)} requested ServiceId '{normalizedServiceId}', but MvOptions is bound to '{configuredServiceId}'.");
+            }
+        }
+
+        if (_legacyEventStore is not null)
+        {
+            var legacyServiceId = ServiceIdValidator.NormalizeAndValidate(_legacyServiceIdProvider!.GetCurrentServiceId());
+            if (!string.Equals(legacyServiceId, normalizedServiceId, StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException(
+                    $"{nameof(PostgresMvExecutor)} requested ServiceId '{normalizedServiceId}', but the legacy aggregate event store is bound to '{legacyServiceId}'. Register IEventStoreFactory for service-scoped MV reads.");
+            }
+        }
+
+        return normalizedServiceId;
+    }
 
     private MvTableBindings CreateBindings(IMvApplyHost host, IReadOnlyList<MvRegistryEntry> entries)
     {

--- a/dcb/src/Sekiban.Dcb.MaterializedView.Postgres/PostgresMvExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.Postgres/PostgresMvExecutor.cs
@@ -30,8 +30,8 @@ public sealed class PostgresMvExecutor : MvExecutorBase<NpgsqlConnection>, IMvEx
         string connectionString)
         : base(registryStore, options, logger, connectionString)
     {
-        _legacyEventStore = eventStore ?? throw new ArgumentNullException(nameof(eventStore));
-        _legacyServiceIdProvider = serviceIdProvider ?? throw new ArgumentNullException(nameof(serviceIdProvider));
+        (_legacyEventStore, _legacyServiceIdProvider) =
+            RequireLegacyCompatibilityDependencies(eventStore, serviceIdProvider);
     }
 
     /// <summary>Creates an executor whose event reads use the standard service-scoped factory.</summary>
@@ -43,17 +43,14 @@ public sealed class PostgresMvExecutor : MvExecutorBase<NpgsqlConnection>, IMvEx
         string connectionString)
         : base(registryStore, options, logger, connectionString)
     {
-        _eventStoreFactory = eventStoreFactory ?? throw new ArgumentNullException(nameof(eventStoreFactory));
+        _eventStoreFactory = RequireEventStoreFactory(eventStoreFactory);
     }
 
     public Task InitializeAsync(
         IMvApplyHost host,
         string? serviceId = null,
         CancellationToken cancellationToken = default)
-    {
-        var exactServiceId = ResolveServiceId(serviceId);
-        return InitializeCoreAsync(host, exactServiceId, cancellationToken);
-    }
+        => InitializeCoreAsync(host, ResolveServiceId(serviceId), cancellationToken);
 
     public async Task<MvCatchUpResult> CatchUpOnceAsync(
         IMvApplyHost host,
@@ -61,7 +58,6 @@ public sealed class PostgresMvExecutor : MvExecutorBase<NpgsqlConnection>, IMvEx
         CancellationToken cancellationToken = default)
     {
         var exactServiceId = ResolveServiceId(serviceId);
-        var currentPosition = await GetCurrentPositionAsync(host, exactServiceId, cancellationToken).ConfigureAwait(false);
         IEventStore eventStore;
         if (_eventStoreFactory is not null)
         {
@@ -74,38 +70,19 @@ public sealed class PostgresMvExecutor : MvExecutorBase<NpgsqlConnection>, IMvEx
                 throw new InvalidOperationException("No legacy event store is registered for materialized views.");
         }
 
-        var readResult = await eventStore.ReadAllSerializableEventsAsync(
-                SortableUniqueId.NullableValue(currentPosition),
-                Options.BatchSize)
-            .ConfigureAwait(false);
-        return await CompleteCatchUpAsync(host, exactServiceId, readResult, cancellationToken).ConfigureAwait(false);
+        return await CatchUpFromStoreAsync(host, exactServiceId, eventStore, cancellationToken).ConfigureAwait(false);
     }
 
-    public async Task<int> ApplySerializableEventsAsync(
+    public Task<int> ApplySerializableEventsAsync(
         IMvApplyHost host,
         IReadOnlyList<SerializableEvent> events,
         string? serviceId = null,
         CancellationToken cancellationToken = default)
-    {
-        var exactServiceId = ResolveServiceId(serviceId);
-        if (events.Count == 0)
-        {
-            return 0;
-        }
-
-        return await ApplySerializableEventsCoreAsync(
-                host,
-                events,
-                exactServiceId,
-                MvApplySource.Stream,
-                cancellationToken)
-            .ConfigureAwait(false);
-    }
+        => ApplyStreamEventsAtBoundaryAsync(host, events, ResolveServiceId(serviceId), cancellationToken);
 
     private string ResolveServiceId(string? requestedServiceId) =>
-        MvServiceIdValidation.Validate(
+        ValidateServiceId(
             requestedServiceId,
-            Options,
             _eventStoreFactory is null ? _legacyServiceIdProvider : null,
             nameof(PostgresMvExecutor));
 

--- a/dcb/src/Sekiban.Dcb.MaterializedView.Postgres/PostgresMvExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.Postgres/PostgresMvExecutor.cs
@@ -50,14 +50,13 @@ public sealed class PostgresMvExecutor : MvExecutorBase<NpgsqlConnection>, IMvEx
         CancellationToken cancellationToken = default)
     {
         var exactServiceId = ValidateServiceIdAtBoundary(serviceId);
-        var eventStore = RequireSelectedEventStore(
-            _eventStoreFactory is null
-                ? _legacyEventStore
-                : _eventStoreFactory!.CreateForService(exactServiceId),
-            exactServiceId,
-            _eventStoreFactory is not null);
-
-        return await CatchUpFromStoreAsync(host, exactServiceId, eventStore, cancellationToken).ConfigureAwait(false);
+        return await CatchUpFromStoreAsync(
+                host,
+                exactServiceId,
+                _eventStoreFactory is null ? _legacyEventStore : _eventStoreFactory!.CreateForService(exactServiceId),
+                _eventStoreFactory is not null,
+                cancellationToken)
+            .ConfigureAwait(false);
     }
 
     protected override async Task<NpgsqlConnection> OpenConnectionAsync(CancellationToken cancellationToken)

--- a/dcb/src/Sekiban.Dcb.MaterializedView.Postgres/PostgresMvExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.Postgres/PostgresMvExecutor.cs
@@ -41,10 +41,8 @@ public sealed class PostgresMvExecutor : MvExecutorBase<NpgsqlConnection>, IMvEx
         IOptions<MvOptions> options,
         ILogger<PostgresMvExecutor> logger,
         string connectionString)
-        : base(registryStore, options, logger, connectionString)
-    {
+        : base(registryStore, options, logger, connectionString) =>
         _eventStoreFactory = RequireEventStoreFactory(eventStoreFactory);
-    }
 
     public Task InitializeAsync(
         IMvApplyHost host,
@@ -58,17 +56,12 @@ public sealed class PostgresMvExecutor : MvExecutorBase<NpgsqlConnection>, IMvEx
         CancellationToken cancellationToken = default)
     {
         var exactServiceId = ResolveServiceId(serviceId);
-        IEventStore eventStore;
-        if (_eventStoreFactory is not null)
-        {
-            eventStore = _eventStoreFactory.CreateForService(exactServiceId) ??
-                throw new InvalidOperationException($"The event-store factory returned null for ServiceId '{exactServiceId}'.");
-        }
-        else
-        {
-            eventStore = _legacyEventStore ??
-                throw new InvalidOperationException("No legacy event store is registered for materialized views.");
-        }
+        var eventStore = RequireSelectedEventStore(
+            _eventStoreFactory is null
+                ? _legacyEventStore
+                : _eventStoreFactory!.CreateForService(exactServiceId),
+            exactServiceId,
+            _eventStoreFactory is not null);
 
         return await CatchUpFromStoreAsync(host, exactServiceId, eventStore, cancellationToken).ConfigureAwait(false);
     }
@@ -81,10 +74,7 @@ public sealed class PostgresMvExecutor : MvExecutorBase<NpgsqlConnection>, IMvEx
         => ApplyStreamEventsAtBoundaryAsync(host, events, ResolveServiceId(serviceId), cancellationToken);
 
     private string ResolveServiceId(string? requestedServiceId) =>
-        ValidateServiceId(
-            requestedServiceId,
-            _eventStoreFactory is null ? _legacyServiceIdProvider : null,
-            nameof(PostgresMvExecutor));
+        ValidateServiceId(requestedServiceId, _eventStoreFactory is null ? _legacyServiceIdProvider : null, nameof(PostgresMvExecutor));
 
     protected override async Task<NpgsqlConnection> OpenConnectionAsync(CancellationToken cancellationToken)
     {

--- a/dcb/src/Sekiban.Dcb.MaterializedView.Postgres/PostgresMvExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.Postgres/PostgresMvExecutor.cs
@@ -5,20 +5,17 @@ using Microsoft.Extensions.Options;
 using Npgsql;
 using Sekiban.Dcb.Common;
 using Sekiban.Dcb.Events;
+using Sekiban.Dcb.MaterializedView;
 using Sekiban.Dcb.ServiceId;
 using Sekiban.Dcb.Storage;
 
 namespace Sekiban.Dcb.MaterializedView.Postgres;
 
-public sealed class PostgresMvExecutor : IMvExecutor
+public sealed class PostgresMvExecutor : MvExecutorBase<NpgsqlConnection>, IMvExecutor
 {
     private readonly IEventStoreFactory? _eventStoreFactory;
     private readonly IEventStore? _legacyEventStore;
     private readonly IServiceIdProvider? _legacyServiceIdProvider;
-    private readonly ILogger<PostgresMvExecutor> _logger;
-    private readonly MvOptions _options;
-    private readonly IMvRegistryStore _registryStore;
-    private readonly string _connectionString;
 
     /// <summary>
     /// Creates the legacy single-service compatibility executor over an aggregate event store.
@@ -31,13 +28,10 @@ public sealed class PostgresMvExecutor : IMvExecutor
         IOptions<MvOptions> options,
         ILogger<PostgresMvExecutor> logger,
         string connectionString)
+        : base(registryStore, options, logger, connectionString)
     {
         _legacyEventStore = eventStore ?? throw new ArgumentNullException(nameof(eventStore));
         _legacyServiceIdProvider = serviceIdProvider ?? throw new ArgumentNullException(nameof(serviceIdProvider));
-        _registryStore = registryStore;
-        _logger = logger;
-        _connectionString = connectionString;
-        _options = options.Value;
     }
 
     /// <summary>Creates an executor whose event reads use the standard service-scoped factory.</summary>
@@ -47,64 +41,18 @@ public sealed class PostgresMvExecutor : IMvExecutor
         IOptions<MvOptions> options,
         ILogger<PostgresMvExecutor> logger,
         string connectionString)
+        : base(registryStore, options, logger, connectionString)
     {
         _eventStoreFactory = eventStoreFactory ?? throw new ArgumentNullException(nameof(eventStoreFactory));
-        _registryStore = registryStore;
-        _logger = logger;
-        _connectionString = connectionString;
-        _options = options.Value;
     }
 
-    public async Task InitializeAsync(
+    public Task InitializeAsync(
         IMvApplyHost host,
         string? serviceId = null,
         CancellationToken cancellationToken = default)
     {
-        serviceId = ResolveServiceId(serviceId);
-        await _registryStore.EnsureInfrastructureAsync(cancellationToken).ConfigureAwait(false);
-
-        await using var connection = new NpgsqlConnection(_connectionString);
-        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
-        await using var transaction = await connection.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
-
-        var bindings = new MvTableBindings(host.ViewName, host.ViewVersion, _options);
-        var statements = await host.InitializeAsync(bindings, cancellationToken).ConfigureAwait(false);
-        foreach (var statement in statements)
-        {
-            await connection.ExecuteAsync(
-                new CommandDefinition(
-                    statement.Sql,
-                    ToDynamicParameters(statement.Parameters),
-                    transaction,
-                    cancellationToken: cancellationToken)).ConfigureAwait(false);
-        }
-
-        foreach (var table in bindings.Tables)
-        {
-            await _registryStore.RegisterAsync(
-                new MvRegistryEntry
-                {
-                    ServiceId = serviceId,
-                    ViewName = host.ViewName,
-                    ViewVersion = host.ViewVersion,
-                    LogicalTable = table.LogicalName,
-                    PhysicalTable = table.PhysicalName,
-                    Status = MvStatus.CatchingUp,
-                    AppliedEventVersion = 0,
-                    LastUpdated = DateTimeOffset.UtcNow
-                },
-                transaction,
-                cancellationToken).ConfigureAwait(false);
-        }
-
-        var active = await _registryStore.GetActiveAsync(serviceId, host.ViewName, cancellationToken).ConfigureAwait(false);
-        if (active is null)
-        {
-            await _registryStore.SetActiveAsync(serviceId, host.ViewName, host.ViewVersion, transaction, cancellationToken)
-                .ConfigureAwait(false);
-        }
-
-        await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+        var exactServiceId = ResolveServiceId(serviceId);
+        return InitializeCoreAsync(host, exactServiceId, cancellationToken);
     }
 
     public async Task<MvCatchUpResult> CatchUpOnceAsync(
@@ -112,24 +60,13 @@ public sealed class PostgresMvExecutor : IMvExecutor
         string? serviceId = null,
         CancellationToken cancellationToken = default)
     {
-        serviceId = ResolveServiceId(serviceId);
-        var entries = await _registryStore.GetEntriesAsync(serviceId, host.ViewName, host.ViewVersion, cancellationToken)
-            .ConfigureAwait(false);
-        if (entries.Count == 0)
-        {
-            await InitializeAsync(host, serviceId, cancellationToken).ConfigureAwait(false);
-            entries = await _registryStore.GetEntriesAsync(serviceId, host.ViewName, host.ViewVersion, cancellationToken)
-                .ConfigureAwait(false);
-        }
-
-        var currentPosition = entries
-            .Select(entry => entry.CurrentPosition)
-            .FirstOrDefault(position => !string.IsNullOrWhiteSpace(position));
+        var exactServiceId = ResolveServiceId(serviceId);
+        var currentPosition = await GetCurrentPositionAsync(host, exactServiceId, cancellationToken).ConfigureAwait(false);
         IEventStore eventStore;
         if (_eventStoreFactory is not null)
         {
-            eventStore = _eventStoreFactory.CreateForService(serviceId) ??
-                throw new InvalidOperationException($"The event-store factory returned null for ServiceId '{serviceId}'.");
+            eventStore = _eventStoreFactory.CreateForService(exactServiceId) ??
+                throw new InvalidOperationException($"The event-store factory returned null for ServiceId '{exactServiceId}'.");
         }
         else
         {
@@ -138,66 +75,10 @@ public sealed class PostgresMvExecutor : IMvExecutor
         }
 
         var readResult = await eventStore.ReadAllSerializableEventsAsync(
-            SortableUniqueId.NullableValue(currentPosition),
-            _options.BatchSize).ConfigureAwait(false);
-
-        if (!readResult.IsSuccess)
-        {
-            var exception = readResult.GetException();
-            if (exception is NotSupportedException)
-            {
-                throw exception;
-            }
-
-            _logger.LogWarning(
-                exception,
-                "Failed to read events for materialized view {ViewName}/{ViewVersion}.",
-                host.ViewName,
-                host.ViewVersion);
-            return new MvCatchUpResult(0, false);
-        }
-
-        var safeThreshold = CreateSafeThreshold(_options.SafeWindowMs);
-        var reachedUnsafeWindow = false;
-        var batch = readResult.GetValue().OrderBy(serializable => serializable.SortableUniqueIdValue).ToList();
-
-        if (batch.Count == 0)
-        {
-            return new MvCatchUpResult(0, false);
-        }
-
-        var safeBatch = new List<SerializableEvent>(batch.Count);
-        foreach (var serializableEvent in batch)
-        {
-            if (!new SortableUniqueId(serializableEvent.SortableUniqueIdValue).IsEarlierThanOrEqual(safeThreshold))
-            {
-                reachedUnsafeWindow = true;
-                break;
-            }
-
-            safeBatch.Add(serializableEvent);
-        }
-
-        if (safeBatch.Count == 0)
-        {
-            return new MvCatchUpResult(0, reachedUnsafeWindow);
-        }
-
-        var appliedEvents = await ApplySerializableEventsCoreAsync(
-                host,
-                safeBatch,
-                serviceId,
-                MvApplySource.CatchUp,
-                cancellationToken)
+                SortableUniqueId.NullableValue(currentPosition),
+                Options.BatchSize)
             .ConfigureAwait(false);
-
-        var lastAppliedSortableUniqueId = appliedEvents > 0
-            ? safeBatch[appliedEvents - 1].SortableUniqueIdValue
-            : null;
-
-        reachedUnsafeWindow |= appliedEvents < safeBatch.Count;
-
-        return new MvCatchUpResult(appliedEvents, reachedUnsafeWindow, lastAppliedSortableUniqueId);
+        return await CompleteCatchUpAsync(host, exactServiceId, readResult, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<int> ApplySerializableEventsAsync(
@@ -206,206 +87,50 @@ public sealed class PostgresMvExecutor : IMvExecutor
         string? serviceId = null,
         CancellationToken cancellationToken = default)
     {
-        serviceId = ResolveServiceId(serviceId);
+        var exactServiceId = ResolveServiceId(serviceId);
         if (events.Count == 0)
         {
             return 0;
         }
 
-        return await ApplySerializableEventsCoreAsync(host, events, serviceId, MvApplySource.Stream, cancellationToken).ConfigureAwait(false);
-    }
-
-    private async Task<int> ApplySerializableEventsCoreAsync(
-        IMvApplyHost host,
-        IReadOnlyList<SerializableEvent> events,
-        string serviceId,
-        MvApplySource source,
-        CancellationToken cancellationToken)
-    {
-        var entries = await _registryStore.GetEntriesAsync(serviceId, host.ViewName, host.ViewVersion, cancellationToken)
+        return await ApplySerializableEventsCoreAsync(
+                host,
+                events,
+                exactServiceId,
+                MvApplySource.Stream,
+                cancellationToken)
             .ConfigureAwait(false);
-        if (entries.Count == 0)
-        {
-            await InitializeAsync(host, serviceId, cancellationToken).ConfigureAwait(false);
-            entries = await _registryStore.GetEntriesAsync(serviceId, host.ViewName, host.ViewVersion, cancellationToken)
-                .ConfigureAwait(false);
-        }
+    }
 
-        var currentPosition = entries
-            .Select(entry => entry.CurrentPosition)
-            .FirstOrDefault(position => !string.IsNullOrWhiteSpace(position));
-        var orderedEvents = events
-            .GroupBy(serializableEvent => serializableEvent.SortableUniqueIdValue)
-            .Select(group => group.First())
-            .Where(serializableEvent =>
-                source == MvApplySource.Stream ||
-                string.IsNullOrWhiteSpace(currentPosition) ||
-                string.Compare(serializableEvent.SortableUniqueIdValue, currentPosition, StringComparison.Ordinal) > 0)
-            .OrderBy(serializableEvent => serializableEvent.SortableUniqueIdValue, StringComparer.Ordinal)
-            .ToList();
+    private string ResolveServiceId(string? requestedServiceId) =>
+        MvServiceIdValidation.Validate(
+            requestedServiceId,
+            Options,
+            _eventStoreFactory is null ? _legacyServiceIdProvider : null,
+            nameof(PostgresMvExecutor));
 
-        if (orderedEvents.Count == 0)
-        {
-            return 0;
-        }
-
-        await using var connection = new NpgsqlConnection(_connectionString);
+    protected override async Task<NpgsqlConnection> OpenConnectionAsync(CancellationToken cancellationToken)
+    {
+        var connection = new NpgsqlConnection(ConnectionString);
         await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
-        var appliedEvents = 0;
-        var bindings = CreateBindings(host, entries);
-
-        foreach (var serializableEvent in orderedEvents)
-        {
-            var applied = await ApplySerializableEventAsync(
-                    connection,
-                    host,
-                    serviceId,
-                    bindings,
-                    serializableEvent,
-                    currentPosition,
-                    source,
-                    cancellationToken)
-                .ConfigureAwait(false);
-            if (!applied)
-            {
-                break;
-            }
-
-            appliedEvents += 1;
-        }
-
-        return appliedEvents;
+        return connection;
     }
 
-    private async Task<bool> ApplySerializableEventAsync(
+    protected override IMvApplyQueryPort CreateQueryPort(
         NpgsqlConnection connection,
-        IMvApplyHost host,
-        string serviceId,
-        MvTableBindings bindings,
-        SerializableEvent serializableEvent,
-        string? currentPosition,
-        MvApplySource source,
-        CancellationToken cancellationToken)
-    {
-        await using var transaction = await connection.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
-        var queryPort = new PostgresMvApplyQueryPort(connection, transaction);
-        var statements = await host.ApplyEventAsync(
-            serializableEvent,
-            bindings,
-            queryPort,
-            serializableEvent.SortableUniqueIdValue,
-            cancellationToken).ConfigureAwait(false);
-        var affectedRows = 0;
-        foreach (var statement in statements)
-        {
-            affectedRows += await connection.ExecuteAsync(
-                new CommandDefinition(
-                    statement.Sql,
-                    ToDynamicParameters(statement.Parameters),
-                    transaction,
-                    cancellationToken: cancellationToken)).ConfigureAwait(false);
-        }
+        IDbTransaction transaction) =>
+        new PostgresMvApplyQueryPort(connection, transaction);
 
-        if (source == MvApplySource.Stream && statements.Count > 0 && affectedRows == 0)
-        {
-            if (!string.IsNullOrWhiteSpace(currentPosition) &&
-                string.Compare(serializableEvent.SortableUniqueIdValue, currentPosition, StringComparison.Ordinal) <= 0)
-            {
-                await transaction.RollbackAsync(cancellationToken).ConfigureAwait(false);
-                return true;
-            }
-
-            await transaction.RollbackAsync(cancellationToken).ConfigureAwait(false);
-            return false;
-        }
-
-        await _registryStore.UpdatePositionAsync(
-            new MvPositionUpdate(
-                serviceId,
-                host.ViewName,
-                host.ViewVersion,
-                serializableEvent.SortableUniqueIdValue,
-                source),
-            transaction: transaction,
-            cancellationToken: cancellationToken).ConfigureAwait(false);
-
-        await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
-        return true;
-    }
-
-    private string ResolveServiceId(string? requestedServiceId)
-    {
-        var callerSuppliedServiceId = !string.IsNullOrWhiteSpace(requestedServiceId);
-        var resolvedServiceId = requestedServiceId;
-        if (string.IsNullOrWhiteSpace(resolvedServiceId))
-        {
-            resolvedServiceId = _options.ServiceId;
-        }
-
-        if (string.IsNullOrWhiteSpace(resolvedServiceId) && _eventStoreFactory is null)
-        {
-            resolvedServiceId = _legacyServiceIdProvider?.GetCurrentServiceId();
-        }
-
-        if (string.IsNullOrWhiteSpace(resolvedServiceId))
-        {
-            throw new InvalidOperationException(
-                $"{nameof(PostgresMvExecutor)} requires an explicit non-empty ServiceId. Configure MvOptions.ServiceId or pass the service id at the caller boundary.");
-        }
-
-        var normalizedServiceId = ServiceIdValidator.NormalizeAndValidate(resolvedServiceId);
-        if (string.Equals(normalizedServiceId, DefaultServiceIdProvider.DefaultServiceId, StringComparison.Ordinal) &&
-            !_options.AllowDefaultServiceId)
-        {
-            throw new InvalidOperationException(
-                $"{nameof(PostgresMvExecutor)} cannot use the implicit default ServiceId. Opt into the named single-service compatibility option AllowDefaultServiceId or provide an explicit non-default service.");
-        }
-
-        if (callerSuppliedServiceId && !string.IsNullOrWhiteSpace(_options.ServiceId))
-        {
-            var configuredServiceId = ServiceIdValidator.NormalizeAndValidate(_options.ServiceId);
-            if (!string.Equals(configuredServiceId, normalizedServiceId, StringComparison.Ordinal))
-            {
-                throw new InvalidOperationException(
-                    $"{nameof(PostgresMvExecutor)} requested ServiceId '{normalizedServiceId}', but MvOptions is bound to '{configuredServiceId}'.");
-            }
-        }
-
-        if (_legacyEventStore is not null)
-        {
-            var legacyServiceId = ServiceIdValidator.NormalizeAndValidate(_legacyServiceIdProvider!.GetCurrentServiceId());
-            if (!string.Equals(legacyServiceId, normalizedServiceId, StringComparison.Ordinal))
-            {
-                throw new InvalidOperationException(
-                    $"{nameof(PostgresMvExecutor)} requested ServiceId '{normalizedServiceId}', but the legacy aggregate event store is bound to '{legacyServiceId}'. Register IEventStoreFactory for service-scoped MV reads.");
-            }
-        }
-
-        return normalizedServiceId;
-    }
-
-    private MvTableBindings CreateBindings(IMvApplyHost host, IReadOnlyList<MvRegistryEntry> entries)
-    {
-        var bindings = new MvTableBindings(host.ViewName, host.ViewVersion, _options);
-        foreach (var entry in entries)
-        {
-            bindings.RegisterTable(entry.LogicalTable, entry.PhysicalTable);
-        }
-
-        return bindings;
-    }
-
-    private static DynamicParameters ToDynamicParameters(IReadOnlyList<MvParam> parameters)
-    {
-        var dynamicParameters = new DynamicParameters();
-        foreach (var parameter in parameters)
-        {
-            dynamicParameters.Add(parameter.Name, MvParamConverter.ToClrValue(parameter));
-        }
-
-        return dynamicParameters;
-    }
-
-    private static SortableUniqueId CreateSafeThreshold(int safeWindowMs) =>
-        new(SortableUniqueId.Generate(DateTime.UtcNow.AddMilliseconds(-safeWindowMs), Guid.Empty));
+    protected override Task<int> ExecuteSqlAsync(
+        NpgsqlConnection connection,
+        string sql,
+        IReadOnlyList<MvParam> parameters,
+        IDbTransaction transaction,
+        CancellationToken cancellationToken) =>
+        connection.ExecuteAsync(
+            new CommandDefinition(
+                sql,
+                ToParameterDictionary(parameters),
+                transaction,
+                cancellationToken: cancellationToken));
 }

--- a/dcb/src/Sekiban.Dcb.MaterializedView.Postgres/PostgresMvExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.Postgres/PostgresMvExecutor.cs
@@ -44,13 +44,7 @@ public sealed class PostgresMvExecutor : MvExecutorBase<NpgsqlConnection>, IMvEx
         : base(registryStore, options, logger, connectionString) =>
         _eventStoreFactory = RequireEventStoreFactory(eventStoreFactory);
 
-    public Task InitializeAsync(
-        IMvApplyHost host,
-        string? serviceId = null,
-        CancellationToken cancellationToken = default)
-        => InitializeAtBoundaryAsync(host, serviceId, cancellationToken);
-
-    public async Task<MvCatchUpResult> CatchUpOnceAsync(
+    public override async Task<MvCatchUpResult> CatchUpOnceAsync(
         IMvApplyHost host,
         string? serviceId = null,
         CancellationToken cancellationToken = default)
@@ -65,13 +59,6 @@ public sealed class PostgresMvExecutor : MvExecutorBase<NpgsqlConnection>, IMvEx
 
         return await CatchUpFromStoreAsync(host, exactServiceId, eventStore, cancellationToken).ConfigureAwait(false);
     }
-
-    public Task<int> ApplySerializableEventsAsync(
-        IMvApplyHost host,
-        IReadOnlyList<SerializableEvent> events,
-        string? serviceId = null,
-        CancellationToken cancellationToken = default)
-        => ApplySerializableEventsAtBoundaryAsync(host, events, serviceId, cancellationToken);
 
     protected override async Task<NpgsqlConnection> OpenConnectionAsync(CancellationToken cancellationToken)
     {

--- a/dcb/src/Sekiban.Dcb.MaterializedView.Postgres/SekibanDcbMaterializedViewPostgresExtensions.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.Postgres/SekibanDcbMaterializedViewPostgresExtensions.cs
@@ -33,21 +33,13 @@ public static class SekibanDcbMaterializedViewPostgresExtensions
         services.TryAddSingleton<IMvStorageInfoProvider>(_ =>
             new MvStorageInfoProvider(new MvStorageInfo(MvDbType.Postgres, connectionString)));
         services.TryAddSingleton<IMvExecutor>(sp =>
-        {
-            var options = sp.GetRequiredService<IOptions<MvOptions>>();
-            var registry = sp.GetRequiredService<IMvRegistryStore>();
-            var logger = sp.GetRequiredService<ILogger<PostgresMvExecutor>>();
-            var factory = sp.GetService<IEventStoreFactory>();
-            return factory is not null
-                ? new PostgresMvExecutor(factory, registry, options, logger, connectionString)
-                : new PostgresMvExecutor(
-                    sp.GetRequiredService<IEventStore>(),
-                    sp.GetRequiredService<IServiceIdProvider>(),
-                    registry,
-                    options,
-                    logger,
-                    connectionString);
-        });
+            SekibanDcbMaterializedViewExtensions.CreateMaterializedViewExecutor<PostgresMvExecutor>(
+                sp,
+                connectionString,
+                static (factory, registry, options, logger, connection) =>
+                    new PostgresMvExecutor(factory, registry, options, logger, connection),
+                static (eventStore, serviceIdProvider, registry, options, logger, connection) =>
+                    new PostgresMvExecutor(eventStore, serviceIdProvider, registry, options, logger, connection)));
         if (registerHostedWorker)
         {
             services.TryAddEnumerable(ServiceDescriptor.Singleton<IHostedService, MvCatchUpWorker>());

--- a/dcb/src/Sekiban.Dcb.MaterializedView.Postgres/SekibanDcbMaterializedViewPostgresExtensions.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.Postgres/SekibanDcbMaterializedViewPostgresExtensions.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Sekiban.Dcb.ServiceId;
+using Sekiban.Dcb.Storage;
 
 namespace Sekiban.Dcb.MaterializedView.Postgres;
 
@@ -32,13 +33,21 @@ public static class SekibanDcbMaterializedViewPostgresExtensions
         services.TryAddSingleton<IMvStorageInfoProvider>(_ =>
             new MvStorageInfoProvider(new MvStorageInfo(MvDbType.Postgres, connectionString)));
         services.TryAddSingleton<IMvExecutor>(sp =>
-            new PostgresMvExecutor(
-                sp.GetRequiredService<Sekiban.Dcb.Storage.IEventStore>(),
-                sp.GetRequiredService<IServiceIdProvider>(),
-                sp.GetRequiredService<IMvRegistryStore>(),
-                sp.GetRequiredService<IOptions<MvOptions>>(),
-                sp.GetRequiredService<ILogger<PostgresMvExecutor>>(),
-                connectionString));
+        {
+            var options = sp.GetRequiredService<IOptions<MvOptions>>();
+            var registry = sp.GetRequiredService<IMvRegistryStore>();
+            var logger = sp.GetRequiredService<ILogger<PostgresMvExecutor>>();
+            var factory = sp.GetService<IEventStoreFactory>();
+            return factory is not null
+                ? new PostgresMvExecutor(factory, registry, options, logger, connectionString)
+                : new PostgresMvExecutor(
+                    sp.GetRequiredService<IEventStore>(),
+                    sp.GetRequiredService<IServiceIdProvider>(),
+                    registry,
+                    options,
+                    logger,
+                    connectionString);
+        });
         if (registerHostedWorker)
         {
             services.TryAddEnumerable(ServiceDescriptor.Singleton<IHostedService, MvCatchUpWorker>());

--- a/dcb/src/Sekiban.Dcb.MaterializedView.SqlServer/SekibanDcbMaterializedViewSqlServerExtensions.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.SqlServer/SekibanDcbMaterializedViewSqlServerExtensions.cs
@@ -33,21 +33,13 @@ public static class SekibanDcbMaterializedViewSqlServerExtensions
         services.TryAddSingleton<IMvStorageInfoProvider>(_ =>
             new MvStorageInfoProvider(new MvStorageInfo(MvDbType.SqlServer, connectionString)));
         services.TryAddSingleton<IMvExecutor>(sp =>
-        {
-            var options = sp.GetRequiredService<IOptions<MvOptions>>();
-            var registry = sp.GetRequiredService<IMvRegistryStore>();
-            var logger = sp.GetRequiredService<ILogger<SqlServerMvExecutor>>();
-            var factory = sp.GetService<IEventStoreFactory>();
-            return factory is not null
-                ? new SqlServerMvExecutor(factory, registry, options, logger, connectionString)
-                : new SqlServerMvExecutor(
-                    sp.GetRequiredService<IEventStore>(),
-                    sp.GetRequiredService<IServiceIdProvider>(),
-                    registry,
-                    options,
-                    logger,
-                    connectionString);
-        });
+            SekibanDcbMaterializedViewExtensions.CreateMaterializedViewExecutor<SqlServerMvExecutor>(
+                sp,
+                connectionString,
+                static (factory, registry, options, logger, connection) =>
+                    new SqlServerMvExecutor(factory, registry, options, logger, connection),
+                static (eventStore, serviceIdProvider, registry, options, logger, connection) =>
+                    new SqlServerMvExecutor(eventStore, serviceIdProvider, registry, options, logger, connection)));
         if (registerHostedWorker)
         {
             services.TryAddEnumerable(ServiceDescriptor.Singleton<IHostedService, MvCatchUpWorker>());

--- a/dcb/src/Sekiban.Dcb.MaterializedView.SqlServer/SekibanDcbMaterializedViewSqlServerExtensions.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.SqlServer/SekibanDcbMaterializedViewSqlServerExtensions.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Sekiban.Dcb.ServiceId;
+using Sekiban.Dcb.Storage;
 
 namespace Sekiban.Dcb.MaterializedView.SqlServer;
 
@@ -32,13 +33,21 @@ public static class SekibanDcbMaterializedViewSqlServerExtensions
         services.TryAddSingleton<IMvStorageInfoProvider>(_ =>
             new MvStorageInfoProvider(new MvStorageInfo(MvDbType.SqlServer, connectionString)));
         services.TryAddSingleton<IMvExecutor>(sp =>
-            new SqlServerMvExecutor(
-                sp.GetRequiredService<Sekiban.Dcb.Storage.IEventStore>(),
-                sp.GetRequiredService<IServiceIdProvider>(),
-                sp.GetRequiredService<IMvRegistryStore>(),
-                sp.GetRequiredService<IOptions<MvOptions>>(),
-                sp.GetRequiredService<ILogger<SqlServerMvExecutor>>(),
-                connectionString));
+        {
+            var options = sp.GetRequiredService<IOptions<MvOptions>>();
+            var registry = sp.GetRequiredService<IMvRegistryStore>();
+            var logger = sp.GetRequiredService<ILogger<SqlServerMvExecutor>>();
+            var factory = sp.GetService<IEventStoreFactory>();
+            return factory is not null
+                ? new SqlServerMvExecutor(factory, registry, options, logger, connectionString)
+                : new SqlServerMvExecutor(
+                    sp.GetRequiredService<IEventStore>(),
+                    sp.GetRequiredService<IServiceIdProvider>(),
+                    registry,
+                    options,
+                    logger,
+                    connectionString);
+        });
         if (registerHostedWorker)
         {
             services.TryAddEnumerable(ServiceDescriptor.Singleton<IHostedService, MvCatchUpWorker>());

--- a/dcb/src/Sekiban.Dcb.MaterializedView.SqlServer/SqlServerMvExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.SqlServer/SqlServerMvExecutor.cs
@@ -50,14 +50,13 @@ public sealed class SqlServerMvExecutor : MvExecutorBase<SqlConnection>, IMvExec
         CancellationToken cancellationToken = default)
     {
         var exactServiceId = ValidateServiceIdAtBoundary(serviceId);
-        var eventStore = RequireSelectedEventStore(
-            _eventStoreFactory is null
-                ? _legacyEventStore
-                : _eventStoreFactory!.CreateForService(exactServiceId),
-            exactServiceId,
-            _eventStoreFactory is not null);
-
-        return await CatchUpFromStoreAsync(host, exactServiceId, eventStore, cancellationToken).ConfigureAwait(false);
+        return await CatchUpFromStoreAsync(
+                host,
+                exactServiceId,
+                _eventStoreFactory is null ? _legacyEventStore : _eventStoreFactory!.CreateForService(exactServiceId),
+                _eventStoreFactory is not null,
+                cancellationToken)
+            .ConfigureAwait(false);
     }
 
     protected override async Task<SqlConnection> OpenConnectionAsync(CancellationToken cancellationToken)

--- a/dcb/src/Sekiban.Dcb.MaterializedView.SqlServer/SqlServerMvExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.SqlServer/SqlServerMvExecutor.cs
@@ -44,13 +44,7 @@ public sealed class SqlServerMvExecutor : MvExecutorBase<SqlConnection>, IMvExec
         : base(registryStore, options, logger, connectionString) =>
         _eventStoreFactory = RequireEventStoreFactory(eventStoreFactory);
 
-    public Task InitializeAsync(
-        IMvApplyHost host,
-        string? serviceId = null,
-        CancellationToken cancellationToken = default)
-        => InitializeAtBoundaryAsync(host, serviceId, cancellationToken);
-
-    public async Task<MvCatchUpResult> CatchUpOnceAsync(
+    public override async Task<MvCatchUpResult> CatchUpOnceAsync(
         IMvApplyHost host,
         string? serviceId = null,
         CancellationToken cancellationToken = default)
@@ -65,13 +59,6 @@ public sealed class SqlServerMvExecutor : MvExecutorBase<SqlConnection>, IMvExec
 
         return await CatchUpFromStoreAsync(host, exactServiceId, eventStore, cancellationToken).ConfigureAwait(false);
     }
-
-    public Task<int> ApplySerializableEventsAsync(
-        IMvApplyHost host,
-        IReadOnlyList<SerializableEvent> events,
-        string? serviceId = null,
-        CancellationToken cancellationToken = default)
-        => ApplySerializableEventsAtBoundaryAsync(host, events, serviceId, cancellationToken);
 
     protected override async Task<SqlConnection> OpenConnectionAsync(CancellationToken cancellationToken)
     {

--- a/dcb/src/Sekiban.Dcb.MaterializedView.SqlServer/SqlServerMvExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.SqlServer/SqlServerMvExecutor.cs
@@ -41,10 +41,8 @@ public sealed class SqlServerMvExecutor : MvExecutorBase<SqlConnection>, IMvExec
         IOptions<MvOptions> options,
         ILogger<SqlServerMvExecutor> logger,
         string connectionString)
-        : base(registryStore, options, logger, connectionString)
-    {
+        : base(registryStore, options, logger, connectionString) =>
         _eventStoreFactory = RequireEventStoreFactory(eventStoreFactory);
-    }
 
     public Task InitializeAsync(
         IMvApplyHost host,
@@ -58,17 +56,12 @@ public sealed class SqlServerMvExecutor : MvExecutorBase<SqlConnection>, IMvExec
         CancellationToken cancellationToken = default)
     {
         var exactServiceId = ResolveServiceId(serviceId);
-        IEventStore eventStore;
-        if (_eventStoreFactory is not null)
-        {
-            eventStore = _eventStoreFactory.CreateForService(exactServiceId) ??
-                throw new InvalidOperationException($"The event-store factory returned null for ServiceId '{exactServiceId}'.");
-        }
-        else
-        {
-            eventStore = _legacyEventStore ??
-                throw new InvalidOperationException("No legacy event store is registered for materialized views.");
-        }
+        var eventStore = RequireSelectedEventStore(
+            _eventStoreFactory is null
+                ? _legacyEventStore
+                : _eventStoreFactory!.CreateForService(exactServiceId),
+            exactServiceId,
+            _eventStoreFactory is not null);
 
         return await CatchUpFromStoreAsync(host, exactServiceId, eventStore, cancellationToken).ConfigureAwait(false);
     }
@@ -81,10 +74,7 @@ public sealed class SqlServerMvExecutor : MvExecutorBase<SqlConnection>, IMvExec
         => ApplyStreamEventsAtBoundaryAsync(host, events, ResolveServiceId(serviceId), cancellationToken);
 
     private string ResolveServiceId(string? requestedServiceId) =>
-        ValidateServiceId(
-            requestedServiceId,
-            _eventStoreFactory is null ? _legacyServiceIdProvider : null,
-            nameof(SqlServerMvExecutor));
+        ValidateServiceId(requestedServiceId, _eventStoreFactory is null ? _legacyServiceIdProvider : null, nameof(SqlServerMvExecutor));
 
     protected override async Task<SqlConnection> OpenConnectionAsync(CancellationToken cancellationToken)
     {

--- a/dcb/src/Sekiban.Dcb.MaterializedView.SqlServer/SqlServerMvExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.SqlServer/SqlServerMvExecutor.cs
@@ -28,7 +28,7 @@ public sealed class SqlServerMvExecutor : MvExecutorBase<SqlConnection>, IMvExec
         IOptions<MvOptions> options,
         ILogger<SqlServerMvExecutor> logger,
         string connectionString)
-        : base(registryStore, options, logger, connectionString)
+        : base(registryStore, options, logger, connectionString, serviceIdProvider)
     {
         (_legacyEventStore, _legacyServiceIdProvider) =
             RequireLegacyCompatibilityDependencies(eventStore, serviceIdProvider);
@@ -48,14 +48,14 @@ public sealed class SqlServerMvExecutor : MvExecutorBase<SqlConnection>, IMvExec
         IMvApplyHost host,
         string? serviceId = null,
         CancellationToken cancellationToken = default)
-        => InitializeCoreAsync(host, ResolveServiceId(serviceId), cancellationToken);
+        => InitializeAtBoundaryAsync(host, serviceId, cancellationToken);
 
     public async Task<MvCatchUpResult> CatchUpOnceAsync(
         IMvApplyHost host,
         string? serviceId = null,
         CancellationToken cancellationToken = default)
     {
-        var exactServiceId = ResolveServiceId(serviceId);
+        var exactServiceId = ValidateServiceIdAtBoundary(serviceId);
         var eventStore = RequireSelectedEventStore(
             _eventStoreFactory is null
                 ? _legacyEventStore
@@ -71,10 +71,7 @@ public sealed class SqlServerMvExecutor : MvExecutorBase<SqlConnection>, IMvExec
         IReadOnlyList<SerializableEvent> events,
         string? serviceId = null,
         CancellationToken cancellationToken = default)
-        => ApplyStreamEventsAtBoundaryAsync(host, events, ResolveServiceId(serviceId), cancellationToken);
-
-    private string ResolveServiceId(string? requestedServiceId) =>
-        ValidateServiceId(requestedServiceId, _eventStoreFactory is null ? _legacyServiceIdProvider : null, nameof(SqlServerMvExecutor));
+        => ApplySerializableEventsAtBoundaryAsync(host, events, serviceId, cancellationToken);
 
     protected override async Task<SqlConnection> OpenConnectionAsync(CancellationToken cancellationToken)
     {

--- a/dcb/src/Sekiban.Dcb.MaterializedView.SqlServer/SqlServerMvExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.SqlServer/SqlServerMvExecutor.cs
@@ -1,23 +1,21 @@
+using System.Data;
 using Dapper;
 using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Sekiban.Dcb.Common;
 using Sekiban.Dcb.Events;
+using Sekiban.Dcb.MaterializedView;
 using Sekiban.Dcb.ServiceId;
 using Sekiban.Dcb.Storage;
 
 namespace Sekiban.Dcb.MaterializedView.SqlServer;
 
-public sealed class SqlServerMvExecutor : IMvExecutor
+public sealed class SqlServerMvExecutor : MvExecutorBase<SqlConnection>, IMvExecutor
 {
     private readonly IEventStoreFactory? _eventStoreFactory;
     private readonly IEventStore? _legacyEventStore;
     private readonly IServiceIdProvider? _legacyServiceIdProvider;
-    private readonly ILogger<SqlServerMvExecutor> _logger;
-    private readonly MvOptions _options;
-    private readonly IMvRegistryStore _registryStore;
-    private readonly string _connectionString;
 
     /// <summary>
     /// Creates the legacy single-service compatibility executor over an aggregate event store.
@@ -30,13 +28,10 @@ public sealed class SqlServerMvExecutor : IMvExecutor
         IOptions<MvOptions> options,
         ILogger<SqlServerMvExecutor> logger,
         string connectionString)
+        : base(registryStore, options, logger, connectionString)
     {
         _legacyEventStore = eventStore ?? throw new ArgumentNullException(nameof(eventStore));
         _legacyServiceIdProvider = serviceIdProvider ?? throw new ArgumentNullException(nameof(serviceIdProvider));
-        _registryStore = registryStore;
-        _logger = logger;
-        _connectionString = connectionString;
-        _options = options.Value;
     }
 
     /// <summary>Creates an executor whose event reads use the standard service-scoped factory.</summary>
@@ -46,64 +41,18 @@ public sealed class SqlServerMvExecutor : IMvExecutor
         IOptions<MvOptions> options,
         ILogger<SqlServerMvExecutor> logger,
         string connectionString)
+        : base(registryStore, options, logger, connectionString)
     {
         _eventStoreFactory = eventStoreFactory ?? throw new ArgumentNullException(nameof(eventStoreFactory));
-        _registryStore = registryStore;
-        _logger = logger;
-        _connectionString = connectionString;
-        _options = options.Value;
     }
 
-    public async Task InitializeAsync(
+    public Task InitializeAsync(
         IMvApplyHost host,
         string? serviceId = null,
         CancellationToken cancellationToken = default)
     {
-        serviceId = ResolveServiceId(serviceId);
-        await _registryStore.EnsureInfrastructureAsync(cancellationToken).ConfigureAwait(false);
-
-        await using var connection = new SqlConnection(_connectionString);
-        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
-        await using var transaction = await connection.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
-
-        var bindings = new MvTableBindings(host.ViewName, host.ViewVersion, _options);
-        var statements = await host.InitializeAsync(bindings, cancellationToken).ConfigureAwait(false);
-        foreach (var statement in statements)
-        {
-            await connection.ExecuteAsync(
-                new CommandDefinition(
-                    statement.Sql,
-                    ToDynamicParameters(statement.Parameters),
-                    transaction,
-                    cancellationToken: cancellationToken)).ConfigureAwait(false);
-        }
-
-        foreach (var table in bindings.Tables)
-        {
-            await _registryStore.RegisterAsync(
-                new MvRegistryEntry
-                {
-                    ServiceId = serviceId,
-                    ViewName = host.ViewName,
-                    ViewVersion = host.ViewVersion,
-                    LogicalTable = table.LogicalName,
-                    PhysicalTable = table.PhysicalName,
-                    Status = MvStatus.CatchingUp,
-                    AppliedEventVersion = 0,
-                    LastUpdated = DateTimeOffset.UtcNow
-                },
-                transaction,
-                cancellationToken).ConfigureAwait(false);
-        }
-
-        var active = await _registryStore.GetActiveAsync(serviceId, host.ViewName, cancellationToken).ConfigureAwait(false);
-        if (active is null)
-        {
-            await _registryStore.SetActiveAsync(serviceId, host.ViewName, host.ViewVersion, transaction, cancellationToken)
-                .ConfigureAwait(false);
-        }
-
-        await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+        var exactServiceId = ResolveServiceId(serviceId);
+        return InitializeCoreAsync(host, exactServiceId, cancellationToken);
     }
 
     public async Task<MvCatchUpResult> CatchUpOnceAsync(
@@ -111,24 +60,13 @@ public sealed class SqlServerMvExecutor : IMvExecutor
         string? serviceId = null,
         CancellationToken cancellationToken = default)
     {
-        serviceId = ResolveServiceId(serviceId);
-        var entries = await _registryStore.GetEntriesAsync(serviceId, host.ViewName, host.ViewVersion, cancellationToken)
-            .ConfigureAwait(false);
-        if (entries.Count == 0)
-        {
-            await InitializeAsync(host, serviceId, cancellationToken).ConfigureAwait(false);
-            entries = await _registryStore.GetEntriesAsync(serviceId, host.ViewName, host.ViewVersion, cancellationToken)
-                .ConfigureAwait(false);
-        }
-
-        var currentPosition = entries
-            .Select(entry => entry.CurrentPosition)
-            .FirstOrDefault(position => !string.IsNullOrWhiteSpace(position));
+        var exactServiceId = ResolveServiceId(serviceId);
+        var currentPosition = await GetCurrentPositionAsync(host, exactServiceId, cancellationToken).ConfigureAwait(false);
         IEventStore eventStore;
         if (_eventStoreFactory is not null)
         {
-            eventStore = _eventStoreFactory.CreateForService(serviceId) ??
-                throw new InvalidOperationException($"The event-store factory returned null for ServiceId '{serviceId}'.");
+            eventStore = _eventStoreFactory.CreateForService(exactServiceId) ??
+                throw new InvalidOperationException($"The event-store factory returned null for ServiceId '{exactServiceId}'.");
         }
         else
         {
@@ -137,66 +75,10 @@ public sealed class SqlServerMvExecutor : IMvExecutor
         }
 
         var readResult = await eventStore.ReadAllSerializableEventsAsync(
-            SortableUniqueId.NullableValue(currentPosition),
-            _options.BatchSize).ConfigureAwait(false);
-
-        if (!readResult.IsSuccess)
-        {
-            var exception = readResult.GetException();
-            if (exception is NotSupportedException)
-            {
-                throw exception;
-            }
-
-            _logger.LogWarning(
-                exception,
-                "Failed to read events for materialized view {ViewName}/{ViewVersion}.",
-                host.ViewName,
-                host.ViewVersion);
-            return new MvCatchUpResult(0, false);
-        }
-
-        var safeThreshold = CreateSafeThreshold(_options.SafeWindowMs);
-        var reachedUnsafeWindow = false;
-        var batch = readResult.GetValue().OrderBy(serializable => serializable.SortableUniqueIdValue).ToList();
-
-        if (batch.Count == 0)
-        {
-            return new MvCatchUpResult(0, false);
-        }
-
-        var safeBatch = new List<SerializableEvent>(batch.Count);
-        foreach (var serializableEvent in batch)
-        {
-            if (!new SortableUniqueId(serializableEvent.SortableUniqueIdValue).IsEarlierThanOrEqual(safeThreshold))
-            {
-                reachedUnsafeWindow = true;
-                break;
-            }
-
-            safeBatch.Add(serializableEvent);
-        }
-
-        if (safeBatch.Count == 0)
-        {
-            return new MvCatchUpResult(0, reachedUnsafeWindow);
-        }
-
-        var appliedEvents = await ApplySerializableEventsCoreAsync(
-                host,
-                safeBatch,
-                serviceId,
-                MvApplySource.CatchUp,
-                cancellationToken)
+                SortableUniqueId.NullableValue(currentPosition),
+                Options.BatchSize)
             .ConfigureAwait(false);
-
-        var lastAppliedSortableUniqueId = appliedEvents > 0
-            ? safeBatch[appliedEvents - 1].SortableUniqueIdValue
-            : null;
-
-        reachedUnsafeWindow |= appliedEvents < safeBatch.Count;
-
-        return new MvCatchUpResult(appliedEvents, reachedUnsafeWindow, lastAppliedSortableUniqueId);
+        return await CompleteCatchUpAsync(host, exactServiceId, readResult, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<int> ApplySerializableEventsAsync(
@@ -205,206 +87,50 @@ public sealed class SqlServerMvExecutor : IMvExecutor
         string? serviceId = null,
         CancellationToken cancellationToken = default)
     {
-        serviceId = ResolveServiceId(serviceId);
+        var exactServiceId = ResolveServiceId(serviceId);
         if (events.Count == 0)
         {
             return 0;
         }
 
-        return await ApplySerializableEventsCoreAsync(host, events, serviceId, MvApplySource.Stream, cancellationToken).ConfigureAwait(false);
-    }
-
-    private async Task<int> ApplySerializableEventsCoreAsync(
-        IMvApplyHost host,
-        IReadOnlyList<SerializableEvent> events,
-        string serviceId,
-        MvApplySource source,
-        CancellationToken cancellationToken)
-    {
-        var entries = await _registryStore.GetEntriesAsync(serviceId, host.ViewName, host.ViewVersion, cancellationToken)
+        return await ApplySerializableEventsCoreAsync(
+                host,
+                events,
+                exactServiceId,
+                MvApplySource.Stream,
+                cancellationToken)
             .ConfigureAwait(false);
-        if (entries.Count == 0)
-        {
-            await InitializeAsync(host, serviceId, cancellationToken).ConfigureAwait(false);
-            entries = await _registryStore.GetEntriesAsync(serviceId, host.ViewName, host.ViewVersion, cancellationToken)
-                .ConfigureAwait(false);
-        }
+    }
 
-        var currentPosition = entries
-            .Select(entry => entry.CurrentPosition)
-            .FirstOrDefault(position => !string.IsNullOrWhiteSpace(position));
-        var orderedEvents = events
-            .GroupBy(serializableEvent => serializableEvent.SortableUniqueIdValue)
-            .Select(group => group.First())
-            .Where(serializableEvent =>
-                source == MvApplySource.Stream ||
-                string.IsNullOrWhiteSpace(currentPosition) ||
-                string.Compare(serializableEvent.SortableUniqueIdValue, currentPosition, StringComparison.Ordinal) > 0)
-            .OrderBy(serializableEvent => serializableEvent.SortableUniqueIdValue, StringComparer.Ordinal)
-            .ToList();
+    private string ResolveServiceId(string? requestedServiceId) =>
+        MvServiceIdValidation.Validate(
+            requestedServiceId,
+            Options,
+            _eventStoreFactory is null ? _legacyServiceIdProvider : null,
+            nameof(SqlServerMvExecutor));
 
-        if (orderedEvents.Count == 0)
-        {
-            return 0;
-        }
-
-        await using var connection = new SqlConnection(_connectionString);
+    protected override async Task<SqlConnection> OpenConnectionAsync(CancellationToken cancellationToken)
+    {
+        var connection = new SqlConnection(ConnectionString);
         await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
-        var appliedEvents = 0;
-        var bindings = CreateBindings(host, entries);
-
-        foreach (var serializableEvent in orderedEvents)
-        {
-            var applied = await ApplySerializableEventAsync(
-                    connection,
-                    host,
-                    serviceId,
-                    bindings,
-                    serializableEvent,
-                    currentPosition,
-                    source,
-                    cancellationToken)
-                .ConfigureAwait(false);
-            if (!applied)
-            {
-                break;
-            }
-
-            appliedEvents += 1;
-        }
-
-        return appliedEvents;
+        return connection;
     }
 
-    private async Task<bool> ApplySerializableEventAsync(
+    protected override IMvApplyQueryPort CreateQueryPort(
         SqlConnection connection,
-        IMvApplyHost host,
-        string serviceId,
-        MvTableBindings bindings,
-        SerializableEvent serializableEvent,
-        string? currentPosition,
-        MvApplySource source,
-        CancellationToken cancellationToken)
-    {
-        await using var transaction = await connection.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
-        var queryPort = new SqlServerMvApplyQueryPort(connection, transaction);
-        var statements = await host.ApplyEventAsync(
-            serializableEvent,
-            bindings,
-            queryPort,
-            serializableEvent.SortableUniqueIdValue,
-            cancellationToken).ConfigureAwait(false);
-        var affectedRows = 0;
-        foreach (var statement in statements)
-        {
-            affectedRows += await connection.ExecuteAsync(
-                new CommandDefinition(
-                    statement.Sql,
-                    ToDynamicParameters(statement.Parameters),
-                    transaction,
-                    cancellationToken: cancellationToken)).ConfigureAwait(false);
-        }
+        IDbTransaction transaction) =>
+        new SqlServerMvApplyQueryPort(connection, transaction);
 
-        if (source == MvApplySource.Stream && statements.Count > 0 && affectedRows == 0)
-        {
-            if (!string.IsNullOrWhiteSpace(currentPosition) &&
-                string.Compare(serializableEvent.SortableUniqueIdValue, currentPosition, StringComparison.Ordinal) <= 0)
-            {
-                await transaction.RollbackAsync(cancellationToken).ConfigureAwait(false);
-                return true;
-            }
-
-            await transaction.RollbackAsync(cancellationToken).ConfigureAwait(false);
-            return false;
-        }
-
-        await _registryStore.UpdatePositionAsync(
-            new MvPositionUpdate(
-                serviceId,
-                host.ViewName,
-                host.ViewVersion,
-                serializableEvent.SortableUniqueIdValue,
-                source),
-            transaction: transaction,
-            cancellationToken: cancellationToken).ConfigureAwait(false);
-
-        await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
-        return true;
-    }
-
-    private string ResolveServiceId(string? requestedServiceId)
-    {
-        var callerSuppliedServiceId = !string.IsNullOrWhiteSpace(requestedServiceId);
-        var resolvedServiceId = requestedServiceId;
-        if (string.IsNullOrWhiteSpace(resolvedServiceId))
-        {
-            resolvedServiceId = _options.ServiceId;
-        }
-
-        if (string.IsNullOrWhiteSpace(resolvedServiceId) && _eventStoreFactory is null)
-        {
-            resolvedServiceId = _legacyServiceIdProvider?.GetCurrentServiceId();
-        }
-
-        if (string.IsNullOrWhiteSpace(resolvedServiceId))
-        {
-            throw new InvalidOperationException(
-                $"{nameof(SqlServerMvExecutor)} requires an explicit non-empty ServiceId. Configure MvOptions.ServiceId or pass the service id at the caller boundary.");
-        }
-
-        var normalizedServiceId = ServiceIdValidator.NormalizeAndValidate(resolvedServiceId);
-        if (string.Equals(normalizedServiceId, DefaultServiceIdProvider.DefaultServiceId, StringComparison.Ordinal) &&
-            !_options.AllowDefaultServiceId)
-        {
-            throw new InvalidOperationException(
-                $"{nameof(SqlServerMvExecutor)} cannot use the implicit default ServiceId. Opt into the named single-service compatibility option AllowDefaultServiceId or provide an explicit non-default service.");
-        }
-
-        if (callerSuppliedServiceId && !string.IsNullOrWhiteSpace(_options.ServiceId))
-        {
-            var configuredServiceId = ServiceIdValidator.NormalizeAndValidate(_options.ServiceId);
-            if (!string.Equals(configuredServiceId, normalizedServiceId, StringComparison.Ordinal))
-            {
-                throw new InvalidOperationException(
-                    $"{nameof(SqlServerMvExecutor)} requested ServiceId '{normalizedServiceId}', but MvOptions is bound to '{configuredServiceId}'.");
-            }
-        }
-
-        if (_legacyEventStore is not null)
-        {
-            var legacyServiceId = ServiceIdValidator.NormalizeAndValidate(_legacyServiceIdProvider!.GetCurrentServiceId());
-            if (!string.Equals(legacyServiceId, normalizedServiceId, StringComparison.Ordinal))
-            {
-                throw new InvalidOperationException(
-                    $"{nameof(SqlServerMvExecutor)} requested ServiceId '{normalizedServiceId}', but the legacy aggregate event store is bound to '{legacyServiceId}'. Register IEventStoreFactory for service-scoped MV reads.");
-            }
-        }
-
-        return normalizedServiceId;
-    }
-
-    private MvTableBindings CreateBindings(IMvApplyHost host, IReadOnlyList<MvRegistryEntry> entries)
-    {
-        var bindings = new MvTableBindings(host.ViewName, host.ViewVersion, _options);
-        foreach (var entry in entries)
-        {
-            bindings.RegisterTable(entry.LogicalTable, entry.PhysicalTable);
-        }
-
-        return bindings;
-    }
-
-    private static DynamicParameters ToDynamicParameters(IReadOnlyList<MvParam> parameters)
-    {
-        var dynamicParameters = new DynamicParameters();
-        foreach (var parameter in parameters)
-        {
-            dynamicParameters.Add(parameter.Name, MvParamConverter.ToClrValue(parameter));
-        }
-
-        return dynamicParameters;
-    }
-
-    private static SortableUniqueId CreateSafeThreshold(int safeWindowMs) =>
-        new(SortableUniqueId.Generate(DateTime.UtcNow.AddMilliseconds(-safeWindowMs), Guid.Empty));
+    protected override Task<int> ExecuteSqlAsync(
+        SqlConnection connection,
+        string sql,
+        IReadOnlyList<MvParam> parameters,
+        IDbTransaction transaction,
+        CancellationToken cancellationToken) =>
+        connection.ExecuteAsync(
+            new CommandDefinition(
+                sql,
+                ToParameterDictionary(parameters),
+                transaction,
+                cancellationToken: cancellationToken));
 }

--- a/dcb/src/Sekiban.Dcb.MaterializedView.SqlServer/SqlServerMvExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.SqlServer/SqlServerMvExecutor.cs
@@ -30,8 +30,8 @@ public sealed class SqlServerMvExecutor : MvExecutorBase<SqlConnection>, IMvExec
         string connectionString)
         : base(registryStore, options, logger, connectionString)
     {
-        _legacyEventStore = eventStore ?? throw new ArgumentNullException(nameof(eventStore));
-        _legacyServiceIdProvider = serviceIdProvider ?? throw new ArgumentNullException(nameof(serviceIdProvider));
+        (_legacyEventStore, _legacyServiceIdProvider) =
+            RequireLegacyCompatibilityDependencies(eventStore, serviceIdProvider);
     }
 
     /// <summary>Creates an executor whose event reads use the standard service-scoped factory.</summary>
@@ -43,17 +43,14 @@ public sealed class SqlServerMvExecutor : MvExecutorBase<SqlConnection>, IMvExec
         string connectionString)
         : base(registryStore, options, logger, connectionString)
     {
-        _eventStoreFactory = eventStoreFactory ?? throw new ArgumentNullException(nameof(eventStoreFactory));
+        _eventStoreFactory = RequireEventStoreFactory(eventStoreFactory);
     }
 
     public Task InitializeAsync(
         IMvApplyHost host,
         string? serviceId = null,
         CancellationToken cancellationToken = default)
-    {
-        var exactServiceId = ResolveServiceId(serviceId);
-        return InitializeCoreAsync(host, exactServiceId, cancellationToken);
-    }
+        => InitializeCoreAsync(host, ResolveServiceId(serviceId), cancellationToken);
 
     public async Task<MvCatchUpResult> CatchUpOnceAsync(
         IMvApplyHost host,
@@ -61,7 +58,6 @@ public sealed class SqlServerMvExecutor : MvExecutorBase<SqlConnection>, IMvExec
         CancellationToken cancellationToken = default)
     {
         var exactServiceId = ResolveServiceId(serviceId);
-        var currentPosition = await GetCurrentPositionAsync(host, exactServiceId, cancellationToken).ConfigureAwait(false);
         IEventStore eventStore;
         if (_eventStoreFactory is not null)
         {
@@ -74,38 +70,19 @@ public sealed class SqlServerMvExecutor : MvExecutorBase<SqlConnection>, IMvExec
                 throw new InvalidOperationException("No legacy event store is registered for materialized views.");
         }
 
-        var readResult = await eventStore.ReadAllSerializableEventsAsync(
-                SortableUniqueId.NullableValue(currentPosition),
-                Options.BatchSize)
-            .ConfigureAwait(false);
-        return await CompleteCatchUpAsync(host, exactServiceId, readResult, cancellationToken).ConfigureAwait(false);
+        return await CatchUpFromStoreAsync(host, exactServiceId, eventStore, cancellationToken).ConfigureAwait(false);
     }
 
-    public async Task<int> ApplySerializableEventsAsync(
+    public Task<int> ApplySerializableEventsAsync(
         IMvApplyHost host,
         IReadOnlyList<SerializableEvent> events,
         string? serviceId = null,
         CancellationToken cancellationToken = default)
-    {
-        var exactServiceId = ResolveServiceId(serviceId);
-        if (events.Count == 0)
-        {
-            return 0;
-        }
-
-        return await ApplySerializableEventsCoreAsync(
-                host,
-                events,
-                exactServiceId,
-                MvApplySource.Stream,
-                cancellationToken)
-            .ConfigureAwait(false);
-    }
+        => ApplyStreamEventsAtBoundaryAsync(host, events, ResolveServiceId(serviceId), cancellationToken);
 
     private string ResolveServiceId(string? requestedServiceId) =>
-        MvServiceIdValidation.Validate(
+        ValidateServiceId(
             requestedServiceId,
-            Options,
             _eventStoreFactory is null ? _legacyServiceIdProvider : null,
             nameof(SqlServerMvExecutor));
 

--- a/dcb/src/Sekiban.Dcb.MaterializedView.SqlServer/SqlServerMvExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.SqlServer/SqlServerMvExecutor.cs
@@ -11,13 +11,18 @@ namespace Sekiban.Dcb.MaterializedView.SqlServer;
 
 public sealed class SqlServerMvExecutor : IMvExecutor
 {
-    private readonly IEventStore _eventStore;
+    private readonly IEventStoreFactory? _eventStoreFactory;
+    private readonly IEventStore? _legacyEventStore;
+    private readonly IServiceIdProvider? _legacyServiceIdProvider;
     private readonly ILogger<SqlServerMvExecutor> _logger;
     private readonly MvOptions _options;
     private readonly IMvRegistryStore _registryStore;
     private readonly string _connectionString;
-    private readonly IServiceIdProvider _serviceIdProvider;
 
+    /// <summary>
+    /// Creates the legacy single-service compatibility executor over an aggregate event store.
+    /// Multi-service hosts should use the <see cref="IEventStoreFactory"/> constructor.
+    /// </summary>
     public SqlServerMvExecutor(
         IEventStore eventStore,
         IServiceIdProvider serviceIdProvider,
@@ -26,8 +31,23 @@ public sealed class SqlServerMvExecutor : IMvExecutor
         ILogger<SqlServerMvExecutor> logger,
         string connectionString)
     {
-        _eventStore = eventStore;
-        _serviceIdProvider = serviceIdProvider;
+        _legacyEventStore = eventStore ?? throw new ArgumentNullException(nameof(eventStore));
+        _legacyServiceIdProvider = serviceIdProvider ?? throw new ArgumentNullException(nameof(serviceIdProvider));
+        _registryStore = registryStore;
+        _logger = logger;
+        _connectionString = connectionString;
+        _options = options.Value;
+    }
+
+    /// <summary>Creates an executor whose event reads use the standard service-scoped factory.</summary>
+    public SqlServerMvExecutor(
+        IEventStoreFactory eventStoreFactory,
+        IMvRegistryStore registryStore,
+        IOptions<MvOptions> options,
+        ILogger<SqlServerMvExecutor> logger,
+        string connectionString)
+    {
+        _eventStoreFactory = eventStoreFactory ?? throw new ArgumentNullException(nameof(eventStoreFactory));
         _registryStore = registryStore;
         _logger = logger;
         _connectionString = connectionString;
@@ -39,8 +59,8 @@ public sealed class SqlServerMvExecutor : IMvExecutor
         string? serviceId = null,
         CancellationToken cancellationToken = default)
     {
-        await _registryStore.EnsureInfrastructureAsync(cancellationToken).ConfigureAwait(false);
         serviceId = ResolveServiceId(serviceId);
+        await _registryStore.EnsureInfrastructureAsync(cancellationToken).ConfigureAwait(false);
 
         await using var connection = new SqlConnection(_connectionString);
         await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
@@ -104,7 +124,19 @@ public sealed class SqlServerMvExecutor : IMvExecutor
         var currentPosition = entries
             .Select(entry => entry.CurrentPosition)
             .FirstOrDefault(position => !string.IsNullOrWhiteSpace(position));
-        var readResult = await _eventStore.ReadAllSerializableEventsAsync(
+        IEventStore eventStore;
+        if (_eventStoreFactory is not null)
+        {
+            eventStore = _eventStoreFactory.CreateForService(serviceId) ??
+                throw new InvalidOperationException($"The event-store factory returned null for ServiceId '{serviceId}'.");
+        }
+        else
+        {
+            eventStore = _legacyEventStore ??
+                throw new InvalidOperationException("No legacy event store is registered for materialized views.");
+        }
+
+        var readResult = await eventStore.ReadAllSerializableEventsAsync(
             SortableUniqueId.NullableValue(currentPosition),
             _options.BatchSize).ConfigureAwait(false);
 
@@ -173,12 +205,12 @@ public sealed class SqlServerMvExecutor : IMvExecutor
         string? serviceId = null,
         CancellationToken cancellationToken = default)
     {
+        serviceId = ResolveServiceId(serviceId);
         if (events.Count == 0)
         {
             return 0;
         }
 
-        serviceId = ResolveServiceId(serviceId);
         return await ApplySerializableEventsCoreAsync(host, events, serviceId, MvApplySource.Stream, cancellationToken).ConfigureAwait(false);
     }
 
@@ -300,10 +332,56 @@ public sealed class SqlServerMvExecutor : IMvExecutor
         return true;
     }
 
-    private string ResolveServiceId(string? serviceId) =>
-        string.IsNullOrWhiteSpace(serviceId)
-            ? _serviceIdProvider.GetCurrentServiceId()
-            : serviceId;
+    private string ResolveServiceId(string? requestedServiceId)
+    {
+        var callerSuppliedServiceId = !string.IsNullOrWhiteSpace(requestedServiceId);
+        var resolvedServiceId = requestedServiceId;
+        if (string.IsNullOrWhiteSpace(resolvedServiceId))
+        {
+            resolvedServiceId = _options.ServiceId;
+        }
+
+        if (string.IsNullOrWhiteSpace(resolvedServiceId) && _eventStoreFactory is null)
+        {
+            resolvedServiceId = _legacyServiceIdProvider?.GetCurrentServiceId();
+        }
+
+        if (string.IsNullOrWhiteSpace(resolvedServiceId))
+        {
+            throw new InvalidOperationException(
+                $"{nameof(SqlServerMvExecutor)} requires an explicit non-empty ServiceId. Configure MvOptions.ServiceId or pass the service id at the caller boundary.");
+        }
+
+        var normalizedServiceId = ServiceIdValidator.NormalizeAndValidate(resolvedServiceId);
+        if (string.Equals(normalizedServiceId, DefaultServiceIdProvider.DefaultServiceId, StringComparison.Ordinal) &&
+            !_options.AllowDefaultServiceId)
+        {
+            throw new InvalidOperationException(
+                $"{nameof(SqlServerMvExecutor)} cannot use the implicit default ServiceId. Opt into the named single-service compatibility option AllowDefaultServiceId or provide an explicit non-default service.");
+        }
+
+        if (callerSuppliedServiceId && !string.IsNullOrWhiteSpace(_options.ServiceId))
+        {
+            var configuredServiceId = ServiceIdValidator.NormalizeAndValidate(_options.ServiceId);
+            if (!string.Equals(configuredServiceId, normalizedServiceId, StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException(
+                    $"{nameof(SqlServerMvExecutor)} requested ServiceId '{normalizedServiceId}', but MvOptions is bound to '{configuredServiceId}'.");
+            }
+        }
+
+        if (_legacyEventStore is not null)
+        {
+            var legacyServiceId = ServiceIdValidator.NormalizeAndValidate(_legacyServiceIdProvider!.GetCurrentServiceId());
+            if (!string.Equals(legacyServiceId, normalizedServiceId, StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException(
+                    $"{nameof(SqlServerMvExecutor)} requested ServiceId '{normalizedServiceId}', but the legacy aggregate event store is bound to '{legacyServiceId}'. Register IEventStoreFactory for service-scoped MV reads.");
+            }
+        }
+
+        return normalizedServiceId;
+    }
 
     private MvTableBindings CreateBindings(IMvApplyHost host, IReadOnlyList<MvRegistryEntry> entries)
     {

--- a/dcb/src/Sekiban.Dcb.MaterializedView.Sqlite/SekibanDcbMaterializedViewSqliteExtensions.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.Sqlite/SekibanDcbMaterializedViewSqliteExtensions.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Sekiban.Dcb.ServiceId;
+using Sekiban.Dcb.Storage;
 
 namespace Sekiban.Dcb.MaterializedView.Sqlite;
 
@@ -32,13 +33,21 @@ public static class SekibanDcbMaterializedViewSqliteExtensions
         services.TryAddSingleton<IMvStorageInfoProvider>(_ =>
             new MvStorageInfoProvider(new MvStorageInfo(MvDbType.Sqlite, connectionString)));
         services.TryAddSingleton<IMvExecutor>(sp =>
-            new SqliteMvExecutor(
-                sp.GetRequiredService<Sekiban.Dcb.Storage.IEventStore>(),
-                sp.GetRequiredService<IServiceIdProvider>(),
-                sp.GetRequiredService<IMvRegistryStore>(),
-                sp.GetRequiredService<IOptions<MvOptions>>(),
-                sp.GetRequiredService<ILogger<SqliteMvExecutor>>(),
-                connectionString));
+        {
+            var options = sp.GetRequiredService<IOptions<MvOptions>>();
+            var registry = sp.GetRequiredService<IMvRegistryStore>();
+            var logger = sp.GetRequiredService<ILogger<SqliteMvExecutor>>();
+            var factory = sp.GetService<IEventStoreFactory>();
+            return factory is not null
+                ? new SqliteMvExecutor(factory, registry, options, logger, connectionString)
+                : new SqliteMvExecutor(
+                    sp.GetRequiredService<IEventStore>(),
+                    sp.GetRequiredService<IServiceIdProvider>(),
+                    registry,
+                    options,
+                    logger,
+                    connectionString);
+        });
         if (registerHostedWorker)
         {
             services.TryAddEnumerable(ServiceDescriptor.Singleton<IHostedService, MvCatchUpWorker>());

--- a/dcb/src/Sekiban.Dcb.MaterializedView.Sqlite/SekibanDcbMaterializedViewSqliteExtensions.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.Sqlite/SekibanDcbMaterializedViewSqliteExtensions.cs
@@ -33,21 +33,13 @@ public static class SekibanDcbMaterializedViewSqliteExtensions
         services.TryAddSingleton<IMvStorageInfoProvider>(_ =>
             new MvStorageInfoProvider(new MvStorageInfo(MvDbType.Sqlite, connectionString)));
         services.TryAddSingleton<IMvExecutor>(sp =>
-        {
-            var options = sp.GetRequiredService<IOptions<MvOptions>>();
-            var registry = sp.GetRequiredService<IMvRegistryStore>();
-            var logger = sp.GetRequiredService<ILogger<SqliteMvExecutor>>();
-            var factory = sp.GetService<IEventStoreFactory>();
-            return factory is not null
-                ? new SqliteMvExecutor(factory, registry, options, logger, connectionString)
-                : new SqliteMvExecutor(
-                    sp.GetRequiredService<IEventStore>(),
-                    sp.GetRequiredService<IServiceIdProvider>(),
-                    registry,
-                    options,
-                    logger,
-                    connectionString);
-        });
+            SekibanDcbMaterializedViewExtensions.CreateMaterializedViewExecutor<SqliteMvExecutor>(
+                sp,
+                connectionString,
+                static (factory, registry, options, logger, connection) =>
+                    new SqliteMvExecutor(factory, registry, options, logger, connection),
+                static (eventStore, serviceIdProvider, registry, options, logger, connection) =>
+                    new SqliteMvExecutor(eventStore, serviceIdProvider, registry, options, logger, connection)));
         if (registerHostedWorker)
         {
             services.TryAddEnumerable(ServiceDescriptor.Singleton<IHostedService, MvCatchUpWorker>());

--- a/dcb/src/Sekiban.Dcb.MaterializedView.Sqlite/SqliteMvExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.Sqlite/SqliteMvExecutor.cs
@@ -1,23 +1,21 @@
+using System.Data;
 using Dapper;
 using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Sekiban.Dcb.Common;
 using Sekiban.Dcb.Events;
+using Sekiban.Dcb.MaterializedView;
 using Sekiban.Dcb.ServiceId;
 using Sekiban.Dcb.Storage;
 
 namespace Sekiban.Dcb.MaterializedView.Sqlite;
 
-public sealed class SqliteMvExecutor : IMvExecutor
+public sealed class SqliteMvExecutor : MvExecutorBase<SqliteConnection>, IMvExecutor
 {
     private readonly IEventStoreFactory? _eventStoreFactory;
     private readonly IEventStore? _legacyEventStore;
     private readonly IServiceIdProvider? _legacyServiceIdProvider;
-    private readonly ILogger<SqliteMvExecutor> _logger;
-    private readonly MvOptions _options;
-    private readonly IMvRegistryStore _registryStore;
-    private readonly string _connectionString;
 
     /// <summary>
     /// Creates the legacy single-service compatibility executor over an aggregate event store.
@@ -30,13 +28,10 @@ public sealed class SqliteMvExecutor : IMvExecutor
         IOptions<MvOptions> options,
         ILogger<SqliteMvExecutor> logger,
         string connectionString)
+        : base(registryStore, options, logger, connectionString)
     {
         _legacyEventStore = eventStore ?? throw new ArgumentNullException(nameof(eventStore));
         _legacyServiceIdProvider = serviceIdProvider ?? throw new ArgumentNullException(nameof(serviceIdProvider));
-        _registryStore = registryStore;
-        _logger = logger;
-        _connectionString = connectionString;
-        _options = options.Value;
     }
 
     /// <summary>Creates an executor whose event reads use the standard service-scoped factory.</summary>
@@ -46,63 +41,18 @@ public sealed class SqliteMvExecutor : IMvExecutor
         IOptions<MvOptions> options,
         ILogger<SqliteMvExecutor> logger,
         string connectionString)
+        : base(registryStore, options, logger, connectionString)
     {
         _eventStoreFactory = eventStoreFactory ?? throw new ArgumentNullException(nameof(eventStoreFactory));
-        _registryStore = registryStore;
-        _logger = logger;
-        _connectionString = connectionString;
-        _options = options.Value;
     }
 
-    public async Task InitializeAsync(
+    public Task InitializeAsync(
         IMvApplyHost host,
         string? serviceId = null,
         CancellationToken cancellationToken = default)
     {
-        serviceId = ResolveServiceId(serviceId);
-        await _registryStore.EnsureInfrastructureAsync(cancellationToken).ConfigureAwait(false);
-
-        await using var connection = await OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
-        await using var transaction = await connection.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
-
-        var bindings = new MvTableBindings(host.ViewName, host.ViewVersion, _options);
-        var statements = await host.InitializeAsync(bindings, cancellationToken).ConfigureAwait(false);
-        foreach (var statement in statements)
-        {
-            await connection.ExecuteAsync(
-                new CommandDefinition(
-                    statement.Sql,
-                    ToDynamicParameters(statement.Parameters),
-                    transaction,
-                    cancellationToken: cancellationToken)).ConfigureAwait(false);
-        }
-
-        foreach (var table in bindings.Tables)
-        {
-            await _registryStore.RegisterAsync(
-                new MvRegistryEntry
-                {
-                    ServiceId = serviceId,
-                    ViewName = host.ViewName,
-                    ViewVersion = host.ViewVersion,
-                    LogicalTable = table.LogicalName,
-                    PhysicalTable = table.PhysicalName,
-                    Status = MvStatus.CatchingUp,
-                    AppliedEventVersion = 0,
-                    LastUpdated = DateTimeOffset.UtcNow
-                },
-                transaction,
-                cancellationToken).ConfigureAwait(false);
-        }
-
-        var active = await _registryStore.GetActiveAsync(serviceId, host.ViewName, cancellationToken).ConfigureAwait(false);
-        if (active is null)
-        {
-            await _registryStore.SetActiveAsync(serviceId, host.ViewName, host.ViewVersion, transaction, cancellationToken)
-                .ConfigureAwait(false);
-        }
-
-        await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+        var exactServiceId = ResolveServiceId(serviceId);
+        return InitializeCoreAsync(host, exactServiceId, cancellationToken);
     }
 
     public async Task<MvCatchUpResult> CatchUpOnceAsync(
@@ -110,24 +60,13 @@ public sealed class SqliteMvExecutor : IMvExecutor
         string? serviceId = null,
         CancellationToken cancellationToken = default)
     {
-        serviceId = ResolveServiceId(serviceId);
-        var entries = await _registryStore.GetEntriesAsync(serviceId, host.ViewName, host.ViewVersion, cancellationToken)
-            .ConfigureAwait(false);
-        if (entries.Count == 0)
-        {
-            await InitializeAsync(host, serviceId, cancellationToken).ConfigureAwait(false);
-            entries = await _registryStore.GetEntriesAsync(serviceId, host.ViewName, host.ViewVersion, cancellationToken)
-                .ConfigureAwait(false);
-        }
-
-        var currentPosition = entries
-            .Select(entry => entry.CurrentPosition)
-            .FirstOrDefault(position => !string.IsNullOrWhiteSpace(position));
+        var exactServiceId = ResolveServiceId(serviceId);
+        var currentPosition = await GetCurrentPositionAsync(host, exactServiceId, cancellationToken).ConfigureAwait(false);
         IEventStore eventStore;
         if (_eventStoreFactory is not null)
         {
-            eventStore = _eventStoreFactory.CreateForService(serviceId) ??
-                throw new InvalidOperationException($"The event-store factory returned null for ServiceId '{serviceId}'.");
+            eventStore = _eventStoreFactory.CreateForService(exactServiceId) ??
+                throw new InvalidOperationException($"The event-store factory returned null for ServiceId '{exactServiceId}'.");
         }
         else
         {
@@ -136,66 +75,10 @@ public sealed class SqliteMvExecutor : IMvExecutor
         }
 
         var readResult = await eventStore.ReadAllSerializableEventsAsync(
-            SortableUniqueId.NullableValue(currentPosition),
-            _options.BatchSize).ConfigureAwait(false);
-
-        if (!readResult.IsSuccess)
-        {
-            var exception = readResult.GetException();
-            if (exception is NotSupportedException)
-            {
-                throw exception;
-            }
-
-            _logger.LogWarning(
-                exception,
-                "Failed to read events for materialized view {ViewName}/{ViewVersion}.",
-                host.ViewName,
-                host.ViewVersion);
-            return new MvCatchUpResult(0, false);
-        }
-
-        var safeThreshold = CreateSafeThreshold(_options.SafeWindowMs);
-        var reachedUnsafeWindow = false;
-        var batch = readResult.GetValue().OrderBy(serializable => serializable.SortableUniqueIdValue).ToList();
-
-        if (batch.Count == 0)
-        {
-            return new MvCatchUpResult(0, false);
-        }
-
-        var safeBatch = new List<SerializableEvent>(batch.Count);
-        foreach (var serializableEvent in batch)
-        {
-            if (!new SortableUniqueId(serializableEvent.SortableUniqueIdValue).IsEarlierThanOrEqual(safeThreshold))
-            {
-                reachedUnsafeWindow = true;
-                break;
-            }
-
-            safeBatch.Add(serializableEvent);
-        }
-
-        if (safeBatch.Count == 0)
-        {
-            return new MvCatchUpResult(0, reachedUnsafeWindow);
-        }
-
-        var appliedEvents = await ApplySerializableEventsCoreAsync(
-                host,
-                safeBatch,
-                serviceId,
-                MvApplySource.CatchUp,
-                cancellationToken)
+                SortableUniqueId.NullableValue(currentPosition),
+                Options.BatchSize)
             .ConfigureAwait(false);
-
-        var lastAppliedSortableUniqueId = appliedEvents > 0
-            ? safeBatch[appliedEvents - 1].SortableUniqueIdValue
-            : null;
-
-        reachedUnsafeWindow |= appliedEvents < safeBatch.Count;
-
-        return new MvCatchUpResult(appliedEvents, reachedUnsafeWindow, lastAppliedSortableUniqueId);
+        return await CompleteCatchUpAsync(host, exactServiceId, readResult, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<int> ApplySerializableEventsAsync(
@@ -204,213 +87,53 @@ public sealed class SqliteMvExecutor : IMvExecutor
         string? serviceId = null,
         CancellationToken cancellationToken = default)
     {
-        serviceId = ResolveServiceId(serviceId);
+        var exactServiceId = ResolveServiceId(serviceId);
         if (events.Count == 0)
         {
             return 0;
         }
 
-        return await ApplySerializableEventsCoreAsync(host, events, serviceId, MvApplySource.Stream, cancellationToken).ConfigureAwait(false);
-    }
-
-    private async Task<int> ApplySerializableEventsCoreAsync(
-        IMvApplyHost host,
-        IReadOnlyList<SerializableEvent> events,
-        string serviceId,
-        MvApplySource source,
-        CancellationToken cancellationToken)
-    {
-        var entries = await _registryStore.GetEntriesAsync(serviceId, host.ViewName, host.ViewVersion, cancellationToken)
+        return await ApplySerializableEventsCoreAsync(
+                host,
+                events,
+                exactServiceId,
+                MvApplySource.Stream,
+                cancellationToken)
             .ConfigureAwait(false);
-        if (entries.Count == 0)
-        {
-            await InitializeAsync(host, serviceId, cancellationToken).ConfigureAwait(false);
-            entries = await _registryStore.GetEntriesAsync(serviceId, host.ViewName, host.ViewVersion, cancellationToken)
-                .ConfigureAwait(false);
-        }
-
-        var currentPosition = entries
-            .Select(entry => entry.CurrentPosition)
-            .FirstOrDefault(position => !string.IsNullOrWhiteSpace(position));
-        var orderedEvents = events
-            .GroupBy(serializableEvent => serializableEvent.SortableUniqueIdValue)
-            .Select(group => group.First())
-            .Where(serializableEvent =>
-                source == MvApplySource.Stream ||
-                string.IsNullOrWhiteSpace(currentPosition) ||
-                string.Compare(serializableEvent.SortableUniqueIdValue, currentPosition, StringComparison.Ordinal) > 0)
-            .OrderBy(serializableEvent => serializableEvent.SortableUniqueIdValue, StringComparer.Ordinal)
-            .ToList();
-
-        if (orderedEvents.Count == 0)
-        {
-            return 0;
-        }
-
-        await using var connection = await OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
-        var appliedEvents = 0;
-        var bindings = CreateBindings(host, entries);
-
-        foreach (var serializableEvent in orderedEvents)
-        {
-            var applied = await ApplySerializableEventAsync(
-                    connection,
-                    host,
-                    serviceId,
-                    bindings,
-                    serializableEvent,
-                    currentPosition,
-                    source,
-                    cancellationToken)
-                .ConfigureAwait(false);
-            if (!applied)
-            {
-                break;
-            }
-
-            appliedEvents += 1;
-        }
-
-        return appliedEvents;
     }
 
-    private async Task<bool> ApplySerializableEventAsync(
-        SqliteConnection connection,
-        IMvApplyHost host,
-        string serviceId,
-        MvTableBindings bindings,
-        SerializableEvent serializableEvent,
-        string? currentPosition,
-        MvApplySource source,
-        CancellationToken cancellationToken)
+    private string ResolveServiceId(string? requestedServiceId) =>
+        MvServiceIdValidation.Validate(
+            requestedServiceId,
+            Options,
+            _eventStoreFactory is null ? _legacyServiceIdProvider : null,
+            nameof(SqliteMvExecutor));
+
+    protected override async Task<SqliteConnection> OpenConnectionAsync(CancellationToken cancellationToken)
     {
-        await using var transaction = await connection.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
-        var queryPort = new SqliteMvApplyQueryPort(connection, transaction);
-        var statements = await host.ApplyEventAsync(
-            serializableEvent,
-            bindings,
-            queryPort,
-            serializableEvent.SortableUniqueIdValue,
-            cancellationToken).ConfigureAwait(false);
-        var affectedRows = 0;
-        foreach (var statement in statements)
-        {
-            affectedRows += await connection.ExecuteAsync(
-                new CommandDefinition(
-                    statement.Sql,
-                    ToDynamicParameters(statement.Parameters),
-                    transaction,
-                    cancellationToken: cancellationToken)).ConfigureAwait(false);
-        }
-
-        if (source == MvApplySource.Stream && statements.Count > 0 && affectedRows == 0)
-        {
-            if (!string.IsNullOrWhiteSpace(currentPosition) &&
-                string.Compare(serializableEvent.SortableUniqueIdValue, currentPosition, StringComparison.Ordinal) <= 0)
-            {
-                await transaction.RollbackAsync(cancellationToken).ConfigureAwait(false);
-                return true;
-            }
-
-            await transaction.RollbackAsync(cancellationToken).ConfigureAwait(false);
-            return false;
-        }
-
-        await _registryStore.UpdatePositionAsync(
-            new MvPositionUpdate(
-                serviceId,
-                host.ViewName,
-                host.ViewVersion,
-                serializableEvent.SortableUniqueIdValue,
-                source),
-            transaction: transaction,
-            cancellationToken: cancellationToken).ConfigureAwait(false);
-
-        await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
-        return true;
-    }
-
-    private string ResolveServiceId(string? requestedServiceId)
-    {
-        var callerSuppliedServiceId = !string.IsNullOrWhiteSpace(requestedServiceId);
-        var resolvedServiceId = requestedServiceId;
-        if (string.IsNullOrWhiteSpace(resolvedServiceId))
-        {
-            resolvedServiceId = _options.ServiceId;
-        }
-
-        if (string.IsNullOrWhiteSpace(resolvedServiceId) && _eventStoreFactory is null)
-        {
-            resolvedServiceId = _legacyServiceIdProvider?.GetCurrentServiceId();
-        }
-
-        if (string.IsNullOrWhiteSpace(resolvedServiceId))
-        {
-            throw new InvalidOperationException(
-                $"{nameof(SqliteMvExecutor)} requires an explicit non-empty ServiceId. Configure MvOptions.ServiceId or pass the service id at the caller boundary.");
-        }
-
-        var normalizedServiceId = ServiceIdValidator.NormalizeAndValidate(resolvedServiceId);
-        if (string.Equals(normalizedServiceId, DefaultServiceIdProvider.DefaultServiceId, StringComparison.Ordinal) &&
-            !_options.AllowDefaultServiceId)
-        {
-            throw new InvalidOperationException(
-                $"{nameof(SqliteMvExecutor)} cannot use the implicit default ServiceId. Opt into the named single-service compatibility option AllowDefaultServiceId or provide an explicit non-default service.");
-        }
-
-        if (callerSuppliedServiceId && !string.IsNullOrWhiteSpace(_options.ServiceId))
-        {
-            var configuredServiceId = ServiceIdValidator.NormalizeAndValidate(_options.ServiceId);
-            if (!string.Equals(configuredServiceId, normalizedServiceId, StringComparison.Ordinal))
-            {
-                throw new InvalidOperationException(
-                    $"{nameof(SqliteMvExecutor)} requested ServiceId '{normalizedServiceId}', but MvOptions is bound to '{configuredServiceId}'.");
-            }
-        }
-
-        if (_legacyEventStore is not null)
-        {
-            var legacyServiceId = ServiceIdValidator.NormalizeAndValidate(_legacyServiceIdProvider!.GetCurrentServiceId());
-            if (!string.Equals(legacyServiceId, normalizedServiceId, StringComparison.Ordinal))
-            {
-                throw new InvalidOperationException(
-                    $"{nameof(SqliteMvExecutor)} requested ServiceId '{normalizedServiceId}', but the legacy aggregate event store is bound to '{legacyServiceId}'. Register IEventStoreFactory for service-scoped MV reads.");
-            }
-        }
-
-        return normalizedServiceId;
-    }
-
-    private MvTableBindings CreateBindings(IMvApplyHost host, IReadOnlyList<MvRegistryEntry> entries)
-    {
-        var bindings = new MvTableBindings(host.ViewName, host.ViewVersion, _options);
-        foreach (var entry in entries)
-        {
-            bindings.RegisterTable(entry.LogicalTable, entry.PhysicalTable);
-        }
-
-        return bindings;
-    }
-
-    private static DynamicParameters ToDynamicParameters(IReadOnlyList<MvParam> parameters)
-    {
-        var dynamicParameters = new DynamicParameters();
-        foreach (var parameter in parameters)
-        {
-            dynamicParameters.Add(parameter.Name, MvParamConverter.ToClrValue(parameter));
-        }
-
-        return dynamicParameters;
-    }
-
-    private static SortableUniqueId CreateSafeThreshold(int safeWindowMs) =>
-        new(SortableUniqueId.Generate(DateTime.UtcNow.AddMilliseconds(-safeWindowMs), Guid.Empty));
-
-    private async Task<SqliteConnection> OpenConnectionAsync(CancellationToken cancellationToken)
-    {
-        var connection = new SqliteConnection(_connectionString);
+        var connection = new SqliteConnection(ConnectionString);
         await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
-        await connection.ExecuteAsync(new CommandDefinition("PRAGMA synchronous=NORMAL;", cancellationToken: cancellationToken)).ConfigureAwait(false);
+        await connection.ExecuteAsync(
+                new CommandDefinition("PRAGMA synchronous=NORMAL;", cancellationToken: cancellationToken))
+            .ConfigureAwait(false);
         return connection;
     }
+
+    protected override IMvApplyQueryPort CreateQueryPort(
+        SqliteConnection connection,
+        IDbTransaction transaction) =>
+        new SqliteMvApplyQueryPort(connection, transaction);
+
+    protected override Task<int> ExecuteSqlAsync(
+        SqliteConnection connection,
+        string sql,
+        IReadOnlyList<MvParam> parameters,
+        IDbTransaction transaction,
+        CancellationToken cancellationToken) =>
+        connection.ExecuteAsync(
+            new CommandDefinition(
+                sql,
+                ToParameterDictionary(parameters),
+                transaction,
+                cancellationToken: cancellationToken));
 }

--- a/dcb/src/Sekiban.Dcb.MaterializedView.Sqlite/SqliteMvExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.Sqlite/SqliteMvExecutor.cs
@@ -30,8 +30,8 @@ public sealed class SqliteMvExecutor : MvExecutorBase<SqliteConnection>, IMvExec
         string connectionString)
         : base(registryStore, options, logger, connectionString)
     {
-        _legacyEventStore = eventStore ?? throw new ArgumentNullException(nameof(eventStore));
-        _legacyServiceIdProvider = serviceIdProvider ?? throw new ArgumentNullException(nameof(serviceIdProvider));
+        (_legacyEventStore, _legacyServiceIdProvider) =
+            RequireLegacyCompatibilityDependencies(eventStore, serviceIdProvider);
     }
 
     /// <summary>Creates an executor whose event reads use the standard service-scoped factory.</summary>
@@ -43,17 +43,14 @@ public sealed class SqliteMvExecutor : MvExecutorBase<SqliteConnection>, IMvExec
         string connectionString)
         : base(registryStore, options, logger, connectionString)
     {
-        _eventStoreFactory = eventStoreFactory ?? throw new ArgumentNullException(nameof(eventStoreFactory));
+        _eventStoreFactory = RequireEventStoreFactory(eventStoreFactory);
     }
 
     public Task InitializeAsync(
         IMvApplyHost host,
         string? serviceId = null,
         CancellationToken cancellationToken = default)
-    {
-        var exactServiceId = ResolveServiceId(serviceId);
-        return InitializeCoreAsync(host, exactServiceId, cancellationToken);
-    }
+        => InitializeCoreAsync(host, ResolveServiceId(serviceId), cancellationToken);
 
     public async Task<MvCatchUpResult> CatchUpOnceAsync(
         IMvApplyHost host,
@@ -61,7 +58,6 @@ public sealed class SqliteMvExecutor : MvExecutorBase<SqliteConnection>, IMvExec
         CancellationToken cancellationToken = default)
     {
         var exactServiceId = ResolveServiceId(serviceId);
-        var currentPosition = await GetCurrentPositionAsync(host, exactServiceId, cancellationToken).ConfigureAwait(false);
         IEventStore eventStore;
         if (_eventStoreFactory is not null)
         {
@@ -74,38 +70,19 @@ public sealed class SqliteMvExecutor : MvExecutorBase<SqliteConnection>, IMvExec
                 throw new InvalidOperationException("No legacy event store is registered for materialized views.");
         }
 
-        var readResult = await eventStore.ReadAllSerializableEventsAsync(
-                SortableUniqueId.NullableValue(currentPosition),
-                Options.BatchSize)
-            .ConfigureAwait(false);
-        return await CompleteCatchUpAsync(host, exactServiceId, readResult, cancellationToken).ConfigureAwait(false);
+        return await CatchUpFromStoreAsync(host, exactServiceId, eventStore, cancellationToken).ConfigureAwait(false);
     }
 
-    public async Task<int> ApplySerializableEventsAsync(
+    public Task<int> ApplySerializableEventsAsync(
         IMvApplyHost host,
         IReadOnlyList<SerializableEvent> events,
         string? serviceId = null,
         CancellationToken cancellationToken = default)
-    {
-        var exactServiceId = ResolveServiceId(serviceId);
-        if (events.Count == 0)
-        {
-            return 0;
-        }
-
-        return await ApplySerializableEventsCoreAsync(
-                host,
-                events,
-                exactServiceId,
-                MvApplySource.Stream,
-                cancellationToken)
-            .ConfigureAwait(false);
-    }
+        => ApplyStreamEventsAtBoundaryAsync(host, events, ResolveServiceId(serviceId), cancellationToken);
 
     private string ResolveServiceId(string? requestedServiceId) =>
-        MvServiceIdValidation.Validate(
+        ValidateServiceId(
             requestedServiceId,
-            Options,
             _eventStoreFactory is null ? _legacyServiceIdProvider : null,
             nameof(SqliteMvExecutor));
 

--- a/dcb/src/Sekiban.Dcb.MaterializedView.Sqlite/SqliteMvExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.Sqlite/SqliteMvExecutor.cs
@@ -28,7 +28,7 @@ public sealed class SqliteMvExecutor : MvExecutorBase<SqliteConnection>, IMvExec
         IOptions<MvOptions> options,
         ILogger<SqliteMvExecutor> logger,
         string connectionString)
-        : base(registryStore, options, logger, connectionString)
+        : base(registryStore, options, logger, connectionString, serviceIdProvider)
     {
         (_legacyEventStore, _legacyServiceIdProvider) =
             RequireLegacyCompatibilityDependencies(eventStore, serviceIdProvider);
@@ -48,14 +48,14 @@ public sealed class SqliteMvExecutor : MvExecutorBase<SqliteConnection>, IMvExec
         IMvApplyHost host,
         string? serviceId = null,
         CancellationToken cancellationToken = default)
-        => InitializeCoreAsync(host, ResolveServiceId(serviceId), cancellationToken);
+        => InitializeAtBoundaryAsync(host, serviceId, cancellationToken);
 
     public async Task<MvCatchUpResult> CatchUpOnceAsync(
         IMvApplyHost host,
         string? serviceId = null,
         CancellationToken cancellationToken = default)
     {
-        var exactServiceId = ResolveServiceId(serviceId);
+        var exactServiceId = ValidateServiceIdAtBoundary(serviceId);
         var eventStore = RequireSelectedEventStore(
             _eventStoreFactory is null
                 ? _legacyEventStore
@@ -71,10 +71,7 @@ public sealed class SqliteMvExecutor : MvExecutorBase<SqliteConnection>, IMvExec
         IReadOnlyList<SerializableEvent> events,
         string? serviceId = null,
         CancellationToken cancellationToken = default)
-        => ApplyStreamEventsAtBoundaryAsync(host, events, ResolveServiceId(serviceId), cancellationToken);
-
-    private string ResolveServiceId(string? requestedServiceId) =>
-        ValidateServiceId(requestedServiceId, _eventStoreFactory is null ? _legacyServiceIdProvider : null, nameof(SqliteMvExecutor));
+        => ApplySerializableEventsAtBoundaryAsync(host, events, serviceId, cancellationToken);
 
     protected override async Task<SqliteConnection> OpenConnectionAsync(CancellationToken cancellationToken)
     {

--- a/dcb/src/Sekiban.Dcb.MaterializedView.Sqlite/SqliteMvExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.Sqlite/SqliteMvExecutor.cs
@@ -11,13 +11,18 @@ namespace Sekiban.Dcb.MaterializedView.Sqlite;
 
 public sealed class SqliteMvExecutor : IMvExecutor
 {
-    private readonly IEventStore _eventStore;
+    private readonly IEventStoreFactory? _eventStoreFactory;
+    private readonly IEventStore? _legacyEventStore;
+    private readonly IServiceIdProvider? _legacyServiceIdProvider;
     private readonly ILogger<SqliteMvExecutor> _logger;
     private readonly MvOptions _options;
     private readonly IMvRegistryStore _registryStore;
     private readonly string _connectionString;
-    private readonly IServiceIdProvider _serviceIdProvider;
 
+    /// <summary>
+    /// Creates the legacy single-service compatibility executor over an aggregate event store.
+    /// Multi-service hosts should use the <see cref="IEventStoreFactory"/> constructor.
+    /// </summary>
     public SqliteMvExecutor(
         IEventStore eventStore,
         IServiceIdProvider serviceIdProvider,
@@ -26,8 +31,23 @@ public sealed class SqliteMvExecutor : IMvExecutor
         ILogger<SqliteMvExecutor> logger,
         string connectionString)
     {
-        _eventStore = eventStore;
-        _serviceIdProvider = serviceIdProvider;
+        _legacyEventStore = eventStore ?? throw new ArgumentNullException(nameof(eventStore));
+        _legacyServiceIdProvider = serviceIdProvider ?? throw new ArgumentNullException(nameof(serviceIdProvider));
+        _registryStore = registryStore;
+        _logger = logger;
+        _connectionString = connectionString;
+        _options = options.Value;
+    }
+
+    /// <summary>Creates an executor whose event reads use the standard service-scoped factory.</summary>
+    public SqliteMvExecutor(
+        IEventStoreFactory eventStoreFactory,
+        IMvRegistryStore registryStore,
+        IOptions<MvOptions> options,
+        ILogger<SqliteMvExecutor> logger,
+        string connectionString)
+    {
+        _eventStoreFactory = eventStoreFactory ?? throw new ArgumentNullException(nameof(eventStoreFactory));
         _registryStore = registryStore;
         _logger = logger;
         _connectionString = connectionString;
@@ -39,8 +59,8 @@ public sealed class SqliteMvExecutor : IMvExecutor
         string? serviceId = null,
         CancellationToken cancellationToken = default)
     {
-        await _registryStore.EnsureInfrastructureAsync(cancellationToken).ConfigureAwait(false);
         serviceId = ResolveServiceId(serviceId);
+        await _registryStore.EnsureInfrastructureAsync(cancellationToken).ConfigureAwait(false);
 
         await using var connection = await OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
         await using var transaction = await connection.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
@@ -103,7 +123,19 @@ public sealed class SqliteMvExecutor : IMvExecutor
         var currentPosition = entries
             .Select(entry => entry.CurrentPosition)
             .FirstOrDefault(position => !string.IsNullOrWhiteSpace(position));
-        var readResult = await _eventStore.ReadAllSerializableEventsAsync(
+        IEventStore eventStore;
+        if (_eventStoreFactory is not null)
+        {
+            eventStore = _eventStoreFactory.CreateForService(serviceId) ??
+                throw new InvalidOperationException($"The event-store factory returned null for ServiceId '{serviceId}'.");
+        }
+        else
+        {
+            eventStore = _legacyEventStore ??
+                throw new InvalidOperationException("No legacy event store is registered for materialized views.");
+        }
+
+        var readResult = await eventStore.ReadAllSerializableEventsAsync(
             SortableUniqueId.NullableValue(currentPosition),
             _options.BatchSize).ConfigureAwait(false);
 
@@ -172,12 +204,12 @@ public sealed class SqliteMvExecutor : IMvExecutor
         string? serviceId = null,
         CancellationToken cancellationToken = default)
     {
+        serviceId = ResolveServiceId(serviceId);
         if (events.Count == 0)
         {
             return 0;
         }
 
-        serviceId = ResolveServiceId(serviceId);
         return await ApplySerializableEventsCoreAsync(host, events, serviceId, MvApplySource.Stream, cancellationToken).ConfigureAwait(false);
     }
 
@@ -298,10 +330,56 @@ public sealed class SqliteMvExecutor : IMvExecutor
         return true;
     }
 
-    private string ResolveServiceId(string? serviceId) =>
-        string.IsNullOrWhiteSpace(serviceId)
-            ? _serviceIdProvider.GetCurrentServiceId()
-            : serviceId;
+    private string ResolveServiceId(string? requestedServiceId)
+    {
+        var callerSuppliedServiceId = !string.IsNullOrWhiteSpace(requestedServiceId);
+        var resolvedServiceId = requestedServiceId;
+        if (string.IsNullOrWhiteSpace(resolvedServiceId))
+        {
+            resolvedServiceId = _options.ServiceId;
+        }
+
+        if (string.IsNullOrWhiteSpace(resolvedServiceId) && _eventStoreFactory is null)
+        {
+            resolvedServiceId = _legacyServiceIdProvider?.GetCurrentServiceId();
+        }
+
+        if (string.IsNullOrWhiteSpace(resolvedServiceId))
+        {
+            throw new InvalidOperationException(
+                $"{nameof(SqliteMvExecutor)} requires an explicit non-empty ServiceId. Configure MvOptions.ServiceId or pass the service id at the caller boundary.");
+        }
+
+        var normalizedServiceId = ServiceIdValidator.NormalizeAndValidate(resolvedServiceId);
+        if (string.Equals(normalizedServiceId, DefaultServiceIdProvider.DefaultServiceId, StringComparison.Ordinal) &&
+            !_options.AllowDefaultServiceId)
+        {
+            throw new InvalidOperationException(
+                $"{nameof(SqliteMvExecutor)} cannot use the implicit default ServiceId. Opt into the named single-service compatibility option AllowDefaultServiceId or provide an explicit non-default service.");
+        }
+
+        if (callerSuppliedServiceId && !string.IsNullOrWhiteSpace(_options.ServiceId))
+        {
+            var configuredServiceId = ServiceIdValidator.NormalizeAndValidate(_options.ServiceId);
+            if (!string.Equals(configuredServiceId, normalizedServiceId, StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException(
+                    $"{nameof(SqliteMvExecutor)} requested ServiceId '{normalizedServiceId}', but MvOptions is bound to '{configuredServiceId}'.");
+            }
+        }
+
+        if (_legacyEventStore is not null)
+        {
+            var legacyServiceId = ServiceIdValidator.NormalizeAndValidate(_legacyServiceIdProvider!.GetCurrentServiceId());
+            if (!string.Equals(legacyServiceId, normalizedServiceId, StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException(
+                    $"{nameof(SqliteMvExecutor)} requested ServiceId '{normalizedServiceId}', but the legacy aggregate event store is bound to '{legacyServiceId}'. Register IEventStoreFactory for service-scoped MV reads.");
+            }
+        }
+
+        return normalizedServiceId;
+    }
 
     private MvTableBindings CreateBindings(IMvApplyHost host, IReadOnlyList<MvRegistryEntry> entries)
     {

--- a/dcb/src/Sekiban.Dcb.MaterializedView.Sqlite/SqliteMvExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.Sqlite/SqliteMvExecutor.cs
@@ -44,13 +44,7 @@ public sealed class SqliteMvExecutor : MvExecutorBase<SqliteConnection>, IMvExec
         : base(registryStore, options, logger, connectionString) =>
         _eventStoreFactory = RequireEventStoreFactory(eventStoreFactory);
 
-    public Task InitializeAsync(
-        IMvApplyHost host,
-        string? serviceId = null,
-        CancellationToken cancellationToken = default)
-        => InitializeAtBoundaryAsync(host, serviceId, cancellationToken);
-
-    public async Task<MvCatchUpResult> CatchUpOnceAsync(
+    public override async Task<MvCatchUpResult> CatchUpOnceAsync(
         IMvApplyHost host,
         string? serviceId = null,
         CancellationToken cancellationToken = default)
@@ -65,13 +59,6 @@ public sealed class SqliteMvExecutor : MvExecutorBase<SqliteConnection>, IMvExec
 
         return await CatchUpFromStoreAsync(host, exactServiceId, eventStore, cancellationToken).ConfigureAwait(false);
     }
-
-    public Task<int> ApplySerializableEventsAsync(
-        IMvApplyHost host,
-        IReadOnlyList<SerializableEvent> events,
-        string? serviceId = null,
-        CancellationToken cancellationToken = default)
-        => ApplySerializableEventsAtBoundaryAsync(host, events, serviceId, cancellationToken);
 
     protected override async Task<SqliteConnection> OpenConnectionAsync(CancellationToken cancellationToken)
     {

--- a/dcb/src/Sekiban.Dcb.MaterializedView.Sqlite/SqliteMvExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.Sqlite/SqliteMvExecutor.cs
@@ -50,14 +50,13 @@ public sealed class SqliteMvExecutor : MvExecutorBase<SqliteConnection>, IMvExec
         CancellationToken cancellationToken = default)
     {
         var exactServiceId = ValidateServiceIdAtBoundary(serviceId);
-        var eventStore = RequireSelectedEventStore(
-            _eventStoreFactory is null
-                ? _legacyEventStore
-                : _eventStoreFactory!.CreateForService(exactServiceId),
-            exactServiceId,
-            _eventStoreFactory is not null);
-
-        return await CatchUpFromStoreAsync(host, exactServiceId, eventStore, cancellationToken).ConfigureAwait(false);
+        return await CatchUpFromStoreAsync(
+                host,
+                exactServiceId,
+                _eventStoreFactory is null ? _legacyEventStore : _eventStoreFactory!.CreateForService(exactServiceId),
+                _eventStoreFactory is not null,
+                cancellationToken)
+            .ConfigureAwait(false);
     }
 
     protected override async Task<SqliteConnection> OpenConnectionAsync(CancellationToken cancellationToken)

--- a/dcb/src/Sekiban.Dcb.MaterializedView.Sqlite/SqliteMvExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.Sqlite/SqliteMvExecutor.cs
@@ -41,10 +41,8 @@ public sealed class SqliteMvExecutor : MvExecutorBase<SqliteConnection>, IMvExec
         IOptions<MvOptions> options,
         ILogger<SqliteMvExecutor> logger,
         string connectionString)
-        : base(registryStore, options, logger, connectionString)
-    {
+        : base(registryStore, options, logger, connectionString) =>
         _eventStoreFactory = RequireEventStoreFactory(eventStoreFactory);
-    }
 
     public Task InitializeAsync(
         IMvApplyHost host,
@@ -58,17 +56,12 @@ public sealed class SqliteMvExecutor : MvExecutorBase<SqliteConnection>, IMvExec
         CancellationToken cancellationToken = default)
     {
         var exactServiceId = ResolveServiceId(serviceId);
-        IEventStore eventStore;
-        if (_eventStoreFactory is not null)
-        {
-            eventStore = _eventStoreFactory.CreateForService(exactServiceId) ??
-                throw new InvalidOperationException($"The event-store factory returned null for ServiceId '{exactServiceId}'.");
-        }
-        else
-        {
-            eventStore = _legacyEventStore ??
-                throw new InvalidOperationException("No legacy event store is registered for materialized views.");
-        }
+        var eventStore = RequireSelectedEventStore(
+            _eventStoreFactory is null
+                ? _legacyEventStore
+                : _eventStoreFactory!.CreateForService(exactServiceId),
+            exactServiceId,
+            _eventStoreFactory is not null);
 
         return await CatchUpFromStoreAsync(host, exactServiceId, eventStore, cancellationToken).ConfigureAwait(false);
     }
@@ -81,10 +74,7 @@ public sealed class SqliteMvExecutor : MvExecutorBase<SqliteConnection>, IMvExec
         => ApplyStreamEventsAtBoundaryAsync(host, events, ResolveServiceId(serviceId), cancellationToken);
 
     private string ResolveServiceId(string? requestedServiceId) =>
-        ValidateServiceId(
-            requestedServiceId,
-            _eventStoreFactory is null ? _legacyServiceIdProvider : null,
-            nameof(SqliteMvExecutor));
+        ValidateServiceId(requestedServiceId, _eventStoreFactory is null ? _legacyServiceIdProvider : null, nameof(SqliteMvExecutor));
 
     protected override async Task<SqliteConnection> OpenConnectionAsync(CancellationToken cancellationToken)
     {

--- a/dcb/src/Sekiban.Dcb.MaterializedView/MvCatchUpWorker.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView/MvCatchUpWorker.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Sekiban.Dcb.ServiceId;
 
 namespace Sekiban.Dcb.MaterializedView;
 
@@ -12,18 +13,33 @@ public sealed class MvCatchUpWorker : BackgroundService
     private readonly ILogger<MvCatchUpWorker> _logger;
     private readonly IReadOnlyList<MvApplyHostRegistration> _registrations;
     private readonly MvOptions _options;
+    private readonly string _serviceId;
 
     public MvCatchUpWorker(
         IMvApplyHostFactory hostFactory,
         IMvExecutor executor,
         IOptions<MvOptions> options,
         ILogger<MvCatchUpWorker> logger)
+        : this(hostFactory, executor, options, logger, serviceId: null)
+    {
+    }
+
+    /// <summary>
+    /// Creates one immutable worker bound to one exact service identity.
+    /// </summary>
+    public MvCatchUpWorker(
+        IMvApplyHostFactory hostFactory,
+        IMvExecutor executor,
+        IOptions<MvOptions> options,
+        ILogger<MvCatchUpWorker> logger,
+        string? serviceId)
     {
         _executor = executor;
         _hostFactory = hostFactory;
         _logger = logger;
         _registrations = hostFactory.GetRegistrations();
         _options = options.Value;
+        _serviceId = ResolveWorkerServiceId(serviceId, _options);
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
@@ -50,7 +66,7 @@ public sealed class MvCatchUpWorker : BackgroundService
         foreach (var registration in _registrations)
         {
             var host = _hostFactory.Create(registration.ViewName, registration.ViewVersion);
-            await _executor.InitializeAsync(host, cancellationToken: stoppingToken).ConfigureAwait(false);
+            await _executor.InitializeAsync(host, _serviceId, stoppingToken).ConfigureAwait(false);
         }
     }
 
@@ -81,7 +97,7 @@ public sealed class MvCatchUpWorker : BackgroundService
         var host = _hostFactory.Create(registration.ViewName, registration.ViewVersion);
         try
         {
-            var result = await _executor.CatchUpOnceAsync(host, cancellationToken: stoppingToken).ConfigureAwait(false);
+            var result = await _executor.CatchUpOnceAsync(host, _serviceId, stoppingToken).ConfigureAwait(false);
             _failureCounts.Remove(GetProjectorKey(registration));
             return new CatchUpCycleResult(result.AppliedEvents, result.ReachedUnsafeWindow, ShouldStop: false);
         }
@@ -129,6 +145,36 @@ public sealed class MvCatchUpWorker : BackgroundService
 
     private static string GetProjectorKey(MvApplyHostRegistration registration) =>
         $"{registration.ViewName}:{registration.ViewVersion}";
+
+    private static string ResolveWorkerServiceId(string? serviceId, MvOptions options)
+    {
+        var requested = string.IsNullOrWhiteSpace(serviceId) ? options.ServiceId : serviceId;
+        if (string.IsNullOrWhiteSpace(requested))
+        {
+            throw new InvalidOperationException(
+                "MvCatchUpWorker requires an exact ServiceId. Configure MvOptions.ServiceId or register a service-bound worker.");
+        }
+
+        var normalized = ServiceIdValidator.NormalizeAndValidate(requested);
+        if (!string.IsNullOrWhiteSpace(serviceId) && !string.IsNullOrWhiteSpace(options.ServiceId))
+        {
+            var configured = ServiceIdValidator.NormalizeAndValidate(options.ServiceId);
+            if (!string.Equals(configured, normalized, StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException(
+                    $"MvCatchUpWorker requested ServiceId '{normalized}', but MvOptions is bound to '{configured}'.");
+            }
+        }
+
+        if (string.Equals(normalized, DefaultServiceIdProvider.DefaultServiceId, StringComparison.Ordinal) &&
+            !options.AllowDefaultServiceId)
+        {
+            throw new InvalidOperationException(
+                "MvCatchUpWorker cannot use the implicit default ServiceId. Set AllowDefaultServiceId only for an explicit single-service compatibility registration.");
+        }
+
+        return normalized;
+    }
 
     private sealed record CatchUpCycleResult(int AppliedEvents, bool ShouldDelay, bool ShouldStop);
 }

--- a/dcb/src/Sekiban.Dcb.MaterializedView/MvExecutorBase.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView/MvExecutorBase.cs
@@ -22,17 +22,20 @@ public abstract class MvExecutorBase<TConnection>
     private readonly ILogger _logger;
     private readonly MvOptions _options;
     private readonly string _connectionString;
+    private readonly IServiceIdProvider? _legacyServiceIdProvider;
 
     protected MvExecutorBase(
         IMvRegistryStore registryStore,
         IOptions<MvOptions> options,
         ILogger logger,
-        string connectionString)
+        string connectionString,
+        IServiceIdProvider? legacyServiceIdProvider = null)
     {
         _registryStore = registryStore;
         _logger = logger;
         _options = options.Value;
         _connectionString = connectionString;
+        _legacyServiceIdProvider = legacyServiceIdProvider;
     }
 
     protected IMvRegistryStore RegistryStore => _registryStore;
@@ -75,6 +78,29 @@ public abstract class MvExecutorBase<TConnection>
         IServiceIdProvider? legacyServiceIdProvider,
         string executorName) =>
         MvServiceIdValidation.Validate(requestedServiceId, _options, legacyServiceIdProvider, executorName);
+
+    protected Task InitializeAtBoundaryAsync(
+        IMvApplyHost host,
+        string? requestedServiceId,
+        CancellationToken cancellationToken) =>
+        InitializeCoreAsync(
+            host,
+            ValidateServiceId(requestedServiceId, _legacyServiceIdProvider, GetType().Name),
+            cancellationToken);
+
+    protected Task<int> ApplySerializableEventsAtBoundaryAsync(
+        IMvApplyHost host,
+        IReadOnlyList<SerializableEvent> events,
+        string? requestedServiceId,
+        CancellationToken cancellationToken) =>
+        ApplyStreamEventsAtBoundaryAsync(
+            host,
+            events,
+            ValidateServiceId(requestedServiceId, _legacyServiceIdProvider, GetType().Name),
+            cancellationToken);
+
+    protected string ValidateServiceIdAtBoundary(string? requestedServiceId) =>
+        ValidateServiceId(requestedServiceId, _legacyServiceIdProvider, GetType().Name);
 
     protected abstract Task<TConnection> OpenConnectionAsync(CancellationToken cancellationToken);
 

--- a/dcb/src/Sekiban.Dcb.MaterializedView/MvExecutorBase.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView/MvExecutorBase.cs
@@ -55,6 +55,21 @@ public abstract class MvExecutorBase<TConnection>
     protected static IEventStoreFactory RequireEventStoreFactory(IEventStoreFactory eventStoreFactory) =>
         eventStoreFactory ?? throw new ArgumentNullException(nameof(eventStoreFactory));
 
+    protected static IEventStore RequireSelectedEventStore(
+        IEventStore? eventStore,
+        string exactServiceId,
+        bool selectedFromFactory)
+    {
+        if (eventStore is not null)
+        {
+            return eventStore;
+        }
+
+        throw selectedFromFactory
+            ? new InvalidOperationException($"The event-store factory returned null for ServiceId '{exactServiceId}'.")
+            : new InvalidOperationException("No legacy event store is registered for materialized views.");
+    }
+
     protected string ValidateServiceId(
         string? requestedServiceId,
         IServiceIdProvider? legacyServiceIdProvider,

--- a/dcb/src/Sekiban.Dcb.MaterializedView/MvExecutorBase.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView/MvExecutorBase.cs
@@ -219,11 +219,13 @@ public abstract class MvExecutorBase<TConnection> : IMvExecutor
     protected async Task<MvCatchUpResult> CatchUpFromStoreAsync(
         IMvApplyHost host,
         string serviceId,
-        IEventStore eventStore,
+        IEventStore? eventStore,
+        bool selectedFromFactory,
         CancellationToken cancellationToken)
     {
+        var selectedEventStore = RequireSelectedEventStore(eventStore, serviceId, selectedFromFactory);
         var currentPosition = await GetCurrentPositionAsync(host, serviceId, cancellationToken).ConfigureAwait(false);
-        var readResult = await eventStore.ReadAllSerializableEventsAsync(
+        var readResult = await selectedEventStore.ReadAllSerializableEventsAsync(
                 SortableUniqueId.NullableValue(currentPosition),
                 _options.BatchSize)
             .ConfigureAwait(false);

--- a/dcb/src/Sekiban.Dcb.MaterializedView/MvExecutorBase.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView/MvExecutorBase.cs
@@ -5,6 +5,8 @@ using Microsoft.Extensions.Options;
 using ResultBoxes;
 using Sekiban.Dcb.Common;
 using Sekiban.Dcb.Events;
+using Sekiban.Dcb.ServiceId;
+using Sekiban.Dcb.Storage;
 
 namespace Sekiban.Dcb.MaterializedView;
 
@@ -38,6 +40,26 @@ public abstract class MvExecutorBase<TConnection>
     protected MvOptions Options => _options;
 
     protected string ConnectionString => _connectionString;
+
+    // These helpers validate dependencies and move database-neutral workflow only. They never resolve or cache an
+    // event store; each provider executor keeps its own factory field and selects its service-scoped source.
+    protected static (IEventStore EventStore, IServiceIdProvider ServiceIdProvider) RequireLegacyCompatibilityDependencies(
+        IEventStore eventStore,
+        IServiceIdProvider serviceIdProvider)
+    {
+        return (
+            eventStore ?? throw new ArgumentNullException(nameof(eventStore)),
+            serviceIdProvider ?? throw new ArgumentNullException(nameof(serviceIdProvider)));
+    }
+
+    protected static IEventStoreFactory RequireEventStoreFactory(IEventStoreFactory eventStoreFactory) =>
+        eventStoreFactory ?? throw new ArgumentNullException(nameof(eventStoreFactory));
+
+    protected string ValidateServiceId(
+        string? requestedServiceId,
+        IServiceIdProvider? legacyServiceIdProvider,
+        string executorName) =>
+        MvServiceIdValidation.Validate(requestedServiceId, _options, legacyServiceIdProvider, executorName);
 
     protected abstract Task<TConnection> OpenConnectionAsync(CancellationToken cancellationToken);
 
@@ -133,6 +155,39 @@ public abstract class MvExecutorBase<TConnection>
         return entries
             .Select(entry => entry.CurrentPosition)
             .FirstOrDefault(position => !string.IsNullOrWhiteSpace(position));
+    }
+
+    protected async Task<MvCatchUpResult> CatchUpFromStoreAsync(
+        IMvApplyHost host,
+        string serviceId,
+        IEventStore eventStore,
+        CancellationToken cancellationToken)
+    {
+        var currentPosition = await GetCurrentPositionAsync(host, serviceId, cancellationToken).ConfigureAwait(false);
+        var readResult = await eventStore.ReadAllSerializableEventsAsync(
+                SortableUniqueId.NullableValue(currentPosition),
+                _options.BatchSize)
+            .ConfigureAwait(false);
+        return await CompleteCatchUpAsync(host, serviceId, readResult, cancellationToken).ConfigureAwait(false);
+    }
+
+    protected Task<int> ApplyStreamEventsAtBoundaryAsync(
+        IMvApplyHost host,
+        IReadOnlyList<SerializableEvent> events,
+        string exactServiceId,
+        CancellationToken cancellationToken)
+    {
+        if (events.Count == 0)
+        {
+            return Task.FromResult(0);
+        }
+
+        return ApplySerializableEventsCoreAsync(
+            host,
+            events,
+            exactServiceId,
+            MvApplySource.Stream,
+            cancellationToken);
     }
 
     protected async Task<MvCatchUpResult> CompleteCatchUpAsync(

--- a/dcb/src/Sekiban.Dcb.MaterializedView/MvExecutorBase.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView/MvExecutorBase.cs
@@ -15,7 +15,7 @@ namespace Sekiban.Dcb.MaterializedView;
 /// Provider executors retain their own event-store factory and perform service validation/source selection
 /// at each public operation boundary before delegating database work here.
 /// </summary>
-public abstract class MvExecutorBase<TConnection>
+public abstract class MvExecutorBase<TConnection> : IMvExecutor
     where TConnection : DbConnection
 {
     private readonly IMvRegistryStore _registryStore;
@@ -101,6 +101,24 @@ public abstract class MvExecutorBase<TConnection>
 
     protected string ValidateServiceIdAtBoundary(string? requestedServiceId) =>
         ValidateServiceId(requestedServiceId, _legacyServiceIdProvider, GetType().Name);
+
+    public Task InitializeAsync(
+        IMvApplyHost host,
+        string? serviceId = null,
+        CancellationToken cancellationToken = default) =>
+        InitializeAtBoundaryAsync(host, serviceId, cancellationToken);
+
+    public Task<int> ApplySerializableEventsAsync(
+        IMvApplyHost host,
+        IReadOnlyList<SerializableEvent> events,
+        string? serviceId = null,
+        CancellationToken cancellationToken = default) =>
+        ApplySerializableEventsAtBoundaryAsync(host, events, serviceId, cancellationToken);
+
+    public abstract Task<MvCatchUpResult> CatchUpOnceAsync(
+        IMvApplyHost host,
+        string? serviceId = null,
+        CancellationToken cancellationToken = default);
 
     protected abstract Task<TConnection> OpenConnectionAsync(CancellationToken cancellationToken);
 

--- a/dcb/src/Sekiban.Dcb.MaterializedView/MvExecutorBase.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView/MvExecutorBase.cs
@@ -1,0 +1,351 @@
+using System.Data;
+using System.Data.Common;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using ResultBoxes;
+using Sekiban.Dcb.Common;
+using Sekiban.Dcb.Events;
+
+namespace Sekiban.Dcb.MaterializedView;
+
+/// <summary>
+/// Database-neutral materialized-view execution workflow.
+/// Provider executors retain their own event-store factory and perform service validation/source selection
+/// at each public operation boundary before delegating database work here.
+/// </summary>
+public abstract class MvExecutorBase<TConnection>
+    where TConnection : DbConnection
+{
+    private readonly IMvRegistryStore _registryStore;
+    private readonly ILogger _logger;
+    private readonly MvOptions _options;
+    private readonly string _connectionString;
+
+    protected MvExecutorBase(
+        IMvRegistryStore registryStore,
+        IOptions<MvOptions> options,
+        ILogger logger,
+        string connectionString)
+    {
+        _registryStore = registryStore;
+        _logger = logger;
+        _options = options.Value;
+        _connectionString = connectionString;
+    }
+
+    protected IMvRegistryStore RegistryStore => _registryStore;
+
+    protected MvOptions Options => _options;
+
+    protected string ConnectionString => _connectionString;
+
+    protected abstract Task<TConnection> OpenConnectionAsync(CancellationToken cancellationToken);
+
+    protected abstract IMvApplyQueryPort CreateQueryPort(
+        TConnection connection,
+        IDbTransaction transaction);
+
+    protected abstract Task<int> ExecuteSqlAsync(
+        TConnection connection,
+        string sql,
+        IReadOnlyList<MvParam> parameters,
+        IDbTransaction transaction,
+        CancellationToken cancellationToken);
+
+    protected async Task InitializeCoreAsync(
+        IMvApplyHost host,
+        string serviceId,
+        CancellationToken cancellationToken)
+    {
+        await _registryStore.EnsureInfrastructureAsync(cancellationToken).ConfigureAwait(false);
+
+        await using var connection = await OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using var transaction = await connection.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
+        var bindings = new MvTableBindings(host.ViewName, host.ViewVersion, _options);
+        var statements = await host.InitializeAsync(bindings, cancellationToken).ConfigureAwait(false);
+        foreach (var statement in statements)
+        {
+            await ExecuteSqlAsync(
+                    connection,
+                    statement.Sql,
+                    statement.Parameters,
+                    transaction,
+                    cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        foreach (var table in bindings.Tables)
+        {
+            await _registryStore.RegisterAsync(
+                    new MvRegistryEntry
+                    {
+                        ServiceId = serviceId,
+                        ViewName = host.ViewName,
+                        ViewVersion = host.ViewVersion,
+                        LogicalTable = table.LogicalName,
+                        PhysicalTable = table.PhysicalName,
+                        Status = MvStatus.CatchingUp,
+                        AppliedEventVersion = 0,
+                        LastUpdated = DateTimeOffset.UtcNow
+                    },
+                    transaction,
+                    cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        var active = await _registryStore.GetActiveAsync(serviceId, host.ViewName, cancellationToken).ConfigureAwait(false);
+        if (active is null)
+        {
+            await _registryStore.SetActiveAsync(
+                    serviceId,
+                    host.ViewName,
+                    host.ViewVersion,
+                    transaction,
+                    cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    protected async Task<string?> GetCurrentPositionAsync(
+        IMvApplyHost host,
+        string serviceId,
+        CancellationToken cancellationToken)
+    {
+        var entries = await _registryStore.GetEntriesAsync(
+                serviceId,
+                host.ViewName,
+                host.ViewVersion,
+                cancellationToken)
+            .ConfigureAwait(false);
+        if (entries.Count == 0)
+        {
+            await InitializeCoreAsync(host, serviceId, cancellationToken).ConfigureAwait(false);
+            entries = await _registryStore.GetEntriesAsync(
+                    serviceId,
+                    host.ViewName,
+                    host.ViewVersion,
+                    cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        return entries
+            .Select(entry => entry.CurrentPosition)
+            .FirstOrDefault(position => !string.IsNullOrWhiteSpace(position));
+    }
+
+    protected async Task<MvCatchUpResult> CompleteCatchUpAsync(
+        IMvApplyHost host,
+        string serviceId,
+        ResultBox<IEnumerable<SerializableEvent>> readResult,
+        CancellationToken cancellationToken)
+    {
+        if (!readResult.IsSuccess)
+        {
+            var exception = readResult.GetException();
+            if (exception is NotSupportedException)
+            {
+                throw exception;
+            }
+
+            _logger.LogWarning(
+                exception,
+                "Failed to read events for materialized view {ViewName}/{ViewVersion}.",
+                host.ViewName,
+                host.ViewVersion);
+            return new MvCatchUpResult(0, false);
+        }
+
+        var safeThreshold = CreateSafeThreshold(_options.SafeWindowMs);
+        var reachedUnsafeWindow = false;
+        var batch = readResult.GetValue().OrderBy(serializable => serializable.SortableUniqueIdValue).ToList();
+
+        if (batch.Count == 0)
+        {
+            return new MvCatchUpResult(0, false);
+        }
+
+        var safeBatch = new List<SerializableEvent>(batch.Count);
+        foreach (var serializableEvent in batch)
+        {
+            if (!new SortableUniqueId(serializableEvent.SortableUniqueIdValue).IsEarlierThanOrEqual(safeThreshold))
+            {
+                reachedUnsafeWindow = true;
+                break;
+            }
+
+            safeBatch.Add(serializableEvent);
+        }
+
+        if (safeBatch.Count == 0)
+        {
+            return new MvCatchUpResult(0, reachedUnsafeWindow);
+        }
+
+        var appliedEvents = await ApplySerializableEventsCoreAsync(
+                host,
+                safeBatch,
+                serviceId,
+                MvApplySource.CatchUp,
+                cancellationToken)
+            .ConfigureAwait(false);
+        var lastAppliedSortableUniqueId = appliedEvents > 0
+            ? safeBatch[appliedEvents - 1].SortableUniqueIdValue
+            : null;
+
+        reachedUnsafeWindow |= appliedEvents < safeBatch.Count;
+        return new MvCatchUpResult(appliedEvents, reachedUnsafeWindow, lastAppliedSortableUniqueId);
+    }
+
+    protected async Task<int> ApplySerializableEventsCoreAsync(
+        IMvApplyHost host,
+        IReadOnlyList<SerializableEvent> events,
+        string serviceId,
+        MvApplySource source,
+        CancellationToken cancellationToken)
+    {
+        var entries = await _registryStore.GetEntriesAsync(
+                serviceId,
+                host.ViewName,
+                host.ViewVersion,
+                cancellationToken)
+            .ConfigureAwait(false);
+        if (entries.Count == 0)
+        {
+            await InitializeCoreAsync(host, serviceId, cancellationToken).ConfigureAwait(false);
+            entries = await _registryStore.GetEntriesAsync(
+                    serviceId,
+                    host.ViewName,
+                    host.ViewVersion,
+                    cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        var currentPosition = entries
+            .Select(entry => entry.CurrentPosition)
+            .FirstOrDefault(position => !string.IsNullOrWhiteSpace(position));
+        var orderedEvents = events
+            .GroupBy(serializableEvent => serializableEvent.SortableUniqueIdValue)
+            .Select(group => group.First())
+            .Where(serializableEvent =>
+                source == MvApplySource.Stream ||
+                string.IsNullOrWhiteSpace(currentPosition) ||
+                string.Compare(serializableEvent.SortableUniqueIdValue, currentPosition, StringComparison.Ordinal) > 0)
+            .OrderBy(serializableEvent => serializableEvent.SortableUniqueIdValue, StringComparer.Ordinal)
+            .ToList();
+
+        if (orderedEvents.Count == 0)
+        {
+            return 0;
+        }
+
+        await using var connection = await OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
+        var appliedEvents = 0;
+        var bindings = CreateBindings(host, entries);
+        foreach (var serializableEvent in orderedEvents)
+        {
+            var applied = await ApplySerializableEventAsync(
+                    connection,
+                    host,
+                    serviceId,
+                    bindings,
+                    serializableEvent,
+                    currentPosition,
+                    source,
+                    cancellationToken)
+                .ConfigureAwait(false);
+            if (!applied)
+            {
+                break;
+            }
+
+            appliedEvents += 1;
+        }
+
+        return appliedEvents;
+    }
+
+    private async Task<bool> ApplySerializableEventAsync(
+        TConnection connection,
+        IMvApplyHost host,
+        string serviceId,
+        MvTableBindings bindings,
+        SerializableEvent serializableEvent,
+        string? currentPosition,
+        MvApplySource source,
+        CancellationToken cancellationToken)
+    {
+        await using var transaction = await connection.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
+        var queryPort = CreateQueryPort(connection, transaction);
+        var statements = await host.ApplyEventAsync(
+                serializableEvent,
+                bindings,
+                queryPort,
+                serializableEvent.SortableUniqueIdValue,
+                cancellationToken)
+            .ConfigureAwait(false);
+        var affectedRows = 0;
+        foreach (var statement in statements)
+        {
+            affectedRows += await ExecuteSqlAsync(
+                    connection,
+                    statement.Sql,
+                    statement.Parameters,
+                    transaction,
+                    cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        if (source == MvApplySource.Stream && statements.Count > 0 && affectedRows == 0)
+        {
+            if (!string.IsNullOrWhiteSpace(currentPosition) &&
+                string.Compare(serializableEvent.SortableUniqueIdValue, currentPosition, StringComparison.Ordinal) <= 0)
+            {
+                await transaction.RollbackAsync(cancellationToken).ConfigureAwait(false);
+                return true;
+            }
+
+            await transaction.RollbackAsync(cancellationToken).ConfigureAwait(false);
+            return false;
+        }
+
+        await _registryStore.UpdatePositionAsync(
+                new MvPositionUpdate(
+                    serviceId,
+                    host.ViewName,
+                    host.ViewVersion,
+                    serializableEvent.SortableUniqueIdValue,
+                    source),
+                transaction,
+                cancellationToken)
+            .ConfigureAwait(false);
+        await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+        return true;
+    }
+
+    protected MvTableBindings CreateBindings(IMvApplyHost host, IReadOnlyList<MvRegistryEntry> entries)
+    {
+        var bindings = new MvTableBindings(host.ViewName, host.ViewVersion, _options);
+        foreach (var entry in entries)
+        {
+            bindings.RegisterTable(entry.LogicalTable, entry.PhysicalTable);
+        }
+
+        return bindings;
+    }
+
+    protected static Dictionary<string, object?> ToParameterDictionary(IReadOnlyList<MvParam> parameters)
+    {
+        var values = new Dictionary<string, object?>(StringComparer.Ordinal);
+        foreach (var parameter in parameters)
+        {
+            values[parameter.Name] = MvParamConverter.ToClrValue(parameter);
+        }
+
+        return values;
+    }
+
+    private static SortableUniqueId CreateSafeThreshold(int safeWindowMs) =>
+        new(SortableUniqueId.Generate(DateTime.UtcNow.AddMilliseconds(-safeWindowMs), Guid.Empty));
+}

--- a/dcb/src/Sekiban.Dcb.MaterializedView/MvOptions.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView/MvOptions.cs
@@ -36,6 +36,19 @@ public sealed class MvOptions
     ///     skip its scheduled cycle and retry on the next tick.
     /// </summary>
     public int CatchUpMaxConcurrentBatches { get; set; } = 1;
+
+    /// <summary>
+    ///     Optional exact service identity used by the hosted MV worker and by direct executor calls that omit an
+    ///     identity. Multi-service hosts should register one service-bound worker per service instead of relying on this
+    ///     ambient option.
+    /// </summary>
+    public string? ServiceId { get; set; }
+
+    /// <summary>
+    ///     Explicitly opts a single-service compatibility registration into the literal <c>default</c> identity.
+    ///     Ordinary multi-service registrations must supply a non-default service id.
+    /// </summary>
+    public bool AllowDefaultServiceId { get; set; }
 }
 
 public static class MvSchemaHelper

--- a/dcb/src/Sekiban.Dcb.MaterializedView/MvServiceIdValidation.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView/MvServiceIdValidation.cs
@@ -1,0 +1,65 @@
+using Sekiban.Dcb.ServiceId;
+
+namespace Sekiban.Dcb.MaterializedView;
+
+/// <summary>
+/// Validates the caller-owned materialized-view service identity before an executor performs I/O.
+/// This helper only normalizes and compares identifiers; it never resolves or caches an event store.
+/// </summary>
+public static class MvServiceIdValidation
+{
+    public static string Validate(
+        string? requestedServiceId,
+        MvOptions options,
+        IServiceIdProvider? legacyServiceIdProvider,
+        string executorName)
+    {
+        var callerSuppliedServiceId = !string.IsNullOrWhiteSpace(requestedServiceId);
+        var resolvedServiceId = requestedServiceId;
+        if (string.IsNullOrWhiteSpace(resolvedServiceId))
+        {
+            resolvedServiceId = options.ServiceId;
+        }
+
+        if (string.IsNullOrWhiteSpace(resolvedServiceId))
+        {
+            resolvedServiceId = legacyServiceIdProvider?.GetCurrentServiceId();
+        }
+
+        if (string.IsNullOrWhiteSpace(resolvedServiceId))
+        {
+            throw new InvalidOperationException(
+                $"{executorName} requires an explicit non-empty ServiceId. Configure MvOptions.ServiceId or pass the service id at the caller boundary.");
+        }
+
+        var normalizedServiceId = ServiceIdValidator.NormalizeAndValidate(resolvedServiceId);
+        if (string.Equals(normalizedServiceId, DefaultServiceIdProvider.DefaultServiceId, StringComparison.Ordinal) &&
+            !options.AllowDefaultServiceId)
+        {
+            throw new InvalidOperationException(
+                $"{executorName} cannot use the implicit default ServiceId. Opt into the named single-service compatibility option AllowDefaultServiceId or provide an explicit non-default service.");
+        }
+
+        if (callerSuppliedServiceId && !string.IsNullOrWhiteSpace(options.ServiceId))
+        {
+            var configuredServiceId = ServiceIdValidator.NormalizeAndValidate(options.ServiceId);
+            if (!string.Equals(configuredServiceId, normalizedServiceId, StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException(
+                    $"{executorName} requested ServiceId '{normalizedServiceId}', but MvOptions is bound to '{configuredServiceId}'.");
+            }
+        }
+
+        if (legacyServiceIdProvider is not null)
+        {
+            var legacyServiceId = ServiceIdValidator.NormalizeAndValidate(legacyServiceIdProvider.GetCurrentServiceId());
+            if (!string.Equals(legacyServiceId, normalizedServiceId, StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException(
+                    $"{executorName} requested ServiceId '{normalizedServiceId}', but the legacy aggregate event store is bound to '{legacyServiceId}'. Register IEventStoreFactory for service-scoped MV reads.");
+            }
+        }
+
+        return normalizedServiceId;
+    }
+}

--- a/dcb/src/Sekiban.Dcb.MaterializedView/SekibanDcbMaterializedViewExtensions.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView/SekibanDcbMaterializedViewExtensions.cs
@@ -1,8 +1,11 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Sekiban.Dcb.Domains;
 using Sekiban.Dcb.ServiceId;
+using Sekiban.Dcb.Storage;
 namespace Sekiban.Dcb.MaterializedView;
 
 public static class SekibanDcbMaterializedViewExtensions
@@ -29,6 +32,45 @@ public static class SekibanDcbMaterializedViewExtensions
         }
 
         return services;
+    }
+
+    /// <summary>
+    /// Selects a provider executor constructor during DI registration. This is only a constructor
+    /// registration helper; it never calls <c>CreateForService</c> and never resolves or caches an
+    /// event store for an operation.
+    /// </summary>
+    public static TExecutor CreateMaterializedViewExecutor<TExecutor>(
+        IServiceProvider services,
+        string connectionString,
+        Func<
+            IEventStoreFactory,
+            IMvRegistryStore,
+            IOptions<MvOptions>,
+            ILogger<TExecutor>,
+            string,
+            TExecutor> factoryConstructor,
+        Func<
+            IEventStore,
+            IServiceIdProvider,
+            IMvRegistryStore,
+            IOptions<MvOptions>,
+            ILogger<TExecutor>,
+            string,
+            TExecutor> legacyConstructor)
+    {
+        var options = services.GetRequiredService<IOptions<MvOptions>>();
+        var registry = services.GetRequiredService<IMvRegistryStore>();
+        var logger = services.GetRequiredService<ILogger<TExecutor>>();
+        var eventStoreFactory = services.GetService<IEventStoreFactory>();
+        return eventStoreFactory is not null
+            ? factoryConstructor(eventStoreFactory, registry, options, logger, connectionString)
+            : legacyConstructor(
+                services.GetRequiredService<IEventStore>(),
+                services.GetRequiredService<IServiceIdProvider>(),
+                registry,
+                options,
+                logger,
+                connectionString);
     }
 
     public static IServiceCollection AddMaterializedView<TView>(this IServiceCollection services)

--- a/dcb/src/Sekiban.Dcb.MaterializedView/SekibanDcbMaterializedViewExtensions.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView/SekibanDcbMaterializedViewExtensions.cs
@@ -1,6 +1,8 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
 using Sekiban.Dcb.Domains;
+using Sekiban.Dcb.ServiceId;
 namespace Sekiban.Dcb.MaterializedView;
 
 public static class SekibanDcbMaterializedViewExtensions
@@ -34,6 +36,32 @@ public static class SekibanDcbMaterializedViewExtensions
     {
         services.TryAddSingleton<TView>();
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IMaterializedViewProjector, TView>(sp => sp.GetRequiredService<TView>()));
+        return services;
+    }
+
+    /// <summary>
+    /// Registers one hosted catch-up worker bound to an exact service id. Call once per service in a multi-service host.
+    /// The provider extension must be called with <c>registerHostedWorker: false</c> when using this method.
+    /// </summary>
+    public static IServiceCollection AddSekibanDcbMaterializedViewWorkerForService(
+        this IServiceCollection services,
+        string serviceId)
+    {
+        var normalized = ServiceIdValidator.NormalizeAndValidate(serviceId);
+        if (string.Equals(normalized, DefaultServiceIdProvider.DefaultServiceId, StringComparison.Ordinal))
+        {
+            throw new ArgumentException(
+                "The service-bound worker API requires a non-default ServiceId. Use MvOptions.AllowDefaultServiceId for explicit single-service compatibility.",
+                nameof(serviceId));
+        }
+
+        services.AddSingleton<IHostedService>(sp =>
+            new MvCatchUpWorker(
+                sp.GetRequiredService<IMvApplyHostFactory>(),
+                sp.GetRequiredService<IMvExecutor>(),
+                sp.GetRequiredService<Microsoft.Extensions.Options.IOptions<MvOptions>>(),
+                sp.GetRequiredService<Microsoft.Extensions.Logging.ILogger<MvCatchUpWorker>>(),
+                normalized));
         return services;
     }
 }

--- a/dcb/src/Sekiban.Dcb.Postgres/SekibanDcbPostgresExtensions.cs
+++ b/dcb/src/Sekiban.Dcb.Postgres/SekibanDcbPostgresExtensions.cs
@@ -35,17 +35,7 @@ public static class SekibanDcbPostgresExtensions
 
         services.AddScoped(sp => sp.GetRequiredService<IDbContextFactory<SekibanDcbDbContext>>().CreateDbContext());
 
-        // Register IEventTypes from DcbDomainTypes (if not already registered)
-        services.TryAddSingleton<IEventTypes>(sp => sp.GetRequiredService<DcbDomainTypes>().EventTypes);
-
-        // Register IEventStore implementation
-        services.AddSingleton<IServiceIdProvider, DefaultServiceIdProvider>();
-        services.TryAddSingleton<IEventStoreFactory, PostgresEventStoreFactory>();
-        services.AddEventStoreAliases<PostgresEventStore>();
-        services.AddConditionalEventStoreCapabilities();
-        services.AddSingleton<IMultiProjectionStateStore, PostgresMultiProjectionStateStore>();
-        services.AddSingleton<IProjectionStatusStore>(sp => (sp.GetService<IMultiProjectionStateStore>() as IProjectionStatusStore)!);
-        services.AddSekibanDcbProjectionStatusReader();
+        AddPostgresEventStoreServices(services);
 
         return services;
     }
@@ -87,17 +77,7 @@ public static class SekibanDcbPostgresExtensions
         // Add a hosted service to ensure database tables exist
         services.AddHostedService<DatabaseInitializerService>();
 
-        // Register IEventTypes from DcbDomainTypes (if not already registered)
-        services.TryAddSingleton<IEventTypes>(sp => sp.GetRequiredService<DcbDomainTypes>().EventTypes);
-
-        // IEventStore実装を登録
-        services.AddSingleton<IServiceIdProvider, DefaultServiceIdProvider>();
-        services.TryAddSingleton<IEventStoreFactory, PostgresEventStoreFactory>();
-        services.AddEventStoreAliases<PostgresEventStore>();
-        services.AddConditionalEventStoreCapabilities();
-        services.AddSingleton<IMultiProjectionStateStore, PostgresMultiProjectionStateStore>();
-        services.AddSingleton<IProjectionStatusStore>(sp => (sp.GetService<IMultiProjectionStateStore>() as IProjectionStatusStore)!);
-        services.AddSekibanDcbProjectionStatusReader();
+        AddPostgresEventStoreServices(services);
 
         return services;
     }
@@ -340,6 +320,18 @@ public static class SekibanDcbPostgresExtensions
                 throw;
             }
         }
+    }
+
+    private static void AddPostgresEventStoreServices(IServiceCollection services)
+    {
+        services.TryAddSingleton<IEventTypes>(sp => sp.GetRequiredService<DcbDomainTypes>().EventTypes);
+        services.AddSingleton<IServiceIdProvider, DefaultServiceIdProvider>();
+        services.TryAddSingleton<IEventStoreFactory, PostgresEventStoreFactory>();
+        services.AddEventStoreAliases<PostgresEventStore>();
+        services.AddConditionalEventStoreCapabilities();
+        services.AddSingleton<IMultiProjectionStateStore, PostgresMultiProjectionStateStore>();
+        services.AddSingleton<IProjectionStatusStore>(sp => (sp.GetService<IMultiProjectionStateStore>() as IProjectionStatusStore)!);
+        services.AddSekibanDcbProjectionStatusReader();
     }
 
     private static string? ResolveConnectionString(IConfiguration configuration, string connectionName)

--- a/dcb/src/Sekiban.Dcb.Postgres/SekibanDcbPostgresExtensions.cs
+++ b/dcb/src/Sekiban.Dcb.Postgres/SekibanDcbPostgresExtensions.cs
@@ -41,9 +41,7 @@ public static class SekibanDcbPostgresExtensions
         // Register IEventStore implementation
         services.AddSingleton<IServiceIdProvider, DefaultServiceIdProvider>();
         services.TryAddSingleton<IEventStoreFactory, PostgresEventStoreFactory>();
-        services.AddSingleton<PostgresEventStore>();
-        services.AddSingleton<IHotEventStore>(sp => sp.GetRequiredService<PostgresEventStore>());
-        services.AddSingleton<IEventStore>(sp => sp.GetRequiredService<IHotEventStore>());
+        services.AddEventStoreAliases<PostgresEventStore>();
         services.AddConditionalEventStoreCapabilities();
         services.AddSingleton<IMultiProjectionStateStore, PostgresMultiProjectionStateStore>();
         services.AddSingleton<IProjectionStatusStore>(sp => (sp.GetService<IMultiProjectionStateStore>() as IProjectionStatusStore)!);
@@ -95,9 +93,7 @@ public static class SekibanDcbPostgresExtensions
         // IEventStore実装を登録
         services.AddSingleton<IServiceIdProvider, DefaultServiceIdProvider>();
         services.TryAddSingleton<IEventStoreFactory, PostgresEventStoreFactory>();
-        services.AddSingleton<PostgresEventStore>();
-        services.AddSingleton<IHotEventStore>(sp => sp.GetRequiredService<PostgresEventStore>());
-        services.AddSingleton<IEventStore>(sp => sp.GetRequiredService<IHotEventStore>());
+        services.AddEventStoreAliases<PostgresEventStore>();
         services.AddConditionalEventStoreCapabilities();
         services.AddSingleton<IMultiProjectionStateStore, PostgresMultiProjectionStateStore>();
         services.AddSingleton<IProjectionStatusStore>(sp => (sp.GetService<IMultiProjectionStateStore>() as IProjectionStatusStore)!);
@@ -132,9 +128,7 @@ public static class SekibanDcbPostgresExtensions
         // IEventStore実装を登録
         services.AddSingleton<IServiceIdProvider, DefaultServiceIdProvider>();
         services.TryAddSingleton<IEventStoreFactory, PostgresEventStoreFactory>();
-        services.AddSingleton<PostgresEventStore>();
-        services.AddSingleton<IHotEventStore>(sp => sp.GetRequiredService<PostgresEventStore>());
-        services.AddSingleton<IEventStore>(sp => sp.GetRequiredService<IHotEventStore>());
+        services.AddEventStoreAliases<PostgresEventStore>();
         services.AddConditionalEventStoreCapabilities();
         services.AddSingleton<IMultiProjectionStateStore, PostgresMultiProjectionStateStore>();
         services.AddSingleton<IProjectionStatusStore>(sp => (sp.GetService<IMultiProjectionStateStore>() as IProjectionStatusStore)!);

--- a/dcb/src/Sekiban.Dcb.Postgres/SekibanDcbPostgresExtensions.cs
+++ b/dcb/src/Sekiban.Dcb.Postgres/SekibanDcbPostgresExtensions.cs
@@ -40,6 +40,7 @@ public static class SekibanDcbPostgresExtensions
 
         // Register IEventStore implementation
         services.AddSingleton<IServiceIdProvider, DefaultServiceIdProvider>();
+        services.TryAddSingleton<IEventStoreFactory, PostgresEventStoreFactory>();
         services.AddSingleton<PostgresEventStore>();
         services.AddSingleton<IHotEventStore>(sp => sp.GetRequiredService<PostgresEventStore>());
         services.AddSingleton<IEventStore>(sp => sp.GetRequiredService<IHotEventStore>());
@@ -93,6 +94,7 @@ public static class SekibanDcbPostgresExtensions
 
         // IEventStore実装を登録
         services.AddSingleton<IServiceIdProvider, DefaultServiceIdProvider>();
+        services.TryAddSingleton<IEventStoreFactory, PostgresEventStoreFactory>();
         services.AddSingleton<PostgresEventStore>();
         services.AddSingleton<IHotEventStore>(sp => sp.GetRequiredService<PostgresEventStore>());
         services.AddSingleton<IEventStore>(sp => sp.GetRequiredService<IHotEventStore>());
@@ -129,6 +131,7 @@ public static class SekibanDcbPostgresExtensions
 
         // IEventStore実装を登録
         services.AddSingleton<IServiceIdProvider, DefaultServiceIdProvider>();
+        services.TryAddSingleton<IEventStoreFactory, PostgresEventStoreFactory>();
         services.AddSingleton<PostgresEventStore>();
         services.AddSingleton<IHotEventStore>(sp => sp.GetRequiredService<PostgresEventStore>());
         services.AddSingleton<IEventStore>(sp => sp.GetRequiredService<IHotEventStore>());

--- a/dcb/src/Sekiban.Dcb.Sqlite/SekibanDcbSqliteExtensions.cs
+++ b/dcb/src/Sekiban.Dcb.Sqlite/SekibanDcbSqliteExtensions.cs
@@ -33,6 +33,12 @@ public static class SekibanDcbSqliteExtensions
         services.AddSingleton(options);
         services.AddSingleton<IServiceIdProvider, DefaultServiceIdProvider>();
         services.TryAddSingleton<IEventTypes>(sp => sp.GetRequiredService<DcbDomainTypes>().EventTypes);
+        services.TryAddSingleton<IEventStoreFactory>(sp =>
+            new SqliteEventStoreFactory(
+                databasePath,
+                sp.GetRequiredService<IEventTypes>(),
+                sp.GetRequiredService<SqliteEventStoreOptions>(),
+                sp.GetService<ILoggerFactory>()));
         services.AddSingleton<IHotEventStore>(sp =>
         {
             var eventTypes = sp.GetRequiredService<IEventTypes>();

--- a/dcb/src/Sekiban.Dcb.Sqlite/SqliteEventStoreFactory.cs
+++ b/dcb/src/Sekiban.Dcb.Sqlite/SqliteEventStoreFactory.cs
@@ -1,0 +1,43 @@
+using Microsoft.Extensions.Logging;
+using Sekiban.Dcb.Capabilities;
+using Sekiban.Dcb.Domains;
+using Sekiban.Dcb.ServiceId;
+using Sekiban.Dcb.Storage;
+
+namespace Sekiban.Dcb.Sqlite;
+
+/// <summary>Creates SQLite event stores bound to one exact ServiceId over one shared database file.</summary>
+public sealed class SqliteEventStoreFactory : IEventStoreFactory, IStorageDurabilityDescriptorProvider,
+    IWriteConditionCapabilityProvider
+{
+    private readonly string _databasePath;
+    private readonly IEventTypes _eventTypes;
+    private readonly SqliteEventStoreOptions _options;
+    private readonly ILoggerFactory? _loggerFactory;
+
+    public SqliteEventStoreFactory(
+        string databasePath,
+        IEventTypes eventTypes,
+        SqliteEventStoreOptions? options = null,
+        ILoggerFactory? loggerFactory = null)
+    {
+        _databasePath = databasePath ?? throw new ArgumentNullException(nameof(databasePath));
+        _eventTypes = eventTypes ?? throw new ArgumentNullException(nameof(eventTypes));
+        _options = options ?? new SqliteEventStoreOptions();
+        _loggerFactory = loggerFactory;
+    }
+
+    public StorageDurabilityDescriptor DescribeStorage() =>
+        new(StorageDurability.Durable, "SQLite (per-service factory)");
+
+    public WriteConditionCapabilityDescriptor DescribeWriteConditions() =>
+        WriteConditionCapabilityDescriptor.Supporting(
+            "SQLite (per-service factory)", WriteConditionKind.SingleEventUniqueKey);
+
+    public IEventStore CreateForService(string serviceId)
+    {
+        var provider = new FixedServiceIdProvider(serviceId);
+        var logger = _loggerFactory?.CreateLogger<SqliteEventStore>();
+        return new SqliteEventStore(_databasePath, _eventTypes, _options, logger, provider);
+    }
+}

--- a/dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/MaterializedViewMultiProviderTests.cs
+++ b/dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/MaterializedViewMultiProviderTests.cs
@@ -1,10 +1,16 @@
 using Dapper;
 using Dcb.Domain.WithoutResult.Weather;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using Sekiban.Dcb.Actors;
+using Sekiban.Dcb.Common;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.MaterializedView;
 using Sekiban.Dcb.MaterializedView.MySql;
 using Sekiban.Dcb.MaterializedView.Sqlite;
 using Sekiban.Dcb.MaterializedView.SqlServer;
+using Sekiban.Dcb.Storage;
 using Xunit;
 
 namespace Sekiban.Dcb.MaterializedView.MultiProvider.Tests;
@@ -73,6 +79,10 @@ public sealed class SqliteMvIntegrationTests(SqliteMvFixture fixture)
 {
     [SkippableFact]
     public Task CatchUp_MaterializesRowsAndRegistry() => MultiProviderAssertions.AssertProviderWorksAsync(fixture);
+
+    [SkippableFact]
+    public Task SharedEventBackend_UsesOnlyTheRequestedService() =>
+        MultiProviderAssertions.AssertServiceIsolationAsync(fixture);
 }
 
 internal static class MultiProviderAssertions
@@ -157,5 +167,105 @@ internal static class MultiProviderAssertions
         Assert.Equal("catchup", registry.LastAppliedSource);
         Assert.False(string.IsNullOrWhiteSpace(registry.CurrentPosition));
         Assert.Equal(1, activeVersion);
+    }
+
+    public static async Task AssertServiceIsolationAsync(SqliteMvFixture fixture)
+    {
+        Skip.IfNot(fixture.IsAvailable, fixture.AvailabilityMessage ?? "SQLite fixture is unavailable.");
+
+        await fixture.ResetAsync().ConfigureAwait(false);
+
+        var sourceFactory = fixture.EventStoreFactory;
+        var serviceA = $"orders-{Guid.NewGuid():N}";
+        var serviceB = $"billing-{Guid.NewGuid():N}";
+        var storeA = sourceFactory.CreateForService(serviceA);
+        var storeB = sourceFactory.CreateForService(serviceB);
+        var projector = fixture.Services.GetRequiredService<CrossProviderWeatherForecastMvV1>();
+        var host = new NativeMvApplyHost(
+            projector,
+            fixture.DomainTypes.EventTypes,
+            MvDbType.Sqlite);
+        var registry = fixture.Services.GetRequiredService<IMvRegistryStore>();
+        var serviceAExecutor = new SqliteMvExecutor(
+            sourceFactory,
+            registry,
+            Options.Create(new MvOptions
+            {
+                ServiceId = serviceA,
+                BatchSize = 100,
+                SafeWindowMs = 0
+            }),
+            NullLogger<SqliteMvExecutor>.Instance,
+            fixture.ConnectionStringForTests);
+        var serviceBExecutor = new SqliteMvExecutor(
+            sourceFactory,
+            registry,
+            Options.Create(new MvOptions
+            {
+                ServiceId = serviceB,
+                BatchSize = 100,
+                SafeWindowMs = 0
+            }),
+            NullLogger<SqliteMvExecutor>.Instance,
+            fixture.ConnectionStringForTests);
+
+        var forecastA = Guid.CreateVersion7();
+        var forecastB = Guid.CreateVersion7();
+        await storeA.WriteSerializableEventsAsync(
+            [CreateForecastEvent(forecastA, "orders-location", DateTimeOffset.UtcNow.AddSeconds(-2), fixture)]).ConfigureAwait(false);
+        await storeB.WriteSerializableEventsAsync(
+            [CreateForecastEvent(forecastB, "billing-location", DateTimeOffset.UtcNow.AddSeconds(-1), fixture)]).ConfigureAwait(false);
+
+        await serviceAExecutor.InitializeAsync(host).ConfigureAwait(false);
+        var serviceAResult = await serviceAExecutor.CatchUpOnceAsync(host).ConfigureAwait(false);
+
+        await using (var connection = await fixture.OpenConnectionAsync().ConfigureAwait(false))
+        {
+            var serviceARowCount = await connection.ExecuteScalarAsync<long>(
+                $"SELECT COUNT(*) FROM {MultiProviderFixtureBase.ForecastTable} WHERE forecast_id = @ForecastId;",
+                new { ForecastId = forecastA.ToString("D") }).ConfigureAwait(false);
+            var serviceBRowCount = await connection.ExecuteScalarAsync<long>(
+                $"SELECT COUNT(*) FROM {MultiProviderFixtureBase.ForecastTable} WHERE forecast_id = @ForecastId;",
+                new { ForecastId = forecastB.ToString("D") }).ConfigureAwait(false);
+
+            Assert.Equal(1, serviceAResult.AppliedEvents);
+            Assert.Equal(1, serviceARowCount);
+            Assert.Equal(0, serviceBRowCount);
+        }
+
+        await serviceBExecutor.InitializeAsync(host).ConfigureAwait(false);
+        var serviceBResult = await serviceBExecutor.CatchUpOnceAsync(host).ConfigureAwait(false);
+
+        await using (var connection = await fixture.OpenConnectionAsync().ConfigureAwait(false))
+        {
+            var serviceBRowCount = await connection.ExecuteScalarAsync<long>(
+                $"SELECT COUNT(*) FROM {MultiProviderFixtureBase.ForecastTable} WHERE forecast_id = @ForecastId;",
+                new { ForecastId = forecastB.ToString("D") }).ConfigureAwait(false);
+
+            Assert.Equal(1, serviceBResult.AppliedEvents);
+            Assert.Equal(1, serviceBRowCount);
+        }
+    }
+
+    private static SerializableEvent CreateForecastEvent(
+        Guid forecastId,
+        string location,
+        DateTimeOffset timestamp,
+        MultiProviderFixtureBase fixture)
+    {
+        var eventId = Guid.CreateVersion7();
+        var evt = new Event(
+            new WeatherForecastCreated(
+                forecastId,
+                location,
+                DateOnly.FromDateTime(timestamp.UtcDateTime),
+                20,
+                "Sunny"),
+            SortableUniqueId.Generate(timestamp.UtcDateTime, eventId),
+            nameof(WeatherForecastCreated),
+            eventId,
+            new EventMetadata("service-scope-test", "service-scope-test", "test"),
+            []);
+        return evt.ToSerializableEvent(fixture.DomainTypes.EventTypes);
     }
 }

--- a/dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/MultiProviderFixtures.cs
+++ b/dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/MultiProviderFixtures.cs
@@ -16,6 +16,7 @@ using Sekiban.Dcb.MaterializedView;
 using Sekiban.Dcb.MaterializedView.MySql;
 using Sekiban.Dcb.MaterializedView.Sqlite;
 using Sekiban.Dcb.MaterializedView.SqlServer;
+using Sekiban.Dcb.ServiceId;
 using Sekiban.Dcb.Storage;
 using Testcontainers.MsSql;
 using Testcontainers.MySql;
@@ -230,6 +231,7 @@ public sealed class RegistryDbRow
 public abstract class MultiProviderFixtureBase : IAsyncLifetime
 {
     internal const string ForecastTable = "sekiban_mv_weatherforecastportable_v1_forecasts";
+    internal const string ServiceId = "multi-provider-service";
 
     private ServiceProvider? _services;
     private string? _connectionString;
@@ -237,6 +239,7 @@ public abstract class MultiProviderFixtureBase : IAsyncLifetime
 
     public ServiceProvider Services => _services ?? throw new InvalidOperationException("Fixture not initialized.");
     public IMvExecutor Executor => Services.GetRequiredService<IMvExecutor>();
+    public IEventStoreFactory EventStoreFactory => Services.GetRequiredService<IEventStoreFactory>();
     public InMemoryEventStore EventStore => Services.GetRequiredService<InMemoryEventStore>();
     public InMemoryObjectAccessor ActorAccessor => Services.GetRequiredService<InMemoryObjectAccessor>();
     public DcbDomainTypes DomainTypes => Services.GetRequiredService<DcbDomainTypes>();
@@ -270,8 +273,13 @@ public abstract class MultiProviderFixtureBase : IAsyncLifetime
         var services = new ServiceCollection();
         services.AddLogging(builder => builder.SetMinimumLevel(LogLevel.Warning));
         services.AddSingleton(DomainType.GetDomainTypes());
-        services.AddSingleton<InMemoryEventStore>(sp => new InMemoryEventStore(sp.GetRequiredService<DcbDomainTypes>().EventTypes));
+        services.AddSingleton<InMemoryEventStore>(sp =>
+            new InMemoryEventStore(
+                sp.GetRequiredService<DcbDomainTypes>().EventTypes,
+                new FixedServiceIdProvider(ServiceId)));
         services.AddSingleton<IEventStore>(sp => sp.GetRequiredService<InMemoryEventStore>());
+        services.AddSingleton<IEventStoreFactory>(sp =>
+            new Sekiban.Dcb.InMemory.InMemoryEventStoreFactory(sp.GetRequiredService<InMemoryEventStore>()));
         services.AddSingleton<InMemoryObjectAccessor>(sp =>
             new InMemoryObjectAccessor(sp.GetRequiredService<IEventStore>(), sp.GetRequiredService<DcbDomainTypes>()));
         services.AddMaterializedView<CrossProviderWeatherForecastMvV1>();
@@ -340,6 +348,7 @@ public sealed class MySqlMvFixture : MultiProviderFixtureBase
     {
         services.AddSekibanDcbMaterializedView(options =>
         {
+            options.ServiceId = ServiceId;
             options.BatchSize = 100;
             options.SafeWindowMs = 0;
             options.PollInterval = TimeSpan.FromMilliseconds(10);
@@ -384,6 +393,7 @@ public sealed class SqlServerMvFixture : MultiProviderFixtureBase
     {
         services.AddSekibanDcbMaterializedView(options =>
         {
+            options.ServiceId = ServiceId;
             options.BatchSize = 100;
             options.SafeWindowMs = 0;
             options.PollInterval = TimeSpan.FromMilliseconds(10);
@@ -425,6 +435,7 @@ public sealed class SqliteMvFixture : MultiProviderFixtureBase
     {
         services.AddSekibanDcbMaterializedView(options =>
         {
+            options.ServiceId = ServiceId;
             options.BatchSize = 100;
             options.SafeWindowMs = 0;
             options.PollInterval = TimeSpan.FromMilliseconds(10);

--- a/dcb/tests/Sekiban.Dcb.MaterializedView.Postgres.Tests/MaterializedViewPostgresFixture.cs
+++ b/dcb/tests/Sekiban.Dcb.MaterializedView.Postgres.Tests/MaterializedViewPostgresFixture.cs
@@ -10,6 +10,7 @@ using Npgsql;
 using Sekiban.Dcb.Testing;
 using Sekiban.Dcb.Postgres;
 using Sekiban.Dcb.MaterializedView.Postgres;
+using Sekiban.Dcb.ServiceId;
 using Sekiban.Dcb.Storage;
 using Testcontainers.PostgreSql;
 using Xunit;
@@ -73,6 +74,8 @@ public sealed class MaterializedViewPostgresFixture : IAsyncLifetime
         services.AddSekibanDcbPostgres(ConnectionString);
         services.AddSekibanDcbMaterializedView(options =>
         {
+            options.ServiceId = DefaultServiceIdProvider.DefaultServiceId;
+            options.AllowDefaultServiceId = true;
             options.BatchSize = 100;
             options.SafeWindowMs = 0;
             options.PollInterval = TimeSpan.FromMilliseconds(10);

--- a/dcb/tests/Sekiban.Dcb.MaterializedView.Postgres.Tests/MaterializedViewPostgresOrleansFixture.cs
+++ b/dcb/tests/Sekiban.Dcb.MaterializedView.Postgres.Tests/MaterializedViewPostgresOrleansFixture.cs
@@ -87,6 +87,8 @@ public sealed class MaterializedViewPostgresOrleansFixture : IAsyncLifetime
         services.AddSekibanDcbPostgres(ConnectionString);
         services.AddSekibanDcbMaterializedView(options =>
         {
+            options.ServiceId = DefaultServiceIdProvider.DefaultServiceId;
+            options.AllowDefaultServiceId = true;
             options.BatchSize = 100;
             options.SafeWindowMs = 0;
             options.PollInterval = TimeSpan.FromMilliseconds(50);
@@ -221,6 +223,8 @@ public sealed class MaterializedViewPostgresOrleansFixture : IAsyncLifetime
                     services.AddSekibanDcbPostgres(SharedConnectionString);
                     services.AddSekibanDcbMaterializedView(options =>
                     {
+                        options.ServiceId = DefaultServiceIdProvider.DefaultServiceId;
+                        options.AllowDefaultServiceId = true;
                         options.BatchSize = 100;
                         options.SafeWindowMs = 0;
                         options.PollInterval = TimeSpan.FromMilliseconds(50);

--- a/dcb/tests/Sekiban.Dcb.MaterializedView.Tests/MaterializedViewUnitTests.cs
+++ b/dcb/tests/Sekiban.Dcb.MaterializedView.Tests/MaterializedViewUnitTests.cs
@@ -146,7 +146,11 @@ public class MaterializedViewUnitTests
         using var worker = new MvCatchUpWorker(
             hostFactory,
             executor,
-            Options.Create(new MvOptions { PollInterval = TimeSpan.FromMilliseconds(10) }),
+            Options.Create(new MvOptions
+            {
+                ServiceId = "worker-test",
+                PollInterval = TimeSpan.FromMilliseconds(10)
+            }),
             NullLogger<MvCatchUpWorker>.Instance);
 
         using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(50));
@@ -156,6 +160,31 @@ public class MaterializedViewUnitTests
 
         Assert.True(executor.InitializeCalls >= 1);
         Assert.True(executor.CatchUpCalls >= 1);
+        Assert.All(executor.ServiceIds, serviceId => Assert.Equal("worker-test", serviceId));
+    }
+
+    [Fact]
+    public void CatchUpWorker_RejectsMissingOrImplicitDefaultServiceBeforeStarting()
+    {
+        var hostFactory = new FakeApplyHostFactory(new FakeApplyHost("Fake", 1));
+        var executor = new FakeMvExecutor();
+
+        Assert.Throws<InvalidOperationException>(() => new MvCatchUpWorker(
+            hostFactory,
+            executor,
+            Options.Create(new MvOptions()),
+            NullLogger<MvCatchUpWorker>.Instance));
+        Assert.Throws<InvalidOperationException>(() => new MvCatchUpWorker(
+            hostFactory,
+            executor,
+            Options.Create(new MvOptions { ServiceId = "default" }),
+            NullLogger<MvCatchUpWorker>.Instance));
+        Assert.Throws<InvalidOperationException>(() => new MvCatchUpWorker(
+            hostFactory,
+            executor,
+            Options.Create(new MvOptions { ServiceId = "orders" }),
+            NullLogger<MvCatchUpWorker>.Instance,
+            "billing"));
     }
 
     [Fact]
@@ -388,6 +417,7 @@ public class MaterializedViewUnitTests
     {
         public int InitializeCalls { get; private set; }
         public int CatchUpCalls { get; private set; }
+        public List<string?> ServiceIds { get; } = [];
 
         public Task InitializeAsync(
             IMvApplyHost host,
@@ -395,6 +425,7 @@ public class MaterializedViewUnitTests
             CancellationToken cancellationToken = default)
         {
             InitializeCalls++;
+            ServiceIds.Add(serviceId);
             return Task.CompletedTask;
         }
 
@@ -404,6 +435,7 @@ public class MaterializedViewUnitTests
             CancellationToken cancellationToken = default)
         {
             CatchUpCalls++;
+            ServiceIds.Add(serviceId);
             return Task.FromResult(new MvCatchUpResult(0, false));
         }
 

--- a/dcb/tests/Sekiban.Dcb.MaterializedView.Tests/MvExecutorServiceBoundaryTests.cs
+++ b/dcb/tests/Sekiban.Dcb.MaterializedView.Tests/MvExecutorServiceBoundaryTests.cs
@@ -1,0 +1,206 @@
+using System.Data;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.MaterializedView;
+using Sekiban.Dcb.MaterializedView.MySql;
+using Sekiban.Dcb.MaterializedView.Postgres;
+using Sekiban.Dcb.MaterializedView.SqlServer;
+using Sekiban.Dcb.MaterializedView.Sqlite;
+using Sekiban.Dcb.Storage;
+using Xunit;
+
+namespace Sekiban.Dcb.MaterializedView.Tests;
+
+public sealed class MvExecutorServiceBoundaryTests
+{
+    [Fact]
+    public async Task AllTargetExecutors_RejectInvalidServiceBeforeRegistryOrSourceIo()
+    {
+        var sourceFactory = new ThrowingEventStoreFactory();
+        var options = Options.Create(new MvOptions());
+        var host = new BoundaryHost();
+        var postgresRegistry = new CountingRegistryStore();
+        var mySqlRegistry = new CountingRegistryStore();
+        var sqlServerRegistry = new CountingRegistryStore();
+        var sqliteRegistry = new CountingRegistryStore();
+        var executors = new (IMvExecutor Executor, CountingRegistryStore Registry)[]
+        {
+            (new PostgresMvExecutor(
+                sourceFactory,
+                postgresRegistry,
+                options,
+                NullLogger<PostgresMvExecutor>.Instance,
+                "Host=unused;Database=unused"), postgresRegistry),
+            (new MySqlMvExecutor(
+                sourceFactory,
+                mySqlRegistry,
+                options,
+                NullLogger<MySqlMvExecutor>.Instance,
+                "Server=unused;Database=unused"), mySqlRegistry),
+            (new SqlServerMvExecutor(
+                sourceFactory,
+                sqlServerRegistry,
+                options,
+                NullLogger<SqlServerMvExecutor>.Instance,
+                "Server=unused;Database=unused"), sqlServerRegistry),
+            (new SqliteMvExecutor(
+                sourceFactory,
+                sqliteRegistry,
+                options,
+                NullLogger<SqliteMvExecutor>.Instance,
+                "Data Source=unused"), sqliteRegistry),
+        };
+
+        foreach (var (executor, registry) in executors)
+        {
+            await Assert.ThrowsAsync<InvalidOperationException>(() => executor.InitializeAsync(host));
+            await Assert.ThrowsAsync<InvalidOperationException>(() => executor.CatchUpOnceAsync(host, " "));
+            await Assert.ThrowsAsync<InvalidOperationException>(() => executor.CatchUpOnceAsync(host, "default"));
+            await Assert.ThrowsAsync<InvalidOperationException>(() => executor.ApplySerializableEventsAsync(host, [], "default"));
+            Assert.Equal(0, registry.EnsureCalls);
+        }
+
+        Assert.Equal(0, sourceFactory.CreateCalls);
+
+        var mismatchSourceFactory = new ThrowingEventStoreFactory();
+        var mismatchOptions = Options.Create(new MvOptions { ServiceId = "bound-service" });
+        var mismatchPostgresRegistry = new CountingRegistryStore();
+        var mismatchMySqlRegistry = new CountingRegistryStore();
+        var mismatchSqlServerRegistry = new CountingRegistryStore();
+        var mismatchSqliteRegistry = new CountingRegistryStore();
+        var mismatchExecutors = new (IMvExecutor Executor, CountingRegistryStore Registry)[]
+        {
+            (new PostgresMvExecutor(
+                mismatchSourceFactory,
+                mismatchPostgresRegistry,
+                mismatchOptions,
+                NullLogger<PostgresMvExecutor>.Instance,
+                "Host=unused;Database=unused"), mismatchPostgresRegistry),
+            (new MySqlMvExecutor(
+                mismatchSourceFactory,
+                mismatchMySqlRegistry,
+                mismatchOptions,
+                NullLogger<MySqlMvExecutor>.Instance,
+                "Server=unused;Database=unused"), mismatchMySqlRegistry),
+            (new SqlServerMvExecutor(
+                mismatchSourceFactory,
+                mismatchSqlServerRegistry,
+                mismatchOptions,
+                NullLogger<SqlServerMvExecutor>.Instance,
+                "Server=unused;Database=unused"), mismatchSqlServerRegistry),
+            (new SqliteMvExecutor(
+                mismatchSourceFactory,
+                mismatchSqliteRegistry,
+                mismatchOptions,
+                NullLogger<SqliteMvExecutor>.Instance,
+                "Data Source=unused"), mismatchSqliteRegistry)
+        };
+
+        foreach (var (executor, registry) in mismatchExecutors)
+        {
+            await Assert.ThrowsAsync<InvalidOperationException>(() => executor.InitializeAsync(host, "other-service"));
+            Assert.Equal(0, registry.EnsureCalls);
+        }
+
+        Assert.Equal(0, mismatchSourceFactory.CreateCalls);
+    }
+
+    [Fact]
+    public void ExistingExecutorConstructorsRemainPublicAndNewFactoryConstructorsAreAdditive()
+    {
+        Assert.Contains(
+            typeof(PostgresMvExecutor).GetConstructors(),
+            constructor => constructor.GetParameters().Length == 6 &&
+                           constructor.GetParameters()[0].ParameterType == typeof(IEventStore));
+        Assert.Contains(
+            typeof(PostgresMvExecutor).GetConstructors(),
+            constructor => constructor.GetParameters().Length == 5 &&
+                           constructor.GetParameters()[0].ParameterType == typeof(IEventStoreFactory));
+        Assert.Contains(
+            typeof(MySqlMvExecutor).GetConstructors(),
+            constructor => constructor.GetParameters().Length == 6 &&
+                           constructor.GetParameters()[0].ParameterType == typeof(IEventStore));
+        Assert.Contains(
+            typeof(MySqlMvExecutor).GetConstructors(),
+            constructor => constructor.GetParameters().Length == 5 &&
+                           constructor.GetParameters()[0].ParameterType == typeof(IEventStoreFactory));
+        Assert.Contains(
+            typeof(SqlServerMvExecutor).GetConstructors(),
+            constructor => constructor.GetParameters().Length == 6 &&
+                           constructor.GetParameters()[0].ParameterType == typeof(IEventStore));
+        Assert.Contains(
+            typeof(SqlServerMvExecutor).GetConstructors(),
+            constructor => constructor.GetParameters().Length == 5 &&
+                           constructor.GetParameters()[0].ParameterType == typeof(IEventStoreFactory));
+        Assert.Contains(
+            typeof(SqliteMvExecutor).GetConstructors(),
+            constructor => constructor.GetParameters().Length == 6 &&
+                           constructor.GetParameters()[0].ParameterType == typeof(IEventStore));
+        Assert.Contains(
+            typeof(SqliteMvExecutor).GetConstructors(),
+            constructor => constructor.GetParameters().Length == 5 &&
+                           constructor.GetParameters()[0].ParameterType == typeof(IEventStoreFactory));
+    }
+
+    private sealed class ThrowingEventStoreFactory : IEventStoreFactory
+    {
+        public int CreateCalls { get; private set; }
+
+        public IEventStore CreateForService(string serviceId)
+        {
+            CreateCalls++;
+            throw new InvalidOperationException("The source factory must not be touched by boundary validation.");
+        }
+    }
+
+    private sealed class CountingRegistryStore : IMvRegistryStore
+    {
+        public int EnsureCalls { get; private set; }
+
+        public Task EnsureInfrastructureAsync(CancellationToken cancellationToken = default)
+        {
+            EnsureCalls++;
+            throw new InvalidOperationException("The registry must not be touched by boundary validation.");
+        }
+
+        public Task RegisterAsync(MvRegistryEntry entry, IDbTransaction? transaction = null, CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public Task UpdatePositionAsync(MvPositionUpdate update, IDbTransaction? transaction = null, CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public Task MarkStreamReceivedAsync(string serviceId, string viewName, int viewVersion, string sortableUniqueId, DateTimeOffset receivedAt, IDbTransaction? transaction = null, CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public Task UpdateStatusAsync(string serviceId, string viewName, int viewVersion, MvStatus status, IDbTransaction? transaction = null, CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public Task<IReadOnlyList<MvRegistryEntry>> GetEntriesAsync(string serviceId, string viewName, int viewVersion, CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public Task<MvActiveEntry?> GetActiveAsync(string serviceId, string viewName, CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public Task SetActiveAsync(string serviceId, string viewName, int activeVersion, IDbTransaction? transaction = null, CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+    }
+
+    private sealed class BoundaryHost : IMvApplyHost
+    {
+        public string ViewName => "Boundary";
+        public int ViewVersion => 1;
+        public IReadOnlyList<string> LogicalTables => ["main"];
+
+        public Task<IReadOnlyList<MvSqlStatementDto>> InitializeAsync(IMvTableBindings tables, CancellationToken ct) =>
+            Task.FromResult<IReadOnlyList<MvSqlStatementDto>>([]);
+
+        public Task<IReadOnlyList<MvSqlStatementDto>> ApplyEventAsync(
+            SerializableEvent ev,
+            IMvTableBindings tables,
+            IMvApplyQueryPort queryPort,
+            string sortableUniqueId,
+            CancellationToken ct) =>
+            Task.FromResult<IReadOnlyList<MvSqlStatementDto>>([]);
+    }
+}

--- a/dcb/tests/Sekiban.Dcb.MaterializedView.Tests/MvServiceScopeTests.cs
+++ b/dcb/tests/Sekiban.Dcb.MaterializedView.Tests/MvServiceScopeTests.cs
@@ -1,0 +1,44 @@
+using Dcb.Domain.WithoutResult;
+using Dcb.Domain.WithoutResult.Order;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.InMemory;
+using Xunit;
+
+namespace Sekiban.Dcb.MaterializedView.Tests;
+
+#pragma warning disable CS0618
+
+public sealed class MvServiceScopeTests
+{
+    [Fact]
+    public async Task InMemoryFactory_SharesBackend_WhilePartitioningServices()
+    {
+        var domainTypes = DomainType.GetDomainTypes();
+        var seedStore = new InMemoryEventStore(domainTypes.EventTypes);
+        var factory = new InMemoryEventStoreFactory(seedStore);
+        var orders = factory.CreateForService("orders");
+        var billing = factory.CreateForService("billing");
+        var ordersAgain = factory.CreateForService("orders");
+
+        var serializableEvent = new Event(
+                new OrderCreated(
+                    Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
+                    DateTimeOffset.UtcNow),
+                "100",
+                nameof(OrderCreated),
+                Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"),
+                new EventMetadata("test", "test", "test"),
+                [])
+            .ToSerializableEvent(domainTypes.EventTypes);
+
+        var writeResult = await orders.WriteSerializableEventsAsync([serializableEvent]);
+
+        Assert.True(writeResult.IsSuccess);
+        Assert.Single((await orders.ReadAllSerializableEventsAsync()).GetValue());
+        Assert.Single((await ordersAgain.ReadAllSerializableEventsAsync()).GetValue());
+        Assert.Empty((await billing.ReadAllSerializableEventsAsync()).GetValue());
+    }
+
+}
+
+#pragma warning restore CS0618

--- a/dcb/tests/Sekiban.Dcb.MaterializedView.Tests/Sekiban.Dcb.MaterializedView.Tests.csproj
+++ b/dcb/tests/Sekiban.Dcb.MaterializedView.Tests/Sekiban.Dcb.MaterializedView.Tests.csproj
@@ -9,6 +9,10 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="Microsoft.Data.SqlClient" Version="6.1.2" />
+        <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.3" />
+        <PackageReference Include="MySqlConnector" Version="2.4.0" />
+        <PackageReference Include="Npgsql" Version="10.0.2" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
         <PackageReference Include="xunit" Version="2.9.3"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
@@ -23,6 +27,10 @@
 
     <ItemGroup>
         <ProjectReference Include="..\..\src\Sekiban.Dcb.MaterializedView\Sekiban.Dcb.MaterializedView.csproj"/>
+        <ProjectReference Include="..\..\src\Sekiban.Dcb.MaterializedView.MySql\Sekiban.Dcb.MaterializedView.MySql.csproj"/>
+        <ProjectReference Include="..\..\src\Sekiban.Dcb.MaterializedView.Postgres\Sekiban.Dcb.MaterializedView.Postgres.csproj"/>
+        <ProjectReference Include="..\..\src\Sekiban.Dcb.MaterializedView.SqlServer\Sekiban.Dcb.MaterializedView.SqlServer.csproj"/>
+        <ProjectReference Include="..\..\src\Sekiban.Dcb.MaterializedView.Sqlite\Sekiban.Dcb.MaterializedView.Sqlite.csproj"/>
         <ProjectReference Include="..\..\internalUsages\Dcb.Domain.WithoutResult\Dcb.Domain.WithoutResult.csproj"/>
     </ItemGroup>
 

--- a/dcb/tests/Sekiban.Dcb.Orleans.Tests/MaterializedViewGrainTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Orleans.Tests/MaterializedViewGrainTests.cs
@@ -8,6 +8,7 @@ using Sekiban.Dcb.Domains;
 using Sekiban.Dcb.Events;
 using Sekiban.Dcb.MaterializedView;
 using Sekiban.Dcb.MaterializedView.Orleans;
+using Sekiban.Dcb.Orleans.ServiceId;
 using Sekiban.Dcb.Orleans.Streams;
 using Sekiban.Dcb.ServiceId;
 using Xunit;
@@ -47,8 +48,9 @@ public class MaterializedViewGrainTests : IAsyncLifetime
     [Fact]
     public async Task MaterializedViewGrain_Should_CatchUp_Then_Process_Stream_Events()
     {
-        var grainKey = MvGrainKey.Build(DefaultServiceIdProvider.DefaultServiceId, TestMaterializedViewProjector.ViewNameConst, 1);
+        var grainKey = MvGrainKey.Build("orders", TestMaterializedViewProjector.ViewNameConst, 1);
         var grain = _cluster.Client.GetGrain<IMaterializedViewGrain>(grainKey);
+        await grain.EnsureStartedAsync();
 
         await WaitUntilAsync(async () =>
         {
@@ -59,7 +61,9 @@ public class MaterializedViewGrainTests : IAsyncLifetime
         var streamedEvent = CreateSerializableEvent(2, DateTime.UtcNow);
         var stream = _cluster.Client
             .GetStreamProvider("EventStreamProvider")
-            .GetStream<SerializableEvent>(StreamId.Create("AllEvents", Guid.Empty));
+            .GetStream<SerializableEvent>(StreamId.Create(
+                ServiceIdGrainKey.BuildStreamNamespace("AllEvents", "orders"),
+                Guid.Empty));
         await stream.OnNextAsync(streamedEvent);
 
         await WaitUntilAsync(() => grain.IsSortableUniqueIdReceived(streamedEvent.SortableUniqueIdValue));
@@ -69,6 +73,7 @@ public class MaterializedViewGrainTests : IAsyncLifetime
         Assert.True(statusAfterStream.SubscriptionActive);
         Assert.Equal(streamedEvent.SortableUniqueIdValue, statusAfterStream.CurrentPosition);
         Assert.Contains(streamedEvent.Id, SharedExecutor.AppliedEventIds);
+        Assert.Contains("orders", SharedExecutor.ServiceIds);
     }
 
     [Fact]
@@ -126,6 +131,7 @@ public class MaterializedViewGrainTests : IAsyncLifetime
                     services.AddSingleton<IEventTypes>(_ => new SimpleEventTypes());
                     services.Configure<MvOptions>(options =>
                     {
+                        options.AllowDefaultServiceId = true;
                         options.PollInterval = TimeSpan.FromMilliseconds(20);
                         options.StreamReorderWindow = TimeSpan.FromMilliseconds(10);
                     });
@@ -178,11 +184,13 @@ public class MaterializedViewGrainTests : IAsyncLifetime
 
         public List<SerializableEvent> InitialEvents { get; } = [];
         public HashSet<Guid> AppliedEventIds { get; } = [];
+        public List<string> ServiceIds { get; } = [];
 
         public void Reset()
         {
             InitialEvents.Clear();
             AppliedEventIds.Clear();
+            ServiceIds.Clear();
         }
 
         public void SeedInitial(params SerializableEvent[] events) => InitialEvents.AddRange(events);
@@ -193,6 +201,7 @@ public class MaterializedViewGrainTests : IAsyncLifetime
             CancellationToken cancellationToken = default)
         {
             serviceId ??= DefaultServiceIdProvider.DefaultServiceId;
+            ServiceIds.Add(serviceId);
             return _registry.RegisterViewAsync(serviceId, host.ViewName, host.ViewVersion, cancellationToken);
         }
 
@@ -202,6 +211,7 @@ public class MaterializedViewGrainTests : IAsyncLifetime
             CancellationToken cancellationToken = default)
         {
             serviceId ??= DefaultServiceIdProvider.DefaultServiceId;
+            ServiceIds.Add(serviceId);
             await InitializeAsync(host, serviceId, cancellationToken);
 
             var currentPosition = await _registry.GetCurrentPositionAsync(serviceId, host.ViewName, host.ViewVersion, cancellationToken);
@@ -242,6 +252,7 @@ public class MaterializedViewGrainTests : IAsyncLifetime
             CancellationToken cancellationToken = default)
         {
             serviceId ??= DefaultServiceIdProvider.DefaultServiceId;
+            ServiceIds.Add(serviceId);
             await InitializeAsync(host, serviceId, cancellationToken);
 
             var currentPosition = await _registry.GetCurrentPositionAsync(serviceId, host.ViewName, host.ViewVersion, cancellationToken);

--- a/docs/dcb_llm/20_materialized_view.md
+++ b/docs/dcb_llm/20_materialized_view.md
@@ -56,6 +56,10 @@ The current runtime is split into provider-neutral core plus provider packages:
 
 The event source of truth is still the DCB event store. Materialized views are downstream projections from that store.
 
+The event source and the materialized-view target are separate dependencies. The source provider may be PostgreSQL,
+Cosmos DB, DynamoDB, SQLite, or another `IEventStore` implementation, while the target executor writes to the
+database registered by the materialized-view provider.
+
 ## High-Level Flow
 
 1. A DCB command writes an event to the global event store.
@@ -106,6 +110,47 @@ builder.Services.AddSekibanDcbMaterializedViewSqlServer(configuration, "DcbMater
 builder.Services.AddSekibanDcbMaterializedViewMySql(configuration, "DcbMaterializedViewMySql");
 builder.Services.AddSekibanDcbMaterializedViewSqlite(configuration, "DcbMaterializedViewSqlite");
 ```
+
+### Service-scoped event sources
+
+Every materialized-view catch-up worker must be bound to one exact, non-empty service id. In a process that hosts more
+than one service, disable the provider's automatic worker and register one immutable worker per service:
+
+```csharp
+builder.Services.AddSekibanDcbMaterializedView();
+builder.Services.AddMaterializedView<WeatherForecastMvV1>();
+
+// Event source and MV target can use different backends/connections.
+builder.Services.AddSekibanDcbPostgres(sourceConnectionString);
+builder.Services.AddSekibanDcbMaterializedViewPostgres(
+    targetConnectionString,
+    registerHostedWorker: false);
+
+builder.Services.AddSekibanDcbMaterializedViewWorkerForService("orders");
+builder.Services.AddSekibanDcbMaterializedViewWorkerForService("billing");
+```
+
+The standard PostgreSQL, Cosmos DB, DynamoDB, and SQLite event-store registrations provide `IEventStoreFactory`. Each
+of the four classic target executors resolves `CreateForService(serviceId)` before reading events, so two services
+sharing one source backend cannot consume one another's events. A custom event source can use the compatible executor
+constructor that accepts `IEventStore`; it must still provide an explicit service identity.
+
+Orleans grain keys carry the same identity. Build a key with
+`MvGrainKey.Build("orders", "WeatherForecast", 1)`; the grain validates and forwards that exact service id to the
+executor before stream setup or store access.
+
+For a deliberately single-service legacy deployment only, opt into the literal default explicitly:
+
+```csharp
+builder.Services.AddSekibanDcbMaterializedView(options =>
+{
+    options.ServiceId = DefaultServiceIdProvider.DefaultServiceId;
+    options.AllowDefaultServiceId = true;
+});
+```
+
+Do not rely on an implicit `default` identity for an ordinary multi-service registration. Missing, blank, default, or
+mismatched identities are rejected before materialized-view infrastructure or event-store I/O.
 
 Projectors still emit SQL directly. For portable projectors, branch on `ctx.DatabaseType` and emit the SQL dialect that
 matches the selected provider. Unsafe Window MV remains PostgreSQL-only in v1.
@@ -233,9 +278,9 @@ They are complementary. A service can use both.
 
 Current implementation status:
 
-- database backend for materialized views: PostgreSQL
+- database backends for materialized views: PostgreSQL, SQL Server, MySQL, and SQLite
 - orchestration host: Orleans
-- event source: existing DCB event store
+- event source: service-scoped existing DCB event store
 
 The sample application in `internalUsages/DcbOrleans.WithoutResult.ApiService` uses:
 

--- a/docs/dcb_llm_ja/20_materialized_view.md
+++ b/docs/dcb_llm_ja/20_materialized_view.md
@@ -57,6 +57,10 @@
 
 イベントの正本はあくまで DCB のイベントストアであり、マテリアライズドビューはその下流投影です。
 
+イベントソースとマテリアライズドビューの書き込み先は独立した依存関係です。イベントソースには PostgreSQL、
+Cosmos DB、DynamoDB、SQLite などの `IEventStore` 実装を使い、マテリアライズドビュー側は別の DB 接続・別の
+provider をターゲットとして使えます。
+
 ## 全体の流れ
 
 1. DCB のコマンドがイベントストアへイベントを書き込む
@@ -111,6 +115,46 @@ builder.Services.AddSekibanDcbMaterializedViewSqlServer(configuration, "DcbMater
 builder.Services.AddSekibanDcbMaterializedViewMySql(configuration, "DcbMaterializedViewMySql");
 builder.Services.AddSekibanDcbMaterializedViewSqlite(configuration, "DcbMaterializedViewSqlite");
 ```
+
+### ServiceId 単位のイベントソース
+
+各マテリアライズドビューの catch-up worker は、空でない 1 つの ServiceId に固定します。1 プロセスで複数
+サービスを動かす場合は provider の自動 worker を無効にし、サービスごとに immutable な worker を 1 つ登録します。
+
+```csharp
+builder.Services.AddSekibanDcbMaterializedView();
+builder.Services.AddMaterializedView<WeatherForecastMvV1>();
+
+// イベントソースと MV のターゲットは別 backend / 別 connection にできます。
+builder.Services.AddSekibanDcbPostgres(sourceConnectionString);
+builder.Services.AddSekibanDcbMaterializedViewPostgres(
+    targetConnectionString,
+    registerHostedWorker: false);
+
+builder.Services.AddSekibanDcbMaterializedViewWorkerForService("orders");
+builder.Services.AddSekibanDcbMaterializedViewWorkerForService("billing");
+```
+
+標準の PostgreSQL、Cosmos DB、DynamoDB、SQLite のイベントストア登録は `IEventStoreFactory` を提供します。
+4 種類の classic MV target executor はイベントを読む前に `CreateForService(serviceId)` を解決するため、同じ
+source backend を共有するサービス同士でもイベントが混ざりません。独自のイベントソースは、互換性のために
+残されている `IEventStore` を受け取る executor コンストラクターを使えますが、ServiceId は明示してください。
+
+Orleans の Grain key にも同じ ServiceId を含めます。`MvGrainKey.Build("orders", "WeatherForecast", 1)` で key を
+作成すると、Grain は stream の準備や store アクセスより前にその ServiceId を検証し、executor へそのまま渡します。
+
+単一サービスの旧構成で literal の `default` を使う場合だけ、明示的に opt-in します。
+
+```csharp
+builder.Services.AddSekibanDcbMaterializedView(options =>
+{
+    options.ServiceId = DefaultServiceIdProvider.DefaultServiceId;
+    options.AllowDefaultServiceId = true;
+});
+```
+
+通常の multi-service 登録で暗黙の `default` に依存しないでください。ServiceId が未指定、空白、default、または
+呼び出し元と不一致の場合は、MV の infrastructure やイベントストアへの I/O より前に拒否されます。
 
 プロジェクターは引き続き SQL を直接返します。複数 provider で 1 つの projector を使いたい場合は、
 `ctx.DatabaseType` を見て SQL 方言を切り替えてください。Unsafe Window MV は v1 時点では PostgreSQL のみです。
@@ -238,9 +282,9 @@ query context から取得できるもの:
 
 現時点の実装範囲:
 
-- DB backend: PostgreSQL
+- DB backend: PostgreSQL、SQL Server、MySQL、SQLite
 - 実行ホスト: Orleans
-- イベントの正本: 既存の DCB event store
+- イベントの正本: ServiceId 単位で解決する既存の DCB event store
 
 サンプル実装 `internalUsages/DcbOrleans.WithoutResult.ApiService` では、
 


### PR DESCRIPTION
## Summary

- Scope every classic materialized-view event read to the exact service-bound `IEventStoreFactory` source in Postgres, MySQL, SQL Server, and SQLite.
- Keep the legacy aggregate-store constructors as explicitly documented single-service compatibility paths, with validation before infrastructure, registry, source, target, or stream I/O.
- Add standard source-factory DI parity for Postgres, Cosmos DB, DynamoDB, and SQLite, plus a shared-backend InMemory service partition proof.
- Propagate exact service identity through the hosted worker and Orleans grain path, and add focused isolation, zero-I/O, compatibility, provider, and EN/JA documentation coverage.
- The forbidden MV-specific `MvEventStoreResolver` was removed; its original bytes were preserved in the content-addressed audit backup listed below.

## Validation

- `dotnet build dcb/Sekiban.Dcb.slnx -c Debug --no-restore`
- `dotnet test dcb/tests/Sekiban.Dcb.MaterializedView.Tests/Sekiban.Dcb.MaterializedView.Tests.csproj -c Debug -f net10.0` — 25 passed, 0 failed
- `dotnet test dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests.csproj -c Debug -f net10.0 --filter FullyQualifiedName~SqliteMvIntegrationTests` — 2 passed, 0 failed
- `dotnet test dcb/tests/Sekiban.Dcb.Orleans.Tests/Sekiban.Dcb.Orleans.Tests.csproj -c Debug -f net10.0 --filter FullyQualifiedName~MaterializedViewGrainTests` — 2 passed, 0 failed
- `dotnet test dcb/Sekiban.Dcb.slnx -c Debug --no-build -f net10.0` — 1,413 passed, 1 skipped, 0 failed
- `dotnet test dcb/Sekiban.Dcb.slnx -c Debug --no-build -f net9.0` — 1,413 passed, 1 skipped, 0 failed
- `git diff --check`

Content-addressed resolver audit:

- SHA-256: `801d6eca8c3750b03d8b7d0aad7591e4bb1d5674e8aae37391c9fb58e11df76e`
- Backup: `/tmp/sek-g25-mv-resolver-audit/801d6eca8c3750b03d8b7d0aad7591e4bb1d5674e8aae37391c9fb58e11df76e/MvEventStoreResolver.cs`
- Source and backup were verified byte-for-byte before removal.

`SEK-G23-REPAIR.md` remains untracked and was excluded from this commit and PR.

Closes #1111
