### PR TITLE
SEK-G31: make SortableUniqueId generation monotonic

### DIFF
--- a/dcb/src/Sekiban.Dcb.Core.Model/Common/ISortableUniqueIdGenerator.cs
+++ b/dcb/src/Sekiban.Dcb.Core.Model/Common/ISortableUniqueIdGenerator.cs
@@ -1,0 +1,128 @@
+using Microsoft.Extensions.Logging;
+
+namespace Sekiban.Dcb.Common;
+
+/// <summary>Allocates strictly increasing SortableUniqueIds within one process and accepts persisted tick seeds.</summary>
+public interface ISortableUniqueIdGenerator
+{
+    /// <summary>Allocates a new 30-digit SortableUniqueId using a fresh random suffix.</summary>
+    string GenerateNew();
+
+    /// <summary>Atomically advances the logical tick floor without allocating an id.</summary>
+    void Seed(long ticks);
+}
+
+/// <summary>
+///     TimeProvider-backed monotonic SortableUniqueId generator. Logical ticks advance through a CAS loop, so clock
+///     rollback and concurrent callers cannot make a later allocation sort before an earlier allocation.
+/// </summary>
+public sealed class MonotonicSortableUniqueIdGenerator : ISortableUniqueIdGenerator
+{
+    private static readonly TimeSpan RollbackWarningInterval = TimeSpan.FromMinutes(1);
+    private readonly ILogger<MonotonicSortableUniqueIdGenerator> _logger;
+    private readonly TimeProvider _timeProvider;
+    private long _lastLogicalTicks = DateTime.MinValue.Ticks;
+    private long _lastObservedUtcTicks = DateTime.MinValue.Ticks;
+    private long _lastRollbackWarningTimestamp = long.MinValue;
+
+    /// <summary>Creates the default generator with <see cref="TimeProvider.System"/>.</summary>
+    public MonotonicSortableUniqueIdGenerator() : this(TimeProvider.System)
+    {
+    }
+
+    /// <summary>Creates a generator using the supplied time source.</summary>
+    public MonotonicSortableUniqueIdGenerator(TimeProvider timeProvider)
+        : this(timeProvider, Microsoft.Extensions.Logging.Abstractions.NullLogger<MonotonicSortableUniqueIdGenerator>.Instance)
+    {
+    }
+
+    /// <summary>Creates a generator using the supplied time source and rollback logger.</summary>
+    public MonotonicSortableUniqueIdGenerator(
+        TimeProvider timeProvider,
+        ILogger<MonotonicSortableUniqueIdGenerator> logger)
+    {
+        _timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    public string GenerateNew()
+    {
+        var nowTicks = _timeProvider.GetUtcNow().UtcTicks;
+        DetectClockRollback(nowTicks);
+
+        while (true)
+        {
+            var observed = Volatile.Read(ref _lastLogicalTicks);
+            if (observed == DateTime.MaxValue.Ticks)
+            {
+                throw new InvalidOperationException("SortableUniqueId logical ticks are exhausted at DateTime.MaxValue.Ticks.");
+            }
+
+            var next = Math.Max(nowTicks, observed + 1);
+            if (Interlocked.CompareExchange(ref _lastLogicalTicks, next, observed) == observed)
+            {
+                return SortableUniqueId.Generate(new DateTime(next, DateTimeKind.Utc), Guid.NewGuid());
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    public void Seed(long ticks)
+    {
+        if (ticks < DateTime.MinValue.Ticks || ticks > DateTime.MaxValue.Ticks)
+        {
+            throw new ArgumentOutOfRangeException(nameof(ticks));
+        }
+
+        while (true)
+        {
+            var observed = Volatile.Read(ref _lastLogicalTicks);
+            if (ticks <= observed || Interlocked.CompareExchange(ref _lastLogicalTicks, ticks, observed) == observed)
+            {
+                return;
+            }
+        }
+    }
+
+    private void DetectClockRollback(long nowTicks)
+    {
+        while (true)
+        {
+            var observedPhysical = Volatile.Read(ref _lastObservedUtcTicks);
+            if (nowTicks < observedPhysical)
+            {
+                LogRollbackRateLimited(observedPhysical, nowTicks);
+                return;
+            }
+
+            if (nowTicks == observedPhysical ||
+                Interlocked.CompareExchange(ref _lastObservedUtcTicks, nowTicks, observedPhysical) == observedPhysical)
+            {
+                return;
+            }
+        }
+    }
+
+    private void LogRollbackRateLimited(long previousTicks, long currentTicks)
+    {
+        var timestamp = _timeProvider.GetTimestamp();
+        while (true)
+        {
+            var last = Volatile.Read(ref _lastRollbackWarningTimestamp);
+            if (last != long.MinValue && _timeProvider.GetElapsedTime(last, timestamp) < RollbackWarningInterval)
+            {
+                return;
+            }
+
+            if (Interlocked.CompareExchange(ref _lastRollbackWarningTimestamp, timestamp, last) == last)
+            {
+                _logger.LogWarning(
+                    "System UTC clock moved backwards from {PreviousUtcTicks} to {CurrentUtcTicks}; SortableUniqueId logical ticks remain monotonic.",
+                    previousTicks,
+                    currentTicks);
+                return;
+            }
+        }
+    }
+}

--- a/dcb/src/Sekiban.Dcb.Core.Model/Common/SortableUniqueId.cs
+++ b/dcb/src/Sekiban.Dcb.Core.Model/Common/SortableUniqueId.cs
@@ -8,8 +8,10 @@ namespace Sekiban.Dcb.Common;
 /// </summary>
 public record SortableUniqueId(string Value)
 {
-    /// <summary>The process-wide allocator used by the legacy static API.</summary>
-    public static ISortableUniqueIdGenerator DefaultGenerator { get; } = new MonotonicSortableUniqueIdGenerator();
+    private static readonly ISortableUniqueIdGenerator ProcessSharedGenerator =
+        new MonotonicSortableUniqueIdGenerator();
+
+    internal static ISortableUniqueIdGenerator GetProcessSharedGenerator() => ProcessSharedGenerator;
     public const int SafeMilliseconds = 5000;
     public const int TickNumberOfLength = 19;
     public const int IdNumberOfLength = 11;
@@ -65,7 +67,7 @@ public record SortableUniqueId(string Value)
     /// <summary>
     ///     Generate Sortable Unique Id from Current UTC time and new Guid
     /// </summary>
-    public static string GenerateNew() => DefaultGenerator.GenerateNew();
+    public static string GenerateNew() => ProcessSharedGenerator.GenerateNew();
 
     /// <summary>
     ///     Generate Safe Sortable Unique Id from Current UTC.

--- a/dcb/src/Sekiban.Dcb.Core.Model/Common/SortableUniqueId.cs
+++ b/dcb/src/Sekiban.Dcb.Core.Model/Common/SortableUniqueId.cs
@@ -8,6 +8,8 @@ namespace Sekiban.Dcb.Common;
 /// </summary>
 public record SortableUniqueId(string Value)
 {
+    /// <summary>The process-wide allocator used by the legacy static API.</summary>
+    public static ISortableUniqueIdGenerator DefaultGenerator { get; } = new MonotonicSortableUniqueIdGenerator();
     public const int SafeMilliseconds = 5000;
     public const int TickNumberOfLength = 19;
     public const int IdNumberOfLength = 11;
@@ -63,7 +65,7 @@ public record SortableUniqueId(string Value)
     /// <summary>
     ///     Generate Sortable Unique Id from Current UTC time and new Guid
     /// </summary>
-    public static string GenerateNew() => Generate(DateTime.UtcNow, Guid.NewGuid());
+    public static string GenerateNew() => DefaultGenerator.GenerateNew();
 
     /// <summary>
     ///     Generate Safe Sortable Unique Id from Current UTC.

--- a/dcb/src/Sekiban.Dcb.Core.Model/Sekiban.Dcb.Core.Model.csproj
+++ b/dcb/src/Sekiban.Dcb.Core.Model/Sekiban.Dcb.Core.Model.csproj
@@ -40,4 +40,10 @@
         </PackageReference>
     </ItemGroup>
 
+    <ItemGroup>
+        <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+            <_Parameter1>Sekiban.Dcb.Core</_Parameter1>
+        </AssemblyAttribute>
+    </ItemGroup>
+
 </Project>

--- a/dcb/src/Sekiban.Dcb.Core.Model/Sekiban.Dcb.Core.Model.csproj
+++ b/dcb/src/Sekiban.Dcb.Core.Model/Sekiban.Dcb.Core.Model.csproj
@@ -33,6 +33,7 @@
     <ItemGroup>
         <PackageReference Include="ResultBoxes" Version="0.4.0"/>
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.3" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.3" />
         <PackageReference Include="Microsoft.Sbom.Targets" Version="4.1.5">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/dcb/src/Sekiban.Dcb.Core/Actors/CoreGeneralSekibanExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Actors/CoreGeneralSekibanExecutor.cs
@@ -4,6 +4,7 @@ using Sekiban.Dcb.Common;
 using Sekiban.Dcb.Events;
 using Sekiban.Dcb.MultiProjections;
 using Sekiban.Dcb.Queries;
+using Sekiban.Dcb.ServiceId;
 using Sekiban.Dcb.Storage;
 using Sekiban.Dcb.Tags;
 using Sekiban.Dcb.Validation;
@@ -25,6 +26,9 @@ public class CoreGeneralSekibanExecutor
     private readonly DcbDomainTypes _domainTypes;
     private readonly IEventPublisher? _eventPublisher;
     private readonly IEventStore _eventStore;
+    private readonly IServiceIdProvider _serviceIdProvider;
+    private readonly ISortableUniqueIdGenerator _sortableUniqueIdGenerator;
+    private readonly SortableUniqueIdSeedCoordinator _sortableUniqueIdSeedCoordinator;
 
     /// <summary>
     ///     Test seam ONLY (never set in production): the EventId / SortableUniqueId generators used by the serialized
@@ -33,7 +37,7 @@ public class CoreGeneralSekibanExecutor
     ///     generators, so production behaviour is unchanged.
     /// </summary>
     internal Func<Guid> ConditionalEventIdFactory { get; set; } = Guid.CreateVersion7;
-    internal Func<string> ConditionalSortableIdFactory { get; set; } = () => SortableUniqueId.GenerateNew();
+    internal Func<string>? ConditionalSortableIdFactory { get; set; }
 
     private const string DefaultExecutedUser = "GeneralSekibanExecutor";
     private const string SerializedExecutedUser = "SerializedSekibanExecutor";
@@ -57,12 +61,45 @@ public class CoreGeneralSekibanExecutor
         DcbDomainTypes domainTypes,
         IEventPublisher? eventPublisher = null,
         IExecutedUserProvider? executedUserProvider = null)
+        : this(
+            eventStore,
+            actorAccessor,
+            domainTypes,
+            eventPublisher,
+            executedUserProvider,
+            SortableUniqueId.DefaultGenerator,
+            new SortableUniqueIdSeedCoordinator(SortableUniqueId.DefaultGenerator),
+            new DefaultServiceIdProvider())
+    {
+    }
+
+    /// <summary>Creates an executor with the process-wide allocator and retryable service-head seed coordinator.</summary>
+    public CoreGeneralSekibanExecutor(
+        IEventStore eventStore,
+        IActorObjectAccessor actorAccessor,
+        DcbDomainTypes domainTypes,
+        IEventPublisher? eventPublisher,
+        IExecutedUserProvider? executedUserProvider,
+        ISortableUniqueIdGenerator sortableUniqueIdGenerator,
+        SortableUniqueIdSeedCoordinator sortableUniqueIdSeedCoordinator,
+        IServiceIdProvider serviceIdProvider)
     {
         _eventStore = eventStore ?? throw new ArgumentNullException(nameof(eventStore));
         _actorAccessor = actorAccessor ?? throw new ArgumentNullException(nameof(actorAccessor));
         _domainTypes = domainTypes ?? throw new ArgumentNullException(nameof(domainTypes));
         _eventPublisher = eventPublisher;
         _executedUserProvider = executedUserProvider;
+        _sortableUniqueIdGenerator = sortableUniqueIdGenerator ??
+                                     throw new ArgumentNullException(nameof(sortableUniqueIdGenerator));
+        _sortableUniqueIdSeedCoordinator = sortableUniqueIdSeedCoordinator ??
+                                           throw new ArgumentNullException(nameof(sortableUniqueIdSeedCoordinator));
+        _serviceIdProvider = serviceIdProvider ?? throw new ArgumentNullException(nameof(serviceIdProvider));
+    }
+
+    private Task EnsureSortableUniqueIdSeededAsync(CancellationToken cancellationToken)
+    {
+        var serviceId = ServiceIdValidator.NormalizeAndValidate(_serviceIdProvider.GetCurrentServiceId());
+        return _sortableUniqueIdSeedCoordinator.EnsureSeededAsync(serviceId, _eventStore, cancellationToken);
     }
 
     private string GetExecutedUser()
@@ -137,6 +174,9 @@ public class CoreGeneralSekibanExecutor
             // Step 3.1: Validate all tags
             TagValidator.ValidateTagsAndThrow(allTags);
 
+            // Establish the persisted floor before any reservation, id allocation, or write.
+            await EnsureSortableUniqueIdSeededAsync(cancellationToken);
+
             // Step 4: According to spec:
             //  - If tag.IsConsistencyTag() == false -> DO NOT reserve (skip)
             //  - If tag.IsConsistencyTag() == true AND tag is ConsistencyTag with SortableUniqueId present -> use that SortableUniqueId
@@ -210,7 +250,7 @@ public class CoreGeneralSekibanExecutor
                 foreach (var e in collectedEvents)
                 {
                     var eId = Guid.CreateVersion7();
-                    var sortable = SortableUniqueId.GenerateNew();
+                    var sortable = _sortableUniqueIdGenerator.GenerateNew();
                     var meta = new EventMetadata(eId.ToString(), command.GetType().Name, executedUser);
                     events.Add(
                         new Event(
@@ -447,6 +487,9 @@ public class CoreGeneralSekibanExecutor
 
             TagValidator.ValidateTagsAndThrow(allTags);
 
+            // Establish the persisted floor before any reservation, id allocation, or write.
+            await EnsureSortableUniqueIdSeededAsync(cancellationToken);
+
             // Step 3: Reserve consistency tags
             var reservations = new Dictionary<ITag, TagWriteReservation>();
             var failedReservations = new List<(ITag Tag, Exception Error)>();
@@ -492,7 +535,7 @@ public class CoreGeneralSekibanExecutor
                 foreach (var candidate in request.EventCandidates)
                 {
                     var eventId = ConditionalEventIdFactory();
-                    var sortableId = ConditionalSortableIdFactory();
+                    var sortableId = (ConditionalSortableIdFactory ?? _sortableUniqueIdGenerator.GenerateNew)();
                     var metadata = new EventMetadata(eventId.ToString(), "SerializedCommit", "SerializedSekibanExecutor");
 
                     serializableEvents.Add(new SerializableEvent(
@@ -976,9 +1019,11 @@ public class CoreGeneralSekibanExecutor
             var single = collectedEvents[0];
             TagValidator.ValidateTagsAndThrow(new HashSet<ITag>(single.Tags));
 
+            await EnsureSortableUniqueIdSeededAsync(cancellationToken);
+
             var executedUser = GetExecutedUser();
             var eventId = ConditionalEventIdFactory();
-            var sortable = SortableUniqueId.GenerateNew();
+            var sortable = _sortableUniqueIdGenerator.GenerateNew();
             var metadata = new EventMetadata(eventId.ToString(), command.GetType().Name, executedUser);
             var domainEvent = new Event(
                 single.Event,
@@ -1064,8 +1109,9 @@ public class CoreGeneralSekibanExecutor
             }
 
             var candidate = request.EventCandidate;
+            await EnsureSortableUniqueIdSeededAsync(cancellationToken);
             var eventId = ConditionalEventIdFactory();
-            var sortableId = ConditionalSortableIdFactory();
+            var sortableId = (ConditionalSortableIdFactory ?? _sortableUniqueIdGenerator.GenerateNew)();
             var metadata = new EventMetadata(eventId.ToString(), "SerializedConditionalCommit", "SerializedSekibanExecutor");
             var serializable = new SerializableEvent(
                 candidate.Payload,

--- a/dcb/src/Sekiban.Dcb.Core/Actors/CoreGeneralSekibanExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Actors/CoreGeneralSekibanExecutor.cs
@@ -67,8 +67,8 @@ public class CoreGeneralSekibanExecutor
             domainTypes,
             eventPublisher,
             executedUserProvider,
-            SortableUniqueId.DefaultGenerator,
-            new SortableUniqueIdSeedCoordinator(SortableUniqueId.DefaultGenerator),
+            ProcessSharedSortableUniqueIdServices.Generator,
+            ProcessSharedSortableUniqueIdServices.SeedCoordinator,
             new DefaultServiceIdProvider())
     {
     }

--- a/dcb/src/Sekiban.Dcb.Core/Actors/ProjectionStatusServiceCollectionExtensions.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Actors/ProjectionStatusServiceCollectionExtensions.cs
@@ -16,6 +16,7 @@ public static class ProjectionStatusServiceCollectionExtensions
     /// </summary>
     public static IServiceCollection AddSekibanDcbProjectionStatusReader(this IServiceCollection services)
     {
+        services.AddSekibanDcbSortableUniqueIdGenerator();
         services.TryAddSingleton<ProjectionStatusOptions>();
         services.TryAddSingleton<ProjectionStatusReadWindowCache>();
         services.TryAddTransient<IProjectionStatusReader>(serviceProvider =>

--- a/dcb/src/Sekiban.Dcb.Core/Actors/SortableUniqueIdSeedCoordinator.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Actors/SortableUniqueIdSeedCoordinator.cs
@@ -1,0 +1,96 @@
+using System.Collections.Concurrent;
+using ResultBoxes;
+using Sekiban.Dcb.Common;
+using Sekiban.Dcb.ServiceId;
+using Sekiban.Dcb.Storage;
+
+namespace Sekiban.Dcb.Actors;
+
+/// <summary>Typed failure raised when an executor cannot establish its service's persisted SortableUniqueId floor.</summary>
+public sealed class SortableUniqueIdSeedException : InvalidOperationException
+{
+    public SortableUniqueIdSeedException(string serviceId, string message, Exception? innerException = null)
+        : base(message, innerException) => ServiceId = serviceId;
+
+    public string ServiceId { get; }
+}
+
+/// <summary>Coordinates one retryable, single-flight store-head seed per normalized service id.</summary>
+public sealed class SortableUniqueIdSeedCoordinator
+{
+    private readonly ConcurrentDictionary<string, Lazy<Task>> _seeds = new(StringComparer.Ordinal);
+    private readonly ISortableUniqueIdGenerator _generator;
+
+    public SortableUniqueIdSeedCoordinator(ISortableUniqueIdGenerator generator) =>
+        _generator = generator ?? throw new ArgumentNullException(nameof(generator));
+
+    public async Task EnsureSeededAsync(
+        string serviceId,
+        IEventStore eventStore,
+        CancellationToken cancellationToken = default)
+    {
+        var normalizedServiceId = ServiceIdValidator.NormalizeAndValidate(serviceId);
+        ArgumentNullException.ThrowIfNull(eventStore);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var seed = _seeds.GetOrAdd(
+            normalizedServiceId,
+            _ => new Lazy<Task>(
+                () => SeedCoreAsync(normalizedServiceId, eventStore, cancellationToken),
+                LazyThreadSafetyMode.ExecutionAndPublication));
+        try
+        {
+            await seed.Value.ConfigureAwait(false);
+        }
+        catch
+        {
+            _seeds.TryRemove(new KeyValuePair<string, Lazy<Task>>(normalizedServiceId, seed));
+            throw;
+        }
+    }
+
+    private async Task SeedCoreAsync(string serviceId, IEventStore eventStore, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        ResultBox<string> result;
+        try
+        {
+            result = await eventStore.GetLatestSortableUniqueIdAsync().ConfigureAwait(false);
+        }
+        catch (Exception exception)
+        {
+            throw new SortableUniqueIdSeedException(
+                serviceId,
+                $"Failed to read the persisted SortableUniqueId head for service '{serviceId}'.",
+                exception);
+        }
+
+        if (!result.IsSuccess)
+        {
+            throw new SortableUniqueIdSeedException(
+                serviceId,
+                $"Failed to read the persisted SortableUniqueId head for service '{serviceId}'.",
+                result.GetException());
+        }
+
+        var head = result.GetValue();
+        if (string.IsNullOrEmpty(head))
+        {
+            return;
+        }
+
+        if (!SortableUniqueId.TryParse(head, out _) ||
+            !long.TryParse(
+                head.AsSpan(0, SortableUniqueId.TickNumberOfLength),
+                System.Globalization.NumberStyles.None,
+                System.Globalization.CultureInfo.InvariantCulture,
+                out var ticks))
+        {
+            throw new SortableUniqueIdSeedException(
+                serviceId,
+                $"The persisted SortableUniqueId head for service '{serviceId}' is malformed.");
+        }
+
+        _generator.Seed(ticks);
+    }
+}

--- a/dcb/src/Sekiban.Dcb.Core/Actors/SortableUniqueIdServiceCollectionExtensions.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Actors/SortableUniqueIdServiceCollectionExtensions.cs
@@ -5,6 +5,14 @@ using Sekiban.Dcb.Common;
 
 namespace Sekiban.Dcb.Actors;
 
+internal static class ProcessSharedSortableUniqueIdServices
+{
+    internal static ISortableUniqueIdGenerator Generator { get; } =
+        SortableUniqueId.GetProcessSharedGenerator();
+
+    internal static SortableUniqueIdSeedCoordinator SeedCoordinator { get; } = new(Generator);
+}
+
 public static class SortableUniqueIdServiceCollectionExtensions
 {
     /// <summary>Registers the process-wide monotonic allocator and service-head seed coordinator.</summary>

--- a/dcb/src/Sekiban.Dcb.Core/Actors/SortableUniqueIdServiceCollectionExtensions.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Actors/SortableUniqueIdServiceCollectionExtensions.cs
@@ -1,0 +1,21 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
+using Sekiban.Dcb.Common;
+
+namespace Sekiban.Dcb.Actors;
+
+public static class SortableUniqueIdServiceCollectionExtensions
+{
+    /// <summary>Registers the process-wide monotonic allocator and service-head seed coordinator.</summary>
+    public static IServiceCollection AddSekibanDcbSortableUniqueIdGenerator(this IServiceCollection services)
+    {
+        services.TryAddSingleton<ISortableUniqueIdGenerator>(serviceProvider =>
+            new MonotonicSortableUniqueIdGenerator(
+                TimeProvider.System,
+                serviceProvider.GetService<ILogger<MonotonicSortableUniqueIdGenerator>>() ??
+                Microsoft.Extensions.Logging.Abstractions.NullLogger<MonotonicSortableUniqueIdGenerator>.Instance));
+        services.TryAddSingleton<SortableUniqueIdSeedCoordinator>();
+        return services;
+    }
+}

--- a/dcb/src/Sekiban.Dcb.Core/Sekiban.Dcb.Core.csproj
+++ b/dcb/src/Sekiban.Dcb.Core/Sekiban.Dcb.Core.csproj
@@ -65,6 +65,12 @@
         <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
             <_Parameter1>Sekiban.Dcb.Orleans.Core</_Parameter1>
         </AssemblyAttribute>
+        <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+            <_Parameter1>Sekiban.Dcb.Orleans.WithResult</_Parameter1>
+        </AssemblyAttribute>
+        <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+            <_Parameter1>Sekiban.Dcb.Orleans.WithoutResult</_Parameter1>
+        </AssemblyAttribute>
     </ItemGroup>
 
 </Project>

--- a/dcb/src/Sekiban.Dcb.Orleans.WithResult/OrleansDcbExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.WithResult/OrleansDcbExecutor.cs
@@ -61,6 +61,33 @@ public class OrleansDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecuto
         _generalExecutor = new GeneralSekibanExecutor(eventStore, _actorAccessor, domainTypes, eventPublisher, executedUserProvider);
     }
 
+    /// <summary>Creates an Orleans executor using the registered process-wide monotonic id allocator.</summary>
+    public OrleansDcbExecutor(
+        IClusterClient clusterClient,
+        IEventStore eventStore,
+        DcbDomainTypes domainTypes,
+        IEventPublisher? eventPublisher,
+        IServiceIdProvider? serviceIdProvider,
+        IExecutedUserProvider? executedUserProvider,
+        ISortableUniqueIdGenerator sortableUniqueIdGenerator,
+        SortableUniqueIdSeedCoordinator sortableUniqueIdSeedCoordinator)
+    {
+        _clusterClient = clusterClient ?? throw new ArgumentNullException(nameof(clusterClient));
+        _eventStore = eventStore ?? throw new ArgumentNullException(nameof(eventStore));
+        _domainTypes = domainTypes ?? throw new ArgumentNullException(nameof(domainTypes));
+        _serviceIdProvider = serviceIdProvider ?? new DefaultServiceIdProvider();
+        _actorAccessor = new OrleansActorObjectAccessor(clusterClient, eventStore, domainTypes, _serviceIdProvider);
+        _generalExecutor = new GeneralSekibanExecutor(
+            eventStore,
+            _actorAccessor,
+            domainTypes,
+            eventPublisher,
+            executedUserProvider,
+            sortableUniqueIdGenerator,
+            sortableUniqueIdSeedCoordinator,
+            _serviceIdProvider);
+    }
+
     /// <summary>
     ///     Execute a command with its built-in handler
     /// </summary>

--- a/dcb/src/Sekiban.Dcb.Orleans.WithResult/OrleansDcbExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.WithResult/OrleansDcbExecutor.cs
@@ -52,13 +52,16 @@ public class OrleansDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecuto
         IEventPublisher? eventPublisher = null,
         IServiceIdProvider? serviceIdProvider = null,
         IExecutedUserProvider? executedUserProvider = null)
+        : this(
+            clusterClient,
+            eventStore,
+            domainTypes,
+            eventPublisher,
+            serviceIdProvider,
+            executedUserProvider,
+            ProcessSharedSortableUniqueIdServices.Generator,
+            ProcessSharedSortableUniqueIdServices.SeedCoordinator)
     {
-        _clusterClient = clusterClient ?? throw new ArgumentNullException(nameof(clusterClient));
-        _eventStore = eventStore ?? throw new ArgumentNullException(nameof(eventStore));
-        _domainTypes = domainTypes ?? throw new ArgumentNullException(nameof(domainTypes));
-        _serviceIdProvider = serviceIdProvider ?? new DefaultServiceIdProvider();
-        _actorAccessor = new OrleansActorObjectAccessor(clusterClient, eventStore, domainTypes, _serviceIdProvider);
-        _generalExecutor = new GeneralSekibanExecutor(eventStore, _actorAccessor, domainTypes, eventPublisher, executedUserProvider);
     }
 
     /// <summary>Creates an Orleans executor using the registered process-wide monotonic id allocator.</summary>

--- a/dcb/src/Sekiban.Dcb.Orleans.WithoutResult/OrleansDcbExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.WithoutResult/OrleansDcbExecutor.cs
@@ -62,6 +62,33 @@ public class OrleansDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecuto
         _generalExecutor = new GeneralSekibanExecutor(eventStore, _actorAccessor, domainTypes, eventPublisher, executedUserProvider);
     }
 
+    /// <summary>Creates an Orleans executor using the registered process-wide monotonic id allocator.</summary>
+    public OrleansDcbExecutor(
+        IClusterClient clusterClient,
+        IEventStore eventStore,
+        DcbDomainTypes domainTypes,
+        IEventPublisher? eventPublisher,
+        IServiceIdProvider? serviceIdProvider,
+        IExecutedUserProvider? executedUserProvider,
+        ISortableUniqueIdGenerator sortableUniqueIdGenerator,
+        SortableUniqueIdSeedCoordinator sortableUniqueIdSeedCoordinator)
+    {
+        _clusterClient = clusterClient ?? throw new ArgumentNullException(nameof(clusterClient));
+        _eventStore = eventStore ?? throw new ArgumentNullException(nameof(eventStore));
+        _domainTypes = domainTypes ?? throw new ArgumentNullException(nameof(domainTypes));
+        _serviceIdProvider = serviceIdProvider ?? new DefaultServiceIdProvider();
+        _actorAccessor = new OrleansActorObjectAccessor(clusterClient, eventStore, domainTypes, _serviceIdProvider);
+        _generalExecutor = new GeneralSekibanExecutor(
+            eventStore,
+            _actorAccessor,
+            domainTypes,
+            eventPublisher,
+            executedUserProvider,
+            sortableUniqueIdGenerator,
+            sortableUniqueIdSeedCoordinator,
+            _serviceIdProvider);
+    }
+
     /// <summary>
     ///     Execute a command with its built-in handler
     /// </summary>

--- a/dcb/src/Sekiban.Dcb.Orleans.WithoutResult/OrleansDcbExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.WithoutResult/OrleansDcbExecutor.cs
@@ -53,13 +53,16 @@ public class OrleansDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecuto
         IEventPublisher? eventPublisher = null,
         IServiceIdProvider? serviceIdProvider = null,
         IExecutedUserProvider? executedUserProvider = null)
+        : this(
+            clusterClient,
+            eventStore,
+            domainTypes,
+            eventPublisher,
+            serviceIdProvider,
+            executedUserProvider,
+            ProcessSharedSortableUniqueIdServices.Generator,
+            ProcessSharedSortableUniqueIdServices.SeedCoordinator)
     {
-        _clusterClient = clusterClient ?? throw new ArgumentNullException(nameof(clusterClient));
-        _eventStore = eventStore ?? throw new ArgumentNullException(nameof(eventStore));
-        _domainTypes = domainTypes ?? throw new ArgumentNullException(nameof(domainTypes));
-        _serviceIdProvider = serviceIdProvider ?? new DefaultServiceIdProvider();
-        _actorAccessor = new OrleansActorObjectAccessor(clusterClient, eventStore, domainTypes, _serviceIdProvider);
-        _generalExecutor = new GeneralSekibanExecutor(eventStore, _actorAccessor, domainTypes, eventPublisher, executedUserProvider);
     }
 
     /// <summary>Creates an Orleans executor using the registered process-wide monotonic id allocator.</summary>

--- a/dcb/src/Sekiban.Dcb.WithResult.Testing/InMemoryDcbExecutorForTesting.cs
+++ b/dcb/src/Sekiban.Dcb.WithResult.Testing/InMemoryDcbExecutorForTesting.cs
@@ -1,7 +1,10 @@
 using Sekiban.Dcb.Capabilities;
+using Sekiban.Dcb.Actors;
+using Sekiban.Dcb.Common;
 using Sekiban.Dcb.InMemory;
 using Sekiban.Dcb.Domains;
 using Sekiban.Dcb.Storage;
+using Sekiban.Dcb.ServiceId;
 namespace Sekiban.Dcb.Testing;
 
 #pragma warning disable CS0618 // the base type is [Obsolete] on purpose, and this is where it points
@@ -41,6 +44,24 @@ public class InMemoryDcbExecutorForTesting : InMemoryDcbExecutor, IExecutorRunti
         IEventStore eventStore,
         IExecutedUserProvider? executedUserProvider = null)
         : base(domainTypes, eventStore, executedUserProvider)
+    {
+    }
+
+    /// <summary>Creates a testing executor using the supplied monotonic allocator.</summary>
+    public InMemoryDcbExecutorForTesting(
+        DcbDomainTypes domainTypes,
+        IEventStore eventStore,
+        IExecutedUserProvider? executedUserProvider,
+        ISortableUniqueIdGenerator sortableUniqueIdGenerator,
+        SortableUniqueIdSeedCoordinator sortableUniqueIdSeedCoordinator,
+        IServiceIdProvider serviceIdProvider)
+        : base(
+            domainTypes,
+            eventStore,
+            executedUserProvider,
+            sortableUniqueIdGenerator,
+            sortableUniqueIdSeedCoordinator,
+            serviceIdProvider)
     {
     }
 

--- a/dcb/src/Sekiban.Dcb.WithResult/Actors/GeneralSekibanExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.WithResult/Actors/GeneralSekibanExecutor.cs
@@ -2,8 +2,10 @@ using ResultBoxes;
 using Sekiban.Dcb.Actors;
 using Sekiban.Dcb.Capabilities;
 using Sekiban.Dcb.Commands;
+using Sekiban.Dcb.Common;
 using Sekiban.Dcb.Events;
 using Sekiban.Dcb.Queries;
+using Sekiban.Dcb.ServiceId;
 using Sekiban.Dcb.Storage;
 using Sekiban.Dcb.Tags;
 namespace Sekiban.Dcb.Actors;
@@ -41,6 +43,29 @@ public class GeneralSekibanExecutor : ISekibanExecutor, ISerializedSekibanDcbExe
     {
         _actorAccessor = actorAccessor;
         _core = new CoreGeneralSekibanExecutor(eventStore, actorAccessor, domainTypes, eventPublisher, executedUserProvider);
+    }
+
+    /// <summary>Creates an executor using the registered process-wide monotonic id allocator.</summary>
+    public GeneralSekibanExecutor(
+        IEventStore eventStore,
+        IActorObjectAccessor actorAccessor,
+        DcbDomainTypes domainTypes,
+        IEventPublisher? eventPublisher,
+        IExecutedUserProvider? executedUserProvider,
+        ISortableUniqueIdGenerator sortableUniqueIdGenerator,
+        SortableUniqueIdSeedCoordinator sortableUniqueIdSeedCoordinator,
+        IServiceIdProvider serviceIdProvider)
+    {
+        _actorAccessor = actorAccessor;
+        _core = new CoreGeneralSekibanExecutor(
+            eventStore,
+            actorAccessor,
+            domainTypes,
+            eventPublisher,
+            executedUserProvider,
+            sortableUniqueIdGenerator,
+            sortableUniqueIdSeedCoordinator,
+            serviceIdProvider);
     }
 
     /// <summary>

--- a/dcb/src/Sekiban.Dcb.WithResult/InMemory/InMemoryDcbExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.WithResult/InMemory/InMemoryDcbExecutor.cs
@@ -56,6 +56,30 @@ public class InMemoryDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecut
         _inner = new GeneralSekibanExecutor(_eventStore, _accessor, _domainTypes, eventPublisher, executedUserProvider);
     }
 
+    /// <summary>Creates an in-memory executor using the supplied monotonic allocator and ambient service identity.</summary>
+    public InMemoryDcbExecutor(
+        DcbDomainTypes domainTypes,
+        IEventStore eventStore,
+        IExecutedUserProvider? executedUserProvider,
+        ISortableUniqueIdGenerator sortableUniqueIdGenerator,
+        SortableUniqueIdSeedCoordinator sortableUniqueIdSeedCoordinator,
+        IServiceIdProvider serviceIdProvider)
+    {
+        _domainTypes = domainTypes ?? throw new ArgumentNullException(nameof(domainTypes));
+        _eventStore = eventStore ?? throw new ArgumentNullException(nameof(eventStore));
+        _accessor = new InMemoryObjectAccessor(_eventStore, _domainTypes);
+        var eventPublisher = new InMemoryMultiProjectionEventPublisher(_accessor);
+        _inner = new GeneralSekibanExecutor(
+            _eventStore,
+            _accessor,
+            _domainTypes,
+            eventPublisher,
+            executedUserProvider,
+            sortableUniqueIdGenerator,
+            sortableUniqueIdSeedCoordinator,
+            serviceIdProvider);
+    }
+
     /// <summary>
     ///     Creates the executor with a built-in lightweight in-memory event store (no external dependencies).
     ///     Obsolete because it is silent about the most important thing it does. A downstream production system

--- a/dcb/src/Sekiban.Dcb.WithoutResult.Testing/InMemoryDcbExecutorForTesting.cs
+++ b/dcb/src/Sekiban.Dcb.WithoutResult.Testing/InMemoryDcbExecutorForTesting.cs
@@ -1,7 +1,10 @@
 using Sekiban.Dcb.Capabilities;
+using Sekiban.Dcb.Actors;
+using Sekiban.Dcb.Common;
 using Sekiban.Dcb.InMemory;
 using Sekiban.Dcb.Domains;
 using Sekiban.Dcb.Storage;
+using Sekiban.Dcb.ServiceId;
 namespace Sekiban.Dcb.Testing;
 
 #pragma warning disable CS0618 // the base type is [Obsolete] on purpose, and this is where it points
@@ -41,6 +44,24 @@ public class InMemoryDcbExecutorForTesting : InMemoryDcbExecutor, IExecutorRunti
         IEventStore eventStore,
         IExecutedUserProvider? executedUserProvider = null)
         : base(domainTypes, eventStore, executedUserProvider)
+    {
+    }
+
+    /// <summary>Creates a testing executor using the supplied monotonic allocator.</summary>
+    public InMemoryDcbExecutorForTesting(
+        DcbDomainTypes domainTypes,
+        IEventStore eventStore,
+        IExecutedUserProvider? executedUserProvider,
+        ISortableUniqueIdGenerator sortableUniqueIdGenerator,
+        SortableUniqueIdSeedCoordinator sortableUniqueIdSeedCoordinator,
+        IServiceIdProvider serviceIdProvider)
+        : base(
+            domainTypes,
+            eventStore,
+            executedUserProvider,
+            sortableUniqueIdGenerator,
+            sortableUniqueIdSeedCoordinator,
+            serviceIdProvider)
     {
     }
 

--- a/dcb/src/Sekiban.Dcb.WithoutResult/Actors/GeneralSekibanExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.WithoutResult/Actors/GeneralSekibanExecutor.cs
@@ -3,8 +3,10 @@ using Sekiban.Dcb.Boundaries;
 using Sekiban.Dcb.Actors;
 using Sekiban.Dcb.Capabilities;
 using Sekiban.Dcb.Commands;
+using Sekiban.Dcb.Common;
 using Sekiban.Dcb.Events;
 using Sekiban.Dcb.Queries;
+using Sekiban.Dcb.ServiceId;
 using Sekiban.Dcb.Storage;
 using Sekiban.Dcb.Tags;
 namespace Sekiban.Dcb.Actors;
@@ -42,6 +44,29 @@ public class GeneralSekibanExecutor : ISekibanExecutor, ISerializedSekibanDcbExe
     {
         _actorAccessor = actorAccessor;
         _core = new CoreGeneralSekibanExecutor(eventStore, actorAccessor, domainTypes, eventPublisher, executedUserProvider);
+    }
+
+    /// <summary>Creates an executor using the registered process-wide monotonic id allocator.</summary>
+    public GeneralSekibanExecutor(
+        IEventStore eventStore,
+        IActorObjectAccessor actorAccessor,
+        DcbDomainTypes domainTypes,
+        IEventPublisher? eventPublisher,
+        IExecutedUserProvider? executedUserProvider,
+        ISortableUniqueIdGenerator sortableUniqueIdGenerator,
+        SortableUniqueIdSeedCoordinator sortableUniqueIdSeedCoordinator,
+        IServiceIdProvider serviceIdProvider)
+    {
+        _actorAccessor = actorAccessor;
+        _core = new CoreGeneralSekibanExecutor(
+            eventStore,
+            actorAccessor,
+            domainTypes,
+            eventPublisher,
+            executedUserProvider,
+            sortableUniqueIdGenerator,
+            sortableUniqueIdSeedCoordinator,
+            serviceIdProvider);
     }
 
     /// <summary>

--- a/dcb/src/Sekiban.Dcb.WithoutResult/InMemory/InMemoryDcbExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.WithoutResult/InMemory/InMemoryDcbExecutor.cs
@@ -57,6 +57,30 @@ public class InMemoryDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecut
         _inner = new GeneralSekibanExecutor(_eventStore, _accessor, _domainTypes, eventPublisher, executedUserProvider);
     }
 
+    /// <summary>Creates an in-memory executor using the supplied monotonic allocator and ambient service identity.</summary>
+    public InMemoryDcbExecutor(
+        DcbDomainTypes domainTypes,
+        IEventStore eventStore,
+        IExecutedUserProvider? executedUserProvider,
+        ISortableUniqueIdGenerator sortableUniqueIdGenerator,
+        SortableUniqueIdSeedCoordinator sortableUniqueIdSeedCoordinator,
+        IServiceIdProvider serviceIdProvider)
+    {
+        _domainTypes = domainTypes ?? throw new ArgumentNullException(nameof(domainTypes));
+        _eventStore = eventStore ?? throw new ArgumentNullException(nameof(eventStore));
+        _accessor = new InMemoryObjectAccessor(_eventStore, _domainTypes);
+        var eventPublisher = new InMemoryMultiProjectionEventPublisher(_accessor);
+        _inner = new GeneralSekibanExecutor(
+            _eventStore,
+            _accessor,
+            _domainTypes,
+            eventPublisher,
+            executedUserProvider,
+            sortableUniqueIdGenerator,
+            sortableUniqueIdSeedCoordinator,
+            serviceIdProvider);
+    }
+
     /// <summary>
     ///     Creates the executor with a built-in lightweight in-memory event store (no external dependencies).
     ///     Obsolete because it is silent about the most important thing it does. A downstream production system

--- a/dcb/tests/Sekiban.Dcb.Orleans.Tests/ExecutorBinaryCompatibilityTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Orleans.Tests/ExecutorBinaryCompatibilityTests.cs
@@ -26,6 +26,16 @@ public class ExecutorBinaryCompatibilityTests
     }
 
     [Fact]
+    public void PreSekibanG31_LongestOrleansConstructor_IsStillPublic()
+    {
+        var expected = "Orleans.IClusterClient,Sekiban.Dcb.Storage.IEventStore,Sekiban.Dcb.DcbDomainTypes,Sekiban.Dcb.Actors.IEventPublisher,Sekiban.Dcb.ServiceId.IServiceIdProvider,Sekiban.Dcb.IExecutedUserProvider".Split(',');
+        Assert.Contains(
+            typeof(OrleansDcbExecutor).GetConstructors(BindingFlags.Instance | BindingFlags.Public),
+            constructor => constructor.GetParameters().Select(parameter => parameter.ParameterType.FullName)
+                .SequenceEqual(expected));
+    }
+
+    [Fact]
     public void PreSekibanG24_MultiProjectionGrain_Constructor_Is_Still_Public()
     {
         // The registry dependencies were added through an overload. Keep the exact pre-G24 surface available to

--- a/dcb/tests/Sekiban.Dcb.Orleans.Tests/SortableUniqueIdLegacyServiceIdentityTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Orleans.Tests/SortableUniqueIdLegacyServiceIdentityTests.cs
@@ -1,0 +1,75 @@
+using System.Reflection;
+using Dcb.Domain;
+using Orleans;
+using Sekiban.Dcb.Commands;
+using Sekiban.Dcb.Common;
+using Sekiban.Dcb.Domains;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.Orleans;
+using Sekiban.Dcb.Testing;
+using Sekiban.Dcb.TestSupport;
+using Xunit;
+
+namespace Sekiban.Dcb.Orleans.Tests;
+
+public class SortableUniqueIdLegacyServiceIdentityTests
+{
+    [Fact]
+    public async Task RetainedFiveArgumentFacadeSeedsAmbientServiceAThenBSeparately()
+    {
+        var domain = DomainType.GetDomainTypes();
+        ((SimpleEventTypes)domain.EventTypes).RegisterEventType<IdentityProbeEvent>();
+        var suffix = Guid.NewGuid().ToString("N");
+        var serviceA = $"g31-orleans-result-a-{suffix}";
+        var serviceB = $"g31-orleans-result-b-{suffix}";
+        var service = new G31MutableServiceIdProvider(serviceA);
+        var inner = new InMemoryEventStore(domain.EventTypes, service);
+        await SeedAsync(inner, domain, service, serviceA, 2035);
+        await SeedAsync(inner, domain, service, serviceB, 2040);
+        var store = new G31ServiceHeadCountingEventStore(inner, service);
+        var client = DispatchProxy.Create<IClusterClient, ThrowingClusterClientProxy>();
+        var executor = new OrleansDcbExecutor(client, store, domain, null, service);
+
+        service.Current = serviceA;
+        var first = await executor.ExecuteAsync(
+            new IdentityProbeCommand(),
+            (_, _) => Task.FromResult(EventOrNone.Event(new EventPayloadWithTags(new IdentityProbeEvent("a"), []))));
+        service.Current = serviceB;
+        var second = await executor.ExecuteAsync(
+            new IdentityProbeCommand(),
+            (_, _) => Task.FromResult(EventOrNone.Event(new EventPayloadWithTags(new IdentityProbeEvent("b"), []))));
+
+        Assert.True(first.IsSuccess);
+        Assert.True(second.IsSuccess);
+        Assert.Equal(1, store.HeadReadsFor(serviceA));
+        Assert.Equal(1, store.HeadReadsFor(serviceB));
+    }
+
+    private static async Task SeedAsync(
+        InMemoryEventStore store,
+        DcbDomainTypes domain,
+        G31MutableServiceIdProvider service,
+        string serviceId,
+        int year)
+    {
+        service.Current = serviceId;
+        var persisted = new Event(
+                new IdentityProbeEvent("seed"),
+                SortableUniqueId.Generate(new DateTime(year, 1, 1, 0, 0, 0, DateTimeKind.Utc), Guid.NewGuid()),
+                nameof(IdentityProbeEvent),
+                Guid.CreateVersion7(),
+                new EventMetadata("seed", "seed", "test"),
+                [])
+            .ToSerializableEvent(domain.EventTypes);
+        Assert.True((await store.WriteSerializableEventsAsync([persisted])).IsSuccess);
+    }
+
+    private sealed record IdentityProbeCommand : ICommand;
+    private sealed record IdentityProbeEvent(string Value) : IEventPayload;
+
+    private class ThrowingClusterClientProxy : DispatchProxy
+    {
+        protected override object? Invoke(MethodInfo? targetMethod, object?[]? args) =>
+            throw new InvalidOperationException($"Unexpected Orleans client call: {targetMethod?.Name}");
+    }
+}

--- a/dcb/tests/Sekiban.Dcb.Postgres.Tests/PostgresWithActorsTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Postgres.Tests/PostgresWithActorsTests.cs
@@ -2,6 +2,8 @@ using Dcb.Domain.ClassRoom;
 using Dcb.Domain.Enrollment;
 using Dcb.Domain.Student;
 using Sekiban.Dcb.Actors;
+using Sekiban.Dcb.Common;
+using Sekiban.Dcb.ServiceId;
 using Sekiban.Dcb.Storage;
 using Sekiban.Dcb.Tags;
 using Xunit;
@@ -11,6 +13,50 @@ public class PostgresWithActorsTests : PostgresTestBase
 {
     public PostgresWithActorsTests(PostgresTestFixture fixture) : base(fixture)
     {
+    }
+
+    [Fact]
+    public async Task RestartWithRolledBackClockSeedsRealPostgresHeadBeforeProductionAllocation()
+    {
+        var service = new DefaultServiceIdProvider();
+        var firstTime = new MutableTimeProvider(new DateTimeOffset(2030, 1, 1, 0, 0, 0, TimeSpan.Zero));
+        var firstGenerator = new MonotonicSortableUniqueIdGenerator(firstTime);
+        var firstExecutor = new GeneralSekibanExecutor(
+            Fixture.EventStore,
+            Fixture.ActorAccessor,
+            Fixture.DomainTypes,
+            null,
+            null,
+            firstGenerator,
+            new SortableUniqueIdSeedCoordinator(firstGenerator),
+            service);
+        var first = await firstExecutor.ExecuteAsync(new CreateStudent(Guid.NewGuid(), "before rollback"));
+        Assert.True(first.IsSuccess);
+
+        var restartedTime = new MutableTimeProvider(new DateTimeOffset(2020, 1, 1, 0, 0, 0, TimeSpan.Zero));
+        var restartedGenerator = new MonotonicSortableUniqueIdGenerator(restartedTime);
+        var restartedExecutor = new GeneralSekibanExecutor(
+            Fixture.EventStore,
+            Fixture.ActorAccessor,
+            Fixture.DomainTypes,
+            null,
+            null,
+            restartedGenerator,
+            new SortableUniqueIdSeedCoordinator(restartedGenerator),
+            service);
+        var afterRestart = await restartedExecutor.ExecuteAsync(new CreateStudent(Guid.NewGuid(), "after rollback"));
+        Assert.True(afterRestart.IsSuccess);
+
+        Assert.True(string.CompareOrdinal(afterRestart.GetValue().SortableUniqueId, first.GetValue().SortableUniqueId) > 0);
+        var catchUp = (await Fixture.EventStore.ReadAllSerializableEventsAsync(
+            new SortableUniqueId(first.GetValue().SortableUniqueId!))).GetValue().ToArray();
+        Assert.Contains(catchUp, item => item.SortableUniqueIdValue == afterRestart.GetValue().SortableUniqueId);
+    }
+
+    private sealed class MutableTimeProvider(DateTimeOffset utcNow) : TimeProvider
+    {
+        public DateTimeOffset UtcNow { get; set; } = utcNow;
+        public override DateTimeOffset GetUtcNow() => UtcNow;
     }
 
     [Fact]

--- a/dcb/tests/Sekiban.Dcb.TestSupport/G31ServiceHeadCountingEventStore.cs
+++ b/dcb/tests/Sekiban.Dcb.TestSupport/G31ServiceHeadCountingEventStore.cs
@@ -1,0 +1,48 @@
+using System.Collections.Concurrent;
+using ResultBoxes;
+using Sekiban.Dcb.Common;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.ServiceId;
+using Sekiban.Dcb.Storage;
+using Sekiban.Dcb.Tags;
+
+namespace Sekiban.Dcb.TestSupport;
+
+public sealed class G31MutableServiceIdProvider(string current) : IServiceIdProvider
+{
+    public string Current { get; set; } = current;
+    public string GetCurrentServiceId() => Current;
+}
+
+public sealed class G31ServiceHeadCountingEventStore(
+    IEventStore inner,
+    IServiceIdProvider serviceIdProvider) : IEventStore
+{
+    private readonly ConcurrentDictionary<string, int> _headReads = new(StringComparer.Ordinal);
+
+    public int HeadReadsFor(string serviceId) => _headReads.GetValueOrDefault(serviceId);
+
+    public Task<ResultBox<string>> GetLatestSortableUniqueIdAsync()
+    {
+        _headReads.AddOrUpdate(serviceIdProvider.GetCurrentServiceId(), 1, (_, count) => count + 1);
+        return inner.GetLatestSortableUniqueIdAsync();
+    }
+
+    public Task<ResultBox<IEnumerable<TagStream>>> ReadTagsAsync(ITag tag) => inner.ReadTagsAsync(tag);
+    public Task<ResultBox<TagState>> GetLatestTagAsync(ITag tag) => inner.GetLatestTagAsync(tag);
+    public Task<ResultBox<bool>> TagExistsAsync(ITag tag) => inner.TagExistsAsync(tag);
+    public Task<ResultBox<long>> GetEventCountAsync(SortableUniqueId? since = null) => inner.GetEventCountAsync(since);
+    public Task<ResultBox<IEnumerable<TagInfo>>> GetAllTagsAsync(string? tagGroup = null) => inner.GetAllTagsAsync(tagGroup);
+    public Task<ResultBox<IEnumerable<SerializableEvent>>> ReadAllSerializableEventsAsync(SortableUniqueId? since = null) =>
+        inner.ReadAllSerializableEventsAsync(since);
+    public Task<ResultBox<IEnumerable<SerializableEvent>>> ReadAllSerializableEventsAsync(
+        SortableUniqueId? since,
+        int? maxCount) => inner.ReadAllSerializableEventsAsync(since, maxCount);
+    public Task<ResultBox<SerializableEvent>> ReadSerializableEventAsync(Guid eventId) =>
+        inner.ReadSerializableEventAsync(eventId);
+    public Task<ResultBox<IEnumerable<SerializableEvent>>> ReadSerializableEventsByTagAsync(
+        ITag tag,
+        SortableUniqueId? since = null) => inner.ReadSerializableEventsByTagAsync(tag, since);
+    public Task<ResultBox<(IReadOnlyList<SerializableEvent> Events, IReadOnlyList<TagWriteResult> TagWrites)>>
+        WriteSerializableEventsAsync(IEnumerable<SerializableEvent> events) => inner.WriteSerializableEventsAsync(events);
+}

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/ConditionalAppend/ConditionalAppendSeamArchitectureTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/ConditionalAppend/ConditionalAppendSeamArchitectureTests.cs
@@ -188,15 +188,16 @@ public class ConditionalAppendSeamArchitectureTests
     public void InternalsVisibleTo_Allowlist_IsExactlyTheIntendedAssemblies()
     {
         // The provider assemblies grant internals only to the intended test assembly; Core grants the four provider
-        // assemblies (for the internal post-commit-response-loss signal) plus Sekiban.Dcb.Orleans.Core (SEK-G18: the Orleans
-        // host reads the internal projection rebuild-required signal without any public API addition) — never a test
-        // assembly. Postgres's own IVT is asserted in Sekiban.Dcb.Postgres.Tests (where the Postgres seam is reachable).
+        // assemblies (for the internal post-commit-response-loss signal), Sekiban.Dcb.Orleans.Core (SEK-G18: the Orleans
+        // host reads the internal projection rebuild-required signal), and the two Orleans facades (SEK-G31: retained
+        // constructors share the process generator/coordinator without adding public API) — never a test assembly.
+        // Postgres's own IVT is asserted in Sekiban.Dcb.Postgres.Tests (where the Postgres seam is reachable).
         AssertIvtAllowlist(typeof(SqliteEventStore).Assembly, "Sekiban.Dcb.WithResult.Tests");
         AssertIvtAllowlist(typeof(CosmosDbEventStore).Assembly, "Sekiban.Dcb.WithResult.Tests");
         AssertIvtAllowlist(
             typeof(IConditionalEventStore).Assembly,
             "Sekiban.Dcb.Postgres", "Sekiban.Dcb.Sqlite", "Sekiban.Dcb.CosmosDb", "Sekiban.Dcb.DynamoDB",
-            "Sekiban.Dcb.Orleans.Core");
+            "Sekiban.Dcb.Orleans.Core", "Sekiban.Dcb.Orleans.WithResult", "Sekiban.Dcb.Orleans.WithoutResult");
     }
 
     [Theory]

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/ConditionalAppend/CosmosConditionalAppendTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/ConditionalAppend/CosmosConditionalAppendTests.cs
@@ -1,4 +1,5 @@
 using Dcb.Domain;
+using Sekiban.Dcb.Actors;
 using Sekiban.Dcb.Common;
 using Sekiban.Dcb.CosmosDb;
 using Sekiban.Dcb.CosmosDb.Models;
@@ -86,6 +87,33 @@ public class CosmosConditionalAppendTests
     }
 
     // ── The shared uniform contract ─────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task RealStoreHeadSeedsMonotonicGeneratorAbovePersistedMaximum()
+    {
+        var lineage = NewLineage();
+        var persistedTicks = new DateTime(2040, 1, 1, 0, 0, 0, DateTimeKind.Utc).Ticks;
+        var persisted = new Event(
+                new ConditionalMarkerEvent("seed"),
+                SortableUniqueId.Generate(new DateTime(persistedTicks, DateTimeKind.Utc), Guid.NewGuid()),
+                nameof(ConditionalMarkerEvent),
+                Guid.CreateVersion7(),
+                new EventMetadata("seed", "seed", "test"),
+                ["Marker:seed"])
+            .ToSerializableEvent(_domain.EventTypes);
+        Assert.True((await lineage.Store.WriteSerializableEventsAsync([persisted])).IsSuccess);
+
+        var generator = new MonotonicSortableUniqueIdGenerator(
+            new FixedTimeProvider(new DateTimeOffset(2020, 1, 1, 0, 0, 0, TimeSpan.Zero)));
+        await new SortableUniqueIdSeedCoordinator(generator).EnsureSeededAsync(ServiceId, lineage.Store);
+
+        Assert.True(string.CompareOrdinal(generator.GenerateNew(), persisted.SortableUniqueIdValue) > 0);
+    }
+
+    private sealed class FixedTimeProvider(DateTimeOffset utcNow) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow() => utcNow;
+    }
 
     [Fact]
     public void Capability_ReportsSingleEventUniqueKey() =>

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/ConditionalAppend/DynamoConditionalAppendTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/ConditionalAppend/DynamoConditionalAppendTests.cs
@@ -3,6 +3,7 @@ using Amazon.DynamoDBv2.Model;
 using Amazon.Runtime;
 using Dcb.Domain;
 using Microsoft.Extensions.Options;
+using Sekiban.Dcb.Actors;
 using Sekiban.Dcb.Common;
 using Sekiban.Dcb.Domains;
 using Sekiban.Dcb.DynamoDB;
@@ -72,6 +73,33 @@ public class DynamoConditionalAppendTests
             .ToSerializableEvent(_domain.EventTypes);
 
     // ── Shared uniform contract ─────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task RealStoreHeadSeedsMonotonicGeneratorAbovePersistedMaximum()
+    {
+        var (store, _) = NewStore();
+        var persistedTicks = new DateTime(2040, 1, 1, 0, 0, 0, DateTimeKind.Utc).Ticks;
+        var persisted = new Event(
+                new ManyTagMarker("seed"),
+                SortableUniqueId.Generate(new DateTime(persistedTicks, DateTimeKind.Utc), Guid.NewGuid()),
+                nameof(ManyTagMarker),
+                Guid.CreateVersion7(),
+                new EventMetadata("seed", "seed", "test"),
+                ["Many:seed"])
+            .ToSerializableEvent(_domain.EventTypes);
+        Assert.True((await store.WriteSerializableEventsAsync([persisted])).IsSuccess);
+
+        var generator = new MonotonicSortableUniqueIdGenerator(
+            new FixedTimeProvider(new DateTimeOffset(2020, 1, 1, 0, 0, 0, TimeSpan.Zero)));
+        await new SortableUniqueIdSeedCoordinator(generator).EnsureSeededAsync(ServiceId, store);
+
+        Assert.True(string.CompareOrdinal(generator.GenerateNew(), persisted.SortableUniqueIdValue) > 0);
+    }
+
+    private sealed class FixedTimeProvider(DateTimeOffset utcNow) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow() => utcNow;
+    }
 
     [Fact]
     public void Capability_ReportsSingleEventUniqueKey() =>
@@ -363,6 +391,25 @@ public class DynamoConditionalAppendTests
                 }
 
                 return Task.FromResult(new GetItemResponse { Item = new Dictionary<string, AttributeValue>() });
+            }
+        }
+
+        public override Task<QueryResponse> QueryAsync(
+            QueryRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            lock (_gate)
+            {
+                var partition = request.ExpressionAttributeValues[":pk"].S;
+                var items = _items
+                    .Where(entry => entry.Key.Table == request.TableName)
+                    .Select(entry => entry.Value)
+                    .Where(item => item.TryGetValue("gsi1pk", out var value) && value.S == partition)
+                    .OrderByDescending(item => item["sortableUniqueId"].S, StringComparer.Ordinal)
+                    .Take(request.Limit ?? int.MaxValue)
+                    .Select(item => new Dictionary<string, AttributeValue>(item))
+                    .ToList();
+                return Task.FromResult(new QueryResponse { Items = items });
             }
         }
     }

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/ExecutorBinaryCompatibilityTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/ExecutorBinaryCompatibilityTests.cs
@@ -1,5 +1,6 @@
 using System.Reflection;
 using Sekiban.Dcb.Actors;
+using Sekiban.Dcb.Common;
 using Sekiban.Dcb.InMemory;
 using Sekiban.Dcb.Testing;
 using Xunit;
@@ -51,6 +52,25 @@ public class ExecutorBinaryCompatibilityTests
             "Generate",
             BindingFlags.Public | BindingFlags.Static,
             [typeof(DateTime), typeof(Guid)]));
+    }
+
+    [Fact]
+    public void SortableUniqueIdExposesNoPublicMutableGlobalGeneratorSeam()
+    {
+        var type = typeof(SortableUniqueId);
+        var publicStaticGeneratorFields = type
+            .GetFields(BindingFlags.Public | BindingFlags.Static)
+            .Where(field => typeof(ISortableUniqueIdGenerator).IsAssignableFrom(field.FieldType));
+        var publicStaticGeneratorProperties = type
+            .GetProperties(BindingFlags.Public | BindingFlags.Static)
+            .Where(property => typeof(ISortableUniqueIdGenerator).IsAssignableFrom(property.PropertyType));
+        var publicStaticGeneratorMethods = type
+            .GetMethods(BindingFlags.Public | BindingFlags.Static)
+            .Where(method => typeof(ISortableUniqueIdGenerator).IsAssignableFrom(method.ReturnType));
+
+        Assert.Empty(publicStaticGeneratorFields);
+        Assert.Empty(publicStaticGeneratorProperties);
+        Assert.Empty(publicStaticGeneratorMethods);
     }
 
     [Theory]

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/ExecutorBinaryCompatibilityTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/ExecutorBinaryCompatibilityTests.cs
@@ -29,6 +29,31 @@ public class ExecutorBinaryCompatibilityTests
     }
 
     [Theory]
+    [InlineData(typeof(CoreGeneralSekibanExecutor), "Sekiban.Dcb.Storage.IEventStore,Sekiban.Dcb.Actors.IActorObjectAccessor,Sekiban.Dcb.DcbDomainTypes,Sekiban.Dcb.Actors.IEventPublisher,Sekiban.Dcb.IExecutedUserProvider")]
+    [InlineData(typeof(GeneralSekibanExecutor), "Sekiban.Dcb.Storage.IEventStore,Sekiban.Dcb.Actors.IActorObjectAccessor,Sekiban.Dcb.DcbDomainTypes,Sekiban.Dcb.Actors.IEventPublisher,Sekiban.Dcb.IExecutedUserProvider")]
+    [InlineData(typeof(InMemoryDcbExecutor), "Sekiban.Dcb.DcbDomainTypes,Sekiban.Dcb.Storage.IEventStore,Sekiban.Dcb.IExecutedUserProvider")]
+    [InlineData(typeof(InMemoryDcbExecutorForTesting), "Sekiban.Dcb.DcbDomainTypes,Sekiban.Dcb.Storage.IEventStore,Sekiban.Dcb.IExecutedUserProvider")]
+    public void PreSekibanG31_LongestConstructor_IsStillPublic(Type executorType, string expectedParameterTypeNames)
+    {
+        var expected = expectedParameterTypeNames.Split(',');
+        Assert.Contains(
+            executorType.GetConstructors(BindingFlags.Instance | BindingFlags.Public),
+            constructor => constructor.GetParameters().Select(parameter => parameter.ParameterType.FullName)
+                .SequenceEqual(expected));
+    }
+
+    [Fact]
+    public void SortableUniqueIdStaticClrSignaturesAreUnchanged()
+    {
+        var type = typeof(Sekiban.Dcb.Common.SortableUniqueId);
+        Assert.NotNull(type.GetMethod("GenerateNew", BindingFlags.Public | BindingFlags.Static, Type.EmptyTypes));
+        Assert.NotNull(type.GetMethod(
+            "Generate",
+            BindingFlags.Public | BindingFlags.Static,
+            [typeof(DateTime), typeof(Guid)]));
+    }
+
+    [Theory]
     [InlineData(typeof(ITagConsistentActorCommon))]
     [InlineData(typeof(GeneralTagConsistentActor))]
     [InlineData(typeof(TagReservationHelper))]

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/SortableUniqueIdGeneratorTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/SortableUniqueIdGeneratorTests.cs
@@ -52,6 +52,50 @@ public class SortableUniqueIdGeneratorTests
     }
 
     [Fact]
+    public void ConcurrentRollbackAndJitterRemainStrictlyMonotonicThroughProductionGenerator()
+    {
+        var anchor = new DateTimeOffset(2035, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        var time = new RollbackJitterTimeProvider(anchor);
+        var generator = new MonotonicSortableUniqueIdGenerator(time);
+        var highWater = generator.GenerateNew();
+        time.BeginRollbackWithJitter();
+        var ids = new string[4_000];
+
+        Parallel.For(0, ids.Length, index => ids[index] = generator.GenerateNew());
+
+        var ticks = ids.Select(ReadTicks).Order().ToArray();
+        Assert.Equal(ids.Length, ids.Distinct(StringComparer.Ordinal).Count());
+        Assert.Equal(ReadTicks(highWater) + 1, ticks[0]);
+        Assert.Equal(ReadTicks(highWater) + ids.Length, ticks[^1]);
+        Assert.All(ticks.Zip(ticks.Skip(1)), pair => Assert.Equal(pair.First + 1, pair.Second));
+    }
+
+    [Fact]
+    public void GenerateAndGetIdStringHaveStableThirtyByteGolden()
+    {
+        var timestamp = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        Assert.Equal("00000000000", SortableUniqueId.GetIdString(Guid.Empty));
+        var generated = SortableUniqueId.Generate(timestamp, Guid.Empty);
+        Assert.Equal("063082281600000000000000000000", generated);
+        Assert.Equal(30, System.Text.Encoding.UTF8.GetByteCount(generated));
+    }
+
+    [Fact]
+    public void EveryGenerationUsesAFreshGuidSuffix()
+    {
+        var generator = new MonotonicSortableUniqueIdGenerator(
+            new MutableTimeProvider(new DateTimeOffset(2035, 1, 1, 0, 0, 0, TimeSpan.Zero)));
+
+        var suffixes = Enumerable.Range(0, 32)
+            .Select(_ => generator.GenerateNew()[SortableUniqueId.TickNumberOfLength..])
+            .ToArray();
+
+        Assert.Equal(suffixes.Length, suffixes.Distinct(StringComparer.Ordinal).Count());
+        Assert.All(suffixes, suffix => Assert.Equal(SortableUniqueId.IdNumberOfLength, suffix.Length));
+    }
+
+    [Fact]
     public void SeedRaisesFloorAndMaxValueIsTypedExhaustion()
     {
         var generator = new MonotonicSortableUniqueIdGenerator(
@@ -102,20 +146,6 @@ public class SortableUniqueIdGeneratorTests
     }
 
     [Fact]
-    public async Task MalformedHeadFailsWithTypedErrorWithoutAllocation()
-    {
-        var generator = new CountingGenerator();
-        var coordinator = new SortableUniqueIdSeedCoordinator(generator);
-
-        var error = await Assert.ThrowsAsync<SortableUniqueIdSeedException>(
-            () => coordinator.EnsureSeededAsync("service-a", new HeadOnlyEventStore("malformed")));
-
-        Assert.Equal("service-a", error.ServiceId);
-        Assert.Equal(0, generator.GenerateCalls);
-        Assert.Equal(0, generator.SeedCalls);
-    }
-
-    [Fact]
     public async Task EmptyStoreSeedIsNoOp()
     {
         var generator = new CountingGenerator();
@@ -139,6 +169,25 @@ public class SortableUniqueIdGeneratorTests
         public override long GetTimestamp() => Volatile.Read(ref _timestamp);
         public override long TimestampFrequency => TimeSpan.TicksPerSecond;
         public void AdvanceTimestamp(TimeSpan elapsed) => Interlocked.Add(ref _timestamp, elapsed.Ticks);
+    }
+
+    private sealed class RollbackJitterTimeProvider(DateTimeOffset anchor) : TimeProvider
+    {
+        private int _jitterIndex;
+        private int _rolledBack;
+
+        public void BeginRollbackWithJitter() => Volatile.Write(ref _rolledBack, 1);
+
+        public override DateTimeOffset GetUtcNow()
+        {
+            if (Volatile.Read(ref _rolledBack) == 0)
+            {
+                return anchor;
+            }
+
+            var jitter = 1 + Math.Abs(Interlocked.Increment(ref _jitterIndex) % 997);
+            return anchor.AddTicks(-jitter);
+        }
     }
 
     private sealed class CountingLogger : ILogger<MonotonicSortableUniqueIdGenerator>

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/SortableUniqueIdGeneratorTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/SortableUniqueIdGeneratorTests.cs
@@ -1,0 +1,210 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using ResultBoxes;
+using Sekiban.Dcb.Actors;
+using Sekiban.Dcb.Common;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.Storage;
+using Sekiban.Dcb.Tags;
+
+namespace Sekiban.Dcb.Tests;
+
+public class SortableUniqueIdGeneratorTests
+{
+    [Fact]
+    public void FrozenClockConcurrentAllocationsHaveUniqueConsecutiveLogicalTicks()
+    {
+        var now = new DateTimeOffset(2026, 8, 11, 12, 0, 0, TimeSpan.Zero);
+        var logger = new CountingLogger();
+        var generator = new MonotonicSortableUniqueIdGenerator(new MutableTimeProvider(now), logger);
+        var ids = new string[2_000];
+
+        Parallel.For(0, ids.Length, index => ids[index] = generator.GenerateNew());
+
+        var ticks = ids.Select(ReadTicks).Order().ToArray();
+        Assert.Equal(ids.Length, ids.Distinct(StringComparer.Ordinal).Count());
+        Assert.Equal(now.UtcTicks, ticks[0]);
+        Assert.Equal(now.UtcTicks + ids.Length - 1, ticks[^1]);
+        Assert.All(ticks.Zip(ticks.Skip(1)), pair => Assert.Equal(pair.First + 1, pair.Second));
+        Assert.All(ids, id => Assert.Equal(30, id.Length));
+        Assert.Equal(0, logger.WarningCount);
+    }
+
+    [Fact]
+    public void ClockRollbackAdvancesLogicalTicksAndLogsOnlyPhysicalRegression()
+    {
+        var time = new MutableTimeProvider(new DateTimeOffset(2026, 8, 11, 12, 0, 0, TimeSpan.Zero));
+        var logger = new CountingLogger();
+        var generator = new MonotonicSortableUniqueIdGenerator(time, logger);
+        var first = generator.GenerateNew();
+
+        time.UtcNow = time.UtcNow.AddMinutes(-5);
+        var second = generator.GenerateNew();
+        var third = generator.GenerateNew();
+
+        Assert.True(string.CompareOrdinal(second, first) > 0);
+        Assert.True(string.CompareOrdinal(third, second) > 0);
+        Assert.Equal(1, logger.WarningCount);
+
+        time.AdvanceTimestamp(TimeSpan.FromMinutes(1));
+        generator.GenerateNew();
+        Assert.Equal(2, logger.WarningCount);
+    }
+
+    [Fact]
+    public void SeedRaisesFloorAndMaxValueIsTypedExhaustion()
+    {
+        var generator = new MonotonicSortableUniqueIdGenerator(
+            new MutableTimeProvider(DateTimeOffset.UnixEpoch));
+        var floor = new DateTimeOffset(2030, 1, 1, 0, 0, 0, TimeSpan.Zero).UtcTicks;
+
+        generator.Seed(floor);
+        Assert.Equal(floor + 1, ReadTicks(generator.GenerateNew()));
+
+        generator.Seed(DateTime.MaxValue.Ticks);
+        var error = Assert.Throws<InvalidOperationException>(() => generator.GenerateNew());
+        Assert.Contains(nameof(DateTime.MaxValue), error.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void DependencyInjectionUsesOneGeneratorAndCoordinator()
+    {
+        var services = new ServiceCollection();
+        services.AddSekibanDcbSortableUniqueIdGenerator();
+        using var provider = services.BuildServiceProvider();
+
+        Assert.Same(
+            provider.GetRequiredService<ISortableUniqueIdGenerator>(),
+            provider.GetRequiredService<ISortableUniqueIdGenerator>());
+        Assert.Same(
+            provider.GetRequiredService<SortableUniqueIdSeedCoordinator>(),
+            provider.GetRequiredService<SortableUniqueIdSeedCoordinator>());
+    }
+
+    [Fact]
+    public async Task ServiceSeedIsSingleFlightAndFailureCanRetry()
+    {
+        var time = new MutableTimeProvider(DateTimeOffset.UnixEpoch);
+        var generator = new MonotonicSortableUniqueIdGenerator(time);
+        var coordinator = new SortableUniqueIdSeedCoordinator(generator);
+        var floor = new DateTimeOffset(2035, 1, 1, 0, 0, 0, TimeSpan.Zero).UtcTicks;
+        var head = SortableUniqueId.Generate(new DateTime(floor, DateTimeKind.Utc), Guid.NewGuid());
+        var store = new HeadOnlyEventStore(head, failFirst: true);
+
+        await Assert.ThrowsAsync<SortableUniqueIdSeedException>(
+            () => coordinator.EnsureSeededAsync("service-a", store));
+
+        await Task.WhenAll(
+            Enumerable.Range(0, 32).Select(_ => coordinator.EnsureSeededAsync("service-a", store)));
+
+        Assert.Equal(2, store.HeadReads);
+        Assert.Equal(floor + 1, ReadTicks(generator.GenerateNew()));
+    }
+
+    [Fact]
+    public async Task MalformedHeadFailsWithTypedErrorWithoutAllocation()
+    {
+        var generator = new CountingGenerator();
+        var coordinator = new SortableUniqueIdSeedCoordinator(generator);
+
+        var error = await Assert.ThrowsAsync<SortableUniqueIdSeedException>(
+            () => coordinator.EnsureSeededAsync("service-a", new HeadOnlyEventStore("malformed")));
+
+        Assert.Equal("service-a", error.ServiceId);
+        Assert.Equal(0, generator.GenerateCalls);
+        Assert.Equal(0, generator.SeedCalls);
+    }
+
+    [Fact]
+    public async Task EmptyStoreSeedIsNoOp()
+    {
+        var generator = new CountingGenerator();
+        var coordinator = new SortableUniqueIdSeedCoordinator(generator);
+
+        await coordinator.EnsureSeededAsync("service-a", new HeadOnlyEventStore(string.Empty));
+
+        Assert.Equal(0, generator.GenerateCalls);
+        Assert.Equal(0, generator.SeedCalls);
+    }
+
+    private static long ReadTicks(string id) => long.Parse(
+        id.AsSpan(0, SortableUniqueId.TickNumberOfLength),
+        System.Globalization.CultureInfo.InvariantCulture);
+
+    private sealed class MutableTimeProvider(DateTimeOffset utcNow) : TimeProvider
+    {
+        private long _timestamp;
+        public DateTimeOffset UtcNow { get; set; } = utcNow;
+        public override DateTimeOffset GetUtcNow() => UtcNow;
+        public override long GetTimestamp() => Volatile.Read(ref _timestamp);
+        public override long TimestampFrequency => TimeSpan.TicksPerSecond;
+        public void AdvanceTimestamp(TimeSpan elapsed) => Interlocked.Add(ref _timestamp, elapsed.Ticks);
+    }
+
+    private sealed class CountingLogger : ILogger<MonotonicSortableUniqueIdGenerator>
+    {
+        private int _warningCount;
+        public int WarningCount => Volatile.Read(ref _warningCount);
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+        public bool IsEnabled(LogLevel logLevel) => true;
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            if (logLevel == LogLevel.Warning)
+            {
+                Interlocked.Increment(ref _warningCount);
+            }
+        }
+    }
+
+    private sealed class CountingGenerator : ISortableUniqueIdGenerator
+    {
+        public int GenerateCalls { get; private set; }
+        public int SeedCalls { get; private set; }
+        public string GenerateNew()
+        {
+            GenerateCalls++;
+            return SortableUniqueId.Generate(DateTime.UtcNow, Guid.NewGuid());
+        }
+        public void Seed(long ticks) => SeedCalls++;
+    }
+
+    private sealed class HeadOnlyEventStore(string head, bool failFirst = false) : IEventStore
+    {
+        private int _headReads;
+        public int HeadReads => Volatile.Read(ref _headReads);
+
+        public Task<ResultBox<string>> GetLatestSortableUniqueIdAsync()
+        {
+            var read = Interlocked.Increment(ref _headReads);
+            return Task.FromResult(failFirst && read == 1
+                ? ResultBox.Error<string>(new InvalidOperationException("head unavailable"))
+                : ResultBox.FromValue(head));
+        }
+
+        public Task<ResultBox<IEnumerable<TagStream>>> ReadTagsAsync(ITag tag) => Throw<IEnumerable<TagStream>>();
+        public Task<ResultBox<TagState>> GetLatestTagAsync(ITag tag) => Throw<TagState>();
+        public Task<ResultBox<bool>> TagExistsAsync(ITag tag) => Throw<bool>();
+        public Task<ResultBox<long>> GetEventCountAsync(SortableUniqueId? since = null) => Throw<long>();
+        public Task<ResultBox<IEnumerable<TagInfo>>> GetAllTagsAsync(string? tagGroup = null) => Throw<IEnumerable<TagInfo>>();
+        public Task<ResultBox<IEnumerable<SerializableEvent>>> ReadAllSerializableEventsAsync(SortableUniqueId? since = null) =>
+            Throw<IEnumerable<SerializableEvent>>();
+        public Task<ResultBox<IEnumerable<SerializableEvent>>> ReadAllSerializableEventsAsync(
+            SortableUniqueId? since,
+            int? maxCount) => Throw<IEnumerable<SerializableEvent>>();
+        public Task<ResultBox<SerializableEvent>> ReadSerializableEventAsync(Guid eventId) => Throw<SerializableEvent>();
+        public Task<ResultBox<IEnumerable<SerializableEvent>>> ReadSerializableEventsByTagAsync(
+            ITag tag,
+            SortableUniqueId? since = null) => Throw<IEnumerable<SerializableEvent>>();
+        public Task<ResultBox<(IReadOnlyList<SerializableEvent> Events, IReadOnlyList<TagWriteResult> TagWrites)>>
+            WriteSerializableEventsAsync(IEnumerable<SerializableEvent> events) =>
+            Throw<(IReadOnlyList<SerializableEvent>, IReadOnlyList<TagWriteResult>)>();
+
+        private static Task<ResultBox<T>> Throw<T>() where T : notnull =>
+            throw new InvalidOperationException("Unexpected event-store operation.");
+    }
+}

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/SortableUniqueIdProductionPathTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/SortableUniqueIdProductionPathTests.cs
@@ -120,6 +120,54 @@ public class SortableUniqueIdProductionPathTests
     }
 
     [Fact]
+    public async Task MalformedHeadFailsBeforeReservationAllocationOrWriteThenRereadsAndRetries()
+    {
+        var domain = BuildDomain();
+        var service = new FixedServiceIdProvider("service-malformed");
+        var inner = new InMemoryConditionalEventStore(domain.EventTypes, service);
+        var store = new CountingConditionalStore(inner) { HeadOverride = "malformed" };
+        var actors = new CountingActorAccessor();
+        var generator = new RecordingGenerator(new MonotonicSortableUniqueIdGenerator(new FrozenTimeProvider()));
+        var executor = new GeneralSekibanExecutor(
+            store,
+            actors,
+            domain,
+            null,
+            null,
+            generator,
+            new SortableUniqueIdSeedCoordinator(generator),
+            service);
+
+        var failed = await executor.ExecuteAsync(
+            new PathCommand(),
+            (_, _) => Task.FromResult(
+                EventOrNone.Event(new PathEvent("blocked"), new ConsistencyPathTag("blocked"))));
+
+        Assert.False(failed.IsSuccess);
+        Assert.IsType<SortableUniqueIdSeedException>(failed.GetException());
+        Assert.Equal(1, store.HeadReads);
+        Assert.Equal(0, generator.GenerateCalls);
+        Assert.Equal(0, actors.ReservationCalls);
+        Assert.Equal(0, store.WriteCalls);
+
+        var validTicks = new DateTime(2040, 1, 1, 0, 0, 0, DateTimeKind.Utc).Ticks;
+        store.HeadOverride = SortableUniqueId.Generate(
+            new DateTime(validTicks, DateTimeKind.Utc),
+            Guid.NewGuid());
+        var retried = await executor.ExecuteAsync(
+            new PathCommand(),
+            (_, _) => Task.FromResult(
+                EventOrNone.Event(new PathEvent("retry"), new ConsistencyPathTag("retry"))));
+
+        Assert.True(retried.IsSuccess);
+        Assert.Equal(2, store.HeadReads);
+        Assert.Equal(1, generator.GenerateCalls);
+        Assert.Equal(1, actors.ReservationCalls);
+        Assert.Equal(1, store.WriteCalls);
+        Assert.True(ReadTicks(generator.GeneratedIds.Single()) > validTicks);
+    }
+
+    [Fact]
     public async Task AmbientServiceChangeSeedsEachServiceOnceBeforeItsFirstProductionWrite()
     {
         var domain = BuildDomain();
@@ -345,16 +393,39 @@ public class SortableUniqueIdProductionPathTests
     private sealed class CountingActorAccessor : IActorObjectAccessor
     {
         private int _calls;
+        private int _reservationCalls;
         public int Calls => Volatile.Read(ref _calls);
+        public int ReservationCalls => Volatile.Read(ref _reservationCalls);
         public Task<ResultBox<T>> GetActorAsync<T>(string actorId) where T : class
         {
             Interlocked.Increment(ref _calls);
-            return Task.FromResult(ResultBox.Error<T>(new InvalidOperationException("actor access forbidden")));
+            if (typeof(T) == typeof(ITagConsistentActorCommon))
+            {
+                return Task.FromResult(ResultBox.FromValue((T)(object)new CountingTagConsistentActor(this, actorId)));
+            }
+            return Task.FromResult(ResultBox.Error<T>(new InvalidOperationException("unexpected actor type")));
         }
         public Task<bool> ActorExistsAsync(string actorId)
         {
             Interlocked.Increment(ref _calls);
             return Task.FromResult(false);
+        }
+
+        private sealed class CountingTagConsistentActor(CountingActorAccessor owner, string actorId)
+            : ITagConsistentActorCommon
+        {
+            public Task<string> GetTagActorIdAsync() => Task.FromResult(actorId);
+            public Task<ResultBox<string>> GetLatestSortableUniqueIdAsync() =>
+                Task.FromResult(ResultBox.FromValue(string.Empty));
+            public Task<ResultBox<TagWriteReservation>> MakeReservationAsync(string? lastSortableUniqueId)
+            {
+                Interlocked.Increment(ref owner._reservationCalls);
+                return Task.FromResult(ResultBox.FromValue(
+                    new TagWriteReservation("reservation", DateTime.MaxValue.ToString("O"), actorId)));
+            }
+            public Task<bool> ConfirmReservationAsync(TagWriteReservation reservation) => Task.FromResult(true);
+            public Task<bool> CancelReservationAsync(TagWriteReservation reservation) => Task.FromResult(true);
+            public Task NotifyEventWrittenAsync() => Task.CompletedTask;
         }
     }
 
@@ -366,6 +437,7 @@ public class SortableUniqueIdProductionPathTests
         private int _headReads;
         private int _writeCalls;
         public bool FailHeadReads { get; set; }
+        public string? HeadOverride { get; set; }
         public int HeadReads => Volatile.Read(ref _headReads);
         public int WriteCalls => Volatile.Read(ref _writeCalls);
         public Dictionary<string, int> HeadReadsByService { get; } = new(StringComparer.Ordinal);
@@ -387,7 +459,9 @@ public class SortableUniqueIdProductionPathTests
             }
             return FailHeadReads
                 ? Task.FromResult(ResultBox.Error<string>(new InvalidOperationException("head unavailable")))
-                : inner.GetLatestSortableUniqueIdAsync();
+                : HeadOverride is not null
+                    ? Task.FromResult(ResultBox.FromValue(HeadOverride))
+                    : inner.GetLatestSortableUniqueIdAsync();
         }
         public Task<ResultBox<(IReadOnlyList<SerializableEvent> Events, IReadOnlyList<TagWriteResult> TagWrites)>>
             WriteSerializableEventsAsync(IEnumerable<SerializableEvent> events)

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/SortableUniqueIdProductionPathTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/SortableUniqueIdProductionPathTests.cs
@@ -1,0 +1,414 @@
+using System.Text.Json;
+using Dcb.Domain;
+using ResultBoxes;
+using Sekiban.Dcb.Actors;
+using Sekiban.Dcb.Capabilities;
+using Sekiban.Dcb.Commands;
+using Sekiban.Dcb.Common;
+using Sekiban.Dcb.Domains;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.ServiceId;
+using Sekiban.Dcb.Sqlite;
+using Sekiban.Dcb.Storage;
+using Sekiban.Dcb.Tags;
+using Sekiban.Dcb.Testing;
+
+namespace Sekiban.Dcb.Tests;
+
+public class SortableUniqueIdProductionPathTests
+{
+    [Fact]
+    public async Task AllFourCoreAllocationBranchesUseInjectedGenerator()
+    {
+        var domain = BuildDomain();
+        var service = new FixedServiceIdProvider("service-a");
+        var inner = new InMemoryConditionalEventStore(domain.EventTypes, service);
+        var store = new CountingConditionalStore(inner);
+        var accessor = new InMemoryObjectAccessor(store, domain);
+        var generator = new RecordingGenerator(new MonotonicSortableUniqueIdGenerator(new FrozenTimeProvider()));
+        var executor = new GeneralSekibanExecutor(
+            store,
+            accessor,
+            domain,
+            null,
+            null,
+            generator,
+            new SortableUniqueIdSeedCoordinator(generator),
+            service);
+
+        var typedMulti = await executor.ExecuteAsync(
+            new PathCommand(),
+            async (_, context) =>
+            {
+                await context.AppendEvent(new PathEvent("typed-1"), new PathTag("typed-1"));
+                return await context.AppendEvent(new PathEvent("typed-2"), new PathTag("typed-2"));
+            });
+        Assert.True(typedMulti.IsSuccess);
+
+        var serialized = (ISerializedSekibanDcbExecutor)executor;
+        var serializedMulti = await serialized.CommitSerializableEventsAsync(
+            new SerializedCommitRequest(
+                [Candidate(domain, "serialized-1"), Candidate(domain, "serialized-2")],
+                []));
+        Assert.True(serializedMulti.IsSuccess);
+
+        var typedConditional = await executor.ExecuteAsync(
+            new PathCommand(),
+            (_, _) => Task.FromResult(
+                EventOrNone.Event(new PathEvent("typed-conditional"), new PathTag("typed-conditional"))),
+            new CommandExecutionOptions
+            {
+                ConditionalAppend = new ConditionalAppendSpecification("typed-key")
+            });
+        Assert.True(typedConditional.IsSuccess);
+
+        var serializedConditional = await ((ISerializedConditionalSekibanDcbExecutor)executor)
+            .CommitSerializableEventConditionallyAsync(
+                new SerializedConditionalCommitRequest(
+                    SerializedConditionalCommitRequest.CurrentVersion,
+                    Candidate(domain, "serialized-conditional"),
+                    "serialized-key"));
+        Assert.True(serializedConditional.IsSuccess);
+
+        Assert.Equal(6, generator.GenerateCalls);
+        Assert.Equal(1, store.HeadReads);
+        var written = (await store.ReadAllSerializableEventsAsync()).GetValue().ToArray();
+        Assert.Equal(6, written.Length);
+        Assert.Equal(generator.GeneratedIds.Order(StringComparer.Ordinal), written.Select(e => e.SortableUniqueIdValue));
+    }
+
+    [Fact]
+    public async Task HeadFailureReturnsTypedErrorBeforeReservationAllocationOrWriteAndRetries()
+    {
+        var domain = BuildDomain();
+        var service = new FixedServiceIdProvider("service-a");
+        var inner = new InMemoryConditionalEventStore(domain.EventTypes, service);
+        var store = new CountingConditionalStore(inner) { FailHeadReads = true };
+        var actors = new CountingActorAccessor();
+        var generator = new RecordingGenerator(new MonotonicSortableUniqueIdGenerator(new FrozenTimeProvider()));
+        var executor = new GeneralSekibanExecutor(
+            store,
+            actors,
+            domain,
+            null,
+            null,
+            generator,
+            new SortableUniqueIdSeedCoordinator(generator),
+            service);
+
+        var failed = await executor.ExecuteAsync(
+            new PathCommand(),
+            (_, _) => Task.FromResult(
+                EventOrNone.Event(new PathEvent("blocked"), new ConsistencyPathTag("blocked"))));
+
+        Assert.False(failed.IsSuccess);
+        Assert.IsType<SortableUniqueIdSeedException>(failed.GetException());
+        Assert.Equal(0, generator.GenerateCalls);
+        Assert.Equal(0, actors.Calls);
+        Assert.Equal(0, store.WriteCalls);
+
+        store.FailHeadReads = false;
+        var retried = await executor.ExecuteAsync(
+            new PathCommand(),
+            (_, _) => Task.FromResult(
+                EventOrNone.Event(new PathEvent("retry"), new PathTag("retry"))));
+
+        Assert.True(retried.IsSuccess);
+        Assert.Equal(2, store.HeadReads);
+        Assert.Equal(1, generator.GenerateCalls);
+        Assert.Equal(1, store.WriteCalls);
+    }
+
+    [Fact]
+    public async Task AmbientServiceChangeSeedsEachServiceOnceBeforeItsFirstProductionWrite()
+    {
+        var domain = BuildDomain();
+        var service = new MutableServiceIdProvider("service-a");
+        var inner = new InMemoryConditionalEventStore(domain.EventTypes, service);
+        var headA = new DateTime(2030, 1, 1, 0, 0, 0, DateTimeKind.Utc).Ticks;
+        var headB = new DateTime(2040, 1, 1, 0, 0, 0, DateTimeKind.Utc).Ticks;
+        await inner.WriteSerializableEventsAsync([Persisted(domain, "head-a", headA)]);
+        service.Current = "service-b";
+        await inner.WriteSerializableEventsAsync([Persisted(domain, "head-b", headB)]);
+
+        var store = new CountingConditionalStore(inner, service);
+        var accessor = new InMemoryObjectAccessor(store, domain);
+        var generator = new RecordingGenerator(new MonotonicSortableUniqueIdGenerator(new FrozenTimeProvider()));
+        var executor = new GeneralSekibanExecutor(
+            store,
+            accessor,
+            domain,
+            null,
+            null,
+            generator,
+            new SortableUniqueIdSeedCoordinator(generator),
+            service);
+
+        service.Current = "service-a";
+        Assert.True((await executor.ExecuteAsync(
+            new PathCommand(),
+            (_, _) => Task.FromResult(EventOrNone.Event(new PathEvent("a"), new PathTag("a"))))).IsSuccess);
+        service.Current = "service-b";
+        Assert.True((await executor.ExecuteAsync(
+            new PathCommand(),
+            (_, _) => Task.FromResult(EventOrNone.Event(new PathEvent("b"), new PathTag("b"))))).IsSuccess);
+        service.Current = "service-a";
+        Assert.True((await executor.ExecuteAsync(
+            new PathCommand(),
+            (_, _) => Task.FromResult(EventOrNone.Event(new PathEvent("a2"), new PathTag("a2"))))).IsSuccess);
+
+        Assert.Equal(1, store.HeadReadsByService["service-a"]);
+        Assert.Equal(1, store.HeadReadsByService["service-b"]);
+        Assert.True(ReadTicks(generator.GeneratedIds[0]) > headA);
+        Assert.True(ReadTicks(generator.GeneratedIds[1]) > headB);
+        Assert.True(ReadTicks(generator.GeneratedIds[2]) > ReadTicks(generator.GeneratedIds[1]));
+    }
+
+    [Fact]
+    public async Task RolledBackClockEventRemainsVisibleToExclusiveCheckpointCatchUp()
+    {
+        var domain = BuildDomain();
+        var service = new FixedServiceIdProvider("service-a");
+        var store = new InMemoryConditionalEventStore(domain.EventTypes, service);
+        var accessor = new InMemoryObjectAccessor(store, domain);
+        var time = new MutableTimeProvider(new DateTimeOffset(2030, 1, 1, 0, 0, 0, TimeSpan.Zero));
+        var generator = new MonotonicSortableUniqueIdGenerator(time);
+        var executor = new GeneralSekibanExecutor(
+            store,
+            accessor,
+            domain,
+            null,
+            null,
+            generator,
+            new SortableUniqueIdSeedCoordinator(generator),
+            service);
+
+        var first = await executor.ExecuteAsync(
+            new PathCommand(),
+            (_, _) => Task.FromResult(EventOrNone.Event(new PathEvent("before"), new PathTag("before"))));
+        Assert.True(first.IsSuccess);
+        var checkpoint = first.GetValue().SortableUniqueId!;
+
+        time.UtcNow = time.UtcNow.AddYears(-10);
+        var afterRollback = await executor.ExecuteAsync(
+            new PathCommand(),
+            (_, _) => Task.FromResult(EventOrNone.Event(new PathEvent("after"), new PathTag("after"))));
+        Assert.True(afterRollback.IsSuccess);
+
+        var catchUp = (await store.ReadAllSerializableEventsAsync(new SortableUniqueId(checkpoint))).GetValue().ToArray();
+        Assert.Single(catchUp);
+        Assert.Equal(afterRollback.GetValue().SortableUniqueId, catchUp[0].SortableUniqueIdValue);
+    }
+
+    [Fact]
+    public async Task SqliteRestartSeedsRealStoreHeadAndPreservesRollbackCatchUpCompleteness()
+    {
+        var databasePath = Path.Combine(Path.GetTempPath(), $"sek-g31-{Guid.NewGuid():N}.db");
+        try
+        {
+            var domain = BuildDomain();
+            var service = new FixedServiceIdProvider("service-a");
+            var firstStore = new SqliteEventStore(databasePath, domain.EventTypes, serviceIdProvider: service);
+            var firstTime = new MutableTimeProvider(new DateTimeOffset(2030, 1, 1, 0, 0, 0, TimeSpan.Zero));
+            var firstGenerator = new MonotonicSortableUniqueIdGenerator(firstTime);
+            var firstExecutor = new GeneralSekibanExecutor(
+                firstStore,
+                new InMemoryObjectAccessor(firstStore, domain),
+                domain,
+                null,
+                null,
+                firstGenerator,
+                new SortableUniqueIdSeedCoordinator(firstGenerator),
+                service);
+            var first = await firstExecutor.ExecuteAsync(
+                new PathCommand(),
+                (_, _) => Task.FromResult(EventOrNone.Event(new PathEvent("before"), new PathTag("before"))));
+            Assert.True(first.IsSuccess);
+
+            var restartedStore = new SqliteEventStore(databasePath, domain.EventTypes, serviceIdProvider: service);
+            var rolledBackTime = new MutableTimeProvider(new DateTimeOffset(2020, 1, 1, 0, 0, 0, TimeSpan.Zero));
+            var restartedGenerator = new MonotonicSortableUniqueIdGenerator(rolledBackTime);
+            var restartedExecutor = new GeneralSekibanExecutor(
+                restartedStore,
+                new InMemoryObjectAccessor(restartedStore, domain),
+                domain,
+                null,
+                null,
+                restartedGenerator,
+                new SortableUniqueIdSeedCoordinator(restartedGenerator),
+                service);
+            var afterRestart = await restartedExecutor.ExecuteAsync(
+                new PathCommand(),
+                (_, _) => Task.FromResult(EventOrNone.Event(new PathEvent("after"), new PathTag("after"))));
+            Assert.True(afterRestart.IsSuccess);
+
+            Assert.True(string.CompareOrdinal(
+                afterRestart.GetValue().SortableUniqueId,
+                first.GetValue().SortableUniqueId) > 0);
+            var catchUp = (await restartedStore.ReadAllSerializableEventsAsync(
+                new SortableUniqueId(first.GetValue().SortableUniqueId!))).GetValue().ToArray();
+            Assert.Single(catchUp);
+            Assert.Equal(afterRestart.GetValue().SortableUniqueId, catchUp[0].SortableUniqueIdValue);
+        }
+        finally
+        {
+            if (File.Exists(databasePath))
+            {
+                File.Delete(databasePath);
+            }
+        }
+    }
+
+    private static DcbDomainTypes BuildDomain()
+    {
+        var domain = DomainType.GetDomainTypes();
+        ((SimpleEventTypes)domain.EventTypes).RegisterEventType<PathEvent>();
+        ((SimpleTagTypes)domain.TagTypes).RegisterTagGroupType<PathTag>();
+        ((SimpleTagTypes)domain.TagTypes).RegisterTagGroupType<ConsistencyPathTag>();
+        return domain;
+    }
+
+    private static SerializableEventCandidate Candidate(DcbDomainTypes domain, string value) =>
+        new(
+            JsonSerializer.SerializeToUtf8Bytes(new PathEvent(value), domain.JsonSerializerOptions),
+            nameof(PathEvent),
+            [$"Path:{value}"]);
+
+    private static SerializableEvent Persisted(DcbDomainTypes domain, string value, long ticks) =>
+        new(
+            JsonSerializer.SerializeToUtf8Bytes(new PathEvent(value), domain.JsonSerializerOptions),
+            SortableUniqueId.Generate(new DateTime(ticks, DateTimeKind.Utc), Guid.NewGuid()),
+            Guid.NewGuid(),
+            new EventMetadata(Guid.NewGuid().ToString(), "seed", "test"),
+            [$"Path:{value}"],
+            nameof(PathEvent));
+
+    private static long ReadTicks(string id) => long.Parse(
+        id.AsSpan(0, SortableUniqueId.TickNumberOfLength),
+        System.Globalization.CultureInfo.InvariantCulture);
+
+    private sealed record PathCommand : ICommand;
+    private sealed record PathEvent(string Value) : IEventPayload;
+
+    private sealed record PathTag(string Id) : IStringTagGroup<PathTag>
+    {
+        public static string TagGroupName => "Path";
+        public static PathTag FromContent(string content) => new(content);
+        public bool IsConsistencyTag() => false;
+        public string GetId() => Id;
+    }
+
+    private sealed record ConsistencyPathTag(string Id) : IStringTagGroup<ConsistencyPathTag>
+    {
+        public static string TagGroupName => "ConsistencyPath";
+        public static ConsistencyPathTag FromContent(string content) => new(content);
+        public bool IsConsistencyTag() => true;
+        public string GetId() => Id;
+    }
+
+    private sealed class FrozenTimeProvider : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow() => new(2030, 1, 1, 0, 0, 0, TimeSpan.Zero);
+    }
+
+    private sealed class MutableTimeProvider(DateTimeOffset utcNow) : TimeProvider
+    {
+        public DateTimeOffset UtcNow { get; set; } = utcNow;
+        public override DateTimeOffset GetUtcNow() => UtcNow;
+    }
+
+    private sealed class MutableServiceIdProvider(string current) : IServiceIdProvider
+    {
+        public string Current { get; set; } = current;
+        public string GetCurrentServiceId() => Current;
+    }
+
+    private sealed class RecordingGenerator(ISortableUniqueIdGenerator inner) : ISortableUniqueIdGenerator
+    {
+        private readonly object _lock = new();
+        private readonly List<string> _ids = [];
+        public int GenerateCalls { get; private set; }
+        public IReadOnlyList<string> GeneratedIds { get { lock (_lock) return _ids.ToArray(); } }
+        public string GenerateNew()
+        {
+            var id = inner.GenerateNew();
+            lock (_lock)
+            {
+                GenerateCalls++;
+                _ids.Add(id);
+            }
+            return id;
+        }
+        public void Seed(long ticks) => inner.Seed(ticks);
+    }
+
+    private sealed class CountingActorAccessor : IActorObjectAccessor
+    {
+        private int _calls;
+        public int Calls => Volatile.Read(ref _calls);
+        public Task<ResultBox<T>> GetActorAsync<T>(string actorId) where T : class
+        {
+            Interlocked.Increment(ref _calls);
+            return Task.FromResult(ResultBox.Error<T>(new InvalidOperationException("actor access forbidden")));
+        }
+        public Task<bool> ActorExistsAsync(string actorId)
+        {
+            Interlocked.Increment(ref _calls);
+            return Task.FromResult(false);
+        }
+    }
+
+    private sealed class CountingConditionalStore(
+        InMemoryConditionalEventStore inner,
+        IServiceIdProvider? serviceIdProvider = null)
+        : IEventStore, IConditionalEventStore, IWriteConditionCapabilityProvider
+    {
+        private int _headReads;
+        private int _writeCalls;
+        public bool FailHeadReads { get; set; }
+        public int HeadReads => Volatile.Read(ref _headReads);
+        public int WriteCalls => Volatile.Read(ref _writeCalls);
+        public Dictionary<string, int> HeadReadsByService { get; } = new(StringComparer.Ordinal);
+
+        public WriteConditionCapabilityDescriptor DescribeWriteConditions() => inner.DescribeWriteConditions();
+        public Task<ResultBox<ConditionalAppendReceipt>> AppendIfUniqueAsync(
+            ConditionalAppendRequest request,
+            CancellationToken cancellationToken = default) => inner.AppendIfUniqueAsync(request, cancellationToken);
+        public Task<ResultBox<string>> GetLatestSortableUniqueIdAsync()
+        {
+            Interlocked.Increment(ref _headReads);
+            if (serviceIdProvider is not null)
+            {
+                var serviceId = serviceIdProvider.GetCurrentServiceId();
+                lock (HeadReadsByService)
+                {
+                    HeadReadsByService[serviceId] = HeadReadsByService.GetValueOrDefault(serviceId) + 1;
+                }
+            }
+            return FailHeadReads
+                ? Task.FromResult(ResultBox.Error<string>(new InvalidOperationException("head unavailable")))
+                : inner.GetLatestSortableUniqueIdAsync();
+        }
+        public Task<ResultBox<(IReadOnlyList<SerializableEvent> Events, IReadOnlyList<TagWriteResult> TagWrites)>>
+            WriteSerializableEventsAsync(IEnumerable<SerializableEvent> events)
+        {
+            Interlocked.Increment(ref _writeCalls);
+            return inner.WriteSerializableEventsAsync(events);
+        }
+        public Task<ResultBox<IEnumerable<TagStream>>> ReadTagsAsync(ITag tag) => inner.ReadTagsAsync(tag);
+        public Task<ResultBox<TagState>> GetLatestTagAsync(ITag tag) => inner.GetLatestTagAsync(tag);
+        public Task<ResultBox<bool>> TagExistsAsync(ITag tag) => inner.TagExistsAsync(tag);
+        public Task<ResultBox<long>> GetEventCountAsync(SortableUniqueId? since = null) => inner.GetEventCountAsync(since);
+        public Task<ResultBox<IEnumerable<TagInfo>>> GetAllTagsAsync(string? tagGroup = null) => inner.GetAllTagsAsync(tagGroup);
+        public Task<ResultBox<IEnumerable<SerializableEvent>>> ReadAllSerializableEventsAsync(SortableUniqueId? since = null) =>
+            inner.ReadAllSerializableEventsAsync(since);
+        public Task<ResultBox<IEnumerable<SerializableEvent>>> ReadAllSerializableEventsAsync(
+            SortableUniqueId? since,
+            int? maxCount) => inner.ReadAllSerializableEventsAsync(since, maxCount);
+        public Task<ResultBox<SerializableEvent>> ReadSerializableEventAsync(Guid eventId) =>
+            inner.ReadSerializableEventAsync(eventId);
+        public Task<ResultBox<IEnumerable<SerializableEvent>>> ReadSerializableEventsByTagAsync(
+            ITag tag,
+            SortableUniqueId? since = null) => inner.ReadSerializableEventsByTagAsync(tag, since);
+    }
+}

--- a/dcb/tests/Sekiban.Dcb.WithoutResult.Tests/ExecutorBinaryCompatibilityTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithoutResult.Tests/ExecutorBinaryCompatibilityTests.cs
@@ -27,6 +27,19 @@ public class ExecutorBinaryCompatibilityTests
         Assert.True(matching.IsPublic);
     }
 
+    [Theory]
+    [InlineData(typeof(GeneralSekibanExecutor), "Sekiban.Dcb.Storage.IEventStore,Sekiban.Dcb.Actors.IActorObjectAccessor,Sekiban.Dcb.DcbDomainTypes,Sekiban.Dcb.Actors.IEventPublisher,Sekiban.Dcb.IExecutedUserProvider")]
+    [InlineData(typeof(InMemoryDcbExecutor), "Sekiban.Dcb.DcbDomainTypes,Sekiban.Dcb.Storage.IEventStore,Sekiban.Dcb.IExecutedUserProvider")]
+    [InlineData(typeof(InMemoryDcbExecutorForTesting), "Sekiban.Dcb.DcbDomainTypes,Sekiban.Dcb.Storage.IEventStore,Sekiban.Dcb.IExecutedUserProvider")]
+    public void PreSekibanG31_LongestConstructor_IsStillPublic(Type executorType, string expectedParameterTypeNames)
+    {
+        var expected = expectedParameterTypeNames.Split(',');
+        Assert.Contains(
+            executorType.GetConstructors(BindingFlags.Instance | BindingFlags.Public),
+            constructor => constructor.GetParameters().Select(parameter => parameter.ParameterType.FullName)
+                .SequenceEqual(expected));
+    }
+
     [Fact]
     public void PreSekibanG23_Orleans_WithoutResult_Constructor_Overload_Is_Public()
     {
@@ -42,5 +55,18 @@ public class ExecutorBinaryCompatibilityTests
 
         Assert.NotNull(matching);
         Assert.True(matching.IsPublic);
+    }
+
+    [Fact]
+    public void PreSekibanG31_LongestOrleansWithoutResultConstructor_IsStillPublic()
+    {
+        var assembly = Assembly.Load("Sekiban.Dcb.Orleans.WithoutResult");
+        var executorType = assembly.GetType("Sekiban.Dcb.Orleans.OrleansDcbExecutor");
+        Assert.NotNull(executorType);
+        var expected = "Orleans.IClusterClient,Sekiban.Dcb.Storage.IEventStore,Sekiban.Dcb.DcbDomainTypes,Sekiban.Dcb.Actors.IEventPublisher,Sekiban.Dcb.ServiceId.IServiceIdProvider,Sekiban.Dcb.IExecutedUserProvider".Split(',');
+        Assert.Contains(
+            executorType!.GetConstructors(BindingFlags.Instance | BindingFlags.Public),
+            constructor => constructor.GetParameters().Select(parameter => parameter.ParameterType.FullName)
+                .SequenceEqual(expected));
     }
 }

--- a/dcb/tests/Sekiban.Dcb.WithoutResult.Tests/SortableUniqueIdLegacyOrleansServiceIdentityTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithoutResult.Tests/SortableUniqueIdLegacyOrleansServiceIdentityTests.cs
@@ -1,0 +1,72 @@
+using System.Reflection;
+using Dcb.Domain.WithoutResult;
+using Orleans;
+using Sekiban.Dcb.Commands;
+using Sekiban.Dcb.Common;
+using Sekiban.Dcb.Domains;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.Orleans;
+using Sekiban.Dcb.Testing;
+using Sekiban.Dcb.TestSupport;
+
+namespace Sekiban.Dcb.WithoutResult.Tests;
+
+public class SortableUniqueIdLegacyOrleansServiceIdentityTests
+{
+    [Fact]
+    public async Task RetainedSixArgumentFacadeSeedsAmbientServiceAThenBSeparately()
+    {
+        var domain = DomainType.GetDomainTypes();
+        ((SimpleEventTypes)domain.EventTypes).RegisterEventType<IdentityProbeEvent>();
+        var suffix = Guid.NewGuid().ToString("N");
+        var serviceA = $"g31-orleans-noresult-a-{suffix}";
+        var serviceB = $"g31-orleans-noresult-b-{suffix}";
+        var service = new G31MutableServiceIdProvider(serviceA);
+        var inner = new InMemoryEventStore(domain.EventTypes, service);
+        await SeedAsync(inner, domain, service, serviceA, 2035);
+        await SeedAsync(inner, domain, service, serviceB, 2040);
+        var store = new G31ServiceHeadCountingEventStore(inner, service);
+        var client = DispatchProxy.Create<IClusterClient, ThrowingClusterClientProxy>();
+        var executor = new OrleansDcbExecutor(client, store, domain, null, service, null);
+
+        service.Current = serviceA;
+        await executor.ExecuteAsync(
+            new IdentityProbeCommand(),
+            (_, _) => Task.FromResult(EventOrNone.FromValue(new EventPayloadWithTags(new IdentityProbeEvent("a"), []))));
+        service.Current = serviceB;
+        await executor.ExecuteAsync(
+            new IdentityProbeCommand(),
+            (_, _) => Task.FromResult(EventOrNone.FromValue(new EventPayloadWithTags(new IdentityProbeEvent("b"), []))));
+
+        Assert.Equal(1, store.HeadReadsFor(serviceA));
+        Assert.Equal(1, store.HeadReadsFor(serviceB));
+    }
+
+    private static async Task SeedAsync(
+        InMemoryEventStore store,
+        DcbDomainTypes domain,
+        G31MutableServiceIdProvider service,
+        string serviceId,
+        int year)
+    {
+        service.Current = serviceId;
+        var persisted = new Event(
+                new IdentityProbeEvent("seed"),
+                SortableUniqueId.Generate(new DateTime(year, 1, 1, 0, 0, 0, DateTimeKind.Utc), Guid.NewGuid()),
+                nameof(IdentityProbeEvent),
+                Guid.CreateVersion7(),
+                new EventMetadata("seed", "seed", "test"),
+                [])
+            .ToSerializableEvent(domain.EventTypes);
+        Assert.True((await store.WriteSerializableEventsAsync([persisted])).IsSuccess);
+    }
+
+    private sealed record IdentityProbeCommand : ICommand;
+    private sealed record IdentityProbeEvent(string Value) : IEventPayload;
+
+    private class ThrowingClusterClientProxy : DispatchProxy
+    {
+        protected override object? Invoke(MethodInfo? targetMethod, object?[]? args) =>
+            throw new InvalidOperationException($"Unexpected Orleans client call: {targetMethod?.Name}");
+    }
+}

--- a/docs/dcb_llm/13_common_issues.md
+++ b/docs/dcb_llm/13_common_issues.md
@@ -485,3 +485,28 @@ transient executor registration. The ambient HTTP-context pattern keeps the prov
 be singleton.
 
 The provider parameter is optional on all executor facades, so existing call sites require no changes.
+
+## Events disappear after a host clock rollback — CLOSED in 10.13.0 (SEK-G31)
+
+**Symptom.** An event is committed successfully but an incremental projection that reads `> checkpoint` never sees it.
+This can happen when the writer's UTC clock moves behind the tick prefix of the last persisted `SortableUniqueId`.
+
+**Fix.** All production executor write paths use one DI-singleton monotonic generator. Before the first event-producing
+operation for each normalized service id, the executor reads that service's persisted head and atomically seeds the
+logical tick floor. Allocation uses `max(TimeProvider.GetUtcNow().UtcTicks, previous + 1)` and keeps the existing fresh
+Guid-derived suffix and 30-digit wire format. A head-read failure fails before reservations, allocation, or writes and
+is retryable; it never falls back to wall-clock time.
+
+**Guarantee boundary.** This protects writes made through the store-aware Sekiban executor paths within one process and
+across their restarts. It is not a distributed sequencer. Size projection `SafeWindow` for the maximum expected skew
+between different hosts. A caller that writes directly to `IEventStore` and constructs ids itself owns this ordering
+responsibility.
+
+**WSL2.** If the clock repeatedly jumps, check for competing Hyper-V and `systemd-timesyncd` synchronization. Update WSL,
+run `wsl --shutdown` from Windows, restart the distribution, and ensure only the intended time-sync mechanism is active.
+The monotonic allocator prevents same-host rollback from hiding events, but correcting persistent clock drift remains an
+operational requirement.
+
+**10.13.0 release note.** DCB executor-generated `SortableUniqueId` values are now monotonic under host-clock rollback
+and are seeded lazily from the per-service store head after restart. Public legacy constructors and static signatures,
+the 30-digit format, and random-suffix semantics remain compatible.

--- a/docs/dcb_llm_ja/13_common_issues.md
+++ b/docs/dcb_llm_ja/13_common_issues.md
@@ -445,3 +445,26 @@ builder.Services.AddSingleton<IExecutedUserProvider>(sp =>
 > **ライフタイムの指針。** executor はプロバイダーをキャプチャします。scoped または transient のプロバイダーを使う場合は、executor も scoped または transient で登録してください。アンビエント HTTP コンテキスト方式ではプロバイダーが singleton なので、executor も singleton にできます。
 
 プロバイダーはすべての実行ファサードのコンストラクタで省略可能な引数なので、既存の呼び出し元に変更は不要です。
+
+## ホスト時刻の巻き戻り後にイベントが見えなくなる — 10.13.0 で解決 (SEK-G31)
+
+**症状**。イベントのコミットは成功したのに、`> checkpoint` で増分読み取りする projection がそのイベントを取得できません。
+writer の UTC 時刻が、最後に永続化された `SortableUniqueId` の tick prefix より前へ戻ると発生し得ます。
+
+**修正**。すべての本番 executor 書き込み経路は、DI singleton の単調増加 generator を共有します。正規化済み service id
+ごとの最初のイベント生成操作より前に、その service の永続 head を読み、論理 tick floor を原子的に seed します。
+割り当ては `max(TimeProvider.GetUtcNow().UtcTicks, previous + 1)` を使用し、既存の fresh Guid 由来 suffix と30桁 wire format
+を維持します。head 読み取り失敗は予約・割り当て・書き込みより前に retryable な型付きエラーとなり、wall-clock へ
+fallback しません。
+
+**保証境界**。これは store-aware な Sekiban executor 経由の書き込みを、単一プロセス内および再起動をまたいで保護します。
+分散 sequencer ではありません。異なるホスト間で想定する最大 clock skew に合わせて projection の `SafeWindow` を設定して
+ください。`IEventStore` へ直接書き込み、独自に id を作る呼び出し元は、この順序保証を自身で負います。
+
+**WSL2**。時刻が繰り返し飛ぶ場合は Hyper-V と `systemd-timesyncd` の競合を確認してください。WSL を更新し、Windows 側で
+`wsl --shutdown` を実行して distribution を再起動し、意図した時刻同期方式だけが有効であることを確認します。単調増加
+allocator は同一ホストの巻き戻りによるイベント欠落を防ぎますが、継続的な clock drift の是正は運用上必要です。
+
+**10.13.0 リリースノート**。DCB executor が生成する `SortableUniqueId` はホスト時刻の巻き戻り下でも単調増加し、再起動後は
+service ごとの store head から lazy seed されます。従来の公開 constructor と static signature、30桁 format、random suffix
+semantics は互換のままです。


### PR DESCRIPTION
## Summary
- add the singleton CAS-based monotonic SortableUniqueId generator with TimeProvider rollback detection and rate-limited warnings
- seed the shared generator lazily and single-flight per normalized service from the authoritative event-store head before allocation, reservation, or write
- route all four Core production allocation paths through the injected generator while preserving constructor and static API compatibility
- add real InMemory, SQLite, PostgreSQL, Cosmos DB, and DynamoDB store-head evidence, mutation-oriented production-path tests, and EN/JA operational guidance for dcb-v10.13.0

## Verification
- dotnet test dcb/Sekiban.Dcb.slnx -f net9.0 --no-restore: 1,531 passed, 1 skipped
- dotnet test dcb/Sekiban.Dcb.slnx -f net10.0 --no-restore: 1,531 passed, 1 skipped
- focused provider head-seed tests net9/net10: 2 passed each
- git diff --check

Closes #1123