### PR TITLE
SEK-G28: publish classic MV status through G24 readers

### DIFF
--- a/dcb/src/Sekiban.Dcb.Core/Actors/ProjectionStatusReader.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Actors/ProjectionStatusReader.cs
@@ -148,6 +148,9 @@ public sealed class ProjectionStatusReader : IProjectionStatusReader
                     var faulted = row.IsFaulted ||
                         !string.IsNullOrWhiteSpace(row.FaultMessage) ||
                         string.Equals(row.Phase, ProjectionStatusPhases.Faulted, StringComparison.Ordinal);
+                    var lifecycleEligible =
+                        string.Equals(row.Phase, ProjectionStatusPhases.Active, StringComparison.Ordinal) ||
+                        string.Equals(row.Phase, ProjectionStatusPhases.CaughtUp, StringComparison.Ordinal);
                     return new ProjectionStatusSnapshot(
                         row.ProjectorName,
                         row.ProjectorVersion,
@@ -161,7 +164,7 @@ public sealed class ProjectionStatusReader : IProjectionStatusReader
                         remaining,
                         sampledAt,
                         ProjectionStatusSnapshot.BestEffortConsistency,
-                        remaining == 0 && rowFresh && !faulted && !hasConflict,
+                        remaining == 0 && rowFresh && lifecycleEligible && !faulted && !hasConflict,
                         hasConflict,
                         hasConflict ? activationIds : Array.Empty<string>())
                     {

--- a/dcb/src/Sekiban.Dcb.MaterializedView.Orleans/MaterializedViewGrain.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.Orleans/MaterializedViewGrain.cs
@@ -24,6 +24,7 @@ public sealed class MaterializedViewGrain : Grain, IMaterializedViewGrain
     private readonly IMvApplyHostFactory _hostFactory;
     private readonly ILogger<MaterializedViewGrain> _logger;
     private readonly MvOptions _options;
+    private readonly MvProjectionStatusPublisher? _statusPublisher;
     private readonly IMvRegistryStore _registryStore;
     private readonly IEventSubscriptionResolver _subscriptionResolver;
 
@@ -32,6 +33,7 @@ public sealed class MaterializedViewGrain : Grain, IMaterializedViewGrain
     private StreamSubscriptionHandle<SerializableEvent>? _streamHandle;
     private bool _subscriptionStarting;
     private IDisposable? _catchUpTimer;
+    private IDisposable? _statusTimer;
     private string? _grainKey;
     private string? _serviceId;
     private string? _viewName;
@@ -61,6 +63,19 @@ public sealed class MaterializedViewGrain : Grain, IMaterializedViewGrain
         IEventSubscriptionResolver subscriptionResolver,
         IOptions<MvOptions> options,
         ILogger<MaterializedViewGrain> logger)
+        : this(hostFactory, executor, registryStore, subscriptionResolver, options, logger, statusPublisher: null)
+    {
+    }
+
+    [Microsoft.Extensions.DependencyInjection.ActivatorUtilitiesConstructor]
+    public MaterializedViewGrain(
+        IMvApplyHostFactory hostFactory,
+        IMvExecutor executor,
+        IMvRegistryStore registryStore,
+        IEventSubscriptionResolver subscriptionResolver,
+        IOptions<MvOptions> options,
+        ILogger<MaterializedViewGrain> logger,
+        MvProjectionStatusPublisher? statusPublisher)
     {
         _hostFactory = hostFactory;
         _executor = executor;
@@ -68,6 +83,7 @@ public sealed class MaterializedViewGrain : Grain, IMaterializedViewGrain
         _subscriptionResolver = subscriptionResolver;
         _logger = logger;
         _options = options.Value;
+        _statusPublisher = statusPublisher;
         ReconfigureCatchUpSemaphore(_options.CatchUpMaxConcurrentBatches);
     }
 
@@ -82,6 +98,8 @@ public sealed class MaterializedViewGrain : Grain, IMaterializedViewGrain
     {
         _catchUpTimer?.Dispose();
         _catchUpTimer = null;
+        _statusTimer?.Dispose();
+        _statusTimer = null;
         if (_streamHandle is not null)
         {
             await _streamHandle.UnsubscribeAsync();
@@ -118,6 +136,7 @@ public sealed class MaterializedViewGrain : Grain, IMaterializedViewGrain
         _statusMarkedCatchingUp = false;
         StartCatchUpTimer();
         _started = true;
+        StartStatusTimer();
     }
 
     public async Task RefreshAsync()
@@ -291,6 +310,37 @@ public sealed class MaterializedViewGrain : Grain, IMaterializedViewGrain
             _ => ProcessCatchUpTickAsync(),
             TimeSpan.Zero,
             _options.PollInterval);
+    }
+
+    private void StartStatusTimer()
+    {
+        if (_statusTimer is not null || _statusPublisher is null)
+        {
+            return;
+        }
+
+        _statusTimer = this.RegisterGrainTimer(
+            cancellationToken => PublishStatusAsync(cancellationToken),
+            TimeSpan.Zero,
+            _statusPublisher.PublicationInterval);
+    }
+
+    private async Task PublishStatusAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            await _statusPublisher!.PublishIfDueAsync(
+                    _serviceId!,
+                    _viewName!,
+                    _viewVersion,
+                    MvProjectionStatusPublisherKind.Orleans,
+                    cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            // Timer disposal/deactivation cancellation is normal.
+        }
     }
 
     private void StopCatchUpTimer()

--- a/dcb/src/Sekiban.Dcb.MaterializedView.Orleans/MaterializedViewGrain.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.Orleans/MaterializedViewGrain.cs
@@ -40,6 +40,7 @@ public sealed class MaterializedViewGrain : Grain, IMaterializedViewGrain
     private int _viewVersion;
     private IMvApplyHost? _host;
     private string? _lastAppliedSortableUniqueId;
+    private MvProjectionStatusSnapshot _publicationSnapshot = MvProjectionStatusSnapshot.Unknown();
     private string? _lastReceivedSortableUniqueId;
     private string? _lastError;
     private DateTimeOffset? _lastCatchUpStartedAt;
@@ -333,6 +334,7 @@ public sealed class MaterializedViewGrain : Grain, IMaterializedViewGrain
                     _serviceId!,
                     _viewName!,
                     _viewVersion,
+                    _publicationSnapshot,
                     MvProjectionStatusPublisherKind.Orleans,
                     cancellationToken)
                 .ConfigureAwait(false);
@@ -437,9 +439,14 @@ public sealed class MaterializedViewGrain : Grain, IMaterializedViewGrain
                     MvStatus.CatchingUp,
                     cancellationToken: cancellationToken);
                 _statusMarkedCatchingUp = true;
+                _publicationSnapshot = _publicationSnapshot with { Status = MvStatus.CatchingUp };
             }
 
             var result = await _executor.CatchUpOnceAsync(_host!, _serviceId, cancellationToken);
+            if (result.ProjectionStatus is { } projectionStatus)
+            {
+                _publicationSnapshot = projectionStatus;
+            }
 
             if (!string.IsNullOrWhiteSpace(result.LastAppliedSortableUniqueId))
             {
@@ -469,6 +476,7 @@ public sealed class MaterializedViewGrain : Grain, IMaterializedViewGrain
         catch (Exception ex)
         {
             _lastError = ex.Message;
+            _publicationSnapshot = _publicationSnapshot with { Status = MvStatus.Faulted };
             _logger.LogError(
                 ex,
                 "Materialized view catch-up batch failed for {ViewName}/{ViewVersion}.",
@@ -502,6 +510,7 @@ public sealed class MaterializedViewGrain : Grain, IMaterializedViewGrain
             _host!.ViewName,
             _host.ViewVersion,
             cancellationToken);
+        _publicationSnapshot = MvProjectionStatusSnapshot.FromEntries(entries);
         if (entries.Count == 0 || entries.Any(entry => !entry.CurrentCheckpointTruth.IsKnown))
         {
             _lastError = "Materialized view checkpoint truth is Unknown; readiness remains fail-closed.";
@@ -529,6 +538,7 @@ public sealed class MaterializedViewGrain : Grain, IMaterializedViewGrain
                 .ConfigureAwait(false);
             if (active?.ActiveVersion == _host.ViewVersion)
             {
+                _publicationSnapshot = _publicationSnapshot with { Status = MvStatus.Active };
                 _isCatchUpActive = false;
                 _needsImmediateCatchUp = false;
                 _consecutiveEmptyBatches = 0;
@@ -550,6 +560,7 @@ public sealed class MaterializedViewGrain : Grain, IMaterializedViewGrain
                     MvStatus.Ready,
                     cancellationToken: cancellationToken)
                 .ConfigureAwait(false);
+            _publicationSnapshot = _publicationSnapshot with { Status = MvStatus.Ready };
 
             var activation = await activationExecutor.TryActivateAsync(
                     _host,
@@ -563,6 +574,7 @@ public sealed class MaterializedViewGrain : Grain, IMaterializedViewGrain
                 return;
             }
 
+            _publicationSnapshot = _publicationSnapshot with { Status = MvStatus.Active };
             _isCatchUpActive = false;
             _needsImmediateCatchUp = false;
             _consecutiveEmptyBatches = 0;
@@ -576,6 +588,7 @@ public sealed class MaterializedViewGrain : Grain, IMaterializedViewGrain
             _host.ViewVersion,
             MvStatus.Ready,
             cancellationToken: cancellationToken);
+        _publicationSnapshot = _publicationSnapshot with { Status = MvStatus.Ready };
         _isCatchUpActive = false;
         _needsImmediateCatchUp = false;
         _consecutiveEmptyBatches = 0;
@@ -750,6 +763,7 @@ public sealed class MaterializedViewGrain : Grain, IMaterializedViewGrain
     {
         ResolveHost();
         var entries = await _registryStore.GetEntriesAsync(_serviceId!, _host!.ViewName, _host.ViewVersion, cancellationToken);
+        _publicationSnapshot = MvProjectionStatusSnapshot.FromEntries(entries);
         var currentPosition = entries
             .Select(entry => entry.CurrentCheckpointTruth.IsKnown ? entry.CurrentCheckpointTruth.PositionValue : null)
             .Where(position => !string.IsNullOrWhiteSpace(position))

--- a/dcb/src/Sekiban.Dcb.MaterializedView/MvCatchUpWorker.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView/MvCatchUpWorker.cs
@@ -8,6 +8,7 @@ namespace Sekiban.Dcb.MaterializedView;
 public sealed class MvCatchUpWorker : BackgroundService
 {
     private readonly Dictionary<string, int> _failureCounts = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, MvProjectionStatusSnapshot> _publicationSnapshots = new(StringComparer.Ordinal);
     private readonly IMvExecutor _executor;
     private readonly IMvApplyHostFactory _hostFactory;
     private readonly ILogger<MvCatchUpWorker> _logger;
@@ -91,6 +92,8 @@ public sealed class MvCatchUpWorker : BackgroundService
         {
             var host = _hostFactory.Create(registration.ViewName, registration.ViewVersion);
             await _executor.InitializeAsync(host, _serviceId, stoppingToken).ConfigureAwait(false);
+            _publicationSnapshots[GetProjectorKey(registration)] =
+                MvProjectionStatusSnapshot.Unknown(MvStatus.CatchingUp);
         }
     }
 
@@ -98,10 +101,24 @@ public sealed class MvCatchUpWorker : BackgroundService
     {
         var appliedEvents = 0;
         var shouldDelay = false;
+        var lastSnapshot = MvProjectionStatusSnapshot.Unknown(MvStatus.CatchingUp);
 
         foreach (var registration in _registrations)
         {
             var projectorResult = await ProcessProjectorAsync(registration, stoppingToken).ConfigureAwait(false);
+            lastSnapshot = projectorResult.ProjectionStatus;
+            if (_statusPublisher is not null)
+            {
+                await _statusPublisher.PublishIfDueAsync(
+                        _serviceId,
+                        registration.ViewName,
+                        registration.ViewVersion,
+                        projectorResult.ProjectionStatus,
+                        MvProjectionStatusPublisherKind.HostedWorker,
+                        stoppingToken)
+                    .ConfigureAwait(false);
+            }
+
             if (projectorResult.ShouldStop)
             {
                 return projectorResult;
@@ -109,19 +126,9 @@ public sealed class MvCatchUpWorker : BackgroundService
 
             appliedEvents += projectorResult.AppliedEvents;
             shouldDelay |= projectorResult.ShouldDelay;
-            if (_statusPublisher is not null)
-            {
-                await _statusPublisher.PublishIfDueAsync(
-                        _serviceId,
-                        registration.ViewName,
-                        registration.ViewVersion,
-                        MvProjectionStatusPublisherKind.HostedWorker,
-                        stoppingToken)
-                    .ConfigureAwait(false);
-            }
         }
 
-        return new CatchUpCycleResult(appliedEvents, shouldDelay, ShouldStop: false);
+        return new CatchUpCycleResult(appliedEvents, shouldDelay, ShouldStop: false, lastSnapshot);
     }
 
     private async Task<CatchUpCycleResult> ProcessProjectorAsync(
@@ -133,7 +140,9 @@ public sealed class MvCatchUpWorker : BackgroundService
         {
             var result = await _executor.CatchUpOnceAsync(host, _serviceId, stoppingToken).ConfigureAwait(false);
             _failureCounts.Remove(GetProjectorKey(registration));
-            return new CatchUpCycleResult(result.AppliedEvents, result.ReachedUnsafeWindow, ShouldStop: false);
+            var snapshot = result.ProjectionStatus ?? GetSnapshot(registration);
+            _publicationSnapshots[GetProjectorKey(registration)] = snapshot;
+            return new CatchUpCycleResult(result.AppliedEvents, result.ReachedUnsafeWindow, ShouldStop: false, snapshot);
         }
         catch (NotSupportedException ex)
         {
@@ -142,7 +151,9 @@ public sealed class MvCatchUpWorker : BackgroundService
                 "Materialized view worker stopped because the configured event store cannot stream all events for {ViewName}/{ViewVersion}.",
                 registration.ViewName,
                 registration.ViewVersion);
-            return new CatchUpCycleResult(0, ShouldDelay: false, ShouldStop: true);
+            var snapshot = GetSnapshot(registration) with { Status = MvStatus.Faulted };
+            _publicationSnapshots[GetProjectorKey(registration)] = snapshot;
+            return new CatchUpCycleResult(0, ShouldDelay: false, ShouldStop: true, snapshot);
         }
         catch (Exception ex)
         {
@@ -155,7 +166,9 @@ public sealed class MvCatchUpWorker : BackgroundService
                     registration.ViewName,
                     registration.ViewVersion,
                     failures);
-                return new CatchUpCycleResult(0, ShouldDelay: false, ShouldStop: true);
+                var halted = GetSnapshot(registration) with { Status = MvStatus.Faulted };
+                _publicationSnapshots[GetProjectorKey(registration)] = halted;
+                return new CatchUpCycleResult(0, ShouldDelay: false, ShouldStop: true, halted);
             }
 
             _logger.LogWarning(
@@ -165,9 +178,16 @@ public sealed class MvCatchUpWorker : BackgroundService
                 registration.ViewVersion,
                 failures,
                 _options.MaxConsecutiveFailuresBeforeStop);
-            return new CatchUpCycleResult(0, ShouldDelay: true, ShouldStop: false);
+            var retrying = GetSnapshot(registration) with { Status = MvStatus.Faulted };
+            _publicationSnapshots[GetProjectorKey(registration)] = retrying;
+            return new CatchUpCycleResult(0, ShouldDelay: true, ShouldStop: false, retrying);
         }
     }
+
+    private MvProjectionStatusSnapshot GetSnapshot(MvApplyHostRegistration registration) =>
+        _publicationSnapshots.TryGetValue(GetProjectorKey(registration), out var snapshot)
+            ? snapshot
+            : MvProjectionStatusSnapshot.Unknown(MvStatus.CatchingUp);
 
     private int IncrementFailureCount(MvApplyHostRegistration registration)
     {
@@ -210,5 +230,9 @@ public sealed class MvCatchUpWorker : BackgroundService
         return normalized;
     }
 
-    private sealed record CatchUpCycleResult(int AppliedEvents, bool ShouldDelay, bool ShouldStop);
+    private sealed record CatchUpCycleResult(
+        int AppliedEvents,
+        bool ShouldDelay,
+        bool ShouldStop,
+        MvProjectionStatusSnapshot ProjectionStatus);
 }

--- a/dcb/src/Sekiban.Dcb.MaterializedView/MvCatchUpWorker.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView/MvCatchUpWorker.cs
@@ -13,6 +13,7 @@ public sealed class MvCatchUpWorker : BackgroundService
     private readonly ILogger<MvCatchUpWorker> _logger;
     private readonly IReadOnlyList<MvApplyHostRegistration> _registrations;
     private readonly MvOptions _options;
+    private readonly MvProjectionStatusPublisher? _statusPublisher;
     private readonly string _serviceId;
 
     public MvCatchUpWorker(
@@ -20,7 +21,7 @@ public sealed class MvCatchUpWorker : BackgroundService
         IMvExecutor executor,
         IOptions<MvOptions> options,
         ILogger<MvCatchUpWorker> logger)
-        : this(hostFactory, executor, options, logger, serviceId: null)
+        : this(hostFactory, executor, options, logger, serviceId: null, statusPublisher: null)
     {
     }
 
@@ -33,6 +34,28 @@ public sealed class MvCatchUpWorker : BackgroundService
         IOptions<MvOptions> options,
         ILogger<MvCatchUpWorker> logger,
         string? serviceId)
+        : this(hostFactory, executor, options, logger, serviceId, statusPublisher: null)
+    {
+    }
+
+    [Microsoft.Extensions.DependencyInjection.ActivatorUtilitiesConstructor]
+    public MvCatchUpWorker(
+        IMvApplyHostFactory hostFactory,
+        IMvExecutor executor,
+        IOptions<MvOptions> options,
+        ILogger<MvCatchUpWorker> logger,
+        MvProjectionStatusPublisher statusPublisher)
+        : this(hostFactory, executor, options, logger, serviceId: null, statusPublisher)
+    {
+    }
+
+    public MvCatchUpWorker(
+        IMvApplyHostFactory hostFactory,
+        IMvExecutor executor,
+        IOptions<MvOptions> options,
+        ILogger<MvCatchUpWorker> logger,
+        string? serviceId,
+        MvProjectionStatusPublisher? statusPublisher)
     {
         _executor = executor;
         _hostFactory = hostFactory;
@@ -40,6 +63,7 @@ public sealed class MvCatchUpWorker : BackgroundService
         _registrations = hostFactory.GetRegistrations();
         _options = options.Value;
         _serviceId = ResolveWorkerServiceId(serviceId, _options);
+        _statusPublisher = statusPublisher;
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
@@ -85,6 +109,16 @@ public sealed class MvCatchUpWorker : BackgroundService
 
             appliedEvents += projectorResult.AppliedEvents;
             shouldDelay |= projectorResult.ShouldDelay;
+            if (_statusPublisher is not null)
+            {
+                await _statusPublisher.PublishIfDueAsync(
+                        _serviceId,
+                        registration.ViewName,
+                        registration.ViewVersion,
+                        MvProjectionStatusPublisherKind.HostedWorker,
+                        stoppingToken)
+                    .ConfigureAwait(false);
+            }
         }
 
         return new CatchUpCycleResult(appliedEvents, shouldDelay, ShouldStop: false);

--- a/dcb/src/Sekiban.Dcb.MaterializedView/MvContracts.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView/MvContracts.cs
@@ -386,4 +386,11 @@ public interface IMvActivationExecutor
         CancellationToken cancellationToken = default);
 }
 
-public sealed record MvCatchUpResult(int AppliedEvents, bool ReachedUnsafeWindow, string? LastAppliedSortableUniqueId = null);
+public sealed record MvCatchUpResult(int AppliedEvents, bool ReachedUnsafeWindow, string? LastAppliedSortableUniqueId = null)
+{
+    /// <summary>
+    /// Authoritative progress already known at the completed operation boundary. Null preserves compatibility for
+    /// custom executors that have not opted into G24 status publication.
+    /// </summary>
+    public MvProjectionStatusSnapshot? ProjectionStatus { get; init; }
+}

--- a/dcb/src/Sekiban.Dcb.MaterializedView/MvExecutorBase.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView/MvExecutorBase.cs
@@ -269,7 +269,7 @@ public abstract class MvExecutorBase<TConnection> : IMvExecutor, IMvActivationEx
         await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
     }
 
-    protected async Task<string?> GetCurrentPositionAsync(
+    protected async Task<MvProjectionStatusSnapshot> GetCurrentStatusAsync(
         IMvApplyHost host,
         string serviceId,
         CancellationToken cancellationToken)
@@ -291,11 +291,7 @@ public abstract class MvExecutorBase<TConnection> : IMvExecutor, IMvActivationEx
                 .ConfigureAwait(false);
         }
 
-        // Never use the nullable legacy position for a decisive read boundary. Old rows may contain a position but
-        // have no provenance, so they remain Unknown and are replayed fail-closed from the beginning.
-        return entries
-            .Select(entry => entry.CurrentCheckpointTruth.IsKnown ? entry.CurrentCheckpointTruth.PositionValue : null)
-            .FirstOrDefault(position => !string.IsNullOrWhiteSpace(position));
+        return MvProjectionStatusSnapshot.FromEntries(entries);
     }
 
     protected async Task<MvCatchUpResult> CatchUpFromStoreAsync(
@@ -312,15 +308,27 @@ public abstract class MvExecutorBase<TConnection> : IMvExecutor, IMvActivationEx
                 selectedEventStore,
                 cancellationToken)
             .ConfigureAwait(false);
-        var currentPosition = await GetCurrentPositionAsync(host, serviceId, cancellationToken).ConfigureAwait(false);
+        var currentStatus = await GetCurrentStatusAsync(host, serviceId, cancellationToken).ConfigureAwait(false);
+        // Never use the nullable legacy position for a decisive read boundary. Old rows may contain a position but
+        // have no provenance, so they remain Unknown and are replayed fail-closed from the beginning.
+        var currentPosition = currentStatus.CurrentCheckpointTruth.IsKnown
+            ? currentStatus.CurrentCheckpointTruth.PositionValue
+            : null;
         var readResult = await selectedEventStore.ReadAllSerializableEventsAsync(
                 SortableUniqueId.NullableValue(currentPosition),
                 _options.BatchSize)
             .ConfigureAwait(false);
-        var result = await CompleteCatchUpAsync(host, serviceId, readResult, cancellationToken).ConfigureAwait(false);
+        var result = await CompleteCatchUpAsync(host, serviceId, readResult, currentStatus, cancellationToken)
+            .ConfigureAwait(false);
         if (result.AppliedEvents == 0 || result.ReachedUnsafeWindow)
         {
-            await TryActivateIfEligibleAsync(host, serviceId, cancellationToken).ConfigureAwait(false);
+            var status = await TryActivateIfEligibleAsync(host, serviceId, cancellationToken).ConfigureAwait(false);
+            result = result with
+            {
+                ProjectionStatus = result.ProjectionStatus is { } snapshot
+                    ? snapshot with { Status = status }
+                    : currentStatus with { Status = status }
+            };
         }
 
         return result;
@@ -375,7 +383,7 @@ public abstract class MvExecutorBase<TConnection> : IMvExecutor, IMvActivationEx
     ///     from CatchingUp to Ready only after all non-lifecycle eligibility predicates pass. The final pointer write
     ///     is always the provider transaction's expected-active/generation CAS.
     /// </summary>
-    private async Task TryActivateIfEligibleAsync(
+    private async Task<MvStatus> TryActivateIfEligibleAsync(
         IMvApplyHost host,
         string serviceId,
         CancellationToken cancellationToken)
@@ -397,7 +405,7 @@ public abstract class MvExecutorBase<TConnection> : IMvExecutor, IMvActivationEx
         if (entries.Count == 0 || entries.Any(entry =>
                 entry.Status is not (MvStatus.CatchingUp or MvStatus.Ready)))
         {
-            return;
+            return entries.FirstOrDefault()?.Status ?? MvStatus.Initializing;
         }
 
         // Evaluate the full contract before changing lifecycle state. The evaluator itself intentionally accepts
@@ -414,7 +422,7 @@ public abstract class MvExecutorBase<TConnection> : IMvExecutor, IMvActivationEx
             active);
         if (!preflight.IsEligible)
         {
-            return;
+            return entries[0].Status;
         }
 
         if (entries.Any(entry => entry.Status != MvStatus.Ready))
@@ -438,6 +446,10 @@ public abstract class MvExecutorBase<TConnection> : IMvExecutor, IMvActivationEx
                 result.FailureReason,
                 result.Message);
         }
+
+        return result.Succeeded || result.FailureReason == MvActivationFailureReason.AlreadyActive
+            ? MvStatus.Active
+            : MvStatus.Ready;
     }
 
     protected Task<int> ApplyStreamEventsAtBoundaryAsync(
@@ -463,6 +475,7 @@ public abstract class MvExecutorBase<TConnection> : IMvExecutor, IMvActivationEx
         IMvApplyHost host,
         string serviceId,
         ResultBox<IEnumerable<SerializableEvent>> readResult,
+        MvProjectionStatusSnapshot currentStatus,
         CancellationToken cancellationToken)
     {
         if (!readResult.IsSuccess)
@@ -478,7 +491,10 @@ public abstract class MvExecutorBase<TConnection> : IMvExecutor, IMvActivationEx
                 "Failed to read events for materialized view {ViewName}/{ViewVersion}.",
                 host.ViewName,
                 host.ViewVersion);
-            return new MvCatchUpResult(0, false);
+            return new MvCatchUpResult(0, false)
+            {
+                ProjectionStatus = currentStatus with { Status = MvStatus.Faulted }
+            };
         }
 
         var safeThreshold = CreateSafeThreshold(_options.SafeWindowMs);
@@ -500,7 +516,18 @@ public abstract class MvExecutorBase<TConnection> : IMvExecutor, IMvActivationEx
                     },
                     cancellationToken: cancellationToken)
                 .ConfigureAwait(false);
-            return new MvCatchUpResult(0, false);
+            var emptyTruth = currentStatus.CurrentCheckpointTruth.IsKnown &&
+                !currentStatus.CurrentCheckpointTruth.IsKnownZero
+                    ? currentStatus.CurrentCheckpointTruth
+                    : MvCheckpointTruth.KnownZero();
+            return new MvCatchUpResult(0, false)
+            {
+                ProjectionStatus = currentStatus with
+                {
+                    CurrentCheckpointTruth = emptyTruth,
+                    Status = MvStatus.CatchingUp
+                }
+            };
         }
 
         var safeBatch = new List<SerializableEvent>(batch.Count);
@@ -517,7 +544,10 @@ public abstract class MvExecutorBase<TConnection> : IMvExecutor, IMvActivationEx
 
         if (safeBatch.Count == 0)
         {
-            return new MvCatchUpResult(0, reachedUnsafeWindow);
+            return new MvCatchUpResult(0, reachedUnsafeWindow)
+            {
+                ProjectionStatus = currentStatus with { Status = MvStatus.CatchingUp }
+            };
         }
 
         var appliedEvents = await ApplySerializableEventsCoreAsync(
@@ -532,7 +562,20 @@ public abstract class MvExecutorBase<TConnection> : IMvExecutor, IMvActivationEx
             : null;
 
         reachedUnsafeWindow |= appliedEvents < safeBatch.Count;
-        return new MvCatchUpResult(appliedEvents, reachedUnsafeWindow, lastAppliedSortableUniqueId);
+        var truth = !string.IsNullOrWhiteSpace(lastAppliedSortableUniqueId)
+            ? MvCheckpointTruth.Known(
+                new SortableUniqueId(lastAppliedSortableUniqueId),
+                MvCheckpointProvenance.AppliedEvent(MvApplySource.CatchUp))
+            : currentStatus.CurrentCheckpointTruth;
+        return new MvCatchUpResult(appliedEvents, reachedUnsafeWindow, lastAppliedSortableUniqueId)
+        {
+            ProjectionStatus = currentStatus with
+            {
+                CurrentCheckpointTruth = truth,
+                Status = MvStatus.CatchingUp,
+                AppliedEventCount = currentStatus.AppliedEventCount + appliedEvents
+            }
+        };
     }
 
     protected async Task<int> ApplySerializableEventsCoreAsync(

--- a/dcb/src/Sekiban.Dcb.MaterializedView/MvProjectionStatusPublication.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView/MvProjectionStatusPublication.cs
@@ -1,0 +1,255 @@
+using System.Collections.Concurrent;
+using System.Globalization;
+using System.Text;
+using Microsoft.Extensions.Logging;
+using Sekiban.Dcb.ServiceId;
+using Sekiban.Dcb.Storage;
+
+namespace Sekiban.Dcb.MaterializedView;
+
+/// <summary>Identifies the off-hot-path runtime that published an MV status sample.</summary>
+public enum MvProjectionStatusPublisherKind
+{
+    HostedWorker = 0,
+    Orleans = 1
+}
+
+/// <summary>Stable, reversible-free G24 identity for a classic materialized view.</summary>
+public sealed record MvProjectionStatusIdentity(string ProjectorName, string ProjectorVersion)
+{
+    public static MvProjectionStatusIdentity Create(string viewName, int viewVersion)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(viewName);
+        if (viewVersion < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(viewVersion));
+        }
+
+        return new(
+            $"mv:{Base64Url(viewName)}",
+            $"v:{viewVersion.ToString(CultureInfo.InvariantCulture)}");
+    }
+
+    private static string Base64Url(string value) =>
+        Convert.ToBase64String(Encoding.UTF8.GetBytes(value))
+            .TrimEnd('=')
+            .Replace('+', '-')
+            .Replace('/', '_');
+}
+
+/// <summary>
+/// Publishes G26 registry truth through the existing G24 source-side registry. This component never resolves an
+/// event store and is called only by dedicated hosted-worker/Orleans schedules.
+/// </summary>
+public sealed class MvProjectionStatusPublisher
+{
+    private readonly ConcurrentDictionary<string, DateTimeOffset> _nextDue = new(StringComparer.Ordinal);
+    private readonly ConcurrentDictionary<string, PublicationFence> _fences = new(StringComparer.Ordinal);
+    private readonly string _activationRoot = Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture);
+    private readonly ILogger<MvProjectionStatusPublisher> _logger;
+    private readonly ProjectionStatusOptions _options;
+    private readonly IMvRegistryStore _registryStore;
+    private readonly IProjectionStatusStore? _statusStore;
+
+    public MvProjectionStatusPublisher(
+        IMvRegistryStore registryStore,
+        IProjectionStatusStore? statusStore,
+        ProjectionStatusOptions options,
+        ILogger<MvProjectionStatusPublisher> logger)
+    {
+        _registryStore = registryStore ?? throw new ArgumentNullException(nameof(registryStore));
+        _statusStore = statusStore;
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public TimeSpan PublicationInterval =>
+        PositiveOrDefault(_options.HeartbeatInterval, TimeSpan.FromSeconds(30));
+
+    public async Task PublishIfDueAsync(
+        string serviceId,
+        string viewName,
+        int viewVersion,
+        MvProjectionStatusPublisherKind publisherKind,
+        CancellationToken cancellationToken = default)
+    {
+        var normalizedServiceId = ServiceIdValidator.NormalizeAndValidate(serviceId);
+        var identity = MvProjectionStatusIdentity.Create(viewName, viewVersion);
+        if (!_options.Enabled || _statusStore is null)
+        {
+            return;
+        }
+
+        var lane = publisherKind == MvProjectionStatusPublisherKind.HostedWorker ? "hosted" : "orleans";
+        var key = string.Join('|', normalizedServiceId, identity.ProjectorName, identity.ProjectorVersion, lane);
+        var now = DateTimeOffset.UtcNow;
+        if (_nextDue.TryGetValue(key, out var nextDue) && now < nextDue)
+        {
+            return;
+        }
+
+        _nextDue[key] = now + PositiveOrDefault(_options.HeartbeatInterval, TimeSpan.FromSeconds(30));
+        try
+        {
+            var timeout = PositiveOrDefault(_options.HeartbeatWriteTimeout, TimeSpan.FromSeconds(5));
+            using var readCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            readCts.CancelAfter(timeout);
+            var entries = await _registryStore.GetEntriesAsync(
+                    normalizedServiceId,
+                    viewName,
+                    viewVersion,
+                    readCts.Token)
+                .WaitAsync(timeout, cancellationToken)
+                .ConfigureAwait(false);
+            var mapped = Map(entries);
+            var fence = _fences.GetOrAdd(key, _ => new PublicationFence());
+            await fence.Gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+            try
+            {
+                await WriteBoundedAsync(
+                        key,
+                        normalizedServiceId,
+                        identity,
+                        lane,
+                        mapped,
+                        fence,
+                        now,
+                        cancellationToken)
+                    .ConfigureAwait(false);
+            }
+            finally
+            {
+                fence.Gate.Release();
+            }
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch
+        {
+            LogFailureRateLimited(key, now);
+        }
+    }
+
+    private async Task WriteBoundedAsync(
+        string key,
+        string serviceId,
+        MvProjectionStatusIdentity identity,
+        string lane,
+        MappedStatus mapped,
+        PublicationFence fence,
+        DateTimeOffset now,
+        CancellationToken cancellationToken)
+    {
+        var expected = fence.Sequence;
+        var next = expected + 1;
+        var heartbeat = new ProjectionStatusHeartbeat(
+            serviceId,
+            identity.ProjectorName,
+            identity.ProjectorVersion,
+            BuildClusterId(_options.ClusterId, lane),
+            $"mv-{lane}-{_activationRoot}",
+            next,
+            mapped.AppliedEventCount,
+            mapped.Position,
+            mapped.Position,
+            now)
+        {
+            Phase = mapped.Phase,
+            LeaseExpiresAtUtc = now + PositiveOrDefault(_options.FreshnessWindow, TimeSpan.FromMinutes(2)),
+            IsFaulted = mapped.IsFaulted,
+            FaultMessage = mapped.IsFaulted ? "materialized view faulted" : null
+        };
+
+        using var writeCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        var timeout = PositiveOrDefault(_options.HeartbeatWriteTimeout, TimeSpan.FromSeconds(5));
+        writeCts.CancelAfter(timeout);
+        var result = await _statusStore!.UpsertAsync(heartbeat, expected, writeCts.Token)
+            .WaitAsync(timeout, cancellationToken)
+            .ConfigureAwait(false);
+        if (!result.IsSuccess)
+        {
+            LogFailureRateLimited(key, now);
+            return;
+        }
+
+        var write = result.GetValue();
+        if (write.Committed)
+        {
+            fence.Sequence = write.Current?.Sequence ?? next;
+            return;
+        }
+
+        // Rebase from the provider-observed token. The next dedicated tick can replace an older process activation,
+        // while that older writer is fenced because its expected sequence is then stale.
+        if (write.Current is { } current && current.Sequence > fence.Sequence)
+        {
+            fence.Sequence = current.Sequence;
+        }
+
+        LogFailureRateLimited(key, now);
+    }
+
+    private void LogFailureRateLimited(string key, DateTimeOffset now)
+    {
+        var fence = _fences.GetOrAdd(key, _ => new PublicationFence());
+        var interval = PositiveOrDefault(_options.HeartbeatFailureLogInterval, TimeSpan.FromSeconds(30));
+        if (now < fence.NextFailureLogAt)
+        {
+            return;
+        }
+
+        fence.NextFailureLogAt = now + interval;
+        _logger.LogWarning("Materialized view status publication failed; the projection runtime continues unaffected.");
+    }
+
+    private static MappedStatus Map(IReadOnlyList<MvRegistryEntry> entries)
+    {
+        if (entries.Count == 0)
+        {
+            return new(ProjectionStatusPhases.Unknown, null, 0, false);
+        }
+
+        var applied = entries.Max(entry => entry.AppliedEventVersion);
+        if (entries.Any(entry => entry.Status == MvStatus.Faulted))
+        {
+            return new(ProjectionStatusPhases.Faulted, null, applied, true);
+        }
+
+        if (entries.Any(entry => !entry.CurrentCheckpointTruth.IsKnown))
+        {
+            return new(ProjectionStatusPhases.Unknown, null, applied, false);
+        }
+
+        var position = entries
+            .Select(entry => entry.CurrentCheckpointTruth.PositionValue!)
+            .OrderBy(value => value, StringComparer.Ordinal)
+            .First();
+        var phase = entries.Any(entry => entry.Status == MvStatus.Initializing)
+            ? ProjectionStatusPhases.Starting
+            : entries.Any(entry => entry.Status == MvStatus.CatchingUp)
+                ? ProjectionStatusPhases.CatchingUp
+                : entries.Any(entry => entry.Status == MvStatus.Ready)
+                    ? ProjectionStatusPhases.CaughtUp
+                    : entries.Any(entry => entry.Status == MvStatus.Active)
+                        ? ProjectionStatusPhases.Active
+                        : ProjectionStatusPhases.Stopped;
+        return new(phase, position, applied, false);
+    }
+
+    private static string BuildClusterId(string clusterId, string lane) =>
+        $"{clusterId}:mv:{lane}";
+
+    private static TimeSpan PositiveOrDefault(TimeSpan value, TimeSpan fallback) =>
+        value > TimeSpan.Zero ? value : fallback;
+
+    private sealed class PublicationFence
+    {
+        public SemaphoreSlim Gate { get; } = new(1, 1);
+        public long Sequence { get; set; }
+        public DateTimeOffset NextFailureLogAt { get; set; }
+    }
+
+    private sealed record MappedStatus(string Phase, string? Position, long AppliedEventCount, bool IsFaulted);
+}

--- a/dcb/src/Sekiban.Dcb.MaterializedView/MvProjectionStatusPublication.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView/MvProjectionStatusPublication.cs
@@ -38,8 +38,53 @@ public sealed record MvProjectionStatusIdentity(string ProjectorName, string Pro
 }
 
 /// <summary>
-/// Publishes G26 registry truth through the existing G24 source-side registry. This component never resolves an
-/// event store and is called only by dedicated hosted-worker/Orleans schedules.
+/// Immutable G26 progress already observed by an MV runtime while doing its normal target work.
+/// The status publisher consumes this value without resolving or querying the target provider.
+/// </summary>
+public sealed record MvProjectionStatusSnapshot(
+    MvCheckpointTruth CurrentCheckpointTruth,
+    MvStatus Status,
+    long AppliedEventCount)
+{
+    public static MvProjectionStatusSnapshot Unknown(MvStatus status = MvStatus.Initializing) =>
+        new(MvCheckpointTruth.Unknown(MvCheckpointUnknownReason.NotObserved), status, 0);
+
+    public static MvProjectionStatusSnapshot FromEntries(IReadOnlyList<MvRegistryEntry> entries)
+    {
+        if (entries.Count == 0)
+        {
+            return Unknown();
+        }
+
+        var applied = entries.Max(entry => entry.AppliedEventVersion);
+        var status = entries.Any(entry => entry.Status == MvStatus.Faulted)
+            ? MvStatus.Faulted
+            : entries.Any(entry => entry.Status == MvStatus.Initializing)
+                ? MvStatus.Initializing
+                : entries.Any(entry => entry.Status == MvStatus.CatchingUp)
+                    ? MvStatus.CatchingUp
+                    : entries.Any(entry => entry.Status == MvStatus.Ready)
+                        ? MvStatus.Ready
+                        : entries.Any(entry => entry.Status == MvStatus.Active)
+                            ? MvStatus.Active
+                            : entries[0].Status;
+        var unknown = entries.FirstOrDefault(entry => !entry.CurrentCheckpointTruth.IsKnown);
+        if (unknown is not null)
+        {
+            return new(unknown.CurrentCheckpointTruth, status, applied);
+        }
+
+        var truth = entries
+            .Select(entry => entry.CurrentCheckpointTruth)
+            .OrderBy(entry => entry.PositionValue, StringComparer.Ordinal)
+            .First();
+        return new(truth, status, applied);
+    }
+}
+
+/// <summary>
+/// Publishes already-known G26 truth through the existing G24 source-side registry. This component has no target
+/// registry dependency and is called only by dedicated hosted-worker/Orleans schedules.
 /// </summary>
 public sealed class MvProjectionStatusPublisher
 {
@@ -48,16 +93,13 @@ public sealed class MvProjectionStatusPublisher
     private readonly string _activationRoot = Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture);
     private readonly ILogger<MvProjectionStatusPublisher> _logger;
     private readonly ProjectionStatusOptions _options;
-    private readonly IMvRegistryStore _registryStore;
     private readonly IProjectionStatusStore? _statusStore;
 
     public MvProjectionStatusPublisher(
-        IMvRegistryStore registryStore,
         IProjectionStatusStore? statusStore,
         ProjectionStatusOptions options,
         ILogger<MvProjectionStatusPublisher> logger)
     {
-        _registryStore = registryStore ?? throw new ArgumentNullException(nameof(registryStore));
         _statusStore = statusStore;
         _options = options ?? throw new ArgumentNullException(nameof(options));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
@@ -70,11 +112,13 @@ public sealed class MvProjectionStatusPublisher
         string serviceId,
         string viewName,
         int viewVersion,
+        MvProjectionStatusSnapshot snapshot,
         MvProjectionStatusPublisherKind publisherKind,
         CancellationToken cancellationToken = default)
     {
         var normalizedServiceId = ServiceIdValidator.NormalizeAndValidate(serviceId);
         var identity = MvProjectionStatusIdentity.Create(viewName, viewVersion);
+        ArgumentNullException.ThrowIfNull(snapshot);
         if (!_options.Enabled || _statusStore is null)
         {
             return;
@@ -91,17 +135,7 @@ public sealed class MvProjectionStatusPublisher
         _nextDue[key] = now + PositiveOrDefault(_options.HeartbeatInterval, TimeSpan.FromSeconds(30));
         try
         {
-            var timeout = PositiveOrDefault(_options.HeartbeatWriteTimeout, TimeSpan.FromSeconds(5));
-            using var readCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-            readCts.CancelAfter(timeout);
-            var entries = await _registryStore.GetEntriesAsync(
-                    normalizedServiceId,
-                    viewName,
-                    viewVersion,
-                    readCts.Token)
-                .WaitAsync(timeout, cancellationToken)
-                .ConfigureAwait(false);
-            var mapped = Map(entries);
+            var mapped = Map(snapshot);
             var fence = _fences.GetOrAdd(key, _ => new PublicationFence());
             await fence.Gate.WaitAsync(cancellationToken).ConfigureAwait(false);
             try
@@ -204,38 +238,27 @@ public sealed class MvProjectionStatusPublisher
         _logger.LogWarning("Materialized view status publication failed; the projection runtime continues unaffected.");
     }
 
-    private static MappedStatus Map(IReadOnlyList<MvRegistryEntry> entries)
+    private static MappedStatus Map(MvProjectionStatusSnapshot snapshot)
     {
-        if (entries.Count == 0)
+        if (snapshot.Status == MvStatus.Faulted)
         {
-            return new(ProjectionStatusPhases.Unknown, null, 0, false);
+            return new(ProjectionStatusPhases.Faulted, null, snapshot.AppliedEventCount, true);
         }
 
-        var applied = entries.Max(entry => entry.AppliedEventVersion);
-        if (entries.Any(entry => entry.Status == MvStatus.Faulted))
+        if (!snapshot.CurrentCheckpointTruth.IsKnown)
         {
-            return new(ProjectionStatusPhases.Faulted, null, applied, true);
+            return new(ProjectionStatusPhases.Unknown, null, snapshot.AppliedEventCount, false);
         }
 
-        if (entries.Any(entry => !entry.CurrentCheckpointTruth.IsKnown))
+        var phase = snapshot.Status switch
         {
-            return new(ProjectionStatusPhases.Unknown, null, applied, false);
-        }
-
-        var position = entries
-            .Select(entry => entry.CurrentCheckpointTruth.PositionValue!)
-            .OrderBy(value => value, StringComparer.Ordinal)
-            .First();
-        var phase = entries.Any(entry => entry.Status == MvStatus.Initializing)
-            ? ProjectionStatusPhases.Starting
-            : entries.Any(entry => entry.Status == MvStatus.CatchingUp)
-                ? ProjectionStatusPhases.CatchingUp
-                : entries.Any(entry => entry.Status == MvStatus.Ready)
-                    ? ProjectionStatusPhases.CaughtUp
-                    : entries.Any(entry => entry.Status == MvStatus.Active)
-                        ? ProjectionStatusPhases.Active
-                        : ProjectionStatusPhases.Stopped;
-        return new(phase, position, applied, false);
+            MvStatus.Initializing => ProjectionStatusPhases.Starting,
+            MvStatus.CatchingUp => ProjectionStatusPhases.CatchingUp,
+            MvStatus.Ready => ProjectionStatusPhases.CaughtUp,
+            MvStatus.Active => ProjectionStatusPhases.Active,
+            _ => ProjectionStatusPhases.Stopped
+        };
+        return new(phase, snapshot.CurrentCheckpointTruth.PositionValue, snapshot.AppliedEventCount, false);
     }
 
     private static string BuildClusterId(string clusterId, string lane) =>

--- a/dcb/src/Sekiban.Dcb.MaterializedView/SekibanDcbMaterializedViewExtensions.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView/SekibanDcbMaterializedViewExtensions.cs
@@ -18,7 +18,6 @@ public static class SekibanDcbMaterializedViewExtensions
         services.TryAddSingleton<ProjectionStatusOptions>();
         services.TryAddSingleton<MvProjectionStatusPublisher>(sp =>
             new MvProjectionStatusPublisher(
-                sp.GetRequiredService<IMvRegistryStore>(),
                 sp.GetService<IProjectionStatusStore>(),
                 sp.GetRequiredService<ProjectionStatusOptions>(),
                 sp.GetRequiredService<ILogger<MvProjectionStatusPublisher>>()));

--- a/dcb/src/Sekiban.Dcb.MaterializedView/SekibanDcbMaterializedViewExtensions.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView/SekibanDcbMaterializedViewExtensions.cs
@@ -15,6 +15,13 @@ public static class SekibanDcbMaterializedViewExtensions
         Action<MvOptions>? configure = null)
     {
         services.AddOptions<MvOptions>();
+        services.TryAddSingleton<ProjectionStatusOptions>();
+        services.TryAddSingleton<MvProjectionStatusPublisher>(sp =>
+            new MvProjectionStatusPublisher(
+                sp.GetRequiredService<IMvRegistryStore>(),
+                sp.GetService<IProjectionStatusStore>(),
+                sp.GetRequiredService<ProjectionStatusOptions>(),
+                sp.GetRequiredService<ILogger<MvProjectionStatusPublisher>>()));
         services.TryAddSingleton<IEventTypes>(sp => sp.GetRequiredService<DcbDomainTypes>().EventTypes);
         services.TryAddSingleton<IMvApplyHostFactory>(sp =>
         {
@@ -103,7 +110,8 @@ public static class SekibanDcbMaterializedViewExtensions
                 sp.GetRequiredService<IMvExecutor>(),
                 sp.GetRequiredService<Microsoft.Extensions.Options.IOptions<MvOptions>>(),
                 sp.GetRequiredService<Microsoft.Extensions.Logging.ILogger<MvCatchUpWorker>>(),
-                normalized));
+                normalized,
+                sp.GetRequiredService<MvProjectionStatusPublisher>()));
         return services;
     }
 }

--- a/dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/MvProjectionStatusTargetIsolationTests.cs
+++ b/dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/MvProjectionStatusTargetIsolationTests.cs
@@ -1,0 +1,501 @@
+using System.Data;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Orleans.Streams;
+using Orleans.TestingHost;
+using ResultBoxes;
+using Sekiban.Dcb.Actors;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.MaterializedView.Orleans;
+using Sekiban.Dcb.MaterializedView.MySql;
+using Sekiban.Dcb.MaterializedView.Postgres;
+using Sekiban.Dcb.MaterializedView.Sqlite;
+using Sekiban.Dcb.MaterializedView.SqlServer;
+using Sekiban.Dcb.Orleans.Streams;
+using Sekiban.Dcb.ServiceId;
+using Sekiban.Dcb.Storage;
+using Sekiban.Dcb.Testing;
+using Xunit;
+
+namespace Sekiban.Dcb.MaterializedView.MultiProvider.Tests;
+
+[Collection(nameof(PostgresMvCollection))]
+public sealed class PostgresMvStatusTargetIsolationTests(PostgresMvFixture fixture) : MvStatusTargetIsolationTests(fixture);
+
+[Collection(nameof(MySqlMvCollection))]
+public sealed class MySqlMvStatusTargetIsolationTests(MySqlMvFixture fixture) : MvStatusTargetIsolationTests(fixture);
+
+[Collection(nameof(SqlServerMvCollection))]
+public sealed class SqlServerMvStatusTargetIsolationTests(SqlServerMvFixture fixture) : MvStatusTargetIsolationTests(fixture);
+
+[Collection(nameof(SqliteMvCollection))]
+public sealed class SqliteMvStatusTargetIsolationTests(SqliteMvFixture fixture) : MvStatusTargetIsolationTests(fixture);
+
+public abstract class MvStatusTargetIsolationTests(MultiProviderFixtureBase fixture)
+{
+    [SkippableFact]
+    public async Task HostedWorker_HeartbeatAndG24Readers_PerformZeroTargetIo()
+    {
+        Skip.IfNot(fixture.IsAvailable, fixture.AvailabilityMessage ?? "Integration fixture is unavailable.");
+        await fixture.ResetAsync().ConfigureAwait(false);
+
+        var targetIo = new TargetProviderIoCounter();
+        var registry = new CountingDelegatingMvRegistryStore(
+            fixture.Services.GetRequiredService<IMvRegistryStore>(),
+            targetIo);
+        await AssertTargetCounterIsNonVacuousAsync(registry, targetIo).ConfigureAwait(false);
+        var statusStore = new CountingProjectionStatusStore(targetIo);
+        var publisher = CreatePublisher(statusStore);
+        var options = fixture.Services.GetRequiredService<IOptions<MvOptions>>();
+        var executor = new BoundaryResettingExecutor(CreateProviderExecutor(registry, options), targetIo);
+        var hostFactory = CreateIsolationHostFactory();
+        using var worker = new MvCatchUpWorker(
+            hostFactory,
+            executor,
+            options,
+            NullLogger<MvCatchUpWorker>.Instance,
+            MultiProviderFixtureBase.ServiceId,
+            publisher);
+
+        await worker.StartAsync(CancellationToken.None).ConfigureAwait(false);
+        await statusStore.Written.Task.WaitAsync(TimeSpan.FromSeconds(15)).ConfigureAwait(false);
+        await worker.StopAsync(CancellationToken.None).ConfigureAwait(false);
+
+        Assert.Equal(0, statusStore.TargetCallsObservedAtUpsert);
+        targetIo.Reset();
+        await AssertReadableThroughExistingG24SurfacesAsync(statusStore, fixture.EventStore).ConfigureAwait(false);
+        Assert.Equal(0, targetIo.FactoryResolutions);
+        Assert.Equal(0, targetIo.OpenCalls);
+        Assert.Equal(0, targetIo.QueryCalls);
+        Assert.Equal(0, targetIo.ProviderCalls);
+    }
+
+    [SkippableFact]
+    public async Task OrleansGrain_HeartbeatAndG24Readers_PerformZeroTargetIo()
+    {
+        Skip.IfNot(fixture.IsAvailable, fixture.AvailabilityMessage ?? "Integration fixture is unavailable.");
+        await fixture.ResetAsync().ConfigureAwait(false);
+
+        var targetIo = new TargetProviderIoCounter();
+        var registry = new CountingDelegatingMvRegistryStore(
+            fixture.Services.GetRequiredService<IMvRegistryStore>(),
+            targetIo);
+        await AssertTargetCounterIsNonVacuousAsync(registry, targetIo).ConfigureAwait(false);
+        var statusStore = new CountingProjectionStatusStore(targetIo);
+        var hostFactory = CreateIsolationHostFactory();
+        var options = fixture.Services.GetRequiredService<IOptions<MvOptions>>();
+        OrleansTargetIsolationContext.Current = new(
+            hostFactory,
+            CreateProviderExecutor(registry, options),
+            registry,
+            fixture.Services.GetRequiredService<IMvStorageInfoProvider>(),
+            options,
+            statusStore);
+
+        var builder = new TestClusterBuilder();
+        builder.Options.InitialSilosCount = 1;
+        builder.Options.ClusterId = $"mv-target-isolation-{Guid.NewGuid():N}";
+        builder.Options.ServiceId = $"mv-target-isolation-{Guid.NewGuid():N}";
+        builder.AddSiloBuilderConfigurator<OrleansTargetIsolationSiloConfigurator>();
+        builder.AddClientBuilderConfigurator<OrleansTargetIsolationClientConfigurator>();
+        using var cluster = builder.Build();
+        try
+        {
+            await cluster.DeployAsync().ConfigureAwait(false);
+            var registration = Assert.Single(hostFactory.GetRegistrations());
+            var grain = cluster.Client.GetGrain<IMaterializedViewGrain>(MvGrainKey.Build(
+                MultiProviderFixtureBase.ServiceId,
+                registration.ViewName,
+                registration.ViewVersion));
+            await grain.EnsureStartedAsync().ConfigureAwait(false);
+            await grain.RefreshAsync().ConfigureAwait(false);
+
+            var writesBefore = statusStore.UpsertCalls;
+            targetIo.Reset();
+            await statusStore.WaitForWriteAfterAsync(writesBefore, TimeSpan.FromSeconds(10)).ConfigureAwait(false);
+            await AssertReadableThroughExistingG24SurfacesAsync(statusStore, fixture.EventStore).ConfigureAwait(false);
+
+            Assert.Equal(0, targetIo.FactoryResolutions);
+            Assert.Equal(0, targetIo.OpenCalls);
+            Assert.Equal(0, targetIo.QueryCalls);
+            Assert.Equal(0, targetIo.ProviderCalls);
+        }
+        finally
+        {
+            await cluster.StopAllSilosAsync().ConfigureAwait(false);
+            OrleansTargetIsolationContext.Current = null;
+        }
+    }
+
+    private static MvProjectionStatusPublisher CreatePublisher(IProjectionStatusStore statusStore) =>
+        new(statusStore, StatusOptions(), NullLogger<MvProjectionStatusPublisher>.Instance);
+
+    private IMvApplyHostFactory CreateIsolationHostFactory() => new NativeMvApplyHostFactory(
+        [new TargetIsolationProjector()],
+        fixture.DomainTypes.EventTypes,
+        fixture.Services.GetRequiredService<IMvStorageInfoProvider>());
+
+    private async Task AssertTargetCounterIsNonVacuousAsync(
+        CountingDelegatingMvRegistryStore registry,
+        TargetProviderIoCounter counter)
+    {
+        await registry.EnsureInfrastructureAsync().ConfigureAwait(false);
+        await registry.GetEntriesAsync(MultiProviderFixtureBase.ServiceId, TargetIsolationProjector.ViewNameConst, 1)
+            .ConfigureAwait(false);
+        Assert.True(counter.ProviderCalls > 0, "The delegating counter did not observe its real target-provider control I/O.");
+        Assert.True(counter.OpenCalls > 0);
+        Assert.True(counter.QueryCalls > 0);
+        counter.Reset();
+    }
+
+    private IMvExecutor CreateProviderExecutor(IMvRegistryStore registry, IOptions<MvOptions> options)
+    {
+        var storage = fixture.Services.GetRequiredService<IMvStorageInfoProvider>().GetStorageInfo();
+        return storage.DatabaseType switch
+        {
+            MvDbType.Postgres => new PostgresMvExecutor(
+                fixture.EventStoreFactory, registry, options, NullLogger<PostgresMvExecutor>.Instance, storage.ConnectionString),
+            MvDbType.MySql => new MySqlMvExecutor(
+                fixture.EventStoreFactory, registry, options, NullLogger<MySqlMvExecutor>.Instance, storage.ConnectionString),
+            MvDbType.SqlServer => new SqlServerMvExecutor(
+                fixture.EventStoreFactory, registry, options, NullLogger<SqlServerMvExecutor>.Instance, storage.ConnectionString),
+            MvDbType.Sqlite => new SqliteMvExecutor(
+                fixture.EventStoreFactory, registry, options, NullLogger<SqliteMvExecutor>.Instance, storage.ConnectionString),
+            _ => throw new NotSupportedException($"Database type '{storage.DatabaseType}' is not supported.")
+        };
+    }
+
+    private static async Task AssertReadableThroughExistingG24SurfacesAsync(
+        IProjectionStatusStore statusStore,
+        IEventStore eventStore)
+    {
+        var serviceIdProvider = new FixedServiceIdProvider(MultiProviderFixtureBase.ServiceId);
+        var reader = new ProjectionStatusReader(statusStore, eventStore, serviceIdProvider, StatusOptions());
+        var identity = MvProjectionStatusIdentity.Create(
+            TargetIsolationProjector.ViewNameConst,
+            1);
+        var request = new ProjectionStatusReadRequest(
+            MultiProviderFixtureBase.ServiceId,
+            identity.ProjectorName,
+            identity.ProjectorVersion);
+        var typed = await reader.ReadAsync(request).ConfigureAwait(false);
+        Assert.True(typed.IsSuccess, typed.IsSuccess ? null : typed.GetException().Message);
+        Assert.Single(typed.GetValue());
+
+        var serialized = new SerializedProjectionStatusReader(reader, serviceIdProvider);
+        var response = await serialized.AcceptAsync(SerializedProjectionStatusReader.SerializeRequest(request))
+            .ConfigureAwait(false);
+        Assert.True(response.IsSuccess, response.IsSuccess ? null : response.GetException().Message);
+        Assert.True(SerializedProjectionStatusReader.Deserialize(response.GetValue()).IsSuccess);
+    }
+
+    internal static ProjectionStatusOptions StatusOptionsForSilo() => new()
+    {
+        ClusterId = "mv-target-isolation",
+        HeartbeatInterval = TimeSpan.FromMilliseconds(25),
+        HeartbeatWriteTimeout = TimeSpan.FromSeconds(1),
+        FreshnessWindow = TimeSpan.FromMinutes(1),
+        SamplingWindow = TimeSpan.Zero
+    };
+
+    private static ProjectionStatusOptions StatusOptions() => StatusOptionsForSilo();
+
+    private sealed class BoundaryResettingExecutor(IMvExecutor inner, TargetProviderIoCounter targetIo) : IMvExecutor
+    {
+        public Task InitializeAsync(IMvApplyHost host, string? serviceId = null, CancellationToken cancellationToken = default) =>
+            inner.InitializeAsync(host, serviceId, cancellationToken);
+
+        public async Task<MvCatchUpResult> CatchUpOnceAsync(
+            IMvApplyHost host,
+            string? serviceId = null,
+            CancellationToken cancellationToken = default)
+        {
+            var result = await inner.CatchUpOnceAsync(host, serviceId, cancellationToken).ConfigureAwait(false);
+            targetIo.Reset();
+            return result;
+        }
+
+        public Task<int> ApplySerializableEventsAsync(
+            IMvApplyHost host,
+            IReadOnlyList<SerializableEvent> events,
+            string? serviceId = null,
+            CancellationToken cancellationToken = default) =>
+            inner.ApplySerializableEventsAsync(host, events, serviceId, cancellationToken);
+    }
+
+    private sealed class FixedServiceIdProvider(string serviceId) : IServiceIdProvider
+    {
+        public string GetCurrentServiceId() => serviceId;
+    }
+
+    private sealed class TargetIsolationProjector : IMaterializedViewProjector
+    {
+        public const string ViewNameConst = "MvStatusTargetIsolation";
+        public string ViewName => ViewNameConst;
+        public int ViewVersion => 1;
+
+        public async Task InitializeAsync(IMvInitContext context, CancellationToken cancellationToken = default)
+        {
+            var table = context.RegisterTable("proof");
+            var sql = context.DatabaseType switch
+            {
+                MvDbType.Postgres or MvDbType.MySql or MvDbType.Sqlite =>
+                    $"CREATE TABLE IF NOT EXISTS {table.PhysicalName} (id INTEGER NOT NULL PRIMARY KEY);",
+                MvDbType.SqlServer =>
+                    $"IF OBJECT_ID(N'{table.PhysicalName}', N'U') IS NULL CREATE TABLE {table.PhysicalName} (id INT NOT NULL PRIMARY KEY);",
+                _ => throw new NotSupportedException($"Database type '{context.DatabaseType}' is not supported.")
+            };
+            await context.ExecuteAsync(sql, cancellationToken: cancellationToken).ConfigureAwait(false);
+        }
+
+        public Task<IReadOnlyList<MvSqlStatement>> ApplyToViewAsync(
+            Sekiban.Dcb.Events.Event ev,
+            IMvApplyContext context,
+            CancellationToken cancellationToken = default) =>
+            Task.FromResult<IReadOnlyList<MvSqlStatement>>([]);
+    }
+}
+
+internal sealed class CountingProjectionStatusStore(TargetProviderIoCounter targetIo) : IProjectionStatusStore
+{
+    private readonly InMemoryMultiProjectionStateStore _inner =
+        new(new FixedStatusServiceIdProvider(MultiProviderFixtureBase.ServiceId));
+    private TaskCompletionSource _written = NewSignal();
+
+    public TaskCompletionSource Written => _written;
+    public int UpsertCalls { get; private set; }
+    public int TargetCallsObservedAtUpsert { get; private set; }
+
+    public async Task<ResultBox<ProjectionStatusWriteResult>> UpsertAsync(
+        ProjectionStatusHeartbeat heartbeat,
+        long expectedSequence,
+        CancellationToken cancellationToken = default)
+    {
+        TargetCallsObservedAtUpsert = Math.Max(TargetCallsObservedAtUpsert, targetIo.ProviderCalls);
+        var result = await _inner.UpsertAsync(heartbeat, expectedSequence, cancellationToken).ConfigureAwait(false);
+        UpsertCalls++;
+        _written.TrySetResult();
+        return result;
+    }
+
+    public Task<ResultBox<IReadOnlyList<ProjectionStatusHeartbeat>>> ListAsync(
+        string? projectorName = null,
+        string? projectorVersion = null,
+        CancellationToken cancellationToken = default) =>
+        _inner.ListAsync(projectorName, projectorVersion, cancellationToken);
+
+    public async Task WaitForWriteAfterAsync(int count, TimeSpan timeout)
+    {
+        while (UpsertCalls <= count)
+        {
+            var signal = _written;
+            if (UpsertCalls > count)
+            {
+                return;
+            }
+            await signal.Task.WaitAsync(timeout).ConfigureAwait(false);
+            if (ReferenceEquals(signal, _written))
+            {
+                _written = NewSignal();
+            }
+        }
+    }
+
+    private static TaskCompletionSource NewSignal() =>
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    private sealed class FixedStatusServiceIdProvider(string serviceId) : IServiceIdProvider
+    {
+        public string GetCurrentServiceId() => serviceId;
+    }
+}
+
+internal sealed class TargetProviderIoCounter
+{
+    public int FactoryResolutions { get; set; }
+    public int OpenCalls { get; set; }
+    public int QueryCalls { get; set; }
+    public int ProviderCalls { get; set; }
+
+    public void Reset() => (FactoryResolutions, OpenCalls, QueryCalls, ProviderCalls) = (0, 0, 0, 0);
+}
+
+/// <summary>
+/// Transparent counter over the concrete provider registry. Every operation delegates to the real target store;
+/// unlike a fake store, provider SQL, connection behavior, and failures remain in the exercised path.
+/// </summary>
+internal sealed class CountingDelegatingMvRegistryStore : IMvRegistryStore
+{
+    private readonly IMvRegistryStore _inner;
+    private readonly TargetProviderIoCounter _counter;
+
+    public CountingDelegatingMvRegistryStore(IMvRegistryStore inner, TargetProviderIoCounter counter)
+    {
+        _inner = inner;
+        _counter = counter;
+        _counter.FactoryResolutions++;
+    }
+
+    public Task EnsureInfrastructureAsync(CancellationToken cancellationToken = default)
+    {
+        Count();
+        return _inner.EnsureInfrastructureAsync(cancellationToken);
+    }
+
+    public Task RegisterAsync(
+        MvRegistryEntry entry,
+        IDbTransaction? transaction = null,
+        CancellationToken cancellationToken = default)
+    {
+        Count();
+        return _inner.RegisterAsync(entry, transaction, cancellationToken);
+    }
+
+    public Task UpdatePositionAsync(
+        MvPositionUpdate update,
+        IDbTransaction? transaction = null,
+        CancellationToken cancellationToken = default)
+    {
+        Count();
+        return _inner.UpdatePositionAsync(update, transaction, cancellationToken);
+    }
+
+    public Task MarkStreamReceivedAsync(
+        string serviceId,
+        string viewName,
+        int viewVersion,
+        string sortableUniqueId,
+        DateTimeOffset receivedAt,
+        IDbTransaction? transaction = null,
+        CancellationToken cancellationToken = default)
+    {
+        Count();
+        return _inner.MarkStreamReceivedAsync(
+            serviceId, viewName, viewVersion, sortableUniqueId, receivedAt, transaction, cancellationToken);
+    }
+
+    public Task UpdateStatusAsync(
+        string serviceId,
+        string viewName,
+        int viewVersion,
+        MvStatus status,
+        IDbTransaction? transaction = null,
+        CancellationToken cancellationToken = default)
+    {
+        Count();
+        return _inner.UpdateStatusAsync(serviceId, viewName, viewVersion, status, transaction, cancellationToken);
+    }
+
+    public Task<IReadOnlyList<MvRegistryEntry>> GetEntriesAsync(
+        string serviceId,
+        string viewName,
+        int viewVersion,
+        CancellationToken cancellationToken = default)
+    {
+        Count(query: true);
+        return _inner.GetEntriesAsync(serviceId, viewName, viewVersion, cancellationToken);
+    }
+
+    public Task<MvActiveEntry?> GetActiveAsync(
+        string serviceId,
+        string viewName,
+        CancellationToken cancellationToken = default)
+    {
+        Count(query: true);
+        return _inner.GetActiveAsync(serviceId, viewName, cancellationToken);
+    }
+
+    public Task SetTargetCheckpointAsync(
+        string serviceId,
+        string viewName,
+        int viewVersion,
+        MvCheckpointTruth targetCheckpointTruth,
+        IDbTransaction? transaction = null,
+        CancellationToken cancellationToken = default)
+    {
+        Count();
+        return _inner.SetTargetCheckpointAsync(
+            serviceId, viewName, viewVersion, targetCheckpointTruth, transaction, cancellationToken);
+    }
+
+    public Task<MvActivationResult> TryActivateAsync(
+        MvActivationRequest request,
+        IDbTransaction? transaction = null,
+        CancellationToken cancellationToken = default)
+    {
+        Count(query: true);
+        return _inner.TryActivateAsync(request, transaction, cancellationToken);
+    }
+
+    public Task SetActiveAsync(
+        string serviceId,
+        string viewName,
+        int activeVersion,
+        IDbTransaction? transaction = null,
+        CancellationToken cancellationToken = default)
+    {
+        Count();
+        return _inner.SetActiveAsync(serviceId, viewName, activeVersion, transaction, cancellationToken);
+    }
+
+    private void Count(bool query = false)
+    {
+        _counter.ProviderCalls++;
+        _counter.OpenCalls++;
+        if (query)
+        {
+            _counter.QueryCalls++;
+        }
+    }
+}
+
+internal sealed record OrleansTargetIsolationContext(
+    IMvApplyHostFactory HostFactory,
+    IMvExecutor Executor,
+    IMvRegistryStore Registry,
+    IMvStorageInfoProvider StorageInfo,
+    IOptions<MvOptions> Options,
+    CountingProjectionStatusStore StatusStore)
+{
+    public static OrleansTargetIsolationContext? Current { get; set; }
+}
+
+internal sealed class OrleansTargetIsolationSiloConfigurator : ISiloConfigurator
+{
+    public void Configure(ISiloBuilder siloBuilder)
+    {
+        var context = OrleansTargetIsolationContext.Current ??
+            throw new InvalidOperationException("Target-isolation context was not initialized.");
+        siloBuilder.ConfigureServices(services =>
+            {
+                services.AddSingleton(context.HostFactory);
+                services.AddSingleton(context.Executor);
+                services.AddSingleton(context.Registry);
+                services.AddSingleton(context.StorageInfo);
+                services.AddSingleton(context.Options);
+                services.AddSingleton<IProjectionStatusStore>(context.StatusStore);
+                services.AddSingleton(MvStatusTargetIsolationTests.StatusOptionsForSilo());
+                services.AddSingleton<MvProjectionStatusPublisher>();
+                services.AddSingleton<IServiceIdProvider>(new FixedOrleansServiceIdProvider(MultiProviderFixtureBase.ServiceId));
+                services.AddSingleton<IEventSubscriptionResolver>(
+                    new DefaultOrleansEventSubscriptionResolver("EventStreamProvider", "AllEvents", Guid.Empty));
+                services.AddSekibanDcbMaterializedViewOrleans(activateOnStartup: false);
+            })
+            .AddMemoryGrainStorage("PubSubStore")
+            .AddMemoryStreams("EventStreamProvider")
+            .AddMemoryGrainStorage("EventStreamProvider");
+    }
+
+    private sealed class FixedOrleansServiceIdProvider(string serviceId) : IServiceIdProvider
+    {
+        public string GetCurrentServiceId() => serviceId;
+    }
+}
+
+internal sealed class OrleansTargetIsolationClientConfigurator : IClientBuilderConfigurator
+{
+    public void Configure(IConfiguration configuration, IClientBuilder clientBuilder) =>
+        clientBuilder.AddMemoryStreams("EventStreamProvider");
+}

--- a/dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests.csproj
+++ b/dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests.csproj
@@ -12,6 +12,7 @@
     <ItemGroup>
         <PackageReference Include="Dapper" Version="2.1.66" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+        <PackageReference Include="Microsoft.Orleans.TestingHost" Version="10.0.1" />
         <PackageReference Include="Testcontainers.PostgreSql" Version="4.10.0" />
         <PackageReference Include="Testcontainers.MsSql" Version="4.10.0" />
         <PackageReference Include="Testcontainers.MySql" Version="4.10.0" />
@@ -33,6 +34,7 @@
 
     <ItemGroup>
         <ProjectReference Include="..\..\src\Sekiban.Dcb.MaterializedView\Sekiban.Dcb.MaterializedView.csproj" />
+        <ProjectReference Include="..\..\src\Sekiban.Dcb.MaterializedView.Orleans\Sekiban.Dcb.MaterializedView.Orleans.csproj" />
         <ProjectReference Include="..\..\src\Sekiban.Dcb.MaterializedView.MySql\Sekiban.Dcb.MaterializedView.MySql.csproj" />
         <ProjectReference Include="..\..\src\Sekiban.Dcb.MaterializedView.Postgres\Sekiban.Dcb.MaterializedView.Postgres.csproj" />
         <ProjectReference Include="..\..\src\Sekiban.Dcb.MaterializedView.Sqlite\Sekiban.Dcb.MaterializedView.Sqlite.csproj" />

--- a/dcb/tests/Sekiban.Dcb.MaterializedView.Tests/MvProjectionStatusPublicationTests.cs
+++ b/dcb/tests/Sekiban.Dcb.MaterializedView.Tests/MvProjectionStatusPublicationTests.cs
@@ -1,0 +1,386 @@
+using System.Data;
+using System.Text;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Hosting;
+using ResultBoxes;
+using Sekiban.Dcb.Actors;
+using Sekiban.Dcb.Common;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.MaterializedView.MySql;
+using Sekiban.Dcb.MaterializedView.Postgres;
+using Sekiban.Dcb.MaterializedView.Sqlite;
+using Sekiban.Dcb.MaterializedView.SqlServer;
+using Sekiban.Dcb.ServiceId;
+using Sekiban.Dcb.Storage;
+using Sekiban.Dcb.Testing;
+using Xunit;
+
+namespace Sekiban.Dcb.MaterializedView.Tests;
+
+public class MvProjectionStatusPublicationTests
+{
+    private const string ServiceId = "orders";
+    private const string ViewName = "Order:Summary/日本語";
+    private const int ViewVersion = 7;
+
+    public static IEnumerable<object[]> ProductionMappingCases()
+    {
+        var nonzero = SortableUniqueId.Generate(DateTime.UnixEpoch.AddHours(1), Guid.Empty);
+        yield return [MvCheckpointTruth.Unknown(), MvStatus.Active, ProjectionStatusPhases.Unknown, null!, false, false];
+        yield return [MvCheckpointTruth.KnownZero(), MvStatus.Active, ProjectionStatusPhases.Active, SortableUniqueId.MinValue.Value, true, false];
+        yield return [MvCheckpointTruth.Known(new SortableUniqueId(nonzero), MvCheckpointProvenance.AppliedEvent(MvApplySource.CatchUp)), MvStatus.Active, ProjectionStatusPhases.Active, nonzero, true, false];
+        yield return [MvCheckpointTruth.KnownZero(), MvStatus.Initializing, ProjectionStatusPhases.Starting, SortableUniqueId.MinValue.Value, false, false];
+        yield return [MvCheckpointTruth.KnownZero(), MvStatus.CatchingUp, ProjectionStatusPhases.CatchingUp, SortableUniqueId.MinValue.Value, false, false];
+        yield return [MvCheckpointTruth.KnownZero(), MvStatus.Ready, ProjectionStatusPhases.CaughtUp, SortableUniqueId.MinValue.Value, true, false];
+        yield return [MvCheckpointTruth.KnownZero(), MvStatus.Retired, ProjectionStatusPhases.Stopped, SortableUniqueId.MinValue.Value, false, false];
+        yield return [MvCheckpointTruth.KnownZero(), MvStatus.Faulted, ProjectionStatusPhases.Faulted, null!, false, true];
+    }
+
+    [Theory]
+    [MemberData(nameof(ProductionMappingCases))]
+    public async Task HostedWorker_MapsAuthoritativeTruthAndLifecycle_ThroughTypedAndSerializedG24Readers(
+        MvCheckpointTruth truth,
+        MvStatus status,
+        string expectedPhase,
+        string? expectedPosition,
+        bool expectedCaughtUp,
+        bool expectedFaulted)
+    {
+        var serviceProvider = new FixedServiceIdProvider(ServiceId);
+        var statusStore = new ObservingStatusStore(serviceProvider);
+        var registry = new StubRegistryStore(CreateEntry(truth, status));
+        var executor = new ObservingExecutor(blockFirstCall: true);
+        executor.StatusWriteCount = () => statusStore.UpsertCalls;
+        var publisher = CreatePublisher(registry, statusStore);
+        using var worker = CreateWorker(executor, publisher);
+
+        await worker.StartAsync(CancellationToken.None);
+        await executor.CatchUpEntered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.Equal(0, statusStore.UpsertCalls);
+        executor.ContinueCatchUp.TrySetResult();
+        await statusStore.Written.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await worker.StopAsync(CancellationToken.None);
+
+        var identity = MvProjectionStatusIdentity.Create(ViewName, ViewVersion);
+        var eventStore = new InMemoryEventStore(serviceProvider);
+        var reader = new ProjectionStatusReader(
+            statusStore,
+            eventStore,
+            serviceProvider,
+            StatusOptions());
+        var request = new ProjectionStatusReadRequest(ServiceId, identity.ProjectorName, identity.ProjectorVersion);
+        var typed = await reader.ReadAsync(request);
+        Assert.True(typed.IsSuccess, typed.IsSuccess ? null : typed.GetException().Message);
+        var snapshot = Assert.Single(typed.GetValue());
+        Assert.Equal(expectedPhase, snapshot.Phase);
+        Assert.Equal(expectedPosition, snapshot.LastAppliedSortableUniqueId);
+        Assert.Equal(expectedPosition, snapshot.LastTraversedSortableUniqueId);
+        Assert.Equal(expectedCaughtUp, snapshot.IsCaughtUp);
+        Assert.Equal(expectedFaulted, snapshot.IsFaulted);
+        Assert.DoesNotContain("Password", snapshot.FaultMessage ?? string.Empty, StringComparison.OrdinalIgnoreCase);
+
+        var serializedReader = new SerializedProjectionStatusReader(reader, serviceProvider);
+        var serialized = await serializedReader.AcceptAsync(SerializedProjectionStatusReader.SerializeRequest(request));
+        Assert.True(serialized.IsSuccess, serialized.IsSuccess ? null : serialized.GetException().Message);
+        var envelope = SerializedProjectionStatusReader.Deserialize(serialized.GetValue());
+        Assert.True(envelope.IsSuccess, envelope.IsSuccess ? null : envelope.GetException().Message);
+        var wireSnapshot = Assert.Single(envelope.GetValue().Snapshots);
+        Assert.Equal(expectedPhase, wireSnapshot.Phase);
+        Assert.Equal(expectedPosition, wireSnapshot.LastTraversedSortableUniqueId);
+        Assert.Equal(expectedCaughtUp, wireSnapshot.IsCaughtUp);
+    }
+
+    [Theory]
+    [InlineData("blocking-status")]
+    [InlineData("blocking-registry")]
+    [InlineData("throwing-registry")]
+    public async Task HostedWorker_IsolatesSlowFailingPublication_WithBoundedTimeoutAndSecretFreeLogging(string failureMode)
+    {
+        const string secret = "Password=super-secret";
+        var registry = new StubRegistryStore(CreateEntry(MvCheckpointTruth.KnownZero(), MvStatus.Active));
+        registry.BlockReads = failureMode == "blocking-registry";
+        registry.ThrowMessage = failureMode == "throwing-registry" ? secret : null;
+        IProjectionStatusStore statusStore = failureMode == "blocking-status"
+            ? new BlockingStatusStore()
+            : new ObservingStatusStore(new FixedServiceIdProvider(ServiceId));
+        var logger = new CapturingLogger<MvProjectionStatusPublisher>();
+        var options = StatusOptions();
+        options.HeartbeatWriteTimeout = TimeSpan.FromMilliseconds(30);
+        options.HeartbeatInterval = TimeSpan.FromMilliseconds(1);
+        var publisher = new MvProjectionStatusPublisher(registry, statusStore, options, logger);
+        var executor = new ObservingExecutor(requiredCalls: 2);
+        using var worker = CreateWorker(executor, publisher, TimeSpan.FromMilliseconds(1));
+
+        await worker.StartAsync(CancellationToken.None);
+        await executor.RequiredCallsReached.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await worker.StopAsync(CancellationToken.None);
+
+        Assert.True(executor.CatchUpCalls >= 2);
+        Assert.All(logger.Messages, message => Assert.DoesNotContain(secret, message, StringComparison.Ordinal));
+        Assert.All(logger.Messages, message => Assert.DoesNotContain("super-secret", message, StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Identity_IsStableAndCollisionFreeForAmbiguousAndUnicodeNames()
+    {
+        var first = MvProjectionStatusIdentity.Create("a:b", 12);
+        var second = MvProjectionStatusIdentity.Create("a", 312);
+        var unicode = MvProjectionStatusIdentity.Create("注文/一覧", 12);
+
+        Assert.Equal(first, MvProjectionStatusIdentity.Create("a:b", 12));
+        Assert.NotEqual(first, second);
+        Assert.NotEqual(first.ProjectorName, unicode.ProjectorName);
+        Assert.Equal("v:12", first.ProjectorVersion);
+    }
+
+    [Fact]
+    public async Task Publication_ValidatesExactServiceBeforeAnyIo_AndDoesNoRegistryIoWithoutSourceStatusStore()
+    {
+        var invalidRegistry = new StubRegistryStore(CreateEntry(MvCheckpointTruth.KnownZero(), MvStatus.Active));
+        var invalidPublisher = CreatePublisher(
+            invalidRegistry,
+            new ObservingStatusStore(new FixedServiceIdProvider(ServiceId)));
+
+        await Assert.ThrowsAsync<ArgumentException>(() => invalidPublisher.PublishIfDueAsync(
+            " ", ViewName, ViewVersion, MvProjectionStatusPublisherKind.HostedWorker));
+        Assert.Equal(0, invalidRegistry.GetEntriesCalls);
+
+        var disabledRegistry = new StubRegistryStore(CreateEntry(MvCheckpointTruth.KnownZero(), MvStatus.Active));
+        var disabledPublisher = new MvProjectionStatusPublisher(
+            disabledRegistry,
+            statusStore: null,
+            StatusOptions(),
+            NullLogger<MvProjectionStatusPublisher>.Instance);
+        await disabledPublisher.PublishIfDueAsync(
+            ServiceId, ViewName, ViewVersion, MvProjectionStatusPublisherKind.HostedWorker);
+        Assert.Equal(0, disabledRegistry.GetEntriesCalls);
+    }
+
+    [Theory]
+    [InlineData("postgres")]
+    [InlineData("mysql")]
+    [InlineData("sqlserver")]
+    [InlineData("sqlite")]
+    public void AllRelationalTargets_ComposeWithTheSameSourceSideStatusPublisher(string provider)
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton<IProjectionStatusStore>(new ObservingStatusStore(new FixedServiceIdProvider(ServiceId)));
+        switch (provider)
+        {
+            case "postgres":
+                services.AddSekibanDcbMaterializedViewPostgres("Host=unused", registerHostedWorker: false);
+                break;
+            case "mysql":
+                services.AddSekibanDcbMaterializedViewMySql("Server=unused", registerHostedWorker: false);
+                break;
+            case "sqlserver":
+                services.AddSekibanDcbMaterializedViewSqlServer("Server=unused", registerHostedWorker: false);
+                break;
+            default:
+                services.AddSekibanDcbMaterializedViewSqlite("Data Source=:memory:", registerHostedWorker: false);
+                break;
+        }
+
+        using var serviceProvider = services.BuildServiceProvider();
+        Assert.NotNull(serviceProvider.GetRequiredService<MvProjectionStatusPublisher>());
+    }
+
+    [Fact]
+    public void PublicWorkerConstructor_RemainsBinaryCompatible()
+    {
+        var legacy = typeof(MvCatchUpWorker).GetConstructor(
+            [typeof(IMvApplyHostFactory), typeof(IMvExecutor), typeof(IOptions<MvOptions>), typeof(ILogger<MvCatchUpWorker>)]);
+        var serviceBound = typeof(MvCatchUpWorker).GetConstructor(
+            [typeof(IMvApplyHostFactory), typeof(IMvExecutor), typeof(IOptions<MvOptions>), typeof(ILogger<MvCatchUpWorker>), typeof(string)]);
+
+        Assert.NotNull(legacy);
+        Assert.NotNull(serviceBound);
+    }
+
+    [Fact]
+    public void HostedWorkerDiConstructor_InjectsTheOffHotPathPublisher()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton<IMvRegistryStore>(new StubRegistryStore(CreateEntry(MvCheckpointTruth.KnownZero(), MvStatus.Active)));
+        services.AddSingleton<IProjectionStatusStore>(new ObservingStatusStore(new FixedServiceIdProvider(ServiceId)));
+        services.AddSingleton<IMvApplyHostFactory>(new StubHostFactory());
+        services.AddSingleton<IMvExecutor>(new ObservingExecutor());
+        services.AddSekibanDcbMaterializedView(options => options.ServiceId = ServiceId);
+        services.AddSingleton<IHostedService, MvCatchUpWorker>();
+
+        using var provider = services.BuildServiceProvider();
+        Assert.IsType<MvCatchUpWorker>(provider.GetRequiredService<IHostedService>());
+        var selected = typeof(MvCatchUpWorker).GetConstructors().Single(constructor =>
+            constructor.GetCustomAttributes(typeof(Microsoft.Extensions.DependencyInjection.ActivatorUtilitiesConstructorAttribute), false).Length == 1);
+        Assert.Contains(selected.GetParameters(), parameter => parameter.ParameterType == typeof(MvProjectionStatusPublisher));
+    }
+
+    private static MvRegistryEntry CreateEntry(MvCheckpointTruth truth, MvStatus status) => new()
+    {
+        ServiceId = ServiceId,
+        ViewName = ViewName,
+        ViewVersion = ViewVersion,
+        LogicalTable = "main",
+        PhysicalTable = "unused",
+        Status = status,
+        CurrentPosition = truth.PositionValue,
+        CurrentCheckpointTruth = truth,
+        AppliedEventVersion = 41,
+        LastUpdated = DateTimeOffset.UtcNow
+    };
+
+    private static ProjectionStatusOptions StatusOptions() => new()
+    {
+        ClusterId = "test-cluster",
+        HeartbeatInterval = TimeSpan.FromMinutes(1),
+        FreshnessWindow = TimeSpan.FromMinutes(2),
+        SamplingWindow = TimeSpan.Zero,
+        HeartbeatWriteTimeout = TimeSpan.FromSeconds(1)
+    };
+
+    private static MvProjectionStatusPublisher CreatePublisher(IMvRegistryStore registry, IProjectionStatusStore statusStore) =>
+        new(registry, statusStore, StatusOptions(), NullLogger<MvProjectionStatusPublisher>.Instance);
+
+    private static MvCatchUpWorker CreateWorker(
+        ObservingExecutor executor,
+        MvProjectionStatusPublisher publisher,
+        TimeSpan? pollInterval = null) =>
+        new(
+            new StubHostFactory(),
+            executor,
+            Options.Create(new MvOptions
+            {
+                ServiceId = ServiceId,
+                PollInterval = pollInterval ?? TimeSpan.FromMilliseconds(10),
+                MaxConsecutiveFailuresBeforeStop = 10
+            }),
+            NullLogger<MvCatchUpWorker>.Instance,
+            ServiceId,
+            publisher);
+
+    private sealed class StubHostFactory : IMvApplyHostFactory
+    {
+        public IReadOnlyList<MvApplyHostRegistration> GetRegistrations() => [new(ViewName, ViewVersion)];
+        public IMvApplyHost Create(string viewName, int viewVersion) => new StubHost();
+    }
+
+    private sealed class StubHost : IMvApplyHost
+    {
+        public string ViewName => MvProjectionStatusPublicationTests.ViewName;
+        public int ViewVersion => MvProjectionStatusPublicationTests.ViewVersion;
+        public IReadOnlyList<string> LogicalTables => ["main"];
+        public Task<IReadOnlyList<MvSqlStatementDto>> InitializeAsync(IMvTableBindings tables, CancellationToken ct) =>
+            Task.FromResult<IReadOnlyList<MvSqlStatementDto>>([]);
+        public Task<IReadOnlyList<MvSqlStatementDto>> ApplyEventAsync(SerializableEvent ev, IMvTableBindings tables, IMvApplyQueryPort queryPort, string sortableUniqueId, CancellationToken ct) =>
+            Task.FromResult<IReadOnlyList<MvSqlStatementDto>>([]);
+    }
+
+    private sealed class ObservingExecutor : IMvExecutor
+    {
+        private readonly int _requiredCalls;
+        private readonly bool _blockFirstCall;
+        public ObservingExecutor(int requiredCalls = 1, bool blockFirstCall = false)
+        {
+            _requiredCalls = requiredCalls;
+            _blockFirstCall = blockFirstCall;
+        }
+        public int CatchUpCalls { get; private set; }
+        public int StatusWritesObservedInsideCatchUp { get; private set; }
+        public Func<int>? StatusWriteCount { get; set; }
+        public TaskCompletionSource RequiredCallsReached { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public TaskCompletionSource CatchUpEntered { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public TaskCompletionSource ContinueCatchUp { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public Task InitializeAsync(IMvApplyHost host, string? serviceId = null, CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public async Task<MvCatchUpResult> CatchUpOnceAsync(IMvApplyHost host, string? serviceId = null, CancellationToken cancellationToken = default)
+        {
+            StatusWritesObservedInsideCatchUp = Math.Max(StatusWritesObservedInsideCatchUp, StatusWriteCount?.Invoke() ?? 0);
+            CatchUpCalls++;
+            CatchUpEntered.TrySetResult();
+            if (_blockFirstCall && CatchUpCalls == 1)
+            {
+                await ContinueCatchUp.Task.WaitAsync(cancellationToken);
+            }
+            if (CatchUpCalls >= _requiredCalls)
+            {
+                RequiredCallsReached.TrySetResult();
+            }
+            return new MvCatchUpResult(0, false);
+        }
+        public Task<int> ApplySerializableEventsAsync(IMvApplyHost host, IReadOnlyList<SerializableEvent> events, string? serviceId = null, CancellationToken cancellationToken = default) => Task.FromResult(0);
+    }
+
+    private sealed class ObservingStatusStore : IProjectionStatusStore
+    {
+        private readonly InMemoryMultiProjectionStateStore _inner;
+        public ObservingStatusStore(IServiceIdProvider serviceIdProvider) => _inner = new(serviceIdProvider);
+        public TaskCompletionSource Written { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public int UpsertCalls { get; private set; }
+        public async Task<ResultBox<ProjectionStatusWriteResult>> UpsertAsync(ProjectionStatusHeartbeat heartbeat, long expectedSequence, CancellationToken cancellationToken = default)
+        {
+            UpsertCalls++;
+            var result = await _inner.UpsertAsync(heartbeat, expectedSequence, cancellationToken);
+            if (result.IsSuccess && result.GetValue().Committed) Written.TrySetResult();
+            return result;
+        }
+        public Task<ResultBox<IReadOnlyList<ProjectionStatusHeartbeat>>> ListAsync(string? projectorName = null, string? projectorVersion = null, CancellationToken cancellationToken = default) =>
+            _inner.ListAsync(projectorName, projectorVersion, cancellationToken);
+    }
+
+    private sealed class BlockingStatusStore : IProjectionStatusStore
+    {
+        private readonly TaskCompletionSource<ResultBox<ProjectionStatusWriteResult>> _never = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public Task<ResultBox<ProjectionStatusWriteResult>> UpsertAsync(ProjectionStatusHeartbeat heartbeat, long expectedSequence, CancellationToken cancellationToken = default) => _never.Task;
+        public Task<ResultBox<IReadOnlyList<ProjectionStatusHeartbeat>>> ListAsync(string? projectorName = null, string? projectorVersion = null, CancellationToken cancellationToken = default) =>
+            Task.FromResult(ResultBox.FromValue<IReadOnlyList<ProjectionStatusHeartbeat>>([]));
+    }
+
+    private sealed class StubRegistryStore(MvRegistryEntry entry) : IMvRegistryStore
+    {
+        private readonly TaskCompletionSource<IReadOnlyList<MvRegistryEntry>> _never =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public int GetEntriesCalls { get; private set; }
+        public bool BlockReads { get; set; }
+        public string? ThrowMessage { get; set; }
+        public Task EnsureInfrastructureAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task RegisterAsync(MvRegistryEntry value, IDbTransaction? transaction = null, CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task UpdatePositionAsync(MvPositionUpdate update, IDbTransaction? transaction = null, CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task MarkStreamReceivedAsync(string serviceId, string viewName, int viewVersion, string sortableUniqueId, DateTimeOffset receivedAt, IDbTransaction? transaction = null, CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task UpdateStatusAsync(string serviceId, string viewName, int viewVersion, MvStatus status, IDbTransaction? transaction = null, CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task<IReadOnlyList<MvRegistryEntry>> GetEntriesAsync(string serviceId, string viewName, int viewVersion, CancellationToken cancellationToken = default)
+        {
+            GetEntriesCalls++;
+            if (ThrowMessage is not null)
+            {
+                return Task.FromException<IReadOnlyList<MvRegistryEntry>>(new InvalidOperationException(ThrowMessage));
+            }
+
+            if (BlockReads)
+            {
+                return _never.Task;
+            }
+
+            return Task.FromResult<IReadOnlyList<MvRegistryEntry>>([entry]);
+        }
+        public Task<MvActiveEntry?> GetActiveAsync(string serviceId, string viewName, CancellationToken cancellationToken = default) => Task.FromResult<MvActiveEntry?>(null);
+        public Task SetActiveAsync(string serviceId, string viewName, int activeVersion, IDbTransaction? transaction = null, CancellationToken cancellationToken = default) => Task.CompletedTask;
+    }
+
+    private sealed class FixedServiceIdProvider(string serviceId) : IServiceIdProvider
+    {
+        public string GetCurrentServiceId() => serviceId;
+    }
+
+    private sealed class CapturingLogger<T> : ILogger<T>
+    {
+        public List<string> Messages { get; } = [];
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+        public bool IsEnabled(LogLevel logLevel) => true;
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter) =>
+            Messages.Add(formatter(state, exception));
+    }
+}

--- a/dcb/tests/Sekiban.Dcb.MaterializedView.Tests/MvProjectionStatusPublicationTests.cs
+++ b/dcb/tests/Sekiban.Dcb.MaterializedView.Tests/MvProjectionStatusPublicationTests.cs
@@ -1,4 +1,4 @@
-using System.Data;
+using System.Diagnostics;
 using System.Text;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -51,10 +51,10 @@ public class MvProjectionStatusPublicationTests
     {
         var serviceProvider = new FixedServiceIdProvider(ServiceId);
         var statusStore = new ObservingStatusStore(serviceProvider);
-        var registry = new StubRegistryStore(CreateEntry(truth, status));
-        var executor = new ObservingExecutor(blockFirstCall: true);
+        var snapshotToPublish = new MvProjectionStatusSnapshot(truth, status, 41);
+        var executor = new ObservingExecutor(snapshotToPublish, blockFirstCall: true);
         executor.StatusWriteCount = () => statusStore.UpsertCalls;
-        var publisher = CreatePublisher(registry, statusStore);
+        var publisher = CreatePublisher(statusStore);
         using var worker = CreateWorker(executor, publisher);
 
         await worker.StartAsync(CancellationToken.None);
@@ -95,23 +95,21 @@ public class MvProjectionStatusPublicationTests
 
     [Theory]
     [InlineData("blocking-status")]
-    [InlineData("blocking-registry")]
-    [InlineData("throwing-registry")]
+    [InlineData("throwing-status")]
     public async Task HostedWorker_IsolatesSlowFailingPublication_WithBoundedTimeoutAndSecretFreeLogging(string failureMode)
     {
         const string secret = "Password=super-secret";
-        var registry = new StubRegistryStore(CreateEntry(MvCheckpointTruth.KnownZero(), MvStatus.Active));
-        registry.BlockReads = failureMode == "blocking-registry";
-        registry.ThrowMessage = failureMode == "throwing-registry" ? secret : null;
         IProjectionStatusStore statusStore = failureMode == "blocking-status"
             ? new BlockingStatusStore()
-            : new ObservingStatusStore(new FixedServiceIdProvider(ServiceId));
+            : new ThrowingStatusStore(secret);
         var logger = new CapturingLogger<MvProjectionStatusPublisher>();
         var options = StatusOptions();
         options.HeartbeatWriteTimeout = TimeSpan.FromMilliseconds(30);
         options.HeartbeatInterval = TimeSpan.FromMilliseconds(1);
-        var publisher = new MvProjectionStatusPublisher(registry, statusStore, options, logger);
-        var executor = new ObservingExecutor(requiredCalls: 2);
+        var publisher = new MvProjectionStatusPublisher(statusStore, options, logger);
+        var executor = new ObservingExecutor(
+            new MvProjectionStatusSnapshot(MvCheckpointTruth.KnownZero(), MvStatus.Active, 0),
+            requiredCalls: 2);
         using var worker = CreateWorker(executor, publisher, TimeSpan.FromMilliseconds(1));
 
         await worker.StartAsync(CancellationToken.None);
@@ -137,26 +135,22 @@ public class MvProjectionStatusPublicationTests
     }
 
     [Fact]
-    public async Task Publication_ValidatesExactServiceBeforeAnyIo_AndDoesNoRegistryIoWithoutSourceStatusStore()
+    public async Task Publication_ValidatesExactServiceBeforeAnyIo_AndDoesNoStatusIoWhenDisabled()
     {
-        var invalidRegistry = new StubRegistryStore(CreateEntry(MvCheckpointTruth.KnownZero(), MvStatus.Active));
-        var invalidPublisher = CreatePublisher(
-            invalidRegistry,
-            new ObservingStatusStore(new FixedServiceIdProvider(ServiceId)));
+        var invalidStore = new ObservingStatusStore(new FixedServiceIdProvider(ServiceId));
+        var invalidPublisher = CreatePublisher(invalidStore);
+        var snapshot = new MvProjectionStatusSnapshot(MvCheckpointTruth.KnownZero(), MvStatus.Active, 0);
 
         await Assert.ThrowsAsync<ArgumentException>(() => invalidPublisher.PublishIfDueAsync(
-            " ", ViewName, ViewVersion, MvProjectionStatusPublisherKind.HostedWorker));
-        Assert.Equal(0, invalidRegistry.GetEntriesCalls);
+            " ", ViewName, ViewVersion, snapshot, MvProjectionStatusPublisherKind.HostedWorker));
+        Assert.Equal(0, invalidStore.UpsertCalls);
 
-        var disabledRegistry = new StubRegistryStore(CreateEntry(MvCheckpointTruth.KnownZero(), MvStatus.Active));
         var disabledPublisher = new MvProjectionStatusPublisher(
-            disabledRegistry,
             statusStore: null,
-            StatusOptions(),
-            NullLogger<MvProjectionStatusPublisher>.Instance);
+            options: StatusOptions(),
+            logger: NullLogger<MvProjectionStatusPublisher>.Instance);
         await disabledPublisher.PublishIfDueAsync(
-            ServiceId, ViewName, ViewVersion, MvProjectionStatusPublisherKind.HostedWorker);
-        Assert.Equal(0, disabledRegistry.GetEntriesCalls);
+            ServiceId, ViewName, ViewVersion, snapshot, MvProjectionStatusPublisherKind.HostedWorker);
     }
 
     [Theory]
@@ -164,7 +158,7 @@ public class MvProjectionStatusPublicationTests
     [InlineData("mysql")]
     [InlineData("sqlserver")]
     [InlineData("sqlite")]
-    public void AllRelationalTargets_ComposeWithTheSameSourceSideStatusPublisher(string provider)
+    public async Task AllRelationalTargets_RunHostedCadenceAndG24Readers_WithoutResolvingTargetProvider(string provider)
     {
         var services = new ServiceCollection();
         services.AddLogging();
@@ -185,8 +179,41 @@ public class MvProjectionStatusPublicationTests
                 break;
         }
 
+        var targetDescriptor = Assert.Single(services, descriptor => descriptor.ServiceType == typeof(IMvRegistryStore));
+        services.Remove(targetDescriptor);
+        using var targetIo = new TargetProviderIoCounter();
+        services.AddSingleton<IMvRegistryStore>(sp =>
+        {
+            targetIo.FactoryResolutions++;
+            return (IMvRegistryStore)(targetDescriptor.ImplementationFactory?.Invoke(sp) ??
+                throw new InvalidOperationException("Provider registry descriptor must use its production factory."));
+        });
+
         using var serviceProvider = services.BuildServiceProvider();
-        Assert.NotNull(serviceProvider.GetRequiredService<MvProjectionStatusPublisher>());
+        var statusStore = Assert.IsType<ObservingStatusStore>(serviceProvider.GetRequiredService<IProjectionStatusStore>());
+        var publisher = serviceProvider.GetRequiredService<MvProjectionStatusPublisher>();
+        var executor = new ObservingExecutor(
+            new MvProjectionStatusSnapshot(MvCheckpointTruth.KnownZero(), MvStatus.Active, 0));
+        using var worker = CreateWorker(executor, publisher);
+        await worker.StartAsync(CancellationToken.None);
+        await statusStore.Written.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await worker.StopAsync(CancellationToken.None);
+
+        var serviceIdProvider = new FixedServiceIdProvider(ServiceId);
+        var reader = new ProjectionStatusReader(
+            statusStore,
+            new InMemoryEventStore(serviceIdProvider),
+            serviceIdProvider,
+            StatusOptions());
+        var identity = MvProjectionStatusIdentity.Create(ViewName, ViewVersion);
+        var request = new ProjectionStatusReadRequest(ServiceId, identity.ProjectorName, identity.ProjectorVersion);
+        Assert.Single((await reader.ReadAsync(request)).GetValue());
+        var serialized = new SerializedProjectionStatusReader(reader, serviceIdProvider);
+        Assert.True((await serialized.AcceptAsync(SerializedProjectionStatusReader.SerializeRequest(request))).IsSuccess);
+        Assert.Equal(0, targetIo.FactoryResolutions);
+        Assert.Equal(0, targetIo.OpenCalls);
+        Assert.Equal(0, targetIo.QueryCalls);
+        Assert.Equal(0, targetIo.ProviderCalls);
     }
 
     [Fact]
@@ -206,10 +233,9 @@ public class MvProjectionStatusPublicationTests
     {
         var services = new ServiceCollection();
         services.AddLogging();
-        services.AddSingleton<IMvRegistryStore>(new StubRegistryStore(CreateEntry(MvCheckpointTruth.KnownZero(), MvStatus.Active)));
         services.AddSingleton<IProjectionStatusStore>(new ObservingStatusStore(new FixedServiceIdProvider(ServiceId)));
         services.AddSingleton<IMvApplyHostFactory>(new StubHostFactory());
-        services.AddSingleton<IMvExecutor>(new ObservingExecutor());
+        services.AddSingleton<IMvExecutor>(new ObservingExecutor(MvProjectionStatusSnapshot.Unknown()));
         services.AddSekibanDcbMaterializedView(options => options.ServiceId = ServiceId);
         services.AddSingleton<IHostedService, MvCatchUpWorker>();
 
@@ -220,20 +246,6 @@ public class MvProjectionStatusPublicationTests
         Assert.Contains(selected.GetParameters(), parameter => parameter.ParameterType == typeof(MvProjectionStatusPublisher));
     }
 
-    private static MvRegistryEntry CreateEntry(MvCheckpointTruth truth, MvStatus status) => new()
-    {
-        ServiceId = ServiceId,
-        ViewName = ViewName,
-        ViewVersion = ViewVersion,
-        LogicalTable = "main",
-        PhysicalTable = "unused",
-        Status = status,
-        CurrentPosition = truth.PositionValue,
-        CurrentCheckpointTruth = truth,
-        AppliedEventVersion = 41,
-        LastUpdated = DateTimeOffset.UtcNow
-    };
-
     private static ProjectionStatusOptions StatusOptions() => new()
     {
         ClusterId = "test-cluster",
@@ -243,8 +255,8 @@ public class MvProjectionStatusPublicationTests
         HeartbeatWriteTimeout = TimeSpan.FromSeconds(1)
     };
 
-    private static MvProjectionStatusPublisher CreatePublisher(IMvRegistryStore registry, IProjectionStatusStore statusStore) =>
-        new(registry, statusStore, StatusOptions(), NullLogger<MvProjectionStatusPublisher>.Instance);
+    private static MvProjectionStatusPublisher CreatePublisher(IProjectionStatusStore statusStore) =>
+        new(statusStore, StatusOptions(), NullLogger<MvProjectionStatusPublisher>.Instance);
 
     private static MvCatchUpWorker CreateWorker(
         ObservingExecutor executor,
@@ -282,10 +294,15 @@ public class MvProjectionStatusPublicationTests
 
     private sealed class ObservingExecutor : IMvExecutor
     {
+        private readonly MvProjectionStatusSnapshot _snapshot;
         private readonly int _requiredCalls;
         private readonly bool _blockFirstCall;
-        public ObservingExecutor(int requiredCalls = 1, bool blockFirstCall = false)
+        public ObservingExecutor(
+            MvProjectionStatusSnapshot snapshot,
+            int requiredCalls = 1,
+            bool blockFirstCall = false)
         {
+            _snapshot = snapshot;
             _requiredCalls = requiredCalls;
             _blockFirstCall = blockFirstCall;
         }
@@ -309,7 +326,7 @@ public class MvProjectionStatusPublicationTests
             {
                 RequiredCallsReached.TrySetResult();
             }
-            return new MvCatchUpResult(0, false);
+            return new MvCatchUpResult(0, false) { ProjectionStatus = _snapshot };
         }
         public Task<int> ApplySerializableEventsAsync(IMvApplyHost host, IReadOnlyList<SerializableEvent> events, string? serviceId = null, CancellationToken cancellationToken = default) => Task.FromResult(0);
     }
@@ -339,35 +356,70 @@ public class MvProjectionStatusPublicationTests
             Task.FromResult(ResultBox.FromValue<IReadOnlyList<ProjectionStatusHeartbeat>>([]));
     }
 
-    private sealed class StubRegistryStore(MvRegistryEntry entry) : IMvRegistryStore
+    private sealed class ThrowingStatusStore(string message) : IProjectionStatusStore
     {
-        private readonly TaskCompletionSource<IReadOnlyList<MvRegistryEntry>> _never =
-            new(TaskCreationOptions.RunContinuationsAsynchronously);
-        public int GetEntriesCalls { get; private set; }
-        public bool BlockReads { get; set; }
-        public string? ThrowMessage { get; set; }
-        public Task EnsureInfrastructureAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
-        public Task RegisterAsync(MvRegistryEntry value, IDbTransaction? transaction = null, CancellationToken cancellationToken = default) => Task.CompletedTask;
-        public Task UpdatePositionAsync(MvPositionUpdate update, IDbTransaction? transaction = null, CancellationToken cancellationToken = default) => Task.CompletedTask;
-        public Task MarkStreamReceivedAsync(string serviceId, string viewName, int viewVersion, string sortableUniqueId, DateTimeOffset receivedAt, IDbTransaction? transaction = null, CancellationToken cancellationToken = default) => Task.CompletedTask;
-        public Task UpdateStatusAsync(string serviceId, string viewName, int viewVersion, MvStatus status, IDbTransaction? transaction = null, CancellationToken cancellationToken = default) => Task.CompletedTask;
-        public Task<IReadOnlyList<MvRegistryEntry>> GetEntriesAsync(string serviceId, string viewName, int viewVersion, CancellationToken cancellationToken = default)
+        public Task<ResultBox<ProjectionStatusWriteResult>> UpsertAsync(
+            ProjectionStatusHeartbeat heartbeat,
+            long expectedSequence,
+            CancellationToken cancellationToken = default) =>
+            Task.FromException<ResultBox<ProjectionStatusWriteResult>>(new InvalidOperationException(message));
+
+        public Task<ResultBox<IReadOnlyList<ProjectionStatusHeartbeat>>> ListAsync(
+            string? projectorName = null,
+            string? projectorVersion = null,
+            CancellationToken cancellationToken = default) =>
+            Task.FromResult(ResultBox.FromValue<IReadOnlyList<ProjectionStatusHeartbeat>>([]));
+    }
+
+    private sealed class TargetProviderIoCounter : IObserver<DiagnosticListener>, IObserver<KeyValuePair<string, object?>>, IDisposable
+    {
+        private readonly List<IDisposable> _subscriptions = [];
+        private readonly IDisposable _allListeners;
+
+        public TargetProviderIoCounter() => _allListeners = DiagnosticListener.AllListeners.Subscribe(this);
+
+        public int FactoryResolutions { get; set; }
+        public int OpenCalls { get; private set; }
+        public int QueryCalls { get; private set; }
+        public int ProviderCalls { get; private set; }
+
+        public void OnNext(DiagnosticListener value)
         {
-            GetEntriesCalls++;
-            if (ThrowMessage is not null)
+            if (value.Name.Contains("Npgsql", StringComparison.OrdinalIgnoreCase) ||
+                value.Name.Contains("MySql", StringComparison.OrdinalIgnoreCase) ||
+                value.Name.Contains("SqlClient", StringComparison.OrdinalIgnoreCase) ||
+                value.Name.Contains("Sqlite", StringComparison.OrdinalIgnoreCase))
             {
-                return Task.FromException<IReadOnlyList<MvRegistryEntry>>(new InvalidOperationException(ThrowMessage));
+                _subscriptions.Add(value.Subscribe(this));
             }
-
-            if (BlockReads)
-            {
-                return _never.Task;
-            }
-
-            return Task.FromResult<IReadOnlyList<MvRegistryEntry>>([entry]);
         }
-        public Task<MvActiveEntry?> GetActiveAsync(string serviceId, string viewName, CancellationToken cancellationToken = default) => Task.FromResult<MvActiveEntry?>(null);
-        public Task SetActiveAsync(string serviceId, string viewName, int activeVersion, IDbTransaction? transaction = null, CancellationToken cancellationToken = default) => Task.CompletedTask;
+
+        public void OnNext(KeyValuePair<string, object?> value)
+        {
+            ProviderCalls++;
+            if (value.Key.Contains("Open", StringComparison.OrdinalIgnoreCase))
+            {
+                OpenCalls++;
+            }
+
+            if (value.Key.Contains("Command", StringComparison.OrdinalIgnoreCase) ||
+                value.Key.Contains("Execute", StringComparison.OrdinalIgnoreCase))
+            {
+                QueryCalls++;
+            }
+        }
+
+        public void OnCompleted() { }
+        public void OnError(Exception error) { }
+
+        public void Dispose()
+        {
+            foreach (var subscription in _subscriptions)
+            {
+                subscription.Dispose();
+            }
+            _allListeners.Dispose();
+        }
     }
 
     private sealed class FixedServiceIdProvider(string serviceId) : IServiceIdProvider

--- a/dcb/tests/Sekiban.Dcb.Orleans.Tests/MaterializedViewGrainTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Orleans.Tests/MaterializedViewGrainTests.cs
@@ -2,6 +2,8 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Configuration;
 using Orleans.Streams;
 using Orleans.TestingHost;
+using Orleans.Runtime;
+using ResultBoxes;
 using Sekiban.Dcb.Actors;
 using Sekiban.Dcb.Common;
 using Sekiban.Dcb.Domains;
@@ -11,6 +13,8 @@ using Sekiban.Dcb.MaterializedView.Orleans;
 using Sekiban.Dcb.Orleans.ServiceId;
 using Sekiban.Dcb.Orleans.Streams;
 using Sekiban.Dcb.ServiceId;
+using Sekiban.Dcb.Storage;
+using Sekiban.Dcb.Testing;
 using Xunit;
 
 namespace Sekiban.Dcb.Orleans.Tests;
@@ -19,6 +23,7 @@ public class MaterializedViewGrainTests : IAsyncLifetime
 {
     private static readonly FakeMvRegistryStore SharedRegistry = new();
     private static readonly FakeMvExecutor SharedExecutor = new(SharedRegistry);
+    private static readonly TestProjectionStatusStore SharedStatusStore = new();
 
     private TestCluster _cluster = null!;
 
@@ -26,6 +31,7 @@ public class MaterializedViewGrainTests : IAsyncLifetime
     {
         SharedRegistry.Reset();
         SharedExecutor.Reset();
+        SharedStatusStore.Reset();
         SharedExecutor.SeedInitial(CreateSerializableEvent(1, DateTime.UtcNow.AddSeconds(-5)));
 
         var builder = new TestClusterBuilder();
@@ -43,6 +49,68 @@ public class MaterializedViewGrainTests : IAsyncLifetime
     {
         await _cluster.StopAllSilosAsync();
         _cluster.Dispose();
+    }
+
+    [Fact]
+    public void MaterializedViewGrain_LegacyPublicConstructor_RemainsAvailable()
+    {
+        var legacy = typeof(MaterializedViewGrain).GetConstructor(
+        [
+            typeof(IMvApplyHostFactory),
+            typeof(IMvExecutor),
+            typeof(IMvRegistryStore),
+            typeof(IEventSubscriptionResolver),
+            typeof(Microsoft.Extensions.Options.IOptions<MvOptions>),
+            typeof(Microsoft.Extensions.Logging.ILogger<MaterializedViewGrain>)
+        ]);
+
+        Assert.NotNull(legacy);
+    }
+
+    [Fact]
+    public async Task PassiveG24Read_DoesNotActivateMvGrain_ButDirectStartActivatesAndPublishes()
+    {
+        var management = _cluster.Client.GetGrain<IManagementGrain>(0);
+        var before = await CountMaterializedViewActivationsAsync(management);
+        Assert.Equal(0, before);
+
+        var identity = MvProjectionStatusIdentity.Create(TestMaterializedViewProjector.ViewNameConst, 1);
+        var serviceIdProvider = new FixedServiceIdProvider("orders");
+        var reader = new ProjectionStatusReader(
+            SharedStatusStore,
+            new InMemoryEventStore(serviceIdProvider),
+            serviceIdProvider,
+            new ProjectionStatusOptions { SamplingWindow = TimeSpan.Zero });
+        var passive = await reader.ReadAsync(new ProjectionStatusReadRequest(
+            "orders",
+            identity.ProjectorName,
+            identity.ProjectorVersion));
+
+        Assert.True(passive.IsSuccess);
+        Assert.Empty(passive.GetValue());
+        Assert.Equal(0, await CountMaterializedViewActivationsAsync(management));
+
+        var grainKey = MvGrainKey.Build("orders", TestMaterializedViewProjector.ViewNameConst, 1);
+        var grain = _cluster.Client.GetGrain<IMaterializedViewGrain>(grainKey);
+        await grain.EnsureStartedAsync();
+        await SharedStatusStore.Written.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Equal(1, await CountMaterializedViewActivationsAsync(management));
+        var published = await reader.ReadAsync(new ProjectionStatusReadRequest(
+            "orders",
+            identity.ProjectorName,
+            identity.ProjectorVersion));
+        Assert.True(published.IsSuccess);
+        var snapshot = Assert.Single(published.GetValue());
+        Assert.StartsWith("mv-orleans-", snapshot.ActivationId, StringComparison.Ordinal);
+        Assert.Equal("orders", SharedStatusStore.LastHeartbeat?.ServiceId);
+    }
+
+    private static async Task<int> CountMaterializedViewActivationsAsync(IManagementGrain management)
+    {
+        var statistics = await management.GetDetailedGrainStatistics(null!, null!);
+        return statistics.Count(statistic =>
+            statistic.GrainType.Contains(nameof(MaterializedViewGrain), StringComparison.Ordinal));
     }
 
     [Fact]
@@ -107,7 +175,7 @@ public class MaterializedViewGrainTests : IAsyncLifetime
         await grain.RefreshAsync();
 
         var entries = await SharedRegistry.GetEntriesAsync(
-            DefaultServiceIdProvider.DefaultServiceId,
+            "orders",
             TestMaterializedViewProjector.ViewNameConst,
             1);
         var entry = Assert.Single(entries);
@@ -159,9 +227,17 @@ public class MaterializedViewGrainTests : IAsyncLifetime
                         options.CatchUpStallThreshold = TimeSpan.FromMilliseconds(150);
                     });
                     services.AddMaterializedView<TestMaterializedViewProjector>();
-                    services.AddSekibanDcbMaterializedViewOrleans();
+                    services.AddSekibanDcbMaterializedViewOrleans(activateOnStartup: false);
                     services.AddSingleton<IMvRegistryStore>(SharedRegistry);
                     services.AddSingleton<IMvExecutor>(SharedExecutor);
+                    services.AddSingleton<IProjectionStatusStore>(SharedStatusStore);
+                    services.AddSingleton(new ProjectionStatusOptions
+                    {
+                        ClusterId = "mv-test-cluster",
+                        HeartbeatInterval = TimeSpan.FromMilliseconds(20),
+                        HeartbeatWriteTimeout = TimeSpan.FromSeconds(1),
+                        SamplingWindow = TimeSpan.Zero
+                    });
                     services.AddSingleton<IEventSubscriptionResolver>(
                         new DefaultOrleansEventSubscriptionResolver("EventStreamProvider", "AllEvents", Guid.Empty));
                     services.AddSingleton<IServiceIdProvider, DefaultServiceIdProvider>();
@@ -180,6 +256,48 @@ public class MaterializedViewGrainTests : IAsyncLifetime
         {
             clientBuilder.AddMemoryStreams("EventStreamProvider");
         }
+    }
+
+    private sealed class FixedServiceIdProvider(string serviceId) : IServiceIdProvider
+    {
+        public string GetCurrentServiceId() => serviceId;
+    }
+
+    private sealed class TestProjectionStatusStore : IProjectionStatusStore
+    {
+        private InMemoryMultiProjectionStateStore _inner = new(new FixedServiceIdProvider("orders"));
+
+        public TaskCompletionSource Written { get; private set; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public ProjectionStatusHeartbeat? LastHeartbeat { get; private set; }
+
+        public void Reset()
+        {
+            _inner = new InMemoryMultiProjectionStateStore(new FixedServiceIdProvider("orders"));
+            Written = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            LastHeartbeat = null;
+        }
+
+        public async Task<ResultBox<ProjectionStatusWriteResult>> UpsertAsync(
+            ProjectionStatusHeartbeat heartbeat,
+            long expectedSequence,
+            CancellationToken cancellationToken = default)
+        {
+            var result = await _inner.UpsertAsync(heartbeat, expectedSequence, cancellationToken);
+            if (result.IsSuccess && result.GetValue().Committed)
+            {
+                LastHeartbeat = heartbeat;
+                Written.TrySetResult();
+            }
+
+            return result;
+        }
+
+        public Task<ResultBox<IReadOnlyList<ProjectionStatusHeartbeat>>> ListAsync(
+            string? projectorName = null,
+            string? projectorVersion = null,
+            CancellationToken cancellationToken = default) =>
+            _inner.ListAsync(projectorName, projectorVersion, cancellationToken);
     }
 
     private sealed class TestMaterializedViewProjector : IMaterializedViewProjector

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/ProjectionStatusRegistryTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/ProjectionStatusRegistryTests.cs
@@ -57,7 +57,10 @@ public sealed class ProjectionStatusRegistryTests
             1,
             events[0].SortableUniqueIdValue,
             events[1].SortableUniqueIdValue,
-            DateTimeOffset.UtcNow);
+            DateTimeOffset.UtcNow)
+        {
+            Phase = ProjectionStatusPhases.Active
+        };
         var heartbeatWrite = await statusStore.UpsertAsync(heartbeat, 0);
         Assert.True(heartbeatWrite.IsSuccess);
 

--- a/docs/dcb_llm/20_materialized_view.md
+++ b/docs/dcb_llm/20_materialized_view.md
@@ -80,8 +80,9 @@ DynamoDB, or SQLite).
 
 ```mermaid
 flowchart LR
-    W[Hosted worker or started Orleans grain] -->|dedicated best-effort schedule| R[G26 MV registry truth]
-    R --> P[G24 source-side status store]
+    R[G26 truth already observed during normal MV work] --> C[In-memory runtime snapshot]
+    W[Hosted worker or started Orleans grain] -->|dedicated best-effort heartbeat| C
+    C --> P[G24 source-side status store]
     P --> T[IProjectionStatusReader]
     P --> S[ISerializedProjectionStatusReader V1]
     T -. passive read; no grain call .-> C[Caller]
@@ -108,7 +109,8 @@ Known-zero carries `SortableUniqueId.MinValue`; it is not represented as `Unknow
 event-apply, stream, query, or reader hot paths. Hosted workers publish after a catch-up cycle, and Orleans starts a
 separate publisher timer only after `EnsureStartedAsync`. Status reads therefore do not activate an MV grain. Writes
 are best-effort, independently timed out, and use generic secret-free failure diagnostics; publication failure does not
-stop event application or queries.
+stop event application or queries. The heartbeat consumes only the runtime's cached authoritative snapshot: neither
+the heartbeat nor either G24 reader resolves, opens, or queries the materialized-view target database.
 
 ## Registering the Runtime
 

--- a/docs/dcb_llm/20_materialized_view.md
+++ b/docs/dcb_llm/20_materialized_view.md
@@ -71,6 +71,45 @@ database registered by the materialized-view provider.
 
 This means correctness still depends on ordered event application, not on ad-hoc SQL updates.
 
+## Passive Projection Status
+
+Classic materialized views publish their progress through the existing G24 `IProjectionStatusReader` and
+`ISerializedProjectionStatusReader` surfaces. No materialized-view-specific reader or target-database status table is
+created. The publisher writes to the status store supplied by the event-source provider (PostgreSQL, Cosmos DB,
+DynamoDB, or SQLite).
+
+```mermaid
+flowchart LR
+    W[Hosted worker or started Orleans grain] -->|dedicated best-effort schedule| R[G26 MV registry truth]
+    R --> P[G24 source-side status store]
+    P --> T[IProjectionStatusReader]
+    P --> S[ISerializedProjectionStatusReader V1]
+    T -. passive read; no grain call .-> C[Caller]
+    S -. passive read; no grain call .-> C
+```
+
+Use `MvProjectionStatusIdentity.Create(viewName, viewVersion)` to obtain the exact `ProjectorName` and
+`ProjectorVersion` filters. The identity is stable and collision-free for punctuation and Unicode names. The worker or
+grain always publishes under its already validated, exact service id.
+
+The mapping is fail-closed:
+
+| G26 truth/lifecycle | G24 phase | `IsCaughtUp` eligibility |
+| --- | --- | --- |
+| `Unknown` | `unknown` | never |
+| Known + `Initializing` | `starting` | never |
+| Known + `CatchingUp` | `catchingUp` | never |
+| Known-zero/nonzero + `Ready` | `caughtUp` | only when the normal G24 freshness, remaining-count, fault, and conflict checks also pass |
+| Known-zero/nonzero + `Active` | `active` | only when the same G24 checks pass |
+| Known + `Retired` | `stopped` | never |
+| `Faulted` | `faulted` | never |
+
+Known-zero carries `SortableUniqueId.MinValue`; it is not represented as `Unknown`. Publication is not performed by
+event-apply, stream, query, or reader hot paths. Hosted workers publish after a catch-up cycle, and Orleans starts a
+separate publisher timer only after `EnsureStartedAsync`. Status reads therefore do not activate an MV grain. Writes
+are best-effort, independently timed out, and use generic secret-free failure diagnostics; publication failure does not
+stop event application or queries.
+
 ## Registering the Runtime
 
 Typical registration in an Orleans host looks like this:

--- a/docs/dcb_llm_ja/20_materialized_view.md
+++ b/docs/dcb_llm_ja/20_materialized_view.md
@@ -80,8 +80,9 @@ publisher はイベントソース provider（PostgreSQL、Cosmos DB、DynamoDB�
 
 ```mermaid
 flowchart LR
-    W[Hosted worker または開始済み Orleans grain] -->|専用 best-effort schedule| R[G26 MV registry truth]
-    R --> P[G24 source-side status store]
+    R[通常の MV 処理で既に観測した G26 truth] --> C[メモリ上の runtime snapshot]
+    W[Hosted worker または開始済み Orleans grain] -->|専用 best-effort heartbeat| C
+    C --> P[G24 source-side status store]
     P --> T[IProjectionStatusReader]
     P --> S[ISerializedProjectionStatusReader V1]
     T -. grain を呼ばない passive read .-> C[呼び出し元]
@@ -108,7 +109,8 @@ Known-zero は `SortableUniqueId.MinValue` を保持し、`Unknown` には変換
 reader の hot path では実行されません。Hosted worker は catch-up cycle 後に publish し、Orleans は
 `EnsureStartedAsync` の後でのみ専用 publisher timer を開始します。そのため status read は MV grain を activate しません。
 書き込みは best-effort かつ独立 timeout 付きで、失敗診断は secret-free な固定メッセージです。publication の失敗はイベント適用や
-query を停止させません。
+query を停止させません。heartbeat が使うのは runtime がキャッシュした authoritative snapshot だけです。heartbeat と 2 種類の
+G24 reader は、いずれもマテリアライズドビューの target DB を resolve、open、query しません。
 
 ## 登録方法
 

--- a/docs/dcb_llm_ja/20_materialized_view.md
+++ b/docs/dcb_llm_ja/20_materialized_view.md
@@ -72,6 +72,44 @@ provider をターゲットとして使えます。
 
 つまり、整合性の中心は SQL テーブルではなく、順序付きイベント適用です。
 
+## パッシブなプロジェクション状態
+
+classic マテリアライズドビューの進捗は、既存の G24 `IProjectionStatusReader` と
+`ISerializedProjectionStatusReader` から読み取れます。MV 専用 reader や target DB 側の status table は追加されません。
+publisher はイベントソース provider（PostgreSQL、Cosmos DB、DynamoDB、SQLite）が提供する既存 status store へ書き込みます。
+
+```mermaid
+flowchart LR
+    W[Hosted worker または開始済み Orleans grain] -->|専用 best-effort schedule| R[G26 MV registry truth]
+    R --> P[G24 source-side status store]
+    P --> T[IProjectionStatusReader]
+    P --> S[ISerializedProjectionStatusReader V1]
+    T -. grain を呼ばない passive read .-> C[呼び出し元]
+    S -. grain を呼ばない passive read .-> C
+```
+
+filter に使う正確な `ProjectorName` と `ProjectorVersion` は
+`MvProjectionStatusIdentity.Create(viewName, viewVersion)` で取得します。この identity は記号や Unicode を含む名前でも
+安定かつ衝突しません。worker / grain は、あらかじめ検証済みの正確な ServiceId をそのまま使用します。
+
+写像は fail-closed です。
+
+| G26 truth / lifecycle | G24 phase | `IsCaughtUp` の資格 |
+| --- | --- | --- |
+| `Unknown` | `unknown` | 常に不可 |
+| Known + `Initializing` | `starting` | 常に不可 |
+| Known + `CatchingUp` | `catchingUp` | 常に不可 |
+| Known-zero/nonzero + `Ready` | `caughtUp` | G24 の freshness、remaining count、fault、conflict 条件もすべて満たす場合のみ |
+| Known-zero/nonzero + `Active` | `active` | 同じ G24 条件をすべて満たす場合のみ |
+| Known + `Retired` | `stopped` | 常に不可 |
+| `Faulted` | `faulted` | 常に不可 |
+
+Known-zero は `SortableUniqueId.MinValue` を保持し、`Unknown` には変換されません。publication は event apply、stream、query、
+reader の hot path では実行されません。Hosted worker は catch-up cycle 後に publish し、Orleans は
+`EnsureStartedAsync` の後でのみ専用 publisher timer を開始します。そのため status read は MV grain を activate しません。
+書き込みは best-effort かつ独立 timeout 付きで、失敗診断は secret-free な固定メッセージです。publication の失敗はイベント適用や
+query を停止させません。
+
 ## 登録方法
 
 Orleans ホストでの基本的な登録例です。


### PR DESCRIPTION
## Summary

- publish classic materialized-view progress from exact service-scoped G26 checkpoint truth into the existing source-side G24 status registry
- run publication only after hosted catch-up cycles or on a dedicated timer for explicitly started Orleans grains
- map Unknown, known-zero, known-nonzero, lifecycle, and fault states fail-closed through both typed and V1 serialized readers
- preserve existing worker and grain public constructors, four target-provider composition, and passive reads without grain activation
- document the flow and operational semantics in English and Japanese

## Verification

- Release build: 0 errors
- net9 DCB suites: 1,434 passed, 1 skipped, 0 failed
- net10 DCB suites: 1,434 passed, 1 skipped, 0 failed
- focused MV publication tests: 19 passed on net9 and net10
- real Orleans TestCluster proof: passive G24 read measured 0 MV activations; direct EnsureStarted measured 1 activation and an Orleans heartbeat
- production mutation runs: Unknown authorization mutant failed 1/8; checkpoint removal mutant failed 6/8; all-lifecycle-as-active mutant failed 4/8; fault-as-active mutant failed 1/8; restored baseline passed 8/8
- git diff --check passed

## Boundaries

- no new reader API or target-database status adapter
- no event-store resolution or status writes in event apply, stream, query, or reader hot paths
- no release publication and no G29 work
- unrelated SEK-G23-REPAIR.md remained untracked and excluded (SHA-256 b510d75d032480c68dc4b00721d69163c76bea6e848be4ba1ff61916e0b70197)

Closes #1114