### PR TITLE
SEK-G29: coordinate materialized view generations

### DIFF
--- a/dcb/src/Sekiban.Dcb.Core/Actors/ProjectionStatusReader.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Actors/ProjectionStatusReader.cs
@@ -172,7 +172,10 @@ public sealed class ProjectionStatusReader : IProjectionStatusReader
                         LeaseExpiresAtUtc = row.LeaseExpiresAtUtc,
                         IsFaulted = faulted,
                         FaultMessage = row.FaultMessage,
-                        IsFresh = rowFresh
+                        IsFresh = rowFresh,
+                        SwitchKind = row.SwitchKind,
+                        SwitchReason = row.SwitchReason,
+                        SwitchedAtUtc = row.SwitchedAtUtc
                     };
                 })
                 .OrderBy(snapshot => snapshot.ProjectorName, StringComparer.Ordinal)

--- a/dcb/src/Sekiban.Dcb.Core/ProjectionStatus/ProjectionStatusModels.cs
+++ b/dcb/src/Sekiban.Dcb.Core/ProjectionStatus/ProjectionStatusModels.cs
@@ -43,6 +43,17 @@ public sealed record ProjectionStatusSnapshot(
     /// <summary>Whether this row satisfied the freshness/lease predicate at sampling time.</summary>
     public bool IsFresh { get; init; }
 
+    /// <summary>Optional active-pointer transition classification supplied by an MV publisher.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? SwitchKind { get; init; }
+
+    /// <summary>Durable operator reason for a forced reverse. Omitted for ordinary projection heartbeats.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? SwitchReason { get; init; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public DateTimeOffset? SwitchedAtUtc { get; init; }
+
     /// <summary>Compatibility/readability alias for callers that call the lease boundary a lease.</summary>
     [JsonIgnore]
     public DateTimeOffset? LeaseUntilUtc => LeaseExpiresAtUtc;
@@ -81,6 +92,10 @@ public sealed record ProjectionStatusHeartbeat(
     /// <summary>A secret-free fault summary, when faulted.</summary>
     public string? FaultMessage { get; init; }
 
+    public string? SwitchKind { get; init; }
+    public string? SwitchReason { get; init; }
+    public DateTimeOffset? SwitchedAtUtc { get; init; }
+
     /// <summary>Compatibility/readability alias for callers that call the lease boundary a lease.</summary>
     [JsonIgnore]
     public DateTimeOffset? LeaseUntilUtc => LeaseExpiresAtUtc;
@@ -108,6 +123,9 @@ public sealed record ProjectionStatusRow(
     public DateTimeOffset? LeaseExpiresAtUtc { get; init; }
     public bool IsFaulted { get; init; }
     public string? FaultMessage { get; init; }
+    public string? SwitchKind { get; init; }
+    public string? SwitchReason { get; init; }
+    public DateTimeOffset? SwitchedAtUtc { get; init; }
 
     public ProjectionStatusHeartbeat ToHeartbeat() => new(
         ServiceId,
@@ -124,7 +142,10 @@ public sealed record ProjectionStatusRow(
         Phase = Phase,
         LeaseExpiresAtUtc = LeaseExpiresAtUtc,
         IsFaulted = IsFaulted,
-        FaultMessage = FaultMessage
+        FaultMessage = FaultMessage,
+        SwitchKind = SwitchKind,
+        SwitchReason = SwitchReason,
+        SwitchedAtUtc = SwitchedAtUtc
     };
 
     public static ProjectionStatusRow FromHeartbeat(ProjectionStatusHeartbeat heartbeat) => new(
@@ -142,7 +163,10 @@ public sealed record ProjectionStatusRow(
         Phase = heartbeat.Phase,
         LeaseExpiresAtUtc = heartbeat.LeaseExpiresAtUtc,
         IsFaulted = heartbeat.IsFaulted,
-        FaultMessage = heartbeat.FaultMessage
+        FaultMessage = heartbeat.FaultMessage,
+        SwitchKind = heartbeat.SwitchKind,
+        SwitchReason = heartbeat.SwitchReason,
+        SwitchedAtUtc = heartbeat.SwitchedAtUtc
     };
 }
 

--- a/dcb/src/Sekiban.Dcb.CosmosDb/Models/CosmosMultiProjectionState.cs
+++ b/dcb/src/Sekiban.Dcb.CosmosDb/Models/CosmosMultiProjectionState.cs
@@ -186,6 +186,15 @@ public class CosmosMultiProjectionState
     [JsonProperty("faultMessage")]
     public string? FaultMessage { get; set; }
 
+    [JsonProperty("switchKind")]
+    public string? SwitchKind { get; set; }
+
+    [JsonProperty("switchReason")]
+    public string? SwitchReason { get; set; }
+
+    [JsonProperty("switchedAtUtc")]
+    public DateTimeOffset? SwitchedAtUtc { get; set; }
+
     /// <summary>
     ///     Creates a CosmosMultiProjectionState from a MultiProjectionStateRecord.
     /// </summary>
@@ -253,7 +262,10 @@ public class CosmosMultiProjectionState
             Phase = heartbeat.Phase,
             LeaseExpiresAtUtc = heartbeat.LeaseExpiresAtUtc,
             IsFaulted = heartbeat.IsFaulted,
-            FaultMessage = heartbeat.FaultMessage
+            FaultMessage = heartbeat.FaultMessage,
+            SwitchKind = heartbeat.SwitchKind,
+            SwitchReason = heartbeat.SwitchReason,
+            SwitchedAtUtc = heartbeat.SwitchedAtUtc
         };
     }
 
@@ -272,7 +284,10 @@ public class CosmosMultiProjectionState
         Phase = Phase ?? ProjectionStatusPhases.Unknown,
         LeaseExpiresAtUtc = LeaseExpiresAtUtc,
         IsFaulted = IsFaulted,
-        FaultMessage = FaultMessage
+        FaultMessage = FaultMessage,
+        SwitchKind = SwitchKind,
+        SwitchReason = SwitchReason,
+        SwitchedAtUtc = SwitchedAtUtc
     };
 
     /// <summary>

--- a/dcb/src/Sekiban.Dcb.DynamoDB/Models/DynamoMultiProjectionState.cs
+++ b/dcb/src/Sekiban.Dcb.DynamoDB/Models/DynamoMultiProjectionState.cs
@@ -1,6 +1,5 @@
 using Amazon.DynamoDBv2.Model;
 using System.Globalization;
-using Sekiban.Dcb;
 using Sekiban.Dcb.MultiProjections;
 
 namespace Sekiban.Dcb.DynamoDB.Models;
@@ -152,6 +151,10 @@ public class DynamoMultiProjectionState
     /// <summary>Secret-free status heartbeat fault summary.</summary>
     public string? FaultMessage { get; set; }
 
+    public string? SwitchKind { get; set; }
+    public string? SwitchReason { get; set; }
+    public DateTimeOffset? SwitchedAtUtc { get; set; }
+
     /// <summary>
     ///     Converts to DynamoDB attribute values.
     /// </summary>
@@ -203,6 +206,12 @@ public class DynamoMultiProjectionState
             item["isFaulted"] = new AttributeValue { BOOL = IsFaulted };
             if (!string.IsNullOrWhiteSpace(FaultMessage))
                 item["faultMessage"] = new AttributeValue { S = FaultMessage };
+            if (!string.IsNullOrWhiteSpace(SwitchKind))
+                item["switchKind"] = new AttributeValue { S = SwitchKind };
+            if (!string.IsNullOrWhiteSpace(SwitchReason))
+                item["switchReason"] = new AttributeValue { S = SwitchReason };
+            if (SwitchedAtUtc.HasValue)
+                item["switchedAtUtc"] = new AttributeValue { S = SwitchedAtUtc.Value.ToString("O") };
         }
 
         if (!string.IsNullOrEmpty(StateData))
@@ -261,7 +270,12 @@ public class DynamoMultiProjectionState
                 ? lease
                 : null,
             IsFaulted = item.GetValueOrDefault("isFaulted")?.BOOL ?? false,
-            FaultMessage = item.GetValueOrDefault("faultMessage")?.S
+            FaultMessage = item.GetValueOrDefault("faultMessage")?.S,
+            SwitchKind = item.GetValueOrDefault("switchKind")?.S,
+            SwitchReason = item.GetValueOrDefault("switchReason")?.S,
+            SwitchedAtUtc = DateTimeOffset.TryParse(item.GetValueOrDefault("switchedAtUtc")?.S, out var switchedAt)
+                ? switchedAt
+                : null
         };
     }
 
@@ -326,7 +340,10 @@ public class DynamoMultiProjectionState
             Phase = heartbeat.Phase,
             LeaseExpiresAtUtc = heartbeat.LeaseExpiresAtUtc,
             IsFaulted = heartbeat.IsFaulted,
-            FaultMessage = heartbeat.FaultMessage
+            FaultMessage = heartbeat.FaultMessage,
+            SwitchKind = heartbeat.SwitchKind,
+            SwitchReason = heartbeat.SwitchReason,
+            SwitchedAtUtc = heartbeat.SwitchedAtUtc
         };
     }
 
@@ -343,14 +360,17 @@ public class DynamoMultiProjectionState
             Sequence,
             AppliedEventCount,
             LastAppliedSortableUniqueId,
-        LastTraversedSortableUniqueId,
-        RecordedAtUtc ?? DateTimeOffset.UtcNow)
-    {
-        Phase = Phase ?? ProjectionStatusPhases.Unknown,
-        LeaseExpiresAtUtc = LeaseExpiresAtUtc,
-        IsFaulted = IsFaulted,
-        FaultMessage = FaultMessage
-    };
+            LastTraversedSortableUniqueId,
+            RecordedAtUtc ?? DateTimeOffset.UtcNow)
+        {
+            Phase = Phase ?? ProjectionStatusPhases.Unknown,
+            LeaseExpiresAtUtc = LeaseExpiresAtUtc,
+            IsFaulted = IsFaulted,
+            FaultMessage = FaultMessage,
+            SwitchKind = SwitchKind,
+            SwitchReason = SwitchReason,
+            SwitchedAtUtc = SwitchedAtUtc
+        };
 
     /// <summary>
     ///     Converts to a MultiProjectionStateRecord.

--- a/dcb/src/Sekiban.Dcb.DynamoDB/Models/DynamoMultiProjectionState.cs
+++ b/dcb/src/Sekiban.Dcb.DynamoDB/Models/DynamoMultiProjectionState.cs
@@ -273,7 +273,11 @@ public class DynamoMultiProjectionState
             FaultMessage = item.GetValueOrDefault("faultMessage")?.S,
             SwitchKind = item.GetValueOrDefault("switchKind")?.S,
             SwitchReason = item.GetValueOrDefault("switchReason")?.S,
-            SwitchedAtUtc = DateTimeOffset.TryParse(item.GetValueOrDefault("switchedAtUtc")?.S, out var switchedAt)
+            SwitchedAtUtc = DateTimeOffset.TryParse(
+                item.GetValueOrDefault("switchedAtUtc")?.S,
+                System.Globalization.CultureInfo.InvariantCulture,
+                System.Globalization.DateTimeStyles.RoundtripKind,
+                out var switchedAt)
                 ? switchedAt
                 : null
         };

--- a/dcb/src/Sekiban.Dcb.MaterializedView.MySql/MySqlMvForcedReverse.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.MySql/MySqlMvForcedReverse.cs
@@ -4,6 +4,15 @@ namespace Sekiban.Dcb.MaterializedView.MySql;
 
 public sealed partial class MySqlMvRegistryStore
 {
+    private const string LegacyActiveUpsertSql = """
+        INSERT INTO sekiban_mv_active (service_id, view_name, active_version, active_generation, activated_at)
+        VALUES (@ServiceId, @ViewName, @ActiveVersion, 1, UTC_TIMESTAMP(6))
+        ON DUPLICATE KEY UPDATE
+            active_version = VALUES(active_version),
+            active_generation = active_generation + 1,
+            activated_at = VALUES(activated_at);
+        """;
+
     private static readonly MvForcedReverseSqlPlan ForcedReverseSql = MvForcedReverseSqlPlan.Create(
         candidateFenceSql: """
             SELECT logical_table FROM sekiban_mv_registry
@@ -16,6 +25,7 @@ public sealed partial class MySqlMvRegistryStore
         releaseSavepointSql: "RELEASE SAVEPOINT sekiban_mv_forced_reverse;");
 
     protected override MvForcedReverseSqlPlan ForcedReversePlan => ForcedReverseSql;
+    protected override string LegacySetActiveSql => LegacyActiveUpsertSql;
     protected override MySqlConnection CreateForcedReverseConnection() => new(_connectionString);
     protected override object FormatForcedReverseTimestamp(DateTimeOffset value) => value.UtcDateTime;
 }

--- a/dcb/src/Sekiban.Dcb.MaterializedView.MySql/MySqlMvForcedReverse.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.MySql/MySqlMvForcedReverse.cs
@@ -1,0 +1,21 @@
+using MySqlConnector;
+
+namespace Sekiban.Dcb.MaterializedView.MySql;
+
+public sealed partial class MySqlMvRegistryStore
+{
+    private static readonly MvForcedReverseSqlPlan ForcedReverseSql = MvForcedReverseSqlPlan.Create(
+        candidateFenceSql: """
+            SELECT logical_table FROM sekiban_mv_registry
+            WHERE service_id = @ServiceId AND view_name = @ViewName AND view_version = @ViewVersion
+            ORDER BY logical_table FOR UPDATE;
+            """,
+        fenceReturnsRows: true,
+        savepointSql: "SAVEPOINT sekiban_mv_forced_reverse;",
+        rollbackSavepointSql: "ROLLBACK TO SAVEPOINT sekiban_mv_forced_reverse;",
+        releaseSavepointSql: "RELEASE SAVEPOINT sekiban_mv_forced_reverse;");
+
+    protected override MvForcedReverseSqlPlan ForcedReversePlan => ForcedReverseSql;
+    protected override MySqlConnection CreateForcedReverseConnection() => new(_connectionString);
+    protected override object FormatForcedReverseTimestamp(DateTimeOffset value) => value.UtcDateTime;
+}

--- a/dcb/src/Sekiban.Dcb.MaterializedView.MySql/MySqlMvRegistryStore.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.MySql/MySqlMvRegistryStore.cs
@@ -4,7 +4,7 @@ using MySqlConnector;
 
 namespace Sekiban.Dcb.MaterializedView.MySql;
 
-public sealed class MySqlMvRegistryStore : IMvRegistryStore
+public sealed partial class MySqlMvRegistryStore : MvForcedReverseRegistryStoreBase<MySqlConnection>, IMvRegistryStore
 {
     private readonly string _connectionString;
 
@@ -51,6 +51,9 @@ public sealed class MySqlMvRegistryStore : IMvRegistryStore
                 active_version INT NOT NULL,
                 active_generation BIGINT NOT NULL DEFAULT 0,
                 activated_at DATETIME(6) NOT NULL,
+                switch_kind VARCHAR(32) NOT NULL DEFAULT 'legacy',
+                switch_reason VARCHAR(1024) NULL,
+                switched_at_utc DATETIME(6) NULL,
                 PRIMARY KEY (service_id, view_name)
             );
             """;
@@ -93,7 +96,7 @@ public sealed class MySqlMvRegistryStore : IMvRegistryStore
                     FROM information_schema.columns
                     WHERE table_schema = DATABASE()
                       AND table_name = 'sekiban_mv_active'
-                      AND column_name = 'active_generation';
+                      AND column_name IN ('active_generation', 'switch_kind', 'switch_reason', 'switched_at_utc');
                     """,
                     cancellationToken: cancellationToken)))
             .ToHashSet(StringComparer.OrdinalIgnoreCase);
@@ -104,6 +107,27 @@ public sealed class MySqlMvRegistryStore : IMvRegistryStore
                         "ALTER TABLE sekiban_mv_active ADD COLUMN active_generation BIGINT NOT NULL DEFAULT 0;",
                         cancellationToken: cancellationToken))
                 .ConfigureAwait(false);
+        }
+
+        if (!activeGenerationColumns.Contains("switch_kind"))
+        {
+            await connection.ExecuteAsync(new CommandDefinition(
+                "ALTER TABLE sekiban_mv_active ADD COLUMN switch_kind VARCHAR(32) NOT NULL DEFAULT 'legacy';",
+                cancellationToken: cancellationToken)).ConfigureAwait(false);
+        }
+
+        if (!activeGenerationColumns.Contains("switch_reason"))
+        {
+            await connection.ExecuteAsync(new CommandDefinition(
+                "ALTER TABLE sekiban_mv_active ADD COLUMN switch_reason VARCHAR(1024) NULL;",
+                cancellationToken: cancellationToken)).ConfigureAwait(false);
+        }
+
+        if (!activeGenerationColumns.Contains("switched_at_utc"))
+        {
+            await connection.ExecuteAsync(new CommandDefinition(
+                "ALTER TABLE sekiban_mv_active ADD COLUMN switched_at_utc DATETIME(6) NULL;",
+                cancellationToken: cancellationToken)).ConfigureAwait(false);
         }
     }
 
@@ -416,7 +440,10 @@ public sealed class MySqlMvRegistryStore : IMvRegistryStore
                    view_name AS ViewName,
                    active_version AS ActiveVersion,
                    active_generation AS Generation,
-                   activated_at AS ActivatedAt
+                   activated_at AS ActivatedAt,
+                   switch_kind AS SwitchKind,
+                   switch_reason AS SwitchReason,
+                   switched_at_utc AS SwitchedAtUtc
             FROM sekiban_mv_active
             WHERE service_id = @ServiceId
               AND view_name = @ViewName;
@@ -438,12 +465,17 @@ public sealed class MySqlMvRegistryStore : IMvRegistryStore
         CancellationToken cancellationToken = default)
     {
         const string sql = """
-            INSERT INTO sekiban_mv_active (service_id, view_name, active_version, active_generation, activated_at)
-            VALUES (@ServiceId, @ViewName, @ActiveVersion, 1, UTC_TIMESTAMP(6))
+            INSERT INTO sekiban_mv_active (
+                service_id, view_name, active_version, active_generation, activated_at,
+                switch_kind, switch_reason, switched_at_utc)
+            VALUES (@ServiceId, @ViewName, @ActiveVersion, 1, UTC_TIMESTAMP(6), 'legacy', NULL, UTC_TIMESTAMP(6))
             ON DUPLICATE KEY UPDATE
                 active_version = VALUES(active_version),
                 active_generation = active_generation + 1,
-                activated_at = VALUES(activated_at);
+                activated_at = VALUES(activated_at),
+                switch_kind = 'legacy',
+                switch_reason = NULL,
+                switched_at_utc = VALUES(switched_at_utc);
             """;
 
         await ExecuteAsync(
@@ -516,6 +548,7 @@ public sealed class MySqlMvRegistryStore : IMvRegistryStore
             request.ExpectedActiveGeneration,
             request.CandidateCount,
             ExpectedStatus = request.ExpectedStatus.ToString().ToLowerInvariant(),
+            SwitchKind = request.SwitchKind.ToString().ToLowerInvariant(),
             request.ExpectedCurrentCheckpointTruth,
             request.ExpectedTargetCheckpointTruth
         };
@@ -532,8 +565,9 @@ public sealed class MySqlMvRegistryStore : IMvRegistryStore
 
         const string insertSql = """
             INSERT INTO sekiban_mv_active (
-                service_id, view_name, active_version, active_generation, activated_at)
-            SELECT @ServiceId, @ViewName, @ViewVersion, 1, UTC_TIMESTAMP(6)
+                service_id, view_name, active_version, active_generation, activated_at,
+                switch_kind, switch_reason, switched_at_utc)
+            SELECT @ServiceId, @ViewName, @ViewVersion, 1, UTC_TIMESTAMP(6), @SwitchKind, NULL, UTC_TIMESTAMP(6)
             WHERE @ExpectedActiveVersion IS NULL
               AND @ExpectedActiveGeneration = 0
             ON DUPLICATE KEY UPDATE active_version = active_version;
@@ -542,7 +576,10 @@ public sealed class MySqlMvRegistryStore : IMvRegistryStore
             UPDATE sekiban_mv_active
             SET active_version = @ViewVersion,
                 active_generation = active_generation + 1,
-                activated_at = UTC_TIMESTAMP(6)
+                activated_at = UTC_TIMESTAMP(6),
+                switch_kind = @SwitchKind,
+                switch_reason = NULL,
+                switched_at_utc = UTC_TIMESTAMP(6)
             WHERE service_id = @ServiceId
               AND view_name = @ViewName
               AND active_version = @ExpectedActiveVersion
@@ -555,6 +592,17 @@ public sealed class MySqlMvRegistryStore : IMvRegistryStore
         {
             return CandidateSnapshotChanged();
         }
+
+        const string markPreviousReadySql = """
+            UPDATE sekiban_mv_registry
+            SET status = 'ready', last_updated = UTC_TIMESTAMP(6)
+            WHERE service_id = @ServiceId
+              AND view_name = @ViewName
+              AND view_version = @ExpectedActiveVersion
+              AND @ExpectedActiveVersion IS NOT NULL;
+            """;
+        await transaction.Connection!.ExecuteAsync(
+            new CommandDefinition(markPreviousReadySql, parameters, transaction, cancellationToken: cancellationToken)).ConfigureAwait(false);
 
         const string markActiveSql = """
             UPDATE sekiban_mv_registry
@@ -716,8 +764,16 @@ public sealed class MySqlMvRegistryStore : IMvRegistryStore
             ReadRequiredInt(row, "ActiveVersion"),
             ReadRequiredDateTimeOffset(row, "ActivatedAt"))
         {
-            Generation = ReadRequiredLong(row, "Generation")
+            Generation = ReadRequiredLong(row, "Generation"),
+            SwitchKind = ReadSwitchKind(row),
+            SwitchReason = ReadNullableString(row, "SwitchReason"),
+            SwitchedAtUtc = ReadNullableDateTimeOffset(row, "SwitchedAtUtc")
         };
+
+    private static MvSwitchKind ReadSwitchKind(IReadOnlyDictionary<string, object?> row) =>
+        Enum.TryParse<MvSwitchKind>(ReadNullableString(row, "SwitchKind"), true, out var kind)
+            ? kind
+            : MvSwitchKind.Legacy;
 
     private static IReadOnlyDictionary<string, object?> ToDictionary(object row)
     {

--- a/dcb/src/Sekiban.Dcb.MaterializedView.MySql/MySqlMvRegistryStore.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.MySql/MySqlMvRegistryStore.cs
@@ -444,33 +444,13 @@ public sealed partial class MySqlMvRegistryStore : MvForcedReverseRegistryStoreB
         return row is null ? null : MapActiveEntry(ToDictionary(row));
     }
 
-    public async Task SetActiveAsync(
+    public Task SetActiveAsync(
         string serviceId,
         string viewName,
         int activeVersion,
         IDbTransaction? transaction = null,
-        CancellationToken cancellationToken = default)
-    {
-        const string sql = """
-            INSERT INTO sekiban_mv_active (
-                service_id, view_name, active_version, active_generation, activated_at,
-                switch_kind, switch_reason, switched_at_utc)
-            VALUES (@ServiceId, @ViewName, @ActiveVersion, 1, UTC_TIMESTAMP(6), 'legacy', NULL, UTC_TIMESTAMP(6))
-            ON DUPLICATE KEY UPDATE
-                active_version = VALUES(active_version),
-                active_generation = active_generation + 1,
-                activated_at = VALUES(activated_at),
-                switch_kind = 'legacy',
-                switch_reason = NULL,
-                switched_at_utc = VALUES(switched_at_utc);
-            """;
-
-        await ExecuteAsync(
-            sql,
-            new { ServiceId = serviceId, ViewName = viewName, ActiveVersion = activeVersion },
-            transaction,
-            cancellationToken).ConfigureAwait(false);
-    }
+        CancellationToken cancellationToken = default) =>
+        SetLegacyActiveAsync(serviceId, viewName, activeVersion, transaction, cancellationToken);
 
     public async Task<MvActivationResult> TryActivateAsync(
         MvActivationRequest request,

--- a/dcb/src/Sekiban.Dcb.MaterializedView.MySql/MySqlMvRegistryStore.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.MySql/MySqlMvRegistryStore.cs
@@ -548,7 +548,6 @@ public sealed partial class MySqlMvRegistryStore : MvForcedReverseRegistryStoreB
             request.ExpectedActiveGeneration,
             request.CandidateCount,
             ExpectedStatus = request.ExpectedStatus.ToString().ToLowerInvariant(),
-            SwitchKind = request.SwitchKind.ToString().ToLowerInvariant(),
             request.ExpectedCurrentCheckpointTruth,
             request.ExpectedTargetCheckpointTruth
         };
@@ -564,10 +563,8 @@ public sealed partial class MySqlMvRegistryStore : MvForcedReverseRegistryStoreB
         }
 
         const string insertSql = """
-            INSERT INTO sekiban_mv_active (
-                service_id, view_name, active_version, active_generation, activated_at,
-                switch_kind, switch_reason, switched_at_utc)
-            SELECT @ServiceId, @ViewName, @ViewVersion, 1, UTC_TIMESTAMP(6), @SwitchKind, NULL, UTC_TIMESTAMP(6)
+            INSERT INTO sekiban_mv_active (service_id, view_name, active_version, active_generation, activated_at)
+            SELECT @ServiceId, @ViewName, @ViewVersion, 1, UTC_TIMESTAMP(6)
             WHERE @ExpectedActiveVersion IS NULL
               AND @ExpectedActiveGeneration = 0
             ON DUPLICATE KEY UPDATE active_version = active_version;
@@ -576,10 +573,7 @@ public sealed partial class MySqlMvRegistryStore : MvForcedReverseRegistryStoreB
             UPDATE sekiban_mv_active
             SET active_version = @ViewVersion,
                 active_generation = active_generation + 1,
-                activated_at = UTC_TIMESTAMP(6),
-                switch_kind = @SwitchKind,
-                switch_reason = NULL,
-                switched_at_utc = UTC_TIMESTAMP(6)
+                activated_at = UTC_TIMESTAMP(6)
             WHERE service_id = @ServiceId
               AND view_name = @ViewName
               AND active_version = @ExpectedActiveVersion
@@ -593,16 +587,7 @@ public sealed partial class MySqlMvRegistryStore : MvForcedReverseRegistryStoreB
             return CandidateSnapshotChanged();
         }
 
-        const string markPreviousReadySql = """
-            UPDATE sekiban_mv_registry
-            SET status = 'ready', last_updated = UTC_TIMESTAMP(6)
-            WHERE service_id = @ServiceId
-              AND view_name = @ViewName
-              AND view_version = @ExpectedActiveVersion
-              AND @ExpectedActiveVersion IS NOT NULL;
-            """;
-        await transaction.Connection!.ExecuteAsync(
-            new CommandDefinition(markPreviousReadySql, parameters, transaction, cancellationToken: cancellationToken)).ConfigureAwait(false);
+        await PersistOrdinarySwitchAuditAsync(transaction, request, cancellationToken).ConfigureAwait(false);
 
         const string markActiveSql = """
             UPDATE sekiban_mv_registry
@@ -757,23 +742,7 @@ public sealed partial class MySqlMvRegistryStore : MvForcedReverseRegistryStoreB
         };
     }
 
-    private static MvActiveEntry MapActiveEntry(IReadOnlyDictionary<string, object?> row) =>
-        new(
-            ReadRequiredString(row, "ServiceId"),
-            ReadRequiredString(row, "ViewName"),
-            ReadRequiredInt(row, "ActiveVersion"),
-            ReadRequiredDateTimeOffset(row, "ActivatedAt"))
-        {
-            Generation = ReadRequiredLong(row, "Generation"),
-            SwitchKind = ReadSwitchKind(row),
-            SwitchReason = ReadNullableString(row, "SwitchReason"),
-            SwitchedAtUtc = ReadNullableDateTimeOffset(row, "SwitchedAtUtc")
-        };
-
-    private static MvSwitchKind ReadSwitchKind(IReadOnlyDictionary<string, object?> row) =>
-        Enum.TryParse<MvSwitchKind>(ReadNullableString(row, "SwitchKind"), true, out var kind)
-            ? kind
-            : MvSwitchKind.Legacy;
+    private static MvActiveEntry MapActiveEntry(IReadOnlyDictionary<string, object?> row) => ReadActiveEntry(row);
 
     private static IReadOnlyDictionary<string, object?> ToDictionary(object row)
     {

--- a/dcb/src/Sekiban.Dcb.MaterializedView.MySql/MySqlMvRegistryStore.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.MySql/MySqlMvRegistryStore.cs
@@ -109,26 +109,13 @@ public sealed partial class MySqlMvRegistryStore : MvForcedReverseRegistryStoreB
                 .ConfigureAwait(false);
         }
 
-        if (!activeGenerationColumns.Contains("switch_kind"))
-        {
-            await connection.ExecuteAsync(new CommandDefinition(
-                "ALTER TABLE sekiban_mv_active ADD COLUMN switch_kind VARCHAR(32) NOT NULL DEFAULT 'legacy';",
-                cancellationToken: cancellationToken)).ConfigureAwait(false);
-        }
-
-        if (!activeGenerationColumns.Contains("switch_reason"))
-        {
-            await connection.ExecuteAsync(new CommandDefinition(
-                "ALTER TABLE sekiban_mv_active ADD COLUMN switch_reason VARCHAR(1024) NULL;",
-                cancellationToken: cancellationToken)).ConfigureAwait(false);
-        }
-
-        if (!activeGenerationColumns.Contains("switched_at_utc"))
-        {
-            await connection.ExecuteAsync(new CommandDefinition(
-                "ALTER TABLE sekiban_mv_active ADD COLUMN switched_at_utc DATETIME(6) NULL;",
-                cancellationToken: cancellationToken)).ConfigureAwait(false);
-        }
+        await EnsureMissingActiveColumnsAsync(
+            connection,
+            activeGenerationColumns,
+            cancellationToken,
+            ("switch_kind", "ALTER TABLE sekiban_mv_active ADD COLUMN switch_kind VARCHAR(32) NOT NULL DEFAULT 'legacy';"),
+            ("switch_reason", "ALTER TABLE sekiban_mv_active ADD COLUMN switch_reason VARCHAR(1024) NULL;"),
+            ("switched_at_utc", "ALTER TABLE sekiban_mv_active ADD COLUMN switched_at_utc DATETIME(6) NULL;")).ConfigureAwait(false);
     }
 
     public async Task RegisterAsync(MvRegistryEntry entry, IDbTransaction? transaction = null, CancellationToken cancellationToken = default)

--- a/dcb/src/Sekiban.Dcb.MaterializedView.Orleans/MvGenerationCoordinatorGrain.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.Orleans/MvGenerationCoordinatorGrain.cs
@@ -1,0 +1,130 @@
+using Orleans.Concurrency;
+using Sekiban.Dcb.Orleans.ServiceId;
+
+namespace Sekiban.Dcb.MaterializedView.Orleans;
+
+[GenerateSerializer, Immutable]
+public sealed record MvGenerationSwitchResult(
+    [property: Id(0)] bool Succeeded,
+    [property: Id(1)] int FailureReason,
+    [property: Id(2)] string Message,
+    [property: Id(3)] long? NewGeneration)
+{
+    internal static MvGenerationSwitchResult From(MvActivationResult result) =>
+        new(result.Succeeded, (int)result.FailureReason, result.Message, result.NewGeneration);
+}
+
+[GenerateSerializer, Immutable]
+public sealed record MvActiveGenerationStatus(
+    [property: Id(0)] string ServiceId,
+    [property: Id(1)] string ViewName,
+    [property: Id(2)] int ActiveVersion,
+    [property: Id(3)] long Generation,
+    [property: Id(4)] int SwitchKind,
+    [property: Id(5)] string? SwitchReason,
+    [property: Id(6)] DateTimeOffset? SwitchedAtUtc);
+
+public interface IMvGenerationCoordinatorGrain : IGrainWithStringKey
+{
+    Task PrepareGenerationAsync(int viewVersion);
+    Task<MvGenerationSwitchResult> SwitchAsync(int viewVersion);
+    Task<MvGenerationSwitchResult> ForceReverseAsync(
+        int retainedVersion,
+        int expectedActiveVersion,
+        long expectedActiveGeneration,
+        string reason);
+
+    [AlwaysInterleave]
+    Task<MvActiveGenerationStatus?> GetActiveAsync();
+}
+
+public static class MvGenerationCoordinatorGrainKey
+{
+    private const string Prefix = "mv-coordinator::";
+
+    public static string Build(string serviceId, string viewName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(viewName);
+        return ServiceIdGrainKey.Build(serviceId, Prefix + viewName);
+    }
+
+    internal static (string ServiceId, string ViewName) Parse(string key)
+    {
+        var (serviceId, raw) = ServiceIdGrainKey.Parse(key);
+        if (!raw.StartsWith(Prefix, StringComparison.Ordinal) || raw.Length == Prefix.Length)
+        {
+            throw new ArgumentException($"Invalid MV generation coordinator key '{key}'.", nameof(key));
+        }
+
+        return (serviceId, raw[Prefix.Length..]);
+    }
+}
+
+/// <summary>Orleans single-flight facade over the same provider-neutral hosted coordinator.</summary>
+public sealed class MvGenerationCoordinatorGrain(
+    IMvGenerationCoordinator coordinator,
+    IMvApplyHostFactory hostFactory) : Grain, IMvGenerationCoordinatorGrain
+{
+    private string _serviceId = string.Empty;
+    private string _viewName = string.Empty;
+
+    public override Task OnActivateAsync(CancellationToken cancellationToken)
+    {
+        (_serviceId, _viewName) = MvGenerationCoordinatorGrainKey.Parse(this.GetPrimaryKeyString());
+        return base.OnActivateAsync(cancellationToken);
+    }
+
+    public async Task PrepareGenerationAsync(int viewVersion)
+    {
+        var host = CreateHost(viewVersion);
+        await coordinator.PrepareGenerationAsync(host, _serviceId).ConfigureAwait(false);
+        var worker = GrainFactory.GetGrain<IMaterializedViewGrain>(MvGrainKey.Build(_serviceId, _viewName, viewVersion));
+        await worker.EnsureStartedAsync().ConfigureAwait(false);
+    }
+
+    public async Task<MvGenerationSwitchResult> SwitchAsync(int viewVersion) =>
+        MvGenerationSwitchResult.From(await coordinator.SwitchAsync(
+                CreateHost(viewVersion),
+                _serviceId,
+                publisherKind: MvProjectionStatusPublisherKind.Orleans)
+            .ConfigureAwait(false));
+
+    public async Task<MvGenerationSwitchResult> ForceReverseAsync(
+        int retainedVersion,
+        int expectedActiveVersion,
+        long expectedActiveGeneration,
+        string reason) =>
+        MvGenerationSwitchResult.From(await coordinator.ForceReverseAsync(
+                CreateHost(retainedVersion),
+                expectedActiveVersion,
+                expectedActiveGeneration,
+                reason,
+                _serviceId,
+                publisherKind: MvProjectionStatusPublisherKind.Orleans)
+            .ConfigureAwait(false));
+
+    public async Task<MvActiveGenerationStatus?> GetActiveAsync()
+    {
+        var active = await coordinator.GetActiveAsync(_viewName, _serviceId).ConfigureAwait(false);
+        return active is null
+            ? null
+            : new MvActiveGenerationStatus(
+                active.ServiceId,
+                active.ViewName,
+                active.ActiveVersion,
+                active.Generation,
+                (int)active.SwitchKind,
+                active.SwitchReason,
+                active.SwitchedAtUtc);
+    }
+
+    private IMvApplyHost CreateHost(int version)
+    {
+        if (version < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(version));
+        }
+
+        return hostFactory.Create(_viewName, version);
+    }
+}

--- a/dcb/src/Sekiban.Dcb.MaterializedView.Orleans/MvOrleansQueryAccessor.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.Orleans/MvOrleansQueryAccessor.cs
@@ -17,6 +17,7 @@ public sealed class MvOrleansQueryContext
         ConnectionString = connectionString;
         Grain = grain;
         Entries = entries;
+        ViewVersion = entries.FirstOrDefault()?.ViewVersion;
     }
 
     public string ServiceId { get; }
@@ -24,6 +25,8 @@ public sealed class MvOrleansQueryContext
     public string ConnectionString { get; }
     public IMaterializedViewGrain Grain { get; }
     public IReadOnlyList<MvRegistryEntry> Entries { get; }
+    public int? ViewVersion { get; }
+    public MvActiveEntry? ActivePointer { get; init; }
 
     public MvRegistryEntry GetRequiredTable(string logicalTable)
     {
@@ -44,6 +47,13 @@ public interface IMvOrleansQueryAccessor
         IMaterializedViewProjector projector,
         string? serviceId = null,
         CancellationToken cancellationToken = default);
+
+    /// <summary>Explicit version-pinned diagnostics. Ordinary reads must use <see cref="GetAsync"/>.</summary>
+    Task<MvOrleansQueryContext> GetPinnedAsync(
+        IMaterializedViewProjector projector,
+        string? serviceId = null,
+        CancellationToken cancellationToken = default) =>
+        throw new NotSupportedException("This accessor does not support explicit version-pinned diagnostics.");
 }
 
 public sealed class MvOrleansQueryAccessor : IMvOrleansQueryAccessor
@@ -74,16 +84,52 @@ public sealed class MvOrleansQueryAccessor : IMvOrleansQueryAccessor
             ? _serviceIdProvider.GetCurrentServiceId()
             : serviceId;
 
-        var grainKey = MvGrainKey.Build(serviceId, projector.ViewName, projector.ViewVersion);
+        var active = await _registryStore.GetActiveAsync(serviceId, projector.ViewName, cancellationToken).ConfigureAwait(false) ??
+            throw new InvalidOperationException($"Materialized view '{projector.ViewName}' has no active generation.");
+        var entries = await _registryStore.GetEntriesAsync(
+            serviceId,
+            projector.ViewName,
+            active.ActiveVersion,
+            cancellationToken).ConfigureAwait(false);
+        if (entries.Count == 0)
+        {
+            throw new InvalidOperationException(
+                $"Active materialized view '{projector.ViewName}' version {active.ActiveVersion} does not exist.");
+        }
+
+        var grainKey = MvGrainKey.Build(serviceId, projector.ViewName, active.ActiveVersion);
         var grain = _client.GetGrain<IMaterializedViewGrain>(grainKey);
         await grain.EnsureStartedAsync().ConfigureAwait(false);
 
+        var storageInfo = _storageInfoProvider.GetStorageInfo();
+        return new MvOrleansQueryContext(serviceId, storageInfo.DatabaseType, storageInfo.ConnectionString, grain, entries)
+        {
+            ActivePointer = active
+        };
+    }
+
+    public async Task<MvOrleansQueryContext> GetPinnedAsync(
+        IMaterializedViewProjector projector,
+        string? serviceId = null,
+        CancellationToken cancellationToken = default)
+    {
+        serviceId = string.IsNullOrWhiteSpace(serviceId)
+            ? _serviceIdProvider.GetCurrentServiceId()
+            : serviceId;
         var entries = await _registryStore.GetEntriesAsync(
             serviceId,
             projector.ViewName,
             projector.ViewVersion,
             cancellationToken).ConfigureAwait(false);
+        if (entries.Count == 0)
+        {
+            throw new InvalidOperationException(
+                $"Pinned materialized view '{projector.ViewName}' version {projector.ViewVersion} does not exist.");
+        }
 
+        var grain = _client.GetGrain<IMaterializedViewGrain>(
+            MvGrainKey.Build(serviceId, projector.ViewName, projector.ViewVersion));
+        await grain.EnsureStartedAsync().ConfigureAwait(false);
         var storageInfo = _storageInfoProvider.GetStorageInfo();
         return new MvOrleansQueryContext(serviceId, storageInfo.DatabaseType, storageInfo.ConnectionString, grain, entries);
     }

--- a/dcb/src/Sekiban.Dcb.MaterializedView.Postgres/PostgresMvForcedReverse.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.Postgres/PostgresMvForcedReverse.cs
@@ -1,0 +1,20 @@
+using Npgsql;
+
+namespace Sekiban.Dcb.MaterializedView.Postgres;
+
+public sealed partial class PostgresMvRegistryStore
+{
+    private static readonly MvForcedReverseSqlPlan ForcedReverseSql = MvForcedReverseSqlPlan.Create(
+        candidateFenceSql: """
+            SELECT logical_table FROM sekiban_mv_registry
+            WHERE service_id = @ServiceId AND view_name = @ViewName AND view_version = @ViewVersion
+            ORDER BY logical_table FOR UPDATE;
+            """,
+        fenceReturnsRows: true,
+        savepointSql: "SAVEPOINT sekiban_mv_forced_reverse;",
+        rollbackSavepointSql: "ROLLBACK TO SAVEPOINT sekiban_mv_forced_reverse;",
+        releaseSavepointSql: "RELEASE SAVEPOINT sekiban_mv_forced_reverse;");
+
+    protected override MvForcedReverseSqlPlan ForcedReversePlan => ForcedReverseSql;
+    protected override NpgsqlConnection CreateForcedReverseConnection() => new(_connectionString);
+}

--- a/dcb/src/Sekiban.Dcb.MaterializedView.Postgres/PostgresMvForcedReverse.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.Postgres/PostgresMvForcedReverse.cs
@@ -4,6 +4,15 @@ namespace Sekiban.Dcb.MaterializedView.Postgres;
 
 public sealed partial class PostgresMvRegistryStore
 {
+    private const string LegacyActiveUpsertSql = """
+        INSERT INTO sekiban_mv_active (service_id, view_name, active_version, active_generation, activated_at)
+        VALUES (@ServiceId, @ViewName, @ActiveVersion, 1, NOW())
+        ON CONFLICT (service_id, view_name) DO UPDATE SET
+            active_version = EXCLUDED.active_version,
+            active_generation = sekiban_mv_active.active_generation + 1,
+            activated_at = EXCLUDED.activated_at;
+        """;
+
     private static readonly MvForcedReverseSqlPlan ForcedReverseSql = MvForcedReverseSqlPlan.Create(
         candidateFenceSql: """
             SELECT logical_table FROM sekiban_mv_registry
@@ -16,5 +25,6 @@ public sealed partial class PostgresMvRegistryStore
         releaseSavepointSql: "RELEASE SAVEPOINT sekiban_mv_forced_reverse;");
 
     protected override MvForcedReverseSqlPlan ForcedReversePlan => ForcedReverseSql;
+    protected override string LegacySetActiveSql => LegacyActiveUpsertSql;
     protected override NpgsqlConnection CreateForcedReverseConnection() => new(_connectionString);
 }

--- a/dcb/src/Sekiban.Dcb.MaterializedView.Postgres/PostgresMvRegistryStore.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.Postgres/PostgresMvRegistryStore.cs
@@ -408,30 +408,13 @@ public sealed partial class PostgresMvRegistryStore : MvForcedReverseRegistrySto
         return row is null ? null : MapActiveEntry(ToDictionary(row));
     }
 
-    public async Task SetActiveAsync(
+    public Task SetActiveAsync(
         string serviceId,
         string viewName,
         int activeVersion,
         IDbTransaction? transaction = null,
-        CancellationToken cancellationToken = default)
-    {
-        const string sql = """
-            INSERT INTO sekiban_mv_active (
-                service_id, view_name, active_version, active_generation, activated_at,
-                switch_kind, switch_reason, switched_at_utc)
-            VALUES (@ServiceId, @ViewName, @ActiveVersion, 1, NOW(), 'legacy', NULL, NOW())
-            ON CONFLICT (service_id, view_name) DO UPDATE SET
-                active_version = EXCLUDED.active_version,
-                active_generation = sekiban_mv_active.active_generation + 1,
-                activated_at = EXCLUDED.activated_at,
-                switch_kind = 'legacy',
-                switch_reason = NULL,
-                switched_at_utc = EXCLUDED.switched_at_utc;
-            """;
-
-        var parameters = new { ServiceId = serviceId, ViewName = viewName, ActiveVersion = activeVersion };
-        await ExecuteAsync(sql, parameters, transaction, cancellationToken).ConfigureAwait(false);
-    }
+        CancellationToken cancellationToken = default) =>
+        SetLegacyActiveAsync(serviceId, viewName, activeVersion, transaction, cancellationToken);
 
     public async Task<MvActivationResult> TryActivateAsync(
         MvActivationRequest request,

--- a/dcb/src/Sekiban.Dcb.MaterializedView.Postgres/PostgresMvRegistryStore.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.Postgres/PostgresMvRegistryStore.cs
@@ -496,7 +496,6 @@ public sealed partial class PostgresMvRegistryStore : MvForcedReverseRegistrySto
             request.ExpectedActiveGeneration,
             request.CandidateCount,
             ExpectedStatus = request.ExpectedStatus.ToString().ToLowerInvariant(),
-            SwitchKind = request.SwitchKind.ToString().ToLowerInvariant(),
             request.ExpectedCurrentCheckpointTruth,
             request.ExpectedTargetCheckpointTruth
         };
@@ -512,10 +511,8 @@ public sealed partial class PostgresMvRegistryStore : MvForcedReverseRegistrySto
         }
 
         const string insertSql = """
-            INSERT INTO sekiban_mv_active (
-                service_id, view_name, active_version, active_generation, activated_at,
-                switch_kind, switch_reason, switched_at_utc)
-            SELECT @ServiceId, @ViewName, @ViewVersion, 1, NOW(), @SwitchKind, NULL, NOW()
+            INSERT INTO sekiban_mv_active (service_id, view_name, active_version, active_generation, activated_at)
+            SELECT @ServiceId, @ViewName, @ViewVersion, 1, NOW()
             WHERE @ExpectedActiveVersion IS NULL
               AND @ExpectedActiveGeneration = 0
             ON CONFLICT (service_id, view_name) DO NOTHING;
@@ -524,10 +521,7 @@ public sealed partial class PostgresMvRegistryStore : MvForcedReverseRegistrySto
             UPDATE sekiban_mv_active
             SET active_version = @ViewVersion,
                 active_generation = active_generation + 1,
-                activated_at = NOW(),
-                switch_kind = @SwitchKind,
-                switch_reason = NULL,
-                switched_at_utc = NOW()
+                activated_at = NOW()
             WHERE service_id = @ServiceId
               AND view_name = @ViewName
               AND active_version = @ExpectedActiveVersion
@@ -541,16 +535,7 @@ public sealed partial class PostgresMvRegistryStore : MvForcedReverseRegistrySto
             return CandidateSnapshotChanged();
         }
 
-        const string markPreviousReadySql = """
-            UPDATE sekiban_mv_registry
-            SET status = 'ready', last_updated = NOW()
-            WHERE service_id = @ServiceId
-              AND view_name = @ViewName
-              AND view_version = @ExpectedActiveVersion
-              AND @ExpectedActiveVersion IS NOT NULL;
-            """;
-        await transaction.Connection!.ExecuteAsync(
-            new CommandDefinition(markPreviousReadySql, parameters, transaction, cancellationToken: cancellationToken)).ConfigureAwait(false);
+        await PersistOrdinarySwitchAuditAsync(transaction, request, cancellationToken).ConfigureAwait(false);
 
         const string markActiveSql = """
             UPDATE sekiban_mv_registry
@@ -705,23 +690,7 @@ public sealed partial class PostgresMvRegistryStore : MvForcedReverseRegistrySto
         };
     }
 
-    private static MvActiveEntry MapActiveEntry(IReadOnlyDictionary<string, object?> row) =>
-        new(
-            ReadRequiredString(row, "ServiceId"),
-            ReadRequiredString(row, "ViewName"),
-            ReadRequiredInt(row, "ActiveVersion"),
-            ReadRequiredDateTimeOffset(row, "ActivatedAt"))
-        {
-            Generation = ReadRequiredLong(row, "Generation"),
-            SwitchKind = ReadSwitchKind(row),
-            SwitchReason = ReadNullableString(row, "SwitchReason"),
-            SwitchedAtUtc = ReadNullableDateTimeOffset(row, "SwitchedAtUtc")
-        };
-
-    private static MvSwitchKind ReadSwitchKind(IReadOnlyDictionary<string, object?> row) =>
-        Enum.TryParse<MvSwitchKind>(ReadNullableString(row, "SwitchKind"), true, out var kind)
-            ? kind
-            : MvSwitchKind.Legacy;
+    private static MvActiveEntry MapActiveEntry(IReadOnlyDictionary<string, object?> row) => ReadActiveEntry(row);
 
     private static IReadOnlyDictionary<string, object?> ToDictionary(object row)
     {

--- a/dcb/src/Sekiban.Dcb.MaterializedView.Postgres/PostgresMvRegistryStore.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.Postgres/PostgresMvRegistryStore.cs
@@ -4,7 +4,7 @@ using Npgsql;
 
 namespace Sekiban.Dcb.MaterializedView.Postgres;
 
-public sealed class PostgresMvRegistryStore : IMvRegistryStore
+public sealed partial class PostgresMvRegistryStore : MvForcedReverseRegistryStoreBase<NpgsqlConnection>, IMvRegistryStore
 {
     private readonly string _connectionString;
 
@@ -51,6 +51,9 @@ public sealed class PostgresMvRegistryStore : IMvRegistryStore
                 active_version INT NOT NULL,
                 active_generation BIGINT NOT NULL DEFAULT 0,
                 activated_at TIMESTAMPTZ NOT NULL,
+                switch_kind TEXT NOT NULL DEFAULT 'legacy',
+                switch_reason TEXT NULL,
+                switched_at_utc TIMESTAMPTZ NULL,
                 PRIMARY KEY (service_id, view_name)
             );
             """;
@@ -67,6 +70,12 @@ public sealed class PostgresMvRegistryStore : IMvRegistryStore
         const string activeGenerationMigrationSql = """
             ALTER TABLE sekiban_mv_active
                 ADD COLUMN IF NOT EXISTS active_generation BIGINT NOT NULL DEFAULT 0;
+            ALTER TABLE sekiban_mv_active
+                ADD COLUMN IF NOT EXISTS switch_kind TEXT NOT NULL DEFAULT 'legacy';
+            ALTER TABLE sekiban_mv_active
+                ADD COLUMN IF NOT EXISTS switch_reason TEXT NULL;
+            ALTER TABLE sekiban_mv_active
+                ADD COLUMN IF NOT EXISTS switched_at_utc TIMESTAMPTZ NULL;
             """;
         await connection.ExecuteAsync(new CommandDefinition(activeGenerationMigrationSql, cancellationToken: cancellationToken)).ConfigureAwait(false);
     }
@@ -382,7 +391,10 @@ public sealed class PostgresMvRegistryStore : IMvRegistryStore
                    view_name AS ViewName,
                    active_version AS ActiveVersion,
                    active_generation AS Generation,
-                   activated_at AS ActivatedAt
+                   activated_at AS ActivatedAt,
+                   switch_kind AS SwitchKind,
+                   switch_reason AS SwitchReason,
+                   switched_at_utc AS SwitchedAtUtc
             FROM sekiban_mv_active
             WHERE service_id = @ServiceId
               AND view_name = @ViewName;
@@ -404,12 +416,17 @@ public sealed class PostgresMvRegistryStore : IMvRegistryStore
         CancellationToken cancellationToken = default)
     {
         const string sql = """
-            INSERT INTO sekiban_mv_active (service_id, view_name, active_version, active_generation, activated_at)
-            VALUES (@ServiceId, @ViewName, @ActiveVersion, 1, NOW())
+            INSERT INTO sekiban_mv_active (
+                service_id, view_name, active_version, active_generation, activated_at,
+                switch_kind, switch_reason, switched_at_utc)
+            VALUES (@ServiceId, @ViewName, @ActiveVersion, 1, NOW(), 'legacy', NULL, NOW())
             ON CONFLICT (service_id, view_name) DO UPDATE SET
                 active_version = EXCLUDED.active_version,
                 active_generation = sekiban_mv_active.active_generation + 1,
-                activated_at = EXCLUDED.activated_at;
+                activated_at = EXCLUDED.activated_at,
+                switch_kind = 'legacy',
+                switch_reason = NULL,
+                switched_at_utc = EXCLUDED.switched_at_utc;
             """;
 
         var parameters = new { ServiceId = serviceId, ViewName = viewName, ActiveVersion = activeVersion };
@@ -479,6 +496,7 @@ public sealed class PostgresMvRegistryStore : IMvRegistryStore
             request.ExpectedActiveGeneration,
             request.CandidateCount,
             ExpectedStatus = request.ExpectedStatus.ToString().ToLowerInvariant(),
+            SwitchKind = request.SwitchKind.ToString().ToLowerInvariant(),
             request.ExpectedCurrentCheckpointTruth,
             request.ExpectedTargetCheckpointTruth
         };
@@ -495,8 +513,9 @@ public sealed class PostgresMvRegistryStore : IMvRegistryStore
 
         const string insertSql = """
             INSERT INTO sekiban_mv_active (
-                service_id, view_name, active_version, active_generation, activated_at)
-            SELECT @ServiceId, @ViewName, @ViewVersion, 1, NOW()
+                service_id, view_name, active_version, active_generation, activated_at,
+                switch_kind, switch_reason, switched_at_utc)
+            SELECT @ServiceId, @ViewName, @ViewVersion, 1, NOW(), @SwitchKind, NULL, NOW()
             WHERE @ExpectedActiveVersion IS NULL
               AND @ExpectedActiveGeneration = 0
             ON CONFLICT (service_id, view_name) DO NOTHING;
@@ -505,7 +524,10 @@ public sealed class PostgresMvRegistryStore : IMvRegistryStore
             UPDATE sekiban_mv_active
             SET active_version = @ViewVersion,
                 active_generation = active_generation + 1,
-                activated_at = NOW()
+                activated_at = NOW(),
+                switch_kind = @SwitchKind,
+                switch_reason = NULL,
+                switched_at_utc = NOW()
             WHERE service_id = @ServiceId
               AND view_name = @ViewName
               AND active_version = @ExpectedActiveVersion
@@ -518,6 +540,17 @@ public sealed class PostgresMvRegistryStore : IMvRegistryStore
         {
             return CandidateSnapshotChanged();
         }
+
+        const string markPreviousReadySql = """
+            UPDATE sekiban_mv_registry
+            SET status = 'ready', last_updated = NOW()
+            WHERE service_id = @ServiceId
+              AND view_name = @ViewName
+              AND view_version = @ExpectedActiveVersion
+              AND @ExpectedActiveVersion IS NOT NULL;
+            """;
+        await transaction.Connection!.ExecuteAsync(
+            new CommandDefinition(markPreviousReadySql, parameters, transaction, cancellationToken: cancellationToken)).ConfigureAwait(false);
 
         const string markActiveSql = """
             UPDATE sekiban_mv_registry
@@ -679,8 +712,16 @@ public sealed class PostgresMvRegistryStore : IMvRegistryStore
             ReadRequiredInt(row, "ActiveVersion"),
             ReadRequiredDateTimeOffset(row, "ActivatedAt"))
         {
-            Generation = ReadRequiredLong(row, "Generation")
+            Generation = ReadRequiredLong(row, "Generation"),
+            SwitchKind = ReadSwitchKind(row),
+            SwitchReason = ReadNullableString(row, "SwitchReason"),
+            SwitchedAtUtc = ReadNullableDateTimeOffset(row, "SwitchedAtUtc")
         };
+
+    private static MvSwitchKind ReadSwitchKind(IReadOnlyDictionary<string, object?> row) =>
+        Enum.TryParse<MvSwitchKind>(ReadNullableString(row, "SwitchKind"), true, out var kind)
+            ? kind
+            : MvSwitchKind.Legacy;
 
     private static IReadOnlyDictionary<string, object?> ToDictionary(object row)
     {

--- a/dcb/src/Sekiban.Dcb.MaterializedView.SqlServer/SqlServerMvForcedReverse.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.SqlServer/SqlServerMvForcedReverse.cs
@@ -4,6 +4,15 @@ namespace Sekiban.Dcb.MaterializedView.SqlServer;
 
 public sealed partial class SqlServerMvRegistryStore
 {
+    private const string LegacyActiveUpsertSql = """
+        UPDATE sekiban_mv_active WITH (UPDLOCK, HOLDLOCK)
+        SET active_version = @ActiveVersion, active_generation = active_generation + 1, activated_at = SYSUTCDATETIME()
+        WHERE service_id = @ServiceId AND view_name = @ViewName;
+        IF @@ROWCOUNT = 0
+            INSERT INTO sekiban_mv_active (service_id, view_name, active_version, active_generation, activated_at)
+            VALUES (@ServiceId, @ViewName, @ActiveVersion, 1, SYSUTCDATETIME());
+        """;
+
     private static readonly MvForcedReverseSqlPlan ForcedReverseSql = MvForcedReverseSqlPlan.Create(
         candidateFenceSql: """
             SELECT logical_table FROM sekiban_mv_registry WITH (UPDLOCK, HOLDLOCK)
@@ -28,5 +37,6 @@ public sealed partial class SqlServerMvRegistryStore
             """);
 
     protected override MvForcedReverseSqlPlan ForcedReversePlan => ForcedReverseSql;
+    protected override string LegacySetActiveSql => LegacyActiveUpsertSql;
     protected override SqlConnection CreateForcedReverseConnection() => new(_connectionString);
 }

--- a/dcb/src/Sekiban.Dcb.MaterializedView.SqlServer/SqlServerMvForcedReverse.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.SqlServer/SqlServerMvForcedReverse.cs
@@ -1,0 +1,32 @@
+using Microsoft.Data.SqlClient;
+
+namespace Sekiban.Dcb.MaterializedView.SqlServer;
+
+public sealed partial class SqlServerMvRegistryStore
+{
+    private static readonly MvForcedReverseSqlPlan ForcedReverseSql = MvForcedReverseSqlPlan.Create(
+        candidateFenceSql: """
+            SELECT logical_table FROM sekiban_mv_registry WITH (UPDLOCK, HOLDLOCK)
+            WHERE service_id = @ServiceId AND view_name = @ViewName AND view_version = @ViewVersion
+            ORDER BY logical_table;
+            """,
+        fenceReturnsRows: true,
+        savepointSql: "SAVE TRANSACTION sekiban_mv_forced_reverse;",
+        rollbackSavepointSql: "ROLLBACK TRANSACTION sekiban_mv_forced_reverse;",
+        releaseSavepointSql: null,
+        pointerCasSql: """
+            UPDATE sekiban_mv_active WITH (UPDLOCK, HOLDLOCK)
+            SET active_version = @ViewVersion,
+                active_generation = active_generation + 1,
+                activated_at = @RequestedAtUtc,
+                switch_kind = 'forced',
+                switch_reason = @Reason,
+                switched_at_utc = @RequestedAtUtc
+            WHERE service_id = @ServiceId AND view_name = @ViewName
+              AND active_version = @ExpectedActiveVersion
+              AND active_generation = @ExpectedActiveGeneration;
+            """);
+
+    protected override MvForcedReverseSqlPlan ForcedReversePlan => ForcedReverseSql;
+    protected override SqlConnection CreateForcedReverseConnection() => new(_connectionString);
+}

--- a/dcb/src/Sekiban.Dcb.MaterializedView.SqlServer/SqlServerMvRegistryStore.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.SqlServer/SqlServerMvRegistryStore.cs
@@ -423,46 +423,13 @@ public sealed partial class SqlServerMvRegistryStore : MvForcedReverseRegistrySt
         return row is null ? null : MapActiveEntry(ToDictionary(row));
     }
 
-    public async Task SetActiveAsync(
+    public Task SetActiveAsync(
         string serviceId,
         string viewName,
         int activeVersion,
         IDbTransaction? transaction = null,
-        CancellationToken cancellationToken = default)
-    {
-        const string sql = """
-            UPDATE sekiban_mv_active WITH (UPDLOCK, HOLDLOCK)
-            SET active_version = @ActiveVersion,
-                active_generation = active_generation + 1,
-                activated_at = SYSUTCDATETIME(),
-                switch_kind = 'legacy',
-                switch_reason = NULL,
-                switched_at_utc = SYSUTCDATETIME()
-            WHERE service_id = @ServiceId
-              AND view_name = @ViewName;
-
-            IF @@ROWCOUNT = 0
-            BEGIN
-                INSERT INTO sekiban_mv_active (
-                    service_id, view_name, active_version, active_generation, activated_at,
-                    switch_kind, switch_reason, switched_at_utc)
-                VALUES (@ServiceId, @ViewName, @ActiveVersion, 1, SYSUTCDATETIME(), 'legacy', NULL, SYSUTCDATETIME());
-            END;
-            """;
-
-        var parameters = new { ServiceId = serviceId, ViewName = viewName, ActiveVersion = activeVersion };
-        if (transaction is not null)
-        {
-            await ExecuteAsync(sql, parameters, transaction, cancellationToken).ConfigureAwait(false);
-            return;
-        }
-
-        await using var connection = new SqlConnection(_connectionString);
-        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
-        await using var localTransaction = await connection.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
-        await connection.ExecuteAsync(new CommandDefinition(sql, parameters, localTransaction, cancellationToken: cancellationToken)).ConfigureAwait(false);
-        await localTransaction.CommitAsync(cancellationToken).ConfigureAwait(false);
-    }
+        CancellationToken cancellationToken = default) =>
+        SetLegacyActiveAsync(serviceId, viewName, activeVersion, transaction, cancellationToken);
 
     public async Task<MvActivationResult> TryActivateAsync(
         MvActivationRequest request,

--- a/dcb/src/Sekiban.Dcb.MaterializedView.SqlServer/SqlServerMvRegistryStore.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.SqlServer/SqlServerMvRegistryStore.cs
@@ -4,7 +4,7 @@ using Microsoft.Data.SqlClient;
 
 namespace Sekiban.Dcb.MaterializedView.SqlServer;
 
-public sealed class SqlServerMvRegistryStore : IMvRegistryStore
+public sealed partial class SqlServerMvRegistryStore : MvForcedReverseRegistryStoreBase<SqlConnection>, IMvRegistryStore
 {
     private readonly string _connectionString;
 
@@ -54,6 +54,9 @@ public sealed class SqlServerMvRegistryStore : IMvRegistryStore
                     active_version INT NOT NULL,
                     active_generation BIGINT NOT NULL CONSTRAINT DF_sekiban_mv_active_generation DEFAULT 0,
                     activated_at DATETIMEOFFSET NOT NULL,
+                    switch_kind NVARCHAR(32) NOT NULL CONSTRAINT DF_sekiban_mv_active_switch_kind DEFAULT 'legacy',
+                    switch_reason NVARCHAR(1024) NULL,
+                    switched_at_utc DATETIMEOFFSET NULL,
                     CONSTRAINT PK_sekiban_mv_active PRIMARY KEY (service_id, view_name)
                 );
             END;
@@ -70,6 +73,12 @@ public sealed class SqlServerMvRegistryStore : IMvRegistryStore
         const string activeGenerationMigrationSql = """
             IF COL_LENGTH(N'sekiban_mv_active', N'active_generation') IS NULL
                 ALTER TABLE sekiban_mv_active ADD active_generation BIGINT NOT NULL CONSTRAINT DF_sekiban_mv_active_generation DEFAULT 0;
+            IF COL_LENGTH(N'sekiban_mv_active', N'switch_kind') IS NULL
+                ALTER TABLE sekiban_mv_active ADD switch_kind NVARCHAR(32) NOT NULL CONSTRAINT DF_sekiban_mv_active_switch_kind DEFAULT 'legacy';
+            IF COL_LENGTH(N'sekiban_mv_active', N'switch_reason') IS NULL
+                ALTER TABLE sekiban_mv_active ADD switch_reason NVARCHAR(1024) NULL;
+            IF COL_LENGTH(N'sekiban_mv_active', N'switched_at_utc') IS NULL
+                ALTER TABLE sekiban_mv_active ADD switched_at_utc DATETIMEOFFSET NULL;
             """;
         await connection.ExecuteAsync(new CommandDefinition(activeGenerationMigrationSql, cancellationToken: cancellationToken)).ConfigureAwait(false);
     }
@@ -397,7 +406,10 @@ public sealed class SqlServerMvRegistryStore : IMvRegistryStore
                    view_name AS ViewName,
                    active_version AS ActiveVersion,
                    active_generation AS Generation,
-                   activated_at AS ActivatedAt
+                   activated_at AS ActivatedAt,
+                   switch_kind AS SwitchKind,
+                   switch_reason AS SwitchReason,
+                   switched_at_utc AS SwitchedAtUtc
             FROM sekiban_mv_active
             WHERE service_id = @ServiceId
               AND view_name = @ViewName;
@@ -422,14 +434,19 @@ public sealed class SqlServerMvRegistryStore : IMvRegistryStore
             UPDATE sekiban_mv_active WITH (UPDLOCK, HOLDLOCK)
             SET active_version = @ActiveVersion,
                 active_generation = active_generation + 1,
-                activated_at = SYSUTCDATETIME()
+                activated_at = SYSUTCDATETIME(),
+                switch_kind = 'legacy',
+                switch_reason = NULL,
+                switched_at_utc = SYSUTCDATETIME()
             WHERE service_id = @ServiceId
               AND view_name = @ViewName;
 
             IF @@ROWCOUNT = 0
             BEGIN
-                INSERT INTO sekiban_mv_active (service_id, view_name, active_version, active_generation, activated_at)
-                VALUES (@ServiceId, @ViewName, @ActiveVersion, 1, SYSUTCDATETIME());
+                INSERT INTO sekiban_mv_active (
+                    service_id, view_name, active_version, active_generation, activated_at,
+                    switch_kind, switch_reason, switched_at_utc)
+                VALUES (@ServiceId, @ViewName, @ActiveVersion, 1, SYSUTCDATETIME(), 'legacy', NULL, SYSUTCDATETIME());
             END;
             """;
 
@@ -509,6 +526,7 @@ public sealed class SqlServerMvRegistryStore : IMvRegistryStore
             request.ExpectedActiveGeneration,
             request.CandidateCount,
             ExpectedStatus = request.ExpectedStatus.ToString().ToLowerInvariant(),
+            SwitchKind = request.SwitchKind.ToString().ToLowerInvariant(),
             request.ExpectedCurrentCheckpointTruth,
             request.ExpectedTargetCheckpointTruth
         };
@@ -530,7 +548,10 @@ public sealed class SqlServerMvRegistryStore : IMvRegistryStore
             UPDATE sekiban_mv_active WITH (UPDLOCK, HOLDLOCK)
             SET active_version = @ViewVersion,
                 active_generation = active_generation + 1,
-                activated_at = SYSUTCDATETIME()
+                activated_at = SYSUTCDATETIME(),
+                switch_kind = @SwitchKind,
+                switch_reason = NULL,
+                switched_at_utc = SYSUTCDATETIME()
             WHERE service_id = @ServiceId
               AND view_name = @ViewName
               AND active_version = @ExpectedActiveVersion
@@ -549,8 +570,9 @@ public sealed class SqlServerMvRegistryStore : IMvRegistryStore
                )
             BEGIN
                 INSERT INTO sekiban_mv_active (
-                    service_id, view_name, active_version, active_generation, activated_at)
-                VALUES (@ServiceId, @ViewName, @ViewVersion, 1, SYSUTCDATETIME());
+                    service_id, view_name, active_version, active_generation, activated_at,
+                    switch_kind, switch_reason, switched_at_utc)
+                VALUES (@ServiceId, @ViewName, @ViewVersion, 1, SYSUTCDATETIME(), @SwitchKind, NULL, SYSUTCDATETIME());
                 IF @@ROWCOUNT = 1
                     SET @changed = 1;
             END;
@@ -564,6 +586,17 @@ public sealed class SqlServerMvRegistryStore : IMvRegistryStore
         {
             return CandidateSnapshotChanged();
         }
+
+        const string markPreviousReadySql = """
+            UPDATE sekiban_mv_registry
+            SET status = 'ready', last_updated = SYSUTCDATETIME()
+            WHERE service_id = @ServiceId
+              AND view_name = @ViewName
+              AND view_version = @ExpectedActiveVersion
+              AND @ExpectedActiveVersion IS NOT NULL;
+            """;
+        await transaction.Connection!.ExecuteAsync(
+            new CommandDefinition(markPreviousReadySql, parameters, transaction, cancellationToken: cancellationToken)).ConfigureAwait(false);
 
         const string markActiveSql = """
             UPDATE sekiban_mv_registry
@@ -720,8 +753,16 @@ public sealed class SqlServerMvRegistryStore : IMvRegistryStore
             ReadRequiredInt(row, "ActiveVersion"),
             ReadRequiredDateTimeOffset(row, "ActivatedAt"))
         {
-            Generation = ReadRequiredLong(row, "Generation")
+            Generation = ReadRequiredLong(row, "Generation"),
+            SwitchKind = ReadSwitchKind(row),
+            SwitchReason = ReadNullableString(row, "SwitchReason"),
+            SwitchedAtUtc = ReadNullableDateTimeOffset(row, "SwitchedAtUtc")
         };
+
+    private static MvSwitchKind ReadSwitchKind(IReadOnlyDictionary<string, object?> row) =>
+        Enum.TryParse<MvSwitchKind>(ReadNullableString(row, "SwitchKind"), true, out var kind)
+            ? kind
+            : MvSwitchKind.Legacy;
 
     private static IReadOnlyDictionary<string, object?> ToDictionary(object row)
     {

--- a/dcb/src/Sekiban.Dcb.MaterializedView.SqlServer/SqlServerMvRegistryStore.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.SqlServer/SqlServerMvRegistryStore.cs
@@ -526,7 +526,6 @@ public sealed partial class SqlServerMvRegistryStore : MvForcedReverseRegistrySt
             request.ExpectedActiveGeneration,
             request.CandidateCount,
             ExpectedStatus = request.ExpectedStatus.ToString().ToLowerInvariant(),
-            SwitchKind = request.SwitchKind.ToString().ToLowerInvariant(),
             request.ExpectedCurrentCheckpointTruth,
             request.ExpectedTargetCheckpointTruth
         };
@@ -548,10 +547,7 @@ public sealed partial class SqlServerMvRegistryStore : MvForcedReverseRegistrySt
             UPDATE sekiban_mv_active WITH (UPDLOCK, HOLDLOCK)
             SET active_version = @ViewVersion,
                 active_generation = active_generation + 1,
-                activated_at = SYSUTCDATETIME(),
-                switch_kind = @SwitchKind,
-                switch_reason = NULL,
-                switched_at_utc = SYSUTCDATETIME()
+                activated_at = SYSUTCDATETIME()
             WHERE service_id = @ServiceId
               AND view_name = @ViewName
               AND active_version = @ExpectedActiveVersion
@@ -569,10 +565,8 @@ public sealed partial class SqlServerMvRegistryStore : MvForcedReverseRegistrySt
                       AND view_name = @ViewName
                )
             BEGIN
-                INSERT INTO sekiban_mv_active (
-                    service_id, view_name, active_version, active_generation, activated_at,
-                    switch_kind, switch_reason, switched_at_utc)
-                VALUES (@ServiceId, @ViewName, @ViewVersion, 1, SYSUTCDATETIME(), @SwitchKind, NULL, SYSUTCDATETIME());
+                INSERT INTO sekiban_mv_active (service_id, view_name, active_version, active_generation, activated_at)
+                VALUES (@ServiceId, @ViewName, @ViewVersion, 1, SYSUTCDATETIME());
                 IF @@ROWCOUNT = 1
                     SET @changed = 1;
             END;
@@ -587,16 +581,7 @@ public sealed partial class SqlServerMvRegistryStore : MvForcedReverseRegistrySt
             return CandidateSnapshotChanged();
         }
 
-        const string markPreviousReadySql = """
-            UPDATE sekiban_mv_registry
-            SET status = 'ready', last_updated = SYSUTCDATETIME()
-            WHERE service_id = @ServiceId
-              AND view_name = @ViewName
-              AND view_version = @ExpectedActiveVersion
-              AND @ExpectedActiveVersion IS NOT NULL;
-            """;
-        await transaction.Connection!.ExecuteAsync(
-            new CommandDefinition(markPreviousReadySql, parameters, transaction, cancellationToken: cancellationToken)).ConfigureAwait(false);
+        await PersistOrdinarySwitchAuditAsync(transaction, request, cancellationToken).ConfigureAwait(false);
 
         const string markActiveSql = """
             UPDATE sekiban_mv_registry
@@ -746,23 +731,7 @@ public sealed partial class SqlServerMvRegistryStore : MvForcedReverseRegistrySt
         };
     }
 
-    private static MvActiveEntry MapActiveEntry(IReadOnlyDictionary<string, object?> row) =>
-        new(
-            ReadRequiredString(row, "ServiceId"),
-            ReadRequiredString(row, "ViewName"),
-            ReadRequiredInt(row, "ActiveVersion"),
-            ReadRequiredDateTimeOffset(row, "ActivatedAt"))
-        {
-            Generation = ReadRequiredLong(row, "Generation"),
-            SwitchKind = ReadSwitchKind(row),
-            SwitchReason = ReadNullableString(row, "SwitchReason"),
-            SwitchedAtUtc = ReadNullableDateTimeOffset(row, "SwitchedAtUtc")
-        };
-
-    private static MvSwitchKind ReadSwitchKind(IReadOnlyDictionary<string, object?> row) =>
-        Enum.TryParse<MvSwitchKind>(ReadNullableString(row, "SwitchKind"), true, out var kind)
-            ? kind
-            : MvSwitchKind.Legacy;
+    private static MvActiveEntry MapActiveEntry(IReadOnlyDictionary<string, object?> row) => ReadActiveEntry(row);
 
     private static IReadOnlyDictionary<string, object?> ToDictionary(object row)
     {

--- a/dcb/src/Sekiban.Dcb.MaterializedView.Sqlite/SqliteMvForcedReverse.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.Sqlite/SqliteMvForcedReverse.cs
@@ -1,0 +1,21 @@
+using Microsoft.Data.Sqlite;
+
+namespace Sekiban.Dcb.MaterializedView.Sqlite;
+
+public sealed partial class SqliteMvRegistryStore
+{
+    private static readonly MvForcedReverseSqlPlan ForcedReverseSql = MvForcedReverseSqlPlan.Create(
+        candidateFenceSql: """
+            UPDATE sekiban_mv_registry SET last_updated = last_updated
+            WHERE service_id = @ServiceId AND view_name = @ViewName AND view_version = @ViewVersion;
+            """,
+        fenceReturnsRows: false,
+        savepointSql: "SAVEPOINT sekiban_mv_forced_reverse;",
+        rollbackSavepointSql: "ROLLBACK TO SAVEPOINT sekiban_mv_forced_reverse;",
+        releaseSavepointSql: "RELEASE SAVEPOINT sekiban_mv_forced_reverse;");
+
+    protected override MvForcedReverseSqlPlan ForcedReversePlan => ForcedReverseSql;
+    protected override SqliteConnection CreateForcedReverseConnection() => new(_connectionString);
+    protected override object FormatForcedReverseTimestamp(DateTimeOffset value) =>
+        SerializeDate(value) ?? throw new InvalidOperationException("A forced-reverse timestamp is required.");
+}

--- a/dcb/src/Sekiban.Dcb.MaterializedView.Sqlite/SqliteMvForcedReverse.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.Sqlite/SqliteMvForcedReverse.cs
@@ -4,6 +4,15 @@ namespace Sekiban.Dcb.MaterializedView.Sqlite;
 
 public sealed partial class SqliteMvRegistryStore
 {
+    private const string LegacyActiveUpsertSql = """
+        INSERT INTO sekiban_mv_active (service_id, view_name, active_version, active_generation, activated_at)
+        VALUES (@ServiceId, @ViewName, @ActiveVersion, 1, @SwitchedAtUtc)
+        ON CONFLICT (service_id, view_name) DO UPDATE SET
+            active_version = excluded.active_version,
+            active_generation = sekiban_mv_active.active_generation + 1,
+            activated_at = excluded.activated_at;
+        """;
+
     private static readonly MvForcedReverseSqlPlan ForcedReverseSql = MvForcedReverseSqlPlan.Create(
         candidateFenceSql: """
             UPDATE sekiban_mv_registry SET last_updated = last_updated
@@ -15,6 +24,7 @@ public sealed partial class SqliteMvRegistryStore
         releaseSavepointSql: "RELEASE SAVEPOINT sekiban_mv_forced_reverse;");
 
     protected override MvForcedReverseSqlPlan ForcedReversePlan => ForcedReverseSql;
+    protected override string LegacySetActiveSql => LegacyActiveUpsertSql;
     protected override SqliteConnection CreateForcedReverseConnection() => new(_connectionString);
     protected override object FormatForcedReverseTimestamp(DateTimeOffset value) =>
         SerializeDate(value) ?? throw new InvalidOperationException("A forced-reverse timestamp is required.");

--- a/dcb/src/Sekiban.Dcb.MaterializedView.Sqlite/SqliteMvRegistryStore.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.Sqlite/SqliteMvRegistryStore.cs
@@ -574,7 +574,6 @@ public sealed partial class SqliteMvRegistryStore : MvForcedReverseRegistryStore
             request.ExpectedActiveGeneration,
             request.CandidateCount,
             ExpectedStatus = request.ExpectedStatus.ToString().ToLowerInvariant(),
-            SwitchKind = request.SwitchKind.ToString().ToLowerInvariant(),
             request.ExpectedCurrentCheckpointTruth,
             request.ExpectedTargetCheckpointTruth,
             ActivatedAt = SerializeDate(DateTimeOffset.UtcNow)
@@ -596,18 +595,12 @@ public sealed partial class SqliteMvRegistryStore : MvForcedReverseRegistryStore
                 view_name,
                 active_version,
                 active_generation,
-                activated_at,
-                switch_kind,
-                switch_reason,
-                switched_at_utc)
+                activated_at)
             SELECT
                 @ServiceId,
                 @ViewName,
                 @ViewVersion,
                 1,
-                @ActivatedAt,
-                @SwitchKind,
-                NULL,
                 @ActivatedAt
             WHERE @ExpectedActiveVersion IS NULL
               AND @ExpectedActiveGeneration = 0
@@ -618,10 +611,7 @@ public sealed partial class SqliteMvRegistryStore : MvForcedReverseRegistryStore
             UPDATE sekiban_mv_active
             SET active_version = @ViewVersion,
                 active_generation = active_generation + 1,
-                activated_at = @ActivatedAt,
-                switch_kind = @SwitchKind,
-                switch_reason = NULL,
-                switched_at_utc = @ActivatedAt
+                activated_at = @ActivatedAt
             WHERE service_id = @ServiceId
               AND view_name = @ViewName
               AND active_version = @ExpectedActiveVersion
@@ -639,16 +629,7 @@ public sealed partial class SqliteMvRegistryStore : MvForcedReverseRegistryStore
             return CandidateSnapshotChanged();
         }
 
-        const string markPreviousReadySql = """
-            UPDATE sekiban_mv_registry
-            SET status = 'ready', last_updated = @ActivatedAt
-            WHERE service_id = @ServiceId
-              AND view_name = @ViewName
-              AND view_version = @ExpectedActiveVersion
-              AND @ExpectedActiveVersion IS NOT NULL;
-            """;
-        await transaction.Connection!.ExecuteAsync(
-            new CommandDefinition(markPreviousReadySql, parameters, transaction, cancellationToken: cancellationToken)).ConfigureAwait(false);
+        await PersistOrdinarySwitchAuditAsync(transaction, request, cancellationToken).ConfigureAwait(false);
 
         const string markActiveSql = """
             UPDATE sekiban_mv_registry
@@ -827,23 +808,7 @@ public sealed partial class SqliteMvRegistryStore : MvForcedReverseRegistryStore
         };
     }
 
-    private static MvActiveEntry MapActiveEntry(IReadOnlyDictionary<string, object?> row) =>
-        new(
-            ReadRequiredString(row, "ServiceId"),
-            ReadRequiredString(row, "ViewName"),
-            ReadRequiredInt(row, "ActiveVersion"),
-            ReadRequiredDateTimeOffset(row, "ActivatedAt"))
-        {
-            Generation = ReadRequiredLong(row, "Generation"),
-            SwitchKind = ReadSwitchKind(row),
-            SwitchReason = ReadNullableString(row, "SwitchReason"),
-            SwitchedAtUtc = ReadNullableDateTimeOffset(row, "SwitchedAtUtc")
-        };
-
-    private static MvSwitchKind ReadSwitchKind(IReadOnlyDictionary<string, object?> row) =>
-        Enum.TryParse<MvSwitchKind>(ReadNullableString(row, "SwitchKind"), true, out var kind)
-            ? kind
-            : MvSwitchKind.Legacy;
+    private static MvActiveEntry MapActiveEntry(IReadOnlyDictionary<string, object?> row) => ReadActiveEntry(row);
 
     private sealed class SqliteColumnInfo
     {

--- a/dcb/src/Sekiban.Dcb.MaterializedView.Sqlite/SqliteMvRegistryStore.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.Sqlite/SqliteMvRegistryStore.cs
@@ -118,26 +118,13 @@ public sealed partial class SqliteMvRegistryStore : MvForcedReverseRegistryStore
                 .ConfigureAwait(false);
         }
 
-        if (!existingColumns.Contains("switch_kind"))
-        {
-            await connection.ExecuteAsync(new CommandDefinition(
-                "ALTER TABLE sekiban_mv_active ADD COLUMN switch_kind TEXT NOT NULL DEFAULT 'legacy';",
-                cancellationToken: cancellationToken)).ConfigureAwait(false);
-        }
-
-        if (!existingColumns.Contains("switch_reason"))
-        {
-            await connection.ExecuteAsync(new CommandDefinition(
-                "ALTER TABLE sekiban_mv_active ADD COLUMN switch_reason TEXT NULL;",
-                cancellationToken: cancellationToken)).ConfigureAwait(false);
-        }
-
-        if (!existingColumns.Contains("switched_at_utc"))
-        {
-            await connection.ExecuteAsync(new CommandDefinition(
-                "ALTER TABLE sekiban_mv_active ADD COLUMN switched_at_utc TEXT NULL;",
-                cancellationToken: cancellationToken)).ConfigureAwait(false);
-        }
+        await EnsureMissingActiveColumnsAsync(
+            connection,
+            existingColumns,
+            cancellationToken,
+            ("switch_kind", "ALTER TABLE sekiban_mv_active ADD COLUMN switch_kind TEXT NOT NULL DEFAULT 'legacy';"),
+            ("switch_reason", "ALTER TABLE sekiban_mv_active ADD COLUMN switch_reason TEXT NULL;"),
+            ("switched_at_utc", "ALTER TABLE sekiban_mv_active ADD COLUMN switched_at_utc TEXT NULL;")).ConfigureAwait(false);
     }
 
     public async Task RegisterAsync(MvRegistryEntry entry, IDbTransaction? transaction = null, CancellationToken cancellationToken = default)

--- a/dcb/src/Sekiban.Dcb.MaterializedView.Sqlite/SqliteMvRegistryStore.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.Sqlite/SqliteMvRegistryStore.cs
@@ -4,7 +4,7 @@ using Microsoft.Data.Sqlite;
 
 namespace Sekiban.Dcb.MaterializedView.Sqlite;
 
-public sealed class SqliteMvRegistryStore : IMvRegistryStore
+public sealed partial class SqliteMvRegistryStore : MvForcedReverseRegistryStoreBase<SqliteConnection>, IMvRegistryStore
 {
     private readonly string _connectionString;
 
@@ -56,6 +56,9 @@ public sealed class SqliteMvRegistryStore : IMvRegistryStore
                 active_version INTEGER NOT NULL,
                 active_generation INTEGER NOT NULL DEFAULT 0,
                 activated_at TEXT NOT NULL,
+                switch_kind TEXT NOT NULL DEFAULT 'legacy',
+                switch_reason TEXT NULL,
+                switched_at_utc TEXT NULL,
                 PRIMARY KEY (service_id, view_name)
             );
             """;
@@ -113,6 +116,27 @@ public sealed class SqliteMvRegistryStore : IMvRegistryStore
                         "ALTER TABLE sekiban_mv_active ADD COLUMN active_generation INTEGER NOT NULL DEFAULT 0;",
                         cancellationToken: cancellationToken))
                 .ConfigureAwait(false);
+        }
+
+        if (!existingColumns.Contains("switch_kind"))
+        {
+            await connection.ExecuteAsync(new CommandDefinition(
+                "ALTER TABLE sekiban_mv_active ADD COLUMN switch_kind TEXT NOT NULL DEFAULT 'legacy';",
+                cancellationToken: cancellationToken)).ConfigureAwait(false);
+        }
+
+        if (!existingColumns.Contains("switch_reason"))
+        {
+            await connection.ExecuteAsync(new CommandDefinition(
+                "ALTER TABLE sekiban_mv_active ADD COLUMN switch_reason TEXT NULL;",
+                cancellationToken: cancellationToken)).ConfigureAwait(false);
+        }
+
+        if (!existingColumns.Contains("switched_at_utc"))
+        {
+            await connection.ExecuteAsync(new CommandDefinition(
+                "ALTER TABLE sekiban_mv_active ADD COLUMN switched_at_utc TEXT NULL;",
+                cancellationToken: cancellationToken)).ConfigureAwait(false);
         }
     }
 
@@ -438,7 +462,10 @@ public sealed class SqliteMvRegistryStore : IMvRegistryStore
                    view_name AS ViewName,
                    active_version AS ActiveVersion,
                    active_generation AS Generation,
-                   activated_at AS ActivatedAt
+                   activated_at AS ActivatedAt,
+                   switch_kind AS SwitchKind,
+                   switch_reason AS SwitchReason,
+                   switched_at_utc AS SwitchedAtUtc
             FROM sekiban_mv_active
             WHERE service_id = @ServiceId
               AND view_name = @ViewName;
@@ -460,12 +487,17 @@ public sealed class SqliteMvRegistryStore : IMvRegistryStore
         CancellationToken cancellationToken = default)
     {
         const string sql = """
-            INSERT INTO sekiban_mv_active (service_id, view_name, active_version, active_generation, activated_at)
-            VALUES (@ServiceId, @ViewName, @ActiveVersion, 1, @ActivatedAt)
+            INSERT INTO sekiban_mv_active (
+                service_id, view_name, active_version, active_generation, activated_at,
+                switch_kind, switch_reason, switched_at_utc)
+            VALUES (@ServiceId, @ViewName, @ActiveVersion, 1, @ActivatedAt, 'legacy', NULL, @ActivatedAt)
             ON CONFLICT (service_id, view_name) DO UPDATE SET
                 active_version = excluded.active_version,
                 active_generation = sekiban_mv_active.active_generation + 1,
-                activated_at = excluded.activated_at;
+                activated_at = excluded.activated_at,
+                switch_kind = 'legacy',
+                switch_reason = NULL,
+                switched_at_utc = excluded.switched_at_utc;
             """;
 
         await ExecuteAsync(
@@ -542,6 +574,7 @@ public sealed class SqliteMvRegistryStore : IMvRegistryStore
             request.ExpectedActiveGeneration,
             request.CandidateCount,
             ExpectedStatus = request.ExpectedStatus.ToString().ToLowerInvariant(),
+            SwitchKind = request.SwitchKind.ToString().ToLowerInvariant(),
             request.ExpectedCurrentCheckpointTruth,
             request.ExpectedTargetCheckpointTruth,
             ActivatedAt = SerializeDate(DateTimeOffset.UtcNow)
@@ -563,12 +596,18 @@ public sealed class SqliteMvRegistryStore : IMvRegistryStore
                 view_name,
                 active_version,
                 active_generation,
-                activated_at)
+                activated_at,
+                switch_kind,
+                switch_reason,
+                switched_at_utc)
             SELECT
                 @ServiceId,
                 @ViewName,
                 @ViewVersion,
                 1,
+                @ActivatedAt,
+                @SwitchKind,
+                NULL,
                 @ActivatedAt
             WHERE @ExpectedActiveVersion IS NULL
               AND @ExpectedActiveGeneration = 0
@@ -579,7 +618,10 @@ public sealed class SqliteMvRegistryStore : IMvRegistryStore
             UPDATE sekiban_mv_active
             SET active_version = @ViewVersion,
                 active_generation = active_generation + 1,
-                activated_at = @ActivatedAt
+                activated_at = @ActivatedAt,
+                switch_kind = @SwitchKind,
+                switch_reason = NULL,
+                switched_at_utc = @ActivatedAt
             WHERE service_id = @ServiceId
               AND view_name = @ViewName
               AND active_version = @ExpectedActiveVersion
@@ -596,6 +638,17 @@ public sealed class SqliteMvRegistryStore : IMvRegistryStore
         {
             return CandidateSnapshotChanged();
         }
+
+        const string markPreviousReadySql = """
+            UPDATE sekiban_mv_registry
+            SET status = 'ready', last_updated = @ActivatedAt
+            WHERE service_id = @ServiceId
+              AND view_name = @ViewName
+              AND view_version = @ExpectedActiveVersion
+              AND @ExpectedActiveVersion IS NOT NULL;
+            """;
+        await transaction.Connection!.ExecuteAsync(
+            new CommandDefinition(markPreviousReadySql, parameters, transaction, cancellationToken: cancellationToken)).ConfigureAwait(false);
 
         const string markActiveSql = """
             UPDATE sekiban_mv_registry
@@ -781,8 +834,16 @@ public sealed class SqliteMvRegistryStore : IMvRegistryStore
             ReadRequiredInt(row, "ActiveVersion"),
             ReadRequiredDateTimeOffset(row, "ActivatedAt"))
         {
-            Generation = ReadRequiredLong(row, "Generation")
+            Generation = ReadRequiredLong(row, "Generation"),
+            SwitchKind = ReadSwitchKind(row),
+            SwitchReason = ReadNullableString(row, "SwitchReason"),
+            SwitchedAtUtc = ReadNullableDateTimeOffset(row, "SwitchedAtUtc")
         };
+
+    private static MvSwitchKind ReadSwitchKind(IReadOnlyDictionary<string, object?> row) =>
+        Enum.TryParse<MvSwitchKind>(ReadNullableString(row, "SwitchKind"), true, out var kind)
+            ? kind
+            : MvSwitchKind.Legacy;
 
     private sealed class SqliteColumnInfo
     {

--- a/dcb/src/Sekiban.Dcb.MaterializedView.Sqlite/SqliteMvRegistryStore.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.Sqlite/SqliteMvRegistryStore.cs
@@ -466,39 +466,13 @@ public sealed partial class SqliteMvRegistryStore : MvForcedReverseRegistryStore
         return row is null ? null : MapActiveEntry(ToDictionary(row));
     }
 
-    public async Task SetActiveAsync(
+    public Task SetActiveAsync(
         string serviceId,
         string viewName,
         int activeVersion,
         IDbTransaction? transaction = null,
-        CancellationToken cancellationToken = default)
-    {
-        const string sql = """
-            INSERT INTO sekiban_mv_active (
-                service_id, view_name, active_version, active_generation, activated_at,
-                switch_kind, switch_reason, switched_at_utc)
-            VALUES (@ServiceId, @ViewName, @ActiveVersion, 1, @ActivatedAt, 'legacy', NULL, @ActivatedAt)
-            ON CONFLICT (service_id, view_name) DO UPDATE SET
-                active_version = excluded.active_version,
-                active_generation = sekiban_mv_active.active_generation + 1,
-                activated_at = excluded.activated_at,
-                switch_kind = 'legacy',
-                switch_reason = NULL,
-                switched_at_utc = excluded.switched_at_utc;
-            """;
-
-        await ExecuteAsync(
-            sql,
-            new
-            {
-                ServiceId = serviceId,
-                ViewName = viewName,
-                ActiveVersion = activeVersion,
-                ActivatedAt = SerializeDate(DateTimeOffset.UtcNow)
-            },
-            transaction,
-            cancellationToken).ConfigureAwait(false);
-    }
+        CancellationToken cancellationToken = default) =>
+        SetLegacyActiveAsync(serviceId, viewName, activeVersion, transaction, cancellationToken);
 
     public async Task<MvActivationResult> TryActivateAsync(
         MvActivationRequest request,

--- a/dcb/src/Sekiban.Dcb.MaterializedView/MvActivation.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView/MvActivation.cs
@@ -181,6 +181,12 @@ public static class MvActivationEligibility
             return (activeRejection, null);
         }
 
+        var switchKind = MvSwitchKind.Initial;
+        if (active is not null)
+        {
+            switchKind = viewVersion > active.ActiveVersion ? MvSwitchKind.Forward : MvSwitchKind.Reverse;
+        }
+
         var request = new MvActivationRequest(
             serviceId,
             viewName,
@@ -192,11 +198,7 @@ public static class MvActivationEligibility
             expectedCurrentTruth,
             expectedTargetTruth)
         {
-            SwitchKind = active is null
-                ? MvSwitchKind.Initial
-                : viewVersion > active.ActiveVersion
-                    ? MvSwitchKind.Forward
-                    : MvSwitchKind.Reverse
+            SwitchKind = switchKind
         };
         return (MvActivationEligibilityResult.Eligible(), request);
     }

--- a/dcb/src/Sekiban.Dcb.MaterializedView/MvActivation.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView/MvActivation.cs
@@ -99,9 +99,9 @@ public static class MvForcedReverseValidation
             return MvActivationResult.Rejected(MvActivationFailureReason.ExpectedGenerationConflict, "The expected active generation cannot be negative.");
         }
 
-        if (request.CandidateCount <= 0 || request.ExpectedStatus is not (MvStatus.Ready or MvStatus.Active))
+        if (request.CandidateCount <= 0 || request.ExpectedStatus != MvStatus.Ready)
         {
-            return MvActivationResult.Rejected(MvActivationFailureReason.UnsafeLifecycle, "Forced reverse requires a retained Ready or Active candidate.");
+            return MvActivationResult.Rejected(MvActivationFailureReason.UnsafeLifecycle, "Forced reverse requires a retained Ready candidate.");
         }
 
         if (string.IsNullOrWhiteSpace(request.Reason) || request.Reason.Length > 1024)

--- a/dcb/src/Sekiban.Dcb.MaterializedView/MvActivation.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView/MvActivation.cs
@@ -49,7 +49,69 @@ public sealed record MvActivationRequest(
     int CandidateCount,
     MvStatus ExpectedStatus,
     string ExpectedCurrentCheckpointTruth,
-    string ExpectedTargetCheckpointTruth);
+    string ExpectedTargetCheckpointTruth)
+{
+    /// <summary>Audit classification inferred by the eligibility boundary; callers cannot force it.</summary>
+    public MvSwitchKind SwitchKind { get; init; } = MvSwitchKind.Initial;
+}
+
+/// <summary>Durable classification of an active-pointer transition.</summary>
+public enum MvSwitchKind
+{
+    Initial = 0,
+    Forward = 1,
+    Reverse = 2,
+    Forced = 3,
+    Legacy = 4
+}
+
+/// <summary>
+///     Separate break-glass request. It is deliberately reverse-only and contains no ordinary-forward mode flag.
+///     Providers may waive checkpoint truth only; identity, lifecycle, existence, and pointer fencing remain required.
+/// </summary>
+public sealed record MvForcedReverseRequest(
+    string ServiceId,
+    string ViewName,
+    int ViewVersion,
+    int ExpectedActiveVersion,
+    long ExpectedActiveGeneration,
+    int CandidateCount,
+    MvStatus ExpectedStatus,
+    string Reason,
+    DateTimeOffset RequestedAtUtc);
+
+public static class MvForcedReverseValidation
+{
+    public static MvActivationResult? Validate(MvForcedReverseRequest request)
+    {
+        if (string.IsNullOrWhiteSpace(request.ServiceId) || string.IsNullOrWhiteSpace(request.ViewName))
+        {
+            return MvActivationResult.Rejected(MvActivationFailureReason.IdentityMismatch, "Forced reverse requires an exact service and view identity.");
+        }
+
+        if (request.ViewVersion < 0 || request.ExpectedActiveVersion <= request.ViewVersion)
+        {
+            return MvActivationResult.Rejected(MvActivationFailureReason.IdentityMismatch, "Forced switching is reverse-only.");
+        }
+
+        if (request.ExpectedActiveGeneration < 0)
+        {
+            return MvActivationResult.Rejected(MvActivationFailureReason.ExpectedGenerationConflict, "The expected active generation cannot be negative.");
+        }
+
+        if (request.CandidateCount <= 0 || request.ExpectedStatus is not (MvStatus.Ready or MvStatus.Active))
+        {
+            return MvActivationResult.Rejected(MvActivationFailureReason.UnsafeLifecycle, "Forced reverse requires a retained Ready or Active candidate.");
+        }
+
+        if (string.IsNullOrWhiteSpace(request.Reason) || request.Reason.Length > 1024)
+        {
+            return MvActivationResult.Rejected(MvActivationFailureReason.ProviderFailure, "Forced reverse requires a non-empty reason of at most 1024 characters.");
+        }
+
+        return null;
+    }
+}
 
 /// <summary>Result of the provider-atomic active-pointer operation.</summary>
 public sealed record MvActivationResult(
@@ -128,7 +190,14 @@ public static class MvActivationEligibility
             entries.Count,
             MvStatus.Ready,
             expectedCurrentTruth,
-            expectedTargetTruth);
+            expectedTargetTruth)
+        {
+            SwitchKind = active is null
+                ? MvSwitchKind.Initial
+                : viewVersion > active.ActiveVersion
+                    ? MvSwitchKind.Forward
+                    : MvSwitchKind.Reverse
+        };
         return (MvActivationEligibilityResult.Eligible(), request);
     }
 

--- a/dcb/src/Sekiban.Dcb.MaterializedView/MvContracts.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView/MvContracts.cs
@@ -148,6 +148,15 @@ public sealed record MvActiveEntry(
     ///     Monotonic compare-and-switch generation. Legacy active rows migrate with generation zero.
     /// </summary>
     public long Generation { get; init; }
+
+    /// <summary>Durable audit classification for the transition that produced this pointer.</summary>
+    public MvSwitchKind SwitchKind { get; init; } = MvSwitchKind.Legacy;
+
+    /// <summary>Actor-supplied reason for a break-glass forced reverse; null for ordinary switches.</summary>
+    public string? SwitchReason { get; init; }
+
+    /// <summary>Timestamp persisted atomically with the active-pointer transition.</summary>
+    public DateTimeOffset? SwitchedAtUtc { get; init; }
 }
 
 public sealed record MvPositionUpdate(
@@ -315,6 +324,16 @@ public interface IMvRegistryStore
         IDbTransaction? transaction = null,
         CancellationToken cancellationToken = default) =>
         throw new NotSupportedException("This registry store does not support atomic materialized-view activation.");
+
+    /// <summary>
+    ///     Provider-atomic break-glass reverse. This is a separately named API so ordinary activation can never
+    ///     acquire a truth-waiver flag accidentally.
+    /// </summary>
+    Task<MvActivationResult> TryForceReverseAsync(
+        MvForcedReverseRequest request,
+        IDbTransaction? transaction = null,
+        CancellationToken cancellationToken = default) =>
+        throw new NotSupportedException("This registry store does not support forced materialized-view reverse switching.");
 
     Task SetActiveAsync(
         string serviceId,

--- a/dcb/src/Sekiban.Dcb.MaterializedView/MvExecutorBase.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView/MvExecutorBase.cs
@@ -436,6 +436,13 @@ public abstract class MvExecutorBase<TConnection> : IMvExecutor, IMvActivationEx
                 .ConfigureAwait(false);
         }
 
+        // Catch-up may authorize the first generation, but a prepared parallel generation never moves the serving
+        // pointer implicitly. Forward and reverse transitions are explicit coordinator operations.
+        if (active is not null)
+        {
+            return MvStatus.Ready;
+        }
+
         var result = await TryActivateAsync(host, serviceId, cancellationToken).ConfigureAwait(false);
         if (!result.Succeeded && !result.IsConflict && result.FailureReason != MvActivationFailureReason.AlreadyActive)
         {

--- a/dcb/src/Sekiban.Dcb.MaterializedView/MvForcedReverseExecution.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView/MvForcedReverseExecution.cs
@@ -373,6 +373,25 @@ public abstract class MvForcedReverseRegistryStoreBase<TConnection>
             FormatForcedReverseTimestamp(DateTimeOffset.UtcNow),
             cancellationToken);
 
+    protected static async Task EnsureMissingActiveColumnsAsync(
+        DbConnection connection,
+        IReadOnlySet<string> existingColumns,
+        CancellationToken cancellationToken,
+        params (string Name, string Sql)[] columns)
+    {
+        foreach (var column in columns)
+        {
+            if (existingColumns.Contains(column.Name))
+            {
+                continue;
+            }
+
+            await using var command = connection.CreateCommand();
+            command.CommandText = column.Sql;
+            await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        }
+    }
+
     protected static MvActiveEntry ReadActiveEntry(IReadOnlyDictionary<string, object?> row)
     {
         var switchKindText = ReadNullableString(row, "SwitchKind");

--- a/dcb/src/Sekiban.Dcb.MaterializedView/MvForcedReverseExecution.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView/MvForcedReverseExecution.cs
@@ -1,0 +1,308 @@
+using System.Data.Common;
+
+namespace Sekiban.Dcb.MaterializedView;
+
+/// <summary>Provider SQL used by the shared forced-reverse transaction mechanics.</summary>
+public sealed record MvForcedReverseSqlPlan(
+    string CandidateFenceSql,
+    bool FenceReturnsRows,
+    string CandidateCountSql,
+    string PointerCasSql,
+    string MarkPreviousReadySql,
+    string MarkCandidateActiveSql,
+    string SavepointSql,
+    string RollbackSavepointSql,
+    string? ReleaseSavepointSql)
+{
+    private const string CommonCandidateCountSql = """
+        SELECT COUNT(*) FROM sekiban_mv_registry
+        WHERE service_id = @ServiceId AND view_name = @ViewName AND view_version = @ViewVersion
+          AND status = @ExpectedStatus;
+        """;
+
+    private const string CommonPointerCasSql = """
+        UPDATE sekiban_mv_active
+        SET active_version = @ViewVersion,
+            active_generation = active_generation + 1,
+            activated_at = @RequestedAtUtc,
+            switch_kind = 'forced',
+            switch_reason = @Reason,
+            switched_at_utc = @RequestedAtUtc
+        WHERE service_id = @ServiceId AND view_name = @ViewName
+          AND active_version = @ExpectedActiveVersion
+          AND active_generation = @ExpectedActiveGeneration;
+        """;
+
+    private const string CommonMarkPreviousReadySql = """
+        UPDATE sekiban_mv_registry SET status = 'ready', last_updated = @RequestedAtUtc
+        WHERE service_id = @ServiceId AND view_name = @ViewName AND view_version = @ExpectedActiveVersion;
+        """;
+
+    private const string CommonMarkCandidateActiveSql = """
+        UPDATE sekiban_mv_registry SET status = 'active', last_updated = @RequestedAtUtc
+        WHERE service_id = @ServiceId AND view_name = @ViewName AND view_version = @ViewVersion
+          AND status = @ExpectedStatus;
+        """;
+
+    public static MvForcedReverseSqlPlan Create(
+        string candidateFenceSql,
+        bool fenceReturnsRows,
+        string savepointSql,
+        string rollbackSavepointSql,
+        string? releaseSavepointSql,
+        string? pointerCasSql = null) =>
+        new(
+            candidateFenceSql,
+            fenceReturnsRows,
+            CommonCandidateCountSql,
+            pointerCasSql ?? CommonPointerCasSql,
+            CommonMarkPreviousReadySql,
+            CommonMarkCandidateActiveSql,
+            savepointSql,
+            rollbackSavepointSql,
+            releaseSavepointSql);
+}
+
+/// <summary>
+///     Shared non-resolution mechanics for forced reverse. Providers still own connections and static SQL; this helper
+///     only enforces transaction, savepoint, exact-row-count, and rollback behavior.
+/// </summary>
+public static class MvForcedReverseExecution
+{
+    public static async Task<MvActivationResult> ExecuteAsync<TConnection>(
+        MvForcedReverseRequest request,
+        System.Data.IDbTransaction? callerTransaction,
+        Func<TConnection> createConnection,
+        MvForcedReverseSqlPlan sql,
+        object requestedAtValue,
+        CancellationToken cancellationToken)
+        where TConnection : DbConnection
+    {
+        var validation = MvForcedReverseValidation.Validate(request);
+        if (validation is not null)
+        {
+            return validation;
+        }
+
+        if (callerTransaction is not null)
+        {
+            return await ExecuteWithSavepointAsync(
+                    RequireDbTransaction(callerTransaction),
+                    request,
+                    sql,
+                    requestedAtValue,
+                    cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        await using var connection = createConnection();
+        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+        await using var transaction = await connection.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
+        var result = await ExecuteInTransactionAsync(
+                transaction,
+                request,
+                sql,
+                requestedAtValue,
+                cancellationToken)
+            .ConfigureAwait(false);
+        if (result.Succeeded)
+        {
+            await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+        }
+        else
+        {
+            await transaction.RollbackAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        return result;
+    }
+
+    private static async Task<MvActivationResult> ExecuteWithSavepointAsync(
+        DbTransaction transaction,
+        MvForcedReverseRequest request,
+        MvForcedReverseSqlPlan sql,
+        object requestedAtValue,
+        CancellationToken cancellationToken)
+    {
+        await ExecuteNonQueryAsync(transaction, sql.SavepointSql, null, cancellationToken).ConfigureAwait(false);
+        try
+        {
+            var result = await ExecuteInTransactionAsync(
+                    transaction,
+                    request,
+                    sql,
+                    requestedAtValue,
+                    cancellationToken)
+                .ConfigureAwait(false);
+            if (!result.Succeeded)
+            {
+                await ExecuteNonQueryAsync(transaction, sql.RollbackSavepointSql, null, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+
+            if (sql.ReleaseSavepointSql is not null)
+            {
+                await ExecuteNonQueryAsync(transaction, sql.ReleaseSavepointSql, null, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+
+            return result;
+        }
+        catch
+        {
+            await ExecuteNonQueryAsync(transaction, sql.RollbackSavepointSql, null, cancellationToken)
+                .ConfigureAwait(false);
+            if (sql.ReleaseSavepointSql is not null)
+            {
+                await ExecuteNonQueryAsync(transaction, sql.ReleaseSavepointSql, null, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+
+            throw;
+        }
+    }
+
+    private static async Task<MvActivationResult> ExecuteInTransactionAsync(
+        DbTransaction transaction,
+        MvForcedReverseRequest request,
+        MvForcedReverseSqlPlan sql,
+        object requestedAtValue,
+        CancellationToken cancellationToken)
+    {
+        var parameters = Parameters(request, requestedAtValue);
+        var fenced = sql.FenceReturnsRows
+            ? await CountRowsAsync(transaction, sql.CandidateFenceSql, parameters, cancellationToken).ConfigureAwait(false)
+            : await ExecuteNonQueryAsync(transaction, sql.CandidateFenceSql, parameters, cancellationToken).ConfigureAwait(false);
+        var matching = Convert.ToInt32(
+            await ExecuteScalarAsync(transaction, sql.CandidateCountSql, parameters, cancellationToken).ConfigureAwait(false),
+            System.Globalization.CultureInfo.InvariantCulture);
+        if (fenced != request.CandidateCount || matching != request.CandidateCount)
+        {
+            return Conflict();
+        }
+
+        if (await ExecuteNonQueryAsync(transaction, sql.PointerCasSql, parameters, cancellationToken).ConfigureAwait(false) != 1)
+        {
+            return Conflict();
+        }
+
+        await ExecuteNonQueryAsync(transaction, sql.MarkPreviousReadySql, parameters, cancellationToken)
+            .ConfigureAwait(false);
+        var marked = await ExecuteNonQueryAsync(
+                transaction,
+                sql.MarkCandidateActiveSql,
+                parameters,
+                cancellationToken)
+            .ConfigureAwait(false);
+        return marked == request.CandidateCount
+            ? MvActivationResult.Success(request.ExpectedActiveGeneration + 1)
+            : Conflict();
+    }
+
+    private static async Task<int> CountRowsAsync(
+        DbTransaction transaction,
+        string sql,
+        IReadOnlyDictionary<string, object?> parameters,
+        CancellationToken cancellationToken)
+    {
+        await using var command = CreateCommand(transaction, sql, parameters);
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+        var count = 0;
+        while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+        {
+            count++;
+        }
+
+        return count;
+    }
+
+    private static async Task<int> ExecuteNonQueryAsync(
+        DbTransaction transaction,
+        string sql,
+        IReadOnlyDictionary<string, object?>? parameters,
+        CancellationToken cancellationToken)
+    {
+        await using var command = CreateCommand(transaction, sql, parameters);
+        return await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private static async Task<object?> ExecuteScalarAsync(
+        DbTransaction transaction,
+        string sql,
+        IReadOnlyDictionary<string, object?> parameters,
+        CancellationToken cancellationToken)
+    {
+        await using var command = CreateCommand(transaction, sql, parameters);
+        return await command.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private static DbCommand CreateCommand(
+        DbTransaction transaction,
+        string sql,
+        IReadOnlyDictionary<string, object?>? parameters)
+    {
+        var connection = transaction.Connection ??
+            throw new InvalidOperationException("The transaction is not associated with a connection.");
+        var command = connection.CreateCommand();
+        command.Transaction = transaction;
+        command.CommandText = sql;
+        if (parameters is null)
+        {
+            return command;
+        }
+
+        foreach (var (name, value) in parameters)
+        {
+            var parameter = command.CreateParameter();
+            parameter.ParameterName = name;
+            parameter.Value = value ?? DBNull.Value;
+            command.Parameters.Add(parameter);
+        }
+
+        return command;
+    }
+
+    private static IReadOnlyDictionary<string, object?> Parameters(
+        MvForcedReverseRequest request,
+        object requestedAtValue) => new Dictionary<string, object?>(StringComparer.Ordinal)
+        {
+            ["ServiceId"] = request.ServiceId,
+            ["ViewName"] = request.ViewName,
+            ["ViewVersion"] = request.ViewVersion,
+            ["ExpectedActiveVersion"] = request.ExpectedActiveVersion,
+            ["ExpectedActiveGeneration"] = request.ExpectedActiveGeneration,
+            ["ExpectedStatus"] = request.ExpectedStatus.ToString().ToLowerInvariant(),
+            ["Reason"] = request.Reason,
+            ["RequestedAtUtc"] = requestedAtValue
+        };
+
+    private static DbTransaction RequireDbTransaction(System.Data.IDbTransaction transaction) =>
+        transaction as DbTransaction ??
+        throw new ArgumentException("The caller transaction must derive from DbTransaction.", nameof(transaction));
+
+    private static MvActivationResult Conflict() => MvActivationResult.Rejected(
+        MvActivationFailureReason.ConcurrentSuperseded,
+        "The forced-reverse identity, pointer fence, lifecycle, or candidate snapshot changed.");
+}
+
+/// <summary>Infrastructure base that keeps the provider entry point free of repeated transaction mechanics.</summary>
+[System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+public abstract class MvForcedReverseRegistryStoreBase<TConnection>
+    where TConnection : DbConnection
+{
+    protected abstract MvForcedReverseSqlPlan ForcedReversePlan { get; }
+    protected abstract TConnection CreateForcedReverseConnection();
+    protected virtual object FormatForcedReverseTimestamp(DateTimeOffset value) => value;
+
+    public Task<MvActivationResult> TryForceReverseAsync(
+        MvForcedReverseRequest request,
+        System.Data.IDbTransaction? transaction = null,
+        CancellationToken cancellationToken = default) =>
+        MvForcedReverseExecution.ExecuteAsync(
+            request,
+            transaction,
+            CreateForcedReverseConnection,
+            ForcedReversePlan,
+            FormatForcedReverseTimestamp(request.RequestedAtUtc),
+            cancellationToken);
+}

--- a/dcb/src/Sekiban.Dcb.MaterializedView/MvForcedReverseExecution.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView/MvForcedReverseExecution.cs
@@ -87,6 +87,76 @@ public sealed record MvOrdinarySwitchAuditSqlPlan(
 /// </summary>
 public static class MvForcedReverseExecution
 {
+    private const string LegacySwitchAuditSql = """
+        UPDATE sekiban_mv_active
+        SET switch_kind = 'legacy', switch_reason = NULL, switched_at_utc = @SwitchedAtUtc
+        WHERE service_id = @ServiceId AND view_name = @ViewName AND active_version = @ActiveVersion;
+        """;
+
+    internal static async Task SetLegacyActiveAsync<TConnection>(
+        string serviceId,
+        string viewName,
+        int activeVersion,
+        System.Data.IDbTransaction? callerTransaction,
+        Func<TConnection> createConnection,
+        string pointerUpsertSql,
+        object switchedAtValue,
+        CancellationToken cancellationToken)
+        where TConnection : DbConnection
+    {
+        var parameters = new Dictionary<string, object?>(StringComparer.Ordinal)
+        {
+            ["ServiceId"] = serviceId,
+            ["ViewName"] = viewName,
+            ["ActiveVersion"] = activeVersion,
+            ["SwitchedAtUtc"] = switchedAtValue
+        };
+        if (callerTransaction is not null)
+        {
+            await SetLegacyActiveInTransactionAsync(
+                RequireDbTransaction(callerTransaction),
+                pointerUpsertSql,
+                parameters,
+                cancellationToken).ConfigureAwait(false);
+            return;
+        }
+
+        await using var connection = createConnection();
+        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+        await using var transaction = await connection.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            await SetLegacyActiveInTransactionAsync(
+                transaction,
+                pointerUpsertSql,
+                parameters,
+                cancellationToken).ConfigureAwait(false);
+            await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch
+        {
+            await transaction.RollbackAsync(cancellationToken).ConfigureAwait(false);
+            throw;
+        }
+    }
+
+    private static async Task SetLegacyActiveInTransactionAsync(
+        DbTransaction transaction,
+        string pointerUpsertSql,
+        IReadOnlyDictionary<string, object?> parameters,
+        CancellationToken cancellationToken)
+    {
+        await ExecuteNonQueryAsync(transaction, pointerUpsertSql, parameters, cancellationToken).ConfigureAwait(false);
+        if (await ExecuteNonQueryAsync(
+                transaction,
+                LegacySwitchAuditSql,
+                parameters,
+                cancellationToken).ConfigureAwait(false) != 1)
+        {
+            throw new InvalidOperationException("The legacy active pointer changed before its switch audit was persisted.");
+        }
+    }
+
     internal static async Task PersistOrdinarySwitchAuditAsync(
         System.Data.IDbTransaction transaction,
         MvActivationRequest request,
@@ -347,6 +417,7 @@ public abstract class MvForcedReverseRegistryStoreBase<TConnection>
     where TConnection : DbConnection
 {
     protected abstract MvForcedReverseSqlPlan ForcedReversePlan { get; }
+    protected abstract string LegacySetActiveSql { get; }
     protected abstract TConnection CreateForcedReverseConnection();
     protected virtual object FormatForcedReverseTimestamp(DateTimeOffset value) => value;
 
@@ -360,6 +431,22 @@ public abstract class MvForcedReverseRegistryStoreBase<TConnection>
             CreateForcedReverseConnection,
             ForcedReversePlan,
             FormatForcedReverseTimestamp(request.RequestedAtUtc),
+            cancellationToken);
+
+    protected Task SetLegacyActiveAsync(
+        string serviceId,
+        string viewName,
+        int activeVersion,
+        System.Data.IDbTransaction? transaction,
+        CancellationToken cancellationToken) =>
+        MvForcedReverseExecution.SetLegacyActiveAsync(
+            serviceId,
+            viewName,
+            activeVersion,
+            transaction,
+            CreateForcedReverseConnection,
+            LegacySetActiveSql,
+            FormatForcedReverseTimestamp(DateTimeOffset.UtcNow),
             cancellationToken);
 
     protected Task PersistOrdinarySwitchAuditAsync(

--- a/dcb/src/Sekiban.Dcb.MaterializedView/MvForcedReverseExecution.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView/MvForcedReverseExecution.cs
@@ -63,12 +63,68 @@ public sealed record MvForcedReverseSqlPlan(
             releaseSavepointSql);
 }
 
+/// <summary>Provider SQL for audit metadata written inside an ordinary activation transaction.</summary>
+public sealed record MvOrdinarySwitchAuditSqlPlan(
+    string PersistActiveAuditSql,
+    string MarkPreviousReadySql)
+{
+    public static MvOrdinarySwitchAuditSqlPlan Common { get; } = new(
+        """
+        UPDATE sekiban_mv_active
+        SET switch_kind = @SwitchKind, switch_reason = NULL, switched_at_utc = @SwitchedAtUtc
+        WHERE service_id = @ServiceId AND view_name = @ViewName AND active_version = @ViewVersion
+          AND active_generation = @ActivatedGeneration;
+        """,
+        """
+        UPDATE sekiban_mv_registry SET status = 'ready', last_updated = @SwitchedAtUtc
+        WHERE service_id = @ServiceId AND view_name = @ViewName AND view_version = @ExpectedActiveVersion;
+        """);
+}
+
 /// <summary>
 ///     Shared non-resolution mechanics for forced reverse. Providers still own connections and static SQL; this helper
 ///     only enforces transaction, savepoint, exact-row-count, and rollback behavior.
 /// </summary>
 public static class MvForcedReverseExecution
 {
+    internal static async Task PersistOrdinarySwitchAuditAsync(
+        System.Data.IDbTransaction transaction,
+        MvActivationRequest request,
+        MvOrdinarySwitchAuditSqlPlan sql,
+        object switchedAtValue,
+        CancellationToken cancellationToken)
+    {
+        var dbTransaction = RequireDbTransaction(transaction);
+        var parameters = new Dictionary<string, object?>(StringComparer.Ordinal)
+        {
+            ["ServiceId"] = request.ServiceId,
+            ["ViewName"] = request.ViewName,
+            ["ViewVersion"] = request.ViewVersion,
+            ["ExpectedActiveVersion"] = request.ExpectedActiveVersion,
+            ["ActivatedGeneration"] = request.ExpectedActiveGeneration + 1,
+            ["SwitchKind"] = request.SwitchKind.ToString().ToLowerInvariant(),
+            ["SwitchedAtUtc"] = switchedAtValue
+        };
+        if (await ExecuteNonQueryAsync(
+                dbTransaction,
+                sql.PersistActiveAuditSql,
+                parameters,
+                cancellationToken).ConfigureAwait(false) != 1)
+        {
+            throw new InvalidOperationException("The activated pointer changed before its switch audit was persisted.");
+        }
+
+        if (request.ExpectedActiveVersion is not null)
+        {
+            await ExecuteNonQueryAsync(
+                    dbTransaction,
+                    sql.MarkPreviousReadySql,
+                    parameters,
+                    cancellationToken)
+                .ConfigureAwait(false);
+        }
+    }
+
     public static async Task<MvActivationResult> ExecuteAsync<TConnection>(
         MvForcedReverseRequest request,
         System.Data.IDbTransaction? callerTransaction,
@@ -305,4 +361,88 @@ public abstract class MvForcedReverseRegistryStoreBase<TConnection>
             ForcedReversePlan,
             FormatForcedReverseTimestamp(request.RequestedAtUtc),
             cancellationToken);
+
+    protected Task PersistOrdinarySwitchAuditAsync(
+        System.Data.IDbTransaction transaction,
+        MvActivationRequest request,
+        CancellationToken cancellationToken) =>
+        MvForcedReverseExecution.PersistOrdinarySwitchAuditAsync(
+            transaction,
+            request,
+            MvOrdinarySwitchAuditSqlPlan.Common,
+            FormatForcedReverseTimestamp(DateTimeOffset.UtcNow),
+            cancellationToken);
+
+    protected static MvActiveEntry ReadActiveEntry(IReadOnlyDictionary<string, object?> row)
+    {
+        var switchKindText = ReadNullableString(row, "SwitchKind");
+        return new MvActiveEntry(
+            ReadRequiredString(row, "ServiceId"),
+            ReadRequiredString(row, "ViewName"),
+            Convert.ToInt32(ReadRequired(row, "ActiveVersion"), System.Globalization.CultureInfo.InvariantCulture),
+            ReadRequiredTimestamp(row, "ActivatedAt"))
+        {
+            Generation = Convert.ToInt64(ReadRequired(row, "Generation"), System.Globalization.CultureInfo.InvariantCulture),
+            SwitchKind = Enum.TryParse<MvSwitchKind>(switchKindText, true, out var kind) ? kind : MvSwitchKind.Legacy,
+            SwitchReason = ReadNullableString(row, "SwitchReason"),
+            SwitchedAtUtc = ReadNullableTimestamp(row, "SwitchedAtUtc")
+        };
+    }
+
+    private static string ReadRequiredString(IReadOnlyDictionary<string, object?> row, string key) =>
+        ReadRequired(row, key).ToString() ??
+        throw new InvalidOperationException($"Registry row value '{key}' cannot be converted to a string.");
+
+    private static string? ReadNullableString(IReadOnlyDictionary<string, object?> row, string key)
+    {
+        var value = Read(row, key);
+        return value is null or DBNull ? null : value.ToString();
+    }
+
+    private static DateTimeOffset ReadRequiredTimestamp(IReadOnlyDictionary<string, object?> row, string key) =>
+        ReadTimestamp(ReadRequired(row, key), key);
+
+    private static DateTimeOffset? ReadNullableTimestamp(IReadOnlyDictionary<string, object?> row, string key)
+    {
+        var value = Read(row, key);
+        return value is null or DBNull ? null : ReadTimestamp(value, key);
+    }
+
+    private static DateTimeOffset ReadTimestamp(object value, string key) => value switch
+    {
+        DateTimeOffset dateTimeOffset => dateTimeOffset,
+        DateTime dateTime => new DateTimeOffset(
+            dateTime.Kind == DateTimeKind.Unspecified
+                ? DateTime.SpecifyKind(dateTime, DateTimeKind.Utc)
+                : dateTime),
+        string text when DateTimeOffset.TryParse(
+            text,
+            System.Globalization.CultureInfo.InvariantCulture,
+            System.Globalization.DateTimeStyles.RoundtripKind,
+            out var parsed) => parsed,
+        _ => throw new InvalidOperationException($"Registry row value '{key}' is not a timestamp.")
+    };
+
+    private static object ReadRequired(IReadOnlyDictionary<string, object?> row, string key) =>
+        Read(row, key) is { } value && value is not DBNull
+            ? value
+            : throw new InvalidOperationException($"Registry row is missing required value '{key}'.");
+
+    private static object? Read(IReadOnlyDictionary<string, object?> row, string key)
+    {
+        if (row.TryGetValue(key, out var value))
+        {
+            return value;
+        }
+
+        foreach (var pair in row)
+        {
+            if (string.Equals(pair.Key, key, StringComparison.OrdinalIgnoreCase))
+            {
+                return pair.Value;
+            }
+        }
+
+        return null;
+    }
 }

--- a/dcb/src/Sekiban.Dcb.MaterializedView/MvGenerationCoordinator.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView/MvGenerationCoordinator.cs
@@ -133,133 +133,87 @@ public sealed class MvGenerationCoordinator : IMvGenerationCoordinator
     {
         ArgumentNullException.ThrowIfNull(retainedCandidate);
         var exactServiceId = ValidateServiceId(serviceId);
-        if (string.IsNullOrWhiteSpace(retainedCandidate.ViewName) || retainedCandidate.ViewVersion < 0)
+        var inputRejection = ValidateForcedReverseInput(
+            retainedCandidate,
+            expectedActiveVersion,
+            expectedActiveGeneration,
+            reason,
+            out var normalizedReason);
+        if (inputRejection is not null)
         {
-            return MvActivationResult.Rejected(
-                MvActivationFailureReason.IdentityMismatch,
-                "Forced reverse requires an exact view identity and a non-negative retained version.");
-        }
-        if (expectedActiveVersion <= retainedCandidate.ViewVersion)
-        {
-            return MvActivationResult.Rejected(
-                MvActivationFailureReason.IdentityMismatch,
-                "Forced switching is reverse-only: the retained candidate version must precede the expected active version.");
-        }
-
-        if (expectedActiveGeneration < 0)
-        {
-            return MvActivationResult.Rejected(
-                MvActivationFailureReason.ExpectedGenerationConflict,
-                "The expected active generation cannot be negative.");
-        }
-
-        if (string.IsNullOrWhiteSpace(reason))
-        {
-            throw new ArgumentException("A non-empty operator reason is required for forced reverse.", nameof(reason));
-        }
-
-        var normalizedReason = reason.Trim();
-        if (normalizedReason.Length > 1024)
-        {
-            throw new ArgumentException("The forced-reverse reason cannot exceed 1024 characters.", nameof(reason));
-        }
-        if (normalizedReason.Any(char.IsControl))
-        {
-            throw new ArgumentException("The forced-reverse reason cannot contain control characters.", nameof(reason));
+            return inputRejection;
         }
 
         return await InLaneAsync(
             exactServiceId,
             retainedCandidate.ViewName,
-            async () =>
-            {
-                var entries = await _registry.GetEntriesAsync(
-                        exactServiceId,
-                        retainedCandidate.ViewName,
-                        retainedCandidate.ViewVersion,
-                        cancellationToken)
-                    .ConfigureAwait(false);
-                if (entries.Count == 0)
-                {
-                    return MvActivationResult.Rejected(
-                        MvActivationFailureReason.CandidateMissing,
-                        "The forced-reverse candidate generation does not exist.");
-                }
-
-                if (entries.Any(entry =>
-                        !string.Equals(entry.ServiceId, exactServiceId, StringComparison.Ordinal) ||
-                        !string.Equals(entry.ViewName, retainedCandidate.ViewName, StringComparison.Ordinal) ||
-                        entry.ViewVersion != retainedCandidate.ViewVersion))
-                {
-                    return MvActivationResult.Rejected(
-                        MvActivationFailureReason.IdentityMismatch,
-                        "The forced-reverse candidate identity does not match the exact service, view, and version.");
-                }
-
-                if (entries.Any(entry => entry.Status is not (MvStatus.Ready or MvStatus.Active)))
-                {
-                    return MvActivationResult.Rejected(
-                        MvActivationFailureReason.UnsafeLifecycle,
-                        "Forced reverse waives checkpoint truth only; the retained generation must remain Ready or Active.");
-                }
-
-                var active = await _registry.GetActiveAsync(
-                        exactServiceId,
-                        retainedCandidate.ViewName,
-                        cancellationToken)
-                    .ConfigureAwait(false);
-                if (active is null ||
-                    active.ActiveVersion != expectedActiveVersion ||
-                    active.Generation != expectedActiveGeneration)
-                {
-                    return MvActivationResult.Rejected(
-                        MvActivationFailureReason.ExpectedActiveConflict,
-                        "The active pointer no longer matches the forced-reverse fence.");
-                }
-
-                var switchedAt = DateTimeOffset.UtcNow;
-                var result = await _registry.TryForceReverseAsync(
-                        new MvForcedReverseRequest(
-                            exactServiceId,
-                            retainedCandidate.ViewName,
-                            retainedCandidate.ViewVersion,
-                            expectedActiveVersion,
-                            expectedActiveGeneration,
-                            entries.Count,
-                            entries[0].Status,
-                            normalizedReason,
-                            switchedAt),
-                        cancellationToken: cancellationToken)
-                    .ConfigureAwait(false);
-                if (result.Succeeded && _statusPublisher is not null)
-                {
-                    var snapshot = MvProjectionStatusSnapshot.FromEntries(entries) with
-                    {
-                        Status = MvStatus.Active,
-                        SwitchKind = MvSwitchKind.Forced,
-                        SwitchReason = normalizedReason,
-                        SwitchedAtUtc = switchedAt
-                    };
-                    try
-                    {
-                        await _statusPublisher.PublishSwitchAsync(
-                                exactServiceId,
-                                retainedCandidate.ViewName,
-                                retainedCandidate.ViewVersion,
-                                snapshot,
-                                publisherKind,
-                                cancellationToken)
-                            .ConfigureAwait(false);
-                    }
-                    catch
-                    {
-                        // Switching is durable before observation. A status failure cannot propagate into MV work.
-                    }
-                }
-
-                return result;
-            },
+            () => ForceReverseInLaneAsync(
+                retainedCandidate,
+                expectedActiveVersion,
+                expectedActiveGeneration,
+                normalizedReason,
+                exactServiceId,
+                publisherKind,
+                cancellationToken),
             cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<MvActivationResult> ForceReverseInLaneAsync(
+        IMvApplyHost retainedCandidate,
+        int expectedActiveVersion,
+        long expectedActiveGeneration,
+        string normalizedReason,
+        string exactServiceId,
+        MvProjectionStatusPublisherKind publisherKind,
+        CancellationToken cancellationToken)
+    {
+        var entries = await _registry.GetEntriesAsync(
+                exactServiceId,
+                retainedCandidate.ViewName,
+                retainedCandidate.ViewVersion,
+                cancellationToken)
+            .ConfigureAwait(false);
+        var candidateRejection = ValidateForcedCandidate(entries, retainedCandidate, exactServiceId);
+        if (candidateRejection is not null)
+        {
+            return candidateRejection;
+        }
+
+        var active = await _registry.GetActiveAsync(exactServiceId, retainedCandidate.ViewName, cancellationToken)
+            .ConfigureAwait(false);
+        if (active is null ||
+            active.ActiveVersion != expectedActiveVersion ||
+            active.Generation != expectedActiveGeneration)
+        {
+            return MvActivationResult.Rejected(
+                MvActivationFailureReason.ExpectedActiveConflict,
+                "The active pointer no longer matches the forced-reverse fence.");
+        }
+
+        var switchedAt = PersistenceTimestampNow();
+        var result = await _registry.TryForceReverseAsync(
+                new MvForcedReverseRequest(
+                    exactServiceId,
+                    retainedCandidate.ViewName,
+                    retainedCandidate.ViewVersion,
+                    expectedActiveVersion,
+                    expectedActiveGeneration,
+                    entries.Count,
+                    entries[0].Status,
+                    normalizedReason,
+                    switchedAt),
+                cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
+        await PublishForcedSwitchAsync(
+            result,
+            entries,
+            retainedCandidate,
+            exactServiceId,
+            normalizedReason,
+            switchedAt,
+            publisherKind,
+            cancellationToken).ConfigureAwait(false);
+        return result;
     }
 
     public Task<MvActiveEntry?> GetActiveAsync(
@@ -274,6 +228,123 @@ public sealed class MvGenerationCoordinator : IMvGenerationCoordinator
 
     private string ValidateServiceId(string? serviceId) =>
         MvServiceIdValidation.Validate(serviceId, _options, _serviceIdProvider, nameof(MvGenerationCoordinator));
+
+    private static DateTimeOffset PersistenceTimestampNow()
+    {
+        var now = DateTimeOffset.UtcNow;
+        return new DateTimeOffset(now.Ticks - (now.Ticks % 10), TimeSpan.Zero);
+    }
+
+    private static MvActivationResult? ValidateForcedReverseInput(
+        IMvApplyHost candidate,
+        int expectedActiveVersion,
+        long expectedActiveGeneration,
+        string reason,
+        out string normalizedReason)
+    {
+        normalizedReason = reason?.Trim() ?? string.Empty;
+        if (string.IsNullOrWhiteSpace(candidate.ViewName) || candidate.ViewVersion < 0)
+        {
+            return MvActivationResult.Rejected(
+                MvActivationFailureReason.IdentityMismatch,
+                "Forced reverse requires an exact view identity and a non-negative retained version.");
+        }
+        if (expectedActiveVersion <= candidate.ViewVersion)
+        {
+            return MvActivationResult.Rejected(
+                MvActivationFailureReason.IdentityMismatch,
+                "Forced switching is reverse-only: the retained candidate version must precede the expected active version.");
+        }
+        if (expectedActiveGeneration < 0)
+        {
+            return MvActivationResult.Rejected(
+                MvActivationFailureReason.ExpectedGenerationConflict,
+                "The expected active generation cannot be negative.");
+        }
+        if (normalizedReason.Length == 0)
+        {
+            throw new ArgumentException("A non-empty operator reason is required for forced reverse.", nameof(reason));
+        }
+        if (normalizedReason.Length > 1024)
+        {
+            throw new ArgumentException("The forced-reverse reason cannot exceed 1024 characters.", nameof(reason));
+        }
+        if (normalizedReason.Any(char.IsControl))
+        {
+            throw new ArgumentException("The forced-reverse reason cannot contain control characters.", nameof(reason));
+        }
+
+        return null;
+    }
+
+    private static MvActivationResult? ValidateForcedCandidate(
+        IReadOnlyList<MvRegistryEntry> entries,
+        IMvApplyHost candidate,
+        string exactServiceId)
+    {
+        if (entries.Count == 0)
+        {
+            return MvActivationResult.Rejected(
+                MvActivationFailureReason.CandidateMissing,
+                "The forced-reverse candidate generation does not exist.");
+        }
+        if (entries.Any(entry =>
+                !string.Equals(entry.ServiceId, exactServiceId, StringComparison.Ordinal) ||
+                !string.Equals(entry.ViewName, candidate.ViewName, StringComparison.Ordinal) ||
+                entry.ViewVersion != candidate.ViewVersion))
+        {
+            return MvActivationResult.Rejected(
+                MvActivationFailureReason.IdentityMismatch,
+                "The forced-reverse candidate identity does not match the exact service, view, and version.");
+        }
+        if (entries.Any(entry => entry.Status is not (MvStatus.Ready or MvStatus.Active)))
+        {
+            return MvActivationResult.Rejected(
+                MvActivationFailureReason.UnsafeLifecycle,
+                "Forced reverse waives checkpoint truth only; the retained generation must remain Ready or Active.");
+        }
+
+        return null;
+    }
+
+    private async Task PublishForcedSwitchAsync(
+        MvActivationResult result,
+        IReadOnlyList<MvRegistryEntry> entries,
+        IMvApplyHost candidate,
+        string exactServiceId,
+        string reason,
+        DateTimeOffset switchedAt,
+        MvProjectionStatusPublisherKind publisherKind,
+        CancellationToken cancellationToken)
+    {
+        if (!result.Succeeded || _statusPublisher is null)
+        {
+            return;
+        }
+
+        var snapshot = MvProjectionStatusSnapshot.FromEntries(entries) with
+        {
+            Status = MvStatus.Active,
+            SwitchKind = MvSwitchKind.Forced,
+            SwitchReason = reason,
+            SwitchedAtUtc = switchedAt
+        };
+        try
+        {
+            await _statusPublisher.PublishSwitchAsync(
+                    exactServiceId,
+                    candidate.ViewName,
+                    candidate.ViewVersion,
+                    snapshot,
+                    publisherKind,
+                    cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch
+        {
+            // Switching is durable before observation. A status failure cannot propagate into MV work.
+        }
+    }
 
     private static void ValidateCandidate(IMvApplyHost candidate)
     {

--- a/dcb/src/Sekiban.Dcb.MaterializedView/MvGenerationCoordinator.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView/MvGenerationCoordinator.cs
@@ -297,11 +297,11 @@ public sealed class MvGenerationCoordinator : IMvGenerationCoordinator
                 MvActivationFailureReason.IdentityMismatch,
                 "The forced-reverse candidate identity does not match the exact service, view, and version.");
         }
-        if (entries.Any(entry => entry.Status is not (MvStatus.Ready or MvStatus.Active)))
+        if (entries.Any(entry => entry.Status != MvStatus.Ready))
         {
             return MvActivationResult.Rejected(
                 MvActivationFailureReason.UnsafeLifecycle,
-                "Forced reverse waives checkpoint truth only; the retained generation must remain Ready or Active.");
+                "Forced reverse waives checkpoint truth only; the retained generation must remain Ready.");
         }
 
         return null;

--- a/dcb/src/Sekiban.Dcb.MaterializedView/MvGenerationCoordinator.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView/MvGenerationCoordinator.cs
@@ -1,0 +1,348 @@
+using System.Collections.Concurrent;
+using Microsoft.Extensions.Options;
+using Sekiban.Dcb.ServiceId;
+
+namespace Sekiban.Dcb.MaterializedView;
+
+/// <summary>Hosted-process generation lifecycle and switch boundary for one exact service/view.</summary>
+public interface IMvGenerationCoordinator
+{
+    Task PrepareGenerationAsync(
+        IMvApplyHost candidate,
+        string? serviceId = null,
+        CancellationToken cancellationToken = default);
+
+    Task<MvActivationResult> SwitchAsync(
+        IMvApplyHost candidate,
+        string? serviceId = null,
+        CancellationToken cancellationToken = default,
+        MvProjectionStatusPublisherKind publisherKind = MvProjectionStatusPublisherKind.HostedWorker);
+
+    Task<MvActivationResult> ForceReverseAsync(
+        IMvApplyHost retainedCandidate,
+        int expectedActiveVersion,
+        long expectedActiveGeneration,
+        string reason,
+        string? serviceId = null,
+        CancellationToken cancellationToken = default,
+        MvProjectionStatusPublisherKind publisherKind = MvProjectionStatusPublisherKind.HostedWorker);
+
+    Task<MvActiveEntry?> GetActiveAsync(
+        string viewName,
+        string? serviceId = null,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+///     Provider-neutral coordinator. Process-local gates provide bounded single-flight behavior while provider CAS
+///     remains the restart-safe and cross-process authority.
+/// </summary>
+public sealed class MvGenerationCoordinator : IMvGenerationCoordinator
+{
+    private readonly ConcurrentDictionary<string, SemaphoreSlim> _lanes = new(StringComparer.Ordinal);
+    private readonly SemaphoreSlim _capacity;
+    private readonly IMvExecutor _executor;
+    private readonly IMvRegistryStore _registry;
+    private readonly MvOptions _options;
+    private readonly IServiceIdProvider? _serviceIdProvider;
+    private readonly MvProjectionStatusPublisher? _statusPublisher;
+
+    public MvGenerationCoordinator(
+        IMvExecutor executor,
+        IMvRegistryStore registry,
+        IOptions<MvOptions> options,
+        IServiceIdProvider? serviceIdProvider = null,
+        MvProjectionStatusPublisher? statusPublisher = null)
+    {
+        _executor = executor;
+        _registry = registry;
+        _options = options.Value;
+        _capacity = new SemaphoreSlim(Math.Max(1, _options.CatchUpMaxConcurrentBatches));
+        _serviceIdProvider = serviceIdProvider;
+        _statusPublisher = statusPublisher;
+    }
+
+    public async Task PrepareGenerationAsync(
+        IMvApplyHost candidate,
+        string? serviceId = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(candidate);
+        ValidateCandidate(candidate);
+        var exactServiceId = ValidateServiceId(serviceId);
+        await InLaneAsync(
+            exactServiceId,
+            candidate.ViewName,
+            async () =>
+            {
+                await _executor.InitializeAsync(candidate, exactServiceId, cancellationToken).ConfigureAwait(false);
+                await _executor.CaptureTargetCheckpointAsync(candidate, exactServiceId, cancellationToken).ConfigureAwait(false);
+                return true;
+            },
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<MvActivationResult> SwitchAsync(
+        IMvApplyHost candidate,
+        string? serviceId = null,
+        CancellationToken cancellationToken = default,
+        MvProjectionStatusPublisherKind publisherKind = MvProjectionStatusPublisherKind.HostedWorker)
+    {
+        ArgumentNullException.ThrowIfNull(candidate);
+        ValidateCandidate(candidate);
+        var exactServiceId = ValidateServiceId(serviceId);
+        return await InLaneAsync(
+            exactServiceId,
+            candidate.ViewName,
+            async () =>
+            {
+                var result = await _executor.TryActivateAsync(candidate, exactServiceId, cancellationToken)
+                    .ConfigureAwait(false);
+                if (result.Succeeded)
+                {
+                    try
+                    {
+                        await PublishActiveSwitchAsync(
+                                exactServiceId,
+                                candidate.ViewName,
+                                candidate.ViewVersion,
+                                publisherKind,
+                                cancellationToken)
+                            .ConfigureAwait(false);
+                    }
+                    catch
+                    {
+                        // The provider CAS is authoritative. Observation is bounded best effort and never reverses
+                        // or obscures a successfully committed pointer transition.
+                    }
+                }
+
+                return result;
+            },
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<MvActivationResult> ForceReverseAsync(
+        IMvApplyHost retainedCandidate,
+        int expectedActiveVersion,
+        long expectedActiveGeneration,
+        string reason,
+        string? serviceId = null,
+        CancellationToken cancellationToken = default,
+        MvProjectionStatusPublisherKind publisherKind = MvProjectionStatusPublisherKind.HostedWorker)
+    {
+        ArgumentNullException.ThrowIfNull(retainedCandidate);
+        var exactServiceId = ValidateServiceId(serviceId);
+        if (string.IsNullOrWhiteSpace(retainedCandidate.ViewName) || retainedCandidate.ViewVersion < 0)
+        {
+            return MvActivationResult.Rejected(
+                MvActivationFailureReason.IdentityMismatch,
+                "Forced reverse requires an exact view identity and a non-negative retained version.");
+        }
+        if (expectedActiveVersion <= retainedCandidate.ViewVersion)
+        {
+            return MvActivationResult.Rejected(
+                MvActivationFailureReason.IdentityMismatch,
+                "Forced switching is reverse-only: the retained candidate version must precede the expected active version.");
+        }
+
+        if (expectedActiveGeneration < 0)
+        {
+            return MvActivationResult.Rejected(
+                MvActivationFailureReason.ExpectedGenerationConflict,
+                "The expected active generation cannot be negative.");
+        }
+
+        if (string.IsNullOrWhiteSpace(reason))
+        {
+            throw new ArgumentException("A non-empty operator reason is required for forced reverse.", nameof(reason));
+        }
+
+        var normalizedReason = reason.Trim();
+        if (normalizedReason.Length > 1024)
+        {
+            throw new ArgumentException("The forced-reverse reason cannot exceed 1024 characters.", nameof(reason));
+        }
+        if (normalizedReason.Any(char.IsControl))
+        {
+            throw new ArgumentException("The forced-reverse reason cannot contain control characters.", nameof(reason));
+        }
+
+        return await InLaneAsync(
+            exactServiceId,
+            retainedCandidate.ViewName,
+            async () =>
+            {
+                var entries = await _registry.GetEntriesAsync(
+                        exactServiceId,
+                        retainedCandidate.ViewName,
+                        retainedCandidate.ViewVersion,
+                        cancellationToken)
+                    .ConfigureAwait(false);
+                if (entries.Count == 0)
+                {
+                    return MvActivationResult.Rejected(
+                        MvActivationFailureReason.CandidateMissing,
+                        "The forced-reverse candidate generation does not exist.");
+                }
+
+                if (entries.Any(entry =>
+                        !string.Equals(entry.ServiceId, exactServiceId, StringComparison.Ordinal) ||
+                        !string.Equals(entry.ViewName, retainedCandidate.ViewName, StringComparison.Ordinal) ||
+                        entry.ViewVersion != retainedCandidate.ViewVersion))
+                {
+                    return MvActivationResult.Rejected(
+                        MvActivationFailureReason.IdentityMismatch,
+                        "The forced-reverse candidate identity does not match the exact service, view, and version.");
+                }
+
+                if (entries.Any(entry => entry.Status is not (MvStatus.Ready or MvStatus.Active)))
+                {
+                    return MvActivationResult.Rejected(
+                        MvActivationFailureReason.UnsafeLifecycle,
+                        "Forced reverse waives checkpoint truth only; the retained generation must remain Ready or Active.");
+                }
+
+                var active = await _registry.GetActiveAsync(
+                        exactServiceId,
+                        retainedCandidate.ViewName,
+                        cancellationToken)
+                    .ConfigureAwait(false);
+                if (active is null ||
+                    active.ActiveVersion != expectedActiveVersion ||
+                    active.Generation != expectedActiveGeneration)
+                {
+                    return MvActivationResult.Rejected(
+                        MvActivationFailureReason.ExpectedActiveConflict,
+                        "The active pointer no longer matches the forced-reverse fence.");
+                }
+
+                var switchedAt = DateTimeOffset.UtcNow;
+                var result = await _registry.TryForceReverseAsync(
+                        new MvForcedReverseRequest(
+                            exactServiceId,
+                            retainedCandidate.ViewName,
+                            retainedCandidate.ViewVersion,
+                            expectedActiveVersion,
+                            expectedActiveGeneration,
+                            entries.Count,
+                            entries[0].Status,
+                            normalizedReason,
+                            switchedAt),
+                        cancellationToken: cancellationToken)
+                    .ConfigureAwait(false);
+                if (result.Succeeded && _statusPublisher is not null)
+                {
+                    var snapshot = MvProjectionStatusSnapshot.FromEntries(entries) with
+                    {
+                        Status = MvStatus.Active,
+                        SwitchKind = MvSwitchKind.Forced,
+                        SwitchReason = normalizedReason,
+                        SwitchedAtUtc = switchedAt
+                    };
+                    try
+                    {
+                        await _statusPublisher.PublishSwitchAsync(
+                                exactServiceId,
+                                retainedCandidate.ViewName,
+                                retainedCandidate.ViewVersion,
+                                snapshot,
+                                publisherKind,
+                                cancellationToken)
+                            .ConfigureAwait(false);
+                    }
+                    catch
+                    {
+                        // Switching is durable before observation. A status failure cannot propagate into MV work.
+                    }
+                }
+
+                return result;
+            },
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    public Task<MvActiveEntry?> GetActiveAsync(
+        string viewName,
+        string? serviceId = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(viewName);
+        var exactServiceId = ValidateServiceId(serviceId);
+        return _registry.GetActiveAsync(exactServiceId, viewName, cancellationToken);
+    }
+
+    private string ValidateServiceId(string? serviceId) =>
+        MvServiceIdValidation.Validate(serviceId, _options, _serviceIdProvider, nameof(MvGenerationCoordinator));
+
+    private static void ValidateCandidate(IMvApplyHost candidate)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(candidate.ViewName);
+        if (candidate.ViewVersion < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(candidate), "A materialized-view version cannot be negative.");
+        }
+    }
+
+    private async Task PublishActiveSwitchAsync(
+        string serviceId,
+        string viewName,
+        int viewVersion,
+        MvProjectionStatusPublisherKind publisherKind,
+        CancellationToken cancellationToken)
+    {
+        if (_statusPublisher is null)
+        {
+            return;
+        }
+
+        var entries = await _registry.GetEntriesAsync(serviceId, viewName, viewVersion, cancellationToken)
+            .ConfigureAwait(false);
+        var active = await _registry.GetActiveAsync(serviceId, viewName, cancellationToken).ConfigureAwait(false);
+        if (entries.Count == 0 || active is null || active.ActiveVersion != viewVersion)
+        {
+            return;
+        }
+
+        await _statusPublisher.PublishSwitchAsync(
+                serviceId,
+                viewName,
+                viewVersion,
+                MvProjectionStatusSnapshot.FromEntries(entries) with
+                {
+                    Status = MvStatus.Active,
+                    SwitchKind = active.SwitchKind,
+                    SwitchReason = active.SwitchReason,
+                    SwitchedAtUtc = active.SwitchedAtUtc
+                },
+                publisherKind,
+                cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    private async Task<T> InLaneAsync<T>(
+        string serviceId,
+        string viewName,
+        Func<Task<T>> action,
+        CancellationToken cancellationToken)
+    {
+        var lane = _lanes.GetOrAdd(string.Join('|', serviceId, viewName), _ => new SemaphoreSlim(1, 1));
+        await lane.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            await _capacity.WaitAsync(cancellationToken).ConfigureAwait(false);
+            try
+            {
+                return await action().ConfigureAwait(false);
+            }
+            finally
+            {
+                _capacity.Release();
+            }
+        }
+        finally
+        {
+            lane.Release();
+        }
+    }
+}

--- a/dcb/src/Sekiban.Dcb.MaterializedView/MvProjectionStatusPublication.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView/MvProjectionStatusPublication.cs
@@ -46,6 +46,10 @@ public sealed record MvProjectionStatusSnapshot(
     MvStatus Status,
     long AppliedEventCount)
 {
+    public MvSwitchKind? SwitchKind { get; init; }
+    public string? SwitchReason { get; init; }
+    public DateTimeOffset? SwitchedAtUtc { get; init; }
+
     public static MvProjectionStatusSnapshot Unknown(MvStatus status = MvStatus.Initializing) =>
         new(MvCheckpointTruth.Unknown(MvCheckpointUnknownReason.NotObserved), status, 0);
 
@@ -140,6 +144,22 @@ public sealed class MvProjectionStatusPublisher
             await fence.Gate.WaitAsync(cancellationToken).ConfigureAwait(false);
             try
             {
+                if (mapped.SwitchKind is not null)
+                {
+                    fence.SwitchKind = mapped.SwitchKind;
+                    fence.SwitchReason = mapped.SwitchReason;
+                    fence.SwitchedAtUtc = mapped.SwitchedAtUtc;
+                }
+                else if (fence.SwitchKind is not null)
+                {
+                    mapped = mapped with
+                    {
+                        SwitchKind = fence.SwitchKind,
+                        SwitchReason = fence.SwitchReason,
+                        SwitchedAtUtc = fence.SwitchedAtUtc
+                    };
+                }
+
                 await WriteBoundedAsync(
                         key,
                         normalizedServiceId,
@@ -164,6 +184,21 @@ public sealed class MvProjectionStatusPublisher
         {
             LogFailureRateLimited(key, now);
         }
+    }
+
+    public Task PublishSwitchAsync(
+        string serviceId,
+        string viewName,
+        int viewVersion,
+        MvProjectionStatusSnapshot snapshot,
+        MvProjectionStatusPublisherKind publisherKind,
+        CancellationToken cancellationToken = default)
+    {
+        var normalizedServiceId = ServiceIdValidator.NormalizeAndValidate(serviceId);
+        var identity = MvProjectionStatusIdentity.Create(viewName, viewVersion);
+        var lane = publisherKind == MvProjectionStatusPublisherKind.HostedWorker ? "hosted" : "orleans";
+        _nextDue.TryRemove(string.Join('|', normalizedServiceId, identity.ProjectorName, identity.ProjectorVersion, lane), out _);
+        return PublishIfDueAsync(normalizedServiceId, viewName, viewVersion, snapshot, publisherKind, cancellationToken);
     }
 
     private async Task WriteBoundedAsync(
@@ -193,7 +228,10 @@ public sealed class MvProjectionStatusPublisher
             Phase = mapped.Phase,
             LeaseExpiresAtUtc = now + PositiveOrDefault(_options.FreshnessWindow, TimeSpan.FromMinutes(2)),
             IsFaulted = mapped.IsFaulted,
-            FaultMessage = mapped.IsFaulted ? "materialized view faulted" : null
+            FaultMessage = mapped.IsFaulted ? "materialized view faulted" : null,
+            SwitchKind = mapped.SwitchKind,
+            SwitchReason = mapped.SwitchReason,
+            SwitchedAtUtc = mapped.SwitchedAtUtc
         };
 
         using var writeCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
@@ -242,12 +280,12 @@ public sealed class MvProjectionStatusPublisher
     {
         if (snapshot.Status == MvStatus.Faulted)
         {
-            return new(ProjectionStatusPhases.Faulted, null, snapshot.AppliedEventCount, true);
+            return MappedStatus.Create(snapshot, ProjectionStatusPhases.Faulted, null, true);
         }
 
         if (!snapshot.CurrentCheckpointTruth.IsKnown)
         {
-            return new(ProjectionStatusPhases.Unknown, null, snapshot.AppliedEventCount, false);
+            return MappedStatus.Create(snapshot, ProjectionStatusPhases.Unknown, null, false);
         }
 
         var phase = snapshot.Status switch
@@ -258,7 +296,7 @@ public sealed class MvProjectionStatusPublisher
             MvStatus.Active => ProjectionStatusPhases.Active,
             _ => ProjectionStatusPhases.Stopped
         };
-        return new(phase, snapshot.CurrentCheckpointTruth.PositionValue, snapshot.AppliedEventCount, false);
+        return MappedStatus.Create(snapshot, phase, snapshot.CurrentCheckpointTruth.PositionValue, false);
     }
 
     private static string BuildClusterId(string clusterId, string lane) =>
@@ -272,7 +310,32 @@ public sealed class MvProjectionStatusPublisher
         public SemaphoreSlim Gate { get; } = new(1, 1);
         public long Sequence { get; set; }
         public DateTimeOffset NextFailureLogAt { get; set; }
+        public string? SwitchKind { get; set; }
+        public string? SwitchReason { get; set; }
+        public DateTimeOffset? SwitchedAtUtc { get; set; }
     }
 
-    private sealed record MappedStatus(string Phase, string? Position, long AppliedEventCount, bool IsFaulted);
+    private sealed record MappedStatus(
+        string Phase,
+        string? Position,
+        long AppliedEventCount,
+        bool IsFaulted,
+        string? SwitchKind,
+        string? SwitchReason,
+        DateTimeOffset? SwitchedAtUtc)
+    {
+        internal static MappedStatus Create(
+            MvProjectionStatusSnapshot snapshot,
+            string phase,
+            string? position,
+            bool faulted) =>
+            new(
+                phase,
+                position,
+                snapshot.AppliedEventCount,
+                faulted,
+                snapshot.SwitchKind?.ToString().ToLowerInvariant(),
+                snapshot.SwitchReason,
+                snapshot.SwitchedAtUtc);
+    }
 }

--- a/dcb/src/Sekiban.Dcb.MaterializedView/SekibanDcbMaterializedViewExtensions.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView/SekibanDcbMaterializedViewExtensions.cs
@@ -32,6 +32,7 @@ public static class SekibanDcbMaterializedViewExtensions
                 sp.GetRequiredService<IEventTypes>(),
                 storageInfoProvider);
         });
+        services.TryAddSingleton<IMvGenerationCoordinator, MvGenerationCoordinator>();
         if (configure is not null)
         {
             services.Configure(configure);

--- a/dcb/src/Sekiban.Dcb.Postgres/PostgresProjectionStatusStore.cs
+++ b/dcb/src/Sekiban.Dcb.Postgres/PostgresProjectionStatusStore.cs
@@ -22,11 +22,17 @@ public partial class PostgresMultiProjectionStateStore
             lease_expires_at_utc timestamp with time zone NULL,
             is_faulted boolean NOT NULL DEFAULT FALSE,
             fault_message varchar(2048) NULL,
+            switch_kind varchar(32) NULL,
+            switch_reason varchar(1024) NULL,
+            switched_at_utc timestamp with time zone NULL,
             CONSTRAINT pk_dcb_projection_statuses PRIMARY KEY
                 (service_id, projector_name, projector_version, cluster_id)
         );
         CREATE INDEX IF NOT EXISTS ix_dcb_projection_statuses_projector
             ON dcb_projection_statuses (service_id, projector_name, projector_version, cluster_id);
+        ALTER TABLE dcb_projection_statuses ADD COLUMN IF NOT EXISTS switch_kind varchar(32) NULL;
+        ALTER TABLE dcb_projection_statuses ADD COLUMN IF NOT EXISTS switch_reason varchar(1024) NULL;
+        ALTER TABLE dcb_projection_statuses ADD COLUMN IF NOT EXISTS switched_at_utc timestamp with time zone NULL;
         """;
 
     public async Task<ResultBox<ProjectionStatusWriteResult>> UpsertAsync(
@@ -63,10 +69,10 @@ public partial class PostgresMultiProjectionStateStore
                 INSERT INTO dcb_projection_statuses
                     (service_id, projector_name, projector_version, cluster_id, activation_id, sequence,
                      applied_event_count, last_applied_sortable_unique_id, last_traversed_sortable_unique_id, recorded_at_utc,
-                     phase, lease_expires_at_utc, is_faulted, fault_message)
+                     phase, lease_expires_at_utc, is_faulted, fault_message, switch_kind, switch_reason, switched_at_utc)
                 SELECT @service_id, @projector_name, @projector_version, @cluster_id, @activation_id, @sequence,
                        @applied_event_count, @last_applied_sortable_unique_id, @last_traversed_sortable_unique_id, @recorded_at_utc,
-                       @phase, @lease_expires_at_utc, @is_faulted, @fault_message
+                       @phase, @lease_expires_at_utc, @is_faulted, @fault_message, @switch_kind, @switch_reason, @switched_at_utc
                 WHERE @expected_sequence = 0
                 ON CONFLICT (service_id, projector_name, projector_version, cluster_id)
                 DO UPDATE SET
@@ -79,12 +85,16 @@ public partial class PostgresMultiProjectionStateStore
                     phase = EXCLUDED.phase,
                     lease_expires_at_utc = EXCLUDED.lease_expires_at_utc,
                     is_faulted = EXCLUDED.is_faulted,
-                    fault_message = EXCLUDED.fault_message
+                    fault_message = EXCLUDED.fault_message,
+                    switch_kind = EXCLUDED.switch_kind,
+                    switch_reason = EXCLUDED.switch_reason,
+                    switched_at_utc = EXCLUDED.switched_at_utc
                 WHERE dcb_projection_statuses.sequence = @expected_sequence
                   AND EXCLUDED.sequence > dcb_projection_statuses.sequence
                 RETURNING service_id, projector_name, projector_version, cluster_id, activation_id, sequence,
                           applied_event_count, last_applied_sortable_unique_id, last_traversed_sortable_unique_id,
-                          recorded_at_utc, phase, lease_expires_at_utc, is_faulted, fault_message;
+                          recorded_at_utc, phase, lease_expires_at_utc, is_faulted, fault_message,
+                          switch_kind, switch_reason, switched_at_utc;
                 """;
             AddParameter(command, "service_id", heartbeat.ServiceId);
             AddParameter(command, "projector_name", heartbeat.ProjectorName);
@@ -100,6 +110,9 @@ public partial class PostgresMultiProjectionStateStore
             AddParameter(command, "lease_expires_at_utc", (object?)heartbeat.LeaseExpiresAtUtc ?? DBNull.Value);
             AddParameter(command, "is_faulted", heartbeat.IsFaulted);
             AddParameter(command, "fault_message", (object?)heartbeat.FaultMessage ?? DBNull.Value);
+            AddParameter(command, "switch_kind", (object?)heartbeat.SwitchKind ?? DBNull.Value);
+            AddParameter(command, "switch_reason", (object?)heartbeat.SwitchReason ?? DBNull.Value);
+            AddParameter(command, "switched_at_utc", (object?)heartbeat.SwitchedAtUtc ?? DBNull.Value);
             AddParameter(command, "expected_sequence", expectedSequence);
 
             await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
@@ -145,7 +158,8 @@ public partial class PostgresMultiProjectionStateStore
             command.CommandText = """
                 SELECT service_id, projector_name, projector_version, cluster_id, activation_id, sequence,
                        applied_event_count, last_applied_sortable_unique_id, last_traversed_sortable_unique_id,
-                       recorded_at_utc, phase, lease_expires_at_utc, is_faulted, fault_message
+                       recorded_at_utc, phase, lease_expires_at_utc, is_faulted, fault_message,
+                       switch_kind, switch_reason, switched_at_utc
                 FROM dcb_projection_statuses
                 WHERE service_id = @service_id
                   AND (@projector_name IS NULL OR projector_name = @projector_name)
@@ -201,7 +215,10 @@ public partial class PostgresMultiProjectionStateStore
         Phase = reader.IsDBNull(10) ? ProjectionStatusPhases.Unknown : reader.GetString(10),
         LeaseExpiresAtUtc = reader.IsDBNull(11) ? null : reader.GetFieldValue<DateTimeOffset>(11),
         IsFaulted = !reader.IsDBNull(12) && reader.GetBoolean(12),
-        FaultMessage = reader.IsDBNull(13) ? null : reader.GetString(13)
+        FaultMessage = reader.IsDBNull(13) ? null : reader.GetString(13),
+        SwitchKind = reader.IsDBNull(14) ? null : reader.GetString(14),
+        SwitchReason = reader.IsDBNull(15) ? null : reader.GetString(15),
+        SwitchedAtUtc = reader.IsDBNull(16) ? null : reader.GetFieldValue<DateTimeOffset>(16)
     };
 
     private static async Task<ProjectionStatusHeartbeat?> ReadCurrentHeartbeatAsync(
@@ -216,7 +233,8 @@ public partial class PostgresMultiProjectionStateStore
         command.CommandText = """
             SELECT service_id, projector_name, projector_version, cluster_id, activation_id, sequence,
                    applied_event_count, last_applied_sortable_unique_id, last_traversed_sortable_unique_id,
-                   recorded_at_utc, phase, lease_expires_at_utc, is_faulted, fault_message
+                   recorded_at_utc, phase, lease_expires_at_utc, is_faulted, fault_message,
+                   switch_kind, switch_reason, switched_at_utc
             FROM dcb_projection_statuses
             WHERE service_id = @service_id AND projector_name = @projector_name
               AND projector_version = @projector_version AND cluster_id = @cluster_id;

--- a/dcb/src/Sekiban.Dcb.Sqlite/SqliteProjectionStatusStore.cs
+++ b/dcb/src/Sekiban.Dcb.Sqlite/SqliteProjectionStatusStore.cs
@@ -24,12 +24,51 @@ public partial class SqliteMultiProjectionStateStore
                 LeaseExpiresAtUtc TEXT NULL,
                 IsFaulted INTEGER NOT NULL DEFAULT 0,
                 FaultMessage TEXT NULL,
+                SwitchKind TEXT NULL,
+                SwitchReason TEXT NULL,
+                SwitchedAtUtc TEXT NULL,
                 PRIMARY KEY (ServiceId, ProjectorName, ProjectorVersion, ClusterId)
             );
             CREATE INDEX IF NOT EXISTS IX_ProjectionStatuses_Projector
                 ON dcb_projection_statuses(ServiceId, ProjectorName, ProjectorVersion, ClusterId);
             """;
         command.ExecuteNonQuery();
+        var columns = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        using (var info = connection.CreateCommand())
+        {
+            info.CommandText = "PRAGMA table_info('dcb_projection_statuses');";
+            using var reader = info.ExecuteReader();
+            while (reader.Read())
+            {
+                columns.Add(reader.GetString(1));
+            }
+        }
+
+        EnsureSwitchColumns(connection, columns);
+    }
+
+    private static void EnsureSwitchColumns(SqliteConnection connection, IReadOnlySet<string> columns)
+    {
+        if (!columns.Contains("SwitchKind"))
+        {
+            using var add = connection.CreateCommand();
+            add.CommandText = "ALTER TABLE dcb_projection_statuses ADD COLUMN SwitchKind TEXT NULL;";
+            add.ExecuteNonQuery();
+        }
+
+        if (!columns.Contains("SwitchReason"))
+        {
+            using var add = connection.CreateCommand();
+            add.CommandText = "ALTER TABLE dcb_projection_statuses ADD COLUMN SwitchReason TEXT NULL;";
+            add.ExecuteNonQuery();
+        }
+
+        if (!columns.Contains("SwitchedAtUtc"))
+        {
+            using var add = connection.CreateCommand();
+            add.CommandText = "ALTER TABLE dcb_projection_statuses ADD COLUMN SwitchedAtUtc TEXT NULL;";
+            add.ExecuteNonQuery();
+        }
     }
 
     public async Task<ResultBox<ProjectionStatusWriteResult>> UpsertAsync(
@@ -62,10 +101,10 @@ public partial class SqliteMultiProjectionStateStore
                 INSERT INTO dcb_projection_statuses
                     (ServiceId, ProjectorName, ProjectorVersion, ClusterId, ActivationId, Sequence,
                      AppliedEventCount, LastAppliedSortableUniqueId, LastTraversedSortableUniqueId, RecordedAtUtc,
-                     Phase, LeaseExpiresAtUtc, IsFaulted, FaultMessage)
+                     Phase, LeaseExpiresAtUtc, IsFaulted, FaultMessage, SwitchKind, SwitchReason, SwitchedAtUtc)
                 SELECT @serviceId, @projectorName, @projectorVersion, @clusterId, @activationId, @sequence,
                        @appliedEventCount, @lastAppliedSortableUniqueId, @lastTraversedSortableUniqueId, @recordedAtUtc,
-                       @phase, @leaseExpiresAtUtc, @isFaulted, @faultMessage
+                       @phase, @leaseExpiresAtUtc, @isFaulted, @faultMessage, @switchKind, @switchReason, @switchedAtUtc
                 WHERE @expectedSequence = 0
                 ON CONFLICT(ServiceId, ProjectorName, ProjectorVersion, ClusterId)
                 DO UPDATE SET
@@ -78,12 +117,15 @@ public partial class SqliteMultiProjectionStateStore
                     Phase = excluded.Phase,
                     LeaseExpiresAtUtc = excluded.LeaseExpiresAtUtc,
                     IsFaulted = excluded.IsFaulted,
-                    FaultMessage = excluded.FaultMessage
+                    FaultMessage = excluded.FaultMessage,
+                    SwitchKind = excluded.SwitchKind,
+                    SwitchReason = excluded.SwitchReason,
+                    SwitchedAtUtc = excluded.SwitchedAtUtc
                 WHERE dcb_projection_statuses.Sequence = @expectedSequence
                   AND excluded.Sequence > dcb_projection_statuses.Sequence
                 RETURNING ServiceId, ProjectorName, ProjectorVersion, ClusterId, ActivationId, Sequence,
                           AppliedEventCount, LastAppliedSortableUniqueId, LastTraversedSortableUniqueId, RecordedAtUtc,
-                          Phase, LeaseExpiresAtUtc, IsFaulted, FaultMessage;
+                          Phase, LeaseExpiresAtUtc, IsFaulted, FaultMessage, SwitchKind, SwitchReason, SwitchedAtUtc;
                 """;
             AddStatusParameter(command, "@serviceId", heartbeat.ServiceId);
             AddStatusParameter(command, "@projectorName", heartbeat.ProjectorName);
@@ -99,6 +141,9 @@ public partial class SqliteMultiProjectionStateStore
             AddStatusParameter(command, "@leaseExpiresAtUtc", (object?)heartbeat.LeaseExpiresAtUtc?.ToString("O") ?? DBNull.Value);
             AddStatusParameter(command, "@isFaulted", heartbeat.IsFaulted ? 1 : 0);
             AddStatusParameter(command, "@faultMessage", (object?)heartbeat.FaultMessage ?? DBNull.Value);
+            AddStatusParameter(command, "@switchKind", (object?)heartbeat.SwitchKind ?? DBNull.Value);
+            AddStatusParameter(command, "@switchReason", (object?)heartbeat.SwitchReason ?? DBNull.Value);
+            AddStatusParameter(command, "@switchedAtUtc", (object?)heartbeat.SwitchedAtUtc?.ToString("O") ?? DBNull.Value);
             AddStatusParameter(command, "@expectedSequence", expectedSequence);
 
             await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
@@ -136,7 +181,7 @@ public partial class SqliteMultiProjectionStateStore
             command.CommandText = """
                 SELECT ServiceId, ProjectorName, ProjectorVersion, ClusterId, ActivationId, Sequence,
                        AppliedEventCount, LastAppliedSortableUniqueId, LastTraversedSortableUniqueId, RecordedAtUtc,
-                       Phase, LeaseExpiresAtUtc, IsFaulted, FaultMessage
+                       Phase, LeaseExpiresAtUtc, IsFaulted, FaultMessage, SwitchKind, SwitchReason, SwitchedAtUtc
                 FROM dcb_projection_statuses
                 WHERE ServiceId = @serviceId
                   AND (@projectorName IS NULL OR ProjectorName = @projectorName)
@@ -184,7 +229,12 @@ public partial class SqliteMultiProjectionStateStore
             ? null
             : DateTimeOffset.Parse(reader.GetString(11), System.Globalization.CultureInfo.InvariantCulture),
         IsFaulted = !reader.IsDBNull(12) && reader.GetInt64(12) != 0,
-        FaultMessage = reader.IsDBNull(13) ? null : reader.GetString(13)
+        FaultMessage = reader.IsDBNull(13) ? null : reader.GetString(13),
+        SwitchKind = reader.IsDBNull(14) ? null : reader.GetString(14),
+        SwitchReason = reader.IsDBNull(15) ? null : reader.GetString(15),
+        SwitchedAtUtc = reader.IsDBNull(16)
+            ? null
+            : DateTimeOffset.Parse(reader.GetString(16), System.Globalization.CultureInfo.InvariantCulture)
     };
 
     private static async Task<ProjectionStatusHeartbeat?> ReadCurrentHeartbeatAsync(
@@ -196,7 +246,7 @@ public partial class SqliteMultiProjectionStateStore
         command.CommandText = """
             SELECT ServiceId, ProjectorName, ProjectorVersion, ClusterId, ActivationId, Sequence,
                    AppliedEventCount, LastAppliedSortableUniqueId, LastTraversedSortableUniqueId, RecordedAtUtc,
-                   Phase, LeaseExpiresAtUtc, IsFaulted, FaultMessage
+                   Phase, LeaseExpiresAtUtc, IsFaulted, FaultMessage, SwitchKind, SwitchReason, SwitchedAtUtc
             FROM dcb_projection_statuses
             WHERE ServiceId = @serviceId AND ProjectorName = @projectorName
               AND ProjectorVersion = @projectorVersion AND ClusterId = @clusterId;

--- a/dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/MvGenerationSwitchTests.cs
+++ b/dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/MvGenerationSwitchTests.cs
@@ -1,0 +1,331 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.DependencyInjection;
+using Sekiban.Dcb.Actors;
+using Sekiban.Dcb.InMemory;
+using Sekiban.Dcb.MaterializedView;
+using Sekiban.Dcb.ServiceId;
+using Xunit;
+
+namespace Sekiban.Dcb.MaterializedView.MultiProvider.Tests;
+
+[Collection(nameof(PostgresMvCollection))]
+public sealed class PostgresMvGenerationSwitchTests(PostgresMvFixture fixture) : MvGenerationSwitchTestsBase(fixture);
+
+[Collection(nameof(MySqlMvCollection))]
+public sealed class MySqlMvGenerationSwitchTests(MySqlMvFixture fixture) : MvGenerationSwitchTestsBase(fixture);
+
+[Collection(nameof(SqlServerMvCollection))]
+public sealed class SqlServerMvGenerationSwitchTests(SqlServerMvFixture fixture) : MvGenerationSwitchTestsBase(fixture);
+
+[Collection(nameof(SqliteMvCollection))]
+public sealed class SqliteMvGenerationSwitchTests(SqliteMvFixture fixture) : MvGenerationSwitchTestsBase(fixture);
+
+public abstract class MvGenerationSwitchTestsBase(MultiProviderFixtureBase fixture)
+{
+    [SkippableFact]
+    public Task PreparingNextGeneration_PreservesActiveGenerationAndIndependentProgress() =>
+        MvGenerationSwitchAssertions.AssertIndependentPreparationAsync(fixture);
+
+    [SkippableFact]
+    public Task OrdinaryForwardAndReverse_UseEligibilityAndPersistDirection() =>
+        MvGenerationSwitchAssertions.AssertOrdinaryForwardAndReverseAsync(fixture);
+
+    [SkippableFact]
+    public Task ForcedReverse_WaivesOnlyTruth_AndPublishesDurableAuditMetadata() =>
+        MvGenerationSwitchAssertions.AssertForcedReverseAsync(fixture);
+
+    [SkippableFact]
+    public Task ForcedReverse_RejectsMissingIdentityAndStaleFenceWithoutMutation() =>
+        MvGenerationSwitchAssertions.AssertForcedReverseFencesAsync(fixture);
+
+    [SkippableFact]
+    public Task ConcurrentForcedReverse_ProviderFenceAllowsExactlyOneWinner() =>
+        MvGenerationSwitchAssertions.AssertForcedReverseRaceAsync(fixture);
+
+    [SkippableFact]
+    public Task ForcedReverse_CallerTransactionRollback_IsRetryable() =>
+        MvGenerationSwitchAssertions.AssertForcedReverseCallerRollbackAsync(fixture);
+}
+
+internal static class MvGenerationSwitchAssertions
+{
+    private const string ServiceId = MultiProviderFixtureBase.ServiceId;
+    private const string ViewName = "GenerationView";
+
+    public static async Task AssertIndependentPreparationAsync(MultiProviderFixtureBase fixture)
+    {
+        var (store, coordinator) = await PrepareAsync(fixture).ConfigureAwait(false);
+        var first = new Host(1);
+        await coordinator.PrepareGenerationAsync(first, ServiceId).ConfigureAwait(false);
+        await fixture.Executor.CatchUpOnceAsync(first, ServiceId).ConfigureAwait(false);
+        if (await store.GetActiveAsync(ServiceId, ViewName).ConfigureAwait(false) is null)
+        {
+            var initial = await coordinator.SwitchAsync(first, ServiceId).ConfigureAwait(false);
+            Assert.True(initial.Succeeded, initial.Message);
+        }
+        var servingBefore = await store.GetEntriesAsync(ServiceId, ViewName, 1).ConfigureAwait(false);
+
+        await coordinator.PrepareGenerationAsync(new Host(2), ServiceId).ConfigureAwait(false);
+
+        var active = Assert.IsType<MvActiveEntry>(await store.GetActiveAsync(ServiceId, ViewName).ConfigureAwait(false));
+        var servingAfter = await store.GetEntriesAsync(ServiceId, ViewName, 1).ConfigureAwait(false);
+        var candidate = await store.GetEntriesAsync(ServiceId, ViewName, 2).ConfigureAwait(false);
+        Assert.Equal(1, active.ActiveVersion);
+        Assert.Equal(2, servingAfter.Count);
+        Assert.Equal(2, candidate.Count);
+        Assert.All(servingAfter, entry => Assert.Equal(MvStatus.Active, entry.Status));
+        Assert.Equal(
+            servingBefore.Select(entry => entry.CurrentCheckpointTruth),
+            servingAfter.Select(entry => entry.CurrentCheckpointTruth));
+        Assert.All(candidate, entry => Assert.True(entry.CurrentCheckpointTruth.IsUnknown));
+        Assert.All(candidate, entry => Assert.True(entry.TargetCheckpointTruth.IsKnown));
+        Assert.Empty(servingAfter.Select(entry => entry.PhysicalTable).Intersect(
+            candidate.Select(entry => entry.PhysicalTable), StringComparer.Ordinal));
+    }
+
+    public static async Task AssertOrdinaryForwardAndReverseAsync(MultiProviderFixtureBase fixture)
+    {
+        var (store, coordinator) = await PrepareAsync(fixture).ConfigureAwait(false);
+        await RegisterAsync(store, 1, known: true).ConfigureAwait(false);
+        await RegisterAsync(store, 2, known: true).ConfigureAwait(false);
+
+        var initial = await coordinator.SwitchAsync(new Host(1), ServiceId).ConfigureAwait(false);
+        var forward = await coordinator.SwitchAsync(new Host(2), ServiceId).ConfigureAwait(false);
+        var reverse = await coordinator.SwitchAsync(new Host(1), ServiceId).ConfigureAwait(false);
+
+        Assert.True(initial.Succeeded);
+        Assert.True(forward.Succeeded);
+        Assert.True(reverse.Succeeded);
+        var active = Assert.IsType<MvActiveEntry>(await store.GetActiveAsync(ServiceId, ViewName).ConfigureAwait(false));
+        Assert.Equal(1, active.ActiveVersion);
+        Assert.Equal(3, active.Generation);
+        Assert.Equal(MvSwitchKind.Reverse, active.SwitchKind);
+        Assert.Null(active.SwitchReason);
+        Assert.NotNull(active.SwitchedAtUtc);
+        Assert.All(await store.GetEntriesAsync(ServiceId, ViewName, 2).ConfigureAwait(false),
+            entry => Assert.Equal(MvStatus.Ready, entry.Status));
+    }
+
+    public static async Task AssertForcedReverseAsync(MultiProviderFixtureBase fixture)
+    {
+        var (store, _) = await PrepareAsync(fixture).ConfigureAwait(false);
+        await RegisterAsync(store, 1, known: false).ConfigureAwait(false);
+        await RegisterAsync(store, 2, known: true).ConfigureAwait(false);
+        await store.SetActiveAsync(ServiceId, ViewName, 2).ConfigureAwait(false);
+
+#pragma warning disable CS0618
+        var sourceStatus = new InMemoryMultiProjectionStateStore(new FixedServiceIdProvider(ServiceId));
+#pragma warning restore CS0618
+        var statusOptions = new ProjectionStatusOptions
+        {
+            Enabled = true,
+            SamplingWindow = TimeSpan.Zero,
+            HeartbeatInterval = TimeSpan.FromMinutes(1),
+            FreshnessWindow = TimeSpan.FromMinutes(2)
+        };
+        var publisher = new MvProjectionStatusPublisher(
+            sourceStatus,
+            statusOptions,
+            NullLogger<MvProjectionStatusPublisher>.Instance);
+        var coordinator = CreateCoordinator(fixture, store, publisher);
+
+        var ordinary = await coordinator.SwitchAsync(new Host(1), ServiceId).ConfigureAwait(false);
+        Assert.False(ordinary.Succeeded);
+        Assert.Equal(MvActivationFailureReason.CurrentCheckpointUnknown, ordinary.FailureReason);
+        Assert.Equal(2, (await store.GetActiveAsync(ServiceId, ViewName).ConfigureAwait(false))!.ActiveVersion);
+
+        const string reason = "operator rollback after incompatible downstream projection";
+        var forced = await coordinator.ForceReverseAsync(new Host(1), 2, 1, reason, ServiceId).ConfigureAwait(false);
+        Assert.True(forced.Succeeded);
+        var active = Assert.IsType<MvActiveEntry>(await store.GetActiveAsync(ServiceId, ViewName).ConfigureAwait(false));
+        Assert.Equal(1, active.ActiveVersion);
+        Assert.Equal(2, active.Generation);
+        Assert.Equal(MvSwitchKind.Forced, active.SwitchKind);
+        Assert.Equal(reason, active.SwitchReason);
+        Assert.NotNull(active.SwitchedAtUtc);
+
+        var restartedCoordinator = CreateCoordinator(fixture, store);
+        var restartedActive = Assert.IsType<MvActiveEntry>(
+            await restartedCoordinator.GetActiveAsync(ViewName, ServiceId).ConfigureAwait(false));
+        Assert.Equal(active, restartedActive);
+
+        var identity = MvProjectionStatusIdentity.Create(ViewName, 1);
+        var reader = new ProjectionStatusReader(
+            sourceStatus,
+            fixture.EventStore,
+            new FixedServiceIdProvider(ServiceId),
+            statusOptions);
+        var typed = await reader.ReadAsync(new ProjectionStatusReadRequest(
+            ServiceId,
+            identity.ProjectorName,
+            identity.ProjectorVersion)).ConfigureAwait(false);
+        var observation = Assert.Single(typed.GetValue());
+        Assert.Equal("forced", observation.SwitchKind);
+        Assert.Equal(reason, observation.SwitchReason);
+        Assert.Equal(active.SwitchedAtUtc, observation.SwitchedAtUtc);
+
+        var serialized = new SerializedProjectionStatusReader(reader, new FixedServiceIdProvider(ServiceId));
+        var bytes = await serialized.AcceptAsync(SerializedProjectionStatusReader.SerializeRequest(
+            new ProjectionStatusReadRequest(ServiceId, identity.ProjectorName, identity.ProjectorVersion))).ConfigureAwait(false);
+        var envelope = SerializedProjectionStatusReader.Deserialize(bytes.GetValue()).GetValue();
+        var serializedObservation = Assert.Single(envelope.Snapshots!);
+        Assert.Equal("forced", serializedObservation.SwitchKind);
+        Assert.Equal(reason, serializedObservation.SwitchReason);
+    }
+
+    public static async Task AssertForcedReverseFencesAsync(MultiProviderFixtureBase fixture)
+    {
+        var (store, coordinator) = await PrepareAsync(fixture).ConfigureAwait(false);
+        await RegisterAsync(store, 1, known: false).ConfigureAwait(false);
+        await RegisterAsync(store, 2, known: true).ConfigureAwait(false);
+        await store.SetActiveAsync(ServiceId, ViewName, 2).ConfigureAwait(false);
+
+        var missing = await coordinator.ForceReverseAsync(new Host(0), 2, 1, "missing generation", ServiceId).ConfigureAwait(false);
+        Assert.False(missing.Succeeded);
+        Assert.Equal(MvActivationFailureReason.CandidateMissing, missing.FailureReason);
+
+        var stale = await coordinator.ForceReverseAsync(new Host(1), 2, 0, "stale fence", ServiceId).ConfigureAwait(false);
+        Assert.False(stale.Succeeded);
+        Assert.Equal(MvActivationFailureReason.ExpectedActiveConflict, stale.FailureReason);
+
+        var wrongDirection = await coordinator.ForceReverseAsync(new Host(3), 2, 1, "forward forbidden", ServiceId).ConfigureAwait(false);
+        Assert.False(wrongDirection.Succeeded);
+        Assert.Equal(MvActivationFailureReason.IdentityMismatch, wrongDirection.FailureReason);
+
+        var active = Assert.IsType<MvActiveEntry>(await store.GetActiveAsync(ServiceId, ViewName).ConfigureAwait(false));
+        Assert.Equal(2, active.ActiveVersion);
+        Assert.Equal(1, active.Generation);
+    }
+
+    public static async Task AssertForcedReverseRaceAsync(MultiProviderFixtureBase fixture)
+    {
+        var (store, _) = await PrepareAsync(fixture).ConfigureAwait(false);
+        await RegisterAsync(store, 1, known: false).ConfigureAwait(false);
+        await RegisterAsync(store, 2, known: true).ConfigureAwait(false);
+        await store.SetActiveAsync(ServiceId, ViewName, 2).ConfigureAwait(false);
+        var request = new MvForcedReverseRequest(
+            ServiceId,
+            ViewName,
+            1,
+            2,
+            1,
+            2,
+            MvStatus.Ready,
+            "concurrent operator rollback",
+            DateTimeOffset.UtcNow);
+
+        var results = await Task.WhenAll(
+            store.TryForceReverseAsync(request),
+            store.TryForceReverseAsync(request)).ConfigureAwait(false);
+
+        Assert.Single(results, result => result.Succeeded);
+        Assert.Single(results, result => !result.Succeeded && result.IsConflict);
+        var active = Assert.IsType<MvActiveEntry>(await store.GetActiveAsync(ServiceId, ViewName).ConfigureAwait(false));
+        Assert.Equal(1, active.ActiveVersion);
+        Assert.Equal(2, active.Generation);
+        Assert.Equal(MvSwitchKind.Forced, active.SwitchKind);
+    }
+
+    public static async Task AssertForcedReverseCallerRollbackAsync(MultiProviderFixtureBase fixture)
+    {
+        var (store, _) = await PrepareAsync(fixture).ConfigureAwait(false);
+        await RegisterAsync(store, 1, known: false).ConfigureAwait(false);
+        await RegisterAsync(store, 2, known: true).ConfigureAwait(false);
+        await store.SetActiveAsync(ServiceId, ViewName, 2).ConfigureAwait(false);
+        var request = new MvForcedReverseRequest(
+            ServiceId,
+            ViewName,
+            1,
+            2,
+            1,
+            2,
+            MvStatus.Ready,
+            "transactional operator rollback",
+            DateTimeOffset.UtcNow);
+
+        await using (var connection = await fixture.OpenConnectionAsync().ConfigureAwait(false))
+        await using (var transaction = await connection.BeginTransactionAsync().ConfigureAwait(false))
+        {
+            var tentative = await store.TryForceReverseAsync(request, transaction).ConfigureAwait(false);
+            Assert.True(tentative.Succeeded, tentative.Message);
+            await transaction.RollbackAsync().ConfigureAwait(false);
+        }
+
+        Assert.Equal(2, (await store.GetActiveAsync(ServiceId, ViewName).ConfigureAwait(false))!.ActiveVersion);
+        var retry = await store.TryForceReverseAsync(request).ConfigureAwait(false);
+        Assert.True(retry.Succeeded, retry.Message);
+        Assert.Equal(1, (await store.GetActiveAsync(ServiceId, ViewName).ConfigureAwait(false))!.ActiveVersion);
+    }
+
+    private static async Task<(IMvRegistryStore Store, MvGenerationCoordinator Coordinator)> PrepareAsync(
+        MultiProviderFixtureBase fixture)
+    {
+        Skip.IfNot(fixture.IsAvailable, fixture.AvailabilityMessage ?? "Integration fixture is unavailable.");
+        await fixture.ResetAsync().ConfigureAwait(false);
+        var store = fixture.Services.GetRequiredService<IMvRegistryStore>();
+        await store.EnsureInfrastructureAsync().ConfigureAwait(false);
+        return (store, CreateCoordinator(fixture, store));
+    }
+
+    private static MvGenerationCoordinator CreateCoordinator(
+        MultiProviderFixtureBase fixture,
+        IMvRegistryStore store,
+        MvProjectionStatusPublisher? publisher = null) =>
+        new(
+            fixture.Executor,
+            store,
+            Options.Create(new MvOptions { ServiceId = ServiceId }),
+            new FixedServiceIdProvider(ServiceId),
+            publisher);
+
+    private static async Task RegisterAsync(IMvRegistryStore store, int version, bool known)
+    {
+        var target = MvCheckpointTruth.KnownZero(MvCheckpointProvenance.AuthoritativeTargetCapture());
+        var current = known
+            ? MvCheckpointTruth.KnownZero(MvCheckpointProvenance.AppliedEvent(MvApplySource.CatchUp))
+            : MvCheckpointTruth.Unknown(MvCheckpointUnknownReason.ReadUnavailable);
+        foreach (var table in new[] { "orders", "items" })
+        {
+            await store.RegisterAsync(new MvRegistryEntry
+            {
+                ServiceId = ServiceId,
+                ViewName = ViewName,
+                ViewVersion = version,
+                LogicalTable = table,
+                PhysicalTable = $"generation_v{version}_{table}",
+                Status = MvStatus.Ready,
+                CurrentPosition = current.PositionValue,
+                TargetPosition = target.PositionValue,
+                CurrentCheckpointTruth = current,
+                TargetCheckpointTruth = target,
+                LastUpdated = DateTimeOffset.UtcNow
+            }).ConfigureAwait(false);
+        }
+    }
+
+    private sealed class Host(int version) : IMvApplyHost
+    {
+        public string ViewName => MvGenerationSwitchAssertions.ViewName;
+        public int ViewVersion => version;
+        public IReadOnlyList<string> LogicalTables => ["orders", "items"];
+
+        public Task<IReadOnlyList<MvSqlStatementDto>> InitializeAsync(IMvTableBindings tables, CancellationToken ct)
+        {
+            foreach (var logicalTable in LogicalTables)
+            {
+                tables.RegisterTable(logicalTable);
+            }
+
+            return Task.FromResult<IReadOnlyList<MvSqlStatementDto>>([]);
+        }
+
+        public Task<IReadOnlyList<MvSqlStatementDto>> ApplyEventAsync(
+            Sekiban.Dcb.Events.SerializableEvent ev,
+            IMvTableBindings tables,
+            IMvApplyQueryPort queryPort,
+            string sortableUniqueId,
+            CancellationToken ct) =>
+            Task.FromResult<IReadOnlyList<MvSqlStatementDto>>([]);
+    }
+}

--- a/dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/MvGenerationSwitchTests.cs
+++ b/dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/MvGenerationSwitchTests.cs
@@ -40,6 +40,18 @@ public abstract class MvGenerationSwitchTestsBase(MultiProviderFixtureBase fixtu
         MvGenerationSwitchAssertions.AssertForcedReverseFencesAsync(fixture);
 
     [SkippableFact]
+    public Task ForcedReverse_RejectsStaleActiveCandidateWithoutMutation() =>
+        MvGenerationSwitchAssertions.AssertStaleActiveCandidateRejectedAsync(fixture);
+
+    [SkippableFact]
+    public Task ForcedReverse_ProviderBoundaryRejectsActiveLifecycleWithoutMutation() =>
+        MvGenerationSwitchAssertions.AssertProviderBoundaryRejectsActiveLifecycleAsync(fixture);
+
+    [SkippableFact]
+    public Task ForcedReverse_ProviderBoundaryFencesExactServiceViewAndVersion() =>
+        MvGenerationSwitchAssertions.AssertProviderBoundaryExactIdentityAsync(fixture);
+
+    [SkippableFact]
     public Task ConcurrentForcedReverse_ProviderFenceAllowsExactlyOneWinner() =>
         MvGenerationSwitchAssertions.AssertForcedReverseRaceAsync(fixture);
 
@@ -198,6 +210,116 @@ internal static class MvGenerationSwitchAssertions
         Assert.Equal(1, active.Generation);
     }
 
+    public static async Task AssertStaleActiveCandidateRejectedAsync(MultiProviderFixtureBase fixture)
+    {
+        var (store, coordinator) = await PrepareAsync(fixture).ConfigureAwait(false);
+        await RegisterAsync(store, 1, known: false, status: MvStatus.Active).ConfigureAwait(false);
+        await RegisterAsync(store, 2, known: true).ConfigureAwait(false);
+        await store.SetActiveAsync(ServiceId, ViewName, 2).ConfigureAwait(false);
+        var pointerBefore = await store.GetActiveAsync(ServiceId, ViewName).ConfigureAwait(false);
+        var candidateBefore = await store.GetEntriesAsync(ServiceId, ViewName, 1).ConfigureAwait(false);
+        var currentBefore = await store.GetEntriesAsync(ServiceId, ViewName, 2).ConfigureAwait(false);
+
+        var result = await coordinator.ForceReverseAsync(
+            new Host(1),
+            2,
+            1,
+            "stale active candidate must remain rejected",
+            ServiceId).ConfigureAwait(false);
+
+        Assert.False(result.Succeeded);
+        Assert.Equal(MvActivationFailureReason.UnsafeLifecycle, result.FailureReason);
+        Assert.Equal(pointerBefore, await store.GetActiveAsync(ServiceId, ViewName).ConfigureAwait(false));
+        Assert.Equal(candidateBefore, await store.GetEntriesAsync(ServiceId, ViewName, 1).ConfigureAwait(false));
+        Assert.Equal(currentBefore, await store.GetEntriesAsync(ServiceId, ViewName, 2).ConfigureAwait(false));
+    }
+
+    public static async Task AssertProviderBoundaryRejectsActiveLifecycleAsync(MultiProviderFixtureBase fixture)
+    {
+        var (store, _) = await PrepareAsync(fixture).ConfigureAwait(false);
+        await RegisterAsync(store, 1, known: false, status: MvStatus.Active).ConfigureAwait(false);
+        await RegisterAsync(store, 2, known: true).ConfigureAwait(false);
+        await store.SetActiveAsync(ServiceId, ViewName, 2).ConfigureAwait(false);
+        var pointerBefore = await store.GetActiveAsync(ServiceId, ViewName).ConfigureAwait(false);
+        var candidateBefore = await store.GetEntriesAsync(ServiceId, ViewName, 1).ConfigureAwait(false);
+        var currentBefore = await store.GetEntriesAsync(ServiceId, ViewName, 2).ConfigureAwait(false);
+        var request = new MvForcedReverseRequest(
+            ServiceId,
+            ViewName,
+            1,
+            2,
+            1,
+            2,
+            MvStatus.Active,
+            "provider boundary must reject active lifecycle",
+            DateTimeOffset.UtcNow);
+
+        var result = await store.TryForceReverseAsync(request).ConfigureAwait(false);
+
+        Assert.False(result.Succeeded);
+        Assert.Equal(MvActivationFailureReason.UnsafeLifecycle, result.FailureReason);
+        Assert.Equal(pointerBefore, await store.GetActiveAsync(ServiceId, ViewName).ConfigureAwait(false));
+        Assert.Equal(candidateBefore, await store.GetEntriesAsync(ServiceId, ViewName, 1).ConfigureAwait(false));
+        Assert.Equal(currentBefore, await store.GetEntriesAsync(ServiceId, ViewName, 2).ConfigureAwait(false));
+    }
+
+    public static async Task AssertProviderBoundaryExactIdentityAsync(MultiProviderFixtureBase fixture)
+    {
+        var (store, _) = await PrepareAsync(fixture).ConfigureAwait(false);
+        const string otherService = "multi-provider-service-decoy";
+        const string otherView = "GenerationViewDecoy";
+
+        await RegisterAsync(store, 0, known: false).ConfigureAwait(false);
+        await RegisterAsync(store, 1, known: false).ConfigureAwait(false);
+        await RegisterAsync(store, 2, known: true).ConfigureAwait(false);
+        await store.SetActiveAsync(ServiceId, ViewName, 2).ConfigureAwait(false);
+        await RegisterAsync(store, 1, known: false, serviceId: otherService).ConfigureAwait(false);
+        await RegisterAsync(store, 2, known: true, serviceId: otherService).ConfigureAwait(false);
+        await store.SetActiveAsync(otherService, ViewName, 2).ConfigureAwait(false);
+        await RegisterAsync(store, 1, known: false, viewName: otherView).ConfigureAwait(false);
+        await RegisterAsync(store, 2, known: true, viewName: otherView).ConfigureAwait(false);
+        await store.SetActiveAsync(ServiceId, otherView, 2).ConfigureAwait(false);
+
+        var otherVersionBefore = await store.GetEntriesAsync(ServiceId, ViewName, 0).ConfigureAwait(false);
+        var otherServiceCandidateBefore = await store.GetEntriesAsync(otherService, ViewName, 1).ConfigureAwait(false);
+        var otherServiceCurrentBefore = await store.GetEntriesAsync(otherService, ViewName, 2).ConfigureAwait(false);
+        var otherServicePointerBefore = await store.GetActiveAsync(otherService, ViewName).ConfigureAwait(false);
+        var otherViewCandidateBefore = await store.GetEntriesAsync(ServiceId, otherView, 1).ConfigureAwait(false);
+        var otherViewCurrentBefore = await store.GetEntriesAsync(ServiceId, otherView, 2).ConfigureAwait(false);
+        var otherViewPointerBefore = await store.GetActiveAsync(ServiceId, otherView).ConfigureAwait(false);
+        var request = new MvForcedReverseRequest(
+            ServiceId,
+            ViewName,
+            1,
+            2,
+            1,
+            2,
+            MvStatus.Ready,
+            "exact provider identity predicates",
+            DateTimeOffset.UtcNow);
+
+        var result = await store.TryForceReverseAsync(request).ConfigureAwait(false);
+
+        Assert.True(result.Succeeded, result.Message);
+        var intendedPointer = Assert.IsType<MvActiveEntry>(
+            await store.GetActiveAsync(ServiceId, ViewName).ConfigureAwait(false));
+        Assert.Equal(1, intendedPointer.ActiveVersion);
+        Assert.Equal(2, intendedPointer.Generation);
+        Assert.All(
+            await store.GetEntriesAsync(ServiceId, ViewName, 1).ConfigureAwait(false),
+            entry => Assert.Equal(MvStatus.Active, entry.Status));
+        Assert.All(
+            await store.GetEntriesAsync(ServiceId, ViewName, 2).ConfigureAwait(false),
+            entry => Assert.Equal(MvStatus.Ready, entry.Status));
+        Assert.Equal(otherVersionBefore, await store.GetEntriesAsync(ServiceId, ViewName, 0).ConfigureAwait(false));
+        Assert.Equal(otherServiceCandidateBefore, await store.GetEntriesAsync(otherService, ViewName, 1).ConfigureAwait(false));
+        Assert.Equal(otherServiceCurrentBefore, await store.GetEntriesAsync(otherService, ViewName, 2).ConfigureAwait(false));
+        Assert.Equal(otherServicePointerBefore, await store.GetActiveAsync(otherService, ViewName).ConfigureAwait(false));
+        Assert.Equal(otherViewCandidateBefore, await store.GetEntriesAsync(ServiceId, otherView, 1).ConfigureAwait(false));
+        Assert.Equal(otherViewCurrentBefore, await store.GetEntriesAsync(ServiceId, otherView, 2).ConfigureAwait(false));
+        Assert.Equal(otherViewPointerBefore, await store.GetActiveAsync(ServiceId, otherView).ConfigureAwait(false));
+    }
+
     public static async Task AssertForcedReverseRaceAsync(MultiProviderFixtureBase fixture)
     {
         var (store, _) = await PrepareAsync(fixture).ConfigureAwait(false);
@@ -279,7 +401,13 @@ internal static class MvGenerationSwitchAssertions
             new FixedServiceIdProvider(ServiceId),
             publisher);
 
-    private static async Task RegisterAsync(IMvRegistryStore store, int version, bool known)
+    private static async Task RegisterAsync(
+        IMvRegistryStore store,
+        int version,
+        bool known,
+        MvStatus status = MvStatus.Ready,
+        string serviceId = ServiceId,
+        string viewName = ViewName)
     {
         var target = MvCheckpointTruth.KnownZero(MvCheckpointProvenance.AuthoritativeTargetCapture());
         var current = known
@@ -289,12 +417,12 @@ internal static class MvGenerationSwitchAssertions
         {
             await store.RegisterAsync(new MvRegistryEntry
             {
-                ServiceId = ServiceId,
-                ViewName = ViewName,
+                ServiceId = serviceId,
+                ViewName = viewName,
                 ViewVersion = version,
                 LogicalTable = table,
-                PhysicalTable = $"generation_v{version}_{table}",
-                Status = MvStatus.Ready,
+                PhysicalTable = $"{serviceId}_{viewName}_v{version}_{table}",
+                Status = status,
                 CurrentPosition = current.PositionValue,
                 TargetPosition = target.PositionValue,
                 CurrentCheckpointTruth = current,

--- a/dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/MvProjectionStatusTargetIsolationTests.cs
+++ b/dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/MvProjectionStatusTargetIsolationTests.cs
@@ -104,7 +104,7 @@ public abstract class MvStatusTargetIsolationTests(MultiProviderFixtureBase fixt
         try
         {
             await cluster.DeployAsync().ConfigureAwait(false);
-            var registration = Assert.Single(hostFactory.GetRegistrations());
+            var registration = Assert.Single(hostFactory.GetRegistrations(), item => item.ViewVersion == 1);
             var grain = cluster.Client.GetGrain<IMaterializedViewGrain>(MvGrainKey.Build(
                 MultiProviderFixtureBase.ServiceId,
                 registration.ViewName,
@@ -129,11 +129,92 @@ public abstract class MvStatusTargetIsolationTests(MultiProviderFixtureBase fixt
         }
     }
 
+    [SkippableFact]
+    public async Task OrleansCoordinator_ForcedReverse_IsDurableAndObservationPerformsZeroTargetIo()
+    {
+        Skip.IfNot(fixture.IsAvailable, fixture.AvailabilityMessage ?? "Integration fixture is unavailable.");
+        await fixture.ResetAsync().ConfigureAwait(false);
+
+        var targetIo = new TargetProviderIoCounter();
+        var registry = new CountingDelegatingMvRegistryStore(
+            fixture.Services.GetRequiredService<IMvRegistryStore>(),
+            targetIo);
+        var statusStore = new CountingProjectionStatusStore(targetIo);
+        var hostFactory = CreateIsolationHostFactory();
+        OrleansTargetIsolationContext.Current = new(
+            hostFactory,
+            CreateProviderExecutor(registry, fixture.Services.GetRequiredService<IOptions<MvOptions>>()),
+            registry,
+            fixture.Services.GetRequiredService<IMvStorageInfoProvider>(),
+            fixture.Services.GetRequiredService<IOptions<MvOptions>>(),
+            statusStore);
+
+        await registry.EnsureInfrastructureAsync().ConfigureAwait(false);
+        var target = MvCheckpointTruth.KnownZero(MvCheckpointProvenance.AuthoritativeTargetCapture());
+        foreach (var version in new[] { 1, 2 })
+        {
+            await registry.RegisterAsync(new MvRegistryEntry
+            {
+                ServiceId = MultiProviderFixtureBase.ServiceId,
+                ViewName = TargetIsolationProjector.ViewNameConst,
+                ViewVersion = version,
+                LogicalTable = "proof",
+                PhysicalTable = $"mv_target_isolation_v{version}_proof",
+                Status = MvStatus.Ready,
+                CurrentCheckpointTruth = version == 1
+                    ? MvCheckpointTruth.Unknown(MvCheckpointUnknownReason.ReadUnavailable)
+                    : MvCheckpointTruth.KnownZero(MvCheckpointProvenance.AppliedEvent(MvApplySource.CatchUp)),
+                TargetCheckpointTruth = target,
+                LastUpdated = DateTimeOffset.UtcNow
+            }).ConfigureAwait(false);
+        }
+        await registry.SetActiveAsync(
+            MultiProviderFixtureBase.ServiceId,
+            TargetIsolationProjector.ViewNameConst,
+            2).ConfigureAwait(false);
+
+        var builder = new TestClusterBuilder();
+        builder.Options.InitialSilosCount = 1;
+        builder.Options.ClusterId = $"mv-generation-switch-{Guid.NewGuid():N}";
+        builder.Options.ServiceId = $"mv-generation-switch-{Guid.NewGuid():N}";
+        builder.AddSiloBuilderConfigurator<OrleansTargetIsolationSiloConfigurator>();
+        builder.AddClientBuilderConfigurator<OrleansTargetIsolationClientConfigurator>();
+        using var cluster = builder.Build();
+        try
+        {
+            await cluster.DeployAsync().ConfigureAwait(false);
+            var coordinator = cluster.Client.GetGrain<IMvGenerationCoordinatorGrain>(
+                MvGenerationCoordinatorGrainKey.Build(
+                    MultiProviderFixtureBase.ServiceId,
+                    TargetIsolationProjector.ViewNameConst));
+
+            var result = await coordinator.ForceReverseAsync(1, 2, 1, "operator retained-generation rollback")
+                .ConfigureAwait(false);
+            Assert.True(result.Succeeded, result.Message);
+            var active = Assert.IsType<MvActiveGenerationStatus>(await coordinator.GetActiveAsync().ConfigureAwait(false));
+            Assert.Equal(1, active.ActiveVersion);
+            Assert.Equal((int)MvSwitchKind.Forced, active.SwitchKind);
+            Assert.Equal("operator retained-generation rollback", active.SwitchReason);
+
+            targetIo.Reset();
+            await AssertReadableThroughExistingG24SurfacesAsync(statusStore, fixture.EventStore).ConfigureAwait(false);
+            Assert.Equal(0, targetIo.FactoryResolutions);
+            Assert.Equal(0, targetIo.OpenCalls);
+            Assert.Equal(0, targetIo.QueryCalls);
+            Assert.Equal(0, targetIo.ProviderCalls);
+        }
+        finally
+        {
+            await cluster.StopAllSilosAsync().ConfigureAwait(false);
+            OrleansTargetIsolationContext.Current = null;
+        }
+    }
+
     private static MvProjectionStatusPublisher CreatePublisher(IProjectionStatusStore statusStore) =>
         new(statusStore, StatusOptions(), NullLogger<MvProjectionStatusPublisher>.Instance);
 
     private IMvApplyHostFactory CreateIsolationHostFactory() => new NativeMvApplyHostFactory(
-        [new TargetIsolationProjector()],
+        [new TargetIsolationProjector(1), new TargetIsolationProjector(2)],
         fixture.DomainTypes.EventTypes,
         fixture.Services.GetRequiredService<IMvStorageInfoProvider>());
 
@@ -230,11 +311,11 @@ public abstract class MvStatusTargetIsolationTests(MultiProviderFixtureBase fixt
         public string GetCurrentServiceId() => serviceId;
     }
 
-    private sealed class TargetIsolationProjector : IMaterializedViewProjector
+    private sealed class TargetIsolationProjector(int version) : IMaterializedViewProjector
     {
         public const string ViewNameConst = "MvStatusTargetIsolation";
         public string ViewName => ViewNameConst;
-        public int ViewVersion => 1;
+        public int ViewVersion => version;
 
         public async Task InitializeAsync(IMvInitContext context, CancellationToken cancellationToken = default)
         {
@@ -429,6 +510,15 @@ internal sealed class CountingDelegatingMvRegistryStore : IMvRegistryStore
         return _inner.TryActivateAsync(request, transaction, cancellationToken);
     }
 
+    public Task<MvActivationResult> TryForceReverseAsync(
+        MvForcedReverseRequest request,
+        IDbTransaction? transaction = null,
+        CancellationToken cancellationToken = default)
+    {
+        Count(query: true);
+        return _inner.TryForceReverseAsync(request, transaction, cancellationToken);
+    }
+
     public Task SetActiveAsync(
         string serviceId,
         string viewName,
@@ -478,6 +568,7 @@ internal sealed class OrleansTargetIsolationSiloConfigurator : ISiloConfigurator
                 services.AddSingleton<IProjectionStatusStore>(context.StatusStore);
                 services.AddSingleton(MvStatusTargetIsolationTests.StatusOptionsForSilo());
                 services.AddSingleton<MvProjectionStatusPublisher>();
+                services.AddSingleton<IMvGenerationCoordinator, MvGenerationCoordinator>();
                 services.AddSingleton<IServiceIdProvider>(new FixedOrleansServiceIdProvider(MultiProviderFixtureBase.ServiceId));
                 services.AddSingleton<IEventSubscriptionResolver>(
                     new DefaultOrleansEventSubscriptionResolver("EventStreamProvider", "AllEvents", Guid.Empty));

--- a/dcb/tests/Sekiban.Dcb.MaterializedView.Tests/MvProjectionStatusPublicationTests.cs
+++ b/dcb/tests/Sekiban.Dcb.MaterializedView.Tests/MvProjectionStatusPublicationTests.cs
@@ -153,6 +153,41 @@ public class MvProjectionStatusPublicationTests
             ServiceId, ViewName, ViewVersion, snapshot, MvProjectionStatusPublisherKind.HostedWorker);
     }
 
+    [Fact]
+    public async Task SwitchAudit_RemainsOnSubsequentCadence_AndOrdinarySwitchClearsForcedReason()
+    {
+        var store = new ObservingStatusStore(new FixedServiceIdProvider(ServiceId));
+        var options = StatusOptions();
+        options.HeartbeatInterval = TimeSpan.Zero;
+        var publisher = new MvProjectionStatusPublisher(store, options, NullLogger<MvProjectionStatusPublisher>.Instance);
+        var now = DateTimeOffset.UtcNow;
+        var progress = new MvProjectionStatusSnapshot(MvCheckpointTruth.KnownZero(), MvStatus.Active, 1);
+
+        await publisher.PublishSwitchAsync(
+            ServiceId,
+            ViewName,
+            ViewVersion,
+            progress with { SwitchKind = MvSwitchKind.Forced, SwitchReason = "operator rollback", SwitchedAtUtc = now },
+            MvProjectionStatusPublisherKind.HostedWorker);
+        await publisher.PublishIfDueAsync(
+            ServiceId, ViewName, ViewVersion, progress, MvProjectionStatusPublisherKind.HostedWorker);
+        var afterCadence = Assert.Single((await store.ListAsync()).GetValue());
+        Assert.Equal("forced", afterCadence.SwitchKind);
+        Assert.Equal("operator rollback", afterCadence.SwitchReason);
+
+        await publisher.PublishSwitchAsync(
+            ServiceId,
+            ViewName,
+            ViewVersion,
+            progress with { SwitchKind = MvSwitchKind.Forward, SwitchedAtUtc = now.AddSeconds(1) },
+            MvProjectionStatusPublisherKind.HostedWorker);
+        await publisher.PublishIfDueAsync(
+            ServiceId, ViewName, ViewVersion, progress, MvProjectionStatusPublisherKind.HostedWorker);
+        var afterOrdinary = Assert.Single((await store.ListAsync()).GetValue());
+        Assert.Equal("forward", afterOrdinary.SwitchKind);
+        Assert.Null(afterOrdinary.SwitchReason);
+    }
+
     [Theory]
     [InlineData("postgres")]
     [InlineData("mysql")]

--- a/dcb/tests/Sekiban.Dcb.Orleans.Tests/MaterializedViewGrainTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Orleans.Tests/MaterializedViewGrainTests.cs
@@ -147,13 +147,42 @@ public class MaterializedViewGrainTests : IAsyncLifetime
     [Fact]
     public async Task MvOrleansQueryAccessor_Should_Return_Runtime_Context()
     {
+        await SharedRegistry.RegisterAsync(new MvRegistryEntry
+        {
+            ServiceId = DefaultServiceIdProvider.DefaultServiceId,
+            ViewName = TestMaterializedViewProjector.ViewNameConst,
+            ViewVersion = 1,
+            LogicalTable = "main",
+            PhysicalTable = "test_mv_v1_main",
+            Status = MvStatus.Ready,
+            CurrentCheckpointTruth = MvCheckpointTruth.KnownZero(MvCheckpointProvenance.AppliedEvent(MvApplySource.CatchUp)),
+            TargetCheckpointTruth = MvCheckpointTruth.KnownZero(MvCheckpointProvenance.AuthoritativeTargetCapture()),
+            LastUpdated = DateTimeOffset.UtcNow
+        });
+        await SharedRegistry.RegisterAsync(new MvRegistryEntry
+        {
+            ServiceId = DefaultServiceIdProvider.DefaultServiceId,
+            ViewName = TestMaterializedViewProjector.ViewNameConst,
+            ViewVersion = 2,
+            LogicalTable = "main",
+            PhysicalTable = "test_mv_v2_main",
+            Status = MvStatus.Ready,
+            CurrentCheckpointTruth = MvCheckpointTruth.KnownZero(MvCheckpointProvenance.AppliedEvent(MvApplySource.CatchUp)),
+            TargetCheckpointTruth = MvCheckpointTruth.KnownZero(MvCheckpointProvenance.AuthoritativeTargetCapture()),
+            LastUpdated = DateTimeOffset.UtcNow
+        });
+        await SharedRegistry.SetActiveAsync(
+            DefaultServiceIdProvider.DefaultServiceId,
+            TestMaterializedViewProjector.ViewNameConst,
+            2);
         var accessor = new MvOrleansQueryAccessor(
             _cluster.Client,
             SharedRegistry,
             new DefaultServiceIdProvider(),
             new MvStorageInfoProvider(new MvStorageInfo(MvDbType.Postgres, "Host=test;Database=mv;")));
 
-        var context = await accessor.GetAsync(new TestMaterializedViewProjector());
+        var callerVersionOne = new TestMaterializedViewProjector();
+        var context = await accessor.GetAsync(callerVersionOne);
         var table = context.GetRequiredTable("main");
 
         Assert.Equal(DefaultServiceIdProvider.DefaultServiceId, context.ServiceId);
@@ -161,6 +190,13 @@ public class MaterializedViewGrainTests : IAsyncLifetime
         Assert.Equal("Host=test;Database=mv;", context.ConnectionString);
         Assert.True(context.Entries.Count > 0);
         Assert.Equal("main", table.LogicalTable);
+        Assert.Equal(2, context.ViewVersion);
+        Assert.Equal(2, Assert.IsType<MvActiveEntry>(context.ActivePointer).ActiveVersion);
+        Assert.Equal("test_mv_v2_main", table.PhysicalTable);
+
+        var pinned = await accessor.GetPinnedAsync(callerVersionOne);
+        Assert.Equal(1, pinned.ViewVersion);
+        Assert.Null(pinned.ActivePointer);
     }
 
     [Fact]
@@ -227,6 +263,7 @@ public class MaterializedViewGrainTests : IAsyncLifetime
                         options.CatchUpStallThreshold = TimeSpan.FromMilliseconds(150);
                     });
                     services.AddMaterializedView<TestMaterializedViewProjector>();
+                    services.AddMaterializedView<TestMaterializedViewProjectorV2>();
                     services.AddSekibanDcbMaterializedViewOrleans(activateOnStartup: false);
                     services.AddSingleton<IMvRegistryStore>(SharedRegistry);
                     services.AddSingleton<IMvExecutor>(SharedExecutor);
@@ -306,6 +343,21 @@ public class MaterializedViewGrainTests : IAsyncLifetime
 
         public string ViewName => ViewNameConst;
         public int ViewVersion => 1;
+
+        public Task InitializeAsync(IMvInitContext ctx, CancellationToken cancellationToken = default) =>
+            Task.CompletedTask;
+
+        public Task<IReadOnlyList<MvSqlStatement>> ApplyToViewAsync(
+            Event ev,
+            IMvApplyContext ctx,
+            CancellationToken cancellationToken = default) =>
+            Task.FromResult<IReadOnlyList<MvSqlStatement>>([]);
+    }
+
+    private sealed class TestMaterializedViewProjectorV2 : IMaterializedViewProjector
+    {
+        public string ViewName => TestMaterializedViewProjector.ViewNameConst;
+        public int ViewVersion => 2;
 
         public Task InitializeAsync(IMvInitContext ctx, CancellationToken cancellationToken = default) =>
             Task.CompletedTask;

--- a/docs/dcb_llm/05_query.md
+++ b/docs/dcb_llm/05_query.md
@@ -122,5 +122,9 @@ This pattern gives you:
 - the active physical table name for each logical table
 - the Orleans grain that can report status or wait for stream delivery
 
+`GetAsync` always resolves the active version once per operation; the projector's declared version does not pin an
+ordinary read. For an operator diagnostic against one retained generation, call the separately named
+`GetPinnedAsync(projector)` and make that exceptional routing choice explicit at the call site.
+
 For the current sample, see `internalUsages/DcbOrleans.WithoutResult.ApiService/Program.cs`. For the full concept and
 setup sequence, see [Materialized View Basics](20_materialized_view.md).

--- a/docs/dcb_llm/20_materialized_view.md
+++ b/docs/dcb_llm/20_materialized_view.md
@@ -304,6 +304,26 @@ superseded attempt returns a typed conflict and leaves the former pointer unchan
 capture, eligibility, and compare-and-switch path, so absence of an active row is only an expected input—not an
 authorization.
 
+### Parallel generations, switching, and rollback (SEK-G29)
+
+`IMvGenerationCoordinator` prepares and switches one exact `(service, view)` at a time. Preparing N+1 uses the existing
+per-version apply engine and does not clear, share a checkpoint with, or stop the active N generation. An ordinary
+`SwitchAsync` is the only forward or reverse path: it applies the SEK-G27 authoritative eligibility rules and the
+provider's atomic active-version/generation compare-and-switch. A failed, stale, or concurrent request leaves the active
+pointer unchanged. The previous generation and its physical tables remain available for diagnostics and an eligible
+ordinary reverse switch.
+
+`MvOrleansQueryAccessor.GetAsync` resolves the active pointer once at the start of an ordinary read and returns entries
+and the Orleans grain for that version. Use the separately named `GetPinnedAsync` only for explicit version diagnostics;
+passing a projector version to `GetAsync` does not override ordinary active routing.
+
+Break-glass rollback is deliberately a different API: `ForceReverseAsync`. It is reverse-only and may waive only
+checkpoint freshness/truth. The retained version must exist with the exact service/view/version identity and a safe
+`Ready` lifecycle, and the expected active version plus generation are still fenced atomically. A forced switch durably
+records `switch_kind=forced`, the operator-supplied reason, and timestamp. That metadata is pushed through the existing
+G24 typed and V1 serialized observation surfaces on the lifecycle publication seam; reading it never opens or queries
+the MV target database. There is no forced-forward flag or mode on the ordinary API.
+
 ## Querying the Tables
 
 Applications should not hardcode the physical table name. Use `IMvOrleansQueryAccessor` to resolve it.

--- a/docs/dcb_llm_ja/05_query.md
+++ b/docs/dcb_llm_ja/05_query.md
@@ -118,5 +118,9 @@ var rows = await connection.QueryAsync<WeatherForecastMvRow>(
 - logical table に対応する active な physical table 名
 - status 確認や待機に使える Orleans grain
 
+`GetAsync` は操作ごとに active version を 1 回解決し、projector が宣言する version で通常 read を pin しません。保持した
+特定 generation を operator 診断で読む場合だけ、別名の `GetPinnedAsync(projector)` を呼び、例外的な routing 選択を
+call site で明示してください。
+
 実例は `internalUsages/DcbOrleans.WithoutResult.ApiService/Program.cs` を参照してください。全体像は
 [マテリアライズドビュー基礎](20_materialized_view.md) にまとめています。

--- a/docs/dcb_llm_ja/20_materialized_view.md
+++ b/docs/dcb_llm_ja/20_materialized_view.md
@@ -306,6 +306,25 @@ active version と単調増加する generation、さらに candidate の checkp
 された試行は型付き conflict を返し、以前の pointer を保持します。初回 activation も同じ capture、eligibility、
 compare-and-switch 経路を通るため、active 行がないことは許可ではなく、比較対象の一つに過ぎません。
 
+### 並行 generation、切替、rollback（SEK-G29）
+
+`IMvGenerationCoordinator` は、厳密な 1 つの `(service, view)` ごとに generation の準備と切替を調停します。N+1 の
+準備には既存の version 別 apply engine を使い、active な N を clear したり checkpoint を共有したり停止したりしません。
+通常の forward / reverse は `SwitchAsync` だけを使い、SEK-G27 の権威的 eligibility と provider の atomic な
+active-version/generation compare-and-switch を通ります。失敗、stale、競合した要求では active pointer は変わりません。
+以前の generation と物理 table は診断と、eligible な通常 reverse のために保持されます。
+
+通常 read の `MvOrleansQueryAccessor.GetAsync` は操作開始時に active pointer を 1 回解決し、その version の entries と
+Orleans grain を返します。明示的な version 診断だけは別名の `GetPinnedAsync` を使います。`GetAsync` に渡す projector の
+version で通常の active routing を上書きすることはできません。
+
+break-glass rollback は別 API の `ForceReverseAsync` です。reverse 専用で、免除できるのは checkpoint の freshness/truth
+だけです。保持した version は厳密な service/view/version identity で存在し、安全な `Ready` lifecycle である必要があり、
+期待する active version と generation は引き続き atomic に fence されます。forced switch は `switch_kind=forced`、operator
+が指定した reason、timestamp を永続化します。この metadata は lifecycle publication seam から既存の G24 typed / V1
+serialized observation へ push され、read 時に MV target database を open/query しません。通常 API に forced-forward の
+flag や mode はありません。
+
 ## テーブルのクエリ方法
 
 物理テーブル名をアプリ側で決め打ちしないでください。`IMvOrleansQueryAccessor` を使って解決します。

--- a/docs/decisions/SEK-G29-materialized-view-generation-switching.md
+++ b/docs/decisions/SEK-G29-materialized-view-generation-switching.md
@@ -1,0 +1,22 @@
+# SEK-G29: Materialized-view generation switching
+
+Status: Accepted
+
+## Decision
+
+Sekiban coordinates materialized-view generations per exact service and view. Each version keeps independent physical
+tables, progress, and apply machinery. Ordinary reads resolve the durable active pointer once per operation; version-pinned
+reads use a separately named diagnostics API.
+
+Forward and ordinary reverse switches use the SEK-G27 eligibility boundary and provider-atomic expected-active/generation
+CAS. The old generation is retained. Break-glass rollback is a separate reverse-only operation that waives only checkpoint
+freshness/truth while preserving identity, lifecycle, existence, and CAS fencing. It durably records forced kind, reason,
+and timestamp and pushes that audit state through the existing G24/G28 source-side observation surface.
+
+## Consequences
+
+- Catch-up and serving can proceed concurrently without sharing checkpoints or adding an apply engine.
+- Restart and cross-process safety depend on the provider CAS; process and grain single-flight only bound local work.
+- A caller cannot force a forward switch or smuggle a force flag into ordinary activation.
+- Observation remains passive and does not resolve, open, or query an MV target database.
+- Retained generations consume storage until a future, explicitly out-of-scope cleanup policy removes them.


### PR DESCRIPTION
## Summary
- add provider-neutral generation coordination with explicit active-pointer routing and separately named reverse-only break-glass API
- persist atomic ordinary/forced switch metadata across PostgreSQL, MySQL, SQL Server, and SQLite and publish it through the existing G28/G24 typed and V1 surfaces
- add production hosted/Orleans, four-provider CAS/race/restart, routing, observation, compatibility, and EN/JA documentation coverage

## Validation
- Release solution build: 0 errors
- CI-equivalent DCB net9: 1,401 passed, 1 known skipped, 0 failed
- CI-equivalent DCB net10: 1,401 passed, 1 known skipped, 0 failed (Azurite startup transient rerun: 4/4 passed)
- MaterializedView unit: 69/69 on net9 and net10
- MultiProvider: 73/73 on net9 and net10
- changed-source dotnet format verification and git diff --check passed

Closes #1115