### PR TITLE
feat(dcb): make materialized view checkpoint truth explicit

### DIFF
--- a/dcb/src/Sekiban.Dcb.MaterializedView.MySql/MySqlMvRegistryStore.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.MySql/MySqlMvRegistryStore.cs
@@ -28,6 +28,8 @@ public sealed class MySqlMvRegistryStore : IMvRegistryStore
                 status VARCHAR(32) NOT NULL,
                 current_position VARCHAR(64) NULL,
                 target_position VARCHAR(64) NULL,
+                current_checkpoint_truth LONGTEXT NULL,
+                target_checkpoint_truth LONGTEXT NULL,
                 last_sortable_unique_id VARCHAR(64) NULL,
                 applied_event_version BIGINT NOT NULL DEFAULT 0,
                 last_applied_source VARCHAR(32) NULL,
@@ -53,6 +55,35 @@ public sealed class MySqlMvRegistryStore : IMvRegistryStore
             """;
 
         await connection.ExecuteAsync(new CommandDefinition(registrySql, cancellationToken: cancellationToken)).ConfigureAwait(false);
+        var checkpointColumns = (await connection.QueryAsync<string>(
+                new CommandDefinition(
+                    """
+                    SELECT column_name
+                    FROM information_schema.columns
+                    WHERE table_schema = DATABASE()
+                      AND table_name = 'sekiban_mv_registry'
+                      AND column_name IN ('current_checkpoint_truth', 'target_checkpoint_truth');
+                    """,
+                    cancellationToken: cancellationToken)))
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        if (!checkpointColumns.Contains("current_checkpoint_truth"))
+        {
+            await connection.ExecuteAsync(
+                    new CommandDefinition(
+                        "ALTER TABLE sekiban_mv_registry ADD COLUMN current_checkpoint_truth LONGTEXT NULL;",
+                        cancellationToken: cancellationToken))
+                .ConfigureAwait(false);
+        }
+
+        if (!checkpointColumns.Contains("target_checkpoint_truth"))
+        {
+            await connection.ExecuteAsync(
+                    new CommandDefinition(
+                        "ALTER TABLE sekiban_mv_registry ADD COLUMN target_checkpoint_truth LONGTEXT NULL;",
+                        cancellationToken: cancellationToken))
+                .ConfigureAwait(false);
+        }
+
         await connection.ExecuteAsync(new CommandDefinition(activeSql, cancellationToken: cancellationToken)).ConfigureAwait(false);
     }
 
@@ -68,6 +99,8 @@ public sealed class MySqlMvRegistryStore : IMvRegistryStore
                 status,
                 current_position,
                 target_position,
+                current_checkpoint_truth,
+                target_checkpoint_truth,
                 last_sortable_unique_id,
                 applied_event_version,
                 last_applied_source,
@@ -88,6 +121,8 @@ public sealed class MySqlMvRegistryStore : IMvRegistryStore
                 @Status,
                 @CurrentPosition,
                 @TargetPosition,
+                @CurrentCheckpointTruth,
+                @TargetCheckpointTruth,
                 @LastSortableUniqueId,
                 @AppliedEventVersion,
                 @LastAppliedSource,
@@ -102,6 +137,14 @@ public sealed class MySqlMvRegistryStore : IMvRegistryStore
             ON DUPLICATE KEY UPDATE
                 physical_table = VALUES(physical_table),
                 last_updated = VALUES(last_updated),
+                current_checkpoint_truth = CASE
+                    WHEN current_checkpoint_truth IS NULL AND current_position IS NULL THEN VALUES(current_checkpoint_truth)
+                    ELSE current_checkpoint_truth
+                END,
+                target_checkpoint_truth = CASE
+                    WHEN target_checkpoint_truth IS NULL AND target_position IS NULL THEN VALUES(target_checkpoint_truth)
+                    ELSE target_checkpoint_truth
+                END,
                 applied_event_version = applied_event_version,
                 last_applied_source = COALESCE(last_applied_source, VALUES(last_applied_source)),
                 last_applied_at = COALESCE(last_applied_at, VALUES(last_applied_at)),
@@ -120,8 +163,10 @@ public sealed class MySqlMvRegistryStore : IMvRegistryStore
             entry.LogicalTable,
             entry.PhysicalTable,
             Status = entry.Status.ToString().ToLowerInvariant(),
-            entry.CurrentPosition,
-            entry.TargetPosition,
+            CurrentPosition = entry.EffectiveCurrentPosition,
+            TargetPosition = entry.EffectiveTargetPosition,
+            CurrentCheckpointTruth = MvCheckpointTruthCodec.Encode(entry.CurrentCheckpointTruth),
+            TargetCheckpointTruth = MvCheckpointTruthCodec.Encode(entry.TargetCheckpointTruth),
             entry.LastSortableUniqueId,
             entry.AppliedEventVersion,
             entry.LastAppliedSource,
@@ -145,9 +190,21 @@ public sealed class MySqlMvRegistryStore : IMvRegistryStore
         const string sql = """
             UPDATE sekiban_mv_registry
             SET current_position = CASE
-                    WHEN current_position IS NULL
+                    WHEN current_checkpoint_truth IS NULL
+                      OR current_position IS NULL
                       OR current_position < @SortableUniqueId THEN @SortableUniqueId
                     ELSE current_position
+                END,
+                current_checkpoint_truth = CASE
+                    WHEN @CheckpointTruth IS NOT NULL
+                      AND (current_checkpoint_truth IS NULL
+                        OR current_position IS NULL
+                        OR current_position <= @SortableUniqueId) THEN @CheckpointTruth
+                    ELSE current_checkpoint_truth
+                END,
+                target_checkpoint_truth = CASE
+                    WHEN @TargetCheckpointTruth IS NOT NULL THEN @TargetCheckpointTruth
+                    ELSE target_checkpoint_truth
                 END,
                 last_sortable_unique_id = CASE
                     WHEN last_sortable_unique_id IS NULL
@@ -155,8 +212,8 @@ public sealed class MySqlMvRegistryStore : IMvRegistryStore
                     ELSE last_sortable_unique_id
                 END,
                 applied_event_version = applied_event_version + @AppliedEventVersionDelta,
-                last_applied_source = @Source,
-                last_applied_at = UTC_TIMESTAMP(6),
+                last_applied_source = CASE WHEN @AppliedEventVersionDelta > 0 THEN @Source ELSE last_applied_source END,
+                last_applied_at = CASE WHEN @AppliedEventVersionDelta > 0 THEN UTC_TIMESTAMP(6) ELSE last_applied_at END,
                 last_stream_applied_sortable_unique_id = CASE
                     WHEN @Source = 'stream'
                       AND (last_stream_applied_sortable_unique_id IS NULL
@@ -164,7 +221,7 @@ public sealed class MySqlMvRegistryStore : IMvRegistryStore
                     ELSE last_stream_applied_sortable_unique_id
                 END,
                 last_catch_up_sortable_unique_id = CASE
-                    WHEN @Source = 'catchup'
+                    WHEN @Source = 'catchup' AND @AppliedEventVersionDelta > 0
                       AND (last_catch_up_sortable_unique_id IS NULL
                         OR last_catch_up_sortable_unique_id < @SortableUniqueId) THEN @SortableUniqueId
                     ELSE last_catch_up_sortable_unique_id
@@ -184,6 +241,10 @@ public sealed class MySqlMvRegistryStore : IMvRegistryStore
                 update.ViewVersion,
                 update.SortableUniqueId,
                 update.AppliedEventVersionDelta,
+                CheckpointTruth = MvCheckpointTruthCodec.Encode(MvCheckpointTruth.FromPositionUpdate(update)),
+                TargetCheckpointTruth = update.TargetCheckpointTruth is null
+                    ? null
+                    : MvCheckpointTruthCodec.Encode(update.TargetCheckpointTruth),
                 Source = update.Source == MvApplySource.Stream ? "stream" : "catchup"
             },
             transaction,
@@ -266,6 +327,8 @@ public sealed class MySqlMvRegistryStore : IMvRegistryStore
                    status AS Status,
                    current_position AS CurrentPosition,
                    target_position AS TargetPosition,
+                   current_checkpoint_truth AS CurrentCheckpointTruth,
+                   target_checkpoint_truth AS TargetCheckpointTruth,
                    last_sortable_unique_id AS LastSortableUniqueId,
                    applied_event_version AS AppliedEventVersion,
                    last_applied_source AS LastAppliedSource,
@@ -354,8 +417,11 @@ public sealed class MySqlMvRegistryStore : IMvRegistryStore
             new CommandDefinition(sql, parameters, transaction, cancellationToken: cancellationToken)).ConfigureAwait(false);
     }
 
-    private static MvRegistryEntry MapEntry(IReadOnlyDictionary<string, object?> row) =>
-        new()
+    private static MvRegistryEntry MapEntry(IReadOnlyDictionary<string, object?> row)
+    {
+        var currentCheckpointTruth = MvCheckpointTruthCodec.Decode(ReadNullableString(row, "CurrentCheckpointTruth"));
+        var targetCheckpointTruth = MvCheckpointTruthCodec.Decode(ReadNullableString(row, "TargetCheckpointTruth"));
+        return new()
         {
             ServiceId = ReadRequiredString(row, "ServiceId"),
             ViewName = ReadRequiredString(row, "ViewName"),
@@ -363,8 +429,10 @@ public sealed class MySqlMvRegistryStore : IMvRegistryStore
             LogicalTable = ReadRequiredString(row, "LogicalTable"),
             PhysicalTable = ReadRequiredString(row, "PhysicalTable"),
             Status = Enum.Parse<MvStatus>(ReadRequiredString(row, "Status"), ignoreCase: true),
-            CurrentPosition = ReadNullableString(row, "CurrentPosition"),
-            TargetPosition = ReadNullableString(row, "TargetPosition"),
+            CurrentPosition = ReadNullableString(row, "CurrentPosition") ?? currentCheckpointTruth.PositionValue,
+            TargetPosition = ReadNullableString(row, "TargetPosition") ?? targetCheckpointTruth.PositionValue,
+            CurrentCheckpointTruth = currentCheckpointTruth,
+            TargetCheckpointTruth = targetCheckpointTruth,
             LastSortableUniqueId = ReadNullableString(row, "LastSortableUniqueId"),
             AppliedEventVersion = ReadRequiredLong(row, "AppliedEventVersion"),
             LastAppliedSource = ReadNullableString(row, "LastAppliedSource"),
@@ -376,6 +444,7 @@ public sealed class MySqlMvRegistryStore : IMvRegistryStore
             LastUpdated = ReadRequiredDateTimeOffset(row, "LastUpdated"),
             Metadata = ReadNullableString(row, "Metadata")
         };
+    }
 
     private static MvActiveEntry MapActiveEntry(IReadOnlyDictionary<string, object?> row) =>
         new(

--- a/dcb/src/Sekiban.Dcb.MaterializedView.Orleans/MaterializedViewGrain.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.Orleans/MaterializedViewGrain.cs
@@ -436,6 +436,22 @@ public sealed class MaterializedViewGrain : Grain, IMaterializedViewGrain
     private async Task CompleteCatchUpAsync(CancellationToken cancellationToken)
     {
         await RefreshPositionFromRegistryAsync(cancellationToken);
+
+        // Registry truth is the readiness gate. A legacy row, failed read, or
+        // malformed/unknown checkpoint must never be promoted to Ready just
+        // because the executor returned an empty batch.
+        var entries = await _registryStore.GetEntriesAsync(
+            _serviceId!,
+            _host!.ViewName,
+            _host.ViewVersion,
+            cancellationToken);
+        if (entries.Count == 0 || entries.Any(entry => !entry.CurrentCheckpointTruth.IsKnown))
+        {
+            _lastError = "Materialized view checkpoint truth is Unknown; readiness remains fail-closed.";
+            _consecutiveEmptyBatches = 0;
+            return;
+        }
+
         await _registryStore.UpdateStatusAsync(
             _serviceId!,
             _host!.ViewName,
@@ -617,7 +633,7 @@ public sealed class MaterializedViewGrain : Grain, IMaterializedViewGrain
         ResolveHost();
         var entries = await _registryStore.GetEntriesAsync(_serviceId!, _host!.ViewName, _host.ViewVersion, cancellationToken);
         var currentPosition = entries
-            .Select(entry => entry.CurrentPosition)
+            .Select(entry => entry.CurrentCheckpointTruth.IsKnown ? entry.CurrentCheckpointTruth.PositionValue : null)
             .Where(position => !string.IsNullOrWhiteSpace(position))
             .OrderByDescending(position => position, StringComparer.Ordinal)
             .FirstOrDefault();

--- a/dcb/src/Sekiban.Dcb.MaterializedView.Postgres/PostgresMvRegistryStore.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.Postgres/PostgresMvRegistryStore.cs
@@ -28,6 +28,8 @@ public sealed class PostgresMvRegistryStore : IMvRegistryStore
                 status TEXT NOT NULL,
                 current_position TEXT NULL,
                 target_position TEXT NULL,
+                current_checkpoint_truth JSONB NULL,
+                target_checkpoint_truth JSONB NULL,
                 last_sortable_unique_id TEXT NULL,
                 applied_event_version BIGINT NOT NULL DEFAULT 0,
                 last_applied_source TEXT NULL,
@@ -53,6 +55,13 @@ public sealed class PostgresMvRegistryStore : IMvRegistryStore
             """;
 
         await connection.ExecuteAsync(new CommandDefinition(registrySql, cancellationToken: cancellationToken)).ConfigureAwait(false);
+        const string checkpointMigrationSql = """
+            ALTER TABLE sekiban_mv_registry
+                ADD COLUMN IF NOT EXISTS current_checkpoint_truth JSONB NULL;
+            ALTER TABLE sekiban_mv_registry
+                ADD COLUMN IF NOT EXISTS target_checkpoint_truth JSONB NULL;
+            """;
+        await connection.ExecuteAsync(new CommandDefinition(checkpointMigrationSql, cancellationToken: cancellationToken)).ConfigureAwait(false);
         await connection.ExecuteAsync(new CommandDefinition(activeSql, cancellationToken: cancellationToken)).ConfigureAwait(false);
     }
 
@@ -68,6 +77,8 @@ public sealed class PostgresMvRegistryStore : IMvRegistryStore
                 status,
                 current_position,
                 target_position,
+                current_checkpoint_truth,
+                target_checkpoint_truth,
                 last_sortable_unique_id,
                 applied_event_version,
                 last_applied_source,
@@ -88,6 +99,8 @@ public sealed class PostgresMvRegistryStore : IMvRegistryStore
                 @Status,
                 @CurrentPosition,
                 @TargetPosition,
+                CAST(@CurrentCheckpointTruth AS JSONB),
+                CAST(@TargetCheckpointTruth AS JSONB),
                 @LastSortableUniqueId,
                 @AppliedEventVersion,
                 @LastAppliedSource,
@@ -102,6 +115,16 @@ public sealed class PostgresMvRegistryStore : IMvRegistryStore
             ON CONFLICT (service_id, view_name, view_version, logical_table) DO UPDATE SET
                 physical_table = EXCLUDED.physical_table,
                 last_updated = EXCLUDED.last_updated,
+                current_checkpoint_truth = CASE
+                    WHEN sekiban_mv_registry.current_checkpoint_truth IS NULL
+                      AND sekiban_mv_registry.current_position IS NULL THEN EXCLUDED.current_checkpoint_truth
+                    ELSE sekiban_mv_registry.current_checkpoint_truth
+                END,
+                target_checkpoint_truth = CASE
+                    WHEN sekiban_mv_registry.target_checkpoint_truth IS NULL
+                      AND sekiban_mv_registry.target_position IS NULL THEN EXCLUDED.target_checkpoint_truth
+                    ELSE sekiban_mv_registry.target_checkpoint_truth
+                END,
                 applied_event_version = sekiban_mv_registry.applied_event_version,
                 last_applied_source = COALESCE(sekiban_mv_registry.last_applied_source, EXCLUDED.last_applied_source),
                 last_applied_at = COALESCE(sekiban_mv_registry.last_applied_at, EXCLUDED.last_applied_at),
@@ -120,8 +143,10 @@ public sealed class PostgresMvRegistryStore : IMvRegistryStore
             entry.LogicalTable,
             entry.PhysicalTable,
             Status = entry.Status.ToString().ToLowerInvariant(),
-            entry.CurrentPosition,
-            entry.TargetPosition,
+            CurrentPosition = entry.EffectiveCurrentPosition,
+            TargetPosition = entry.EffectiveTargetPosition,
+            CurrentCheckpointTruth = MvCheckpointTruthCodec.Encode(entry.CurrentCheckpointTruth),
+            TargetCheckpointTruth = MvCheckpointTruthCodec.Encode(entry.TargetCheckpointTruth),
             entry.LastSortableUniqueId,
             entry.AppliedEventVersion,
             entry.LastAppliedSource,
@@ -154,9 +179,21 @@ public sealed class PostgresMvRegistryStore : IMvRegistryStore
         const string sql = """
             UPDATE sekiban_mv_registry
             SET current_position = CASE
-                    WHEN current_position IS NULL
+                    WHEN current_checkpoint_truth IS NULL
+                      OR current_position IS NULL
                       OR current_position < @SortableUniqueId THEN @SortableUniqueId
                     ELSE current_position
+                END,
+                current_checkpoint_truth = CASE
+                    WHEN @CheckpointTruth IS NOT NULL
+                      AND (current_checkpoint_truth IS NULL
+                        OR current_position IS NULL
+                        OR current_position <= @SortableUniqueId) THEN CAST(@CheckpointTruth AS JSONB)
+                    ELSE current_checkpoint_truth
+                END,
+                target_checkpoint_truth = CASE
+                    WHEN @TargetCheckpointTruth IS NOT NULL THEN CAST(@TargetCheckpointTruth AS JSONB)
+                    ELSE target_checkpoint_truth
                 END,
                 last_sortable_unique_id = CASE
                     WHEN last_sortable_unique_id IS NULL
@@ -164,8 +201,8 @@ public sealed class PostgresMvRegistryStore : IMvRegistryStore
                     ELSE last_sortable_unique_id
                 END,
                 applied_event_version = applied_event_version + @AppliedEventVersionDelta,
-                last_applied_source = @Source,
-                last_applied_at = NOW(),
+                last_applied_source = CASE WHEN @AppliedEventVersionDelta > 0 THEN @Source ELSE last_applied_source END,
+                last_applied_at = CASE WHEN @AppliedEventVersionDelta > 0 THEN NOW() ELSE last_applied_at END,
                 last_stream_applied_sortable_unique_id = CASE
                     WHEN @Source = 'stream'
                       AND (last_stream_applied_sortable_unique_id IS NULL
@@ -173,7 +210,7 @@ public sealed class PostgresMvRegistryStore : IMvRegistryStore
                     ELSE last_stream_applied_sortable_unique_id
                 END,
                 last_catch_up_sortable_unique_id = CASE
-                    WHEN @Source = 'catchup'
+                    WHEN @Source = 'catchup' AND @AppliedEventVersionDelta > 0
                       AND (last_catch_up_sortable_unique_id IS NULL
                         OR last_catch_up_sortable_unique_id < @SortableUniqueId) THEN @SortableUniqueId
                     ELSE last_catch_up_sortable_unique_id
@@ -191,6 +228,10 @@ public sealed class PostgresMvRegistryStore : IMvRegistryStore
             update.ViewVersion,
             update.SortableUniqueId,
             update.AppliedEventVersionDelta,
+            CheckpointTruth = MvCheckpointTruthCodec.Encode(MvCheckpointTruth.FromPositionUpdate(update)),
+            TargetCheckpointTruth = update.TargetCheckpointTruth is null
+                ? null
+                : MvCheckpointTruthCodec.Encode(update.TargetCheckpointTruth),
             Source = update.Source == MvApplySource.Stream ? "stream" : "catchup"
         };
         await ExecuteAsync(sql, parameters, transaction, cancellationToken).ConfigureAwait(false);
@@ -266,6 +307,8 @@ public sealed class PostgresMvRegistryStore : IMvRegistryStore
                    status AS Status,
                    current_position AS CurrentPosition,
                    target_position AS TargetPosition,
+                   current_checkpoint_truth::text AS CurrentCheckpointTruth,
+                   target_checkpoint_truth::text AS TargetCheckpointTruth,
                    last_sortable_unique_id AS LastSortableUniqueId,
                    applied_event_version AS AppliedEventVersion,
                    last_applied_source AS LastAppliedSource,
@@ -351,8 +394,11 @@ public sealed class PostgresMvRegistryStore : IMvRegistryStore
             new CommandDefinition(sql, parameters, transaction, cancellationToken: cancellationToken)).ConfigureAwait(false);
     }
 
-    private static MvRegistryEntry MapEntry(IReadOnlyDictionary<string, object?> row) =>
-        new()
+    private static MvRegistryEntry MapEntry(IReadOnlyDictionary<string, object?> row)
+    {
+        var currentCheckpointTruth = MvCheckpointTruthCodec.Decode(ReadNullableString(row, "CurrentCheckpointTruth"));
+        var targetCheckpointTruth = MvCheckpointTruthCodec.Decode(ReadNullableString(row, "TargetCheckpointTruth"));
+        return new()
         {
             ServiceId = ReadRequiredString(row, "ServiceId"),
             ViewName = ReadRequiredString(row, "ViewName"),
@@ -360,8 +406,10 @@ public sealed class PostgresMvRegistryStore : IMvRegistryStore
             LogicalTable = ReadRequiredString(row, "LogicalTable"),
             PhysicalTable = ReadRequiredString(row, "PhysicalTable"),
             Status = Enum.Parse<MvStatus>(ReadRequiredString(row, "Status"), ignoreCase: true),
-            CurrentPosition = ReadNullableString(row, "CurrentPosition"),
-            TargetPosition = ReadNullableString(row, "TargetPosition"),
+            CurrentPosition = ReadNullableString(row, "CurrentPosition") ?? currentCheckpointTruth.PositionValue,
+            TargetPosition = ReadNullableString(row, "TargetPosition") ?? targetCheckpointTruth.PositionValue,
+            CurrentCheckpointTruth = currentCheckpointTruth,
+            TargetCheckpointTruth = targetCheckpointTruth,
             LastSortableUniqueId = ReadNullableString(row, "LastSortableUniqueId"),
             AppliedEventVersion = ReadRequiredLong(row, "AppliedEventVersion"),
             LastAppliedSource = ReadNullableString(row, "LastAppliedSource"),
@@ -373,6 +421,7 @@ public sealed class PostgresMvRegistryStore : IMvRegistryStore
             LastUpdated = ReadRequiredDateTimeOffset(row, "LastUpdated"),
             Metadata = ReadNullableString(row, "Metadata")
         };
+    }
 
     private static MvActiveEntry MapActiveEntry(IReadOnlyDictionary<string, object?> row) =>
         new(

--- a/dcb/src/Sekiban.Dcb.MaterializedView.SqlServer/SqlServerMvRegistryStore.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.SqlServer/SqlServerMvRegistryStore.cs
@@ -30,6 +30,8 @@ public sealed class SqlServerMvRegistryStore : IMvRegistryStore
                     status NVARCHAR(32) NOT NULL,
                     current_position NVARCHAR(64) NULL,
                     target_position NVARCHAR(64) NULL,
+                    current_checkpoint_truth NVARCHAR(MAX) NULL,
+                    target_checkpoint_truth NVARCHAR(MAX) NULL,
                     last_sortable_unique_id NVARCHAR(64) NULL,
                     applied_event_version BIGINT NOT NULL CONSTRAINT DF_sekiban_mv_registry_applied_event_version DEFAULT 0,
                     last_applied_source NVARCHAR(32) NULL,
@@ -57,6 +59,13 @@ public sealed class SqlServerMvRegistryStore : IMvRegistryStore
             """;
 
         await connection.ExecuteAsync(new CommandDefinition(sql, cancellationToken: cancellationToken)).ConfigureAwait(false);
+        const string checkpointMigrationSql = """
+            IF COL_LENGTH(N'sekiban_mv_registry', N'current_checkpoint_truth') IS NULL
+                ALTER TABLE sekiban_mv_registry ADD current_checkpoint_truth NVARCHAR(MAX) NULL;
+            IF COL_LENGTH(N'sekiban_mv_registry', N'target_checkpoint_truth') IS NULL
+                ALTER TABLE sekiban_mv_registry ADD target_checkpoint_truth NVARCHAR(MAX) NULL;
+            """;
+        await connection.ExecuteAsync(new CommandDefinition(checkpointMigrationSql, cancellationToken: cancellationToken)).ConfigureAwait(false);
     }
 
     public async Task RegisterAsync(MvRegistryEntry entry, IDbTransaction? transaction = null, CancellationToken cancellationToken = default)
@@ -65,6 +74,14 @@ public sealed class SqlServerMvRegistryStore : IMvRegistryStore
             UPDATE sekiban_mv_registry WITH (UPDLOCK, HOLDLOCK)
             SET physical_table = @PhysicalTable,
                 last_updated = @LastUpdated,
+                current_checkpoint_truth = CASE
+                    WHEN current_checkpoint_truth IS NULL AND current_position IS NULL THEN @CurrentCheckpointTruth
+                    ELSE current_checkpoint_truth
+                END,
+                target_checkpoint_truth = CASE
+                    WHEN target_checkpoint_truth IS NULL AND target_position IS NULL THEN @TargetCheckpointTruth
+                    ELSE target_checkpoint_truth
+                END,
                 last_applied_source = COALESCE(last_applied_source, @LastAppliedSource),
                 last_applied_at = COALESCE(last_applied_at, @LastAppliedAt),
                 last_stream_received_sortable_unique_id = COALESCE(last_stream_received_sortable_unique_id, @LastStreamReceivedSortableUniqueId),
@@ -88,6 +105,8 @@ public sealed class SqlServerMvRegistryStore : IMvRegistryStore
                     status,
                     current_position,
                     target_position,
+                    current_checkpoint_truth,
+                    target_checkpoint_truth,
                     last_sortable_unique_id,
                     applied_event_version,
                     last_applied_source,
@@ -108,6 +127,8 @@ public sealed class SqlServerMvRegistryStore : IMvRegistryStore
                     @Status,
                     @CurrentPosition,
                     @TargetPosition,
+                    @CurrentCheckpointTruth,
+                    @TargetCheckpointTruth,
                     @LastSortableUniqueId,
                     @AppliedEventVersion,
                     @LastAppliedSource,
@@ -130,8 +151,10 @@ public sealed class SqlServerMvRegistryStore : IMvRegistryStore
             entry.LogicalTable,
             entry.PhysicalTable,
             Status = entry.Status.ToString().ToLowerInvariant(),
-            entry.CurrentPosition,
-            entry.TargetPosition,
+            CurrentPosition = entry.EffectiveCurrentPosition,
+            TargetPosition = entry.EffectiveTargetPosition,
+            CurrentCheckpointTruth = MvCheckpointTruthCodec.Encode(entry.CurrentCheckpointTruth),
+            TargetCheckpointTruth = MvCheckpointTruthCodec.Encode(entry.TargetCheckpointTruth),
             entry.LastSortableUniqueId,
             entry.AppliedEventVersion,
             entry.LastAppliedSource,
@@ -165,9 +188,21 @@ public sealed class SqlServerMvRegistryStore : IMvRegistryStore
         const string sql = """
             UPDATE sekiban_mv_registry
             SET current_position = CASE
-                    WHEN current_position IS NULL
+                    WHEN current_checkpoint_truth IS NULL
+                      OR current_position IS NULL
                       OR current_position < @SortableUniqueId THEN @SortableUniqueId
                     ELSE current_position
+                END,
+                current_checkpoint_truth = CASE
+                    WHEN @CheckpointTruth IS NOT NULL
+                      AND (current_checkpoint_truth IS NULL
+                        OR current_position IS NULL
+                        OR current_position <= @SortableUniqueId) THEN @CheckpointTruth
+                    ELSE current_checkpoint_truth
+                END,
+                target_checkpoint_truth = CASE
+                    WHEN @TargetCheckpointTruth IS NOT NULL THEN @TargetCheckpointTruth
+                    ELSE target_checkpoint_truth
                 END,
                 last_sortable_unique_id = CASE
                     WHEN last_sortable_unique_id IS NULL
@@ -175,8 +210,8 @@ public sealed class SqlServerMvRegistryStore : IMvRegistryStore
                     ELSE last_sortable_unique_id
                 END,
                 applied_event_version = applied_event_version + @AppliedEventVersionDelta,
-                last_applied_source = @Source,
-                last_applied_at = SYSUTCDATETIME(),
+                last_applied_source = CASE WHEN @AppliedEventVersionDelta > 0 THEN @Source ELSE last_applied_source END,
+                last_applied_at = CASE WHEN @AppliedEventVersionDelta > 0 THEN SYSUTCDATETIME() ELSE last_applied_at END,
                 last_stream_applied_sortable_unique_id = CASE
                     WHEN @Source = 'stream'
                       AND (last_stream_applied_sortable_unique_id IS NULL
@@ -184,7 +219,7 @@ public sealed class SqlServerMvRegistryStore : IMvRegistryStore
                     ELSE last_stream_applied_sortable_unique_id
                 END,
                 last_catch_up_sortable_unique_id = CASE
-                    WHEN @Source = 'catchup'
+                    WHEN @Source = 'catchup' AND @AppliedEventVersionDelta > 0
                       AND (last_catch_up_sortable_unique_id IS NULL
                         OR last_catch_up_sortable_unique_id < @SortableUniqueId) THEN @SortableUniqueId
                     ELSE last_catch_up_sortable_unique_id
@@ -202,6 +237,10 @@ public sealed class SqlServerMvRegistryStore : IMvRegistryStore
             update.ViewVersion,
             update.SortableUniqueId,
             update.AppliedEventVersionDelta,
+            CheckpointTruth = MvCheckpointTruthCodec.Encode(MvCheckpointTruth.FromPositionUpdate(update)),
+            TargetCheckpointTruth = update.TargetCheckpointTruth is null
+                ? null
+                : MvCheckpointTruthCodec.Encode(update.TargetCheckpointTruth),
             Source = update.Source == MvApplySource.Stream ? "stream" : "catchup"
         };
         await ExecuteAsync(sql, parameters, transaction, cancellationToken).ConfigureAwait(false);
@@ -283,6 +322,8 @@ public sealed class SqlServerMvRegistryStore : IMvRegistryStore
                    status AS Status,
                    current_position AS CurrentPosition,
                    target_position AS TargetPosition,
+                   current_checkpoint_truth AS CurrentCheckpointTruth,
+                   target_checkpoint_truth AS TargetCheckpointTruth,
                    last_sortable_unique_id AS LastSortableUniqueId,
                    applied_event_version AS AppliedEventVersion,
                    last_applied_source AS LastAppliedSource,
@@ -384,8 +425,11 @@ public sealed class SqlServerMvRegistryStore : IMvRegistryStore
             new CommandDefinition(sql, parameters, transaction, cancellationToken: cancellationToken)).ConfigureAwait(false);
     }
 
-    private static MvRegistryEntry MapEntry(IReadOnlyDictionary<string, object?> row) =>
-        new()
+    private static MvRegistryEntry MapEntry(IReadOnlyDictionary<string, object?> row)
+    {
+        var currentCheckpointTruth = MvCheckpointTruthCodec.Decode(ReadNullableString(row, "CurrentCheckpointTruth"));
+        var targetCheckpointTruth = MvCheckpointTruthCodec.Decode(ReadNullableString(row, "TargetCheckpointTruth"));
+        return new()
         {
             ServiceId = ReadRequiredString(row, "ServiceId"),
             ViewName = ReadRequiredString(row, "ViewName"),
@@ -393,8 +437,10 @@ public sealed class SqlServerMvRegistryStore : IMvRegistryStore
             LogicalTable = ReadRequiredString(row, "LogicalTable"),
             PhysicalTable = ReadRequiredString(row, "PhysicalTable"),
             Status = Enum.Parse<MvStatus>(ReadRequiredString(row, "Status"), ignoreCase: true),
-            CurrentPosition = ReadNullableString(row, "CurrentPosition"),
-            TargetPosition = ReadNullableString(row, "TargetPosition"),
+            CurrentPosition = ReadNullableString(row, "CurrentPosition") ?? currentCheckpointTruth.PositionValue,
+            TargetPosition = ReadNullableString(row, "TargetPosition") ?? targetCheckpointTruth.PositionValue,
+            CurrentCheckpointTruth = currentCheckpointTruth,
+            TargetCheckpointTruth = targetCheckpointTruth,
             LastSortableUniqueId = ReadNullableString(row, "LastSortableUniqueId"),
             AppliedEventVersion = ReadRequiredLong(row, "AppliedEventVersion"),
             LastAppliedSource = ReadNullableString(row, "LastAppliedSource"),
@@ -406,6 +452,7 @@ public sealed class SqlServerMvRegistryStore : IMvRegistryStore
             LastUpdated = ReadRequiredDateTimeOffset(row, "LastUpdated"),
             Metadata = ReadNullableString(row, "Metadata")
         };
+    }
 
     private static MvActiveEntry MapActiveEntry(IReadOnlyDictionary<string, object?> row) =>
         new(

--- a/dcb/src/Sekiban.Dcb.MaterializedView.Sqlite/SqliteMvRegistryStore.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.Sqlite/SqliteMvRegistryStore.cs
@@ -33,6 +33,8 @@ public sealed class SqliteMvRegistryStore : IMvRegistryStore
                 status TEXT NOT NULL,
                 current_position TEXT NULL,
                 target_position TEXT NULL,
+                current_checkpoint_truth TEXT NULL,
+                target_checkpoint_truth TEXT NULL,
                 last_sortable_unique_id TEXT NULL,
                 applied_event_version INTEGER NOT NULL DEFAULT 0,
                 last_applied_source TEXT NULL,
@@ -59,7 +61,31 @@ public sealed class SqliteMvRegistryStore : IMvRegistryStore
 
         await connection.ExecuteAsync(new CommandDefinition(pragmaSql, cancellationToken: cancellationToken)).ConfigureAwait(false);
         await connection.ExecuteAsync(new CommandDefinition(registrySql, cancellationToken: cancellationToken)).ConfigureAwait(false);
+        await EnsureCheckpointColumnsAsync(connection, cancellationToken).ConfigureAwait(false);
         await connection.ExecuteAsync(new CommandDefinition(activeSql, cancellationToken: cancellationToken)).ConfigureAwait(false);
+    }
+
+    private static async Task EnsureCheckpointColumnsAsync(
+        SqliteConnection connection,
+        CancellationToken cancellationToken)
+    {
+        var existingColumns = (await connection.QueryAsync<SqliteColumnInfo>(
+                new CommandDefinition("PRAGMA table_info('sekiban_mv_registry');", cancellationToken: cancellationToken))
+            .ConfigureAwait(false))
+            .Select(column => column.Name)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var column in new[] { "current_checkpoint_truth", "target_checkpoint_truth" })
+        {
+            if (!existingColumns.Contains(column))
+            {
+                await connection.ExecuteAsync(
+                        new CommandDefinition(
+                            $"ALTER TABLE sekiban_mv_registry ADD COLUMN {column} TEXT NULL;",
+                            cancellationToken: cancellationToken))
+                    .ConfigureAwait(false);
+            }
+        }
     }
 
     public async Task RegisterAsync(MvRegistryEntry entry, IDbTransaction? transaction = null, CancellationToken cancellationToken = default)
@@ -74,6 +100,8 @@ public sealed class SqliteMvRegistryStore : IMvRegistryStore
                 status,
                 current_position,
                 target_position,
+                current_checkpoint_truth,
+                target_checkpoint_truth,
                 last_sortable_unique_id,
                 applied_event_version,
                 last_applied_source,
@@ -94,6 +122,8 @@ public sealed class SqliteMvRegistryStore : IMvRegistryStore
                 @Status,
                 @CurrentPosition,
                 @TargetPosition,
+                @CurrentCheckpointTruth,
+                @TargetCheckpointTruth,
                 @LastSortableUniqueId,
                 @AppliedEventVersion,
                 @LastAppliedSource,
@@ -108,6 +138,16 @@ public sealed class SqliteMvRegistryStore : IMvRegistryStore
             ON CONFLICT (service_id, view_name, view_version, logical_table) DO UPDATE SET
                 physical_table = excluded.physical_table,
                 last_updated = excluded.last_updated,
+                current_checkpoint_truth = CASE
+                    WHEN sekiban_mv_registry.current_checkpoint_truth IS NULL
+                      AND sekiban_mv_registry.current_position IS NULL THEN excluded.current_checkpoint_truth
+                    ELSE sekiban_mv_registry.current_checkpoint_truth
+                END,
+                target_checkpoint_truth = CASE
+                    WHEN sekiban_mv_registry.target_checkpoint_truth IS NULL
+                      AND sekiban_mv_registry.target_position IS NULL THEN excluded.target_checkpoint_truth
+                    ELSE sekiban_mv_registry.target_checkpoint_truth
+                END,
                 applied_event_version = sekiban_mv_registry.applied_event_version,
                 last_applied_source = COALESCE(sekiban_mv_registry.last_applied_source, excluded.last_applied_source),
                 last_applied_at = COALESCE(sekiban_mv_registry.last_applied_at, excluded.last_applied_at),
@@ -126,8 +166,10 @@ public sealed class SqliteMvRegistryStore : IMvRegistryStore
             entry.LogicalTable,
             entry.PhysicalTable,
             Status = entry.Status.ToString().ToLowerInvariant(),
-            entry.CurrentPosition,
-            entry.TargetPosition,
+            CurrentPosition = entry.EffectiveCurrentPosition,
+            TargetPosition = entry.EffectiveTargetPosition,
+            CurrentCheckpointTruth = MvCheckpointTruthCodec.Encode(entry.CurrentCheckpointTruth),
+            TargetCheckpointTruth = MvCheckpointTruthCodec.Encode(entry.TargetCheckpointTruth),
             entry.LastSortableUniqueId,
             entry.AppliedEventVersion,
             entry.LastAppliedSource,
@@ -151,9 +193,21 @@ public sealed class SqliteMvRegistryStore : IMvRegistryStore
         const string sql = """
             UPDATE sekiban_mv_registry
             SET current_position = CASE
-                    WHEN current_position IS NULL
+                    WHEN current_checkpoint_truth IS NULL
+                      OR current_position IS NULL
                       OR current_position < @SortableUniqueId THEN @SortableUniqueId
                     ELSE current_position
+                END,
+                current_checkpoint_truth = CASE
+                    WHEN @CheckpointTruth IS NOT NULL
+                      AND (current_checkpoint_truth IS NULL
+                        OR current_position IS NULL
+                        OR current_position <= @SortableUniqueId) THEN @CheckpointTruth
+                    ELSE current_checkpoint_truth
+                END,
+                target_checkpoint_truth = CASE
+                    WHEN @TargetCheckpointTruth IS NOT NULL THEN @TargetCheckpointTruth
+                    ELSE target_checkpoint_truth
                 END,
                 last_sortable_unique_id = CASE
                     WHEN last_sortable_unique_id IS NULL
@@ -161,8 +215,8 @@ public sealed class SqliteMvRegistryStore : IMvRegistryStore
                     ELSE last_sortable_unique_id
                 END,
                 applied_event_version = applied_event_version + @AppliedEventVersionDelta,
-                last_applied_source = @Source,
-                last_applied_at = @Now,
+                last_applied_source = CASE WHEN @AppliedEventVersionDelta > 0 THEN @Source ELSE last_applied_source END,
+                last_applied_at = CASE WHEN @AppliedEventVersionDelta > 0 THEN @Now ELSE last_applied_at END,
                 last_stream_applied_sortable_unique_id = CASE
                     WHEN @Source = 'stream'
                       AND (last_stream_applied_sortable_unique_id IS NULL
@@ -170,7 +224,7 @@ public sealed class SqliteMvRegistryStore : IMvRegistryStore
                     ELSE last_stream_applied_sortable_unique_id
                 END,
                 last_catch_up_sortable_unique_id = CASE
-                    WHEN @Source = 'catchup'
+                    WHEN @Source = 'catchup' AND @AppliedEventVersionDelta > 0
                       AND (last_catch_up_sortable_unique_id IS NULL
                         OR last_catch_up_sortable_unique_id < @SortableUniqueId) THEN @SortableUniqueId
                     ELSE last_catch_up_sortable_unique_id
@@ -190,6 +244,10 @@ public sealed class SqliteMvRegistryStore : IMvRegistryStore
                 update.ViewVersion,
                 update.SortableUniqueId,
                 update.AppliedEventVersionDelta,
+                CheckpointTruth = MvCheckpointTruthCodec.Encode(MvCheckpointTruth.FromPositionUpdate(update)),
+                TargetCheckpointTruth = update.TargetCheckpointTruth is null
+                    ? null
+                    : MvCheckpointTruthCodec.Encode(update.TargetCheckpointTruth),
                 Source = update.Source == MvApplySource.Stream ? "stream" : "catchup",
                 Now = SerializeDate(DateTimeOffset.UtcNow)
             },
@@ -281,6 +339,8 @@ public sealed class SqliteMvRegistryStore : IMvRegistryStore
                    status AS Status,
                    current_position AS CurrentPosition,
                    target_position AS TargetPosition,
+                   current_checkpoint_truth AS CurrentCheckpointTruth,
+                   target_checkpoint_truth AS TargetCheckpointTruth,
                    last_sortable_unique_id AS LastSortableUniqueId,
                    applied_event_version AS AppliedEventVersion,
                    last_applied_source AS LastAppliedSource,
@@ -375,8 +435,11 @@ public sealed class SqliteMvRegistryStore : IMvRegistryStore
             new CommandDefinition(sql, parameters, transaction, cancellationToken: cancellationToken)).ConfigureAwait(false);
     }
 
-    private static MvRegistryEntry MapEntry(IReadOnlyDictionary<string, object?> row) =>
-        new()
+    private static MvRegistryEntry MapEntry(IReadOnlyDictionary<string, object?> row)
+    {
+        var currentCheckpointTruth = MvCheckpointTruthCodec.Decode(ReadNullableString(row, "CurrentCheckpointTruth"));
+        var targetCheckpointTruth = MvCheckpointTruthCodec.Decode(ReadNullableString(row, "TargetCheckpointTruth"));
+        return new()
         {
             ServiceId = ReadRequiredString(row, "ServiceId"),
             ViewName = ReadRequiredString(row, "ViewName"),
@@ -384,8 +447,10 @@ public sealed class SqliteMvRegistryStore : IMvRegistryStore
             LogicalTable = ReadRequiredString(row, "LogicalTable"),
             PhysicalTable = ReadRequiredString(row, "PhysicalTable"),
             Status = Enum.Parse<MvStatus>(ReadRequiredString(row, "Status"), ignoreCase: true),
-            CurrentPosition = ReadNullableString(row, "CurrentPosition"),
-            TargetPosition = ReadNullableString(row, "TargetPosition"),
+            CurrentPosition = ReadNullableString(row, "CurrentPosition") ?? currentCheckpointTruth.PositionValue,
+            TargetPosition = ReadNullableString(row, "TargetPosition") ?? targetCheckpointTruth.PositionValue,
+            CurrentCheckpointTruth = currentCheckpointTruth,
+            TargetCheckpointTruth = targetCheckpointTruth,
             LastSortableUniqueId = ReadNullableString(row, "LastSortableUniqueId"),
             AppliedEventVersion = ReadRequiredLong(row, "AppliedEventVersion"),
             LastAppliedSource = ReadNullableString(row, "LastAppliedSource"),
@@ -397,6 +462,7 @@ public sealed class SqliteMvRegistryStore : IMvRegistryStore
             LastUpdated = ReadRequiredDateTimeOffset(row, "LastUpdated"),
             Metadata = ReadNullableString(row, "Metadata")
         };
+    }
 
     private static MvActiveEntry MapActiveEntry(IReadOnlyDictionary<string, object?> row) =>
         new(
@@ -404,6 +470,11 @@ public sealed class SqliteMvRegistryStore : IMvRegistryStore
             ReadRequiredString(row, "ViewName"),
             ReadRequiredInt(row, "ActiveVersion"),
             ReadRequiredDateTimeOffset(row, "ActivatedAt"));
+
+    private sealed class SqliteColumnInfo
+    {
+        public string Name { get; init; } = string.Empty;
+    }
 
     private static IReadOnlyDictionary<string, object?> ToDictionary(object row)
     {

--- a/dcb/src/Sekiban.Dcb.MaterializedView.Sqlite/SqliteMvRegistryStore.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.Sqlite/SqliteMvRegistryStore.cs
@@ -75,16 +75,22 @@ public sealed class SqliteMvRegistryStore : IMvRegistryStore
             .Select(column => column.Name)
             .ToHashSet(StringComparer.OrdinalIgnoreCase);
 
-        foreach (var column in new[] { "current_checkpoint_truth", "target_checkpoint_truth" })
+        if (!existingColumns.Contains("current_checkpoint_truth"))
         {
-            if (!existingColumns.Contains(column))
-            {
-                await connection.ExecuteAsync(
-                        new CommandDefinition(
-                            $"ALTER TABLE sekiban_mv_registry ADD COLUMN {column} TEXT NULL;",
-                            cancellationToken: cancellationToken))
-                    .ConfigureAwait(false);
-            }
+            await connection.ExecuteAsync(
+                    new CommandDefinition(
+                        "ALTER TABLE sekiban_mv_registry ADD COLUMN current_checkpoint_truth TEXT NULL;",
+                        cancellationToken: cancellationToken))
+                .ConfigureAwait(false);
+        }
+
+        if (!existingColumns.Contains("target_checkpoint_truth"))
+        {
+            await connection.ExecuteAsync(
+                    new CommandDefinition(
+                        "ALTER TABLE sekiban_mv_registry ADD COLUMN target_checkpoint_truth TEXT NULL;",
+                        cancellationToken: cancellationToken))
+                .ConfigureAwait(false);
         }
     }
 

--- a/dcb/src/Sekiban.Dcb.MaterializedView/MvCheckpointTruth.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView/MvCheckpointTruth.cs
@@ -1,0 +1,399 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Sekiban.Dcb.Common;
+
+namespace Sekiban.Dcb.MaterializedView;
+
+/// <summary>
+///     The two-state wire contract for an authoritative materialized-view checkpoint.
+///     Unknown is deliberately not a position and must never be treated as zero.
+/// </summary>
+public enum MvCheckpointTruthState
+{
+    Unknown = 0,
+    Known = 1
+}
+
+/// <summary>Stable, provider-neutral reasons for an Unknown checkpoint.</summary>
+public enum MvCheckpointUnknownReason
+{
+    NotObserved = 0,
+    LegacyNull = 1,
+    ReadUnavailable = 2,
+    Malformed = 3
+}
+
+/// <summary>Stable provenance categories for a Known checkpoint.</summary>
+public enum MvCheckpointProvenanceKind
+{
+    AppliedEvent = 0,
+    AuthoritativeEmptyHistory = 1,
+    LegacyCompatibility = 2
+}
+
+/// <summary>
+///     Secret-free provenance for a Known checkpoint. The optional apply source is diagnostic only;
+///     the position remains authoritative because it was observed at the registry boundary.
+/// </summary>
+public sealed record MvCheckpointProvenance(
+    MvCheckpointProvenanceKind Kind,
+    DateTimeOffset ObservedAtUtc,
+    MvApplySource? ApplySource = null)
+{
+    public static MvCheckpointProvenance AppliedEvent(MvApplySource source, DateTimeOffset? observedAtUtc = null) =>
+        new(MvCheckpointProvenanceKind.AppliedEvent, observedAtUtc ?? DateTimeOffset.UtcNow, source);
+
+    public static MvCheckpointProvenance AuthoritativeEmptyHistory(DateTimeOffset? observedAtUtc = null) =>
+        new(MvCheckpointProvenanceKind.AuthoritativeEmptyHistory, observedAtUtc ?? DateTimeOffset.UtcNow, MvApplySource.CatchUp);
+}
+
+/// <summary>
+///     Provider-neutral authoritative checkpoint truth.
+///
+///     A Known-zero checkpoint uses <see cref="SortableUniqueId.MinValue"/> and is distinct from Unknown.
+///     Unknown has no sortable position, so all readiness/comparison predicates fail closed for it.
+/// </summary>
+[JsonConverter(typeof(MvCheckpointTruthJsonConverter))]
+public sealed record MvCheckpointTruth
+{
+    private MvCheckpointTruth(
+        MvCheckpointTruthState state,
+        string? positionValue,
+        bool isKnownZero,
+        MvCheckpointUnknownReason? unknownReason,
+        MvCheckpointProvenance? provenance)
+    {
+        State = state;
+        PositionValue = positionValue;
+        IsKnownZero = isKnownZero;
+        UnknownReason = unknownReason;
+        Provenance = provenance;
+    }
+
+    public MvCheckpointTruthState State { get; }
+    public string? PositionValue { get; }
+    public bool IsKnownZero { get; }
+    public MvCheckpointUnknownReason? UnknownReason { get; }
+    public MvCheckpointProvenance? Provenance { get; }
+
+    public bool IsKnown => State == MvCheckpointTruthState.Known;
+    public bool IsUnknown => State == MvCheckpointTruthState.Unknown;
+
+    public SortableUniqueId? Position =>
+        PositionValue is null ? null : new SortableUniqueId(PositionValue);
+
+    public static MvCheckpointTruth Unknown(MvCheckpointUnknownReason reason = MvCheckpointUnknownReason.NotObserved) =>
+        new(MvCheckpointTruthState.Unknown, null, false, reason, null);
+
+    public static MvCheckpointTruth Known(
+        SortableUniqueId position,
+        MvCheckpointProvenance provenance) =>
+        KnownAt(position, provenance);
+
+    public static MvCheckpointTruth KnownAt(
+        SortableUniqueId position,
+        MvCheckpointProvenance provenance)
+    {
+        ArgumentNullException.ThrowIfNull(position);
+        ArgumentNullException.ThrowIfNull(provenance);
+        EnsureValidPosition(position.Value, nameof(position));
+        return new(
+            MvCheckpointTruthState.Known,
+            position.Value,
+            string.Equals(position.Value, SortableUniqueId.MinValue.Value, StringComparison.Ordinal),
+            null,
+            provenance);
+    }
+
+    public static MvCheckpointTruth KnownZero(MvCheckpointProvenance? provenance = null) =>
+        KnownAt(
+            SortableUniqueId.MinValue,
+            provenance ?? MvCheckpointProvenance.AuthoritativeEmptyHistory());
+
+    /// <summary>
+    ///     Returns true only when both checkpoints are Known and the current position is at or after the target.
+    ///     Unknown on either side is never coerced to zero.
+    /// </summary>
+    public bool Satisfies(MvCheckpointTruth target)
+    {
+        ArgumentNullException.ThrowIfNull(target);
+        if (!IsKnown || !target.IsKnown || Position is null || target.Position is null)
+        {
+            return false;
+        }
+
+        return Position.IsLaterThanOrEqual(target.Position);
+    }
+
+    /// <summary>Fail-closed comparison against a raw sortable id.</summary>
+    public bool Satisfies(string? targetSortableUniqueId)
+    {
+        if (!IsKnown || !SortableUniqueId.TryParse(targetSortableUniqueId ?? string.Empty, out var target) || target is null)
+        {
+            return false;
+        }
+
+        return Position is not null && Position.IsLaterThanOrEqual(target);
+    }
+
+    public static MvCheckpointTruth FromPositionUpdate(MvPositionUpdate update) =>
+        update.CheckpointTruth ?? KnownAt(
+            ParsePosition(update.SortableUniqueId),
+            MvCheckpointProvenance.AppliedEvent(update.Source));
+
+    private static SortableUniqueId ParsePosition(string value)
+    {
+        if (!SortableUniqueId.TryParse(value, out var parsed) || parsed is null)
+        {
+            throw new MvCheckpointMalformedException(
+                $"SortableUniqueId '{value}' is not a valid checkpoint position.",
+                nameof(value));
+        }
+
+        return parsed;
+    }
+
+    private static void EnsureValidPosition(string value, string fieldName)
+    {
+        if (!SortableUniqueId.TryParse(value, out _))
+        {
+            throw new MvCheckpointMalformedException(
+                $"Checkpoint position '{value}' is not a valid SortableUniqueId.",
+                fieldName);
+        }
+    }
+}
+
+/// <summary>JSON adapter for public diagnostics; registry persistence uses <see cref="MvCheckpointTruthCodec"/> directly.</summary>
+public sealed class MvCheckpointTruthJsonConverter : JsonConverter<MvCheckpointTruth>
+{
+    public override MvCheckpointTruth Read(
+        ref Utf8JsonReader reader,
+        Type typeToConvert,
+        JsonSerializerOptions options)
+    {
+        using var document = JsonDocument.ParseValue(ref reader);
+        return MvCheckpointTruthCodec.Decode(document.RootElement.GetRawText());
+    }
+
+    public override void Write(
+        Utf8JsonWriter writer,
+        MvCheckpointTruth value,
+        JsonSerializerOptions options)
+    {
+        using var document = JsonDocument.Parse(MvCheckpointTruthCodec.Encode(value));
+        document.RootElement.WriteTo(writer);
+    }
+}
+
+/// <summary>Typed failure raised when a persisted checkpoint truth is malformed.</summary>
+public sealed class MvCheckpointMalformedException : FormatException
+{
+    public MvCheckpointMalformedException(string message, string fieldName, Exception? innerException = null)
+        : base(message, innerException)
+    {
+        FieldName = fieldName;
+    }
+
+    public string FieldName { get; }
+}
+
+/// <summary>
+///     Stable JSON codec for registry columns. The codec accepts only the explicit Known/Unknown shape;
+///     a null column is the legacy-null compatibility path and becomes Unknown.
+/// </summary>
+public static class MvCheckpointTruthCodec
+{
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DictionaryKeyPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = false
+    };
+
+    public static string Encode(MvCheckpointTruth truth)
+    {
+        ArgumentNullException.ThrowIfNull(truth);
+
+        return JsonSerializer.Serialize(
+            new WireEnvelope
+            {
+                State = truth.IsKnown ? "known" : "unknown",
+                Position = truth.PositionValue,
+                KnownZero = truth.IsKnownZero,
+                Reason = truth.UnknownReason is { } reason ? ToWireReason(reason) : null,
+                Provenance = truth.Provenance is null
+                    ? null
+                    : new WireProvenance
+                    {
+                        Kind = ToWireKind(truth.Provenance.Kind),
+                        ObservedAtUtc = truth.Provenance.ObservedAtUtc,
+                        ApplySource = truth.Provenance.ApplySource?.ToString().ToLowerInvariant()
+                    }
+            },
+            SerializerOptions);
+    }
+
+    public static MvCheckpointTruth Decode(string? serialized)
+    {
+        if (string.IsNullOrWhiteSpace(serialized))
+        {
+            return MvCheckpointTruth.Unknown(MvCheckpointUnknownReason.LegacyNull);
+        }
+
+        WireEnvelope envelope;
+        try
+        {
+            envelope = JsonSerializer.Deserialize<WireEnvelope>(serialized, SerializerOptions)
+                ?? throw new MvCheckpointMalformedException("Checkpoint truth JSON is null.", "root");
+        }
+        catch (MvCheckpointMalformedException)
+        {
+            throw;
+        }
+        catch (JsonException ex)
+        {
+            throw new MvCheckpointMalformedException("Checkpoint truth JSON is malformed.", "root", ex);
+        }
+
+        if (string.Equals(envelope.State, "unknown", StringComparison.OrdinalIgnoreCase))
+        {
+            if (envelope.Position is not null || envelope.KnownZero)
+            {
+                throw new MvCheckpointMalformedException(
+                    "An Unknown checkpoint cannot carry a position or Known-zero marker.",
+                    "state");
+            }
+
+            return MvCheckpointTruth.Unknown(ParseReason(envelope.Reason));
+        }
+
+        if (!string.Equals(envelope.State, "known", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new MvCheckpointMalformedException(
+                "Checkpoint truth state must be 'known' or 'unknown'.",
+                "state");
+        }
+
+        if (string.IsNullOrWhiteSpace(envelope.Position))
+        {
+            throw new MvCheckpointMalformedException(
+                "A Known checkpoint must carry a SortableUniqueId position.",
+                "position");
+        }
+
+        if (!SortableUniqueId.TryParse(envelope.Position, out var position) || position is null)
+        {
+            throw new MvCheckpointMalformedException(
+                $"Checkpoint position '{envelope.Position}' is not a valid SortableUniqueId.",
+                "position");
+        }
+
+        if (envelope.Provenance is null)
+        {
+            throw new MvCheckpointMalformedException(
+                "A Known checkpoint must carry provenance.",
+                "provenance");
+        }
+
+        var provenance = ParseProvenance(envelope.Provenance);
+        var expectedKnownZero = string.Equals(
+            position.Value,
+            SortableUniqueId.MinValue.Value,
+            StringComparison.Ordinal);
+        if (expectedKnownZero != envelope.KnownZero)
+        {
+            throw new MvCheckpointMalformedException(
+                "Known-zero must be explicit and must use SortableUniqueId.MinValue.",
+                "knownZero");
+        }
+
+        return MvCheckpointTruth.KnownAt(position, provenance);
+    }
+
+    private static MvCheckpointUnknownReason ParseReason(string? reason)
+    {
+        if (reason is null)
+        {
+            throw new MvCheckpointMalformedException(
+                "An Unknown checkpoint must carry a stable reason.",
+                "reason");
+        }
+
+        return reason switch
+        {
+            "notObserved" or "NotObserved" => MvCheckpointUnknownReason.NotObserved,
+            "legacyNull" or "LegacyNull" => MvCheckpointUnknownReason.LegacyNull,
+            "readUnavailable" or "ReadUnavailable" => MvCheckpointUnknownReason.ReadUnavailable,
+            "malformed" or "Malformed" => MvCheckpointUnknownReason.Malformed,
+            _ => throw new MvCheckpointMalformedException(
+                $"Unknown checkpoint reason '{reason}'.",
+                "reason")
+        };
+    }
+
+    private static MvCheckpointProvenance ParseProvenance(WireProvenance wire)
+    {
+        var kind = wire.Kind switch
+        {
+            "appliedEvent" or "AppliedEvent" => MvCheckpointProvenanceKind.AppliedEvent,
+            "authoritativeEmptyHistory" or "AuthoritativeEmptyHistory" => MvCheckpointProvenanceKind.AuthoritativeEmptyHistory,
+            "legacyCompatibility" or "LegacyCompatibility" => MvCheckpointProvenanceKind.LegacyCompatibility,
+            _ => throw new MvCheckpointMalformedException($"Unknown checkpoint provenance kind '{wire.Kind}'.", "provenance.kind")
+        };
+
+        MvApplySource? applySource = wire.ApplySource switch
+        {
+            null => null,
+            "catchup" or "CatchUp" => MvApplySource.CatchUp,
+            "stream" or "Stream" => MvApplySource.Stream,
+            _ => throw new MvCheckpointMalformedException(
+                $"Unknown checkpoint apply source '{wire.ApplySource}'.",
+                "provenance.applySource")
+        };
+
+        if (wire.ObservedAtUtc is null || wire.ObservedAtUtc == default)
+        {
+            throw new MvCheckpointMalformedException(
+                "Checkpoint provenance must carry observedAtUtc.",
+                "provenance.observedAtUtc");
+        }
+
+        return new MvCheckpointProvenance(kind, wire.ObservedAtUtc.Value, applySource);
+    }
+
+    private static string ToWireReason(MvCheckpointUnknownReason reason) =>
+        reason switch
+        {
+            MvCheckpointUnknownReason.NotObserved => "notObserved",
+            MvCheckpointUnknownReason.LegacyNull => "legacyNull",
+            MvCheckpointUnknownReason.ReadUnavailable => "readUnavailable",
+            MvCheckpointUnknownReason.Malformed => "malformed",
+            _ => throw new ArgumentOutOfRangeException(nameof(reason), reason, "Unknown checkpoint reason.")
+        };
+
+    private static string ToWireKind(MvCheckpointProvenanceKind kind) =>
+        kind switch
+        {
+            MvCheckpointProvenanceKind.AppliedEvent => "appliedEvent",
+            MvCheckpointProvenanceKind.AuthoritativeEmptyHistory => "authoritativeEmptyHistory",
+            MvCheckpointProvenanceKind.LegacyCompatibility => "legacyCompatibility",
+            _ => throw new ArgumentOutOfRangeException(nameof(kind), kind, "Unknown checkpoint provenance kind.")
+        };
+
+    private sealed class WireEnvelope
+    {
+        [JsonPropertyName("state")] public string? State { get; set; }
+        [JsonPropertyName("position")] public string? Position { get; set; }
+        [JsonPropertyName("knownZero")] public bool KnownZero { get; set; }
+        [JsonPropertyName("reason")] public string? Reason { get; set; }
+        [JsonPropertyName("provenance")] public WireProvenance? Provenance { get; set; }
+    }
+
+    private sealed class WireProvenance
+    {
+        [JsonPropertyName("kind")] public string? Kind { get; set; }
+        [JsonPropertyName("observedAtUtc")] public DateTimeOffset? ObservedAtUtc { get; set; }
+        [JsonPropertyName("applySource")] public string? ApplySource { get; set; }
+    }
+}

--- a/dcb/src/Sekiban.Dcb.MaterializedView/MvContracts.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView/MvContracts.cs
@@ -1,5 +1,6 @@
 using System.Data;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using Sekiban.Dcb.Events;
 
 namespace Sekiban.Dcb.MaterializedView;
@@ -77,6 +78,43 @@ public sealed record MvRegistryEntry
     public MvStatus Status { get; init; }
     public string? CurrentPosition { get; init; }
     public string? TargetPosition { get; init; }
+    /// <summary>
+    ///     Authoritative checkpoint truth. This is separate from the nullable legacy position fields so an old
+    ///     null row cannot be silently interpreted as a zero position.
+    /// </summary>
+    public MvCheckpointTruth CurrentCheckpointTruth { get; init; } = MvCheckpointTruth.Unknown();
+    public MvCheckpointTruth TargetCheckpointTruth { get; init; } = MvCheckpointTruth.Unknown();
+
+    [JsonIgnore]
+    public MvCheckpointTruth CurrentCheckpoint
+    {
+        get => CurrentCheckpointTruth;
+        init => CurrentCheckpointTruth = value;
+    }
+
+    [JsonIgnore]
+    public MvCheckpointTruth TargetCheckpoint
+    {
+        get => TargetCheckpointTruth;
+        init => TargetCheckpointTruth = value;
+    }
+
+    [JsonIgnore]
+    public string? EffectiveCurrentPosition => CurrentPosition ?? CurrentCheckpointTruth.PositionValue;
+
+    [JsonIgnore]
+    public string? EffectiveTargetPosition => TargetPosition ?? TargetCheckpointTruth.PositionValue;
+
+    [JsonIgnore]
+    public MvCheckpointDiagnostic CheckpointDiagnostic =>
+        new(
+            ServiceId,
+            ViewName,
+            ViewVersion,
+            LogicalTable,
+            Status,
+            CurrentCheckpointTruth,
+            TargetCheckpointTruth);
     public string? LastSortableUniqueId { get; init; }
     public long AppliedEventVersion { get; init; }
     public string? LastAppliedSource { get; init; }
@@ -88,6 +126,16 @@ public sealed record MvRegistryEntry
     public DateTimeOffset LastUpdated { get; init; }
     public string? Metadata { get; init; }
 }
+
+/// <summary>Secret-free diagnostics DTO exposing authoritative MV checkpoint truth for operators and query tooling.</summary>
+public sealed record MvCheckpointDiagnostic(
+    string ServiceId,
+    string ViewName,
+    int ViewVersion,
+    string LogicalTable,
+    MvStatus Status,
+    MvCheckpointTruth Current,
+    MvCheckpointTruth Target);
 
 public sealed record MvActiveEntry(
     string ServiceId,
@@ -101,7 +149,14 @@ public sealed record MvPositionUpdate(
     int ViewVersion,
     string SortableUniqueId,
     MvApplySource Source,
-    long AppliedEventVersionDelta = 1);
+    long AppliedEventVersionDelta = 1)
+{
+    /// <summary>Optional explicit truth. Null retains source-compatible position-update behavior.</summary>
+    public MvCheckpointTruth? CheckpointTruth { get; init; }
+
+    /// <summary>Optional target truth update used by registry diagnostics.</summary>
+    public MvCheckpointTruth? TargetCheckpointTruth { get; init; }
+}
 
 public interface IMvTableBindings
 {

--- a/dcb/src/Sekiban.Dcb.MaterializedView/MvExecutorBase.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView/MvExecutorBase.cs
@@ -166,6 +166,8 @@ public abstract class MvExecutorBase<TConnection> : IMvExecutor
                         LogicalTable = table.LogicalName,
                         PhysicalTable = table.PhysicalName,
                         Status = MvStatus.CatchingUp,
+                        CurrentCheckpointTruth = MvCheckpointTruth.Unknown(MvCheckpointUnknownReason.NotObserved),
+                        TargetCheckpointTruth = MvCheckpointTruth.Unknown(MvCheckpointUnknownReason.NotObserved),
                         AppliedEventVersion = 0,
                         LastUpdated = DateTimeOffset.UtcNow
                     },
@@ -211,8 +213,10 @@ public abstract class MvExecutorBase<TConnection> : IMvExecutor
                 .ConfigureAwait(false);
         }
 
+        // Never use the nullable legacy position for a decisive read boundary. Old rows may contain a position but
+        // have no provenance, so they remain Unknown and are replayed fail-closed from the beginning.
         return entries
-            .Select(entry => entry.CurrentPosition)
+            .Select(entry => entry.CurrentCheckpointTruth.IsKnown ? entry.CurrentCheckpointTruth.PositionValue : null)
             .FirstOrDefault(position => !string.IsNullOrWhiteSpace(position));
     }
 
@@ -279,6 +283,19 @@ public abstract class MvExecutorBase<TConnection> : IMvExecutor
 
         if (batch.Count == 0)
         {
+            await _registryStore.UpdatePositionAsync(
+                    new MvPositionUpdate(
+                        serviceId,
+                        host.ViewName,
+                        host.ViewVersion,
+                        SortableUniqueId.MinValue.Value,
+                        MvApplySource.CatchUp,
+                        AppliedEventVersionDelta: 0)
+                    {
+                        CheckpointTruth = MvCheckpointTruth.KnownZero()
+                    },
+                    cancellationToken: cancellationToken)
+                .ConfigureAwait(false);
             return new MvCatchUpResult(0, false);
         }
 
@@ -339,7 +356,7 @@ public abstract class MvExecutorBase<TConnection> : IMvExecutor
         }
 
         var currentPosition = entries
-            .Select(entry => entry.CurrentPosition)
+            .Select(entry => entry.CurrentCheckpointTruth.IsKnown ? entry.CurrentCheckpointTruth.PositionValue : null)
             .FirstOrDefault(position => !string.IsNullOrWhiteSpace(position));
         var orderedEvents = events
             .GroupBy(serializableEvent => serializableEvent.SortableUniqueIdValue)

--- a/dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/MaterializedViewMultiProviderTests.cs
+++ b/dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/MaterializedViewMultiProviderTests.cs
@@ -65,6 +65,9 @@ public sealed class MySqlMvIntegrationTests(MySqlMvFixture fixture)
 {
     [SkippableFact]
     public Task CatchUp_MaterializesRowsAndRegistry() => MultiProviderAssertions.AssertProviderWorksAsync(fixture);
+
+    [SkippableFact]
+    public Task LegacyRegistry_IsMigratedWithoutRowLoss() => MultiProviderAssertions.AssertLegacyRegistryMigratesAsync(fixture);
 }
 
 [Collection(nameof(SqlServerMvCollection))]
@@ -72,6 +75,9 @@ public sealed class SqlServerMvIntegrationTests(SqlServerMvFixture fixture)
 {
     [SkippableFact]
     public Task CatchUp_MaterializesRowsAndRegistry() => MultiProviderAssertions.AssertProviderWorksAsync(fixture);
+
+    [SkippableFact]
+    public Task LegacyRegistry_IsMigratedWithoutRowLoss() => MultiProviderAssertions.AssertLegacyRegistryMigratesAsync(fixture);
 }
 
 [Collection(nameof(SqliteMvCollection))]
@@ -81,12 +87,40 @@ public sealed class SqliteMvIntegrationTests(SqliteMvFixture fixture)
     public Task CatchUp_MaterializesRowsAndRegistry() => MultiProviderAssertions.AssertProviderWorksAsync(fixture);
 
     [SkippableFact]
+    public Task LegacyRegistry_IsMigratedWithoutRowLoss() => MultiProviderAssertions.AssertLegacyRegistryMigratesAsync(fixture);
+
+    [SkippableFact]
     public Task SharedEventBackend_UsesOnlyTheRequestedService() =>
         MultiProviderAssertions.AssertServiceIsolationAsync(fixture);
 }
 
 internal static class MultiProviderAssertions
 {
+    public static async Task AssertLegacyRegistryMigratesAsync(MultiProviderFixtureBase fixture)
+    {
+        Skip.IfNot(fixture.IsAvailable, fixture.AvailabilityMessage ?? "Integration fixture is unavailable.");
+
+        await fixture.PrepareLegacyRegistryAsync().ConfigureAwait(false);
+        var registryStore = fixture.Services.GetRequiredService<IMvRegistryStore>();
+        await registryStore.EnsureInfrastructureAsync().ConfigureAwait(false);
+
+        var entries = await registryStore.GetEntriesAsync("legacy-service", "Legacy", 1).ConfigureAwait(false);
+        var entry = Assert.Single(entries);
+        Assert.Equal("legacy_orders", entry.PhysicalTable);
+        Assert.True(entry.CurrentCheckpointTruth.IsUnknown);
+        Assert.Equal(MvCheckpointUnknownReason.LegacyNull, entry.CurrentCheckpointTruth.UnknownReason);
+        Assert.Null(entry.CurrentPosition);
+        Assert.Equal(1, await CountLegacyRowsAsync(fixture).ConfigureAwait(false));
+    }
+
+    private static async Task<long> CountLegacyRowsAsync(MultiProviderFixtureBase fixture)
+    {
+        await using var connection = await fixture.OpenConnectionAsync().ConfigureAwait(false);
+        return await connection.ExecuteScalarAsync<long>(
+                "SELECT COUNT(*) FROM sekiban_mv_registry WHERE service_id = 'legacy-service';")
+            .ConfigureAwait(false);
+    }
+
     public static async Task AssertProviderWorksAsync(MultiProviderFixtureBase fixture)
     {
         Skip.IfNot(fixture.IsAvailable, fixture.AvailabilityMessage ?? "Integration fixture is unavailable.");
@@ -96,6 +130,29 @@ internal static class MultiProviderAssertions
         var projector = fixture.Services.GetRequiredService<CrossProviderWeatherForecastMvV1>();
         await fixture.Executor.InitializeAsync(new NativeMvApplyHost(projector, fixture.DomainTypes.EventTypes, fixture.Services.GetRequiredService<IMvStorageInfoProvider>().GetStorageInfo().DatabaseType))
             .ConfigureAwait(false);
+        var registryStore = fixture.Services.GetRequiredService<IMvRegistryStore>();
+        var initialRegistryEntries = await registryStore.GetEntriesAsync(
+                MultiProviderFixtureBase.ServiceId,
+                projector.ViewName,
+                projector.ViewVersion)
+            .ConfigureAwait(false);
+        Assert.NotEmpty(initialRegistryEntries);
+        Assert.All(initialRegistryEntries, entry => Assert.True(entry.CurrentCheckpointTruth.IsUnknown));
+
+        var emptyCatchUp = await fixture.Executor.CatchUpOnceAsync(
+                new NativeMvApplyHost(projector, fixture.DomainTypes.EventTypes, fixture.Services.GetRequiredService<IMvStorageInfoProvider>().GetStorageInfo().DatabaseType))
+            .ConfigureAwait(false);
+        var emptyHistoryEntries = await registryStore.GetEntriesAsync(
+                MultiProviderFixtureBase.ServiceId,
+                projector.ViewName,
+                projector.ViewVersion)
+            .ConfigureAwait(false);
+        Assert.Equal(0, emptyCatchUp.AppliedEvents);
+        Assert.All(emptyHistoryEntries, entry =>
+        {
+            Assert.True(entry.CurrentCheckpointTruth.IsKnownZero);
+            Assert.False(entry.CurrentCheckpointTruth.IsUnknown);
+        });
 
         var executor = new GeneralSekibanExecutor(fixture.EventStore, fixture.ActorAccessor, fixture.DomainTypes);
         var forecastId = Guid.CreateVersion7();
@@ -130,6 +187,12 @@ internal static class MultiProviderAssertions
         var secondCatchUp = await fixture.Executor.CatchUpOnceAsync(
             new NativeMvApplyHost(projector, fixture.DomainTypes.EventTypes, fixture.Services.GetRequiredService<IMvStorageInfoProvider>().GetStorageInfo().DatabaseType))
             .ConfigureAwait(false);
+        var finalRegistryEntries = await registryStore.GetEntriesAsync(
+                MultiProviderFixtureBase.ServiceId,
+                projector.ViewName,
+                projector.ViewVersion)
+            .ConfigureAwait(false);
+        Assert.All(finalRegistryEntries, entry => Assert.True(entry.CurrentCheckpointTruth.IsKnown));
 
         await using var connection = await fixture.OpenConnectionAsync().ConfigureAwait(false);
         var row = await connection.QuerySingleAsync<ForecastDbRow>(

--- a/dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/MultiProviderFixtures.cs
+++ b/dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/MultiProviderFixtures.cs
@@ -257,6 +257,7 @@ public abstract class MultiProviderFixtureBase : IAsyncLifetime
     protected abstract void RegisterProvider(IServiceCollection services, string connectionString);
     protected abstract DbConnection CreateConnection(string connectionString);
     protected abstract string ResetSql { get; }
+    protected abstract string LegacyRegistrySql { get; }
 
     public async Task InitializeAsync()
     {
@@ -314,6 +315,22 @@ public abstract class MultiProviderFixtureBase : IAsyncLifetime
         await connection.ExecuteAsync(ResetSql).ConfigureAwait(false);
     }
 
+    public async Task PrepareLegacyRegistryAsync()
+    {
+        EnsureAvailable();
+        await ResetAsync().ConfigureAwait(false);
+        await using var connection = await OpenConnectionAsync().ConfigureAwait(false);
+        await connection.ExecuteAsync(LegacyRegistrySql).ConfigureAwait(false);
+        await connection.ExecuteAsync(
+                """
+                INSERT INTO sekiban_mv_registry (
+                    service_id, view_name, view_version, logical_table, physical_table, status, last_updated)
+                VALUES ('legacy-service', 'Legacy', 1, 'orders', 'legacy_orders', 'ready', @LastUpdated);
+                """,
+                new { LastUpdated = DateTimeOffset.UtcNow })
+            .ConfigureAwait(false);
+    }
+
     public void EnsureAvailable()
     {
         if (_skipReason is not null)
@@ -364,6 +381,30 @@ public sealed class MySqlMvFixture : MultiProviderFixtureBase
         DROP TABLE IF EXISTS sekiban_mv_registry;
         """;
 
+    protected override string LegacyRegistrySql => """
+        CREATE TABLE sekiban_mv_registry (
+            service_id VARCHAR(255) NOT NULL,
+            view_name VARCHAR(255) NOT NULL,
+            view_version INT NOT NULL,
+            logical_table VARCHAR(255) NOT NULL,
+            physical_table VARCHAR(255) NOT NULL,
+            status VARCHAR(32) NOT NULL,
+            current_position VARCHAR(64) NULL,
+            target_position VARCHAR(64) NULL,
+            last_sortable_unique_id VARCHAR(64) NULL,
+            applied_event_version BIGINT NOT NULL DEFAULT 0,
+            last_applied_source VARCHAR(32) NULL,
+            last_applied_at DATETIME(6) NULL,
+            last_stream_received_sortable_unique_id VARCHAR(64) NULL,
+            last_stream_received_at DATETIME(6) NULL,
+            last_stream_applied_sortable_unique_id VARCHAR(64) NULL,
+            last_catch_up_sortable_unique_id VARCHAR(64) NULL,
+            last_updated DATETIME(6) NOT NULL,
+            metadata LONGTEXT NULL,
+            PRIMARY KEY (service_id, view_name, view_version, logical_table)
+        );
+        """;
+
     public override async Task DisposeAsync()
     {
         await base.DisposeAsync().ConfigureAwait(false);
@@ -409,6 +450,30 @@ public sealed class SqlServerMvFixture : MultiProviderFixtureBase
         IF OBJECT_ID(N'sekiban_mv_registry', N'U') IS NOT NULL DROP TABLE sekiban_mv_registry;
         """;
 
+    protected override string LegacyRegistrySql => """
+        CREATE TABLE sekiban_mv_registry (
+            service_id NVARCHAR(255) NOT NULL,
+            view_name NVARCHAR(255) NOT NULL,
+            view_version INT NOT NULL,
+            logical_table NVARCHAR(255) NOT NULL,
+            physical_table NVARCHAR(255) NOT NULL,
+            status NVARCHAR(32) NOT NULL,
+            current_position NVARCHAR(64) NULL,
+            target_position NVARCHAR(64) NULL,
+            last_sortable_unique_id NVARCHAR(64) NULL,
+            applied_event_version BIGINT NOT NULL CONSTRAINT DF_legacy_registry_applied_event_version DEFAULT 0,
+            last_applied_source NVARCHAR(32) NULL,
+            last_applied_at DATETIMEOFFSET NULL,
+            last_stream_received_sortable_unique_id NVARCHAR(64) NULL,
+            last_stream_received_at DATETIMEOFFSET NULL,
+            last_stream_applied_sortable_unique_id NVARCHAR(64) NULL,
+            last_catch_up_sortable_unique_id NVARCHAR(64) NULL,
+            last_updated DATETIMEOFFSET NOT NULL,
+            metadata NVARCHAR(MAX) NULL,
+            CONSTRAINT PK_legacy_sekiban_mv_registry PRIMARY KEY (service_id, view_name, view_version, logical_table)
+        );
+        """;
+
     public override async Task DisposeAsync()
     {
         await base.DisposeAsync().ConfigureAwait(false);
@@ -449,6 +514,30 @@ public sealed class SqliteMvFixture : MultiProviderFixtureBase
         DROP TABLE IF EXISTS sekiban_mv_weatherforecastportable_v1_forecasts;
         DROP TABLE IF EXISTS sekiban_mv_active;
         DROP TABLE IF EXISTS sekiban_mv_registry;
+        """;
+
+    protected override string LegacyRegistrySql => """
+        CREATE TABLE sekiban_mv_registry (
+            service_id TEXT NOT NULL,
+            view_name TEXT NOT NULL,
+            view_version INTEGER NOT NULL,
+            logical_table TEXT NOT NULL,
+            physical_table TEXT NOT NULL,
+            status TEXT NOT NULL,
+            current_position TEXT NULL,
+            target_position TEXT NULL,
+            last_sortable_unique_id TEXT NULL,
+            applied_event_version INTEGER NOT NULL DEFAULT 0,
+            last_applied_source TEXT NULL,
+            last_applied_at TEXT NULL,
+            last_stream_received_sortable_unique_id TEXT NULL,
+            last_stream_received_at TEXT NULL,
+            last_stream_applied_sortable_unique_id TEXT NULL,
+            last_catch_up_sortable_unique_id TEXT NULL,
+            last_updated TEXT NOT NULL,
+            metadata TEXT NULL,
+            PRIMARY KEY (service_id, view_name, view_version, logical_table)
+        );
         """;
 
     public override async Task DisposeAsync()

--- a/dcb/tests/Sekiban.Dcb.MaterializedView.Postgres.Tests/MaterializedViewPostgresFixture.cs
+++ b/dcb/tests/Sekiban.Dcb.MaterializedView.Postgres.Tests/MaterializedViewPostgresFixture.cs
@@ -122,6 +122,40 @@ public sealed class MaterializedViewPostgresFixture : IAsyncLifetime
             """);
     }
 
+    public async Task PrepareLegacyRegistryAsync()
+    {
+        EnsureAvailable();
+        await ResetAsync();
+        await using var connection = await OpenConnectionAsync();
+        await connection.ExecuteAsync(
+            """
+            CREATE TABLE sekiban_mv_registry (
+                service_id TEXT NOT NULL,
+                view_name TEXT NOT NULL,
+                view_version INT NOT NULL,
+                logical_table TEXT NOT NULL,
+                physical_table TEXT NOT NULL,
+                status TEXT NOT NULL,
+                current_position TEXT NULL,
+                target_position TEXT NULL,
+                last_sortable_unique_id TEXT NULL,
+                applied_event_version BIGINT NOT NULL DEFAULT 0,
+                last_applied_source TEXT NULL,
+                last_applied_at TIMESTAMPTZ NULL,
+                last_stream_received_sortable_unique_id TEXT NULL,
+                last_stream_received_at TIMESTAMPTZ NULL,
+                last_stream_applied_sortable_unique_id TEXT NULL,
+                last_catch_up_sortable_unique_id TEXT NULL,
+                last_updated TIMESTAMPTZ NOT NULL,
+                metadata JSONB NULL,
+                PRIMARY KEY (service_id, view_name, view_version, logical_table)
+            );
+            INSERT INTO sekiban_mv_registry (
+                service_id, view_name, view_version, logical_table, physical_table, status, last_updated)
+            VALUES ('legacy-service', 'Legacy', 1, 'orders', 'legacy_orders', 'ready', NOW());
+            """);
+    }
+
     public void EnsureAvailable()
     {
         if (_skipReason is not null)

--- a/dcb/tests/Sekiban.Dcb.MaterializedView.Postgres.Tests/MaterializedViewPostgresTests.cs
+++ b/dcb/tests/Sekiban.Dcb.MaterializedView.Postgres.Tests/MaterializedViewPostgresTests.cs
@@ -2,11 +2,13 @@ using Dcb.Domain.WithoutResult.Order;
 using Dcb.Domain.WithoutResult.MaterializedViews;
 using Dcb.Domain.WithoutResult.Weather;
 using Dapper;
+using Microsoft.Extensions.DependencyInjection;
 using Npgsql;
 using Sekiban.Dcb.Actors;
 using Sekiban.Dcb.Events;
 using Sekiban.Dcb.MaterializedView;
 using Sekiban.Dcb.MaterializedView.Postgres;
+using Sekiban.Dcb.ServiceId;
 using Xunit;
 
 namespace Sekiban.Dcb.MaterializedView.Postgres.Tests;
@@ -25,6 +27,11 @@ public sealed class MaterializedViewPostgresTests(MaterializedViewPostgresFixtur
 
         await fixture.Executor.InitializeAsync(ApplyHost(fixture.Projector));
 
+        var initialEntries = await fixture.Services.GetRequiredService<IMvRegistryStore>()
+            .GetEntriesAsync(DefaultServiceIdProvider.DefaultServiceId, fixture.Projector.ViewName, fixture.Projector.ViewVersion);
+        Assert.NotEmpty(initialEntries);
+        Assert.All(initialEntries, entry => Assert.True(entry.CurrentCheckpointTruth.IsUnknown));
+
         await using var connection = await fixture.OpenConnectionAsync();
         var registryCount = await connection.ExecuteScalarAsync<int>("SELECT COUNT(*) FROM sekiban_mv_registry;");
         var activeVersion = await connection.ExecuteScalarAsync<int>("SELECT active_version FROM sekiban_mv_active WHERE view_name = 'OrderSummary';");
@@ -40,11 +47,43 @@ public sealed class MaterializedViewPostgresTests(MaterializedViewPostgresFixtur
     }
 
     [SkippableFact]
+    public async Task LegacyRegistry_IsMigratedWithoutRowLoss()
+    {
+        Skip.IfNot(fixture.IsAvailable, fixture.AvailabilityMessage ?? "Postgres fixture is unavailable.");
+        await fixture.PrepareLegacyRegistryAsync();
+
+        var registryStore = fixture.Services.GetRequiredService<IMvRegistryStore>();
+        await registryStore.EnsureInfrastructureAsync();
+        var entries = await registryStore.GetEntriesAsync("legacy-service", "Legacy", 1);
+        var entry = Assert.Single(entries);
+
+        Assert.Equal("legacy_orders", entry.PhysicalTable);
+        Assert.True(entry.CurrentCheckpointTruth.IsUnknown);
+        Assert.Equal(MvCheckpointUnknownReason.LegacyNull, entry.CurrentCheckpointTruth.UnknownReason);
+        Assert.Null(entry.CurrentPosition);
+
+        await using var connection = await fixture.OpenConnectionAsync();
+        var rowCount = await connection.ExecuteScalarAsync<int>(
+            "SELECT COUNT(*) FROM sekiban_mv_registry WHERE service_id = 'legacy-service';");
+        Assert.Equal(1, rowCount);
+    }
+
+    [SkippableFact]
     public async Task CatchUp_MaterializesRowsAndIsIdempotent()
     {
         Skip.IfNot(fixture.IsAvailable, fixture.AvailabilityMessage ?? "Postgres fixture is unavailable.");
         await fixture.ResetAsync();
         await fixture.Executor.InitializeAsync(ApplyHost(fixture.Projector));
+
+        var emptyCatchUp = await fixture.Executor.CatchUpOnceAsync(ApplyHost(fixture.Projector));
+        var emptyEntries = await fixture.Services.GetRequiredService<IMvRegistryStore>()
+            .GetEntriesAsync(DefaultServiceIdProvider.DefaultServiceId, fixture.Projector.ViewName, fixture.Projector.ViewVersion);
+        Assert.Equal(0, emptyCatchUp.AppliedEvents);
+        Assert.All(emptyEntries, entry =>
+        {
+            Assert.True(entry.CurrentCheckpointTruth.IsKnownZero);
+            Assert.False(entry.CurrentCheckpointTruth.IsUnknown);
+        });
 
         var executor = new GeneralSekibanExecutor(fixture.EventStore, fixture.ActorAccessor, fixture.DomainTypes);
         var orderId = Guid.CreateVersion7();
@@ -64,6 +103,10 @@ public sealed class MaterializedViewPostgresTests(MaterializedViewPostgresFixtur
 
         var firstCatchUp = await fixture.Executor.CatchUpOnceAsync(ApplyHost(fixture.Projector));
         var secondCatchUp = await fixture.Executor.CatchUpOnceAsync(ApplyHost(fixture.Projector));
+
+        var finalEntries = await fixture.Services.GetRequiredService<IMvRegistryStore>()
+            .GetEntriesAsync(DefaultServiceIdProvider.DefaultServiceId, fixture.Projector.ViewName, fixture.Projector.ViewVersion);
+        Assert.All(finalEntries, entry => Assert.True(entry.CurrentCheckpointTruth.IsKnown));
 
         await using var connection = await fixture.OpenConnectionAsync();
         var orderRow = await connection.QuerySingleAsync<OrderQueryRow>(
@@ -165,6 +208,7 @@ public sealed class MaterializedViewPostgresTests(MaterializedViewPostgresFixtur
                 """
                 UPDATE sekiban_mv_registry
                 SET current_position = NULL,
+                    current_checkpoint_truth = NULL,
                     last_sortable_unique_id = NULL
                 WHERE view_name = 'OrderSummary';
                 """);

--- a/dcb/tests/Sekiban.Dcb.MaterializedView.Tests/MvCheckpointTruthTests.cs
+++ b/dcb/tests/Sekiban.Dcb.MaterializedView.Tests/MvCheckpointTruthTests.cs
@@ -1,0 +1,103 @@
+using System.Text.Json;
+using Sekiban.Dcb.Common;
+using Sekiban.Dcb.MaterializedView;
+using Xunit;
+
+namespace Sekiban.Dcb.MaterializedView.Tests;
+
+public sealed class MvCheckpointTruthTests
+{
+    private static readonly SortableUniqueId NonZeroPosition =
+        new(SortableUniqueId.Generate(new DateTime(2026, 8, 10, 12, 0, 0, DateTimeKind.Utc), Guid.Empty));
+
+    [Fact]
+    public void Unknown_KnownZero_AndKnownNonzero_RoundTripWithDistinctWireTruth()
+    {
+        var unknown = MvCheckpointTruth.Unknown(MvCheckpointUnknownReason.NotObserved);
+        var knownZero = MvCheckpointTruth.KnownZero(
+            new MvCheckpointProvenance(
+                MvCheckpointProvenanceKind.AuthoritativeEmptyHistory,
+                DateTimeOffset.Parse("2026-08-10T12:00:00Z")));
+        var known = MvCheckpointTruth.Known(
+            NonZeroPosition,
+            new MvCheckpointProvenance(
+                MvCheckpointProvenanceKind.AppliedEvent,
+                DateTimeOffset.Parse("2026-08-10T12:01:00Z"),
+                MvApplySource.CatchUp));
+
+        var unknownWire = MvCheckpointTruthCodec.Encode(unknown);
+        var knownZeroWire = MvCheckpointTruthCodec.Encode(knownZero);
+        var knownWire = MvCheckpointTruthCodec.Encode(known);
+
+        Assert.NotEqual(unknownWire, knownZeroWire);
+        Assert.NotEqual(knownZeroWire, knownWire);
+        Assert.True(MvCheckpointTruthCodec.Decode(unknownWire).IsUnknown);
+        Assert.Equal(MvCheckpointUnknownReason.NotObserved, MvCheckpointTruthCodec.Decode(unknownWire).UnknownReason);
+        Assert.True(MvCheckpointTruthCodec.Decode(knownZeroWire).IsKnownZero);
+        Assert.Equal(SortableUniqueId.MinValue.Value, MvCheckpointTruthCodec.Decode(knownZeroWire).PositionValue);
+        Assert.Equal(NonZeroPosition.Value, MvCheckpointTruthCodec.Decode(knownWire).PositionValue);
+        Assert.Equal(MvCheckpointProvenanceKind.AppliedEvent, MvCheckpointTruthCodec.Decode(knownWire).Provenance!.Kind);
+    }
+
+    [Fact]
+    public void Unknown_NeverSatisfiesKnownZeroOrKnownPosition()
+    {
+        var unknown = MvCheckpointTruth.Unknown();
+        var knownZero = MvCheckpointTruth.KnownZero();
+        var known = MvCheckpointTruth.Known(NonZeroPosition, MvCheckpointProvenance.AppliedEvent(MvApplySource.Stream));
+
+        Assert.False(unknown.Satisfies(knownZero));
+        Assert.False(unknown.Satisfies(known));
+        Assert.False(unknown.Satisfies(SortableUniqueId.MinValue.Value));
+        Assert.True(known.Satisfies(knownZero));
+        Assert.True(known.Satisfies(NonZeroPosition.Value));
+        Assert.False(knownZero.Satisfies(NonZeroPosition.Value));
+    }
+
+    [Fact]
+    public void LegacyNull_DecodesAsUnknown_WithoutFabricatingZero()
+    {
+        var decoded = MvCheckpointTruthCodec.Decode(null);
+
+        Assert.True(decoded.IsUnknown);
+        Assert.Equal(MvCheckpointUnknownReason.LegacyNull, decoded.UnknownReason);
+        Assert.Null(decoded.PositionValue);
+        Assert.False(decoded.IsKnownZero);
+    }
+
+    [Fact]
+    public void PublicRegistryEntry_RoundTripsCheckpointTruthThroughJson()
+    {
+        var entry = new MvRegistryEntry
+        {
+            ServiceId = "service",
+            ViewName = "View",
+            ViewVersion = 1,
+            LogicalTable = "rows",
+            PhysicalTable = "view_rows",
+            CurrentCheckpointTruth = MvCheckpointTruth.Known(
+                NonZeroPosition,
+                MvCheckpointProvenance.AppliedEvent(MvApplySource.Stream)),
+            TargetCheckpointTruth = MvCheckpointTruth.KnownZero(),
+            LastUpdated = DateTimeOffset.UtcNow
+        };
+
+        var roundTripped = JsonSerializer.Deserialize<MvRegistryEntry>(JsonSerializer.Serialize(entry));
+
+        Assert.NotNull(roundTripped);
+        Assert.Equal(NonZeroPosition.Value, roundTripped!.CurrentCheckpointTruth.PositionValue);
+        Assert.True(roundTripped.TargetCheckpointTruth.IsKnownZero);
+    }
+
+    [Theory]
+    [InlineData("{\"state\":\"known\",\"position\":\"bad\",\"knownZero\":false,\"provenance\":{\"kind\":\"appliedEvent\",\"observedAtUtc\":\"2026-08-10T12:00:00Z\"}}")]
+    [InlineData("{\"state\":\"known\",\"position\":\"000000000000000000000000000000\",\"knownZero\":false,\"provenance\":{\"kind\":\"appliedEvent\",\"observedAtUtc\":\"2026-08-10T12:00:00Z\"}}")]
+    [InlineData("{\"state\":\"known\",\"position\":\"000000000000000000000000000000\",\"knownZero\":true}")]
+    [InlineData("{\"state\":\"maybe\"}")]
+    public void MalformedTruth_FailsWithTypedException(string serialized)
+    {
+        var exception = Assert.Throws<MvCheckpointMalformedException>(() => MvCheckpointTruthCodec.Decode(serialized));
+
+        Assert.False(string.IsNullOrWhiteSpace(exception.FieldName));
+    }
+}

--- a/dcb/tests/Sekiban.Dcb.MaterializedView.Tests/SqliteMvRegistryTruthTests.cs
+++ b/dcb/tests/Sekiban.Dcb.MaterializedView.Tests/SqliteMvRegistryTruthTests.cs
@@ -1,0 +1,158 @@
+using System.Data;
+using Dapper;
+using Microsoft.Data.Sqlite;
+using Sekiban.Dcb.Common;
+using Sekiban.Dcb.MaterializedView;
+using Sekiban.Dcb.MaterializedView.Sqlite;
+using Xunit;
+
+namespace Sekiban.Dcb.MaterializedView.Tests;
+
+public sealed class SqliteMvRegistryTruthTests
+{
+    [Fact]
+    public async Task NewRows_PersistUnknownKnownZeroAndKnownPositionWithoutLosingLegacyFields()
+    {
+        var databasePath = Path.Combine(Path.GetTempPath(), $"sekiban-mv-truth-{Guid.NewGuid():N}.db");
+        try
+        {
+            var store = new SqliteMvRegistryStore($"Data Source={databasePath}");
+            await store.EnsureInfrastructureAsync();
+
+            await store.RegisterAsync(CreateEntry("orders", "orders_table"));
+            var initial = Assert.Single(await store.GetEntriesAsync("truth-service", "Truth", 1));
+            Assert.True(initial.CurrentCheckpointTruth.IsUnknown);
+            Assert.Equal(MvCheckpointUnknownReason.NotObserved, initial.CurrentCheckpointTruth.UnknownReason);
+
+            await store.UpdatePositionAsync(
+                new MvPositionUpdate(
+                    "truth-service",
+                    "Truth",
+                    1,
+                    SortableUniqueId.MinValue.Value,
+                    MvApplySource.CatchUp,
+                    AppliedEventVersionDelta: 0)
+                {
+                    CheckpointTruth = MvCheckpointTruth.KnownZero()
+                });
+            var knownZero = Assert.Single(await store.GetEntriesAsync("truth-service", "Truth", 1));
+            Assert.True(knownZero.CurrentCheckpointTruth.IsKnownZero);
+            Assert.Equal(SortableUniqueId.MinValue.Value, knownZero.CurrentPosition);
+
+            var position = SortableUniqueId.Generate(DateTime.UtcNow.AddMinutes(-1), Guid.NewGuid());
+            await store.UpdatePositionAsync(
+                new MvPositionUpdate("truth-service", "Truth", 1, position, MvApplySource.Stream));
+            var known = Assert.Single(await store.GetEntriesAsync("truth-service", "Truth", 1));
+            Assert.True(known.CurrentCheckpointTruth.IsKnown);
+            Assert.False(known.CurrentCheckpointTruth.IsKnownZero);
+            Assert.Equal(position, known.CurrentCheckpointTruth.PositionValue);
+            Assert.Equal(position, known.CurrentPosition);
+        }
+        finally
+        {
+            if (File.Exists(databasePath))
+            {
+                File.Delete(databasePath);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task ExistingLegacySchema_IsMigratedAndNullCheckpointRemainsUnknown()
+    {
+        var databasePath = Path.Combine(Path.GetTempPath(), $"sekiban-mv-legacy-{Guid.NewGuid():N}.db");
+        try
+        {
+            await using (var connection = new SqliteConnection($"Data Source={databasePath}"))
+            {
+                await connection.OpenAsync();
+                await connection.ExecuteAsync(
+                    """
+                    CREATE TABLE sekiban_mv_registry (
+                        service_id TEXT NOT NULL,
+                        view_name TEXT NOT NULL,
+                        view_version INTEGER NOT NULL,
+                        logical_table TEXT NOT NULL,
+                        physical_table TEXT NOT NULL,
+                        status TEXT NOT NULL,
+                        current_position TEXT NULL,
+                        target_position TEXT NULL,
+                        last_sortable_unique_id TEXT NULL,
+                        applied_event_version INTEGER NOT NULL DEFAULT 0,
+                        last_applied_source TEXT NULL,
+                        last_applied_at TEXT NULL,
+                        last_stream_received_sortable_unique_id TEXT NULL,
+                        last_stream_received_at TEXT NULL,
+                        last_stream_applied_sortable_unique_id TEXT NULL,
+                        last_catch_up_sortable_unique_id TEXT NULL,
+                        last_updated TEXT NOT NULL,
+                        metadata TEXT NULL,
+                        PRIMARY KEY (service_id, view_name, view_version, logical_table)
+                    );
+                    INSERT INTO sekiban_mv_registry (
+                        service_id, view_name, view_version, logical_table, physical_table, status, last_updated)
+                    VALUES ('truth-service', 'Truth', 1, 'orders', 'orders_table', 'ready', @LastUpdated);
+                    """,
+                    new { LastUpdated = DateTimeOffset.UtcNow.ToString("O") });
+            }
+
+            var store = new SqliteMvRegistryStore($"Data Source={databasePath}");
+            await store.EnsureInfrastructureAsync();
+            await using var migratedConnection = new SqliteConnection($"Data Source={databasePath}");
+            await migratedConnection.OpenAsync();
+            var columns = (await migratedConnection.QueryAsync<string>(
+                    "SELECT name FROM pragma_table_info('sekiban_mv_registry');"))
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+            Assert.Contains("current_checkpoint_truth", columns);
+            Assert.Contains("target_checkpoint_truth", columns);
+
+            var entry = Assert.Single(await store.GetEntriesAsync("truth-service", "Truth", 1));
+            Assert.True(entry.CurrentCheckpointTruth.IsUnknown);
+            Assert.Equal(MvCheckpointUnknownReason.LegacyNull, entry.CurrentCheckpointTruth.UnknownReason);
+            Assert.Null(entry.CurrentPosition);
+
+            var legacyPosition = SortableUniqueId.Generate(DateTime.UtcNow.AddMinutes(-2), Guid.NewGuid());
+            await migratedConnection.ExecuteAsync(
+                "UPDATE sekiban_mv_registry SET current_position = @LegacyPosition WHERE service_id = 'truth-service';",
+                new { LegacyPosition = legacyPosition });
+            // Initialization re-registers an existing legacy row. It must not
+            // turn the legacy position into authoritative truth or prevent a
+            // subsequent empty-history proof from becoming Known-zero.
+            await store.RegisterAsync(CreateEntry("truth-service", "orders_table"));
+            await store.UpdatePositionAsync(
+                new MvPositionUpdate(
+                    "truth-service",
+                    "Truth",
+                    1,
+                    SortableUniqueId.MinValue.Value,
+                    MvApplySource.CatchUp,
+                    AppliedEventVersionDelta: 0)
+                {
+                    CheckpointTruth = MvCheckpointTruth.KnownZero()
+                });
+
+            var rebuilt = Assert.Single(await store.GetEntriesAsync("truth-service", "Truth", 1));
+            Assert.True(rebuilt.CurrentCheckpointTruth.IsKnownZero);
+            Assert.Equal(SortableUniqueId.MinValue.Value, rebuilt.CurrentPosition);
+        }
+        finally
+        {
+            if (File.Exists(databasePath))
+            {
+                File.Delete(databasePath);
+            }
+        }
+    }
+
+    private static MvRegistryEntry CreateEntry(string serviceId, string physicalTable) =>
+        new()
+        {
+            ServiceId = serviceId == "orders" ? "truth-service" : serviceId,
+            ViewName = "Truth",
+            ViewVersion = 1,
+            LogicalTable = "orders",
+            PhysicalTable = physicalTable,
+            Status = MvStatus.CatchingUp,
+            LastUpdated = DateTimeOffset.UtcNow
+        };
+}

--- a/dcb/tests/Sekiban.Dcb.Orleans.Tests/MaterializedViewGrainTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Orleans.Tests/MaterializedViewGrainTests.cs
@@ -95,6 +95,28 @@ public class MaterializedViewGrainTests : IAsyncLifetime
         Assert.Equal("main", table.LogicalTable);
     }
 
+    [Fact]
+    public async Task UnknownCheckpoint_DoesNotPromoteGrainToReady()
+    {
+        SharedExecutor.InitialEvents.Clear();
+        SharedRegistry.ForceUnknownCheckpointReads = true;
+
+        var grainKey = MvGrainKey.Build("orders", TestMaterializedViewProjector.ViewNameConst, 1);
+        var grain = _cluster.Client.GetGrain<IMaterializedViewGrain>(grainKey);
+        await grain.EnsureStartedAsync();
+        await grain.RefreshAsync();
+
+        var entries = await SharedRegistry.GetEntriesAsync(
+            DefaultServiceIdProvider.DefaultServiceId,
+            TestMaterializedViewProjector.ViewNameConst,
+            1);
+        var entry = Assert.Single(entries);
+        Assert.True(
+            entry.CurrentCheckpointTruth.IsUnknown,
+            $"state={entry.CurrentCheckpointTruth.State}, position={entry.CurrentCheckpointTruth.PositionValue}, status={entry.Status}, initial={SharedExecutor.InitialEvents.Count}");
+        Assert.NotEqual(MvStatus.Ready, entry.Status);
+    }
+
     private static SerializableEvent CreateSerializableEvent(int ordinal, DateTime timestampUtc) =>
         new(
             Payload: [],
@@ -134,6 +156,7 @@ public class MaterializedViewGrainTests : IAsyncLifetime
                         options.AllowDefaultServiceId = true;
                         options.PollInterval = TimeSpan.FromMilliseconds(20);
                         options.StreamReorderWindow = TimeSpan.FromMilliseconds(10);
+                        options.CatchUpStallThreshold = TimeSpan.FromMilliseconds(150);
                     });
                     services.AddMaterializedView<TestMaterializedViewProjector>();
                     services.AddSekibanDcbMaterializedViewOrleans();
@@ -225,6 +248,19 @@ public class MaterializedViewGrainTests : IAsyncLifetime
 
             if (batch.Count == 0)
             {
+                await _registry.UpdatePositionAsync(
+                    new MvPositionUpdate(
+                        serviceId,
+                        host.ViewName,
+                        host.ViewVersion,
+                        SortableUniqueId.MinValue.Value,
+                        MvApplySource.CatchUp,
+                        AppliedEventVersionDelta: 0)
+                    {
+                        CheckpointTruth = MvCheckpointTruth.KnownZero()
+                    },
+                    cancellationToken: cancellationToken);
+
                 return new MvCatchUpResult(0, false);
             }
 
@@ -291,10 +327,13 @@ public class MaterializedViewGrainTests : IAsyncLifetime
         private readonly Dictionary<(string ServiceId, string ViewName, int ViewVersion, string LogicalTable), MvRegistryEntry> _entries = [];
         private readonly Dictionary<(string ServiceId, string ViewName), MvActiveEntry> _active = [];
 
+        public bool ForceUnknownCheckpointReads { get; set; }
+
         public void Reset()
         {
             _entries.Clear();
             _active.Clear();
+            ForceUnknownCheckpointReads = false;
         }
 
         public Task EnsureInfrastructureAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
@@ -316,15 +355,17 @@ public class MaterializedViewGrainTests : IAsyncLifetime
                          key.ViewVersion == update.ViewVersion).ToList())
             {
                 var entry = _entries[key];
+                var checkpointTruth = MvCheckpointTruth.FromPositionUpdate(update);
                 _entries[key] = entry with
                 {
                     CurrentPosition = update.SortableUniqueId,
+                    CurrentCheckpointTruth = checkpointTruth,
                     LastSortableUniqueId = update.SortableUniqueId,
                     AppliedEventVersion = entry.AppliedEventVersion + update.AppliedEventVersionDelta,
                     LastAppliedSource = update.Source == MvApplySource.Stream ? "stream" : "catchup",
                     LastAppliedAt = DateTimeOffset.UtcNow,
                     LastStreamAppliedSortableUniqueId = update.Source == MvApplySource.Stream ? update.SortableUniqueId : entry.LastStreamAppliedSortableUniqueId,
-                    LastCatchUpSortableUniqueId = update.Source == MvApplySource.CatchUp ? update.SortableUniqueId : entry.LastCatchUpSortableUniqueId,
+                    LastCatchUpSortableUniqueId = update.Source == MvApplySource.CatchUp && update.AppliedEventVersionDelta > 0 ? update.SortableUniqueId : entry.LastCatchUpSortableUniqueId,
                     LastUpdated = DateTimeOffset.UtcNow
                 };
             }
@@ -387,7 +428,14 @@ public class MaterializedViewGrainTests : IAsyncLifetime
         {
             IReadOnlyList<MvRegistryEntry> entries = _entries
                 .Where(pair => pair.Key.ServiceId == serviceId && pair.Key.ViewName == viewName && pair.Key.ViewVersion == viewVersion)
-                .Select(pair => pair.Value)
+                .Select(pair => ForceUnknownCheckpointReads
+                    ? pair.Value with
+                    {
+                        CurrentPosition = null,
+                        CurrentCheckpointTruth = MvCheckpointTruth.Unknown(MvCheckpointUnknownReason.ReadUnavailable),
+                        Status = MvStatus.CatchingUp
+                    }
+                    : pair.Value)
                 .OrderBy(entry => entry.LogicalTable, StringComparer.Ordinal)
                 .ToList();
             return Task.FromResult(entries);

--- a/docs/dcb_llm/20_materialized_view.md
+++ b/docs/dcb_llm/20_materialized_view.md
@@ -232,6 +232,16 @@ The runtime stores operational metadata per logical table:
 - applied event version count
 - last stream-applied and catch-up-applied sortable ids
 
+`MvRegistryEntry.CurrentCheckpointTruth` and `TargetCheckpointTruth` are the authoritative checkpoint values. Each value is
+explicitly `Known` or `Unknown` and carries its provenance (for example, an applied event or an authoritative empty
+history). A known zero uses `SortableUniqueId.MinValue`; it is not the same state as unknown. The nullable
+`CurrentPosition` and `TargetPosition` properties remain for source compatibility and display of legacy rows, but they are
+not used to make a readiness or ordering decision on their own.
+
+The four relational providers store this truth in additive checkpoint columns and migrate existing registry tables without
+discarding rows. A legacy null column decodes as `Unknown(LegacyNull)`. Invalid serialized truth is rejected as a typed
+`MvCheckpointMalformedException`; comparisons and readiness checks fail closed whenever either side is unknown or malformed.
+
 This metadata is used to:
 
 - discover the active physical table

--- a/docs/dcb_llm_ja/20_materialized_view.md
+++ b/docs/dcb_llm_ja/20_materialized_view.md
@@ -236,6 +236,16 @@ WHERE id = @Id
 - 適用済みイベント数
 - stream 側 / catch-up 側の最終適用 sortable id
 
+`MvRegistryEntry.CurrentCheckpointTruth` と `TargetCheckpointTruth` がチェックポイントの正本です。それぞれは明示的な
+`Known` / `Unknown` 状態と provenance（適用したイベント、権威的な空履歴など）を持ちます。known zero は
+`SortableUniqueId.MinValue` で表し、unknown とは別の状態です。nullable の `CurrentPosition` / `TargetPosition` は
+ソース互換性と legacy 行の表示のために残っていますが、それだけで readiness や順序を判定することはありません。
+
+4 つの relational provider はチェックポイント列を追加して正本を保存し、既存の registry 行を失わずに migration
+します。legacy の null は `Unknown(LegacyNull)` として復号されます。シリアライズされた truth が不正なら型付きの
+`MvCheckpointMalformedException` を返し、どちらかが unknown または malformed の比較・readiness 判定は fail closed
+になります。
+
 用途は次の通りです。
 
 - 現在有効な物理テーブルの解決


### PR DESCRIPTION
Closes #1112

## Summary
- Adds provider-neutral Known/Unknown materialized-view checkpoint truth with provenance, deterministic codec, legacy-null compatibility, Known-zero distinction, typed malformed failures, fail-closed comparisons, readiness, and diagnostics.
- Persists and migrates checkpoint truth across PostgreSQL, MySQL, SQL Server, and SQLite while retaining nullable legacy position fields and public compatibility.
- Adds common provider, legacy migration, JSON/killing, SQLite replay, Orleans grain readiness, and EN/JA documentation coverage.

## Verification
- `dotnet test dcb/Sekiban.Dcb.slnx -c Debug -f net9.0 --no-restore`: 1,416 passed, 1 skipped.
- `dotnet test dcb/Sekiban.Dcb.slnx -c Debug -f net10.0 --no-restore`: 1,416 passed, 1 skipped.
- Targeted truth/SQLite and Orleans tests passed on net9/net10.
- Targeted `dotnet format --verify-no-changes` and `git diff --check` passed.
- `SEK-G23-REPAIR.md` remains untracked, excluded, and byte-identical (SHA256 `b510d75d032480c68dc4b00721d69163c76bea6e848be4ba1ff61916e0b70197`).