### PR TITLE
feat(dcb): gate materialized view activation on authoritative eligibility

### DIFF
--- a/dcb/src/Sekiban.Dcb.MaterializedView.MySql/MySqlMvExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.MySql/MySqlMvExecutor.cs
@@ -53,11 +53,16 @@ public sealed class MySqlMvExecutor : MvExecutorBase<MySqlConnection>, IMvExecut
         return await CatchUpFromStoreAsync(
                 host,
                 exactServiceId,
-                _eventStoreFactory is null ? _legacyEventStore : _eventStoreFactory!.CreateForService(exactServiceId),
+                SelectEventStoreForService(exactServiceId),
                 _eventStoreFactory is not null,
                 cancellationToken)
             .ConfigureAwait(false);
     }
+
+    protected override IEventStore SelectEventStoreForService(string exactServiceId) =>
+        _eventStoreFactory is not null
+            ? _eventStoreFactory.CreateForService(exactServiceId)
+            : _legacyEventStore!;
 
     protected override async Task<MySqlConnection> OpenConnectionAsync(CancellationToken cancellationToken)
     {

--- a/dcb/src/Sekiban.Dcb.MaterializedView.MySql/MySqlMvRegistryStore.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.MySql/MySqlMvRegistryStore.cs
@@ -49,6 +49,7 @@ public sealed class MySqlMvRegistryStore : IMvRegistryStore
                 service_id VARCHAR(200) NOT NULL,
                 view_name VARCHAR(200) NOT NULL,
                 active_version INT NOT NULL,
+                active_generation BIGINT NOT NULL DEFAULT 0,
                 activated_at DATETIME(6) NOT NULL,
                 PRIMARY KEY (service_id, view_name)
             );
@@ -85,6 +86,25 @@ public sealed class MySqlMvRegistryStore : IMvRegistryStore
         }
 
         await connection.ExecuteAsync(new CommandDefinition(activeSql, cancellationToken: cancellationToken)).ConfigureAwait(false);
+        var activeGenerationColumns = (await connection.QueryAsync<string>(
+                new CommandDefinition(
+                    """
+                    SELECT column_name
+                    FROM information_schema.columns
+                    WHERE table_schema = DATABASE()
+                      AND table_name = 'sekiban_mv_active'
+                      AND column_name = 'active_generation';
+                    """,
+                    cancellationToken: cancellationToken)))
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        if (!activeGenerationColumns.Contains("active_generation"))
+        {
+            await connection.ExecuteAsync(
+                    new CommandDefinition(
+                        "ALTER TABLE sekiban_mv_active ADD COLUMN active_generation BIGINT NOT NULL DEFAULT 0;",
+                        cancellationToken: cancellationToken))
+                .ConfigureAwait(false);
+        }
     }
 
     public async Task RegisterAsync(MvRegistryEntry entry, IDbTransaction? transaction = null, CancellationToken cancellationToken = default)
@@ -312,6 +332,38 @@ public sealed class MySqlMvRegistryStore : IMvRegistryStore
             cancellationToken).ConfigureAwait(false);
     }
 
+    public async Task SetTargetCheckpointAsync(
+        string serviceId,
+        string viewName,
+        int viewVersion,
+        MvCheckpointTruth targetCheckpointTruth,
+        IDbTransaction? transaction = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(targetCheckpointTruth);
+        const string sql = """
+            UPDATE sekiban_mv_registry
+            SET target_position = @TargetPosition,
+                target_checkpoint_truth = @TargetCheckpointTruth,
+                last_updated = UTC_TIMESTAMP(6)
+            WHERE service_id = @ServiceId
+              AND view_name = @ViewName
+              AND view_version = @ViewVersion;
+            """;
+        await ExecuteAsync(
+            sql,
+            new
+            {
+                ServiceId = serviceId,
+                ViewName = viewName,
+                ViewVersion = viewVersion,
+                TargetPosition = targetCheckpointTruth.PositionValue,
+                TargetCheckpointTruth = MvCheckpointTruthCodec.Encode(targetCheckpointTruth)
+            },
+            transaction,
+            cancellationToken).ConfigureAwait(false);
+    }
+
     public async Task<IReadOnlyList<MvRegistryEntry>> GetEntriesAsync(
         string serviceId,
         string viewName,
@@ -363,6 +415,7 @@ public sealed class MySqlMvRegistryStore : IMvRegistryStore
             SELECT service_id AS ServiceId,
                    view_name AS ViewName,
                    active_version AS ActiveVersion,
+                   active_generation AS Generation,
                    activated_at AS ActivatedAt
             FROM sekiban_mv_active
             WHERE service_id = @ServiceId
@@ -385,10 +438,11 @@ public sealed class MySqlMvRegistryStore : IMvRegistryStore
         CancellationToken cancellationToken = default)
     {
         const string sql = """
-            INSERT INTO sekiban_mv_active (service_id, view_name, active_version, activated_at)
-            VALUES (@ServiceId, @ViewName, @ActiveVersion, UTC_TIMESTAMP(6))
+            INSERT INTO sekiban_mv_active (service_id, view_name, active_version, active_generation, activated_at)
+            VALUES (@ServiceId, @ViewName, @ActiveVersion, 1, UTC_TIMESTAMP(6))
             ON DUPLICATE KEY UPDATE
                 active_version = VALUES(active_version),
+                active_generation = active_generation + 1,
                 activated_at = VALUES(activated_at);
             """;
 
@@ -397,6 +451,181 @@ public sealed class MySqlMvRegistryStore : IMvRegistryStore
             new { ServiceId = serviceId, ViewName = viewName, ActiveVersion = activeVersion },
             transaction,
             cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<MvActivationResult> TryActivateAsync(
+        MvActivationRequest request,
+        IDbTransaction? transaction = null,
+        CancellationToken cancellationToken = default)
+    {
+        var validation = ValidateActivationRequest(request);
+        if (validation is not null)
+        {
+            return validation;
+        }
+
+        if (transaction is not null)
+        {
+            return await TryActivateInTransactionAsync(transaction, request, cancellationToken).ConfigureAwait(false);
+        }
+
+        await using var connection = new MySqlConnection(_connectionString);
+        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+        await using var localTransaction = await connection.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
+        var result = await TryActivateInTransactionAsync(localTransaction, request, cancellationToken).ConfigureAwait(false);
+        if (!result.Succeeded)
+        {
+            await localTransaction.RollbackAsync(cancellationToken).ConfigureAwait(false);
+            return result;
+        }
+
+        await localTransaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+        return result;
+    }
+
+    private async Task<MvActivationResult> TryActivateInTransactionAsync(
+        IDbTransaction transaction,
+        MvActivationRequest request,
+        CancellationToken cancellationToken)
+    {
+        const string insertSql = """
+            INSERT INTO sekiban_mv_active (
+                service_id, view_name, active_version, active_generation, activated_at)
+            SELECT @ServiceId, @ViewName, @ViewVersion, 1, UTC_TIMESTAMP(6)
+            WHERE @ExpectedActiveVersion IS NULL
+              AND @ExpectedActiveGeneration = 0
+              AND (
+                    SELECT COUNT(*)
+                    FROM sekiban_mv_registry
+                    WHERE service_id = @ServiceId
+                      AND view_name = @ViewName
+                      AND view_version = @ViewVersion
+                  ) = @CandidateCount
+              AND NOT EXISTS (
+                    SELECT 1
+                    FROM sekiban_mv_registry
+                    WHERE service_id = @ServiceId
+                      AND view_name = @ViewName
+                      AND view_version = @ViewVersion
+                      AND (
+                            status <> @ExpectedStatus
+                         OR current_checkpoint_truth <> @ExpectedCurrentCheckpointTruth
+                         OR target_checkpoint_truth <> @ExpectedTargetCheckpointTruth
+                      )
+                  )
+            ON DUPLICATE KEY UPDATE active_version = active_version;
+            """;
+        const string updateSql = """
+            UPDATE sekiban_mv_active
+            SET active_version = @ViewVersion,
+                active_generation = active_generation + 1,
+                activated_at = UTC_TIMESTAMP(6)
+            WHERE service_id = @ServiceId
+              AND view_name = @ViewName
+              AND active_version = @ExpectedActiveVersion
+              AND active_generation = @ExpectedActiveGeneration
+              AND (
+                    SELECT COUNT(*)
+                    FROM sekiban_mv_registry
+                    WHERE service_id = @ServiceId
+                      AND view_name = @ViewName
+                      AND view_version = @ViewVersion
+                  ) = @CandidateCount
+              AND NOT EXISTS (
+                    SELECT 1
+                    FROM sekiban_mv_registry
+                    WHERE service_id = @ServiceId
+                      AND view_name = @ViewName
+                      AND view_version = @ViewVersion
+                      AND (
+                            status <> @ExpectedStatus
+                         OR current_checkpoint_truth <> @ExpectedCurrentCheckpointTruth
+                         OR target_checkpoint_truth <> @ExpectedTargetCheckpointTruth
+                      )
+                  );
+            """;
+        var parameters = new
+        {
+            request.ServiceId,
+            request.ViewName,
+            request.ViewVersion,
+            request.ExpectedActiveVersion,
+            request.ExpectedActiveGeneration,
+            request.CandidateCount,
+            ExpectedStatus = request.ExpectedStatus.ToString().ToLowerInvariant(),
+            request.ExpectedCurrentCheckpointTruth,
+            request.ExpectedTargetCheckpointTruth
+        };
+        var affected = request.ExpectedActiveVersion is null
+            ? await transaction.Connection!.ExecuteAsync(new CommandDefinition(insertSql, parameters, transaction, cancellationToken: cancellationToken)).ConfigureAwait(false)
+            : await transaction.Connection!.ExecuteAsync(new CommandDefinition(updateSql, parameters, transaction, cancellationToken: cancellationToken)).ConfigureAwait(false);
+        if (affected == 0)
+        {
+            return MvActivationResult.Rejected(
+                MvActivationFailureReason.ConcurrentSuperseded,
+                "The expected active pointer, generation, or candidate snapshot changed before activation.");
+        }
+
+        const string markActiveSql = """
+            UPDATE sekiban_mv_registry
+            SET status = 'active', last_updated = UTC_TIMESTAMP(6)
+            WHERE service_id = @ServiceId
+              AND view_name = @ViewName
+              AND view_version = @ViewVersion
+              AND status = @ExpectedStatus
+              AND current_checkpoint_truth = @ExpectedCurrentCheckpointTruth
+              AND target_checkpoint_truth = @ExpectedTargetCheckpointTruth;
+            """;
+        await transaction.Connection!.ExecuteAsync(
+                new CommandDefinition(markActiveSql, parameters, transaction, cancellationToken: cancellationToken))
+            .ConfigureAwait(false);
+        return MvActivationResult.Success(request.ExpectedActiveGeneration + 1);
+    }
+
+    private static MvActivationResult? ValidateActivationRequest(MvActivationRequest request)
+    {
+        if (request.ExpectedActiveGeneration < 0)
+        {
+            return MvActivationResult.Rejected(
+                MvActivationFailureReason.ExpectedGenerationConflict,
+                "The expected active generation cannot be negative.");
+        }
+
+        if (request.CandidateCount <= 0 || request.ExpectedStatus != MvStatus.Ready)
+        {
+            return MvActivationResult.Rejected(MvActivationFailureReason.UnsafeLifecycle, "Atomic activation accepts only a non-empty Ready candidate snapshot.");
+        }
+
+        try
+        {
+            var current = MvCheckpointTruthCodec.Decode(request.ExpectedCurrentCheckpointTruth);
+            var target = MvCheckpointTruthCodec.Decode(request.ExpectedTargetCheckpointTruth);
+            if (!current.IsKnown)
+            {
+                return MvActivationResult.Rejected(MvActivationFailureReason.CurrentCheckpointUnknown, "Atomic activation requires Known current checkpoint truth.");
+            }
+
+            if (current.Provenance is null || current.Provenance.Kind == MvCheckpointProvenanceKind.LegacyCompatibility)
+            {
+                return MvActivationResult.Rejected(MvActivationFailureReason.MissingProvenance, "Atomic activation requires non-legacy current checkpoint provenance.");
+            }
+
+            if (!target.IsKnown || target.Provenance?.Kind != MvCheckpointProvenanceKind.AuthoritativeTargetCapture)
+            {
+                return MvActivationResult.Rejected(MvActivationFailureReason.TargetUnknown, "Atomic activation requires an authoritative Known target checkpoint.");
+            }
+
+            if (!current.Satisfies(target))
+            {
+                return MvActivationResult.Rejected(MvActivationFailureReason.BehindTarget, "Atomic activation requires the current checkpoint to satisfy the target.");
+            }
+        }
+        catch (MvCheckpointMalformedException ex)
+        {
+            return MvActivationResult.Rejected(MvActivationFailureReason.ProviderFailure, ex.Message);
+        }
+
+        return null;
     }
 
     private async Task ExecuteAsync(
@@ -451,7 +680,10 @@ public sealed class MySqlMvRegistryStore : IMvRegistryStore
             ReadRequiredString(row, "ServiceId"),
             ReadRequiredString(row, "ViewName"),
             ReadRequiredInt(row, "ActiveVersion"),
-            ReadRequiredDateTimeOffset(row, "ActivatedAt"));
+            ReadRequiredDateTimeOffset(row, "ActivatedAt"))
+        {
+            Generation = ReadRequiredLong(row, "Generation")
+        };
 
     private static IReadOnlyDictionary<string, object?> ToDictionary(object row)
     {

--- a/dcb/src/Sekiban.Dcb.MaterializedView.MySql/MySqlMvRegistryStore.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.MySql/MySqlMvRegistryStore.cs
@@ -466,7 +466,7 @@ public sealed class MySqlMvRegistryStore : IMvRegistryStore
 
         if (transaction is not null)
         {
-            return await TryActivateInTransactionAsync(transaction, request, cancellationToken).ConfigureAwait(false);
+            return await TryActivateWithSavepointAsync(transaction, request, cancellationToken).ConfigureAwait(false);
         }
 
         await using var connection = new MySqlConnection(_connectionString);
@@ -488,61 +488,24 @@ public sealed class MySqlMvRegistryStore : IMvRegistryStore
         MvActivationRequest request,
         CancellationToken cancellationToken)
     {
-        const string insertSql = """
-            INSERT INTO sekiban_mv_active (
-                service_id, view_name, active_version, active_generation, activated_at)
-            SELECT @ServiceId, @ViewName, @ViewVersion, 1, UTC_TIMESTAMP(6)
-            WHERE @ExpectedActiveVersion IS NULL
-              AND @ExpectedActiveGeneration = 0
-              AND (
-                    SELECT COUNT(*)
-                    FROM sekiban_mv_registry
-                    WHERE service_id = @ServiceId
-                      AND view_name = @ViewName
-                      AND view_version = @ViewVersion
-                  ) = @CandidateCount
-              AND NOT EXISTS (
-                    SELECT 1
-                    FROM sekiban_mv_registry
-                    WHERE service_id = @ServiceId
-                      AND view_name = @ViewName
-                      AND view_version = @ViewVersion
-                      AND (
-                            status <> @ExpectedStatus
-                         OR current_checkpoint_truth <> @ExpectedCurrentCheckpointTruth
-                         OR target_checkpoint_truth <> @ExpectedTargetCheckpointTruth
-                      )
-                  )
-            ON DUPLICATE KEY UPDATE active_version = active_version;
-            """;
-        const string updateSql = """
-            UPDATE sekiban_mv_active
-            SET active_version = @ViewVersion,
-                active_generation = active_generation + 1,
-                activated_at = UTC_TIMESTAMP(6)
+        const string lockCandidatesSql = """
+            SELECT logical_table
+            FROM sekiban_mv_registry
             WHERE service_id = @ServiceId
               AND view_name = @ViewName
-              AND active_version = @ExpectedActiveVersion
-              AND active_generation = @ExpectedActiveGeneration
-              AND (
-                    SELECT COUNT(*)
-                    FROM sekiban_mv_registry
-                    WHERE service_id = @ServiceId
-                      AND view_name = @ViewName
-                      AND view_version = @ViewVersion
-                  ) = @CandidateCount
-              AND NOT EXISTS (
-                    SELECT 1
-                    FROM sekiban_mv_registry
-                    WHERE service_id = @ServiceId
-                      AND view_name = @ViewName
-                      AND view_version = @ViewVersion
-                      AND (
-                            status <> @ExpectedStatus
-                         OR current_checkpoint_truth <> @ExpectedCurrentCheckpointTruth
-                         OR target_checkpoint_truth <> @ExpectedTargetCheckpointTruth
-                      )
-                  );
+              AND view_version = @ViewVersion
+            ORDER BY logical_table
+            FOR UPDATE;
+            """;
+        const string matchingCandidatesSql = """
+            SELECT COUNT(*)
+            FROM sekiban_mv_registry
+            WHERE service_id = @ServiceId
+              AND view_name = @ViewName
+              AND view_version = @ViewVersion
+              AND status = @ExpectedStatus
+              AND current_checkpoint_truth = @ExpectedCurrentCheckpointTruth
+              AND target_checkpoint_truth = @ExpectedTargetCheckpointTruth;
             """;
         var parameters = new
         {
@@ -556,14 +519,41 @@ public sealed class MySqlMvRegistryStore : IMvRegistryStore
             request.ExpectedCurrentCheckpointTruth,
             request.ExpectedTargetCheckpointTruth
         };
+        var lockedCandidates = (await transaction.Connection!.QueryAsync<string>(
+                new CommandDefinition(lockCandidatesSql, parameters, transaction, cancellationToken: cancellationToken))
+            .ConfigureAwait(false)).AsList();
+        var matchingCandidates = await transaction.Connection!.ExecuteScalarAsync<int>(
+                new CommandDefinition(matchingCandidatesSql, parameters, transaction, cancellationToken: cancellationToken))
+            .ConfigureAwait(false);
+        if (lockedCandidates.Count != request.CandidateCount || matchingCandidates != request.CandidateCount)
+        {
+            return CandidateSnapshotChanged();
+        }
+
+        const string insertSql = """
+            INSERT INTO sekiban_mv_active (
+                service_id, view_name, active_version, active_generation, activated_at)
+            SELECT @ServiceId, @ViewName, @ViewVersion, 1, UTC_TIMESTAMP(6)
+            WHERE @ExpectedActiveVersion IS NULL
+              AND @ExpectedActiveGeneration = 0
+            ON DUPLICATE KEY UPDATE active_version = active_version;
+            """;
+        const string updateSql = """
+            UPDATE sekiban_mv_active
+            SET active_version = @ViewVersion,
+                active_generation = active_generation + 1,
+                activated_at = UTC_TIMESTAMP(6)
+            WHERE service_id = @ServiceId
+              AND view_name = @ViewName
+              AND active_version = @ExpectedActiveVersion
+              AND active_generation = @ExpectedActiveGeneration;
+            """;
         var affected = request.ExpectedActiveVersion is null
             ? await transaction.Connection!.ExecuteAsync(new CommandDefinition(insertSql, parameters, transaction, cancellationToken: cancellationToken)).ConfigureAwait(false)
             : await transaction.Connection!.ExecuteAsync(new CommandDefinition(updateSql, parameters, transaction, cancellationToken: cancellationToken)).ConfigureAwait(false);
         if (affected == 0)
         {
-            return MvActivationResult.Rejected(
-                MvActivationFailureReason.ConcurrentSuperseded,
-                "The expected active pointer, generation, or candidate snapshot changed before activation.");
+            return CandidateSnapshotChanged();
         }
 
         const string markActiveSql = """
@@ -576,11 +566,55 @@ public sealed class MySqlMvRegistryStore : IMvRegistryStore
               AND current_checkpoint_truth = @ExpectedCurrentCheckpointTruth
               AND target_checkpoint_truth = @ExpectedTargetCheckpointTruth;
             """;
-        await transaction.Connection!.ExecuteAsync(
+        var marked = await transaction.Connection!.ExecuteAsync(
                 new CommandDefinition(markActiveSql, parameters, transaction, cancellationToken: cancellationToken))
             .ConfigureAwait(false);
+        if (marked != request.CandidateCount)
+        {
+            return CandidateSnapshotChanged();
+        }
+
         return MvActivationResult.Success(request.ExpectedActiveGeneration + 1);
     }
+
+    private async Task<MvActivationResult> TryActivateWithSavepointAsync(
+        IDbTransaction transaction,
+        MvActivationRequest request,
+        CancellationToken cancellationToken)
+    {
+        const string createSavepointSql = "SAVEPOINT sekiban_mv_activation;";
+        const string rollbackSavepointSql = "ROLLBACK TO SAVEPOINT sekiban_mv_activation;";
+        const string releaseSavepointSql = "RELEASE SAVEPOINT sekiban_mv_activation;";
+        var connection = transaction.Connection ?? throw new InvalidOperationException("The transaction is not associated with a connection.");
+        await connection.ExecuteAsync(
+            new CommandDefinition(createSavepointSql, transaction: transaction, cancellationToken: cancellationToken)).ConfigureAwait(false);
+        try
+        {
+            var result = await TryActivateInTransactionAsync(transaction, request, cancellationToken).ConfigureAwait(false);
+            if (!result.Succeeded)
+            {
+                await connection.ExecuteAsync(
+                    new CommandDefinition(rollbackSavepointSql, transaction: transaction, cancellationToken: cancellationToken)).ConfigureAwait(false);
+            }
+
+            await connection.ExecuteAsync(
+                new CommandDefinition(releaseSavepointSql, transaction: transaction, cancellationToken: cancellationToken)).ConfigureAwait(false);
+            return result;
+        }
+        catch
+        {
+            await connection.ExecuteAsync(
+                new CommandDefinition(rollbackSavepointSql, transaction: transaction, cancellationToken: cancellationToken)).ConfigureAwait(false);
+            await connection.ExecuteAsync(
+                new CommandDefinition(releaseSavepointSql, transaction: transaction, cancellationToken: cancellationToken)).ConfigureAwait(false);
+            throw;
+        }
+    }
+
+    private static MvActivationResult CandidateSnapshotChanged() =>
+        MvActivationResult.Rejected(
+            MvActivationFailureReason.ConcurrentSuperseded,
+            "The expected active pointer, generation, or candidate snapshot changed before activation.");
 
     private static MvActivationResult? ValidateActivationRequest(MvActivationRequest request)
     {

--- a/dcb/src/Sekiban.Dcb.MaterializedView.Orleans/MaterializedViewGrain.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.Orleans/MaterializedViewGrain.cs
@@ -100,6 +100,13 @@ public sealed class MaterializedViewGrain : Grain, IMaterializedViewGrain
 
         ResolveHost();
         await _executor.InitializeAsync(_host!, _serviceId, CancellationToken.None);
+        if (_executor is IMvActivationExecutor activationExecutor)
+        {
+            // Target capture is an explicit lifecycle step. Initialization creates registry rows only; it never
+            // treats the absence of an active pointer as permission to cut over.
+            await activationExecutor.CaptureTargetCheckpointAsync(_host!, _serviceId, CancellationToken.None);
+        }
+
         await RefreshPositionFromRegistryAsync(CancellationToken.None);
         await StartSubscriptionAsync();
 
@@ -449,6 +456,67 @@ public sealed class MaterializedViewGrain : Grain, IMaterializedViewGrain
         {
             _lastError = "Materialized view checkpoint truth is Unknown; readiness remains fail-closed.";
             _consecutiveEmptyBatches = 0;
+            return;
+        }
+
+        if (_executor is IMvActivationExecutor activationExecutor)
+        {
+            if (entries.Any(entry =>
+                    entry.Status == MvStatus.Faulted ||
+                    !entry.TargetCheckpointTruth.IsKnown ||
+                    entry.TargetCheckpointTruth.Provenance?.Kind != MvCheckpointProvenanceKind.AuthoritativeTargetCapture ||
+                    !entry.CurrentCheckpointTruth.Satisfies(entry.TargetCheckpointTruth)))
+            {
+                _lastError = "Materialized view candidate is not at its authoritative target; readiness remains fail-closed.";
+                _consecutiveEmptyBatches = 0;
+                return;
+            }
+
+            var active = await _registryStore.GetActiveAsync(
+                    _serviceId!,
+                    _host!.ViewName,
+                    cancellationToken)
+                .ConfigureAwait(false);
+            if (active?.ActiveVersion == _host.ViewVersion)
+            {
+                _isCatchUpActive = false;
+                _needsImmediateCatchUp = false;
+                _consecutiveEmptyBatches = 0;
+                _lastCatchUpCompletedAt = DateTimeOffset.UtcNow;
+                return;
+            }
+
+            if (entries.Any(entry => entry.Status is not (MvStatus.CatchingUp or MvStatus.Ready)))
+            {
+                _lastError = "Materialized view candidate lifecycle is not eligible for activation.";
+                _consecutiveEmptyBatches = 0;
+                return;
+            }
+
+            await _registryStore.UpdateStatusAsync(
+                    _serviceId!,
+                    _host.ViewName,
+                    _host.ViewVersion,
+                    MvStatus.Ready,
+                    cancellationToken: cancellationToken)
+                .ConfigureAwait(false);
+
+            var activation = await activationExecutor.TryActivateAsync(
+                    _host,
+                    _serviceId,
+                    cancellationToken)
+                .ConfigureAwait(false);
+            if (!activation.Succeeded && activation.FailureReason != MvActivationFailureReason.AlreadyActive)
+            {
+                _lastError = $"Materialized view activation was rejected: {activation.FailureReason}.";
+                _consecutiveEmptyBatches = 0;
+                return;
+            }
+
+            _isCatchUpActive = false;
+            _needsImmediateCatchUp = false;
+            _consecutiveEmptyBatches = 0;
+            _lastCatchUpCompletedAt = DateTimeOffset.UtcNow;
             return;
         }
 

--- a/dcb/src/Sekiban.Dcb.MaterializedView.Postgres/PostgresMvExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.Postgres/PostgresMvExecutor.cs
@@ -53,11 +53,16 @@ public sealed class PostgresMvExecutor : MvExecutorBase<NpgsqlConnection>, IMvEx
         return await CatchUpFromStoreAsync(
                 host,
                 exactServiceId,
-                _eventStoreFactory is null ? _legacyEventStore : _eventStoreFactory!.CreateForService(exactServiceId),
+                SelectEventStoreForService(exactServiceId),
                 _eventStoreFactory is not null,
                 cancellationToken)
             .ConfigureAwait(false);
     }
+
+    protected override IEventStore SelectEventStoreForService(string exactServiceId) =>
+        _eventStoreFactory is not null
+            ? _eventStoreFactory.CreateForService(exactServiceId)
+            : _legacyEventStore!;
 
     protected override async Task<NpgsqlConnection> OpenConnectionAsync(CancellationToken cancellationToken)
     {

--- a/dcb/src/Sekiban.Dcb.MaterializedView.Postgres/PostgresMvRegistryStore.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.Postgres/PostgresMvRegistryStore.cs
@@ -429,7 +429,7 @@ public sealed class PostgresMvRegistryStore : IMvRegistryStore
 
         if (transaction is not null)
         {
-            return await TryActivateInTransactionAsync(transaction, request, cancellationToken).ConfigureAwait(false);
+            return await TryActivateWithSavepointAsync(transaction, request, cancellationToken).ConfigureAwait(false);
         }
 
         await using var connection = new NpgsqlConnection(_connectionString);
@@ -451,61 +451,24 @@ public sealed class PostgresMvRegistryStore : IMvRegistryStore
         MvActivationRequest request,
         CancellationToken cancellationToken)
     {
-        const string insertSql = """
-            INSERT INTO sekiban_mv_active (
-                service_id, view_name, active_version, active_generation, activated_at)
-            SELECT @ServiceId, @ViewName, @ViewVersion, 1, NOW()
-            WHERE @ExpectedActiveVersion IS NULL
-              AND @ExpectedActiveGeneration = 0
-              AND (
-                    SELECT COUNT(*)
-                    FROM sekiban_mv_registry
-                    WHERE service_id = @ServiceId
-                      AND view_name = @ViewName
-                      AND view_version = @ViewVersion
-                  ) = @CandidateCount
-              AND NOT EXISTS (
-                    SELECT 1
-                    FROM sekiban_mv_registry
-                    WHERE service_id = @ServiceId
-                      AND view_name = @ViewName
-                      AND view_version = @ViewVersion
-                      AND (
-                            status <> @ExpectedStatus
-                         OR current_checkpoint_truth <> CAST(@ExpectedCurrentCheckpointTruth AS jsonb)
-                         OR target_checkpoint_truth <> CAST(@ExpectedTargetCheckpointTruth AS jsonb)
-                      )
-                  )
-            ON CONFLICT (service_id, view_name) DO NOTHING;
-            """;
-        const string updateSql = """
-            UPDATE sekiban_mv_active
-            SET active_version = @ViewVersion,
-                active_generation = active_generation + 1,
-                activated_at = NOW()
+        const string lockCandidatesSql = """
+            SELECT logical_table
+            FROM sekiban_mv_registry
             WHERE service_id = @ServiceId
               AND view_name = @ViewName
-              AND active_version = @ExpectedActiveVersion
-              AND active_generation = @ExpectedActiveGeneration
-              AND (
-                    SELECT COUNT(*)
-                    FROM sekiban_mv_registry
-                    WHERE service_id = @ServiceId
-                      AND view_name = @ViewName
-                      AND view_version = @ViewVersion
-                  ) = @CandidateCount
-              AND NOT EXISTS (
-                    SELECT 1
-                    FROM sekiban_mv_registry
-                    WHERE service_id = @ServiceId
-                      AND view_name = @ViewName
-                      AND view_version = @ViewVersion
-                      AND (
-                            status <> @ExpectedStatus
-                         OR current_checkpoint_truth <> CAST(@ExpectedCurrentCheckpointTruth AS jsonb)
-                         OR target_checkpoint_truth <> CAST(@ExpectedTargetCheckpointTruth AS jsonb)
-                      )
-                  );
+              AND view_version = @ViewVersion
+            ORDER BY logical_table
+            FOR UPDATE;
+            """;
+        const string matchingCandidatesSql = """
+            SELECT COUNT(*)
+            FROM sekiban_mv_registry
+            WHERE service_id = @ServiceId
+              AND view_name = @ViewName
+              AND view_version = @ViewVersion
+              AND status = @ExpectedStatus
+              AND current_checkpoint_truth = CAST(@ExpectedCurrentCheckpointTruth AS jsonb)
+              AND target_checkpoint_truth = CAST(@ExpectedTargetCheckpointTruth AS jsonb);
             """;
         var parameters = new
         {
@@ -519,14 +482,41 @@ public sealed class PostgresMvRegistryStore : IMvRegistryStore
             request.ExpectedCurrentCheckpointTruth,
             request.ExpectedTargetCheckpointTruth
         };
+        var lockedCandidates = (await transaction.Connection!.QueryAsync<string>(
+                new CommandDefinition(lockCandidatesSql, parameters, transaction, cancellationToken: cancellationToken))
+            .ConfigureAwait(false)).AsList();
+        var matchingCandidates = await transaction.Connection!.ExecuteScalarAsync<int>(
+                new CommandDefinition(matchingCandidatesSql, parameters, transaction, cancellationToken: cancellationToken))
+            .ConfigureAwait(false);
+        if (lockedCandidates.Count != request.CandidateCount || matchingCandidates != request.CandidateCount)
+        {
+            return CandidateSnapshotChanged();
+        }
+
+        const string insertSql = """
+            INSERT INTO sekiban_mv_active (
+                service_id, view_name, active_version, active_generation, activated_at)
+            SELECT @ServiceId, @ViewName, @ViewVersion, 1, NOW()
+            WHERE @ExpectedActiveVersion IS NULL
+              AND @ExpectedActiveGeneration = 0
+            ON CONFLICT (service_id, view_name) DO NOTHING;
+            """;
+        const string updateSql = """
+            UPDATE sekiban_mv_active
+            SET active_version = @ViewVersion,
+                active_generation = active_generation + 1,
+                activated_at = NOW()
+            WHERE service_id = @ServiceId
+              AND view_name = @ViewName
+              AND active_version = @ExpectedActiveVersion
+              AND active_generation = @ExpectedActiveGeneration;
+            """;
         var affected = request.ExpectedActiveVersion is null
             ? await transaction.Connection!.ExecuteAsync(new CommandDefinition(insertSql, parameters, transaction, cancellationToken: cancellationToken)).ConfigureAwait(false)
             : await transaction.Connection!.ExecuteAsync(new CommandDefinition(updateSql, parameters, transaction, cancellationToken: cancellationToken)).ConfigureAwait(false);
         if (affected == 0)
         {
-            return MvActivationResult.Rejected(
-                MvActivationFailureReason.ConcurrentSuperseded,
-                "The expected active pointer, generation, or candidate snapshot changed before activation.");
+            return CandidateSnapshotChanged();
         }
 
         const string markActiveSql = """
@@ -539,11 +529,55 @@ public sealed class PostgresMvRegistryStore : IMvRegistryStore
               AND current_checkpoint_truth = CAST(@ExpectedCurrentCheckpointTruth AS jsonb)
               AND target_checkpoint_truth = CAST(@ExpectedTargetCheckpointTruth AS jsonb);
             """;
-        await transaction.Connection!.ExecuteAsync(
+        var marked = await transaction.Connection!.ExecuteAsync(
                 new CommandDefinition(markActiveSql, parameters, transaction, cancellationToken: cancellationToken))
             .ConfigureAwait(false);
+        if (marked != request.CandidateCount)
+        {
+            return CandidateSnapshotChanged();
+        }
+
         return MvActivationResult.Success(request.ExpectedActiveGeneration + 1);
     }
+
+    private async Task<MvActivationResult> TryActivateWithSavepointAsync(
+        IDbTransaction transaction,
+        MvActivationRequest request,
+        CancellationToken cancellationToken)
+    {
+        const string createSavepointSql = "SAVEPOINT sekiban_mv_activation;";
+        const string rollbackSavepointSql = "ROLLBACK TO SAVEPOINT sekiban_mv_activation;";
+        const string releaseSavepointSql = "RELEASE SAVEPOINT sekiban_mv_activation;";
+        var connection = transaction.Connection ?? throw new InvalidOperationException("The transaction is not associated with a connection.");
+        await connection.ExecuteAsync(
+            new CommandDefinition(createSavepointSql, transaction: transaction, cancellationToken: cancellationToken)).ConfigureAwait(false);
+        try
+        {
+            var result = await TryActivateInTransactionAsync(transaction, request, cancellationToken).ConfigureAwait(false);
+            if (!result.Succeeded)
+            {
+                await connection.ExecuteAsync(
+                    new CommandDefinition(rollbackSavepointSql, transaction: transaction, cancellationToken: cancellationToken)).ConfigureAwait(false);
+            }
+
+            await connection.ExecuteAsync(
+                new CommandDefinition(releaseSavepointSql, transaction: transaction, cancellationToken: cancellationToken)).ConfigureAwait(false);
+            return result;
+        }
+        catch
+        {
+            await connection.ExecuteAsync(
+                new CommandDefinition(rollbackSavepointSql, transaction: transaction, cancellationToken: cancellationToken)).ConfigureAwait(false);
+            await connection.ExecuteAsync(
+                new CommandDefinition(releaseSavepointSql, transaction: transaction, cancellationToken: cancellationToken)).ConfigureAwait(false);
+            throw;
+        }
+    }
+
+    private static MvActivationResult CandidateSnapshotChanged() =>
+        MvActivationResult.Rejected(
+            MvActivationFailureReason.ConcurrentSuperseded,
+            "The expected active pointer, generation, or candidate snapshot changed before activation.");
 
     private static MvActivationResult? ValidateActivationRequest(MvActivationRequest request)
     {

--- a/dcb/src/Sekiban.Dcb.MaterializedView.Postgres/PostgresMvRegistryStore.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.Postgres/PostgresMvRegistryStore.cs
@@ -49,6 +49,7 @@ public sealed class PostgresMvRegistryStore : IMvRegistryStore
                 service_id TEXT NOT NULL,
                 view_name TEXT NOT NULL,
                 active_version INT NOT NULL,
+                active_generation BIGINT NOT NULL DEFAULT 0,
                 activated_at TIMESTAMPTZ NOT NULL,
                 PRIMARY KEY (service_id, view_name)
             );
@@ -63,6 +64,11 @@ public sealed class PostgresMvRegistryStore : IMvRegistryStore
             """;
         await connection.ExecuteAsync(new CommandDefinition(checkpointMigrationSql, cancellationToken: cancellationToken)).ConfigureAwait(false);
         await connection.ExecuteAsync(new CommandDefinition(activeSql, cancellationToken: cancellationToken)).ConfigureAwait(false);
+        const string activeGenerationMigrationSql = """
+            ALTER TABLE sekiban_mv_active
+                ADD COLUMN IF NOT EXISTS active_generation BIGINT NOT NULL DEFAULT 0;
+            """;
+        await connection.ExecuteAsync(new CommandDefinition(activeGenerationMigrationSql, cancellationToken: cancellationToken)).ConfigureAwait(false);
     }
 
     public async Task RegisterAsync(MvRegistryEntry entry, IDbTransaction? transaction = null, CancellationToken cancellationToken = default)
@@ -292,6 +298,38 @@ public sealed class PostgresMvRegistryStore : IMvRegistryStore
         await ExecuteAsync(sql, parameters, transaction, cancellationToken).ConfigureAwait(false);
     }
 
+    public async Task SetTargetCheckpointAsync(
+        string serviceId,
+        string viewName,
+        int viewVersion,
+        MvCheckpointTruth targetCheckpointTruth,
+        IDbTransaction? transaction = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(targetCheckpointTruth);
+        const string sql = """
+            UPDATE sekiban_mv_registry
+            SET target_position = @TargetPosition,
+                target_checkpoint_truth = CAST(@TargetCheckpointTruth AS jsonb),
+                last_updated = NOW()
+            WHERE service_id = @ServiceId
+              AND view_name = @ViewName
+              AND view_version = @ViewVersion;
+            """;
+        await ExecuteAsync(
+            sql,
+            new
+            {
+                ServiceId = serviceId,
+                ViewName = viewName,
+                ViewVersion = viewVersion,
+                TargetPosition = targetCheckpointTruth.PositionValue,
+                TargetCheckpointTruth = MvCheckpointTruthCodec.Encode(targetCheckpointTruth)
+            },
+            transaction,
+            cancellationToken).ConfigureAwait(false);
+    }
+
     public async Task<IReadOnlyList<MvRegistryEntry>> GetEntriesAsync(
         string serviceId,
         string viewName,
@@ -343,6 +381,7 @@ public sealed class PostgresMvRegistryStore : IMvRegistryStore
             SELECT service_id AS ServiceId,
                    view_name AS ViewName,
                    active_version AS ActiveVersion,
+                   active_generation AS Generation,
                    activated_at AS ActivatedAt
             FROM sekiban_mv_active
             WHERE service_id = @ServiceId
@@ -365,15 +404,191 @@ public sealed class PostgresMvRegistryStore : IMvRegistryStore
         CancellationToken cancellationToken = default)
     {
         const string sql = """
-            INSERT INTO sekiban_mv_active (service_id, view_name, active_version, activated_at)
-            VALUES (@ServiceId, @ViewName, @ActiveVersion, NOW())
+            INSERT INTO sekiban_mv_active (service_id, view_name, active_version, active_generation, activated_at)
+            VALUES (@ServiceId, @ViewName, @ActiveVersion, 1, NOW())
             ON CONFLICT (service_id, view_name) DO UPDATE SET
                 active_version = EXCLUDED.active_version,
+                active_generation = sekiban_mv_active.active_generation + 1,
                 activated_at = EXCLUDED.activated_at;
             """;
 
         var parameters = new { ServiceId = serviceId, ViewName = viewName, ActiveVersion = activeVersion };
         await ExecuteAsync(sql, parameters, transaction, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<MvActivationResult> TryActivateAsync(
+        MvActivationRequest request,
+        IDbTransaction? transaction = null,
+        CancellationToken cancellationToken = default)
+    {
+        var validation = ValidateActivationRequest(request);
+        if (validation is not null)
+        {
+            return validation;
+        }
+
+        if (transaction is not null)
+        {
+            return await TryActivateInTransactionAsync(transaction, request, cancellationToken).ConfigureAwait(false);
+        }
+
+        await using var connection = new NpgsqlConnection(_connectionString);
+        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+        await using var localTransaction = await connection.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
+        var result = await TryActivateInTransactionAsync(localTransaction, request, cancellationToken).ConfigureAwait(false);
+        if (!result.Succeeded)
+        {
+            await localTransaction.RollbackAsync(cancellationToken).ConfigureAwait(false);
+            return result;
+        }
+
+        await localTransaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+        return result;
+    }
+
+    private async Task<MvActivationResult> TryActivateInTransactionAsync(
+        IDbTransaction transaction,
+        MvActivationRequest request,
+        CancellationToken cancellationToken)
+    {
+        const string insertSql = """
+            INSERT INTO sekiban_mv_active (
+                service_id, view_name, active_version, active_generation, activated_at)
+            SELECT @ServiceId, @ViewName, @ViewVersion, 1, NOW()
+            WHERE @ExpectedActiveVersion IS NULL
+              AND @ExpectedActiveGeneration = 0
+              AND (
+                    SELECT COUNT(*)
+                    FROM sekiban_mv_registry
+                    WHERE service_id = @ServiceId
+                      AND view_name = @ViewName
+                      AND view_version = @ViewVersion
+                  ) = @CandidateCount
+              AND NOT EXISTS (
+                    SELECT 1
+                    FROM sekiban_mv_registry
+                    WHERE service_id = @ServiceId
+                      AND view_name = @ViewName
+                      AND view_version = @ViewVersion
+                      AND (
+                            status <> @ExpectedStatus
+                         OR current_checkpoint_truth <> CAST(@ExpectedCurrentCheckpointTruth AS jsonb)
+                         OR target_checkpoint_truth <> CAST(@ExpectedTargetCheckpointTruth AS jsonb)
+                      )
+                  )
+            ON CONFLICT (service_id, view_name) DO NOTHING;
+            """;
+        const string updateSql = """
+            UPDATE sekiban_mv_active
+            SET active_version = @ViewVersion,
+                active_generation = active_generation + 1,
+                activated_at = NOW()
+            WHERE service_id = @ServiceId
+              AND view_name = @ViewName
+              AND active_version = @ExpectedActiveVersion
+              AND active_generation = @ExpectedActiveGeneration
+              AND (
+                    SELECT COUNT(*)
+                    FROM sekiban_mv_registry
+                    WHERE service_id = @ServiceId
+                      AND view_name = @ViewName
+                      AND view_version = @ViewVersion
+                  ) = @CandidateCount
+              AND NOT EXISTS (
+                    SELECT 1
+                    FROM sekiban_mv_registry
+                    WHERE service_id = @ServiceId
+                      AND view_name = @ViewName
+                      AND view_version = @ViewVersion
+                      AND (
+                            status <> @ExpectedStatus
+                         OR current_checkpoint_truth <> CAST(@ExpectedCurrentCheckpointTruth AS jsonb)
+                         OR target_checkpoint_truth <> CAST(@ExpectedTargetCheckpointTruth AS jsonb)
+                      )
+                  );
+            """;
+        var parameters = new
+        {
+            request.ServiceId,
+            request.ViewName,
+            request.ViewVersion,
+            request.ExpectedActiveVersion,
+            request.ExpectedActiveGeneration,
+            request.CandidateCount,
+            ExpectedStatus = request.ExpectedStatus.ToString().ToLowerInvariant(),
+            request.ExpectedCurrentCheckpointTruth,
+            request.ExpectedTargetCheckpointTruth
+        };
+        var affected = request.ExpectedActiveVersion is null
+            ? await transaction.Connection!.ExecuteAsync(new CommandDefinition(insertSql, parameters, transaction, cancellationToken: cancellationToken)).ConfigureAwait(false)
+            : await transaction.Connection!.ExecuteAsync(new CommandDefinition(updateSql, parameters, transaction, cancellationToken: cancellationToken)).ConfigureAwait(false);
+        if (affected == 0)
+        {
+            return MvActivationResult.Rejected(
+                MvActivationFailureReason.ConcurrentSuperseded,
+                "The expected active pointer, generation, or candidate snapshot changed before activation.");
+        }
+
+        const string markActiveSql = """
+            UPDATE sekiban_mv_registry
+            SET status = 'active', last_updated = NOW()
+            WHERE service_id = @ServiceId
+              AND view_name = @ViewName
+              AND view_version = @ViewVersion
+              AND status = @ExpectedStatus
+              AND current_checkpoint_truth = CAST(@ExpectedCurrentCheckpointTruth AS jsonb)
+              AND target_checkpoint_truth = CAST(@ExpectedTargetCheckpointTruth AS jsonb);
+            """;
+        await transaction.Connection!.ExecuteAsync(
+                new CommandDefinition(markActiveSql, parameters, transaction, cancellationToken: cancellationToken))
+            .ConfigureAwait(false);
+        return MvActivationResult.Success(request.ExpectedActiveGeneration + 1);
+    }
+
+    private static MvActivationResult? ValidateActivationRequest(MvActivationRequest request)
+    {
+        if (request.ExpectedActiveGeneration < 0)
+        {
+            return MvActivationResult.Rejected(
+                MvActivationFailureReason.ExpectedGenerationConflict,
+                "The expected active generation cannot be negative.");
+        }
+
+        if (request.CandidateCount <= 0 || request.ExpectedStatus != MvStatus.Ready)
+        {
+            return MvActivationResult.Rejected(MvActivationFailureReason.UnsafeLifecycle, "Atomic activation accepts only a non-empty Ready candidate snapshot.");
+        }
+
+        try
+        {
+            var current = MvCheckpointTruthCodec.Decode(request.ExpectedCurrentCheckpointTruth);
+            var target = MvCheckpointTruthCodec.Decode(request.ExpectedTargetCheckpointTruth);
+            if (!current.IsKnown)
+            {
+                return MvActivationResult.Rejected(MvActivationFailureReason.CurrentCheckpointUnknown, "Atomic activation requires Known current checkpoint truth.");
+            }
+
+            if (current.Provenance is null || current.Provenance.Kind == MvCheckpointProvenanceKind.LegacyCompatibility)
+            {
+                return MvActivationResult.Rejected(MvActivationFailureReason.MissingProvenance, "Atomic activation requires non-legacy current checkpoint provenance.");
+            }
+
+            if (!target.IsKnown || target.Provenance?.Kind != MvCheckpointProvenanceKind.AuthoritativeTargetCapture)
+            {
+                return MvActivationResult.Rejected(MvActivationFailureReason.TargetUnknown, "Atomic activation requires an authoritative Known target checkpoint.");
+            }
+
+            if (!current.Satisfies(target))
+            {
+                return MvActivationResult.Rejected(MvActivationFailureReason.BehindTarget, "Atomic activation requires the current checkpoint to satisfy the target.");
+            }
+        }
+        catch (MvCheckpointMalformedException ex)
+        {
+            return MvActivationResult.Rejected(MvActivationFailureReason.ProviderFailure, ex.Message);
+        }
+
+        return null;
     }
 
     private async Task ExecuteAsync(
@@ -428,7 +643,10 @@ public sealed class PostgresMvRegistryStore : IMvRegistryStore
             ReadRequiredString(row, "ServiceId"),
             ReadRequiredString(row, "ViewName"),
             ReadRequiredInt(row, "ActiveVersion"),
-            ReadRequiredDateTimeOffset(row, "ActivatedAt"));
+            ReadRequiredDateTimeOffset(row, "ActivatedAt"))
+        {
+            Generation = ReadRequiredLong(row, "Generation")
+        };
 
     private static IReadOnlyDictionary<string, object?> ToDictionary(object row)
     {

--- a/dcb/src/Sekiban.Dcb.MaterializedView.SqlServer/SqlServerMvExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.SqlServer/SqlServerMvExecutor.cs
@@ -53,11 +53,16 @@ public sealed class SqlServerMvExecutor : MvExecutorBase<SqlConnection>, IMvExec
         return await CatchUpFromStoreAsync(
                 host,
                 exactServiceId,
-                _eventStoreFactory is null ? _legacyEventStore : _eventStoreFactory!.CreateForService(exactServiceId),
+                SelectEventStoreForService(exactServiceId),
                 _eventStoreFactory is not null,
                 cancellationToken)
             .ConfigureAwait(false);
     }
+
+    protected override IEventStore SelectEventStoreForService(string exactServiceId) =>
+        _eventStoreFactory is not null
+            ? _eventStoreFactory.CreateForService(exactServiceId)
+            : _legacyEventStore!;
 
     protected override async Task<SqlConnection> OpenConnectionAsync(CancellationToken cancellationToken)
     {

--- a/dcb/src/Sekiban.Dcb.MaterializedView.SqlServer/SqlServerMvRegistryStore.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.SqlServer/SqlServerMvRegistryStore.cs
@@ -52,6 +52,7 @@ public sealed class SqlServerMvRegistryStore : IMvRegistryStore
                     service_id NVARCHAR(200) NOT NULL,
                     view_name NVARCHAR(200) NOT NULL,
                     active_version INT NOT NULL,
+                    active_generation BIGINT NOT NULL CONSTRAINT DF_sekiban_mv_active_generation DEFAULT 0,
                     activated_at DATETIMEOFFSET NOT NULL,
                     CONSTRAINT PK_sekiban_mv_active PRIMARY KEY (service_id, view_name)
                 );
@@ -66,6 +67,11 @@ public sealed class SqlServerMvRegistryStore : IMvRegistryStore
                 ALTER TABLE sekiban_mv_registry ADD target_checkpoint_truth NVARCHAR(MAX) NULL;
             """;
         await connection.ExecuteAsync(new CommandDefinition(checkpointMigrationSql, cancellationToken: cancellationToken)).ConfigureAwait(false);
+        const string activeGenerationMigrationSql = """
+            IF COL_LENGTH(N'sekiban_mv_active', N'active_generation') IS NULL
+                ALTER TABLE sekiban_mv_active ADD active_generation BIGINT NOT NULL CONSTRAINT DF_sekiban_mv_active_generation DEFAULT 0;
+            """;
+        await connection.ExecuteAsync(new CommandDefinition(activeGenerationMigrationSql, cancellationToken: cancellationToken)).ConfigureAwait(false);
     }
 
     public async Task RegisterAsync(MvRegistryEntry entry, IDbTransaction? transaction = null, CancellationToken cancellationToken = default)
@@ -307,6 +313,38 @@ public sealed class SqlServerMvRegistryStore : IMvRegistryStore
             cancellationToken).ConfigureAwait(false);
     }
 
+    public async Task SetTargetCheckpointAsync(
+        string serviceId,
+        string viewName,
+        int viewVersion,
+        MvCheckpointTruth targetCheckpointTruth,
+        IDbTransaction? transaction = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(targetCheckpointTruth);
+        const string sql = """
+            UPDATE sekiban_mv_registry
+            SET target_position = @TargetPosition,
+                target_checkpoint_truth = @TargetCheckpointTruth,
+                last_updated = SYSUTCDATETIME()
+            WHERE service_id = @ServiceId
+              AND view_name = @ViewName
+              AND view_version = @ViewVersion;
+            """;
+        await ExecuteAsync(
+            sql,
+            new
+            {
+                ServiceId = serviceId,
+                ViewName = viewName,
+                ViewVersion = viewVersion,
+                TargetPosition = targetCheckpointTruth.PositionValue,
+                TargetCheckpointTruth = MvCheckpointTruthCodec.Encode(targetCheckpointTruth)
+            },
+            transaction,
+            cancellationToken).ConfigureAwait(false);
+    }
+
     public async Task<IReadOnlyList<MvRegistryEntry>> GetEntriesAsync(
         string serviceId,
         string viewName,
@@ -358,6 +396,7 @@ public sealed class SqlServerMvRegistryStore : IMvRegistryStore
             SELECT service_id AS ServiceId,
                    view_name AS ViewName,
                    active_version AS ActiveVersion,
+                   active_generation AS Generation,
                    activated_at AS ActivatedAt
             FROM sekiban_mv_active
             WHERE service_id = @ServiceId
@@ -382,14 +421,15 @@ public sealed class SqlServerMvRegistryStore : IMvRegistryStore
         const string sql = """
             UPDATE sekiban_mv_active WITH (UPDLOCK, HOLDLOCK)
             SET active_version = @ActiveVersion,
+                active_generation = active_generation + 1,
                 activated_at = SYSUTCDATETIME()
             WHERE service_id = @ServiceId
               AND view_name = @ViewName;
 
             IF @@ROWCOUNT = 0
             BEGIN
-                INSERT INTO sekiban_mv_active (service_id, view_name, active_version, activated_at)
-                VALUES (@ServiceId, @ViewName, @ActiveVersion, SYSUTCDATETIME());
+                INSERT INTO sekiban_mv_active (service_id, view_name, active_version, active_generation, activated_at)
+                VALUES (@ServiceId, @ViewName, @ActiveVersion, 1, SYSUTCDATETIME());
             END;
             """;
 
@@ -405,6 +445,197 @@ public sealed class SqlServerMvRegistryStore : IMvRegistryStore
         await using var localTransaction = await connection.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
         await connection.ExecuteAsync(new CommandDefinition(sql, parameters, localTransaction, cancellationToken: cancellationToken)).ConfigureAwait(false);
         await localTransaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<MvActivationResult> TryActivateAsync(
+        MvActivationRequest request,
+        IDbTransaction? transaction = null,
+        CancellationToken cancellationToken = default)
+    {
+        var validation = ValidateActivationRequest(request);
+        if (validation is not null)
+        {
+            return validation;
+        }
+
+        if (transaction is not null)
+        {
+            return await TryActivateInTransactionAsync(transaction, request, cancellationToken).ConfigureAwait(false);
+        }
+
+        await using var connection = new SqlConnection(_connectionString);
+        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+        await using var localTransaction = await connection.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
+        var result = await TryActivateInTransactionAsync(localTransaction, request, cancellationToken).ConfigureAwait(false);
+        if (!result.Succeeded)
+        {
+            await localTransaction.RollbackAsync(cancellationToken).ConfigureAwait(false);
+            return result;
+        }
+
+        await localTransaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+        return result;
+    }
+
+    private async Task<MvActivationResult> TryActivateInTransactionAsync(
+        IDbTransaction transaction,
+        MvActivationRequest request,
+        CancellationToken cancellationToken)
+    {
+        const string sql = """
+            SET NOCOUNT ON;
+            DECLARE @changed INT = 0;
+
+            UPDATE sekiban_mv_active WITH (UPDLOCK, HOLDLOCK)
+            SET active_version = @ViewVersion,
+                active_generation = active_generation + 1,
+                activated_at = SYSUTCDATETIME()
+            WHERE service_id = @ServiceId
+              AND view_name = @ViewName
+              AND active_version = @ExpectedActiveVersion
+              AND active_generation = @ExpectedActiveGeneration
+              AND (
+                    SELECT COUNT(*)
+                    FROM sekiban_mv_registry
+                    WHERE service_id = @ServiceId
+                      AND view_name = @ViewName
+                      AND view_version = @ViewVersion
+                  ) = @CandidateCount
+              AND NOT EXISTS (
+                    SELECT 1
+                    FROM sekiban_mv_registry
+                    WHERE service_id = @ServiceId
+                      AND view_name = @ViewName
+                      AND view_version = @ViewVersion
+                      AND (
+                            status <> @ExpectedStatus
+                         OR current_checkpoint_truth <> @ExpectedCurrentCheckpointTruth
+                         OR target_checkpoint_truth <> @ExpectedTargetCheckpointTruth
+                      )
+                  );
+            IF @@ROWCOUNT = 1
+                SET @changed = 1;
+
+            IF @changed = 0
+               AND @ExpectedActiveVersion IS NULL
+               AND @ExpectedActiveGeneration = 0
+               AND NOT EXISTS (
+                    SELECT 1
+                    FROM sekiban_mv_active WITH (UPDLOCK, HOLDLOCK)
+                    WHERE service_id = @ServiceId
+                      AND view_name = @ViewName
+               )
+               AND (
+                    SELECT COUNT(*)
+                    FROM sekiban_mv_registry
+                    WHERE service_id = @ServiceId
+                      AND view_name = @ViewName
+                      AND view_version = @ViewVersion
+                   ) = @CandidateCount
+               AND NOT EXISTS (
+                    SELECT 1
+                    FROM sekiban_mv_registry
+                    WHERE service_id = @ServiceId
+                      AND view_name = @ViewName
+                      AND view_version = @ViewVersion
+                      AND (
+                            status <> @ExpectedStatus
+                         OR current_checkpoint_truth <> @ExpectedCurrentCheckpointTruth
+                         OR target_checkpoint_truth <> @ExpectedTargetCheckpointTruth
+                      )
+               )
+            BEGIN
+                INSERT INTO sekiban_mv_active (
+                    service_id, view_name, active_version, active_generation, activated_at)
+                VALUES (@ServiceId, @ViewName, @ViewVersion, 1, SYSUTCDATETIME());
+                IF @@ROWCOUNT = 1
+                    SET @changed = 1;
+            END;
+
+            SELECT @changed;
+            """;
+        var parameters = new
+        {
+            request.ServiceId,
+            request.ViewName,
+            request.ViewVersion,
+            request.ExpectedActiveVersion,
+            request.ExpectedActiveGeneration,
+            request.CandidateCount,
+            ExpectedStatus = request.ExpectedStatus.ToString().ToLowerInvariant(),
+            request.ExpectedCurrentCheckpointTruth,
+            request.ExpectedTargetCheckpointTruth
+        };
+        var affected = await transaction.Connection!.ExecuteScalarAsync<int>(
+                new CommandDefinition(sql, parameters, transaction, cancellationToken: cancellationToken))
+            .ConfigureAwait(false);
+        if (affected == 0)
+        {
+            return MvActivationResult.Rejected(
+                MvActivationFailureReason.ConcurrentSuperseded,
+                "The expected active pointer, generation, or candidate snapshot changed before activation.");
+        }
+
+        const string markActiveSql = """
+            UPDATE sekiban_mv_registry
+            SET status = 'active', last_updated = SYSUTCDATETIME()
+            WHERE service_id = @ServiceId
+              AND view_name = @ViewName
+              AND view_version = @ViewVersion
+              AND status = @ExpectedStatus
+              AND current_checkpoint_truth = @ExpectedCurrentCheckpointTruth
+              AND target_checkpoint_truth = @ExpectedTargetCheckpointTruth;
+            """;
+        await transaction.Connection!.ExecuteAsync(
+                new CommandDefinition(markActiveSql, parameters, transaction, cancellationToken: cancellationToken))
+            .ConfigureAwait(false);
+        return MvActivationResult.Success(request.ExpectedActiveGeneration + 1);
+    }
+
+    private static MvActivationResult? ValidateActivationRequest(MvActivationRequest request)
+    {
+        if (request.ExpectedActiveGeneration < 0)
+        {
+            return MvActivationResult.Rejected(
+                MvActivationFailureReason.ExpectedGenerationConflict,
+                "The expected active generation cannot be negative.");
+        }
+
+        if (request.CandidateCount <= 0 || request.ExpectedStatus != MvStatus.Ready)
+        {
+            return MvActivationResult.Rejected(MvActivationFailureReason.UnsafeLifecycle, "Atomic activation accepts only a non-empty Ready candidate snapshot.");
+        }
+
+        try
+        {
+            var current = MvCheckpointTruthCodec.Decode(request.ExpectedCurrentCheckpointTruth);
+            var target = MvCheckpointTruthCodec.Decode(request.ExpectedTargetCheckpointTruth);
+            if (!current.IsKnown)
+            {
+                return MvActivationResult.Rejected(MvActivationFailureReason.CurrentCheckpointUnknown, "Atomic activation requires Known current checkpoint truth.");
+            }
+
+            if (current.Provenance is null || current.Provenance.Kind == MvCheckpointProvenanceKind.LegacyCompatibility)
+            {
+                return MvActivationResult.Rejected(MvActivationFailureReason.MissingProvenance, "Atomic activation requires non-legacy current checkpoint provenance.");
+            }
+
+            if (!target.IsKnown || target.Provenance?.Kind != MvCheckpointProvenanceKind.AuthoritativeTargetCapture)
+            {
+                return MvActivationResult.Rejected(MvActivationFailureReason.TargetUnknown, "Atomic activation requires an authoritative Known target checkpoint.");
+            }
+
+            if (!current.Satisfies(target))
+            {
+                return MvActivationResult.Rejected(MvActivationFailureReason.BehindTarget, "Atomic activation requires the current checkpoint to satisfy the target.");
+            }
+        }
+        catch (MvCheckpointMalformedException ex)
+        {
+            return MvActivationResult.Rejected(MvActivationFailureReason.ProviderFailure, ex.Message);
+        }
+
+        return null;
     }
 
     private async Task ExecuteAsync(
@@ -459,7 +690,10 @@ public sealed class SqlServerMvRegistryStore : IMvRegistryStore
             ReadRequiredString(row, "ServiceId"),
             ReadRequiredString(row, "ViewName"),
             ReadRequiredInt(row, "ActiveVersion"),
-            ReadRequiredDateTimeOffset(row, "ActivatedAt"));
+            ReadRequiredDateTimeOffset(row, "ActivatedAt"))
+        {
+            Generation = ReadRequiredLong(row, "Generation")
+        };
 
     private static IReadOnlyDictionary<string, object?> ToDictionary(object row)
     {

--- a/dcb/src/Sekiban.Dcb.MaterializedView.SqlServer/SqlServerMvRegistryStore.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.SqlServer/SqlServerMvRegistryStore.cs
@@ -460,7 +460,7 @@ public sealed class SqlServerMvRegistryStore : IMvRegistryStore
 
         if (transaction is not null)
         {
-            return await TryActivateInTransactionAsync(transaction, request, cancellationToken).ConfigureAwait(false);
+            return await TryActivateWithSavepointAsync(transaction, request, cancellationToken).ConfigureAwait(false);
         }
 
         await using var connection = new SqlConnection(_connectionString);
@@ -482,77 +482,23 @@ public sealed class SqlServerMvRegistryStore : IMvRegistryStore
         MvActivationRequest request,
         CancellationToken cancellationToken)
     {
-        const string sql = """
-            SET NOCOUNT ON;
-            DECLARE @changed INT = 0;
-
-            UPDATE sekiban_mv_active WITH (UPDLOCK, HOLDLOCK)
-            SET active_version = @ViewVersion,
-                active_generation = active_generation + 1,
-                activated_at = SYSUTCDATETIME()
+        const string lockCandidatesSql = """
+            SELECT logical_table
+            FROM sekiban_mv_registry WITH (UPDLOCK, HOLDLOCK)
             WHERE service_id = @ServiceId
               AND view_name = @ViewName
-              AND active_version = @ExpectedActiveVersion
-              AND active_generation = @ExpectedActiveGeneration
-              AND (
-                    SELECT COUNT(*)
-                    FROM sekiban_mv_registry
-                    WHERE service_id = @ServiceId
-                      AND view_name = @ViewName
-                      AND view_version = @ViewVersion
-                  ) = @CandidateCount
-              AND NOT EXISTS (
-                    SELECT 1
-                    FROM sekiban_mv_registry
-                    WHERE service_id = @ServiceId
-                      AND view_name = @ViewName
-                      AND view_version = @ViewVersion
-                      AND (
-                            status <> @ExpectedStatus
-                         OR current_checkpoint_truth <> @ExpectedCurrentCheckpointTruth
-                         OR target_checkpoint_truth <> @ExpectedTargetCheckpointTruth
-                      )
-                  );
-            IF @@ROWCOUNT = 1
-                SET @changed = 1;
-
-            IF @changed = 0
-               AND @ExpectedActiveVersion IS NULL
-               AND @ExpectedActiveGeneration = 0
-               AND NOT EXISTS (
-                    SELECT 1
-                    FROM sekiban_mv_active WITH (UPDLOCK, HOLDLOCK)
-                    WHERE service_id = @ServiceId
-                      AND view_name = @ViewName
-               )
-               AND (
-                    SELECT COUNT(*)
-                    FROM sekiban_mv_registry
-                    WHERE service_id = @ServiceId
-                      AND view_name = @ViewName
-                      AND view_version = @ViewVersion
-                   ) = @CandidateCount
-               AND NOT EXISTS (
-                    SELECT 1
-                    FROM sekiban_mv_registry
-                    WHERE service_id = @ServiceId
-                      AND view_name = @ViewName
-                      AND view_version = @ViewVersion
-                      AND (
-                            status <> @ExpectedStatus
-                         OR current_checkpoint_truth <> @ExpectedCurrentCheckpointTruth
-                         OR target_checkpoint_truth <> @ExpectedTargetCheckpointTruth
-                      )
-               )
-            BEGIN
-                INSERT INTO sekiban_mv_active (
-                    service_id, view_name, active_version, active_generation, activated_at)
-                VALUES (@ServiceId, @ViewName, @ViewVersion, 1, SYSUTCDATETIME());
-                IF @@ROWCOUNT = 1
-                    SET @changed = 1;
-            END;
-
-            SELECT @changed;
+              AND view_version = @ViewVersion
+            ORDER BY logical_table;
+            """;
+        const string matchingCandidatesSql = """
+            SELECT COUNT(*)
+            FROM sekiban_mv_registry
+            WHERE service_id = @ServiceId
+              AND view_name = @ViewName
+              AND view_version = @ViewVersion
+              AND status = @ExpectedStatus
+              AND current_checkpoint_truth = @ExpectedCurrentCheckpointTruth
+              AND target_checkpoint_truth = @ExpectedTargetCheckpointTruth;
             """;
         var parameters = new
         {
@@ -566,14 +512,57 @@ public sealed class SqlServerMvRegistryStore : IMvRegistryStore
             request.ExpectedCurrentCheckpointTruth,
             request.ExpectedTargetCheckpointTruth
         };
+        var lockedCandidates = (await transaction.Connection!.QueryAsync<string>(
+                new CommandDefinition(lockCandidatesSql, parameters, transaction, cancellationToken: cancellationToken))
+            .ConfigureAwait(false)).AsList();
+        var matchingCandidates = await transaction.Connection!.ExecuteScalarAsync<int>(
+                new CommandDefinition(matchingCandidatesSql, parameters, transaction, cancellationToken: cancellationToken))
+            .ConfigureAwait(false);
+        if (lockedCandidates.Count != request.CandidateCount || matchingCandidates != request.CandidateCount)
+        {
+            return CandidateSnapshotChanged();
+        }
+
+        const string sql = """
+            SET NOCOUNT ON;
+            DECLARE @changed INT = 0;
+
+            UPDATE sekiban_mv_active WITH (UPDLOCK, HOLDLOCK)
+            SET active_version = @ViewVersion,
+                active_generation = active_generation + 1,
+                activated_at = SYSUTCDATETIME()
+            WHERE service_id = @ServiceId
+              AND view_name = @ViewName
+              AND active_version = @ExpectedActiveVersion
+              AND active_generation = @ExpectedActiveGeneration;
+            IF @@ROWCOUNT = 1
+                SET @changed = 1;
+
+            IF @changed = 0
+               AND @ExpectedActiveVersion IS NULL
+               AND @ExpectedActiveGeneration = 0
+               AND NOT EXISTS (
+                    SELECT 1
+                    FROM sekiban_mv_active WITH (UPDLOCK, HOLDLOCK)
+                    WHERE service_id = @ServiceId
+                      AND view_name = @ViewName
+               )
+            BEGIN
+                INSERT INTO sekiban_mv_active (
+                    service_id, view_name, active_version, active_generation, activated_at)
+                VALUES (@ServiceId, @ViewName, @ViewVersion, 1, SYSUTCDATETIME());
+                IF @@ROWCOUNT = 1
+                    SET @changed = 1;
+            END;
+
+            SELECT @changed;
+            """;
         var affected = await transaction.Connection!.ExecuteScalarAsync<int>(
                 new CommandDefinition(sql, parameters, transaction, cancellationToken: cancellationToken))
             .ConfigureAwait(false);
         if (affected == 0)
         {
-            return MvActivationResult.Rejected(
-                MvActivationFailureReason.ConcurrentSuperseded,
-                "The expected active pointer, generation, or candidate snapshot changed before activation.");
+            return CandidateSnapshotChanged();
         }
 
         const string markActiveSql = """
@@ -586,11 +575,50 @@ public sealed class SqlServerMvRegistryStore : IMvRegistryStore
               AND current_checkpoint_truth = @ExpectedCurrentCheckpointTruth
               AND target_checkpoint_truth = @ExpectedTargetCheckpointTruth;
             """;
-        await transaction.Connection!.ExecuteAsync(
+        var marked = await transaction.Connection!.ExecuteAsync(
                 new CommandDefinition(markActiveSql, parameters, transaction, cancellationToken: cancellationToken))
             .ConfigureAwait(false);
+        if (marked != request.CandidateCount)
+        {
+            return CandidateSnapshotChanged();
+        }
+
         return MvActivationResult.Success(request.ExpectedActiveGeneration + 1);
     }
+
+    private async Task<MvActivationResult> TryActivateWithSavepointAsync(
+        IDbTransaction transaction,
+        MvActivationRequest request,
+        CancellationToken cancellationToken)
+    {
+        const string createSavepointSql = "SAVE TRANSACTION sekiban_mv_activation;";
+        const string rollbackSavepointSql = "ROLLBACK TRANSACTION sekiban_mv_activation;";
+        var connection = transaction.Connection ?? throw new InvalidOperationException("The transaction is not associated with a connection.");
+        await connection.ExecuteAsync(
+            new CommandDefinition(createSavepointSql, transaction: transaction, cancellationToken: cancellationToken)).ConfigureAwait(false);
+        try
+        {
+            var result = await TryActivateInTransactionAsync(transaction, request, cancellationToken).ConfigureAwait(false);
+            if (!result.Succeeded)
+            {
+                await connection.ExecuteAsync(
+                    new CommandDefinition(rollbackSavepointSql, transaction: transaction, cancellationToken: cancellationToken)).ConfigureAwait(false);
+            }
+
+            return result;
+        }
+        catch
+        {
+            await connection.ExecuteAsync(
+                new CommandDefinition(rollbackSavepointSql, transaction: transaction, cancellationToken: cancellationToken)).ConfigureAwait(false);
+            throw;
+        }
+    }
+
+    private static MvActivationResult CandidateSnapshotChanged() =>
+        MvActivationResult.Rejected(
+            MvActivationFailureReason.ConcurrentSuperseded,
+            "The expected active pointer, generation, or candidate snapshot changed before activation.");
 
     private static MvActivationResult? ValidateActivationRequest(MvActivationRequest request)
     {

--- a/dcb/src/Sekiban.Dcb.MaterializedView.Sqlite/SqliteMvExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.Sqlite/SqliteMvExecutor.cs
@@ -53,11 +53,16 @@ public sealed class SqliteMvExecutor : MvExecutorBase<SqliteConnection>, IMvExec
         return await CatchUpFromStoreAsync(
                 host,
                 exactServiceId,
-                _eventStoreFactory is null ? _legacyEventStore : _eventStoreFactory!.CreateForService(exactServiceId),
+                SelectEventStoreForService(exactServiceId),
                 _eventStoreFactory is not null,
                 cancellationToken)
             .ConfigureAwait(false);
     }
+
+    protected override IEventStore SelectEventStoreForService(string exactServiceId) =>
+        _eventStoreFactory is not null
+            ? _eventStoreFactory.CreateForService(exactServiceId)
+            : _legacyEventStore!;
 
     protected override async Task<SqliteConnection> OpenConnectionAsync(CancellationToken cancellationToken)
     {

--- a/dcb/src/Sekiban.Dcb.MaterializedView.Sqlite/SqliteMvRegistryStore.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.Sqlite/SqliteMvRegistryStore.cs
@@ -54,6 +54,7 @@ public sealed class SqliteMvRegistryStore : IMvRegistryStore
                 service_id TEXT NOT NULL,
                 view_name TEXT NOT NULL,
                 active_version INTEGER NOT NULL,
+                active_generation INTEGER NOT NULL DEFAULT 0,
                 activated_at TEXT NOT NULL,
                 PRIMARY KEY (service_id, view_name)
             );
@@ -63,6 +64,7 @@ public sealed class SqliteMvRegistryStore : IMvRegistryStore
         await connection.ExecuteAsync(new CommandDefinition(registrySql, cancellationToken: cancellationToken)).ConfigureAwait(false);
         await EnsureCheckpointColumnsAsync(connection, cancellationToken).ConfigureAwait(false);
         await connection.ExecuteAsync(new CommandDefinition(activeSql, cancellationToken: cancellationToken)).ConfigureAwait(false);
+        await EnsureActiveGenerationColumnAsync(connection, cancellationToken).ConfigureAwait(false);
     }
 
     private static async Task EnsureCheckpointColumnsAsync(
@@ -89,6 +91,26 @@ public sealed class SqliteMvRegistryStore : IMvRegistryStore
             await connection.ExecuteAsync(
                     new CommandDefinition(
                         "ALTER TABLE sekiban_mv_registry ADD COLUMN target_checkpoint_truth TEXT NULL;",
+                        cancellationToken: cancellationToken))
+                .ConfigureAwait(false);
+        }
+    }
+
+    private static async Task EnsureActiveGenerationColumnAsync(
+        SqliteConnection connection,
+        CancellationToken cancellationToken)
+    {
+        var existingColumns = (await connection.QueryAsync<SqliteColumnInfo>(
+                new CommandDefinition("PRAGMA table_info('sekiban_mv_active');", cancellationToken: cancellationToken))
+            .ConfigureAwait(false))
+            .Select(column => column.Name)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        if (!existingColumns.Contains("active_generation"))
+        {
+            await connection.ExecuteAsync(
+                    new CommandDefinition(
+                        "ALTER TABLE sekiban_mv_active ADD COLUMN active_generation INTEGER NOT NULL DEFAULT 0;",
                         cancellationToken: cancellationToken))
                 .ConfigureAwait(false);
         }
@@ -330,6 +352,40 @@ public sealed class SqliteMvRegistryStore : IMvRegistryStore
             cancellationToken).ConfigureAwait(false);
     }
 
+    public async Task SetTargetCheckpointAsync(
+        string serviceId,
+        string viewName,
+        int viewVersion,
+        MvCheckpointTruth targetCheckpointTruth,
+        IDbTransaction? transaction = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(targetCheckpointTruth);
+        const string sql = """
+            UPDATE sekiban_mv_registry
+            SET target_position = @TargetPosition,
+                target_checkpoint_truth = @TargetCheckpointTruth,
+                last_updated = @Now
+            WHERE service_id = @ServiceId
+              AND view_name = @ViewName
+              AND view_version = @ViewVersion;
+            """;
+
+        await ExecuteAsync(
+            sql,
+            new
+            {
+                ServiceId = serviceId,
+                ViewName = viewName,
+                ViewVersion = viewVersion,
+                TargetPosition = targetCheckpointTruth.PositionValue,
+                TargetCheckpointTruth = MvCheckpointTruthCodec.Encode(targetCheckpointTruth),
+                Now = SerializeDate(DateTimeOffset.UtcNow)
+            },
+            transaction,
+            cancellationToken).ConfigureAwait(false);
+    }
+
     public async Task<IReadOnlyList<MvRegistryEntry>> GetEntriesAsync(
         string serviceId,
         string viewName,
@@ -381,6 +437,7 @@ public sealed class SqliteMvRegistryStore : IMvRegistryStore
             SELECT service_id AS ServiceId,
                    view_name AS ViewName,
                    active_version AS ActiveVersion,
+                   active_generation AS Generation,
                    activated_at AS ActivatedAt
             FROM sekiban_mv_active
             WHERE service_id = @ServiceId
@@ -403,10 +460,11 @@ public sealed class SqliteMvRegistryStore : IMvRegistryStore
         CancellationToken cancellationToken = default)
     {
         const string sql = """
-            INSERT INTO sekiban_mv_active (service_id, view_name, active_version, activated_at)
-            VALUES (@ServiceId, @ViewName, @ActiveVersion, @ActivatedAt)
+            INSERT INTO sekiban_mv_active (service_id, view_name, active_version, active_generation, activated_at)
+            VALUES (@ServiceId, @ViewName, @ActiveVersion, 1, @ActivatedAt)
             ON CONFLICT (service_id, view_name) DO UPDATE SET
                 active_version = excluded.active_version,
+                active_generation = sekiban_mv_active.active_generation + 1,
                 activated_at = excluded.activated_at;
             """;
 
@@ -421,6 +479,221 @@ public sealed class SqliteMvRegistryStore : IMvRegistryStore
             },
             transaction,
             cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<MvActivationResult> TryActivateAsync(
+        MvActivationRequest request,
+        IDbTransaction? transaction = null,
+        CancellationToken cancellationToken = default)
+    {
+        var validation = ValidateActivationRequest(request);
+        if (validation is not null)
+        {
+            return validation;
+        }
+
+        if (transaction is not null)
+        {
+            return await TryActivateInTransactionAsync(transaction, request, cancellationToken).ConfigureAwait(false);
+        }
+
+        await using var connection = new SqliteConnection(_connectionString);
+        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+        await using var localTransaction = await connection.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
+        var result = await TryActivateInTransactionAsync(localTransaction, request, cancellationToken).ConfigureAwait(false);
+        if (!result.Succeeded)
+        {
+            await localTransaction.RollbackAsync(cancellationToken).ConfigureAwait(false);
+            return result;
+        }
+
+        await localTransaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+        return result;
+    }
+
+    private async Task<MvActivationResult> TryActivateInTransactionAsync(
+        IDbTransaction transaction,
+        MvActivationRequest request,
+        CancellationToken cancellationToken)
+    {
+        const string insertSql = """
+            INSERT INTO sekiban_mv_active (
+                service_id,
+                view_name,
+                active_version,
+                active_generation,
+                activated_at)
+            SELECT
+                @ServiceId,
+                @ViewName,
+                @ViewVersion,
+                1,
+                @ActivatedAt
+            WHERE @ExpectedActiveVersion IS NULL
+              AND @ExpectedActiveGeneration = 0
+              AND (
+                    SELECT COUNT(*)
+                    FROM sekiban_mv_registry
+                    WHERE service_id = @ServiceId
+                      AND view_name = @ViewName
+                      AND view_version = @ViewVersion
+                  ) = @CandidateCount
+              AND NOT EXISTS (
+                    SELECT 1
+                    FROM sekiban_mv_registry
+                    WHERE service_id = @ServiceId
+                      AND view_name = @ViewName
+                      AND view_version = @ViewVersion
+                      AND (
+                            status <> @ExpectedStatus
+                         OR current_checkpoint_truth <> @ExpectedCurrentCheckpointTruth
+                         OR target_checkpoint_truth <> @ExpectedTargetCheckpointTruth
+                      )
+                  )
+            ON CONFLICT (service_id, view_name) DO NOTHING;
+            """;
+
+        const string updateSql = """
+            UPDATE sekiban_mv_active
+            SET active_version = @ViewVersion,
+                active_generation = active_generation + 1,
+                activated_at = @ActivatedAt
+            WHERE service_id = @ServiceId
+              AND view_name = @ViewName
+              AND active_version = @ExpectedActiveVersion
+              AND active_generation = @ExpectedActiveGeneration
+              AND (
+                    SELECT COUNT(*)
+                    FROM sekiban_mv_registry
+                    WHERE service_id = @ServiceId
+                      AND view_name = @ViewName
+                      AND view_version = @ViewVersion
+                  ) = @CandidateCount
+              AND NOT EXISTS (
+                    SELECT 1
+                    FROM sekiban_mv_registry
+                    WHERE service_id = @ServiceId
+                      AND view_name = @ViewName
+                      AND view_version = @ViewVersion
+                      AND (
+                            status <> @ExpectedStatus
+                         OR current_checkpoint_truth <> @ExpectedCurrentCheckpointTruth
+                         OR target_checkpoint_truth <> @ExpectedTargetCheckpointTruth
+                      )
+                  );
+            """;
+
+        var parameters = new
+        {
+            request.ServiceId,
+            request.ViewName,
+            request.ViewVersion,
+            request.ExpectedActiveVersion,
+            request.ExpectedActiveGeneration,
+            request.CandidateCount,
+            ExpectedStatus = request.ExpectedStatus.ToString().ToLowerInvariant(),
+            request.ExpectedCurrentCheckpointTruth,
+            request.ExpectedTargetCheckpointTruth,
+            ActivatedAt = SerializeDate(DateTimeOffset.UtcNow)
+        };
+        var affected = request.ExpectedActiveVersion is null
+            ? await transaction.Connection!.ExecuteAsync(
+                new CommandDefinition(insertSql, parameters, transaction, cancellationToken: cancellationToken)).ConfigureAwait(false)
+            : await transaction.Connection!.ExecuteAsync(
+                new CommandDefinition(updateSql, parameters, transaction, cancellationToken: cancellationToken)).ConfigureAwait(false);
+
+        if (affected == 0)
+        {
+            return MvActivationResult.Rejected(
+                MvActivationFailureReason.ConcurrentSuperseded,
+                "The expected active pointer, generation, or candidate snapshot changed before activation.");
+        }
+
+        const string markActiveSql = """
+            UPDATE sekiban_mv_registry
+            SET status = 'active',
+                last_updated = @Now
+            WHERE service_id = @ServiceId
+              AND view_name = @ViewName
+              AND view_version = @ViewVersion
+              AND status = @ExpectedStatus
+              AND current_checkpoint_truth = @ExpectedCurrentCheckpointTruth
+              AND target_checkpoint_truth = @ExpectedTargetCheckpointTruth;
+            """;
+        await transaction.Connection!.ExecuteAsync(
+                new CommandDefinition(
+                    markActiveSql,
+                    new
+                    {
+                        request.ServiceId,
+                        request.ViewName,
+                        request.ViewVersion,
+                        ExpectedStatus = request.ExpectedStatus.ToString().ToLowerInvariant(),
+                        request.ExpectedCurrentCheckpointTruth,
+                        request.ExpectedTargetCheckpointTruth,
+                        Now = SerializeDate(DateTimeOffset.UtcNow)
+                    },
+                    transaction,
+                    cancellationToken: cancellationToken))
+            .ConfigureAwait(false);
+
+        return MvActivationResult.Success(request.ExpectedActiveGeneration + 1);
+    }
+
+    private static MvActivationResult? ValidateActivationRequest(MvActivationRequest request)
+    {
+        if (request.ExpectedActiveGeneration < 0)
+        {
+            return MvActivationResult.Rejected(
+                MvActivationFailureReason.ExpectedGenerationConflict,
+                "The expected active generation cannot be negative.");
+        }
+
+        if (request.CandidateCount <= 0 || request.ExpectedStatus != MvStatus.Ready)
+        {
+            return MvActivationResult.Rejected(
+                MvActivationFailureReason.UnsafeLifecycle,
+                "Atomic activation accepts only a non-empty Ready candidate snapshot.");
+        }
+
+        try
+        {
+            var current = MvCheckpointTruthCodec.Decode(request.ExpectedCurrentCheckpointTruth);
+            var target = MvCheckpointTruthCodec.Decode(request.ExpectedTargetCheckpointTruth);
+            if (!current.IsKnown)
+            {
+                return MvActivationResult.Rejected(
+                    MvActivationFailureReason.CurrentCheckpointUnknown,
+                    "Atomic activation requires Known current checkpoint truth.");
+            }
+
+            if (current.Provenance is null || current.Provenance.Kind == MvCheckpointProvenanceKind.LegacyCompatibility)
+            {
+                return MvActivationResult.Rejected(
+                    MvActivationFailureReason.MissingProvenance,
+                    "Atomic activation requires non-legacy current checkpoint provenance.");
+            }
+
+            if (!target.IsKnown || target.Provenance?.Kind != MvCheckpointProvenanceKind.AuthoritativeTargetCapture)
+            {
+                return MvActivationResult.Rejected(
+                    MvActivationFailureReason.TargetUnknown,
+                    "Atomic activation requires an authoritative Known target checkpoint.");
+            }
+
+            if (!current.Satisfies(target))
+            {
+                return MvActivationResult.Rejected(
+                    MvActivationFailureReason.BehindTarget,
+                    "Atomic activation requires the current checkpoint to satisfy the target.");
+            }
+        }
+        catch (MvCheckpointMalformedException ex)
+        {
+            return MvActivationResult.Rejected(MvActivationFailureReason.ProviderFailure, ex.Message);
+        }
+
+        return null;
     }
 
     private async Task ExecuteAsync(
@@ -475,7 +748,10 @@ public sealed class SqliteMvRegistryStore : IMvRegistryStore
             ReadRequiredString(row, "ServiceId"),
             ReadRequiredString(row, "ViewName"),
             ReadRequiredInt(row, "ActiveVersion"),
-            ReadRequiredDateTimeOffset(row, "ActivatedAt"));
+            ReadRequiredDateTimeOffset(row, "ActivatedAt"))
+        {
+            Generation = ReadRequiredLong(row, "Generation")
+        };
 
     private sealed class SqliteColumnInfo
     {

--- a/dcb/src/Sekiban.Dcb.MaterializedView.Sqlite/SqliteMvRegistryStore.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.Sqlite/SqliteMvRegistryStore.cs
@@ -494,7 +494,7 @@ public sealed class SqliteMvRegistryStore : IMvRegistryStore
 
         if (transaction is not null)
         {
-            return await TryActivateInTransactionAsync(transaction, request, cancellationToken).ConfigureAwait(false);
+            return await TryActivateWithSavepointAsync(transaction, request, cancellationToken).ConfigureAwait(false);
         }
 
         await using var connection = new SqliteConnection(_connectionString);
@@ -516,6 +516,47 @@ public sealed class SqliteMvRegistryStore : IMvRegistryStore
         MvActivationRequest request,
         CancellationToken cancellationToken)
     {
+        const string fenceCandidatesSql = """
+            UPDATE sekiban_mv_registry
+            SET last_updated = last_updated
+            WHERE service_id = @ServiceId
+              AND view_name = @ViewName
+              AND view_version = @ViewVersion;
+            """;
+        const string matchingCandidatesSql = """
+            SELECT COUNT(*)
+            FROM sekiban_mv_registry
+            WHERE service_id = @ServiceId
+              AND view_name = @ViewName
+              AND view_version = @ViewVersion
+              AND status = @ExpectedStatus
+              AND current_checkpoint_truth = @ExpectedCurrentCheckpointTruth
+              AND target_checkpoint_truth = @ExpectedTargetCheckpointTruth;
+            """;
+        var parameters = new
+        {
+            request.ServiceId,
+            request.ViewName,
+            request.ViewVersion,
+            request.ExpectedActiveVersion,
+            request.ExpectedActiveGeneration,
+            request.CandidateCount,
+            ExpectedStatus = request.ExpectedStatus.ToString().ToLowerInvariant(),
+            request.ExpectedCurrentCheckpointTruth,
+            request.ExpectedTargetCheckpointTruth,
+            ActivatedAt = SerializeDate(DateTimeOffset.UtcNow)
+        };
+        var fencedCandidates = await transaction.Connection!.ExecuteAsync(
+                new CommandDefinition(fenceCandidatesSql, parameters, transaction, cancellationToken: cancellationToken))
+            .ConfigureAwait(false);
+        var matchingCandidates = await transaction.Connection!.ExecuteScalarAsync<int>(
+                new CommandDefinition(matchingCandidatesSql, parameters, transaction, cancellationToken: cancellationToken))
+            .ConfigureAwait(false);
+        if (fencedCandidates != request.CandidateCount || matchingCandidates != request.CandidateCount)
+        {
+            return CandidateSnapshotChanged();
+        }
+
         const string insertSql = """
             INSERT INTO sekiban_mv_active (
                 service_id,
@@ -531,25 +572,6 @@ public sealed class SqliteMvRegistryStore : IMvRegistryStore
                 @ActivatedAt
             WHERE @ExpectedActiveVersion IS NULL
               AND @ExpectedActiveGeneration = 0
-              AND (
-                    SELECT COUNT(*)
-                    FROM sekiban_mv_registry
-                    WHERE service_id = @ServiceId
-                      AND view_name = @ViewName
-                      AND view_version = @ViewVersion
-                  ) = @CandidateCount
-              AND NOT EXISTS (
-                    SELECT 1
-                    FROM sekiban_mv_registry
-                    WHERE service_id = @ServiceId
-                      AND view_name = @ViewName
-                      AND view_version = @ViewVersion
-                      AND (
-                            status <> @ExpectedStatus
-                         OR current_checkpoint_truth <> @ExpectedCurrentCheckpointTruth
-                         OR target_checkpoint_truth <> @ExpectedTargetCheckpointTruth
-                      )
-                  )
             ON CONFLICT (service_id, view_name) DO NOTHING;
             """;
 
@@ -561,41 +583,9 @@ public sealed class SqliteMvRegistryStore : IMvRegistryStore
             WHERE service_id = @ServiceId
               AND view_name = @ViewName
               AND active_version = @ExpectedActiveVersion
-              AND active_generation = @ExpectedActiveGeneration
-              AND (
-                    SELECT COUNT(*)
-                    FROM sekiban_mv_registry
-                    WHERE service_id = @ServiceId
-                      AND view_name = @ViewName
-                      AND view_version = @ViewVersion
-                  ) = @CandidateCount
-              AND NOT EXISTS (
-                    SELECT 1
-                    FROM sekiban_mv_registry
-                    WHERE service_id = @ServiceId
-                      AND view_name = @ViewName
-                      AND view_version = @ViewVersion
-                      AND (
-                            status <> @ExpectedStatus
-                         OR current_checkpoint_truth <> @ExpectedCurrentCheckpointTruth
-                         OR target_checkpoint_truth <> @ExpectedTargetCheckpointTruth
-                      )
-                  );
+              AND active_generation = @ExpectedActiveGeneration;
             """;
 
-        var parameters = new
-        {
-            request.ServiceId,
-            request.ViewName,
-            request.ViewVersion,
-            request.ExpectedActiveVersion,
-            request.ExpectedActiveGeneration,
-            request.CandidateCount,
-            ExpectedStatus = request.ExpectedStatus.ToString().ToLowerInvariant(),
-            request.ExpectedCurrentCheckpointTruth,
-            request.ExpectedTargetCheckpointTruth,
-            ActivatedAt = SerializeDate(DateTimeOffset.UtcNow)
-        };
         var affected = request.ExpectedActiveVersion is null
             ? await transaction.Connection!.ExecuteAsync(
                 new CommandDefinition(insertSql, parameters, transaction, cancellationToken: cancellationToken)).ConfigureAwait(false)
@@ -604,9 +594,7 @@ public sealed class SqliteMvRegistryStore : IMvRegistryStore
 
         if (affected == 0)
         {
-            return MvActivationResult.Rejected(
-                MvActivationFailureReason.ConcurrentSuperseded,
-                "The expected active pointer, generation, or candidate snapshot changed before activation.");
+            return CandidateSnapshotChanged();
         }
 
         const string markActiveSql = """
@@ -620,7 +608,7 @@ public sealed class SqliteMvRegistryStore : IMvRegistryStore
               AND current_checkpoint_truth = @ExpectedCurrentCheckpointTruth
               AND target_checkpoint_truth = @ExpectedTargetCheckpointTruth;
             """;
-        await transaction.Connection!.ExecuteAsync(
+        var marked = await transaction.Connection!.ExecuteAsync(
                 new CommandDefinition(
                     markActiveSql,
                     new
@@ -636,9 +624,52 @@ public sealed class SqliteMvRegistryStore : IMvRegistryStore
                     transaction,
                     cancellationToken: cancellationToken))
             .ConfigureAwait(false);
+        if (marked != request.CandidateCount)
+        {
+            return CandidateSnapshotChanged();
+        }
 
         return MvActivationResult.Success(request.ExpectedActiveGeneration + 1);
     }
+
+    private async Task<MvActivationResult> TryActivateWithSavepointAsync(
+        IDbTransaction transaction,
+        MvActivationRequest request,
+        CancellationToken cancellationToken)
+    {
+        const string createSavepointSql = "SAVEPOINT sekiban_mv_activation;";
+        const string rollbackSavepointSql = "ROLLBACK TO SAVEPOINT sekiban_mv_activation;";
+        const string releaseSavepointSql = "RELEASE SAVEPOINT sekiban_mv_activation;";
+        var connection = transaction.Connection ?? throw new InvalidOperationException("The transaction is not associated with a connection.");
+        await connection.ExecuteAsync(
+            new CommandDefinition(createSavepointSql, transaction: transaction, cancellationToken: cancellationToken)).ConfigureAwait(false);
+        try
+        {
+            var result = await TryActivateInTransactionAsync(transaction, request, cancellationToken).ConfigureAwait(false);
+            if (!result.Succeeded)
+            {
+                await connection.ExecuteAsync(
+                    new CommandDefinition(rollbackSavepointSql, transaction: transaction, cancellationToken: cancellationToken)).ConfigureAwait(false);
+            }
+
+            await connection.ExecuteAsync(
+                new CommandDefinition(releaseSavepointSql, transaction: transaction, cancellationToken: cancellationToken)).ConfigureAwait(false);
+            return result;
+        }
+        catch
+        {
+            await connection.ExecuteAsync(
+                new CommandDefinition(rollbackSavepointSql, transaction: transaction, cancellationToken: cancellationToken)).ConfigureAwait(false);
+            await connection.ExecuteAsync(
+                new CommandDefinition(releaseSavepointSql, transaction: transaction, cancellationToken: cancellationToken)).ConfigureAwait(false);
+            throw;
+        }
+    }
+
+    private static MvActivationResult CandidateSnapshotChanged() =>
+        MvActivationResult.Rejected(
+            MvActivationFailureReason.ConcurrentSuperseded,
+            "The expected active pointer, generation, or candidate snapshot changed before activation.");
 
     private static MvActivationResult? ValidateActivationRequest(MvActivationRequest request)
     {

--- a/dcb/src/Sekiban.Dcb.MaterializedView/MvActivation.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView/MvActivation.cs
@@ -94,67 +94,10 @@ public static class MvActivationEligibility
 
         foreach (var entry in entries)
         {
-            if (!string.Equals(entry.ServiceId, serviceId, StringComparison.Ordinal) ||
-                !string.Equals(entry.ViewName, viewName, StringComparison.Ordinal) ||
-                entry.ViewVersion != viewVersion)
+            var rejection = EvaluateEntry(serviceId, viewName, viewVersion, entry);
+            if (rejection is not null)
             {
-                return Reject(
-                    MvActivationFailureReason.IdentityMismatch,
-                    "The candidate registry row does not match the requested service, view, and version.");
-            }
-
-            if (entry.Status == MvStatus.Faulted)
-            {
-                return Reject(
-                    MvActivationFailureReason.Faulted,
-                    "A faulted materialized-view candidate cannot become active.");
-            }
-
-            if (entry.Status != MvStatus.Ready)
-            {
-                return Reject(
-                    MvActivationFailureReason.UnsafeLifecycle,
-                    $"The candidate lifecycle is '{entry.Status}', but only Ready candidates may become active.");
-            }
-
-            if (!entry.TargetCheckpointTruth.IsKnown)
-            {
-                return Reject(
-                    MvActivationFailureReason.TargetUnknown,
-                    "The candidate target checkpoint is Unknown.");
-            }
-
-            if (!entry.CurrentCheckpointTruth.IsKnown)
-            {
-                return Reject(
-                    MvActivationFailureReason.CurrentCheckpointUnknown,
-                    "The candidate current checkpoint is Unknown.");
-            }
-
-            if (entry.TargetCheckpointTruth.Provenance?.Kind != MvCheckpointProvenanceKind.AuthoritativeTargetCapture ||
-                entry.CurrentCheckpointTruth.Provenance is null ||
-                entry.CurrentCheckpointTruth.Provenance.Kind == MvCheckpointProvenanceKind.LegacyCompatibility)
-            {
-                return Reject(
-                    MvActivationFailureReason.MissingProvenance,
-                    "Activation requires authoritative target provenance and non-legacy current provenance.");
-            }
-
-            if ((entry.CurrentPosition is not null &&
-                 !string.Equals(entry.CurrentPosition, entry.CurrentCheckpointTruth.PositionValue, StringComparison.Ordinal)) ||
-                (entry.TargetPosition is not null &&
-                 !string.Equals(entry.TargetPosition, entry.TargetCheckpointTruth.PositionValue, StringComparison.Ordinal)))
-            {
-                return Reject(
-                    MvActivationFailureReason.CandidateStateMismatch,
-                    "Legacy position fields disagree with typed checkpoint truth.");
-            }
-
-            if (!entry.CurrentCheckpointTruth.Satisfies(entry.TargetCheckpointTruth))
-            {
-                return Reject(
-                    MvActivationFailureReason.BehindTarget,
-                    "The candidate current checkpoint is behind its captured target.");
+                return (rejection, null);
             }
         }
 
@@ -170,20 +113,10 @@ public static class MvActivationEligibility
                 "Materialized-view registry rows do not share one checkpoint snapshot.");
         }
 
-        if (active is not null &&
-            (!string.Equals(active.ServiceId, serviceId, StringComparison.Ordinal) ||
-             !string.Equals(active.ViewName, viewName, StringComparison.Ordinal)))
+        var activeRejection = EvaluateActivePointer(serviceId, viewName, viewVersion, active);
+        if (activeRejection is not null)
         {
-            return Reject(
-                MvActivationFailureReason.IdentityMismatch,
-                "The active pointer identity does not match the requested service and view.");
-        }
-
-        if (active is not null && active.ActiveVersion == viewVersion)
-        {
-            return Reject(
-                MvActivationFailureReason.AlreadyActive,
-                "The candidate version is already active.");
+            return (activeRejection, null);
         }
 
         var request = new MvActivationRequest(
@@ -197,6 +130,120 @@ public static class MvActivationEligibility
             expectedCurrentTruth,
             expectedTargetTruth);
         return (MvActivationEligibilityResult.Eligible(), request);
+    }
+
+    private static MvActivationEligibilityResult? EvaluateEntry(
+        string serviceId,
+        string viewName,
+        int viewVersion,
+        MvRegistryEntry entry) =>
+        EvaluateEntryIdentity(serviceId, viewName, viewVersion, entry) ??
+        EvaluateEntryLifecycle(entry) ??
+        EvaluateEntryTruth(entry) ??
+        EvaluateEntryPositionConsistency(entry) ??
+        EvaluateEntryOrdering(entry);
+
+    private static MvActivationEligibilityResult? EvaluateEntryIdentity(
+        string serviceId,
+        string viewName,
+        int viewVersion,
+        MvRegistryEntry entry) =>
+        string.Equals(entry.ServiceId, serviceId, StringComparison.Ordinal) &&
+        string.Equals(entry.ViewName, viewName, StringComparison.Ordinal) &&
+        entry.ViewVersion == viewVersion
+            ? null
+            : MvActivationEligibilityResult.Rejected(
+                MvActivationFailureReason.IdentityMismatch,
+                "The candidate registry row does not match the requested service, view, and version.");
+
+    private static MvActivationEligibilityResult? EvaluateEntryLifecycle(MvRegistryEntry entry)
+    {
+        if (entry.Status == MvStatus.Faulted)
+        {
+            return MvActivationEligibilityResult.Rejected(
+                MvActivationFailureReason.Faulted,
+                "A faulted materialized-view candidate cannot become active.");
+        }
+
+        return entry.Status == MvStatus.Ready
+            ? null
+            : MvActivationEligibilityResult.Rejected(
+                MvActivationFailureReason.UnsafeLifecycle,
+                $"The candidate lifecycle is '{entry.Status}', but only Ready candidates may become active.");
+    }
+
+    private static MvActivationEligibilityResult? EvaluateEntryTruth(MvRegistryEntry entry)
+    {
+        if (!entry.TargetCheckpointTruth.IsKnown)
+        {
+            return MvActivationEligibilityResult.Rejected(
+                MvActivationFailureReason.TargetUnknown,
+                "The candidate target checkpoint is Unknown.");
+        }
+
+        if (!entry.CurrentCheckpointTruth.IsKnown)
+        {
+            return MvActivationEligibilityResult.Rejected(
+                MvActivationFailureReason.CurrentCheckpointUnknown,
+                "The candidate current checkpoint is Unknown.");
+        }
+
+        return HasActivationProvenance(entry)
+            ? null
+            : MvActivationEligibilityResult.Rejected(
+                MvActivationFailureReason.MissingProvenance,
+                "Activation requires authoritative target provenance and non-legacy current provenance.");
+    }
+
+    private static bool HasActivationProvenance(MvRegistryEntry entry) =>
+        entry.TargetCheckpointTruth.Provenance?.Kind == MvCheckpointProvenanceKind.AuthoritativeTargetCapture &&
+        entry.CurrentCheckpointTruth.Provenance is not null &&
+        entry.CurrentCheckpointTruth.Provenance.Kind != MvCheckpointProvenanceKind.LegacyCompatibility;
+
+    private static MvActivationEligibilityResult? EvaluateEntryPositionConsistency(MvRegistryEntry entry)
+    {
+        var currentMatches = entry.CurrentPosition is null ||
+            string.Equals(entry.CurrentPosition, entry.CurrentCheckpointTruth.PositionValue, StringComparison.Ordinal);
+        var targetMatches = entry.TargetPosition is null ||
+            string.Equals(entry.TargetPosition, entry.TargetCheckpointTruth.PositionValue, StringComparison.Ordinal);
+        return currentMatches && targetMatches
+            ? null
+            : MvActivationEligibilityResult.Rejected(
+                MvActivationFailureReason.CandidateStateMismatch,
+                "Legacy position fields disagree with typed checkpoint truth.");
+    }
+
+    private static MvActivationEligibilityResult? EvaluateEntryOrdering(MvRegistryEntry entry) =>
+        entry.CurrentCheckpointTruth.Satisfies(entry.TargetCheckpointTruth)
+            ? null
+            : MvActivationEligibilityResult.Rejected(
+                MvActivationFailureReason.BehindTarget,
+                "The candidate current checkpoint is behind its captured target.");
+
+    private static MvActivationEligibilityResult? EvaluateActivePointer(
+        string serviceId,
+        string viewName,
+        int viewVersion,
+        MvActiveEntry? active)
+    {
+        if (active is null)
+        {
+            return null;
+        }
+
+        if (!string.Equals(active.ServiceId, serviceId, StringComparison.Ordinal) ||
+            !string.Equals(active.ViewName, viewName, StringComparison.Ordinal))
+        {
+            return MvActivationEligibilityResult.Rejected(
+                MvActivationFailureReason.IdentityMismatch,
+                "The active pointer identity does not match the requested service and view.");
+        }
+
+        return active.ActiveVersion == viewVersion
+            ? MvActivationEligibilityResult.Rejected(
+                MvActivationFailureReason.AlreadyActive,
+                "The candidate version is already active.")
+            : null;
     }
 
     private static (MvActivationEligibilityResult Eligibility, MvActivationRequest? Request) Reject(

--- a/dcb/src/Sekiban.Dcb.MaterializedView/MvActivation.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView/MvActivation.cs
@@ -1,0 +1,206 @@
+namespace Sekiban.Dcb.MaterializedView;
+
+/// <summary>Typed reasons why a materialized-view candidate cannot become active.</summary>
+public enum MvActivationFailureReason
+{
+    None = 0,
+    CandidateMissing = 1,
+    IdentityMismatch = 2,
+    TargetUnknown = 3,
+    CurrentCheckpointUnknown = 4,
+    BehindTarget = 5,
+    UnsafeLifecycle = 6,
+    Faulted = 7,
+    MissingProvenance = 8,
+    CandidateStateMismatch = 9,
+    AlreadyActive = 10,
+    ExpectedActiveConflict = 11,
+    ExpectedGenerationConflict = 12,
+    ConcurrentSuperseded = 13,
+    ProviderFailure = 14
+}
+
+/// <summary>Provider-neutral result of evaluating a candidate before any active-pointer mutation.</summary>
+public sealed record MvActivationEligibilityResult(
+    bool IsEligible,
+    MvActivationFailureReason FailureReason,
+    string Message)
+{
+    public static MvActivationEligibilityResult Eligible() =>
+        new(true, MvActivationFailureReason.None, "Candidate is eligible for activation.");
+
+    public static MvActivationEligibilityResult Rejected(
+        MvActivationFailureReason reason,
+        string message) =>
+        new(false, reason, message);
+}
+
+/// <summary>
+///     Immutable candidate snapshot passed to the provider CAS operation. The encoded checkpoint values are the
+///     exact values observed during eligibility evaluation, so a concurrent target/current update cannot be silently
+///     activated by a later compare-and-switch.
+/// </summary>
+public sealed record MvActivationRequest(
+    string ServiceId,
+    string ViewName,
+    int ViewVersion,
+    int? ExpectedActiveVersion,
+    long ExpectedActiveGeneration,
+    int CandidateCount,
+    MvStatus ExpectedStatus,
+    string ExpectedCurrentCheckpointTruth,
+    string ExpectedTargetCheckpointTruth);
+
+/// <summary>Result of the provider-atomic active-pointer operation.</summary>
+public sealed record MvActivationResult(
+    bool Succeeded,
+    MvActivationFailureReason FailureReason,
+    string Message,
+    long? NewGeneration = null)
+{
+    public bool IsConflict =>
+        FailureReason is MvActivationFailureReason.ExpectedActiveConflict
+            or MvActivationFailureReason.ExpectedGenerationConflict
+            or MvActivationFailureReason.ConcurrentSuperseded;
+
+    public static MvActivationResult Success(long generation) =>
+        new(true, MvActivationFailureReason.None, "Candidate became active.", generation);
+
+    public static MvActivationResult Rejected(
+        MvActivationFailureReason reason,
+        string message) =>
+        new(false, reason, message);
+}
+
+/// <summary>
+///     Common fail-closed eligibility evaluator. It deliberately consumes only registry truth and the active
+///     pointer snapshot; it never consults G24 sampled status or an event-store count.
+/// </summary>
+public static class MvActivationEligibility
+{
+    public static (MvActivationEligibilityResult Eligibility, MvActivationRequest? Request) Evaluate(
+        string serviceId,
+        string viewName,
+        int viewVersion,
+        IReadOnlyList<MvRegistryEntry> entries,
+        MvActiveEntry? active)
+    {
+        if (entries.Count == 0)
+        {
+            return Reject(
+                MvActivationFailureReason.CandidateMissing,
+                "The candidate has no registered materialized-view rows.");
+        }
+
+        foreach (var entry in entries)
+        {
+            if (!string.Equals(entry.ServiceId, serviceId, StringComparison.Ordinal) ||
+                !string.Equals(entry.ViewName, viewName, StringComparison.Ordinal) ||
+                entry.ViewVersion != viewVersion)
+            {
+                return Reject(
+                    MvActivationFailureReason.IdentityMismatch,
+                    "The candidate registry row does not match the requested service, view, and version.");
+            }
+
+            if (entry.Status == MvStatus.Faulted)
+            {
+                return Reject(
+                    MvActivationFailureReason.Faulted,
+                    "A faulted materialized-view candidate cannot become active.");
+            }
+
+            if (entry.Status != MvStatus.Ready)
+            {
+                return Reject(
+                    MvActivationFailureReason.UnsafeLifecycle,
+                    $"The candidate lifecycle is '{entry.Status}', but only Ready candidates may become active.");
+            }
+
+            if (!entry.TargetCheckpointTruth.IsKnown)
+            {
+                return Reject(
+                    MvActivationFailureReason.TargetUnknown,
+                    "The candidate target checkpoint is Unknown.");
+            }
+
+            if (!entry.CurrentCheckpointTruth.IsKnown)
+            {
+                return Reject(
+                    MvActivationFailureReason.CurrentCheckpointUnknown,
+                    "The candidate current checkpoint is Unknown.");
+            }
+
+            if (entry.TargetCheckpointTruth.Provenance?.Kind != MvCheckpointProvenanceKind.AuthoritativeTargetCapture ||
+                entry.CurrentCheckpointTruth.Provenance is null ||
+                entry.CurrentCheckpointTruth.Provenance.Kind == MvCheckpointProvenanceKind.LegacyCompatibility)
+            {
+                return Reject(
+                    MvActivationFailureReason.MissingProvenance,
+                    "Activation requires authoritative target provenance and non-legacy current provenance.");
+            }
+
+            if ((entry.CurrentPosition is not null &&
+                 !string.Equals(entry.CurrentPosition, entry.CurrentCheckpointTruth.PositionValue, StringComparison.Ordinal)) ||
+                (entry.TargetPosition is not null &&
+                 !string.Equals(entry.TargetPosition, entry.TargetCheckpointTruth.PositionValue, StringComparison.Ordinal)))
+            {
+                return Reject(
+                    MvActivationFailureReason.CandidateStateMismatch,
+                    "Legacy position fields disagree with typed checkpoint truth.");
+            }
+
+            if (!entry.CurrentCheckpointTruth.Satisfies(entry.TargetCheckpointTruth))
+            {
+                return Reject(
+                    MvActivationFailureReason.BehindTarget,
+                    "The candidate current checkpoint is behind its captured target.");
+            }
+        }
+
+        var first = entries[0];
+        var expectedCurrentTruth = MvCheckpointTruthCodec.Encode(first.CurrentCheckpointTruth);
+        var expectedTargetTruth = MvCheckpointTruthCodec.Encode(first.TargetCheckpointTruth);
+        if (entries.Any(entry =>
+                !string.Equals(MvCheckpointTruthCodec.Encode(entry.CurrentCheckpointTruth), expectedCurrentTruth, StringComparison.Ordinal) ||
+                !string.Equals(MvCheckpointTruthCodec.Encode(entry.TargetCheckpointTruth), expectedTargetTruth, StringComparison.Ordinal)))
+        {
+            return Reject(
+                MvActivationFailureReason.CandidateStateMismatch,
+                "Materialized-view registry rows do not share one checkpoint snapshot.");
+        }
+
+        if (active is not null &&
+            (!string.Equals(active.ServiceId, serviceId, StringComparison.Ordinal) ||
+             !string.Equals(active.ViewName, viewName, StringComparison.Ordinal)))
+        {
+            return Reject(
+                MvActivationFailureReason.IdentityMismatch,
+                "The active pointer identity does not match the requested service and view.");
+        }
+
+        if (active is not null && active.ActiveVersion == viewVersion)
+        {
+            return Reject(
+                MvActivationFailureReason.AlreadyActive,
+                "The candidate version is already active.");
+        }
+
+        var request = new MvActivationRequest(
+            serviceId,
+            viewName,
+            viewVersion,
+            active?.ActiveVersion,
+            active?.Generation ?? 0,
+            entries.Count,
+            MvStatus.Ready,
+            expectedCurrentTruth,
+            expectedTargetTruth);
+        return (MvActivationEligibilityResult.Eligible(), request);
+    }
+
+    private static (MvActivationEligibilityResult Eligibility, MvActivationRequest? Request) Reject(
+        MvActivationFailureReason reason,
+        string message) =>
+        (MvActivationEligibilityResult.Rejected(reason, message), null);
+}

--- a/dcb/src/Sekiban.Dcb.MaterializedView/MvCheckpointTruth.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView/MvCheckpointTruth.cs
@@ -28,7 +28,8 @@ public enum MvCheckpointProvenanceKind
 {
     AppliedEvent = 0,
     AuthoritativeEmptyHistory = 1,
-    LegacyCompatibility = 2
+    LegacyCompatibility = 2,
+    AuthoritativeTargetCapture = 3
 }
 
 /// <summary>
@@ -45,6 +46,9 @@ public sealed record MvCheckpointProvenance(
 
     public static MvCheckpointProvenance AuthoritativeEmptyHistory(DateTimeOffset? observedAtUtc = null) =>
         new(MvCheckpointProvenanceKind.AuthoritativeEmptyHistory, observedAtUtc ?? DateTimeOffset.UtcNow, MvApplySource.CatchUp);
+
+    public static MvCheckpointProvenance AuthoritativeTargetCapture(DateTimeOffset? observedAtUtc = null) =>
+        new(MvCheckpointProvenanceKind.AuthoritativeTargetCapture, observedAtUtc ?? DateTimeOffset.UtcNow);
 }
 
 /// <summary>
@@ -339,6 +343,7 @@ public static class MvCheckpointTruthCodec
             "appliedEvent" or "AppliedEvent" => MvCheckpointProvenanceKind.AppliedEvent,
             "authoritativeEmptyHistory" or "AuthoritativeEmptyHistory" => MvCheckpointProvenanceKind.AuthoritativeEmptyHistory,
             "legacyCompatibility" or "LegacyCompatibility" => MvCheckpointProvenanceKind.LegacyCompatibility,
+            "authoritativeTargetCapture" or "AuthoritativeTargetCapture" => MvCheckpointProvenanceKind.AuthoritativeTargetCapture,
             _ => throw new MvCheckpointMalformedException($"Unknown checkpoint provenance kind '{wire.Kind}'.", "provenance.kind")
         };
 
@@ -378,6 +383,7 @@ public static class MvCheckpointTruthCodec
             MvCheckpointProvenanceKind.AppliedEvent => "appliedEvent",
             MvCheckpointProvenanceKind.AuthoritativeEmptyHistory => "authoritativeEmptyHistory",
             MvCheckpointProvenanceKind.LegacyCompatibility => "legacyCompatibility",
+            MvCheckpointProvenanceKind.AuthoritativeTargetCapture => "authoritativeTargetCapture",
             _ => throw new ArgumentOutOfRangeException(nameof(kind), kind, "Unknown checkpoint provenance kind.")
         };
 

--- a/dcb/src/Sekiban.Dcb.MaterializedView/MvContracts.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView/MvContracts.cs
@@ -19,7 +19,8 @@ public enum MvStatus
     CatchingUp = 1,
     Ready = 2,
     Active = 3,
-    Retired = 4
+    Retired = 4,
+    Faulted = 5
 }
 
 public enum MvApplySource
@@ -141,7 +142,13 @@ public sealed record MvActiveEntry(
     string ServiceId,
     string ViewName,
     int ActiveVersion,
-    DateTimeOffset ActivatedAt);
+    DateTimeOffset ActivatedAt)
+{
+    /// <summary>
+    ///     Monotonic compare-and-switch generation. Legacy active rows migrate with generation zero.
+    /// </summary>
+    public long Generation { get; init; }
+}
 
 public sealed record MvPositionUpdate(
     string ServiceId,
@@ -285,6 +292,30 @@ public interface IMvRegistryStore
         string viewName,
         CancellationToken cancellationToken = default);
 
+    /// <summary>
+    ///     Stores one authoritative target snapshot without changing the current position or active pointer.
+    ///     Providers implement this operation for the G27 activation boundary; the default keeps older custom
+    ///     registry implementations source-compatible until they opt into activation.
+    /// </summary>
+    Task SetTargetCheckpointAsync(
+        string serviceId,
+        string viewName,
+        int viewVersion,
+        MvCheckpointTruth targetCheckpointTruth,
+        IDbTransaction? transaction = null,
+        CancellationToken cancellationToken = default) =>
+        throw new NotSupportedException("This registry store does not support authoritative activation targets.");
+
+    /// <summary>
+    ///     Provider-atomic expected-active/generation compare-and-switch. This is the only new activation mutation
+    ///     used by the G27 executors; <see cref="SetActiveAsync"/> remains as a legacy compatibility operation.
+    /// </summary>
+    Task<MvActivationResult> TryActivateAsync(
+        MvActivationRequest request,
+        IDbTransaction? transaction = null,
+        CancellationToken cancellationToken = default) =>
+        throw new NotSupportedException("This registry store does not support atomic materialized-view activation.");
+
     Task SetActiveAsync(
         string serviceId,
         string viewName,
@@ -317,6 +348,40 @@ public interface IMvExecutor
     Task<int> ApplySerializableEventsAsync(
         IMvApplyHost host,
         IReadOnlyList<SerializableEvent> events,
+        string? serviceId = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    ///     Additive G27 operation. Older custom executors retain source/binary compatibility and report unsupported
+    ///     activation until they implement the authoritative target boundary.
+    /// </summary>
+    Task<MvCheckpointTruth> CaptureTargetCheckpointAsync(
+        IMvApplyHost host,
+        string? serviceId = null,
+        CancellationToken cancellationToken = default) =>
+        throw new NotSupportedException("This materialized-view executor does not support authoritative target capture.");
+
+    /// <summary>Additive G27 provider-atomic cutover operation.</summary>
+    Task<MvActivationResult> TryActivateAsync(
+        IMvApplyHost host,
+        string? serviceId = null,
+        CancellationToken cancellationToken = default) =>
+        throw new NotSupportedException("This materialized-view executor does not support atomic activation.");
+}
+
+/// <summary>
+///     Additive G27 activation surface implemented by the four provider executors. It is separate from
+///     <see cref="IMvExecutor"/> so existing custom executors remain binary/source compatible.
+/// </summary>
+public interface IMvActivationExecutor
+{
+    Task<MvCheckpointTruth> CaptureTargetCheckpointAsync(
+        IMvApplyHost host,
+        string? serviceId = null,
+        CancellationToken cancellationToken = default);
+
+    Task<MvActivationResult> TryActivateAsync(
+        IMvApplyHost host,
         string? serviceId = null,
         CancellationToken cancellationToken = default);
 }

--- a/dcb/src/Sekiban.Dcb.MaterializedView/MvExecutorBase.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView/MvExecutorBase.cs
@@ -15,7 +15,7 @@ namespace Sekiban.Dcb.MaterializedView;
 /// Provider executors retain their own event-store factory and perform service validation/source selection
 /// at each public operation boundary before delegating database work here.
 /// </summary>
-public abstract class MvExecutorBase<TConnection> : IMvExecutor
+public abstract class MvExecutorBase<TConnection> : IMvExecutor, IMvActivationExecutor
     where TConnection : DbConnection
 {
     private readonly IMvRegistryStore _registryStore;
@@ -133,6 +133,96 @@ public abstract class MvExecutorBase<TConnection> : IMvExecutor
         IDbTransaction transaction,
         CancellationToken cancellationToken);
 
+    /// <summary>
+    ///     Provider-owned service selection. The caller validates the identity before this method is reached; each
+    ///     concrete executor keeps the factory field and performs its direct CreateForService call here.
+    /// </summary>
+    protected abstract IEventStore SelectEventStoreForService(string exactServiceId);
+
+    public async Task<MvCheckpointTruth> CaptureTargetCheckpointAsync(
+        IMvApplyHost host,
+        string? serviceId = null,
+        CancellationToken cancellationToken = default)
+    {
+        var exactServiceId = ValidateServiceIdAtBoundary(serviceId);
+        var entries = await _registryStore.GetEntriesAsync(
+                exactServiceId,
+                host.ViewName,
+                host.ViewVersion,
+                cancellationToken)
+            .ConfigureAwait(false);
+        if (entries.Count == 0)
+        {
+            await InitializeCoreAsync(host, exactServiceId, cancellationToken).ConfigureAwait(false);
+        }
+
+        var target = await CaptureTargetCheckpointFromStoreAsync(SelectEventStoreForService(exactServiceId))
+            .ConfigureAwait(false);
+        await _registryStore.SetTargetCheckpointAsync(
+                exactServiceId,
+                host.ViewName,
+                host.ViewVersion,
+                target,
+                cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
+        return target;
+    }
+
+    public async Task<MvActivationResult> TryActivateAsync(
+        IMvApplyHost host,
+        string? serviceId = null,
+        CancellationToken cancellationToken = default)
+    {
+        var exactServiceId = ValidateServiceIdAtBoundary(serviceId);
+        var entries = await _registryStore.GetEntriesAsync(
+                exactServiceId,
+                host.ViewName,
+                host.ViewVersion,
+                cancellationToken)
+            .ConfigureAwait(false);
+        var active = await _registryStore.GetActiveAsync(
+                exactServiceId,
+                host.ViewName,
+                cancellationToken)
+            .ConfigureAwait(false);
+        var (eligibility, request) = MvActivationEligibility.Evaluate(
+            exactServiceId,
+            host.ViewName,
+            host.ViewVersion,
+            entries,
+            active);
+        if (!eligibility.IsEligible || request is null)
+        {
+            return MvActivationResult.Rejected(eligibility.FailureReason, eligibility.Message);
+        }
+
+        try
+        {
+            return await _registryStore.TryActivateAsync(
+                    request,
+                    cancellationToken: cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (NotSupportedException ex)
+        {
+            _logger.LogWarning(
+                ex,
+                "Atomic materialized-view activation is not available for {ViewName}/{ViewVersion}.",
+                host.ViewName,
+                host.ViewVersion);
+            return MvActivationResult.Rejected(MvActivationFailureReason.ProviderFailure, ex.Message);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogWarning(
+                ex,
+                "Atomic materialized-view activation failed without changing the candidate contract for {ViewName}/{ViewVersion}.",
+                host.ViewName,
+                host.ViewVersion);
+            return MvActivationResult.Rejected(MvActivationFailureReason.ProviderFailure, ex.Message);
+        }
+    }
+
     protected async Task InitializeCoreAsync(
         IMvApplyHost host,
         string serviceId,
@@ -171,18 +261,6 @@ public abstract class MvExecutorBase<TConnection> : IMvExecutor
                         AppliedEventVersion = 0,
                         LastUpdated = DateTimeOffset.UtcNow
                     },
-                    transaction,
-                    cancellationToken)
-                .ConfigureAwait(false);
-        }
-
-        var active = await _registryStore.GetActiveAsync(serviceId, host.ViewName, cancellationToken).ConfigureAwait(false);
-        if (active is null)
-        {
-            await _registryStore.SetActiveAsync(
-                    serviceId,
-                    host.ViewName,
-                    host.ViewVersion,
                     transaction,
                     cancellationToken)
                 .ConfigureAwait(false);
@@ -228,12 +306,138 @@ public abstract class MvExecutorBase<TConnection> : IMvExecutor
         CancellationToken cancellationToken)
     {
         var selectedEventStore = RequireSelectedEventStore(eventStore, serviceId, selectedFromFactory);
+        await EnsureTargetCheckpointCapturedAsync(
+                host,
+                serviceId,
+                selectedEventStore,
+                cancellationToken)
+            .ConfigureAwait(false);
         var currentPosition = await GetCurrentPositionAsync(host, serviceId, cancellationToken).ConfigureAwait(false);
         var readResult = await selectedEventStore.ReadAllSerializableEventsAsync(
                 SortableUniqueId.NullableValue(currentPosition),
                 _options.BatchSize)
             .ConfigureAwait(false);
-        return await CompleteCatchUpAsync(host, serviceId, readResult, cancellationToken).ConfigureAwait(false);
+        var result = await CompleteCatchUpAsync(host, serviceId, readResult, cancellationToken).ConfigureAwait(false);
+        if (result.AppliedEvents == 0 || result.ReachedUnsafeWindow)
+        {
+            await TryActivateIfEligibleAsync(host, serviceId, cancellationToken).ConfigureAwait(false);
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    ///     Captures the source head once for a candidate until it has authoritative target provenance. A failed
+    ///     capture is persisted as Unknown and retried on the next catch-up turn; it never authorizes activation.
+    /// </summary>
+    private async Task EnsureTargetCheckpointCapturedAsync(
+        IMvApplyHost host,
+        string serviceId,
+        IEventStore eventStore,
+        CancellationToken cancellationToken)
+    {
+        var entries = await _registryStore.GetEntriesAsync(
+                serviceId,
+                host.ViewName,
+                host.ViewVersion,
+                cancellationToken)
+            .ConfigureAwait(false);
+        if (entries.Count == 0)
+        {
+            await InitializeCoreAsync(host, serviceId, cancellationToken).ConfigureAwait(false);
+            entries = await _registryStore.GetEntriesAsync(
+                    serviceId,
+                    host.ViewName,
+                    host.ViewVersion,
+                    cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        if (entries.Count == 0 || entries.All(entry =>
+                entry.TargetCheckpointTruth.IsKnown &&
+                entry.TargetCheckpointTruth.Provenance?.Kind == MvCheckpointProvenanceKind.AuthoritativeTargetCapture))
+        {
+            return;
+        }
+
+        var target = await CaptureTargetCheckpointFromStoreAsync(eventStore).ConfigureAwait(false);
+        await _registryStore.SetTargetCheckpointAsync(
+                serviceId,
+                host.ViewName,
+                host.ViewVersion,
+                target,
+                cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    /// <summary>
+    ///     The direct executor/worker path and the Orleans path share this promotion boundary. A candidate may move
+    ///     from CatchingUp to Ready only after all non-lifecycle eligibility predicates pass. The final pointer write
+    ///     is always the provider transaction's expected-active/generation CAS.
+    /// </summary>
+    private async Task TryActivateIfEligibleAsync(
+        IMvApplyHost host,
+        string serviceId,
+        CancellationToken cancellationToken)
+    {
+        var entries = await _registryStore.GetEntriesAsync(
+                serviceId,
+                host.ViewName,
+                host.ViewVersion,
+                cancellationToken)
+            .ConfigureAwait(false);
+        var active = await _registryStore.GetActiveAsync(
+                serviceId,
+                host.ViewName,
+                cancellationToken)
+            .ConfigureAwait(false);
+
+        // Retired and faulted rows are terminal lifecycle states. Only the normal catch-up/ready transition may be
+        // promoted by this automatic initial-activation path.
+        if (entries.Count == 0 || entries.Any(entry =>
+                entry.Status is not (MvStatus.CatchingUp or MvStatus.Ready)))
+        {
+            return;
+        }
+
+        // Evaluate the full contract before changing lifecycle state. The evaluator itself intentionally accepts
+        // only Ready, so use an immutable Ready projection only for this preflight; the real request is re-read after
+        // the status mutation and is checked again by the provider transaction.
+        var readyEntries = entries
+            .Select(entry => entry with { Status = MvStatus.Ready })
+            .ToList();
+        var (preflight, _) = MvActivationEligibility.Evaluate(
+            serviceId,
+            host.ViewName,
+            host.ViewVersion,
+            readyEntries,
+            active);
+        if (!preflight.IsEligible)
+        {
+            return;
+        }
+
+        if (entries.Any(entry => entry.Status != MvStatus.Ready))
+        {
+            await _registryStore.UpdateStatusAsync(
+                    serviceId,
+                    host.ViewName,
+                    host.ViewVersion,
+                    MvStatus.Ready,
+                    cancellationToken: cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        var result = await TryActivateAsync(host, serviceId, cancellationToken).ConfigureAwait(false);
+        if (!result.Succeeded && !result.IsConflict && result.FailureReason != MvActivationFailureReason.AlreadyActive)
+        {
+            _logger.LogWarning(
+                "Materialized-view candidate was not activated for {ViewName}/{ViewVersion}: {Reason} ({Message})",
+                host.ViewName,
+                host.ViewVersion,
+                result.FailureReason,
+                result.Message);
+        }
     }
 
     protected Task<int> ApplyStreamEventsAtBoundaryAsync(
@@ -481,4 +685,34 @@ public abstract class MvExecutorBase<TConnection> : IMvExecutor
 
     private static SortableUniqueId CreateSafeThreshold(int safeWindowMs) =>
         new(SortableUniqueId.Generate(DateTime.UtcNow.AddMilliseconds(-safeWindowMs), Guid.Empty));
+
+    private static async Task<MvCheckpointTruth> CaptureTargetCheckpointFromStoreAsync(IEventStore eventStore)
+    {
+        try
+        {
+            var result = await eventStore.GetLatestSortableUniqueIdAsync().ConfigureAwait(false);
+            if (!result.IsSuccess)
+            {
+                return MvCheckpointTruth.Unknown(MvCheckpointUnknownReason.ReadUnavailable);
+            }
+
+            var latestSortableUniqueId = result.GetValue();
+            if (string.IsNullOrWhiteSpace(latestSortableUniqueId))
+            {
+                return MvCheckpointTruth.KnownZero(MvCheckpointProvenance.AuthoritativeTargetCapture());
+            }
+
+            return MvCheckpointTruth.Known(
+                new SortableUniqueId(latestSortableUniqueId),
+                MvCheckpointProvenance.AuthoritativeTargetCapture());
+        }
+        catch (MvCheckpointMalformedException)
+        {
+            return MvCheckpointTruth.Unknown(MvCheckpointUnknownReason.Malformed);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            return MvCheckpointTruth.Unknown(MvCheckpointUnknownReason.ReadUnavailable);
+        }
+    }
 }

--- a/dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/MaterializedViewMultiProviderTests.cs
+++ b/dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/MaterializedViewMultiProviderTests.cs
@@ -137,6 +137,10 @@ internal static class MultiProviderAssertions
                 projector.ViewVersion)
             .ConfigureAwait(false);
         Assert.NotEmpty(initialRegistryEntries);
+        Assert.Null(await registryStore.GetActiveAsync(
+                MultiProviderFixtureBase.ServiceId,
+                projector.ViewName)
+            .ConfigureAwait(false));
         Assert.All(initialRegistryEntries, entry => Assert.True(entry.CurrentCheckpointTruth.IsUnknown));
 
         var emptyCatchUp = await fixture.Executor.CatchUpOnceAsync(

--- a/dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/MultiProviderFixtures.cs
+++ b/dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/MultiProviderFixtures.cs
@@ -9,17 +9,20 @@ using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using MySqlConnector;
+using Npgsql;
 using Sekiban.Dcb.Actors;
 using Sekiban.Dcb.Events;
 using Sekiban.Dcb.Testing;
 using Sekiban.Dcb.MaterializedView;
 using Sekiban.Dcb.MaterializedView.MySql;
+using Sekiban.Dcb.MaterializedView.Postgres;
 using Sekiban.Dcb.MaterializedView.Sqlite;
 using Sekiban.Dcb.MaterializedView.SqlServer;
 using Sekiban.Dcb.ServiceId;
 using Sekiban.Dcb.Storage;
 using Testcontainers.MsSql;
 using Testcontainers.MySql;
+using Testcontainers.PostgreSql;
 using Xunit;
 
 namespace Sekiban.Dcb.MaterializedView.MultiProvider.Tests;
@@ -258,6 +261,15 @@ public abstract class MultiProviderFixtureBase : IAsyncLifetime
     protected abstract DbConnection CreateConnection(string connectionString);
     protected abstract string ResetSql { get; }
     protected abstract string LegacyRegistrySql { get; }
+    public abstract string CreateCandidateMismatchTriggerSql { get; }
+    public abstract string DropCandidateMismatchTriggerSql { get; }
+    public virtual string CandidateTruthUpdateSql => """
+        UPDATE sekiban_mv_registry
+        SET target_checkpoint_truth = @TargetTruth
+        WHERE service_id = @ServiceId
+          AND view_name = @ViewName
+          AND view_version = @ViewVersion;
+        """;
 
     public async Task InitializeAsync()
     {
@@ -343,6 +355,107 @@ public abstract class MultiProviderFixtureBase : IAsyncLifetime
     private void ThrowUnavailable() => throw new InvalidOperationException(_skipReason);
 }
 
+public sealed class PostgresMvFixture : MultiProviderFixtureBase
+{
+    private PostgreSqlContainer? _container;
+
+    protected override MvDbType DatabaseType => MvDbType.Postgres;
+
+    protected override async Task<string> CreateConnectionStringAsync()
+    {
+        _container = new PostgreSqlBuilder("postgres:16-alpine")
+            .WithDatabase("sekiban_mv_test")
+            .WithUsername("test_user")
+            .WithPassword("test_password")
+            .Build();
+
+        await _container.StartAsync().ConfigureAwait(false);
+        return _container.GetConnectionString();
+    }
+
+    protected override void RegisterProvider(IServiceCollection services, string connectionString)
+    {
+        services.AddSekibanDcbMaterializedView(options =>
+        {
+            options.ServiceId = ServiceId;
+            options.BatchSize = 100;
+            options.SafeWindowMs = 0;
+            options.PollInterval = TimeSpan.FromMilliseconds(10);
+        });
+        services.AddSekibanDcbMaterializedViewPostgres(connectionString, registerHostedWorker: false);
+    }
+
+    protected override DbConnection CreateConnection(string connectionString) => new NpgsqlConnection(connectionString);
+
+    protected override string ResetSql => """
+        DROP TABLE IF EXISTS sekiban_mv_weatherforecastportable_v1_forecasts;
+        DROP TABLE IF EXISTS sekiban_mv_active;
+        DROP TABLE IF EXISTS sekiban_mv_registry;
+        """;
+
+    protected override string LegacyRegistrySql => """
+        CREATE TABLE sekiban_mv_registry (
+            service_id TEXT NOT NULL,
+            view_name TEXT NOT NULL,
+            view_version INT NOT NULL,
+            logical_table TEXT NOT NULL,
+            physical_table TEXT NOT NULL,
+            status TEXT NOT NULL,
+            current_position TEXT NULL,
+            target_position TEXT NULL,
+            last_sortable_unique_id TEXT NULL,
+            applied_event_version BIGINT NOT NULL DEFAULT 0,
+            last_applied_source TEXT NULL,
+            last_applied_at TIMESTAMPTZ NULL,
+            last_stream_received_sortable_unique_id TEXT NULL,
+            last_stream_received_at TIMESTAMPTZ NULL,
+            last_stream_applied_sortable_unique_id TEXT NULL,
+            last_catch_up_sortable_unique_id TEXT NULL,
+            last_updated TIMESTAMPTZ NOT NULL,
+            metadata JSONB NULL,
+            PRIMARY KEY (service_id, view_name, view_version, logical_table)
+        );
+        """;
+
+    public override string CandidateTruthUpdateSql => """
+        UPDATE sekiban_mv_registry
+        SET target_checkpoint_truth = CAST(@TargetTruth AS jsonb)
+        WHERE service_id = @ServiceId
+          AND view_name = @ViewName
+          AND view_version = @ViewVersion;
+        """;
+
+    public override string CreateCandidateMismatchTriggerSql => """
+        CREATE OR REPLACE FUNCTION sekiban_mv_force_candidate_mismatch() RETURNS trigger AS $$
+        BEGIN
+            UPDATE sekiban_mv_registry
+            SET status = 'catchingup'
+            WHERE service_id = NEW.service_id
+              AND view_name = NEW.view_name
+              AND view_version = NEW.active_version;
+            RETURN NEW;
+        END;
+        $$ LANGUAGE plpgsql;
+        CREATE TRIGGER sekiban_mv_force_candidate_mismatch
+        AFTER INSERT ON sekiban_mv_active
+        FOR EACH ROW EXECUTE FUNCTION sekiban_mv_force_candidate_mismatch();
+        """;
+
+    public override string DropCandidateMismatchTriggerSql => """
+        DROP TRIGGER IF EXISTS sekiban_mv_force_candidate_mismatch ON sekiban_mv_active;
+        DROP FUNCTION IF EXISTS sekiban_mv_force_candidate_mismatch();
+        """;
+
+    public override async Task DisposeAsync()
+    {
+        await base.DisposeAsync().ConfigureAwait(false);
+        if (_container is not null)
+        {
+            await _container.DisposeAsync().ConfigureAwait(false);
+        }
+    }
+}
+
 public sealed class MySqlMvFixture : MultiProviderFixtureBase
 {
     private MySqlContainer? _container;
@@ -355,6 +468,7 @@ public sealed class MySqlMvFixture : MultiProviderFixtureBase
             .WithDatabase("sekiban_mv_test")
             .WithUsername("test_user")
             .WithPassword("test_password")
+            .WithCommand("--log-bin-trust-function-creators=1")
             .Build();
 
         await _container.StartAsync().ConfigureAwait(false);
@@ -404,6 +518,20 @@ public sealed class MySqlMvFixture : MultiProviderFixtureBase
             PRIMARY KEY (service_id, view_name, view_version, logical_table)
         );
         """;
+
+    public override string CreateCandidateMismatchTriggerSql => """
+        CREATE TRIGGER sekiban_mv_force_candidate_mismatch
+        AFTER INSERT ON sekiban_mv_active
+        FOR EACH ROW
+        UPDATE sekiban_mv_registry
+        SET status = 'catchingup'
+        WHERE service_id = NEW.service_id
+          AND view_name = NEW.view_name
+          AND view_version = NEW.active_version;
+        """;
+
+    public override string DropCandidateMismatchTriggerSql =>
+        "DROP TRIGGER IF EXISTS sekiban_mv_force_candidate_mismatch;";
 
     public override async Task DisposeAsync()
     {
@@ -474,6 +602,26 @@ public sealed class SqlServerMvFixture : MultiProviderFixtureBase
         );
         """;
 
+    public override string CreateCandidateMismatchTriggerSql => """
+        CREATE TRIGGER sekiban_mv_force_candidate_mismatch ON sekiban_mv_active
+        AFTER INSERT AS
+        BEGIN
+            SET NOCOUNT ON;
+            UPDATE registry
+            SET status = 'catchingup'
+            FROM sekiban_mv_registry AS registry
+            INNER JOIN inserted AS active
+                ON registry.service_id = active.service_id
+               AND registry.view_name = active.view_name
+               AND registry.view_version = active.active_version;
+        END;
+        """;
+
+    public override string DropCandidateMismatchTriggerSql => """
+        IF OBJECT_ID(N'sekiban_mv_force_candidate_mismatch', N'TR') IS NOT NULL
+            DROP TRIGGER sekiban_mv_force_candidate_mismatch;
+        """;
+
     public override async Task DisposeAsync()
     {
         await base.DisposeAsync().ConfigureAwait(false);
@@ -539,6 +687,21 @@ public sealed class SqliteMvFixture : MultiProviderFixtureBase
             PRIMARY KEY (service_id, view_name, view_version, logical_table)
         );
         """;
+
+    public override string CreateCandidateMismatchTriggerSql => """
+        CREATE TRIGGER sekiban_mv_force_candidate_mismatch
+        AFTER INSERT ON sekiban_mv_active
+        BEGIN
+            UPDATE sekiban_mv_registry
+            SET status = 'catchingup'
+            WHERE service_id = NEW.service_id
+              AND view_name = NEW.view_name
+              AND view_version = NEW.active_version;
+        END;
+        """;
+
+    public override string DropCandidateMismatchTriggerSql =>
+        "DROP TRIGGER IF EXISTS sekiban_mv_force_candidate_mismatch;";
 
     public override async Task DisposeAsync()
     {

--- a/dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/MvActivationAtomicityTests.cs
+++ b/dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/MvActivationAtomicityTests.cs
@@ -1,0 +1,250 @@
+using System.Data.Common;
+using Dapper;
+using Microsoft.Extensions.DependencyInjection;
+using Sekiban.Dcb.Common;
+using Sekiban.Dcb.MaterializedView;
+using Xunit;
+
+namespace Sekiban.Dcb.MaterializedView.MultiProvider.Tests;
+
+[CollectionDefinition(nameof(PostgresMvCollection))]
+public sealed class PostgresMvCollection : ICollectionFixture<PostgresMvFixture>;
+
+[Collection(nameof(PostgresMvCollection))]
+public sealed class PostgresMvActivationAtomicityTests(PostgresMvFixture fixture) : MvActivationAtomicityTestsBase(fixture);
+
+[Collection(nameof(MySqlMvCollection))]
+public sealed class MySqlMvActivationAtomicityTests(MySqlMvFixture fixture) : MvActivationAtomicityTestsBase(fixture);
+
+[Collection(nameof(SqlServerMvCollection))]
+public sealed class SqlServerMvActivationAtomicityTests(SqlServerMvFixture fixture) : MvActivationAtomicityTestsBase(fixture);
+
+[Collection(nameof(SqliteMvCollection))]
+public sealed class SqliteMvActivationAtomicityTests(SqliteMvFixture fixture) : MvActivationAtomicityTestsBase(fixture);
+
+public abstract class MvActivationAtomicityTestsBase(MultiProviderFixtureBase fixture)
+{
+    [SkippableFact]
+    public Task SameGenerationConcurrency_HasExactlyOneWinner() =>
+        MvActivationAtomicityAssertions.AssertExactlyOneWinnerAsync(fixture);
+
+    [SkippableFact]
+    public Task CandidateChangeInterleaving_IsFencedAndRejectedWithoutPointerMutation() =>
+        MvActivationAtomicityAssertions.AssertCandidateChangeInterleavingAsync(fixture);
+
+    [SkippableFact]
+    public Task InvalidAndDirectBypassRequests_LeavePointerUnchanged() =>
+        MvActivationAtomicityAssertions.AssertInvalidAndBypassZeroMutationAsync(fixture);
+
+    [SkippableFact]
+    public Task ProviderFailure_LeavesCandidateRetryableAndRetrySucceeds() =>
+        MvActivationAtomicityAssertions.AssertProviderFailureRetryAsync(fixture);
+
+    [SkippableFact]
+    public Task CallerTransactionFailure_IsRolledBackToOperationSavepoint() =>
+        MvActivationAtomicityAssertions.AssertCallerTransactionRollbackAsync(fixture);
+
+    [SkippableFact]
+    public Task MarkActiveCountMismatch_RollsBackPointerAndEveryCandidateMutation() =>
+        MvActivationAtomicityAssertions.AssertMarkCountMismatchRollbackAsync(fixture);
+}
+
+internal static class MvActivationAtomicityAssertions
+{
+    private const string ServiceId = "activation-service";
+    private const string ViewName = "AtomicView";
+    private const int ViewVersion = 2;
+
+    public static async Task AssertExactlyOneWinnerAsync(MultiProviderFixtureBase fixture)
+    {
+        var (store, request) = await PrepareEligibleCandidateAsync(fixture).ConfigureAwait(false);
+
+        var results = await Task.WhenAll(
+            store.TryActivateAsync(request),
+            store.TryActivateAsync(request)).ConfigureAwait(false);
+
+        Assert.Single(results, result => result.Succeeded);
+        Assert.Single(results, result => !result.Succeeded && result.IsConflict);
+        var active = await store.GetActiveAsync(ServiceId, ViewName).ConfigureAwait(false);
+        Assert.NotNull(active);
+        Assert.Equal(ViewVersion, active.ActiveVersion);
+        Assert.Equal(1, active.Generation);
+        Assert.All(
+            await store.GetEntriesAsync(ServiceId, ViewName, ViewVersion).ConfigureAwait(false),
+            entry => Assert.Equal(MvStatus.Active, entry.Status));
+    }
+
+    public static async Task AssertCandidateChangeInterleavingAsync(MultiProviderFixtureBase fixture)
+    {
+        var (store, request) = await PrepareEligibleCandidateAsync(fixture).ConfigureAwait(false);
+        await using var blockerConnection = await fixture.OpenConnectionAsync().ConfigureAwait(false);
+        await using var blockerTransaction = await blockerConnection.BeginTransactionAsync().ConfigureAwait(false);
+        var changedTarget = EncodeCheckpoint("changed-target", DateTime.UnixEpoch.AddMinutes(3),
+            MvCheckpointProvenance.AuthoritativeTargetCapture());
+        await blockerConnection.ExecuteAsync(
+            new CommandDefinition(
+                fixture.CandidateTruthUpdateSql,
+                new { ServiceId, ViewName, ViewVersion, TargetTruth = changedTarget },
+                blockerTransaction)).ConfigureAwait(false);
+
+        // Microsoft.Data.Sqlite may synchronously wait for its busy timeout inside ExecuteAsync, so put the
+        // competing operation on its own worker to make the lock interleaving observable for every provider.
+        var activationTask = Task.Run(() => store.TryActivateAsync(request));
+        await Task.Delay(100).ConfigureAwait(false);
+        Assert.False(activationTask.IsCompleted, "Activation must wait for the transaction holding the candidate fence.");
+        await blockerTransaction.CommitAsync().ConfigureAwait(false);
+
+        var result = await activationTask.ConfigureAwait(false);
+        Assert.False(result.Succeeded);
+        Assert.Equal(MvActivationFailureReason.ConcurrentSuperseded, result.FailureReason);
+        Assert.Null(await store.GetActiveAsync(ServiceId, ViewName).ConfigureAwait(false));
+    }
+
+    public static async Task AssertInvalidAndBypassZeroMutationAsync(MultiProviderFixtureBase fixture)
+    {
+        var (store, request) = await PrepareEligibleCandidateAsync(fixture).ConfigureAwait(false);
+        var invalid = await store.TryActivateAsync(request with
+        {
+            ExpectedTargetCheckpointTruth = MvCheckpointTruthCodec.Encode(
+                MvCheckpointTruth.Unknown(MvCheckpointUnknownReason.ReadUnavailable))
+        }).ConfigureAwait(false);
+        Assert.False(invalid.Succeeded);
+        Assert.Equal(MvActivationFailureReason.TargetUnknown, invalid.FailureReason);
+        Assert.Null(await store.GetActiveAsync(ServiceId, ViewName).ConfigureAwait(false));
+
+        await using (var connection = await fixture.OpenConnectionAsync().ConfigureAwait(false))
+        {
+            await connection.ExecuteAsync(
+                """
+                UPDATE sekiban_mv_registry
+                SET status = 'catchingup'
+                WHERE service_id = @ServiceId AND view_name = @ViewName AND view_version = @ViewVersion;
+                """,
+                new { ServiceId, ViewName, ViewVersion }).ConfigureAwait(false);
+        }
+
+        var bypass = await store.TryActivateAsync(request).ConfigureAwait(false);
+        Assert.False(bypass.Succeeded);
+        Assert.Equal(MvActivationFailureReason.ConcurrentSuperseded, bypass.FailureReason);
+        Assert.Null(await store.GetActiveAsync(ServiceId, ViewName).ConfigureAwait(false));
+    }
+
+    public static async Task AssertProviderFailureRetryAsync(MultiProviderFixtureBase fixture)
+    {
+        var (store, request) = await PrepareEligibleCandidateAsync(fixture).ConfigureAwait(false);
+        await using (var connection = await fixture.OpenConnectionAsync().ConfigureAwait(false))
+        {
+            await connection.ExecuteAsync("DROP TABLE sekiban_mv_active;").ConfigureAwait(false);
+        }
+
+        await Assert.ThrowsAnyAsync<Exception>(() => store.TryActivateAsync(request)).ConfigureAwait(false);
+        Assert.All(
+            await store.GetEntriesAsync(ServiceId, ViewName, ViewVersion).ConfigureAwait(false),
+            entry => Assert.Equal(MvStatus.Ready, entry.Status));
+
+        await store.EnsureInfrastructureAsync().ConfigureAwait(false);
+        var retry = await store.TryActivateAsync(request).ConfigureAwait(false);
+        Assert.True(retry.Succeeded);
+        Assert.Equal(1, retry.NewGeneration);
+    }
+
+    public static async Task AssertCallerTransactionRollbackAsync(MultiProviderFixtureBase fixture)
+    {
+        var (store, request) = await PrepareEligibleCandidateAsync(fixture).ConfigureAwait(false);
+        await using var connection = await fixture.OpenConnectionAsync().ConfigureAwait(false);
+        await using var transaction = await connection.BeginTransactionAsync().ConfigureAwait(false);
+        var rejected = await store.TryActivateAsync(request with { CandidateCount = request.CandidateCount + 1 }, transaction)
+            .ConfigureAwait(false);
+        Assert.False(rejected.Succeeded);
+        await transaction.CommitAsync().ConfigureAwait(false);
+
+        Assert.Null(await store.GetActiveAsync(ServiceId, ViewName).ConfigureAwait(false));
+        Assert.All(
+            await store.GetEntriesAsync(ServiceId, ViewName, ViewVersion).ConfigureAwait(false),
+            entry => Assert.Equal(MvStatus.Ready, entry.Status));
+    }
+
+    public static async Task AssertMarkCountMismatchRollbackAsync(MultiProviderFixtureBase fixture)
+    {
+        var (store, request) = await PrepareEligibleCandidateAsync(fixture).ConfigureAwait(false);
+        await using (var connection = await fixture.OpenConnectionAsync().ConfigureAwait(false))
+        {
+            await connection.ExecuteAsync(fixture.CreateCandidateMismatchTriggerSql).ConfigureAwait(false);
+        }
+
+        var mismatch = await store.TryActivateAsync(request).ConfigureAwait(false);
+        Assert.False(mismatch.Succeeded);
+        Assert.Equal(MvActivationFailureReason.ConcurrentSuperseded, mismatch.FailureReason);
+        Assert.Null(await store.GetActiveAsync(ServiceId, ViewName).ConfigureAwait(false));
+        Assert.All(
+            await store.GetEntriesAsync(ServiceId, ViewName, ViewVersion).ConfigureAwait(false),
+            entry => Assert.Equal(MvStatus.Ready, entry.Status));
+
+        await using (var connection = await fixture.OpenConnectionAsync().ConfigureAwait(false))
+        {
+            await connection.ExecuteAsync(fixture.DropCandidateMismatchTriggerSql).ConfigureAwait(false);
+        }
+
+        var retry = await store.TryActivateAsync(request).ConfigureAwait(false);
+        Assert.True(retry.Succeeded);
+    }
+
+    private static async Task<(IMvRegistryStore Store, MvActivationRequest Request)> PrepareEligibleCandidateAsync(
+        MultiProviderFixtureBase fixture)
+    {
+        Skip.IfNot(fixture.IsAvailable, fixture.AvailabilityMessage ?? "Integration fixture is unavailable.");
+        await fixture.ResetAsync().ConfigureAwait(false);
+        var store = fixture.Services.GetRequiredService<IMvRegistryStore>();
+        await store.EnsureInfrastructureAsync().ConfigureAwait(false);
+        var current = Checkpoint("same", DateTime.UnixEpoch.AddMinutes(2),
+            MvCheckpointProvenance.AppliedEvent(MvApplySource.CatchUp));
+        var target = Checkpoint("same", DateTime.UnixEpoch.AddMinutes(2),
+            MvCheckpointProvenance.AuthoritativeTargetCapture());
+        await store.RegisterAsync(CreateEntry("orders", current, target)).ConfigureAwait(false);
+        await store.RegisterAsync(CreateEntry("items", current, target)).ConfigureAwait(false);
+        var entries = await store.GetEntriesAsync(ServiceId, ViewName, ViewVersion).ConfigureAwait(false);
+        var (eligibility, request) = MvActivationEligibility.Evaluate(ServiceId, ViewName, ViewVersion, entries, null);
+        Assert.True(eligibility.IsEligible);
+        return (store, Assert.IsType<MvActivationRequest>(request));
+    }
+
+    private static MvRegistryEntry CreateEntry(
+        string logicalTable,
+        MvCheckpointTruth current,
+        MvCheckpointTruth target) => new()
+    {
+        ServiceId = ServiceId,
+        ViewName = ViewName,
+        ViewVersion = ViewVersion,
+        LogicalTable = logicalTable,
+        PhysicalTable = $"atomic_{logicalTable}",
+        Status = MvStatus.Ready,
+        CurrentPosition = current.PositionValue,
+        TargetPosition = target.PositionValue,
+        CurrentCheckpointTruth = current,
+        TargetCheckpointTruth = target,
+        AppliedEventVersion = 1,
+        LastUpdated = DateTimeOffset.UtcNow
+    };
+
+    private static MvCheckpointTruth Checkpoint(
+        string seed,
+        DateTime timestamp,
+        MvCheckpointProvenance provenance) =>
+        MvCheckpointTruth.Known(
+            new SortableUniqueId(SortableUniqueId.Generate(timestamp, StableGuid(seed))),
+            provenance);
+
+    private static string EncodeCheckpoint(
+        string seed,
+        DateTime timestamp,
+        MvCheckpointProvenance provenance) =>
+        MvCheckpointTruthCodec.Encode(Checkpoint(seed, timestamp, provenance));
+
+    private static Guid StableGuid(string seed) => seed switch
+    {
+        "same" => new Guid("00000000-0000-0000-0000-000000000010"),
+        "changed-target" => new Guid("00000000-0000-0000-0000-000000000020"),
+        _ => throw new ArgumentOutOfRangeException(nameof(seed))
+    };
+}

--- a/dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests.csproj
+++ b/dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests.csproj
@@ -12,6 +12,7 @@
     <ItemGroup>
         <PackageReference Include="Dapper" Version="2.1.66" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+        <PackageReference Include="Testcontainers.PostgreSql" Version="4.10.0" />
         <PackageReference Include="Testcontainers.MsSql" Version="4.10.0" />
         <PackageReference Include="Testcontainers.MySql" Version="4.10.0" />
         <PackageReference Include="xunit" Version="2.9.3" />
@@ -33,6 +34,7 @@
     <ItemGroup>
         <ProjectReference Include="..\..\src\Sekiban.Dcb.MaterializedView\Sekiban.Dcb.MaterializedView.csproj" />
         <ProjectReference Include="..\..\src\Sekiban.Dcb.MaterializedView.MySql\Sekiban.Dcb.MaterializedView.MySql.csproj" />
+        <ProjectReference Include="..\..\src\Sekiban.Dcb.MaterializedView.Postgres\Sekiban.Dcb.MaterializedView.Postgres.csproj" />
         <ProjectReference Include="..\..\src\Sekiban.Dcb.MaterializedView.Sqlite\Sekiban.Dcb.MaterializedView.Sqlite.csproj" />
         <ProjectReference Include="..\..\src\Sekiban.Dcb.MaterializedView.SqlServer\Sekiban.Dcb.MaterializedView.SqlServer.csproj" />
         <ProjectReference Include="..\..\src\Sekiban.Dcb.WithoutResult\Sekiban.Dcb.WithoutResult.csproj" />

--- a/dcb/tests/Sekiban.Dcb.MaterializedView.Postgres.Tests/MaterializedViewPostgresTests.cs
+++ b/dcb/tests/Sekiban.Dcb.MaterializedView.Postgres.Tests/MaterializedViewPostgresTests.cs
@@ -34,14 +34,21 @@ public sealed class MaterializedViewPostgresTests(MaterializedViewPostgresFixtur
 
         await using var connection = await fixture.OpenConnectionAsync();
         var registryCount = await connection.ExecuteScalarAsync<int>("SELECT COUNT(*) FROM sekiban_mv_registry;");
-        var activeVersion = await connection.ExecuteScalarAsync<int>("SELECT active_version FROM sekiban_mv_active WHERE view_name = 'OrderSummary';");
+        var activeVersionBeforeCatchUp = await connection.ExecuteScalarAsync<int?>(
+            "SELECT active_version FROM sekiban_mv_active WHERE view_name = 'OrderSummary';");
         var ordersExists = await connection.ExecuteScalarAsync<bool>(
             "SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'sekiban_mv_ordersummary_v1_orders');");
         var itemsExists = await connection.ExecuteScalarAsync<bool>(
             "SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'sekiban_mv_ordersummary_v1_items');");
 
         Assert.Equal(2, registryCount);
-        Assert.Equal(1, activeVersion);
+        Assert.Null(activeVersionBeforeCatchUp);
+
+        await fixture.Executor.CatchUpOnceAsync(ApplyHost(fixture.Projector));
+        await using var postCatchUpConnection = await fixture.OpenConnectionAsync();
+        var activeVersionAfterCatchUp = await postCatchUpConnection.ExecuteScalarAsync<int?>(
+            "SELECT active_version FROM sekiban_mv_active WHERE view_name = 'OrderSummary';");
+        Assert.Equal(1, activeVersionAfterCatchUp);
         Assert.True(ordersExists);
         Assert.True(itemsExists);
     }

--- a/dcb/tests/Sekiban.Dcb.MaterializedView.Tests/MvActivationEligibilityTests.cs
+++ b/dcb/tests/Sekiban.Dcb.MaterializedView.Tests/MvActivationEligibilityTests.cs
@@ -1,0 +1,173 @@
+using Microsoft.Data.Sqlite;
+using Sekiban.Dcb.Common;
+using Sekiban.Dcb.MaterializedView;
+using Sekiban.Dcb.MaterializedView.Sqlite;
+using Xunit;
+
+namespace Sekiban.Dcb.MaterializedView.Tests;
+
+public sealed class MvActivationEligibilityTests
+{
+    [Fact]
+    public void UnknownTarget_IsRejectedBeforeAnyActivationRequestIsCreated()
+    {
+        var current = KnownCheckpoint("current", MvCheckpointProvenance.AppliedEvent(MvApplySource.CatchUp));
+        var entry = CreateEntry(
+            "orders",
+            "Weather",
+            2,
+            MvStatus.Ready,
+            current,
+            MvCheckpointTruth.Unknown(MvCheckpointUnknownReason.ReadUnavailable));
+
+        var (eligibility, request) = MvActivationEligibility.Evaluate(
+            "orders",
+            "Weather",
+            2,
+            [entry],
+            active: null);
+
+        Assert.False(eligibility.IsEligible);
+        Assert.Equal(MvActivationFailureReason.TargetUnknown, eligibility.FailureReason);
+        Assert.Null(request);
+    }
+
+    [Fact]
+    public void BehindCandidate_IsRejectedEvenWhenASeparateBestEffortStatusWouldSayCaughtUp()
+    {
+        // This value represents the kind of sampled G24 status that must not be consulted by G27. The eligibility
+        // API has no status/count input; only the persisted authoritative truth below can authorize a cutover.
+        var g24IsCaughtUp = true;
+        var current = KnownCheckpoint("current", MvCheckpointProvenance.AppliedEvent(MvApplySource.CatchUp));
+        var target = KnownCheckpoint("target", MvCheckpointProvenance.AuthoritativeTargetCapture());
+        var entry = CreateEntry("orders", "Weather", 2, MvStatus.Ready, current, target);
+
+        var (eligibility, request) = MvActivationEligibility.Evaluate(
+            "orders",
+            "Weather",
+            2,
+            [entry],
+            active: null);
+
+        Assert.True(g24IsCaughtUp);
+        Assert.False(eligibility.IsEligible);
+        Assert.Equal(MvActivationFailureReason.BehindTarget, eligibility.FailureReason);
+        Assert.Null(request);
+    }
+
+    [Fact]
+    public void EligibleCandidate_CarriesExpectedActiveAndGenerationSnapshot()
+    {
+        var checkpoint = KnownCheckpoint("same", MvCheckpointProvenance.AppliedEvent(MvApplySource.CatchUp));
+        var target = KnownCheckpoint("same", MvCheckpointProvenance.AuthoritativeTargetCapture());
+        var entry = CreateEntry("orders", "Weather", 2, MvStatus.Ready, checkpoint, target);
+        var active = new MvActiveEntry("orders", "Weather", 1, DateTimeOffset.UtcNow)
+        {
+            Generation = 7
+        };
+
+        var (eligibility, request) = MvActivationEligibility.Evaluate(
+            "orders",
+            "Weather",
+            2,
+            [entry],
+            active);
+
+        Assert.True(eligibility.IsEligible);
+        Assert.NotNull(request);
+        Assert.Equal(1, request.ExpectedActiveVersion);
+        Assert.Equal(7, request.ExpectedActiveGeneration);
+        Assert.Equal(MvStatus.Ready, request.ExpectedStatus);
+    }
+
+    [Fact]
+    public async Task SqliteRegistry_UsesExpectedGenerationAndLeavesPointerUnchangedForInvalidOrStaleRequests()
+    {
+        var connectionString = $"Data Source=file:sek-g27-{Guid.NewGuid():N};Mode=Memory;Cache=Shared";
+        await using var anchor = new SqliteConnection(connectionString);
+        await anchor.OpenAsync();
+
+        var store = new SqliteMvRegistryStore(connectionString);
+        await store.EnsureInfrastructureAsync();
+
+        var checkpoint = KnownCheckpoint("same", MvCheckpointProvenance.AppliedEvent(MvApplySource.CatchUp));
+        var target = KnownCheckpoint("same", MvCheckpointProvenance.AuthoritativeTargetCapture());
+        await store.RegisterAsync(CreateEntry("orders", "Weather", 2, MvStatus.Ready, checkpoint, target));
+
+        var entries = await store.GetEntriesAsync("orders", "Weather", 2);
+        var (eligibility, request) = MvActivationEligibility.Evaluate("orders", "Weather", 2, entries, null);
+        Assert.True(eligibility.IsEligible);
+        Assert.NotNull(request);
+
+        var invalid = await store.TryActivateAsync(
+            request! with
+            {
+                ExpectedTargetCheckpointTruth = MvCheckpointTruthCodec.Encode(
+                    MvCheckpointTruth.Unknown(MvCheckpointUnknownReason.Malformed))
+            });
+        Assert.False(invalid.Succeeded);
+        Assert.Equal(MvActivationFailureReason.TargetUnknown, invalid.FailureReason);
+        Assert.Null(await store.GetActiveAsync("orders", "Weather"));
+
+        var winner = await store.TryActivateAsync(request!);
+        var stale = await store.TryActivateAsync(request!);
+
+        Assert.True(winner.Succeeded);
+        Assert.Equal(1, winner.NewGeneration);
+        Assert.False(stale.Succeeded);
+        Assert.True(stale.IsConflict);
+
+        var active = await store.GetActiveAsync("orders", "Weather");
+        Assert.NotNull(active);
+        Assert.Equal(2, active.ActiveVersion);
+        Assert.Equal(1, active.Generation);
+        Assert.All(
+            await store.GetEntriesAsync("orders", "Weather", 2),
+            entry => Assert.Equal(MvStatus.Active, entry.Status));
+    }
+
+    private static MvRegistryEntry CreateEntry(
+        string serviceId,
+        string viewName,
+        int viewVersion,
+        MvStatus status,
+        MvCheckpointTruth current,
+        MvCheckpointTruth target) =>
+        new()
+        {
+            ServiceId = serviceId,
+            ViewName = viewName,
+            ViewVersion = viewVersion,
+            LogicalTable = "main",
+            PhysicalTable = "weather_main",
+            Status = status,
+            CurrentPosition = current.PositionValue,
+            TargetPosition = target.PositionValue,
+            CurrentCheckpointTruth = current,
+            TargetCheckpointTruth = target,
+            AppliedEventVersion = 1,
+            LastUpdated = DateTimeOffset.UtcNow
+        };
+
+    private static MvCheckpointTruth KnownCheckpoint(
+        string seed,
+        MvCheckpointProvenance provenance)
+    {
+        var id = GuidUtility.Create(seed);
+        return MvCheckpointTruth.Known(
+            new SortableUniqueId(SortableUniqueId.Generate(DateTime.UnixEpoch.AddMinutes(1), id)),
+            provenance);
+    }
+}
+
+internal static class GuidUtility
+{
+    public static Guid Create(string value) =>
+        new(value switch
+        {
+            "current" => "00000000-0000-0000-0000-000000000001",
+            "target" => "00000000-0000-0000-0000-000000000002",
+            "same" => "00000000-0000-0000-0000-000000000003",
+            _ => throw new ArgumentOutOfRangeException(nameof(value))
+        });
+}

--- a/dcb/tests/Sekiban.Dcb.MaterializedView.Tests/MvActivationEligibilityTests.cs
+++ b/dcb/tests/Sekiban.Dcb.MaterializedView.Tests/MvActivationEligibilityTests.cs
@@ -1,13 +1,42 @@
+using Dcb.Domain.WithoutResult;
 using Microsoft.Data.Sqlite;
+using Sekiban.Dcb;
+using Sekiban.Dcb.Actors;
 using Sekiban.Dcb.Common;
 using Sekiban.Dcb.MaterializedView;
 using Sekiban.Dcb.MaterializedView.Sqlite;
+using Sekiban.Dcb.ServiceId;
+using Sekiban.Dcb.Testing;
 using Xunit;
 
 namespace Sekiban.Dcb.MaterializedView.Tests;
 
 public sealed class MvActivationEligibilityTests
 {
+    [Fact]
+    public void MissingCandidate_HasTypedRejection() =>
+        AssertRejected(
+            MvActivationFailureReason.CandidateMissing,
+            "orders",
+            "Weather",
+            2,
+            []);
+
+    [Fact]
+    public void CandidateIdentityMismatch_HasTypedRejection()
+    {
+        var entry = EligibleEntry() with { ServiceId = "billing" };
+        AssertRejected(MvActivationFailureReason.IdentityMismatch, "orders", "Weather", 2, [entry]);
+    }
+
+    [Fact]
+    public void FaultedLifecycle_HasTypedRejection() =>
+        AssertRejected(MvActivationFailureReason.Faulted, entries: [EligibleEntry() with { Status = MvStatus.Faulted }]);
+
+    [Fact]
+    public void NonReadyLifecycle_HasTypedRejection() =>
+        AssertRejected(MvActivationFailureReason.UnsafeLifecycle, entries: [EligibleEntry() with { Status = MvStatus.CatchingUp }]);
+
     [Fact]
     public void UnknownTarget_IsRejectedBeforeAnyActivationRequestIsCreated()
     {
@@ -33,27 +62,116 @@ public sealed class MvActivationEligibilityTests
     }
 
     [Fact]
-    public void BehindCandidate_IsRejectedEvenWhenASeparateBestEffortStatusWouldSayCaughtUp()
+    public void UnknownCurrent_HasTypedRejection() =>
+        AssertRejected(
+            MvActivationFailureReason.CurrentCheckpointUnknown,
+            entries:
+            [
+                EligibleEntry() with
+                {
+                    CurrentPosition = null,
+                    CurrentCheckpointTruth = MvCheckpointTruth.Unknown(MvCheckpointUnknownReason.ReadUnavailable)
+                }
+            ]);
+
+    [Fact]
+    public void MissingAuthoritativeProvenance_HasTypedRejection()
     {
-        // This value represents the kind of sampled G24 status that must not be consulted by G27. The eligibility
-        // API has no status/count input; only the persisted authoritative truth below can authorize a cutover.
-        var g24IsCaughtUp = true;
+        var same = KnownCheckpoint("same", MvCheckpointProvenance.AppliedEvent(MvApplySource.CatchUp));
+        AssertRejected(
+            MvActivationFailureReason.MissingProvenance,
+            entries: [CreateEntry("orders", "Weather", 2, MvStatus.Ready, same, same)]);
+    }
+
+    [Fact]
+    public void LegacyPositionMismatch_HasTypedRejection() =>
+        AssertRejected(
+            MvActivationFailureReason.CandidateStateMismatch,
+            entries: [EligibleEntry() with { CurrentPosition = KnownCheckpoint("target", MvCheckpointProvenance.AppliedEvent(MvApplySource.CatchUp)).PositionValue }]);
+
+    [Fact]
+    public async Task FavorableWiredG24Observation_CannotAuthorizeBehindCandidate()
+    {
+        const string serviceId = "orders";
+        var serviceIdProvider = new FixedServiceIdProvider(serviceId);
+        var statusStore = new InMemoryMultiProjectionStateStore(serviceIdProvider);
+        var eventStore = new InMemoryEventStore(DomainType.GetDomainTypes().EventTypes, serviceIdProvider);
+        var now = DateTimeOffset.UtcNow;
+        var write = await statusStore.UpsertAsync(
+            new ProjectionStatusHeartbeat(
+                serviceId,
+                "Weather",
+                "2",
+                "cluster-a",
+                "activation-a",
+                1,
+                0,
+                null,
+                null,
+                now)
+            {
+                Phase = ProjectionStatusPhases.CaughtUp,
+                LeaseExpiresAtUtc = now.AddMinutes(1)
+            },
+            expectedSequence: 0);
+        Assert.True(write.IsSuccess);
+        var statusResult = await new ProjectionStatusReader(
+                statusStore,
+                eventStore,
+                serviceIdProvider,
+                new ProjectionStatusOptions { FreshnessWindow = TimeSpan.FromMinutes(1) })
+            .ReadAsync(new ProjectionStatusReadRequest(serviceId, "Weather", "2"));
+        Assert.True(statusResult.IsSuccess);
+        var g24Observation = Assert.Single(statusResult.GetValue());
+        Assert.True(g24Observation.IsCaughtUp);
+
         var current = KnownCheckpoint("current", MvCheckpointProvenance.AppliedEvent(MvApplySource.CatchUp));
         var target = KnownCheckpoint("target", MvCheckpointProvenance.AuthoritativeTargetCapture());
-        var entry = CreateEntry("orders", "Weather", 2, MvStatus.Ready, current, target);
+        var entry = CreateEntry(serviceId, "Weather", 2, MvStatus.Ready, current, target);
 
         var (eligibility, request) = MvActivationEligibility.Evaluate(
-            "orders",
+            serviceId,
             "Weather",
             2,
             [entry],
             active: null);
 
-        Assert.True(g24IsCaughtUp);
         Assert.False(eligibility.IsEligible);
         Assert.Equal(MvActivationFailureReason.BehindTarget, eligibility.FailureReason);
         Assert.Null(request);
     }
+
+    [Fact]
+    public void CandidateRowsWithDifferentTruthSnapshots_HaveTypedRejection()
+    {
+        var first = EligibleEntry() with { LogicalTable = "first" };
+        var later = MvCheckpointTruth.Known(
+            new SortableUniqueId(SortableUniqueId.Generate(
+                DateTime.UnixEpoch.AddMinutes(2),
+                GuidUtility.Create("target"))),
+            MvCheckpointProvenance.AppliedEvent(MvApplySource.CatchUp));
+        var second = EligibleEntry() with
+        {
+            LogicalTable = "second",
+            CurrentPosition = later.PositionValue,
+            CurrentCheckpointTruth = later
+        };
+        AssertRejected(MvActivationFailureReason.CandidateStateMismatch, entries: [first, second]);
+    }
+
+    [Fact]
+    public void ActivePointerIdentityMismatch_HasTypedRejection() =>
+        AssertRejected(
+            MvActivationFailureReason.IdentityMismatch,
+            entries: [EligibleEntry()],
+            active: new MvActiveEntry("billing", "Weather", 1, DateTimeOffset.UtcNow));
+
+    [Fact]
+    public void AlreadyActive_HasTypedRejection() =>
+        AssertRejected(
+            MvActivationFailureReason.AlreadyActive,
+            entries: [EligibleEntry()],
+            active: new MvActiveEntry("orders", "Weather", 2, DateTimeOffset.UtcNow));
 
     [Fact]
     public void EligibleCandidate_CarriesExpectedActiveAndGenerationSnapshot()
@@ -148,6 +266,32 @@ public sealed class MvActivationEligibilityTests
             AppliedEventVersion = 1,
             LastUpdated = DateTimeOffset.UtcNow
         };
+
+    private static MvRegistryEntry EligibleEntry()
+    {
+        var current = KnownCheckpoint("same", MvCheckpointProvenance.AppliedEvent(MvApplySource.CatchUp));
+        var target = KnownCheckpoint("same", MvCheckpointProvenance.AuthoritativeTargetCapture());
+        return CreateEntry("orders", "Weather", 2, MvStatus.Ready, current, target);
+    }
+
+    private static void AssertRejected(
+        MvActivationFailureReason expected,
+        string serviceId = "orders",
+        string viewName = "Weather",
+        int viewVersion = 2,
+        IReadOnlyList<MvRegistryEntry>? entries = null,
+        MvActiveEntry? active = null)
+    {
+        var (eligibility, request) = MvActivationEligibility.Evaluate(
+            serviceId,
+            viewName,
+            viewVersion,
+            entries ?? [EligibleEntry()],
+            active);
+        Assert.False(eligibility.IsEligible);
+        Assert.Equal(expected, eligibility.FailureReason);
+        Assert.Null(request);
+    }
 
     private static MvCheckpointTruth KnownCheckpoint(
         string seed,

--- a/dcb/tests/Sekiban.Dcb.MaterializedView.Tests/MvActivationEligibilityTests.cs
+++ b/dcb/tests/Sekiban.Dcb.MaterializedView.Tests/MvActivationEligibilityTests.cs
@@ -1,11 +1,18 @@
 using Dcb.Domain.WithoutResult;
 using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.DependencyInjection;
 using Sekiban.Dcb;
 using Sekiban.Dcb.Actors;
 using Sekiban.Dcb.Common;
+using Sekiban.Dcb.Domains;
+using Sekiban.Dcb.Events;
 using Sekiban.Dcb.MaterializedView;
+using Sekiban.Dcb.MaterializedView.MySql;
+using Sekiban.Dcb.MaterializedView.Postgres;
+using Sekiban.Dcb.MaterializedView.SqlServer;
 using Sekiban.Dcb.MaterializedView.Sqlite;
 using Sekiban.Dcb.ServiceId;
+using Sekiban.Dcb.Storage;
 using Sekiban.Dcb.Testing;
 using Xunit;
 
@@ -90,12 +97,43 @@ public sealed class MvActivationEligibilityTests
             entries: [EligibleEntry() with { CurrentPosition = KnownCheckpoint("target", MvCheckpointProvenance.AppliedEvent(MvApplySource.CatchUp)).PositionValue }]);
 
     [Fact]
-    public async Task FavorableWiredG24Observation_CannotAuthorizeBehindCandidate()
+    public async Task ProductionSqliteActivation_FavorableG24ObservationCannotAuthorizeUnknownTruth()
     {
         const string serviceId = "orders";
+        var connectionString = $"Data Source=file:sek-g27-g24-{Guid.NewGuid():N};Mode=Memory;Cache=Shared";
+        await using var anchor = new SqliteConnection(connectionString);
+        await anchor.OpenAsync();
+
         var serviceIdProvider = new FixedServiceIdProvider(serviceId);
         var statusStore = new InMemoryMultiProjectionStateStore(serviceIdProvider);
         var eventStore = new InMemoryEventStore(DomainType.GetDomainTypes().EventTypes, serviceIdProvider);
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton(DomainType.GetDomainTypes());
+        services.AddSingleton<IServiceIdProvider>(serviceIdProvider);
+        services.AddSingleton(eventStore);
+        services.AddSingleton<IEventStore>(eventStore);
+        services.AddSingleton<IEventStoreFactory>(new Sekiban.Dcb.InMemory.InMemoryEventStoreFactory(eventStore));
+        services.AddSingleton(statusStore);
+        services.AddSingleton<IProjectionStatusStore>(statusStore);
+        services.AddSingleton(new ProjectionStatusOptions { FreshnessWindow = TimeSpan.FromMinutes(1) });
+        services.AddSekibanDcbProjectionStatusReader();
+        services.AddSekibanDcbMaterializedView(options => options.ServiceId = serviceId);
+        services.AddSekibanDcbMaterializedViewSqlite(connectionString, registerHostedWorker: false);
+        using var provider = services.BuildServiceProvider();
+
+        var registry = provider.GetRequiredService<IMvRegistryStore>();
+        await registry.EnsureInfrastructureAsync();
+        var current = KnownCheckpoint("current", MvCheckpointProvenance.AppliedEvent(MvApplySource.CatchUp));
+        await registry.RegisterAsync(
+            CreateEntry(
+                serviceId,
+                "Weather",
+                2,
+                MvStatus.Ready,
+                current,
+                MvCheckpointTruth.Unknown(MvCheckpointUnknownReason.ReadUnavailable)));
+
         var now = DateTimeOffset.UtcNow;
         var write = await statusStore.UpsertAsync(
             new ProjectionStatusHeartbeat(
@@ -115,30 +153,44 @@ public sealed class MvActivationEligibilityTests
             },
             expectedSequence: 0);
         Assert.True(write.IsSuccess);
-        var statusResult = await new ProjectionStatusReader(
-                statusStore,
-                eventStore,
-                serviceIdProvider,
-                new ProjectionStatusOptions { FreshnessWindow = TimeSpan.FromMinutes(1) })
+        var statusResult = await provider.GetRequiredService<IProjectionStatusReader>()
             .ReadAsync(new ProjectionStatusReadRequest(serviceId, "Weather", "2"));
         Assert.True(statusResult.IsSuccess);
         var g24Observation = Assert.Single(statusResult.GetValue());
         Assert.True(g24Observation.IsCaughtUp);
 
-        var current = KnownCheckpoint("current", MvCheckpointProvenance.AppliedEvent(MvApplySource.CatchUp));
-        var target = KnownCheckpoint("target", MvCheckpointProvenance.AuthoritativeTargetCapture());
-        var entry = CreateEntry(serviceId, "Weather", 2, MvStatus.Ready, current, target);
+        var providerExecutor = Assert.IsType<SqliteMvExecutor>(provider.GetRequiredService<IMvExecutor>());
+        var activationExecutor = Assert.IsAssignableFrom<IMvActivationExecutor>(providerExecutor);
+        var activePointerWritesBefore = await CountActivePointersAsync(anchor);
+        var result = await activationExecutor.TryActivateAsync(new ActivationHost(), serviceId);
 
-        var (eligibility, request) = MvActivationEligibility.Evaluate(
-            serviceId,
-            "Weather",
-            2,
-            [entry],
-            active: null);
+        Assert.False(result.Succeeded);
+        Assert.Equal(MvActivationFailureReason.TargetUnknown, result.FailureReason);
+        Assert.Null(await registry.GetActiveAsync(serviceId, "Weather"));
+        Assert.Equal(activePointerWritesBefore, await CountActivePointersAsync(anchor));
+        Assert.Equal(0, activePointerWritesBefore);
+    }
 
-        Assert.False(eligibility.IsEligible);
-        Assert.Equal(MvActivationFailureReason.BehindTarget, eligibility.FailureReason);
-        Assert.Null(request);
+    [Fact]
+    public void ProductionActivationSurface_HasNoG24AuthorizationDependency()
+    {
+        Type[] productionActivationTypes =
+        [
+            typeof(MvExecutorBase<>),
+            typeof(MySqlMvExecutor),
+            typeof(PostgresMvExecutor),
+            typeof(SqlServerMvExecutor),
+            typeof(SqliteMvExecutor)
+        ];
+
+        var dependencyTypes = productionActivationTypes.SelectMany(type =>
+            type.GetConstructors().SelectMany(constructor => constructor.GetParameters().Select(parameter => parameter.ParameterType))
+                .Concat(type.GetFields(System.Reflection.BindingFlags.Instance |
+                    System.Reflection.BindingFlags.NonPublic |
+                    System.Reflection.BindingFlags.Public |
+                    System.Reflection.BindingFlags.DeclaredOnly).Select(field => field.FieldType)));
+
+        Assert.DoesNotContain(dependencyTypes, IsG24AuthorizationType);
     }
 
     [Fact]
@@ -301,6 +353,38 @@ public sealed class MvActivationEligibilityTests
         return MvCheckpointTruth.Known(
             new SortableUniqueId(SortableUniqueId.Generate(DateTime.UnixEpoch.AddMinutes(1), id)),
             provenance);
+    }
+
+    private static async Task<long> CountActivePointersAsync(SqliteConnection connection)
+    {
+        await using var command = connection.CreateCommand();
+        command.CommandText = "SELECT COUNT(*) FROM sekiban_mv_active";
+        return Convert.ToInt64(await command.ExecuteScalarAsync());
+    }
+
+    private static bool IsG24AuthorizationType(Type type) =>
+        type == typeof(IProjectionStatusReader) ||
+        type == typeof(ProjectionStatusSnapshot) ||
+        type == typeof(ProjectionStatusReadRequest);
+
+    private sealed class ActivationHost : IMvApplyHost
+    {
+        public string ViewName => "Weather";
+        public int ViewVersion => 2;
+        public IReadOnlyList<string> LogicalTables => ["main"];
+
+        public Task<IReadOnlyList<MvSqlStatementDto>> InitializeAsync(
+            IMvTableBindings tables,
+            CancellationToken ct) =>
+            Task.FromResult<IReadOnlyList<MvSqlStatementDto>>([]);
+
+        public Task<IReadOnlyList<MvSqlStatementDto>> ApplyEventAsync(
+            SerializableEvent ev,
+            IMvTableBindings tables,
+            IMvApplyQueryPort queryPort,
+            string sortableUniqueId,
+            CancellationToken ct) =>
+            Task.FromResult<IReadOnlyList<MvSqlStatementDto>>([]);
     }
 }
 

--- a/dcb/tests/Sekiban.Dcb.MaterializedView.Tests/MvExecutorServiceBoundaryTests.cs
+++ b/dcb/tests/Sekiban.Dcb.MaterializedView.Tests/MvExecutorServiceBoundaryTests.cs
@@ -58,6 +58,11 @@ public sealed class MvExecutorServiceBoundaryTests
             await Assert.ThrowsAsync<InvalidOperationException>(() => executor.CatchUpOnceAsync(host, " "));
             await Assert.ThrowsAsync<InvalidOperationException>(() => executor.CatchUpOnceAsync(host, "default"));
             await Assert.ThrowsAsync<InvalidOperationException>(() => executor.ApplySerializableEventsAsync(host, [], "default"));
+            var activationExecutor = Assert.IsAssignableFrom<IMvActivationExecutor>(executor);
+            await Assert.ThrowsAsync<InvalidOperationException>(() =>
+                activationExecutor.CaptureTargetCheckpointAsync(host, "default"));
+            await Assert.ThrowsAsync<InvalidOperationException>(() =>
+                activationExecutor.TryActivateAsync(host, "default"));
             Assert.Equal(0, registry.EnsureCalls);
         }
 

--- a/dcb/tests/Sekiban.Dcb.MaterializedView.Tests/Sekiban.Dcb.MaterializedView.Tests.csproj
+++ b/dcb/tests/Sekiban.Dcb.MaterializedView.Tests/Sekiban.Dcb.MaterializedView.Tests.csproj
@@ -31,6 +31,7 @@
         <ProjectReference Include="..\..\src\Sekiban.Dcb.MaterializedView.Postgres\Sekiban.Dcb.MaterializedView.Postgres.csproj"/>
         <ProjectReference Include="..\..\src\Sekiban.Dcb.MaterializedView.SqlServer\Sekiban.Dcb.MaterializedView.SqlServer.csproj"/>
         <ProjectReference Include="..\..\src\Sekiban.Dcb.MaterializedView.Sqlite\Sekiban.Dcb.MaterializedView.Sqlite.csproj"/>
+        <ProjectReference Include="..\..\src\Sekiban.Dcb.Core.Testing\Sekiban.Dcb.Core.Testing.csproj"/>
         <ProjectReference Include="..\..\internalUsages\Dcb.Domain.WithoutResult\Dcb.Domain.WithoutResult.csproj"/>
     </ItemGroup>
 

--- a/dcb/tests/Sekiban.Dcb.Orleans.Tests/MaterializedViewGrainTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Orleans.Tests/MaterializedViewGrainTests.cs
@@ -199,7 +199,7 @@ public class MaterializedViewGrainTests : IAsyncLifetime
             Task.FromResult<IReadOnlyList<MvSqlStatement>>([]);
     }
 
-    private sealed class FakeMvExecutor : IMvExecutor
+    private sealed class FakeMvExecutor : IMvExecutor, IMvActivationExecutor
     {
         private readonly FakeMvRegistryStore _registry;
 
@@ -248,18 +248,21 @@ public class MaterializedViewGrainTests : IAsyncLifetime
 
             if (batch.Count == 0)
             {
-                await _registry.UpdatePositionAsync(
-                    new MvPositionUpdate(
-                        serviceId,
-                        host.ViewName,
-                        host.ViewVersion,
-                        SortableUniqueId.MinValue.Value,
-                        MvApplySource.CatchUp,
-                        AppliedEventVersionDelta: 0)
-                    {
-                        CheckpointTruth = MvCheckpointTruth.KnownZero()
-                    },
-                    cancellationToken: cancellationToken);
+                if (string.IsNullOrWhiteSpace(currentPosition))
+                {
+                    await _registry.UpdatePositionAsync(
+                        new MvPositionUpdate(
+                            serviceId,
+                            host.ViewName,
+                            host.ViewVersion,
+                            SortableUniqueId.MinValue.Value,
+                            MvApplySource.CatchUp,
+                            AppliedEventVersionDelta: 0)
+                        {
+                            CheckpointTruth = MvCheckpointTruth.KnownZero()
+                        },
+                        cancellationToken: cancellationToken);
+                }
 
                 return new MvCatchUpResult(0, false);
             }
@@ -319,6 +322,58 @@ public class MaterializedViewGrainTests : IAsyncLifetime
                     ordered.Count),
                 cancellationToken: cancellationToken);
             return ordered.Count;
+        }
+
+        public async Task<MvCheckpointTruth> CaptureTargetCheckpointAsync(
+            IMvApplyHost host,
+            string? serviceId = null,
+            CancellationToken cancellationToken = default)
+        {
+            serviceId ??= DefaultServiceIdProvider.DefaultServiceId;
+            var latest = InitialEvents
+                .Select(serializableEvent => serializableEvent.SortableUniqueIdValue)
+                .OrderBy(value => value, StringComparer.Ordinal)
+                .LastOrDefault();
+            var target = string.IsNullOrWhiteSpace(latest)
+                ? MvCheckpointTruth.KnownZero(MvCheckpointProvenance.AuthoritativeTargetCapture())
+                : MvCheckpointTruth.Known(
+                    new SortableUniqueId(latest),
+                    MvCheckpointProvenance.AuthoritativeTargetCapture());
+            await _registry.SetTargetCheckpointAsync(
+                    serviceId,
+                    host.ViewName,
+                    host.ViewVersion,
+                    target,
+                    cancellationToken: cancellationToken)
+                .ConfigureAwait(false);
+            return target;
+        }
+
+        public async Task<MvActivationResult> TryActivateAsync(
+            IMvApplyHost host,
+            string? serviceId = null,
+            CancellationToken cancellationToken = default)
+        {
+            serviceId ??= DefaultServiceIdProvider.DefaultServiceId;
+            var entries = await _registry.GetEntriesAsync(
+                    serviceId,
+                    host.ViewName,
+                    host.ViewVersion,
+                    cancellationToken)
+                .ConfigureAwait(false);
+            var active = await _registry.GetActiveAsync(serviceId, host.ViewName, cancellationToken).ConfigureAwait(false);
+            var (eligibility, request) = MvActivationEligibility.Evaluate(
+                serviceId,
+                host.ViewName,
+                host.ViewVersion,
+                entries,
+                active);
+            if (!eligibility.IsEligible || request is null)
+            {
+                return MvActivationResult.Rejected(eligibility.FailureReason, eligibility.Message);
+            }
+
+            return await _registry.TryActivateAsync(request, cancellationToken: cancellationToken).ConfigureAwait(false);
         }
     }
 
@@ -458,6 +513,79 @@ public class MaterializedViewGrainTests : IAsyncLifetime
             return Task.CompletedTask;
         }
 
+        public Task SetTargetCheckpointAsync(
+            string serviceId,
+            string viewName,
+            int viewVersion,
+            MvCheckpointTruth targetCheckpointTruth,
+            System.Data.IDbTransaction? transaction = null,
+            CancellationToken cancellationToken = default)
+        {
+            foreach (var key in _entries.Keys.Where(key =>
+                         key.ServiceId == serviceId && key.ViewName == viewName && key.ViewVersion == viewVersion).ToList())
+            {
+                var entry = _entries[key];
+                _entries[key] = entry with
+                {
+                    TargetPosition = targetCheckpointTruth.PositionValue,
+                    TargetCheckpointTruth = targetCheckpointTruth,
+                    LastUpdated = DateTimeOffset.UtcNow
+                };
+            }
+
+            return Task.CompletedTask;
+        }
+
+        public Task<MvActivationResult> TryActivateAsync(
+            MvActivationRequest request,
+            System.Data.IDbTransaction? transaction = null,
+            CancellationToken cancellationToken = default)
+        {
+            if (!_active.TryGetValue((request.ServiceId, request.ViewName), out var active))
+            {
+                if (request.ExpectedActiveVersion is not null || request.ExpectedActiveGeneration != 0)
+                {
+                    return Task.FromResult(MvActivationResult.Rejected(
+                        MvActivationFailureReason.ConcurrentSuperseded,
+                        "The expected active pointer changed."));
+                }
+            }
+            else if (active.ActiveVersion != request.ExpectedActiveVersion ||
+                     active.Generation != request.ExpectedActiveGeneration)
+            {
+                return Task.FromResult(MvActivationResult.Rejected(
+                    MvActivationFailureReason.ConcurrentSuperseded,
+                    "The expected active pointer or generation changed."));
+            }
+
+            var keys = _entries.Keys.Where(key =>
+                key.ServiceId == request.ServiceId &&
+                key.ViewName == request.ViewName &&
+                key.ViewVersion == request.ViewVersion).ToList();
+            if (keys.Count != request.CandidateCount || keys.Any(key => _entries[key].Status != request.ExpectedStatus))
+            {
+                return Task.FromResult(MvActivationResult.Rejected(
+                    MvActivationFailureReason.ConcurrentSuperseded,
+                    "The candidate snapshot changed."));
+            }
+
+            var generation = request.ExpectedActiveGeneration + 1;
+            _active[(request.ServiceId, request.ViewName)] = new MvActiveEntry(
+                request.ServiceId,
+                request.ViewName,
+                request.ViewVersion,
+                DateTimeOffset.UtcNow)
+            {
+                Generation = generation
+            };
+            foreach (var key in keys)
+            {
+                _entries[key] = _entries[key] with { Status = MvStatus.Active };
+            }
+
+            return Task.FromResult(MvActivationResult.Success(generation));
+        }
+
         public async Task RegisterViewAsync(string serviceId, string viewName, int viewVersion, CancellationToken cancellationToken)
         {
             var key = (serviceId, viewName, viewVersion, "main");
@@ -479,7 +607,6 @@ public class MaterializedViewGrainTests : IAsyncLifetime
                     LastUpdated = DateTimeOffset.UtcNow
                 },
                 cancellationToken: cancellationToken);
-            await SetActiveAsync(serviceId, viewName, viewVersion, cancellationToken: cancellationToken);
         }
 
         public async Task<string?> GetCurrentPositionAsync(string serviceId, string viewName, int viewVersion, CancellationToken cancellationToken)

--- a/docs/dcb_llm/20_materialized_view.md
+++ b/docs/dcb_llm/20_materialized_view.md
@@ -248,6 +248,21 @@ This metadata is used to:
 - report status to operators
 - decide whether a view is catching up, ready, or active
 
+### Authoritative activation (SEK-G27)
+
+An MV version is not active merely because initialization succeeded or because no active row exists. The activation
+boundary first captures the event-store head as a `Known` target with
+`MvCheckpointProvenanceKind.AuthoritativeTargetCapture`. The candidate must then have matching service/view/version
+identity, `Ready` lifecycle, `Known` current and target truth, non-legacy provenance, and a current checkpoint at or
+after the captured target. Unknown, malformed, stale, behind, faulted, or unsafe candidates are rejected without
+changing the active pointer. G24 sampled status and event counts are diagnostics only; they are never cutover evidence.
+
+The four relational registry stores expose `TryActivateAsync`. It compares the expected active version and monotonic
+generation together with the exact candidate checkpoint snapshot inside one provider transaction. A conflicting or
+superseded attempt returns a typed conflict and leaves the former pointer unchanged. Initial activation uses this same
+capture, eligibility, and compare-and-switch path, so absence of an active row is only an expected input—not an
+authorization.
+
 ## Querying the Tables
 
 Applications should not hardcode the physical table name. Use `IMvOrleansQueryAccessor` to resolve it.

--- a/docs/dcb_llm_ja/20_materialized_view.md
+++ b/docs/dcb_llm_ja/20_materialized_view.md
@@ -252,6 +252,20 @@ WHERE id = @Id
 - 運用向け status 表示
 - catch-up 中か ready か active かの判断
 
+### 権威的な activation（SEK-G27）
+
+MV の初期化が成功したことや active 行が存在しないことだけでは、version を active にしません。activation の境界で
+まず event store の head を `Known` target として取得し、`MvCheckpointProvenanceKind.AuthoritativeTargetCapture` の
+provenance を付けます。その後、candidate は service/view/version の identity、`Ready` lifecycle、`Known` の current と
+target、legacy ではない provenance、current が取得済み target 以上であることを満たす必要があります。Unknown、malformed、
+stale、behind、faulted、unsafe な candidate は型付き拒否となり、active pointer を変更しません。G24 の sampled status や
+event count は診断情報に過ぎず、cutover の証拠には使いません。
+
+4 つの relational registry store は `TryActivateAsync` を提供します。この操作は provider の 1 transaction 内で、期待する
+active version と単調増加する generation、さらに candidate の checkpoint snapshot 全体を比較します。競合または superseded
+された試行は型付き conflict を返し、以前の pointer を保持します。初回 activation も同じ capture、eligibility、
+compare-and-switch 経路を通るため、active 行がないことは許可ではなく、比較対象の一つに過ぎません。
+
 ## テーブルのクエリ方法
 
 物理テーブル名をアプリ側で決め打ちしないでください。`IMvOrleansQueryAccessor` を使って解決します。


### PR DESCRIPTION
Closes #1113. Adds authoritative target capture, typed fail-closed eligibility, four-provider expected active/generation CAS, no initialization auto-activation, initial activation through the same boundary, compatibility surfaces, race/zero-mutation tests, and EN/JA docs. Verification: full dcb solution net9/net10, MaterializedView unit/integration/Postgres suites, git diff --check.