### PR TITLE
feat(dcb): add verify-only materialized view initialization

### DIFF
--- a/dcb/internalUsages/Dcb.Domain.WithoutResult/MaterializedViews/OrderSummaryMvV1.cs
+++ b/dcb/internalUsages/Dcb.Domain.WithoutResult/MaterializedViews/OrderSummaryMvV1.cs
@@ -4,13 +4,44 @@ using Sekiban.Dcb.MaterializedView;
 
 namespace Dcb.Domain.WithoutResult.MaterializedViews;
 
-public sealed class OrderSummaryMvV1 : IMaterializedViewProjector
+public sealed class OrderSummaryMvV1 : IMaterializedViewProjector, IMvSchemaRequirementsProvider
 {
     public string ViewName => "OrderSummary";
     public int ViewVersion => 1;
 
     public MvTable Orders { get; private set; } = default!;
     public MvTable Items { get; private set; } = default!;
+
+    public IReadOnlyList<MvSchemaTableRequirement> GetSchemaRequirements(
+        MvDbType databaseType,
+        IMvTableBindings tables) =>
+    [
+        new MvSchemaTableRequirement(
+            "orders",
+            tables.GetPhysicalName("orders"),
+            [
+                new("id", MvSchemaTypeFamily.Guid, false),
+                new("status", MvSchemaTypeFamily.String, false),
+                new("total", MvSchemaTypeFamily.Decimal, false),
+                new("created_at", MvSchemaTypeFamily.DateTime, false),
+                new("_last_sortable_unique_id", MvSchemaTypeFamily.String, false),
+                new("_last_applied_at", MvSchemaTypeFamily.DateTime, false)
+            ],
+            ["id"]),
+        new MvSchemaTableRequirement(
+            "items",
+            tables.GetPhysicalName("items"),
+            [
+                new("id", MvSchemaTypeFamily.Guid, false),
+                new("order_id", MvSchemaTypeFamily.Guid, false),
+                new("product_name", MvSchemaTypeFamily.String, false),
+                new("quantity", MvSchemaTypeFamily.Integer, false),
+                new("unit_price", MvSchemaTypeFamily.Decimal, false),
+                new("_last_sortable_unique_id", MvSchemaTypeFamily.String, false),
+                new("_last_applied_at", MvSchemaTypeFamily.DateTime, false)
+            ],
+            ["id"])
+    ];
 
     public async Task InitializeAsync(IMvInitContext ctx, CancellationToken cancellationToken = default)
     {

--- a/dcb/internalUsages/Dcb.Domain.WithoutResult/MaterializedViews/WeatherForecastMvV1.cs
+++ b/dcb/internalUsages/Dcb.Domain.WithoutResult/MaterializedViews/WeatherForecastMvV1.cs
@@ -4,12 +4,32 @@ using Sekiban.Dcb.MaterializedView;
 
 namespace Dcb.Domain.WithoutResult.MaterializedViews;
 
-public sealed class WeatherForecastMvV1 : IMaterializedViewProjector
+public sealed class WeatherForecastMvV1 : IMaterializedViewProjector, IMvSchemaRequirementsProvider
 {
     public string ViewName => "WeatherForecast";
     public int ViewVersion => 1;
 
     public MvTable Forecasts { get; private set; } = default!;
+
+    public IReadOnlyList<MvSchemaTableRequirement> GetSchemaRequirements(
+        MvDbType databaseType,
+        IMvTableBindings tables) =>
+    [
+        new MvSchemaTableRequirement(
+            "forecasts",
+            tables.GetPhysicalName("forecasts"),
+            [
+                new("forecast_id", MvSchemaTypeFamily.Guid, false),
+                new("location", MvSchemaTypeFamily.String, false),
+                new("forecast_date", MvSchemaTypeFamily.DateTime, false),
+                new("temperature_c", MvSchemaTypeFamily.Integer, false),
+                new("summary", MvSchemaTypeFamily.String, true),
+                new("is_deleted", MvSchemaTypeFamily.Boolean, false),
+                new("_last_sortable_unique_id", MvSchemaTypeFamily.String, false),
+                new("_last_applied_at", MvSchemaTypeFamily.DateTime, false)
+            ],
+            ["forecast_id"])
+    ];
 
     public async Task InitializeAsync(IMvInitContext ctx, CancellationToken cancellationToken = default)
     {

--- a/dcb/src/Sekiban.Dcb.MaterializedView.MySql/MySqlMvExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.MySql/MySqlMvExecutor.cs
@@ -17,6 +17,8 @@ public sealed class MySqlMvExecutor : MvExecutorBase<MySqlConnection>, IMvExecut
     private readonly IEventStore? _legacyEventStore;
     private readonly IServiceIdProvider? _legacyServiceIdProvider;
 
+    protected override MvDbType DatabaseType => MvDbType.MySql;
+
     /// <summary>
     /// Creates the legacy single-service compatibility executor over an aggregate event store.
     /// Multi-service hosts should use the <see cref="IEventStoreFactory"/> constructor.

--- a/dcb/src/Sekiban.Dcb.MaterializedView.MySql/MySqlMvRegistryStore.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.MySql/MySqlMvRegistryStore.cs
@@ -8,6 +8,7 @@ public sealed partial class MySqlMvRegistryStore : MvForcedReverseRegistryStoreB
 {
     private readonly string _connectionString;
     private readonly Action<string>? _catalogCommandRecorder;
+    private readonly Action<string>? _readOnlyConnectionRecorder;
 
     public MySqlMvRegistryStore(string connectionString)
         : this(connectionString, null)
@@ -15,10 +16,28 @@ public sealed partial class MySqlMvRegistryStore : MvForcedReverseRegistryStoreB
     }
 
     public MySqlMvRegistryStore(string connectionString, Action<string>? catalogCommandRecorder)
+        : this(connectionString, catalogCommandRecorder, null)
+    {
+    }
+
+    public MySqlMvRegistryStore(
+        string connectionString,
+        Action<string>? catalogCommandRecorder,
+        Action<string>? readOnlyConnectionRecorder)
     {
         _connectionString = connectionString;
         _catalogCommandRecorder = catalogCommandRecorder;
+        _readOnlyConnectionRecorder = readOnlyConnectionRecorder;
     }
+
+    private string ReadOnlyConnectionString => _connectionString;
+
+    private void RecordReadOnlyConnection() => _readOnlyConnectionRecorder?.Invoke("mysql:transaction_read_only=on");
+
+    private static async Task SetReadOnlySessionAsync(MySqlConnection connection, CancellationToken cancellationToken) =>
+        await connection.ExecuteAsync(
+                new CommandDefinition("SET SESSION TRANSACTION READ ONLY;", cancellationToken: cancellationToken))
+            .ConfigureAwait(false);
 
     private CommandDefinition CatalogCommand(
         string sql,
@@ -391,11 +410,20 @@ public sealed partial class MySqlMvRegistryStore : MvForcedReverseRegistryStoreB
             cancellationToken).ConfigureAwait(false);
     }
 
-    public async Task<IReadOnlyList<MvRegistryEntry>> GetEntriesAsync(
+    public Task<IReadOnlyList<MvRegistryEntry>> GetEntriesAsync(
         string serviceId,
         string viewName,
         int viewVersion,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default) =>
+        ReadEntriesWithConnectionAsync(_connectionString, readOnly: false, serviceId, viewName, viewVersion, cancellationToken);
+
+    private async Task<IReadOnlyList<MvRegistryEntry>> ReadEntriesWithConnectionAsync(
+        string connectionString,
+        bool readOnly,
+        string serviceId,
+        string viewName,
+        int viewVersion,
+        CancellationToken cancellationToken)
     {
         const string sql = """
             SELECT service_id AS ServiceId,
@@ -425,8 +453,12 @@ public sealed partial class MySqlMvRegistryStore : MvForcedReverseRegistryStoreB
             ORDER BY logical_table;
             """;
 
-        await using var connection = new MySqlConnection(_connectionString);
+        await using var connection = new MySqlConnection(connectionString);
         await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+        if (readOnly)
+        {
+            await SetReadOnlySessionAsync(connection, cancellationToken).ConfigureAwait(false);
+        }
         var rows = await connection.QueryAsync(
             CatalogCommand(sql, new { ServiceId = serviceId, ViewName = viewName, ViewVersion = viewVersion }, cancellationToken))
             .ConfigureAwait(false);
@@ -437,13 +469,24 @@ public sealed partial class MySqlMvRegistryStore : MvForcedReverseRegistryStoreB
         string serviceId,
         string viewName,
         int viewVersion,
-        CancellationToken cancellationToken = default) =>
-        GetEntriesAsync(serviceId, viewName, viewVersion, cancellationToken);
+        CancellationToken cancellationToken = default)
+    {
+        RecordReadOnlyConnection();
+        return ReadEntriesWithConnectionAsync(ReadOnlyConnectionString, readOnly: true, serviceId, viewName, viewVersion, cancellationToken);
+    }
 
-    public async Task<MvActiveEntry?> GetActiveAsync(
+    public Task<MvActiveEntry?> GetActiveAsync(
         string serviceId,
         string viewName,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default) =>
+        ReadActiveWithConnectionAsync(_connectionString, readOnly: false, serviceId, viewName, cancellationToken);
+
+    private async Task<MvActiveEntry?> ReadActiveWithConnectionAsync(
+        string connectionString,
+        bool readOnly,
+        string serviceId,
+        string viewName,
+        CancellationToken cancellationToken)
     {
         const string sql = """
             SELECT service_id AS ServiceId,
@@ -459,12 +502,25 @@ public sealed partial class MySqlMvRegistryStore : MvForcedReverseRegistryStoreB
               AND view_name = @ViewName;
             """;
 
-        await using var connection = new MySqlConnection(_connectionString);
+        await using var connection = new MySqlConnection(connectionString);
         await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+        if (readOnly)
+        {
+            await SetReadOnlySessionAsync(connection, cancellationToken).ConfigureAwait(false);
+        }
         var row = await connection.QuerySingleOrDefaultAsync(
             new CommandDefinition(sql, new { ServiceId = serviceId, ViewName = viewName }, cancellationToken: cancellationToken))
             .ConfigureAwait(false);
         return row is null ? null : MapActiveEntry(ToDictionary(row));
+    }
+
+    public Task<MvActiveEntry?> ReadActiveAsync(
+        string serviceId,
+        string viewName,
+        CancellationToken cancellationToken = default)
+    {
+        RecordReadOnlyConnection();
+        return ReadActiveWithConnectionAsync(ReadOnlyConnectionString, readOnly: true, serviceId, viewName, cancellationToken);
     }
 
     public Task SetActiveAsync(

--- a/dcb/src/Sekiban.Dcb.MaterializedView.MySql/MySqlMvRegistryStore.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.MySql/MySqlMvRegistryStore.cs
@@ -4,13 +4,29 @@ using MySqlConnector;
 
 namespace Sekiban.Dcb.MaterializedView.MySql;
 
-public sealed partial class MySqlMvRegistryStore : MvForcedReverseRegistryStoreBase<MySqlConnection>, IMvRegistryStore, IMvSchemaVerifier
+public sealed partial class MySqlMvRegistryStore : MvForcedReverseRegistryStoreBase<MySqlConnection>, IMvRegistryStore, IMvReadOnlyMvInspector
 {
     private readonly string _connectionString;
+    private readonly Action<string>? _catalogCommandRecorder;
 
     public MySqlMvRegistryStore(string connectionString)
+        : this(connectionString, null)
+    {
+    }
+
+    public MySqlMvRegistryStore(string connectionString, Action<string>? catalogCommandRecorder)
     {
         _connectionString = connectionString;
+        _catalogCommandRecorder = catalogCommandRecorder;
+    }
+
+    private CommandDefinition CatalogCommand(
+        string sql,
+        object? parameters = null,
+        CancellationToken cancellationToken = default)
+    {
+        _catalogCommandRecorder?.Invoke(sql);
+        return new CommandDefinition(sql, parameters, cancellationToken: cancellationToken);
     }
 
     public async Task EnsureInfrastructureAsync(CancellationToken cancellationToken = default)
@@ -412,10 +428,17 @@ public sealed partial class MySqlMvRegistryStore : MvForcedReverseRegistryStoreB
         await using var connection = new MySqlConnection(_connectionString);
         await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
         var rows = await connection.QueryAsync(
-            new CommandDefinition(sql, new { ServiceId = serviceId, ViewName = viewName, ViewVersion = viewVersion }, cancellationToken: cancellationToken))
+            CatalogCommand(sql, new { ServiceId = serviceId, ViewName = viewName, ViewVersion = viewVersion }, cancellationToken))
             .ConfigureAwait(false);
         return rows.Select(row => (MvRegistryEntry)MapEntry(ToDictionary(row))).ToList();
     }
+
+    public Task<IReadOnlyList<MvRegistryEntry>> ReadRegistryEntriesAsync(
+        string serviceId,
+        string viewName,
+        int viewVersion,
+        CancellationToken cancellationToken = default) =>
+        GetEntriesAsync(serviceId, viewName, viewVersion, cancellationToken);
 
     public async Task<MvActiveEntry?> GetActiveAsync(
         string serviceId,

--- a/dcb/src/Sekiban.Dcb.MaterializedView.MySql/MySqlMvRegistryStore.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.MySql/MySqlMvRegistryStore.cs
@@ -4,7 +4,7 @@ using MySqlConnector;
 
 namespace Sekiban.Dcb.MaterializedView.MySql;
 
-public sealed partial class MySqlMvRegistryStore : MvForcedReverseRegistryStoreBase<MySqlConnection>, IMvRegistryStore
+public sealed partial class MySqlMvRegistryStore : MvForcedReverseRegistryStoreBase<MySqlConnection>, IMvRegistryStore, IMvSchemaVerifier
 {
     private readonly string _connectionString;
 

--- a/dcb/src/Sekiban.Dcb.MaterializedView.MySql/MySqlMvSchemaVerifier.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.MySql/MySqlMvSchemaVerifier.cs
@@ -19,7 +19,7 @@ public sealed partial class MySqlMvRegistryStore
                 .Distinct(StringComparer.OrdinalIgnoreCase)
                 .ToArray();
             var columns = await connection.QueryAsync<MySqlSchemaColumn>(
-                    new CommandDefinition(
+                    CatalogCommand(
                         """
                         SELECT table_name AS TableName,
                                column_name AS ColumnName,
@@ -34,7 +34,7 @@ public sealed partial class MySqlMvRegistryStore
                         cancellationToken: cancellationToken))
                 .ConfigureAwait(false);
             var primaryKeys = await connection.QueryAsync<MySqlSchemaPrimaryKeyColumn>(
-                    new CommandDefinition(
+                    CatalogCommand(
                         """
                         SELECT table_name AS TableName,
                                column_name AS ColumnName,

--- a/dcb/src/Sekiban.Dcb.MaterializedView.MySql/MySqlMvSchemaVerifier.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.MySql/MySqlMvSchemaVerifier.cs
@@ -12,8 +12,10 @@ public sealed partial class MySqlMvRegistryStore
     {
         try
         {
-            await using var connection = new MySqlConnection(_connectionString);
+            RecordReadOnlyConnection();
+            await using var connection = new MySqlConnection(ReadOnlyConnectionString);
             await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+            await SetReadOnlySessionAsync(connection, cancellationToken).ConfigureAwait(false);
             var tableNames = requirements
                 .Select(requirement => requirement.PhysicalTable)
                 .Distinct(StringComparer.OrdinalIgnoreCase)
@@ -25,7 +27,13 @@ public sealed partial class MySqlMvRegistryStore
                                column_name AS ColumnName,
                                data_type AS DataType,
                                column_type AS ColumnType,
-                               is_nullable AS IsNullable
+                               is_nullable AS IsNullable,
+                               column_default AS DefaultSql,
+                               extra AS Extra,
+                               generation_expression AS GenerationExpression,
+                               character_maximum_length AS MaxLength,
+                               numeric_precision AS NumericPrecision,
+                               numeric_scale AS NumericScale
                         FROM information_schema.columns
                         WHERE table_schema = DATABASE()
                           AND table_name IN @TableNames;
@@ -47,6 +55,23 @@ public sealed partial class MySqlMvRegistryStore
                         new { TableNames = tableNames },
                         cancellationToken: cancellationToken))
                 .ConfigureAwait(false);
+            var indexes = await connection.QueryAsync<MySqlSchemaIndexColumn>(
+                    CatalogCommand(
+                        """
+                        SELECT table_name AS TableName,
+                               index_name AS Name,
+                               non_unique AS NonUnique,
+                               column_name AS ColumnName,
+                               seq_in_index AS Ordinal
+                        FROM information_schema.statistics
+                        WHERE table_schema = DATABASE()
+                          AND table_name IN @TableNames
+                          AND index_name <> 'PRIMARY'
+                        ORDER BY table_name, index_name, seq_in_index;
+                        """,
+                        new { TableNames = tableNames },
+                        cancellationToken: cancellationToken))
+                .ConfigureAwait(false);
 
             return MvSchemaRequirements.Validate(
                 requirements,
@@ -55,11 +80,26 @@ public sealed partial class MySqlMvRegistryStore
                         column.TableName,
                         column.ColumnName,
                         MapType(column.DataType, column.ColumnType),
-                        string.Equals(column.IsNullable, "YES", StringComparison.OrdinalIgnoreCase))),
+                        string.Equals(column.IsNullable, "YES", StringComparison.OrdinalIgnoreCase))
+                    {
+                        DefaultSql = column.DefaultSql,
+                        IsGenerated = column.Extra.Contains("GENERATED", StringComparison.OrdinalIgnoreCase),
+                        GenerationExpression = column.GenerationExpression,
+                        MaxLength = column.MaxLength is <= int.MaxValue ? (int?)column.MaxLength : null,
+                        Precision = column.NumericPrecision,
+                        Scale = column.NumericScale
+                    }),
                     primaryKeys.Select(column => new MvObservedSchemaPrimaryKeyColumn(
                         column.TableName,
                         column.ColumnName,
-                        column.Ordinal))));
+                        column.Ordinal)),
+                    indexes
+                        .GroupBy(index => (index.TableName, index.Name), StringTupleComparer.Instance)
+                        .Select(group => new MvObservedSchemaIndex(
+                            group.Key.TableName,
+                            group.Key.Name,
+                            group.OrderBy(index => index.Ordinal).Select(index => index.ColumnName).ToList(),
+                            group.First().NonUnique == 0))));
         }
         catch (OperationCanceledException)
         {
@@ -102,6 +142,12 @@ public sealed partial class MySqlMvRegistryStore
         public string DataType { get; init; } = string.Empty;
         public string ColumnType { get; init; } = string.Empty;
         public string IsNullable { get; init; } = string.Empty;
+        public string? DefaultSql { get; init; }
+        public string Extra { get; init; } = string.Empty;
+        public string? GenerationExpression { get; init; }
+        public long? MaxLength { get; init; }
+        public int? NumericPrecision { get; init; }
+        public int? NumericScale { get; init; }
     }
 
     private sealed class MySqlSchemaPrimaryKeyColumn
@@ -109,5 +155,28 @@ public sealed partial class MySqlMvRegistryStore
         public string TableName { get; init; } = string.Empty;
         public string ColumnName { get; init; } = string.Empty;
         public int Ordinal { get; init; }
+    }
+
+    private sealed class MySqlSchemaIndexColumn
+    {
+        public string TableName { get; init; } = string.Empty;
+        public string Name { get; init; } = string.Empty;
+        public int NonUnique { get; init; }
+        public string ColumnName { get; init; } = string.Empty;
+        public int Ordinal { get; init; }
+    }
+
+    private sealed class StringTupleComparer : IEqualityComparer<(string TableName, string Name)>
+    {
+        public static StringTupleComparer Instance { get; } = new();
+
+        public bool Equals((string TableName, string Name) x, (string TableName, string Name) y) =>
+            string.Equals(x.TableName, y.TableName, StringComparison.OrdinalIgnoreCase) &&
+            string.Equals(x.Name, y.Name, StringComparison.OrdinalIgnoreCase);
+
+        public int GetHashCode((string TableName, string Name) obj) =>
+            HashCode.Combine(
+                StringComparer.OrdinalIgnoreCase.GetHashCode(obj.TableName),
+                StringComparer.OrdinalIgnoreCase.GetHashCode(obj.Name));
     }
 }

--- a/dcb/src/Sekiban.Dcb.MaterializedView.MySql/MySqlMvSchemaVerifier.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.MySql/MySqlMvSchemaVerifier.cs
@@ -1,0 +1,113 @@
+using Dapper;
+using MySqlConnector;
+using Sekiban.Dcb.MaterializedView;
+
+namespace Sekiban.Dcb.MaterializedView.MySql;
+
+public sealed partial class MySqlMvRegistryStore
+{
+    public async Task<MvSchemaVerificationResult> VerifySchemaAsync(
+        IReadOnlyList<MvSchemaTableRequirement> requirements,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            await using var connection = new MySqlConnection(_connectionString);
+            await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+            var tableNames = requirements
+                .Select(requirement => requirement.PhysicalTable)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+            var columns = await connection.QueryAsync<MySqlSchemaColumn>(
+                    new CommandDefinition(
+                        """
+                        SELECT table_name AS TableName,
+                               column_name AS ColumnName,
+                               data_type AS DataType,
+                               column_type AS ColumnType,
+                               is_nullable AS IsNullable
+                        FROM information_schema.columns
+                        WHERE table_schema = DATABASE()
+                          AND table_name IN @TableNames;
+                        """,
+                        new { TableNames = tableNames },
+                        cancellationToken: cancellationToken))
+                .ConfigureAwait(false);
+            var primaryKeys = await connection.QueryAsync<MySqlSchemaPrimaryKeyColumn>(
+                    new CommandDefinition(
+                        """
+                        SELECT table_name AS TableName,
+                               column_name AS ColumnName,
+                               ordinal_position AS Ordinal
+                        FROM information_schema.key_column_usage
+                        WHERE constraint_schema = DATABASE()
+                          AND constraint_name = 'PRIMARY'
+                          AND table_name IN @TableNames;
+                        """,
+                        new { TableNames = tableNames },
+                        cancellationToken: cancellationToken))
+                .ConfigureAwait(false);
+
+            return MvSchemaRequirements.Validate(
+                requirements,
+                MvSchemaRequirements.Observe(
+                    columns.Select(column => new MvObservedSchemaColumn(
+                        column.TableName,
+                        column.ColumnName,
+                        MapType(column.DataType, column.ColumnType),
+                        string.Equals(column.IsNullable, "YES", StringComparison.OrdinalIgnoreCase))),
+                    primaryKeys.Select(column => new MvObservedSchemaPrimaryKeyColumn(
+                        column.TableName,
+                        column.ColumnName,
+                        column.Ordinal))));
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch
+        {
+            return MvSchemaVerificationResult.Failed(
+                MvInitializationFailureReason.UnsupportedProviderCapability,
+                "MySQL schema metadata verification is unavailable.");
+        }
+    }
+
+    private static MvSchemaTypeFamily MapType(string dataType, string columnType)
+    {
+        var type = $"{dataType} {columnType}".ToLowerInvariant();
+        if (type.Contains("json", StringComparison.Ordinal)) return MvSchemaTypeFamily.Json;
+        if (type.Contains("tinyint(1)", StringComparison.Ordinal) || type.Contains("boolean", StringComparison.Ordinal) ||
+            type.Contains("bool", StringComparison.Ordinal)) return MvSchemaTypeFamily.Boolean;
+        if (type.Contains("datetime", StringComparison.Ordinal) || type.Contains("timestamp", StringComparison.Ordinal) ||
+            type.Contains("date", StringComparison.Ordinal) || type.Contains("time", StringComparison.Ordinal))
+            return MvSchemaTypeFamily.DateTime;
+        if (type.Contains("int", StringComparison.Ordinal) || type.Contains("bit", StringComparison.Ordinal))
+            return MvSchemaTypeFamily.Integer;
+        if (type.Contains("decimal", StringComparison.Ordinal) || type.Contains("numeric", StringComparison.Ordinal))
+            return MvSchemaTypeFamily.Decimal;
+        if (type.Contains("double", StringComparison.Ordinal) || type.Contains("float", StringComparison.Ordinal))
+            return MvSchemaTypeFamily.FloatingPoint;
+        if (type.Contains("blob", StringComparison.Ordinal) || type.Contains("binary", StringComparison.Ordinal))
+            return MvSchemaTypeFamily.Binary;
+        if (type.Contains("char", StringComparison.Ordinal) || type.Contains("text", StringComparison.Ordinal))
+            return MvSchemaTypeFamily.String;
+        return MvSchemaTypeFamily.Any;
+    }
+
+    private sealed class MySqlSchemaColumn
+    {
+        public string TableName { get; init; } = string.Empty;
+        public string ColumnName { get; init; } = string.Empty;
+        public string DataType { get; init; } = string.Empty;
+        public string ColumnType { get; init; } = string.Empty;
+        public string IsNullable { get; init; } = string.Empty;
+    }
+
+    private sealed class MySqlSchemaPrimaryKeyColumn
+    {
+        public string TableName { get; init; } = string.Empty;
+        public string ColumnName { get; init; } = string.Empty;
+        public int Ordinal { get; init; }
+    }
+}

--- a/dcb/src/Sekiban.Dcb.MaterializedView.Orleans/MaterializedViewGrain.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.Orleans/MaterializedViewGrain.cs
@@ -28,6 +28,8 @@ public sealed class MaterializedViewGrain : Grain, IMaterializedViewGrain
     private readonly IMvRegistryStore _registryStore;
     private readonly IEventSubscriptionResolver _subscriptionResolver;
 
+    private bool IsVerifyOnly => _options.InitializationMode == MvInitializationMode.VerifyOnly;
+
     private readonly List<SerializableEvent> _pendingStreamEvents = [];
     private IAsyncStream<SerializableEvent>? _stream;
     private StreamSubscriptionHandle<SerializableEvent>? _streamHandle;
@@ -119,6 +121,14 @@ public sealed class MaterializedViewGrain : Grain, IMaterializedViewGrain
 
         ResolveHost();
         await _executor.InitializeAsync(_host!, _serviceId, CancellationToken.None);
+        if (IsVerifyOnly)
+        {
+            // Verify-only is an inspection lifecycle, not a catch-up lifecycle. Do not subscribe, capture a target,
+            // mark status, apply events, or let a timer reach registry mutations after the schema gate succeeds.
+            _started = true;
+            return;
+        }
+
         if (_executor is IMvActivationExecutor activationExecutor)
         {
             // Target capture is an explicit lifecycle step. Initialization creates registry rows only; it never
@@ -143,6 +153,11 @@ public sealed class MaterializedViewGrain : Grain, IMaterializedViewGrain
     public async Task RefreshAsync()
     {
         await EnsureStartedAsync();
+
+        if (IsVerifyOnly)
+        {
+            return;
+        }
 
         // Activate catch-up for any callers that explicitly request a refresh.
         if (!_isCatchUpActive)
@@ -389,6 +404,11 @@ public sealed class MaterializedViewGrain : Grain, IMaterializedViewGrain
     /// </summary>
     private async Task<bool> RunCatchUpTickAsync(bool ignoreImmediateFlag, CancellationToken cancellationToken)
     {
+        if (IsVerifyOnly)
+        {
+            return false;
+        }
+
         if (!_isCatchUpActive)
         {
             StopCatchUpTimer();
@@ -500,6 +520,11 @@ public sealed class MaterializedViewGrain : Grain, IMaterializedViewGrain
 
     private async Task CompleteCatchUpAsync(CancellationToken cancellationToken)
     {
+        if (IsVerifyOnly)
+        {
+            return;
+        }
+
         await RefreshPositionFromRegistryAsync(cancellationToken);
 
         // Registry truth is the readiness gate. A legacy row, failed read, or
@@ -703,6 +728,11 @@ public sealed class MaterializedViewGrain : Grain, IMaterializedViewGrain
 
     internal async Task OnStreamBatchAsync(IEnumerable<SerializableEvent> events)
     {
+        if (IsVerifyOnly)
+        {
+            return;
+        }
+
         var batch = events
             .OrderBy(serializableEvent => serializableEvent.SortableUniqueIdValue, StringComparer.Ordinal)
             .ToList();
@@ -762,7 +792,9 @@ public sealed class MaterializedViewGrain : Grain, IMaterializedViewGrain
     private async Task RefreshPositionFromRegistryAsync(CancellationToken cancellationToken)
     {
         ResolveHost();
-        var entries = await _registryStore.GetEntriesAsync(_serviceId!, _host!.ViewName, _host.ViewVersion, cancellationToken);
+        var entries = IsVerifyOnly && _registryStore is IMvReadOnlyMvInspector inspector
+            ? await inspector.ReadRegistryEntriesAsync(_serviceId!, _host!.ViewName, _host.ViewVersion, cancellationToken)
+            : await _registryStore.GetEntriesAsync(_serviceId!, _host!.ViewName, _host.ViewVersion, cancellationToken);
         _publicationSnapshot = MvProjectionStatusSnapshot.FromEntries(entries);
         var currentPosition = entries
             .Select(entry => entry.CurrentCheckpointTruth.IsKnown ? entry.CurrentCheckpointTruth.PositionValue : null)

--- a/dcb/src/Sekiban.Dcb.MaterializedView.Postgres/PostgresMvExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.Postgres/PostgresMvExecutor.cs
@@ -17,6 +17,8 @@ public sealed class PostgresMvExecutor : MvExecutorBase<NpgsqlConnection>, IMvEx
     private readonly IEventStore? _legacyEventStore;
     private readonly IServiceIdProvider? _legacyServiceIdProvider;
 
+    protected override MvDbType DatabaseType => MvDbType.Postgres;
+
     /// <summary>
     /// Creates the legacy single-service compatibility executor over an aggregate event store.
     /// Multi-service hosts should use the <see cref="IEventStoreFactory"/> constructor.

--- a/dcb/src/Sekiban.Dcb.MaterializedView.Postgres/PostgresMvRegistryStore.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.Postgres/PostgresMvRegistryStore.cs
@@ -8,6 +8,7 @@ public sealed partial class PostgresMvRegistryStore : MvForcedReverseRegistrySto
 {
     private readonly string _connectionString;
     private readonly Action<string>? _catalogCommandRecorder;
+    private readonly Action<string>? _readOnlyConnectionRecorder;
 
     public PostgresMvRegistryStore(string connectionString)
         : this(connectionString, null)
@@ -15,10 +16,33 @@ public sealed partial class PostgresMvRegistryStore : MvForcedReverseRegistrySto
     }
 
     public PostgresMvRegistryStore(string connectionString, Action<string>? catalogCommandRecorder)
+        : this(connectionString, catalogCommandRecorder, null)
+    {
+    }
+
+    public PostgresMvRegistryStore(
+        string connectionString,
+        Action<string>? catalogCommandRecorder,
+        Action<string>? readOnlyConnectionRecorder)
     {
         _connectionString = connectionString;
         _catalogCommandRecorder = catalogCommandRecorder;
+        _readOnlyConnectionRecorder = readOnlyConnectionRecorder;
     }
+
+    private string ReadOnlyConnectionString
+    {
+        get
+        {
+            var builder = new NpgsqlConnectionStringBuilder(_connectionString);
+            builder.Options = string.IsNullOrWhiteSpace(builder.Options)
+                ? "-c default_transaction_read_only=on"
+                : $"{builder.Options} -c default_transaction_read_only=on";
+            return builder.ConnectionString;
+        }
+    }
+
+    private void RecordReadOnlyConnection() => _readOnlyConnectionRecorder?.Invoke("postgres:default_transaction_read_only=on");
 
     private CommandDefinition CatalogCommand(
         string sql,
@@ -355,11 +379,19 @@ public sealed partial class PostgresMvRegistryStore : MvForcedReverseRegistrySto
             cancellationToken).ConfigureAwait(false);
     }
 
-    public async Task<IReadOnlyList<MvRegistryEntry>> GetEntriesAsync(
+    public Task<IReadOnlyList<MvRegistryEntry>> GetEntriesAsync(
         string serviceId,
         string viewName,
         int viewVersion,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default) =>
+        ReadEntriesWithConnectionAsync(_connectionString, serviceId, viewName, viewVersion, cancellationToken);
+
+    private async Task<IReadOnlyList<MvRegistryEntry>> ReadEntriesWithConnectionAsync(
+        string connectionString,
+        string serviceId,
+        string viewName,
+        int viewVersion,
+        CancellationToken cancellationToken)
     {
         const string sql = """
             SELECT service_id AS ServiceId,
@@ -389,7 +421,7 @@ public sealed partial class PostgresMvRegistryStore : MvForcedReverseRegistrySto
             ORDER BY logical_table;
             """;
 
-        await using var connection = new NpgsqlConnection(_connectionString);
+        await using var connection = new NpgsqlConnection(connectionString);
         await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
         var rows = await connection.QueryAsync(
             CatalogCommand(sql, new { ServiceId = serviceId, ViewName = viewName, ViewVersion = viewVersion }, cancellationToken))
@@ -401,13 +433,23 @@ public sealed partial class PostgresMvRegistryStore : MvForcedReverseRegistrySto
         string serviceId,
         string viewName,
         int viewVersion,
-        CancellationToken cancellationToken = default) =>
-        GetEntriesAsync(serviceId, viewName, viewVersion, cancellationToken);
+        CancellationToken cancellationToken = default)
+    {
+        RecordReadOnlyConnection();
+        return ReadEntriesWithConnectionAsync(ReadOnlyConnectionString, serviceId, viewName, viewVersion, cancellationToken);
+    }
 
-    public async Task<MvActiveEntry?> GetActiveAsync(
+    public Task<MvActiveEntry?> GetActiveAsync(
         string serviceId,
         string viewName,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default) =>
+        ReadActiveWithConnectionAsync(_connectionString, serviceId, viewName, cancellationToken);
+
+    private async Task<MvActiveEntry?> ReadActiveWithConnectionAsync(
+        string connectionString,
+        string serviceId,
+        string viewName,
+        CancellationToken cancellationToken)
     {
         const string sql = """
             SELECT service_id AS ServiceId,
@@ -423,12 +465,21 @@ public sealed partial class PostgresMvRegistryStore : MvForcedReverseRegistrySto
               AND view_name = @ViewName;
             """;
 
-        await using var connection = new NpgsqlConnection(_connectionString);
+        await using var connection = new NpgsqlConnection(connectionString);
         await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
         var row = await connection.QuerySingleOrDefaultAsync(
             new CommandDefinition(sql, new { ServiceId = serviceId, ViewName = viewName }, cancellationToken: cancellationToken))
             .ConfigureAwait(false);
         return row is null ? null : MapActiveEntry(ToDictionary(row));
+    }
+
+    public Task<MvActiveEntry?> ReadActiveAsync(
+        string serviceId,
+        string viewName,
+        CancellationToken cancellationToken = default)
+    {
+        RecordReadOnlyConnection();
+        return ReadActiveWithConnectionAsync(ReadOnlyConnectionString, serviceId, viewName, cancellationToken);
     }
 
     public Task SetActiveAsync(

--- a/dcb/src/Sekiban.Dcb.MaterializedView.Postgres/PostgresMvRegistryStore.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.Postgres/PostgresMvRegistryStore.cs
@@ -4,13 +4,29 @@ using Npgsql;
 
 namespace Sekiban.Dcb.MaterializedView.Postgres;
 
-public sealed partial class PostgresMvRegistryStore : MvForcedReverseRegistryStoreBase<NpgsqlConnection>, IMvRegistryStore, IMvSchemaVerifier
+public sealed partial class PostgresMvRegistryStore : MvForcedReverseRegistryStoreBase<NpgsqlConnection>, IMvRegistryStore, IMvReadOnlyMvInspector
 {
     private readonly string _connectionString;
+    private readonly Action<string>? _catalogCommandRecorder;
 
     public PostgresMvRegistryStore(string connectionString)
+        : this(connectionString, null)
+    {
+    }
+
+    public PostgresMvRegistryStore(string connectionString, Action<string>? catalogCommandRecorder)
     {
         _connectionString = connectionString;
+        _catalogCommandRecorder = catalogCommandRecorder;
+    }
+
+    private CommandDefinition CatalogCommand(
+        string sql,
+        object? parameters = null,
+        CancellationToken cancellationToken = default)
+    {
+        _catalogCommandRecorder?.Invoke(sql);
+        return new CommandDefinition(sql, parameters, cancellationToken: cancellationToken);
     }
 
     public async Task EnsureInfrastructureAsync(CancellationToken cancellationToken = default)
@@ -376,10 +392,17 @@ public sealed partial class PostgresMvRegistryStore : MvForcedReverseRegistrySto
         await using var connection = new NpgsqlConnection(_connectionString);
         await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
         var rows = await connection.QueryAsync(
-            new CommandDefinition(sql, new { ServiceId = serviceId, ViewName = viewName, ViewVersion = viewVersion }, cancellationToken: cancellationToken))
+            CatalogCommand(sql, new { ServiceId = serviceId, ViewName = viewName, ViewVersion = viewVersion }, cancellationToken))
             .ConfigureAwait(false);
         return rows.Select(row => (MvRegistryEntry)MapEntry(ToDictionary(row))).ToList();
     }
+
+    public Task<IReadOnlyList<MvRegistryEntry>> ReadRegistryEntriesAsync(
+        string serviceId,
+        string viewName,
+        int viewVersion,
+        CancellationToken cancellationToken = default) =>
+        GetEntriesAsync(serviceId, viewName, viewVersion, cancellationToken);
 
     public async Task<MvActiveEntry?> GetActiveAsync(
         string serviceId,

--- a/dcb/src/Sekiban.Dcb.MaterializedView.Postgres/PostgresMvRegistryStore.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.Postgres/PostgresMvRegistryStore.cs
@@ -4,7 +4,7 @@ using Npgsql;
 
 namespace Sekiban.Dcb.MaterializedView.Postgres;
 
-public sealed partial class PostgresMvRegistryStore : MvForcedReverseRegistryStoreBase<NpgsqlConnection>, IMvRegistryStore
+public sealed partial class PostgresMvRegistryStore : MvForcedReverseRegistryStoreBase<NpgsqlConnection>, IMvRegistryStore, IMvSchemaVerifier
 {
     private readonly string _connectionString;
 

--- a/dcb/src/Sekiban.Dcb.MaterializedView.Postgres/PostgresMvSchemaVerifier.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.Postgres/PostgresMvSchemaVerifier.cs
@@ -12,7 +12,8 @@ public sealed partial class PostgresMvRegistryStore
     {
         try
         {
-            await using var connection = new NpgsqlConnection(_connectionString);
+            RecordReadOnlyConnection();
+            await using var connection = new NpgsqlConnection(ReadOnlyConnectionString);
             await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
             var tableNames = requirements
                 .Select(requirement => requirement.PhysicalTable)
@@ -26,7 +27,13 @@ public sealed partial class PostgresMvRegistryStore
                                column_name AS ColumnName,
                                data_type AS DataType,
                                udt_name AS UdtName,
-                               is_nullable AS IsNullable
+                               is_nullable AS IsNullable,
+                               column_default AS DefaultSql,
+                               is_generated AS IsGenerated,
+                               generation_expression AS GenerationExpression,
+                               character_maximum_length AS MaxLength,
+                               numeric_precision AS Precision,
+                               numeric_scale AS Scale
                         FROM information_schema.columns
                         WHERE table_schema = current_schema()
                           AND table_name = ANY(@TableNames);
@@ -52,6 +59,21 @@ public sealed partial class PostgresMvRegistryStore
                         new { TableNames = tableNames },
                         cancellationToken: cancellationToken))
                 .ConfigureAwait(false);
+            var indexes = await connection.QueryAsync<PostgresSchemaIndex>(
+                    CatalogCommand(
+                        """
+                        SELECT tablename AS TableName,
+                               indexname AS Name,
+                               indexdef LIKE '%UNIQUE INDEX%' AS IsUnique,
+                               regexp_replace(indexdef, '^.*\\((.*)\\).*$', '\\1') AS ColumnList
+                        FROM pg_indexes
+                        WHERE schemaname = current_schema()
+                          AND tablename = ANY(@TableNames)
+                          AND indexdef NOT LIKE '%PRIMARY KEY%';
+                        """,
+                        new { TableNames = tableNames },
+                        cancellationToken: cancellationToken))
+                .ConfigureAwait(false);
 
             return MvSchemaRequirements.Validate(
                 requirements,
@@ -60,11 +82,27 @@ public sealed partial class PostgresMvRegistryStore
                         column.TableName,
                         column.ColumnName,
                         MapType(column.DataType, column.UdtName),
-                        string.Equals(column.IsNullable, "YES", StringComparison.OrdinalIgnoreCase))),
+                        string.Equals(column.IsNullable, "YES", StringComparison.OrdinalIgnoreCase))
+                    {
+                        DefaultSql = column.DefaultSql,
+                        IsGenerated = string.Equals(column.IsGenerated, "ALWAYS", StringComparison.OrdinalIgnoreCase),
+                        GenerationExpression = column.GenerationExpression,
+                        MaxLength = column.MaxLength,
+                        Precision = column.Precision,
+                        Scale = column.Scale
+                    }),
                     primaryKeys.Select(column => new MvObservedSchemaPrimaryKeyColumn(
                         column.TableName,
                         column.ColumnName,
-                        column.Ordinal))));
+                        column.Ordinal)),
+                    indexes.Select(index => new MvObservedSchemaIndex(
+                        index.TableName,
+                        index.Name,
+                        index.ColumnList
+                            .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                            .Select(column => column.Trim('"'))
+                            .ToList(),
+                        index.IsUnique))));
         }
         catch (OperationCanceledException)
         {
@@ -106,6 +144,12 @@ public sealed partial class PostgresMvRegistryStore
         public string DataType { get; init; } = string.Empty;
         public string UdtName { get; init; } = string.Empty;
         public string IsNullable { get; init; } = string.Empty;
+        public string? DefaultSql { get; init; }
+        public string? IsGenerated { get; init; }
+        public string? GenerationExpression { get; init; }
+        public int? MaxLength { get; init; }
+        public int? Precision { get; init; }
+        public int? Scale { get; init; }
     }
 
     private sealed class PostgresSchemaPrimaryKeyColumn
@@ -113,5 +157,13 @@ public sealed partial class PostgresMvRegistryStore
         public string TableName { get; init; } = string.Empty;
         public string ColumnName { get; init; } = string.Empty;
         public int Ordinal { get; init; }
+    }
+
+    private sealed class PostgresSchemaIndex
+    {
+        public string TableName { get; init; } = string.Empty;
+        public string Name { get; init; } = string.Empty;
+        public bool IsUnique { get; init; }
+        public string ColumnList { get; init; } = string.Empty;
     }
 }

--- a/dcb/src/Sekiban.Dcb.MaterializedView.Postgres/PostgresMvSchemaVerifier.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.Postgres/PostgresMvSchemaVerifier.cs
@@ -20,7 +20,7 @@ public sealed partial class PostgresMvRegistryStore
                 .ToArray();
 
             var columns = await connection.QueryAsync<PostgresSchemaColumn>(
-                    new CommandDefinition(
+                    CatalogCommand(
                         """
                         SELECT table_name AS TableName,
                                column_name AS ColumnName,
@@ -35,7 +35,7 @@ public sealed partial class PostgresMvRegistryStore
                         cancellationToken: cancellationToken))
                 .ConfigureAwait(false);
             var primaryKeys = await connection.QueryAsync<PostgresSchemaPrimaryKeyColumn>(
-                    new CommandDefinition(
+                    CatalogCommand(
                         """
                         SELECT tc.table_name AS TableName,
                                kcu.column_name AS ColumnName,

--- a/dcb/src/Sekiban.Dcb.MaterializedView.Postgres/PostgresMvSchemaVerifier.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.Postgres/PostgresMvSchemaVerifier.cs
@@ -1,0 +1,117 @@
+using Dapper;
+using Npgsql;
+using Sekiban.Dcb.MaterializedView;
+
+namespace Sekiban.Dcb.MaterializedView.Postgres;
+
+public sealed partial class PostgresMvRegistryStore
+{
+    public async Task<MvSchemaVerificationResult> VerifySchemaAsync(
+        IReadOnlyList<MvSchemaTableRequirement> requirements,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            await using var connection = new NpgsqlConnection(_connectionString);
+            await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+            var tableNames = requirements
+                .Select(requirement => requirement.PhysicalTable)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+
+            var columns = await connection.QueryAsync<PostgresSchemaColumn>(
+                    new CommandDefinition(
+                        """
+                        SELECT table_name AS TableName,
+                               column_name AS ColumnName,
+                               data_type AS DataType,
+                               udt_name AS UdtName,
+                               is_nullable AS IsNullable
+                        FROM information_schema.columns
+                        WHERE table_schema = current_schema()
+                          AND table_name = ANY(@TableNames);
+                        """,
+                        new { TableNames = tableNames },
+                        cancellationToken: cancellationToken))
+                .ConfigureAwait(false);
+            var primaryKeys = await connection.QueryAsync<PostgresSchemaPrimaryKeyColumn>(
+                    new CommandDefinition(
+                        """
+                        SELECT tc.table_name AS TableName,
+                               kcu.column_name AS ColumnName,
+                               kcu.ordinal_position AS Ordinal
+                        FROM information_schema.table_constraints AS tc
+                        INNER JOIN information_schema.key_column_usage AS kcu
+                            ON tc.constraint_name = kcu.constraint_name
+                           AND tc.table_schema = kcu.table_schema
+                           AND tc.table_name = kcu.table_name
+                        WHERE tc.table_schema = current_schema()
+                          AND tc.constraint_type = 'PRIMARY KEY'
+                          AND tc.table_name = ANY(@TableNames);
+                        """,
+                        new { TableNames = tableNames },
+                        cancellationToken: cancellationToken))
+                .ConfigureAwait(false);
+
+            return MvSchemaRequirements.Validate(
+                requirements,
+                MvSchemaRequirements.Observe(
+                    columns.Select(column => new MvObservedSchemaColumn(
+                        column.TableName,
+                        column.ColumnName,
+                        MapType(column.DataType, column.UdtName),
+                        string.Equals(column.IsNullable, "YES", StringComparison.OrdinalIgnoreCase))),
+                    primaryKeys.Select(column => new MvObservedSchemaPrimaryKeyColumn(
+                        column.TableName,
+                        column.ColumnName,
+                        column.Ordinal))));
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch
+        {
+            return MvSchemaVerificationResult.Failed(
+                MvInitializationFailureReason.UnsupportedProviderCapability,
+                "PostgreSQL schema metadata verification is unavailable.");
+        }
+    }
+
+    private static MvSchemaTypeFamily MapType(string dataType, string udtName)
+    {
+        var type = $"{dataType} {udtName}".ToLowerInvariant();
+        if (type.Contains("json", StringComparison.Ordinal)) return MvSchemaTypeFamily.Json;
+        if (type.Contains("uuid", StringComparison.Ordinal)) return MvSchemaTypeFamily.Guid;
+        if (type.Contains("bool", StringComparison.Ordinal)) return MvSchemaTypeFamily.Boolean;
+        if (type.Contains("timestamp", StringComparison.Ordinal) ||
+            type.Contains("date", StringComparison.Ordinal) ||
+            type.Contains("time", StringComparison.Ordinal)) return MvSchemaTypeFamily.DateTime;
+        if (type.Contains("int", StringComparison.Ordinal) || type.Contains("serial", StringComparison.Ordinal))
+            return MvSchemaTypeFamily.Integer;
+        if (type.Contains("numeric", StringComparison.Ordinal) || type.Contains("decimal", StringComparison.Ordinal))
+            return MvSchemaTypeFamily.Decimal;
+        if (type.Contains("double", StringComparison.Ordinal) || type.Contains("real", StringComparison.Ordinal))
+            return MvSchemaTypeFamily.FloatingPoint;
+        if (type.Contains("bytea", StringComparison.Ordinal)) return MvSchemaTypeFamily.Binary;
+        if (type.Contains("char", StringComparison.Ordinal) || type.Contains("text", StringComparison.Ordinal))
+            return MvSchemaTypeFamily.String;
+        return MvSchemaTypeFamily.Any;
+    }
+
+    private sealed class PostgresSchemaColumn
+    {
+        public string TableName { get; init; } = string.Empty;
+        public string ColumnName { get; init; } = string.Empty;
+        public string DataType { get; init; } = string.Empty;
+        public string UdtName { get; init; } = string.Empty;
+        public string IsNullable { get; init; } = string.Empty;
+    }
+
+    private sealed class PostgresSchemaPrimaryKeyColumn
+    {
+        public string TableName { get; init; } = string.Empty;
+        public string ColumnName { get; init; } = string.Empty;
+        public int Ordinal { get; init; }
+    }
+}

--- a/dcb/src/Sekiban.Dcb.MaterializedView.Postgres/PostgresMvSchemaVerifier.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.Postgres/PostgresMvSchemaVerifier.cs
@@ -62,14 +62,26 @@ public sealed partial class PostgresMvRegistryStore
             var indexes = await connection.QueryAsync<PostgresSchemaIndex>(
                     CatalogCommand(
                         """
-                        SELECT tablename AS TableName,
-                               indexname AS Name,
-                               indexdef LIKE '%UNIQUE INDEX%' AS IsUnique,
-                               regexp_replace(indexdef, '^.*\\((.*)\\).*$', '\\1') AS ColumnList
-                        FROM pg_indexes
-                        WHERE schemaname = current_schema()
-                          AND tablename = ANY(@TableNames)
-                          AND indexdef NOT LIKE '%PRIMARY KEY%';
+                        SELECT tables.relname AS TableName,
+                               indexes.relname AS Name,
+                               index_metadata.indisunique AS IsUnique,
+                               string_agg(columns.attname, ',' ORDER BY key_columns.ordinality) AS ColumnList
+                        FROM pg_class AS tables
+                        INNER JOIN pg_namespace AS schemas
+                            ON schemas.oid = tables.relnamespace
+                           AND schemas.nspname = current_schema()
+                        INNER JOIN pg_index AS index_metadata
+                            ON index_metadata.indrelid = tables.oid
+                           AND index_metadata.indisprimary = FALSE
+                        INNER JOIN pg_class AS indexes
+                            ON indexes.oid = index_metadata.indexrelid
+                        CROSS JOIN LATERAL unnest(index_metadata.indkey) WITH ORDINALITY AS key_columns(attnum, ordinality)
+                        INNER JOIN pg_attribute AS columns
+                            ON columns.attrelid = tables.oid
+                           AND columns.attnum = key_columns.attnum
+                        WHERE tables.relkind = 'r'
+                          AND tables.relname = ANY(@TableNames)
+                        GROUP BY tables.relname, indexes.relname, index_metadata.indisunique;
                         """,
                         new { TableNames = tableNames },
                         cancellationToken: cancellationToken))

--- a/dcb/src/Sekiban.Dcb.MaterializedView.SqlServer/SekibanDcbMaterializedViewSqlServerExtensions.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.SqlServer/SekibanDcbMaterializedViewSqlServerExtensions.cs
@@ -29,7 +29,12 @@ public static class SekibanDcbMaterializedViewSqlServerExtensions
     {
         services.AddSekibanDcbMaterializedView();
         services.TryAddSingleton<IServiceIdProvider, DefaultServiceIdProvider>();
-        services.TryAddSingleton<IMvRegistryStore>(_ => new SqlServerMvRegistryStore(connectionString));
+        services.TryAddSingleton<IMvRegistryStore>(sp =>
+            new SqlServerMvRegistryStore(
+                connectionString,
+                null,
+                null,
+                sp.GetRequiredService<IOptions<MvOptions>>().Value.SqlServerInspectionConnectionString));
         services.TryAddSingleton<IMvStorageInfoProvider>(_ =>
             new MvStorageInfoProvider(new MvStorageInfo(MvDbType.SqlServer, connectionString)));
         services.TryAddSingleton<IMvExecutor>(sp =>

--- a/dcb/src/Sekiban.Dcb.MaterializedView.SqlServer/SqlServerMvExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.SqlServer/SqlServerMvExecutor.cs
@@ -17,6 +17,8 @@ public sealed class SqlServerMvExecutor : MvExecutorBase<SqlConnection>, IMvExec
     private readonly IEventStore? _legacyEventStore;
     private readonly IServiceIdProvider? _legacyServiceIdProvider;
 
+    protected override MvDbType DatabaseType => MvDbType.SqlServer;
+
     /// <summary>
     /// Creates the legacy single-service compatibility executor over an aggregate event store.
     /// Multi-service hosts should use the <see cref="IEventStoreFactory"/> constructor.

--- a/dcb/src/Sekiban.Dcb.MaterializedView.SqlServer/SqlServerMvRegistryStore.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.SqlServer/SqlServerMvRegistryStore.cs
@@ -4,13 +4,29 @@ using Microsoft.Data.SqlClient;
 
 namespace Sekiban.Dcb.MaterializedView.SqlServer;
 
-public sealed partial class SqlServerMvRegistryStore : MvForcedReverseRegistryStoreBase<SqlConnection>, IMvRegistryStore, IMvSchemaVerifier
+public sealed partial class SqlServerMvRegistryStore : MvForcedReverseRegistryStoreBase<SqlConnection>, IMvRegistryStore, IMvReadOnlyMvInspector
 {
     private readonly string _connectionString;
+    private readonly Action<string>? _catalogCommandRecorder;
 
     public SqlServerMvRegistryStore(string connectionString)
+        : this(connectionString, null)
+    {
+    }
+
+    public SqlServerMvRegistryStore(string connectionString, Action<string>? catalogCommandRecorder)
     {
         _connectionString = connectionString;
+        _catalogCommandRecorder = catalogCommandRecorder;
+    }
+
+    private CommandDefinition CatalogCommand(
+        string sql,
+        object? parameters = null,
+        CancellationToken cancellationToken = default)
+    {
+        _catalogCommandRecorder?.Invoke(sql);
+        return new CommandDefinition(sql, parameters, cancellationToken: cancellationToken);
     }
 
     public async Task EnsureInfrastructureAsync(CancellationToken cancellationToken = default)
@@ -391,10 +407,17 @@ public sealed partial class SqlServerMvRegistryStore : MvForcedReverseRegistrySt
         await using var connection = new SqlConnection(_connectionString);
         await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
         var rows = await connection.QueryAsync(
-            new CommandDefinition(sql, new { ServiceId = serviceId, ViewName = viewName, ViewVersion = viewVersion }, cancellationToken: cancellationToken))
+            CatalogCommand(sql, new { ServiceId = serviceId, ViewName = viewName, ViewVersion = viewVersion }, cancellationToken))
             .ConfigureAwait(false);
         return rows.Select(row => (MvRegistryEntry)MapEntry(ToDictionary(row))).ToList();
     }
+
+    public Task<IReadOnlyList<MvRegistryEntry>> ReadRegistryEntriesAsync(
+        string serviceId,
+        string viewName,
+        int viewVersion,
+        CancellationToken cancellationToken = default) =>
+        GetEntriesAsync(serviceId, viewName, viewVersion, cancellationToken);
 
     public async Task<MvActiveEntry?> GetActiveAsync(
         string serviceId,

--- a/dcb/src/Sekiban.Dcb.MaterializedView.SqlServer/SqlServerMvRegistryStore.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.SqlServer/SqlServerMvRegistryStore.cs
@@ -8,6 +8,7 @@ public sealed partial class SqlServerMvRegistryStore : MvForcedReverseRegistrySt
 {
     private readonly string _connectionString;
     private readonly Action<string>? _catalogCommandRecorder;
+    private readonly Action<string>? _readOnlyConnectionRecorder;
 
     public SqlServerMvRegistryStore(string connectionString)
         : this(connectionString, null)
@@ -15,10 +16,33 @@ public sealed partial class SqlServerMvRegistryStore : MvForcedReverseRegistrySt
     }
 
     public SqlServerMvRegistryStore(string connectionString, Action<string>? catalogCommandRecorder)
+        : this(connectionString, catalogCommandRecorder, null)
+    {
+    }
+
+    public SqlServerMvRegistryStore(
+        string connectionString,
+        Action<string>? catalogCommandRecorder,
+        Action<string>? readOnlyConnectionRecorder)
     {
         _connectionString = connectionString;
         _catalogCommandRecorder = catalogCommandRecorder;
+        _readOnlyConnectionRecorder = readOnlyConnectionRecorder;
     }
+
+    private string ReadOnlyConnectionString
+    {
+        get
+        {
+            var builder = new SqlConnectionStringBuilder(_connectionString)
+            {
+                ApplicationIntent = ApplicationIntent.ReadOnly
+            };
+            return builder.ConnectionString;
+        }
+    }
+
+    private void RecordReadOnlyConnection() => _readOnlyConnectionRecorder?.Invoke("sqlserver:ApplicationIntent=ReadOnly");
 
     private CommandDefinition CatalogCommand(
         string sql,
@@ -370,11 +394,19 @@ public sealed partial class SqlServerMvRegistryStore : MvForcedReverseRegistrySt
             cancellationToken).ConfigureAwait(false);
     }
 
-    public async Task<IReadOnlyList<MvRegistryEntry>> GetEntriesAsync(
+    public Task<IReadOnlyList<MvRegistryEntry>> GetEntriesAsync(
         string serviceId,
         string viewName,
         int viewVersion,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default) =>
+        ReadEntriesWithConnectionAsync(_connectionString, serviceId, viewName, viewVersion, cancellationToken);
+
+    private async Task<IReadOnlyList<MvRegistryEntry>> ReadEntriesWithConnectionAsync(
+        string connectionString,
+        string serviceId,
+        string viewName,
+        int viewVersion,
+        CancellationToken cancellationToken)
     {
         const string sql = """
             SELECT service_id AS ServiceId,
@@ -404,7 +436,7 @@ public sealed partial class SqlServerMvRegistryStore : MvForcedReverseRegistrySt
             ORDER BY logical_table;
             """;
 
-        await using var connection = new SqlConnection(_connectionString);
+        await using var connection = new SqlConnection(connectionString);
         await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
         var rows = await connection.QueryAsync(
             CatalogCommand(sql, new { ServiceId = serviceId, ViewName = viewName, ViewVersion = viewVersion }, cancellationToken))
@@ -416,13 +448,23 @@ public sealed partial class SqlServerMvRegistryStore : MvForcedReverseRegistrySt
         string serviceId,
         string viewName,
         int viewVersion,
-        CancellationToken cancellationToken = default) =>
-        GetEntriesAsync(serviceId, viewName, viewVersion, cancellationToken);
+        CancellationToken cancellationToken = default)
+    {
+        RecordReadOnlyConnection();
+        return ReadEntriesWithConnectionAsync(ReadOnlyConnectionString, serviceId, viewName, viewVersion, cancellationToken);
+    }
 
-    public async Task<MvActiveEntry?> GetActiveAsync(
+    public Task<MvActiveEntry?> GetActiveAsync(
         string serviceId,
         string viewName,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default) =>
+        ReadActiveWithConnectionAsync(_connectionString, serviceId, viewName, cancellationToken);
+
+    private async Task<MvActiveEntry?> ReadActiveWithConnectionAsync(
+        string connectionString,
+        string serviceId,
+        string viewName,
+        CancellationToken cancellationToken)
     {
         const string sql = """
             SELECT service_id AS ServiceId,
@@ -438,12 +480,21 @@ public sealed partial class SqlServerMvRegistryStore : MvForcedReverseRegistrySt
               AND view_name = @ViewName;
             """;
 
-        await using var connection = new SqlConnection(_connectionString);
+        await using var connection = new SqlConnection(connectionString);
         await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
         var row = await connection.QuerySingleOrDefaultAsync(
             new CommandDefinition(sql, new { ServiceId = serviceId, ViewName = viewName }, cancellationToken: cancellationToken))
             .ConfigureAwait(false);
         return row is null ? null : MapActiveEntry(ToDictionary(row));
+    }
+
+    public Task<MvActiveEntry?> ReadActiveAsync(
+        string serviceId,
+        string viewName,
+        CancellationToken cancellationToken = default)
+    {
+        RecordReadOnlyConnection();
+        return ReadActiveWithConnectionAsync(ReadOnlyConnectionString, serviceId, viewName, cancellationToken);
     }
 
     public Task SetActiveAsync(

--- a/dcb/src/Sekiban.Dcb.MaterializedView.SqlServer/SqlServerMvRegistryStore.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.SqlServer/SqlServerMvRegistryStore.cs
@@ -9,40 +9,137 @@ public sealed partial class SqlServerMvRegistryStore : MvForcedReverseRegistrySt
     private readonly string _connectionString;
     private readonly Action<string>? _catalogCommandRecorder;
     private readonly Action<string>? _readOnlyConnectionRecorder;
+    private readonly string? _inspectionConnectionString;
 
     public SqlServerMvRegistryStore(string connectionString)
-        : this(connectionString, null)
+        : this(connectionString, null, null, null)
     {
     }
 
     public SqlServerMvRegistryStore(string connectionString, Action<string>? catalogCommandRecorder)
-        : this(connectionString, catalogCommandRecorder, null)
+        : this(connectionString, catalogCommandRecorder, null, null)
     {
     }
 
     public SqlServerMvRegistryStore(
         string connectionString,
         Action<string>? catalogCommandRecorder,
-        Action<string>? readOnlyConnectionRecorder)
+        Action<string>? readOnlyConnectionRecorder,
+        string? inspectionConnectionString = null)
     {
         _connectionString = connectionString;
         _catalogCommandRecorder = catalogCommandRecorder;
         _readOnlyConnectionRecorder = readOnlyConnectionRecorder;
+        _inspectionConnectionString = inspectionConnectionString;
     }
 
-    private string ReadOnlyConnectionString
+    private string? ReadOnlyConnectionString => _inspectionConnectionString;
+
+    private void RecordReadOnlyConnection() => _readOnlyConnectionRecorder?.Invoke("sqlserver:restricted-inspection-principal");
+
+    private const string DatabaseWritePermissionsSql = """
+        SELECT permission_name
+        FROM fn_my_permissions(NULL, 'DATABASE')
+        WHERE permission_name IN (
+            'INSERT', 'UPDATE', 'DELETE', 'ALTER', 'CONTROL', 'TAKE OWNERSHIP', 'IMPERSONATE',
+            'CREATE TABLE', 'CREATE VIEW', 'CREATE PROCEDURE', 'ALTER ANY SCHEMA', 'ALTER ANY USER',
+            'ALTER ANY ROLE');
+        """;
+
+    private const string ObjectWritePermissionsSql = """
+        IF OBJECT_ID(@ObjectName, 'U') IS NOT NULL
+        BEGIN
+            SELECT permission_name
+            FROM fn_my_permissions(@ObjectName, 'OBJECT')
+            WHERE permission_name IN (
+                'INSERT', 'UPDATE', 'DELETE', 'ALTER', 'CONTROL', 'TAKE OWNERSHIP', 'IMPERSONATE');
+        END;
+        """;
+
+    private const string ReadOnlyIdentitySql = """
+        SELECT USER_NAME() AS DatabasePrincipal,
+               SCHEMA_NAME() AS SchemaName,
+               HAS_PERMS_BY_NAME(DB_NAME(), 'DATABASE', 'SELECT') AS CanSelect,
+               HAS_PERMS_BY_NAME(DB_NAME(), 'DATABASE', 'VIEW DEFINITION') AS CanViewDefinition;
+        """;
+
+    private async Task<MvInitializationFailure?> CheckInspectionCapabilityAsync(
+        IEnumerable<string> objectNames,
+        CancellationToken cancellationToken)
     {
-        get
+        if (string.IsNullOrWhiteSpace(ReadOnlyConnectionString))
         {
-            var builder = new SqlConnectionStringBuilder(_connectionString)
+            return new MvInitializationFailure(
+                MvInitializationFailureReason.UnsupportedProviderCapability,
+                "SQL Server verify-only inspection requires an explicit least-privilege inspection connection string.");
+        }
+
+        try
+        {
+            await using var connection = new SqlConnection(ReadOnlyConnectionString);
+            await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+            var identity = await connection.QuerySingleAsync<SqlServerInspectionIdentity>(
+                    new CommandDefinition(ReadOnlyIdentitySql, cancellationToken: cancellationToken))
+                .ConfigureAwait(false);
+            if (identity.CanSelect != 1 ||
+                identity.CanViewDefinition != 1 ||
+                string.IsNullOrWhiteSpace(identity.DatabasePrincipal) ||
+                string.IsNullOrWhiteSpace(identity.SchemaName) ||
+                string.Equals(identity.DatabasePrincipal, "dbo", StringComparison.OrdinalIgnoreCase))
             {
-                ApplicationIntent = ApplicationIntent.ReadOnly
-            };
-            return builder.ConnectionString;
+                return new MvInitializationFailure(
+                    MvInitializationFailureReason.UnsupportedProviderCapability,
+                    "SQL Server inspection principal does not provide distinct catalog-read and metadata-definition capabilities.");
+            }
+
+            var databaseWritePermissions = await connection.QueryAsync<string>(
+                    new CommandDefinition(DatabaseWritePermissionsSql, cancellationToken: cancellationToken))
+                .ConfigureAwait(false);
+            if (databaseWritePermissions.Any())
+            {
+                return new MvInitializationFailure(
+                    MvInitializationFailureReason.UnsupportedProviderCapability,
+                    "SQL Server inspection principal has database write permissions and cannot be used for verify-only inspection.");
+            }
+
+            foreach (var objectName in objectNames.Distinct(StringComparer.OrdinalIgnoreCase))
+            {
+                var objectWritePermissions = await connection.QueryAsync<string>(
+                        new CommandDefinition(
+                            ObjectWritePermissionsSql,
+                            new { ObjectName = $"{identity.SchemaName}.{objectName}" },
+                            cancellationToken: cancellationToken))
+                    .ConfigureAwait(false);
+                if (objectWritePermissions.Any())
+                {
+                    return new MvInitializationFailure(
+                        MvInitializationFailureReason.UnsupportedProviderCapability,
+                        $"SQL Server inspection principal has write permissions on catalog target '{objectName}'.");
+                }
+            }
+
+            return null;
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch
+        {
+            return new MvInitializationFailure(
+                MvInitializationFailureReason.UnsupportedProviderCapability,
+                "SQL Server could not establish the least-privilege inspection capability.");
         }
     }
 
-    private void RecordReadOnlyConnection() => _readOnlyConnectionRecorder?.Invoke("sqlserver:ApplicationIntent=ReadOnly");
+    private sealed class SqlServerInspectionIdentity
+    {
+        public string? DatabasePrincipal { get; init; }
+        public string? SchemaName { get; init; }
+        public int CanSelect { get; init; }
+        public int CanViewDefinition { get; init; }
+    }
 
     private CommandDefinition CatalogCommand(
         string sql,
@@ -444,14 +541,29 @@ public sealed partial class SqlServerMvRegistryStore : MvForcedReverseRegistrySt
         return rows.Select(row => (MvRegistryEntry)MapEntry(ToDictionary(row))).ToList();
     }
 
-    public Task<IReadOnlyList<MvRegistryEntry>> ReadRegistryEntriesAsync(
+    public async Task<IReadOnlyList<MvRegistryEntry>> ReadRegistryEntriesAsync(
         string serviceId,
         string viewName,
         int viewVersion,
         CancellationToken cancellationToken = default)
     {
+        var capabilityFailure = await CheckInspectionCapabilityAsync(
+                ["sekiban_mv_registry", "sekiban_mv_active"],
+                cancellationToken)
+            .ConfigureAwait(false);
+        if (capabilityFailure is not null)
+        {
+            throw new MvInitializationException(capabilityFailure);
+        }
+
         RecordReadOnlyConnection();
-        return ReadEntriesWithConnectionAsync(ReadOnlyConnectionString, serviceId, viewName, viewVersion, cancellationToken);
+        return await ReadEntriesWithConnectionAsync(
+                ReadOnlyConnectionString!,
+                serviceId,
+                viewName,
+                viewVersion,
+                cancellationToken)
+            .ConfigureAwait(false);
     }
 
     public Task<MvActiveEntry?> GetActiveAsync(
@@ -488,13 +600,27 @@ public sealed partial class SqlServerMvRegistryStore : MvForcedReverseRegistrySt
         return row is null ? null : MapActiveEntry(ToDictionary(row));
     }
 
-    public Task<MvActiveEntry?> ReadActiveAsync(
+    public async Task<MvActiveEntry?> ReadActiveAsync(
         string serviceId,
         string viewName,
         CancellationToken cancellationToken = default)
     {
+        var capabilityFailure = await CheckInspectionCapabilityAsync(
+                ["sekiban_mv_registry", "sekiban_mv_active"],
+                cancellationToken)
+            .ConfigureAwait(false);
+        if (capabilityFailure is not null)
+        {
+            throw new MvInitializationException(capabilityFailure);
+        }
+
         RecordReadOnlyConnection();
-        return ReadActiveWithConnectionAsync(ReadOnlyConnectionString, serviceId, viewName, cancellationToken);
+        return await ReadActiveWithConnectionAsync(
+                ReadOnlyConnectionString!,
+                serviceId,
+                viewName,
+                cancellationToken)
+            .ConfigureAwait(false);
     }
 
     public Task SetActiveAsync(

--- a/dcb/src/Sekiban.Dcb.MaterializedView.SqlServer/SqlServerMvRegistryStore.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.SqlServer/SqlServerMvRegistryStore.cs
@@ -4,7 +4,7 @@ using Microsoft.Data.SqlClient;
 
 namespace Sekiban.Dcb.MaterializedView.SqlServer;
 
-public sealed partial class SqlServerMvRegistryStore : MvForcedReverseRegistryStoreBase<SqlConnection>, IMvRegistryStore
+public sealed partial class SqlServerMvRegistryStore : MvForcedReverseRegistryStoreBase<SqlConnection>, IMvRegistryStore, IMvSchemaVerifier
 {
     private readonly string _connectionString;
 

--- a/dcb/src/Sekiban.Dcb.MaterializedView.SqlServer/SqlServerMvSchemaVerifier.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.SqlServer/SqlServerMvSchemaVerifier.cs
@@ -12,7 +12,8 @@ public sealed partial class SqlServerMvRegistryStore
     {
         try
         {
-            await using var connection = new SqlConnection(_connectionString);
+            RecordReadOnlyConnection();
+            await using var connection = new SqlConnection(ReadOnlyConnectionString);
             await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
             var tableNames = requirements
                 .Select(requirement => requirement.PhysicalTable)
@@ -21,13 +22,30 @@ public sealed partial class SqlServerMvRegistryStore
             var columns = await connection.QueryAsync<SqlServerSchemaColumn>(
                     CatalogCommand(
                         """
-                        SELECT TABLE_NAME AS TableName,
-                               COLUMN_NAME AS ColumnName,
-                               DATA_TYPE AS DataType,
-                               IS_NULLABLE AS IsNullable
-                        FROM INFORMATION_SCHEMA.COLUMNS
-                        WHERE TABLE_SCHEMA = SCHEMA_NAME()
-                          AND TABLE_NAME IN @TableNames;
+                        SELECT information_columns.TABLE_NAME AS TableName,
+                               information_columns.COLUMN_NAME AS ColumnName,
+                               information_columns.DATA_TYPE AS DataType,
+                               information_columns.IS_NULLABLE AS IsNullable,
+                               information_columns.COLUMN_DEFAULT AS DefaultSql,
+                               system_columns.is_computed AS IsGenerated,
+                               computed_columns.definition AS GenerationExpression,
+                               CASE WHEN information_columns.CHARACTER_MAXIMUM_LENGTH = -1 THEN NULL ELSE information_columns.CHARACTER_MAXIMUM_LENGTH END AS MaxLength,
+                               information_columns.NUMERIC_PRECISION AS Precision,
+                               information_columns.NUMERIC_SCALE AS Scale
+                        FROM INFORMATION_SCHEMA.COLUMNS AS information_columns
+                        INNER JOIN sys.tables AS system_tables
+                            ON system_tables.name = information_columns.TABLE_NAME
+                        INNER JOIN sys.schemas AS schemas
+                            ON schemas.schema_id = system_tables.schema_id
+                           AND schemas.name = information_columns.TABLE_SCHEMA
+                        INNER JOIN sys.columns AS system_columns
+                            ON system_columns.object_id = system_tables.object_id
+                           AND system_columns.name = information_columns.COLUMN_NAME
+                        LEFT JOIN sys.computed_columns AS computed_columns
+                            ON computed_columns.object_id = system_columns.object_id
+                           AND computed_columns.column_id = system_columns.column_id
+                        WHERE information_columns.TABLE_SCHEMA = SCHEMA_NAME()
+                          AND information_columns.TABLE_NAME IN @TableNames;
                         """,
                         new { TableNames = tableNames },
                         cancellationToken: cancellationToken))
@@ -54,6 +72,33 @@ public sealed partial class SqlServerMvRegistryStore
                         new { TableNames = tableNames },
                         cancellationToken: cancellationToken))
                 .ConfigureAwait(false);
+            var indexes = await connection.QueryAsync<SqlServerSchemaIndexColumn>(
+                    CatalogCommand(
+                        """
+                        SELECT tables.name AS TableName,
+                               indexes.name AS Name,
+                               indexes.is_unique AS IsUnique,
+                               columns.name AS ColumnName,
+                               index_columns.key_ordinal AS Ordinal
+                        FROM sys.tables AS tables
+                        INNER JOIN sys.indexes AS indexes
+                            ON indexes.object_id = tables.object_id
+                           AND indexes.is_primary_key = 0
+                           AND indexes.is_unique_constraint = 0
+                        INNER JOIN sys.index_columns AS index_columns
+                            ON index_columns.object_id = indexes.object_id
+                           AND index_columns.index_id = indexes.index_id
+                           AND index_columns.key_ordinal > 0
+                        INNER JOIN sys.columns AS columns
+                            ON columns.object_id = index_columns.object_id
+                           AND columns.column_id = index_columns.column_id
+                        WHERE SCHEMA_NAME(tables.schema_id) = SCHEMA_NAME()
+                          AND tables.name IN @TableNames
+                        ORDER BY tables.name, indexes.name, index_columns.key_ordinal;
+                        """,
+                        new { TableNames = tableNames },
+                        cancellationToken: cancellationToken))
+                .ConfigureAwait(false);
 
             return MvSchemaRequirements.Validate(
                 requirements,
@@ -62,11 +107,26 @@ public sealed partial class SqlServerMvRegistryStore
                         column.TableName,
                         column.ColumnName,
                         MapType(column.DataType),
-                        string.Equals(column.IsNullable, "YES", StringComparison.OrdinalIgnoreCase))),
+                        string.Equals(column.IsNullable, "YES", StringComparison.OrdinalIgnoreCase))
+                    {
+                        DefaultSql = column.DefaultSql,
+                        IsGenerated = column.IsGenerated,
+                        GenerationExpression = column.GenerationExpression,
+                        MaxLength = column.MaxLength,
+                        Precision = column.Precision,
+                        Scale = column.Scale
+                    }),
                     primaryKeys.Select(column => new MvObservedSchemaPrimaryKeyColumn(
                         column.TableName,
                         column.ColumnName,
-                        column.Ordinal))));
+                        column.Ordinal)),
+                    indexes
+                        .GroupBy(index => (index.TableName, index.Name), StringTupleComparer.Instance)
+                        .Select(group => new MvObservedSchemaIndex(
+                            group.Key.TableName,
+                            group.Key.Name,
+                            group.OrderBy(index => index.Ordinal).Select(index => index.ColumnName).ToList(),
+                            group.First().IsUnique))));
         }
         catch (OperationCanceledException)
         {
@@ -102,6 +162,12 @@ public sealed partial class SqlServerMvRegistryStore
         public string ColumnName { get; init; } = string.Empty;
         public string DataType { get; init; } = string.Empty;
         public string IsNullable { get; init; } = string.Empty;
+        public string? DefaultSql { get; init; }
+        public bool IsGenerated { get; init; }
+        public string? GenerationExpression { get; init; }
+        public int? MaxLength { get; init; }
+        public int? Precision { get; init; }
+        public int? Scale { get; init; }
     }
 
     private sealed class SqlServerSchemaPrimaryKeyColumn
@@ -109,5 +175,28 @@ public sealed partial class SqlServerMvRegistryStore
         public string TableName { get; init; } = string.Empty;
         public string ColumnName { get; init; } = string.Empty;
         public int Ordinal { get; init; }
+    }
+
+    private sealed class SqlServerSchemaIndexColumn
+    {
+        public string TableName { get; init; } = string.Empty;
+        public string Name { get; init; } = string.Empty;
+        public bool IsUnique { get; init; }
+        public string ColumnName { get; init; } = string.Empty;
+        public int Ordinal { get; init; }
+    }
+
+    private sealed class StringTupleComparer : IEqualityComparer<(string TableName, string Name)>
+    {
+        public static StringTupleComparer Instance { get; } = new();
+
+        public bool Equals((string TableName, string Name) x, (string TableName, string Name) y) =>
+            string.Equals(x.TableName, y.TableName, StringComparison.OrdinalIgnoreCase) &&
+            string.Equals(x.Name, y.Name, StringComparison.OrdinalIgnoreCase);
+
+        public int GetHashCode((string TableName, string Name) obj) =>
+            HashCode.Combine(
+                StringComparer.OrdinalIgnoreCase.GetHashCode(obj.TableName),
+                StringComparer.OrdinalIgnoreCase.GetHashCode(obj.Name));
     }
 }

--- a/dcb/src/Sekiban.Dcb.MaterializedView.SqlServer/SqlServerMvSchemaVerifier.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.SqlServer/SqlServerMvSchemaVerifier.cs
@@ -19,7 +19,7 @@ public sealed partial class SqlServerMvRegistryStore
                 .Distinct(StringComparer.OrdinalIgnoreCase)
                 .ToArray();
             var columns = await connection.QueryAsync<SqlServerSchemaColumn>(
-                    new CommandDefinition(
+                    CatalogCommand(
                         """
                         SELECT TABLE_NAME AS TableName,
                                COLUMN_NAME AS ColumnName,
@@ -33,7 +33,7 @@ public sealed partial class SqlServerMvRegistryStore
                         cancellationToken: cancellationToken))
                 .ConfigureAwait(false);
             var primaryKeys = await connection.QueryAsync<SqlServerSchemaPrimaryKeyColumn>(
-                    new CommandDefinition(
+                    CatalogCommand(
                         """
                         SELECT tables.name AS TableName,
                                columns.name AS ColumnName,

--- a/dcb/src/Sekiban.Dcb.MaterializedView.SqlServer/SqlServerMvSchemaVerifier.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.SqlServer/SqlServerMvSchemaVerifier.cs
@@ -1,0 +1,113 @@
+using Dapper;
+using Microsoft.Data.SqlClient;
+using Sekiban.Dcb.MaterializedView;
+
+namespace Sekiban.Dcb.MaterializedView.SqlServer;
+
+public sealed partial class SqlServerMvRegistryStore
+{
+    public async Task<MvSchemaVerificationResult> VerifySchemaAsync(
+        IReadOnlyList<MvSchemaTableRequirement> requirements,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            await using var connection = new SqlConnection(_connectionString);
+            await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+            var tableNames = requirements
+                .Select(requirement => requirement.PhysicalTable)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+            var columns = await connection.QueryAsync<SqlServerSchemaColumn>(
+                    new CommandDefinition(
+                        """
+                        SELECT TABLE_NAME AS TableName,
+                               COLUMN_NAME AS ColumnName,
+                               DATA_TYPE AS DataType,
+                               IS_NULLABLE AS IsNullable
+                        FROM INFORMATION_SCHEMA.COLUMNS
+                        WHERE TABLE_SCHEMA = SCHEMA_NAME()
+                          AND TABLE_NAME IN @TableNames;
+                        """,
+                        new { TableNames = tableNames },
+                        cancellationToken: cancellationToken))
+                .ConfigureAwait(false);
+            var primaryKeys = await connection.QueryAsync<SqlServerSchemaPrimaryKeyColumn>(
+                    new CommandDefinition(
+                        """
+                        SELECT tables.name AS TableName,
+                               columns.name AS ColumnName,
+                               index_columns.key_ordinal AS Ordinal
+                        FROM sys.tables AS tables
+                        INNER JOIN sys.indexes AS indexes
+                            ON indexes.object_id = tables.object_id
+                           AND indexes.is_primary_key = 1
+                        INNER JOIN sys.index_columns AS index_columns
+                            ON index_columns.object_id = indexes.object_id
+                           AND index_columns.index_id = indexes.index_id
+                        INNER JOIN sys.columns AS columns
+                            ON columns.object_id = index_columns.object_id
+                           AND columns.column_id = index_columns.column_id
+                        WHERE SCHEMA_NAME(tables.schema_id) = SCHEMA_NAME()
+                          AND tables.name IN @TableNames;
+                        """,
+                        new { TableNames = tableNames },
+                        cancellationToken: cancellationToken))
+                .ConfigureAwait(false);
+
+            return MvSchemaRequirements.Validate(
+                requirements,
+                MvSchemaRequirements.Observe(
+                    columns.Select(column => new MvObservedSchemaColumn(
+                        column.TableName,
+                        column.ColumnName,
+                        MapType(column.DataType),
+                        string.Equals(column.IsNullable, "YES", StringComparison.OrdinalIgnoreCase))),
+                    primaryKeys.Select(column => new MvObservedSchemaPrimaryKeyColumn(
+                        column.TableName,
+                        column.ColumnName,
+                        column.Ordinal))));
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch
+        {
+            return MvSchemaVerificationResult.Failed(
+                MvInitializationFailureReason.UnsupportedProviderCapability,
+                "SQL Server schema metadata verification is unavailable.");
+        }
+    }
+
+    private static MvSchemaTypeFamily MapType(string dataType)
+    {
+        var type = dataType.ToLowerInvariant();
+        if (type is "uniqueidentifier") return MvSchemaTypeFamily.Guid;
+        if (type is "bit") return MvSchemaTypeFamily.Boolean;
+        if (type.Contains("date", StringComparison.Ordinal) || type.Contains("time", StringComparison.Ordinal))
+            return MvSchemaTypeFamily.DateTime;
+        if (type is "tinyint" or "smallint" or "int" or "bigint") return MvSchemaTypeFamily.Integer;
+        if (type is "decimal" or "numeric" or "money" or "smallmoney") return MvSchemaTypeFamily.Decimal;
+        if (type is "float" or "real") return MvSchemaTypeFamily.FloatingPoint;
+        if (type.Contains("binary", StringComparison.Ordinal) || type is "image") return MvSchemaTypeFamily.Binary;
+        if (type.Contains("char", StringComparison.Ordinal) || type.Contains("text", StringComparison.Ordinal))
+            return MvSchemaTypeFamily.String;
+        return MvSchemaTypeFamily.Any;
+    }
+
+    private sealed class SqlServerSchemaColumn
+    {
+        public string TableName { get; init; } = string.Empty;
+        public string ColumnName { get; init; } = string.Empty;
+        public string DataType { get; init; } = string.Empty;
+        public string IsNullable { get; init; } = string.Empty;
+    }
+
+    private sealed class SqlServerSchemaPrimaryKeyColumn
+    {
+        public string TableName { get; init; } = string.Empty;
+        public string ColumnName { get; init; } = string.Empty;
+        public int Ordinal { get; init; }
+    }
+}

--- a/dcb/src/Sekiban.Dcb.MaterializedView.SqlServer/SqlServerMvSchemaVerifier.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.SqlServer/SqlServerMvSchemaVerifier.cs
@@ -12,8 +12,18 @@ public sealed partial class SqlServerMvRegistryStore
     {
         try
         {
+            var capabilityFailure = await CheckInspectionCapabilityAsync(
+                    requirements
+                        .SelectMany(requirement => new[] { requirement.PhysicalTable, "sekiban_mv_registry", "sekiban_mv_active" }),
+                    cancellationToken)
+                .ConfigureAwait(false);
+            if (capabilityFailure is not null)
+            {
+                return new MvSchemaVerificationResult(false, capabilityFailure);
+            }
+
             RecordReadOnlyConnection();
-            await using var connection = new SqlConnection(ReadOnlyConnectionString);
+            await using var connection = new SqlConnection(ReadOnlyConnectionString!);
             await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
             var tableNames = requirements
                 .Select(requirement => requirement.PhysicalTable)

--- a/dcb/src/Sekiban.Dcb.MaterializedView.Sqlite/SqliteMvExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.Sqlite/SqliteMvExecutor.cs
@@ -17,6 +17,8 @@ public sealed class SqliteMvExecutor : MvExecutorBase<SqliteConnection>, IMvExec
     private readonly IEventStore? _legacyEventStore;
     private readonly IServiceIdProvider? _legacyServiceIdProvider;
 
+    protected override MvDbType DatabaseType => MvDbType.Sqlite;
+
     /// <summary>
     /// Creates the legacy single-service compatibility executor over an aggregate event store.
     /// Multi-service hosts should use the <see cref="IEventStoreFactory"/> constructor.

--- a/dcb/src/Sekiban.Dcb.MaterializedView.Sqlite/SqliteMvRegistryStore.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.Sqlite/SqliteMvRegistryStore.cs
@@ -4,13 +4,29 @@ using Microsoft.Data.Sqlite;
 
 namespace Sekiban.Dcb.MaterializedView.Sqlite;
 
-public sealed partial class SqliteMvRegistryStore : MvForcedReverseRegistryStoreBase<SqliteConnection>, IMvRegistryStore, IMvSchemaVerifier
+public sealed partial class SqliteMvRegistryStore : MvForcedReverseRegistryStoreBase<SqliteConnection>, IMvRegistryStore, IMvReadOnlyMvInspector
 {
     private readonly string _connectionString;
+    private readonly Action<string>? _catalogCommandRecorder;
 
     public SqliteMvRegistryStore(string connectionString)
+        : this(connectionString, null)
+    {
+    }
+
+    public SqliteMvRegistryStore(string connectionString, Action<string>? catalogCommandRecorder)
     {
         _connectionString = connectionString;
+        _catalogCommandRecorder = catalogCommandRecorder;
+    }
+
+    private CommandDefinition CatalogCommand(
+        string sql,
+        object? parameters = null,
+        CancellationToken cancellationToken = default)
+    {
+        _catalogCommandRecorder?.Invoke(sql);
+        return new CommandDefinition(sql, parameters, cancellationToken: cancellationToken);
     }
 
     public async Task EnsureInfrastructureAsync(CancellationToken cancellationToken = default)
@@ -434,10 +450,17 @@ public sealed partial class SqliteMvRegistryStore : MvForcedReverseRegistryStore
         await using var connection = new SqliteConnection(_connectionString);
         await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
         var rows = await connection.QueryAsync(
-            new CommandDefinition(sql, new { ServiceId = serviceId, ViewName = viewName, ViewVersion = viewVersion }, cancellationToken: cancellationToken))
+            CatalogCommand(sql, new { ServiceId = serviceId, ViewName = viewName, ViewVersion = viewVersion }, cancellationToken))
             .ConfigureAwait(false);
         return rows.Select(row => (MvRegistryEntry)MapEntry(ToDictionary(row))).ToList();
     }
+
+    public Task<IReadOnlyList<MvRegistryEntry>> ReadRegistryEntriesAsync(
+        string serviceId,
+        string viewName,
+        int viewVersion,
+        CancellationToken cancellationToken = default) =>
+        GetEntriesAsync(serviceId, viewName, viewVersion, cancellationToken);
 
     public async Task<MvActiveEntry?> GetActiveAsync(
         string serviceId,

--- a/dcb/src/Sekiban.Dcb.MaterializedView.Sqlite/SqliteMvRegistryStore.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.Sqlite/SqliteMvRegistryStore.cs
@@ -8,6 +8,7 @@ public sealed partial class SqliteMvRegistryStore : MvForcedReverseRegistryStore
 {
     private readonly string _connectionString;
     private readonly Action<string>? _catalogCommandRecorder;
+    private readonly Action<string>? _readOnlyConnectionRecorder;
 
     public SqliteMvRegistryStore(string connectionString)
         : this(connectionString, null)
@@ -15,10 +16,33 @@ public sealed partial class SqliteMvRegistryStore : MvForcedReverseRegistryStore
     }
 
     public SqliteMvRegistryStore(string connectionString, Action<string>? catalogCommandRecorder)
+        : this(connectionString, catalogCommandRecorder, null)
+    {
+    }
+
+    public SqliteMvRegistryStore(
+        string connectionString,
+        Action<string>? catalogCommandRecorder,
+        Action<string>? readOnlyConnectionRecorder)
     {
         _connectionString = connectionString;
         _catalogCommandRecorder = catalogCommandRecorder;
+        _readOnlyConnectionRecorder = readOnlyConnectionRecorder;
     }
+
+    private string ReadOnlyConnectionString
+    {
+        get
+        {
+            var builder = new SqliteConnectionStringBuilder(_connectionString)
+            {
+                Mode = SqliteOpenMode.ReadOnly
+            };
+            return builder.ToString();
+        }
+    }
+
+    private void RecordReadOnlyConnection() => _readOnlyConnectionRecorder?.Invoke("sqlite:Mode=ReadOnly");
 
     private CommandDefinition CatalogCommand(
         string sql,
@@ -413,11 +437,19 @@ public sealed partial class SqliteMvRegistryStore : MvForcedReverseRegistryStore
             cancellationToken).ConfigureAwait(false);
     }
 
-    public async Task<IReadOnlyList<MvRegistryEntry>> GetEntriesAsync(
+    public Task<IReadOnlyList<MvRegistryEntry>> GetEntriesAsync(
         string serviceId,
         string viewName,
         int viewVersion,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default) =>
+        ReadEntriesWithConnectionAsync(_connectionString, serviceId, viewName, viewVersion, cancellationToken);
+
+    private async Task<IReadOnlyList<MvRegistryEntry>> ReadEntriesWithConnectionAsync(
+        string connectionString,
+        string serviceId,
+        string viewName,
+        int viewVersion,
+        CancellationToken cancellationToken)
     {
         const string sql = """
             SELECT service_id AS ServiceId,
@@ -447,7 +479,7 @@ public sealed partial class SqliteMvRegistryStore : MvForcedReverseRegistryStore
             ORDER BY logical_table;
             """;
 
-        await using var connection = new SqliteConnection(_connectionString);
+        await using var connection = new SqliteConnection(connectionString);
         await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
         var rows = await connection.QueryAsync(
             CatalogCommand(sql, new { ServiceId = serviceId, ViewName = viewName, ViewVersion = viewVersion }, cancellationToken))
@@ -459,13 +491,23 @@ public sealed partial class SqliteMvRegistryStore : MvForcedReverseRegistryStore
         string serviceId,
         string viewName,
         int viewVersion,
-        CancellationToken cancellationToken = default) =>
-        GetEntriesAsync(serviceId, viewName, viewVersion, cancellationToken);
+        CancellationToken cancellationToken = default)
+    {
+        RecordReadOnlyConnection();
+        return ReadEntriesWithConnectionAsync(ReadOnlyConnectionString, serviceId, viewName, viewVersion, cancellationToken);
+    }
 
-    public async Task<MvActiveEntry?> GetActiveAsync(
+    public Task<MvActiveEntry?> GetActiveAsync(
         string serviceId,
         string viewName,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default) =>
+        ReadActiveWithConnectionAsync(_connectionString, serviceId, viewName, cancellationToken);
+
+    private async Task<MvActiveEntry?> ReadActiveWithConnectionAsync(
+        string connectionString,
+        string serviceId,
+        string viewName,
+        CancellationToken cancellationToken)
     {
         const string sql = """
             SELECT service_id AS ServiceId,
@@ -481,12 +523,21 @@ public sealed partial class SqliteMvRegistryStore : MvForcedReverseRegistryStore
               AND view_name = @ViewName;
             """;
 
-        await using var connection = new SqliteConnection(_connectionString);
+        await using var connection = new SqliteConnection(connectionString);
         await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
         var row = await connection.QuerySingleOrDefaultAsync(
             new CommandDefinition(sql, new { ServiceId = serviceId, ViewName = viewName }, cancellationToken: cancellationToken))
             .ConfigureAwait(false);
         return row is null ? null : MapActiveEntry(ToDictionary(row));
+    }
+
+    public Task<MvActiveEntry?> ReadActiveAsync(
+        string serviceId,
+        string viewName,
+        CancellationToken cancellationToken = default)
+    {
+        RecordReadOnlyConnection();
+        return ReadActiveWithConnectionAsync(ReadOnlyConnectionString, serviceId, viewName, cancellationToken);
     }
 
     public Task SetActiveAsync(

--- a/dcb/src/Sekiban.Dcb.MaterializedView.Sqlite/SqliteMvRegistryStore.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.Sqlite/SqliteMvRegistryStore.cs
@@ -4,7 +4,7 @@ using Microsoft.Data.Sqlite;
 
 namespace Sekiban.Dcb.MaterializedView.Sqlite;
 
-public sealed partial class SqliteMvRegistryStore : MvForcedReverseRegistryStoreBase<SqliteConnection>, IMvRegistryStore
+public sealed partial class SqliteMvRegistryStore : MvForcedReverseRegistryStoreBase<SqliteConnection>, IMvRegistryStore, IMvSchemaVerifier
 {
     private readonly string _connectionString;
 

--- a/dcb/src/Sekiban.Dcb.MaterializedView.Sqlite/SqliteMvSchemaVerifier.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.Sqlite/SqliteMvSchemaVerifier.cs
@@ -7,7 +7,7 @@ namespace Sekiban.Dcb.MaterializedView.Sqlite;
 public sealed partial class SqliteMvRegistryStore
 {
     private const string TableInfoSql =
-        "SELECT name AS Name, type AS Type, \"notnull\" AS \"NotNull\", pk AS Pk FROM pragma_table_xinfo(@TableName) WHERE hidden = 0;";
+        "SELECT name AS Name, type AS Type, \"notnull\" AS \"NotNull\", pk AS Pk, dflt_value AS DefaultSql, hidden AS Hidden FROM pragma_table_xinfo(@TableName);";
 
     public async Task<MvSchemaVerificationResult> VerifySchemaAsync(
         IReadOnlyList<MvSchemaTableRequirement> requirements,
@@ -15,10 +15,12 @@ public sealed partial class SqliteMvRegistryStore
     {
         try
         {
-            await using var connection = new SqliteConnection(_connectionString);
+            RecordReadOnlyConnection();
+            await using var connection = new SqliteConnection(ReadOnlyConnectionString);
             await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
             var columns = new List<MvObservedSchemaColumn>();
             var primaryKeys = new List<MvObservedSchemaPrimaryKeyColumn>();
+            var indexes = new List<MvObservedSchemaIndex>();
             foreach (var tableName in requirements.Select(requirement => requirement.PhysicalTable).Distinct(StringComparer.OrdinalIgnoreCase))
             {
                 ValidateContractIdentifier(tableName);
@@ -45,7 +47,11 @@ public sealed partial class SqliteMvRegistryStore
                         tableName,
                         column.Name,
                         MapType(column.Name, column.Type),
-                        column.NotNull == 0));
+                        column.NotNull == 0)
+                    {
+                        DefaultSql = column.DefaultSql,
+                        IsGenerated = column.Hidden is 2 or 3
+                    });
                     if (column.Pk > 0)
                     {
                         primaryKeys.Add(new MvObservedSchemaPrimaryKeyColumn(
@@ -54,11 +60,34 @@ public sealed partial class SqliteMvRegistryStore
                             column.Pk));
                     }
                 }
+
+                var tableIndexes = await connection.QueryAsync<SqliteSchemaIndex>(
+                        CatalogCommand(
+                            "SELECT name AS Name, \"unique\" AS IsUnique FROM pragma_index_list(@TableName) WHERE origin <> 'pk';",
+                            new { TableName = tableName },
+                            cancellationToken: cancellationToken))
+                    .ConfigureAwait(false);
+                foreach (var index in tableIndexes)
+                {
+                    ValidateContractIdentifier(index.Name);
+                    var indexColumns = await connection.QueryAsync<SqliteSchemaIndexColumn>(
+                            CatalogCommand(
+                                "SELECT name AS ColumnName, seqno AS Ordinal FROM pragma_index_info(@IndexName) ORDER BY seqno;",
+                                new { IndexName = index.Name },
+                                cancellationToken: cancellationToken))
+                        .ConfigureAwait(false);
+                    indexes.Add(
+                        new MvObservedSchemaIndex(
+                            tableName,
+                            index.Name,
+                            indexColumns.OrderBy(column => column.Ordinal).Select(column => column.ColumnName).ToList(),
+                            index.IsUnique != 0));
+                }
             }
 
             return MvSchemaRequirements.Validate(
                 requirements,
-                MvSchemaRequirements.Observe(columns, primaryKeys));
+                MvSchemaRequirements.Observe(columns, primaryKeys, indexes));
         }
         catch (OperationCanceledException)
         {
@@ -117,5 +146,19 @@ public sealed partial class SqliteMvRegistryStore
         public string? Type { get; init; }
         public int NotNull { get; init; }
         public int Pk { get; init; }
+        public string? DefaultSql { get; init; }
+        public int Hidden { get; init; }
+    }
+
+    private sealed class SqliteSchemaIndex
+    {
+        public string Name { get; init; } = string.Empty;
+        public int IsUnique { get; init; }
+    }
+
+    private sealed class SqliteSchemaIndexColumn
+    {
+        public string ColumnName { get; init; } = string.Empty;
+        public int Ordinal { get; init; }
     }
 }

--- a/dcb/src/Sekiban.Dcb.MaterializedView.Sqlite/SqliteMvSchemaVerifier.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.Sqlite/SqliteMvSchemaVerifier.cs
@@ -7,7 +7,7 @@ namespace Sekiban.Dcb.MaterializedView.Sqlite;
 public sealed partial class SqliteMvRegistryStore
 {
     private const string TableInfoSql =
-        "SELECT name AS Name, type AS Type, \"notnull\" AS \"NotNull\", pk AS Pk FROM pragma_table_info(@TableName);";
+        "SELECT name AS Name, type AS Type, \"notnull\" AS \"NotNull\", pk AS Pk FROM pragma_table_xinfo(@TableName) WHERE hidden = 0;";
 
     public async Task<MvSchemaVerificationResult> VerifySchemaAsync(
         IReadOnlyList<MvSchemaTableRequirement> requirements,
@@ -23,7 +23,7 @@ public sealed partial class SqliteMvRegistryStore
             {
                 ValidateContractIdentifier(tableName);
                 var objectType = await connection.ExecuteScalarAsync<string?>(
-                        new CommandDefinition(
+                        CatalogCommand(
                             "SELECT type FROM sqlite_master WHERE name = @TableName;",
                             new { TableName = tableName },
                             cancellationToken: cancellationToken))
@@ -34,7 +34,7 @@ public sealed partial class SqliteMvRegistryStore
                 }
 
                 var tableInfo = await connection.QueryAsync<SqliteSchemaColumn>(
-                        new CommandDefinition(
+                        CatalogCommand(
                             TableInfoSql,
                             new { TableName = tableName },
                             cancellationToken: cancellationToken))

--- a/dcb/src/Sekiban.Dcb.MaterializedView.Sqlite/SqliteMvSchemaVerifier.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.Sqlite/SqliteMvSchemaVerifier.cs
@@ -1,0 +1,102 @@
+using Dapper;
+using Microsoft.Data.Sqlite;
+using Sekiban.Dcb.MaterializedView;
+
+namespace Sekiban.Dcb.MaterializedView.Sqlite;
+
+public sealed partial class SqliteMvRegistryStore
+{
+    public async Task<MvSchemaVerificationResult> VerifySchemaAsync(
+        IReadOnlyList<MvSchemaTableRequirement> requirements,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            await using var connection = new SqliteConnection(_connectionString);
+            await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+            var columns = new List<MvObservedSchemaColumn>();
+            var primaryKeys = new List<MvObservedSchemaPrimaryKeyColumn>();
+            foreach (var tableName in requirements.Select(requirement => requirement.PhysicalTable).Distinct(StringComparer.OrdinalIgnoreCase))
+            {
+                var objectType = await connection.ExecuteScalarAsync<string?>(
+                        new CommandDefinition(
+                            "SELECT type FROM sqlite_master WHERE name = @TableName;",
+                            new { TableName = tableName },
+                            cancellationToken: cancellationToken))
+                    .ConfigureAwait(false);
+                if (!string.Equals(objectType, "table", StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                var tableInfo = await connection.QueryAsync<SqliteSchemaColumn>(
+                        new CommandDefinition(
+                            $"PRAGMA table_info('{EscapeLiteral(tableName)}');",
+                            cancellationToken: cancellationToken))
+                    .ConfigureAwait(false);
+                foreach (var column in tableInfo)
+                {
+                    columns.Add(new MvObservedSchemaColumn(
+                        tableName,
+                        column.name,
+                        MapType(column.name, column.type),
+                        column.notnull == 0));
+                    if (column.pk > 0)
+                    {
+                        primaryKeys.Add(new MvObservedSchemaPrimaryKeyColumn(
+                            tableName,
+                            column.name,
+                            column.pk));
+                    }
+                }
+            }
+
+            return MvSchemaRequirements.Validate(
+                requirements,
+                MvSchemaRequirements.Observe(columns, primaryKeys));
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch
+        {
+            return MvSchemaVerificationResult.Failed(
+                MvInitializationFailureReason.UnsupportedProviderCapability,
+                "SQLite schema metadata verification is unavailable.");
+        }
+    }
+
+    private static string EscapeLiteral(string value) => value.Replace("'", "''", StringComparison.Ordinal);
+
+    private static MvSchemaTypeFamily MapType(string columnName, string? declaredType)
+    {
+        var type = declaredType?.ToLowerInvariant() ?? string.Empty;
+        var name = columnName.ToLowerInvariant();
+        if (type.Contains("json", StringComparison.Ordinal)) return MvSchemaTypeFamily.Json;
+        if (type.Contains("bool", StringComparison.Ordinal) || name.Contains("deleted", StringComparison.Ordinal))
+            return MvSchemaTypeFamily.Boolean;
+        if (type.Contains("date", StringComparison.Ordinal) || type.Contains("time", StringComparison.Ordinal))
+            return MvSchemaTypeFamily.DateTime;
+        if (name.Contains("date", StringComparison.Ordinal) || name.EndsWith("_at", StringComparison.Ordinal) ||
+            name is "activated_at" or "last_updated" or "switched_at_utc")
+            return MvSchemaTypeFamily.DateTime;
+        if (type.Contains("int", StringComparison.Ordinal)) return MvSchemaTypeFamily.Integer;
+        if (type.Contains("real", StringComparison.Ordinal) || type.Contains("floa", StringComparison.Ordinal) ||
+            type.Contains("doub", StringComparison.Ordinal)) return MvSchemaTypeFamily.FloatingPoint;
+        if (type.Contains("numeric", StringComparison.Ordinal) || type.Contains("decimal", StringComparison.Ordinal))
+            return MvSchemaTypeFamily.Decimal;
+        if (type.Contains("blob", StringComparison.Ordinal)) return MvSchemaTypeFamily.Binary;
+        if (type.Contains("char", StringComparison.Ordinal) || type.Contains("clob", StringComparison.Ordinal) ||
+            type.Contains("text", StringComparison.Ordinal)) return MvSchemaTypeFamily.String;
+        return MvSchemaTypeFamily.Any;
+    }
+
+    private sealed class SqliteSchemaColumn
+    {
+        public string name { get; init; } = string.Empty;
+        public string? type { get; init; }
+        public int notnull { get; init; }
+        public int pk { get; init; }
+    }
+}

--- a/dcb/src/Sekiban.Dcb.MaterializedView.Sqlite/SqliteMvSchemaVerifier.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.Sqlite/SqliteMvSchemaVerifier.cs
@@ -8,6 +8,8 @@ public sealed partial class SqliteMvRegistryStore
 {
     private const string TableInfoSql =
         "SELECT name AS Name, type AS Type, \"notnull\" AS \"NotNull\", pk AS Pk, dflt_value AS DefaultSql, hidden AS Hidden FROM pragma_table_xinfo(@TableName);";
+    private const string TableDefinitionSql =
+        "SELECT sql AS Definition FROM sqlite_master WHERE type = 'table' AND name = @TableName;";
 
     public async Task<MvSchemaVerificationResult> VerifySchemaAsync(
         IReadOnlyList<MvSchemaTableRequirement> requirements,
@@ -41,8 +43,18 @@ public sealed partial class SqliteMvRegistryStore
                             new { TableName = tableName },
                             cancellationToken: cancellationToken))
                     .ConfigureAwait(false);
+                var tableDefinition = await connection.ExecuteScalarAsync<string?>(
+                        CatalogCommand(
+                            TableDefinitionSql,
+                            new { TableName = tableName },
+                            cancellationToken: cancellationToken))
+                    .ConfigureAwait(false);
                 foreach (var column in tableInfo)
                 {
+                    var dimensions = ParseDeclaredType(column.Type);
+                    var generationExpression = column.Hidden is 2 or 3
+                        ? ExtractGenerationExpression(tableDefinition, column.Name)
+                        : null;
                     columns.Add(new MvObservedSchemaColumn(
                         tableName,
                         column.Name,
@@ -50,7 +62,11 @@ public sealed partial class SqliteMvRegistryStore
                         column.NotNull == 0)
                     {
                         DefaultSql = column.DefaultSql,
-                        IsGenerated = column.Hidden is 2 or 3
+                        IsGenerated = column.Hidden is 2 or 3,
+                        GenerationExpression = generationExpression,
+                        MaxLength = dimensions.MaxLength,
+                        Precision = dimensions.Precision,
+                        Scale = dimensions.Scale
                     });
                     if (column.Pk > 0)
                     {
@@ -85,6 +101,7 @@ public sealed partial class SqliteMvRegistryStore
                 }
             }
 
+            EnsureRequiredMetadataCanBeInspected(requirements, columns);
             return MvSchemaRequirements.Validate(
                 requirements,
                 MvSchemaRequirements.Observe(columns, primaryKeys, indexes));
@@ -92,6 +109,15 @@ public sealed partial class SqliteMvRegistryStore
         catch (OperationCanceledException)
         {
             throw;
+        }
+        catch (UnsupportedSchemaCapabilityException ex)
+        {
+            return MvSchemaVerificationResult.Failed(
+                MvInitializationFailureReason.UnsupportedProviderCapability,
+                ex.Message,
+                ex.LogicalTable,
+                ex.PhysicalTable,
+                ex.Column);
         }
         catch
         {
@@ -116,6 +142,260 @@ public sealed partial class SqliteMvRegistryStore
 
     private static bool IsAsciiLetter(char character) =>
         character is >= 'A' and <= 'Z' or >= 'a' and <= 'z';
+
+    private static void EnsureRequiredMetadataCanBeInspected(
+        IReadOnlyList<MvSchemaTableRequirement> requirements,
+        IReadOnlyList<MvObservedSchemaColumn> columns)
+    {
+        var observedColumns = columns.ToDictionary(
+            column => (column.TableName, column.Name),
+            StringTupleComparer.Instance);
+        foreach (var requirement in requirements)
+        {
+            foreach (var expected in requirement.Columns)
+            {
+                if (!observedColumns.TryGetValue((requirement.PhysicalTable, expected.Name), out var actual))
+                {
+                    continue;
+                }
+
+                if (actual.IsGenerated && actual.GenerationExpression is null)
+                {
+                    throw new UnsupportedSchemaCapabilityException(
+                        "SQLite pragma metadata identifies a generated column, but its generation expression could not be derived from sqlite_master.",
+                        requirement.LogicalTable,
+                        requirement.PhysicalTable,
+                        expected.Name);
+                }
+
+                if (expected.GenerationExpression is not null && actual.GenerationExpression is null && actual.IsGenerated)
+                {
+                    throw new UnsupportedSchemaCapabilityException(
+                        "SQLite cannot faithfully inspect the required generated-column expression.",
+                        requirement.LogicalTable,
+                        requirement.PhysicalTable,
+                        expected.Name);
+                }
+
+                if (expected.MaxLength is not null && actual.MaxLength is null)
+                {
+                    throw new UnsupportedSchemaCapabilityException(
+                        "SQLite cannot faithfully inspect the required declared character or binary length.",
+                        requirement.LogicalTable,
+                        requirement.PhysicalTable,
+                        expected.Name);
+                }
+
+                if ((expected.Precision is not null || expected.Scale is not null) &&
+                    (actual.Precision is null || actual.Scale is null))
+                {
+                    throw new UnsupportedSchemaCapabilityException(
+                        "SQLite cannot faithfully inspect the required declared numeric precision and scale.",
+                        requirement.LogicalTable,
+                        requirement.PhysicalTable,
+                        expected.Name);
+                }
+            }
+        }
+    }
+
+    private static (int? MaxLength, int? Precision, int? Scale) ParseDeclaredType(string? declaredType)
+    {
+        if (string.IsNullOrWhiteSpace(declaredType))
+        {
+            return (null, null, null);
+        }
+
+        var openParen = declaredType.IndexOf('(');
+        var closeParen = declaredType.LastIndexOf(')');
+        if (openParen < 0 || closeParen <= openParen)
+        {
+            return (null, null, null);
+        }
+
+        var baseType = declaredType[..openParen].Trim().ToUpperInvariant();
+        var arguments = declaredType[(openParen + 1)..closeParen]
+            .Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+        if (arguments.Length is < 1 or > 2 || !int.TryParse(arguments[0], out var first) || first < 0)
+        {
+            return (null, null, null);
+        }
+        int? second = null;
+        if (arguments.Length == 2)
+        {
+            if (!int.TryParse(arguments[1], out var parsedSecond) || parsedSecond < 0)
+            {
+                return (null, null, null);
+            }
+
+            second = parsedSecond;
+        }
+
+        if (baseType is "CHAR" or "CHARACTER" or "VARCHAR" or "NCHAR" or "NVARCHAR" or
+            "BINARY" or "VARBINARY" or "CLOB" or "TEXT" or "BLOB")
+        {
+            return (first, null, null);
+        }
+
+        if (baseType is "DECIMAL" or "NUMERIC" or "NUMBER")
+        {
+            return (null, first, second ?? 0);
+        }
+
+        return (null, null, null);
+    }
+
+    private static string? ExtractGenerationExpression(string? tableDefinition, string columnName)
+    {
+        if (string.IsNullOrWhiteSpace(tableDefinition))
+        {
+            return null;
+        }
+
+        var openParen = tableDefinition.IndexOf('(');
+        var closeParen = tableDefinition.LastIndexOf(')');
+        if (openParen < 0 || closeParen <= openParen)
+        {
+            return null;
+        }
+
+        foreach (var definition in SplitTopLevelDefinitions(tableDefinition[(openParen + 1)..closeParen]))
+        {
+            if (!TryReadLeadingIdentifier(definition, out var definitionColumn) ||
+                !string.Equals(definitionColumn, columnName, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            var generatedIndex = definition.IndexOf("GENERATED", StringComparison.OrdinalIgnoreCase);
+            var asIndex = generatedIndex >= 0
+                ? definition.IndexOf("AS", generatedIndex, StringComparison.OrdinalIgnoreCase)
+                : definition.IndexOf(" AS ", StringComparison.OrdinalIgnoreCase);
+            if (asIndex < 0)
+            {
+                return null;
+            }
+
+            var expressionStart = definition.IndexOf('(', asIndex);
+            if (expressionStart < 0 || !TryReadBalancedExpression(definition, expressionStart, out var expression))
+            {
+                return null;
+            }
+
+            return expression;
+        }
+
+        return null;
+    }
+
+    private static IReadOnlyList<string> SplitTopLevelDefinitions(string definitions)
+    {
+        var result = new List<string>();
+        var start = 0;
+        var depth = 0;
+        var quote = '\0';
+        for (var index = 0; index < definitions.Length; index++)
+        {
+            var current = definitions[index];
+            if (quote != '\0')
+            {
+                if (current == quote && (quote != '\'' || index + 1 >= definitions.Length || definitions[index + 1] != '\''))
+                {
+                    quote = '\0';
+                }
+                else if (current == quote && quote == '\'')
+                {
+                    index++;
+                }
+
+                continue;
+            }
+
+            if (current is '\'' or '"' or '`')
+            {
+                quote = current;
+            }
+            else if (current == '(')
+            {
+                depth++;
+            }
+            else if (current == ')')
+            {
+                depth--;
+            }
+            else if (current == ',' && depth == 0)
+            {
+                result.Add(definitions[start..index]);
+                start = index + 1;
+            }
+        }
+
+        result.Add(definitions[start..]);
+        return result;
+    }
+
+    private static bool TryReadLeadingIdentifier(string definition, out string identifier)
+    {
+        var value = definition.TrimStart();
+        if (value.Length == 0 || value.StartsWith("CONSTRAINT ", StringComparison.OrdinalIgnoreCase) ||
+            value.StartsWith("PRIMARY ", StringComparison.OrdinalIgnoreCase) ||
+            value.StartsWith("UNIQUE ", StringComparison.OrdinalIgnoreCase) ||
+            value.StartsWith("CHECK ", StringComparison.OrdinalIgnoreCase) ||
+            value.StartsWith("FOREIGN ", StringComparison.OrdinalIgnoreCase))
+        {
+            identifier = string.Empty;
+            return false;
+        }
+
+        var end = 0;
+        while (end < value.Length && (IsAsciiLetter(value[end]) || char.IsAsciiDigit(value[end]) || value[end] == '_'))
+        {
+            end++;
+        }
+
+        identifier = end == 0 ? string.Empty : value[..end];
+        return end > 0;
+    }
+
+    private static bool TryReadBalancedExpression(string value, int openParen, out string expression)
+    {
+        var depth = 0;
+        var quote = '\0';
+        for (var index = openParen; index < value.Length; index++)
+        {
+            var current = value[index];
+            if (quote != '\0')
+            {
+                if (current == quote && (quote != '\'' || index + 1 >= value.Length || value[index + 1] != '\''))
+                {
+                    quote = '\0';
+                }
+                else if (current == quote && quote == '\'')
+                {
+                    index++;
+                }
+
+                continue;
+            }
+
+            if (current is '\'' or '"' or '`')
+            {
+                quote = current;
+            }
+            else if (current == '(')
+            {
+                depth++;
+            }
+            else if (current == ')' && --depth == 0)
+            {
+                expression = value[(openParen + 1)..index].Trim();
+                return true;
+            }
+        }
+
+        expression = string.Empty;
+        return false;
+    }
 
     private static MvSchemaTypeFamily MapType(string columnName, string? declaredType)
     {
@@ -148,6 +428,31 @@ public sealed partial class SqliteMvRegistryStore
         public int Pk { get; init; }
         public string? DefaultSql { get; init; }
         public int Hidden { get; init; }
+    }
+
+    private sealed class UnsupportedSchemaCapabilityException(
+        string message,
+        string? logicalTable,
+        string? physicalTable,
+        string? column) : Exception(message)
+    {
+        public string? LogicalTable { get; } = logicalTable;
+        public string? PhysicalTable { get; } = physicalTable;
+        public string? Column { get; } = column;
+    }
+
+    private sealed class StringTupleComparer : IEqualityComparer<(string TableName, string Name)>
+    {
+        public static StringTupleComparer Instance { get; } = new();
+
+        public bool Equals((string TableName, string Name) x, (string TableName, string Name) y) =>
+            string.Equals(x.TableName, y.TableName, StringComparison.OrdinalIgnoreCase) &&
+            string.Equals(x.Name, y.Name, StringComparison.OrdinalIgnoreCase);
+
+        public int GetHashCode((string TableName, string Name) obj) =>
+            HashCode.Combine(
+                StringComparer.OrdinalIgnoreCase.GetHashCode(obj.TableName),
+                StringComparer.OrdinalIgnoreCase.GetHashCode(obj.Name));
     }
 
     private sealed class SqliteSchemaIndex

--- a/dcb/src/Sekiban.Dcb.MaterializedView.Sqlite/SqliteMvSchemaVerifier.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.Sqlite/SqliteMvSchemaVerifier.cs
@@ -6,6 +6,9 @@ namespace Sekiban.Dcb.MaterializedView.Sqlite;
 
 public sealed partial class SqliteMvRegistryStore
 {
+    private const string TableInfoSql =
+        "SELECT name AS Name, type AS Type, \"notnull\" AS \"NotNull\", pk AS Pk FROM pragma_table_info(@TableName);";
+
     public async Task<MvSchemaVerificationResult> VerifySchemaAsync(
         IReadOnlyList<MvSchemaTableRequirement> requirements,
         CancellationToken cancellationToken = default)
@@ -18,6 +21,7 @@ public sealed partial class SqliteMvRegistryStore
             var primaryKeys = new List<MvObservedSchemaPrimaryKeyColumn>();
             foreach (var tableName in requirements.Select(requirement => requirement.PhysicalTable).Distinct(StringComparer.OrdinalIgnoreCase))
             {
+                ValidateContractIdentifier(tableName);
                 var objectType = await connection.ExecuteScalarAsync<string?>(
                         new CommandDefinition(
                             "SELECT type FROM sqlite_master WHERE name = @TableName;",
@@ -31,22 +35,23 @@ public sealed partial class SqliteMvRegistryStore
 
                 var tableInfo = await connection.QueryAsync<SqliteSchemaColumn>(
                         new CommandDefinition(
-                            $"PRAGMA table_info('{EscapeLiteral(tableName)}');",
+                            TableInfoSql,
+                            new { TableName = tableName },
                             cancellationToken: cancellationToken))
                     .ConfigureAwait(false);
                 foreach (var column in tableInfo)
                 {
                     columns.Add(new MvObservedSchemaColumn(
                         tableName,
-                        column.name,
-                        MapType(column.name, column.type),
-                        column.notnull == 0));
-                    if (column.pk > 0)
+                        column.Name,
+                        MapType(column.Name, column.Type),
+                        column.NotNull == 0));
+                    if (column.Pk > 0)
                     {
                         primaryKeys.Add(new MvObservedSchemaPrimaryKeyColumn(
                             tableName,
-                            column.name,
-                            column.pk));
+                            column.Name,
+                            column.Pk));
                     }
                 }
             }
@@ -67,7 +72,21 @@ public sealed partial class SqliteMvRegistryStore
         }
     }
 
-    private static string EscapeLiteral(string value) => value.Replace("'", "''", StringComparison.Ordinal);
+    private static void ValidateContractIdentifier(string identifier)
+    {
+        if (string.IsNullOrWhiteSpace(identifier) ||
+            !(IsAsciiLetter(identifier[0]) || identifier[0] == '_') ||
+            identifier.Any(character =>
+                !(IsAsciiLetter(character) || char.IsAsciiDigit(character) || character == '_')))
+        {
+            throw new ArgumentException(
+                $"SQLite schema identifier '{identifier}' must contain only ASCII letters, digits, and underscores.",
+                nameof(identifier));
+        }
+    }
+
+    private static bool IsAsciiLetter(char character) =>
+        character is >= 'A' and <= 'Z' or >= 'a' and <= 'z';
 
     private static MvSchemaTypeFamily MapType(string columnName, string? declaredType)
     {
@@ -94,9 +113,9 @@ public sealed partial class SqliteMvRegistryStore
 
     private sealed class SqliteSchemaColumn
     {
-        public string name { get; init; } = string.Empty;
-        public string? type { get; init; }
-        public int notnull { get; init; }
-        public int pk { get; init; }
+        public string Name { get; init; } = string.Empty;
+        public string? Type { get; init; }
+        public int NotNull { get; init; }
+        public int Pk { get; init; }
     }
 }

--- a/dcb/src/Sekiban.Dcb.MaterializedView/MvApplyHostSupport.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView/MvApplyHostSupport.cs
@@ -217,9 +217,17 @@ public sealed class NativeMvApplyHost : IMvApplyHost
     public IReadOnlyList<string> LogicalTables => _logicalTables;
 
     public IReadOnlyList<MvSchemaTableRequirement> GetSchemaRequirements(IMvTableBindings tables) =>
-        _projector is IMvSchemaRequirementsProvider provider
+        GetSchemaContract(tables)?.Tables ??
+        (_projector is IMvSchemaRequirementsProvider provider
             ? provider.GetSchemaRequirements(_databaseType, tables)
-            : [];
+            : []);
+
+    public MvSchemaContract? GetSchemaContract(IMvTableBindings tables) =>
+        _projector is IMvSchemaContractProvider contractProvider
+            ? contractProvider.GetSchemaContract(_databaseType, tables)
+            : _projector is IMvSchemaRequirementsProvider requirementsProvider
+                ? new MvSchemaContract(MvSchemaContract.CurrentFormatVersion, requirementsProvider.GetSchemaRequirements(_databaseType, tables))
+                : null;
 
     public async Task<IReadOnlyList<MvSqlStatementDto>> InitializeAsync(IMvTableBindings tables, CancellationToken ct)
     {
@@ -299,11 +307,11 @@ public sealed class NativeMvApplyHost : IMvApplyHost
         public System.Data.IDbConnection Connection =>
             _queryPort is IMvApplyDbConnectionPort dbConnectionPort
                 ? dbConnectionPort.Connection
-                : throw new NotSupportedException("Native MV apply host does not expose raw connections.");
+                : throw RawAccessRejected("connection");
         public System.Data.IDbTransaction Transaction =>
             _queryPort is IMvApplyDbConnectionPort dbConnectionPort
                 ? dbConnectionPort.Transaction
-                : throw new NotSupportedException("Native MV apply host does not expose raw transactions.");
+                : throw RawAccessRejected("transaction");
         public Event CurrentEvent { get; }
         public string CurrentSortableUniqueId { get; }
 
@@ -338,6 +346,11 @@ public sealed class NativeMvApplyHost : IMvApplyHost
 
         public MvTable GetDependencyViewTable<TView>(string logicalTable) where TView : IMaterializedViewProjector =>
             throw new NotSupportedException("Cross-view reads are not supported by the native MV apply host adapter.");
+
+        private Exception RawAccessRejected(string surface) =>
+            _queryPort is MvPolicyEnforcingQueryPort enforcingPort
+                ? enforcingPort.RejectRawAccess($"raw {surface}")
+                : new NotSupportedException($"Native MV apply host does not expose raw {surface}s.");
     }
 
     private sealed class JsonElementMvRow : IMvRow

--- a/dcb/src/Sekiban.Dcb.MaterializedView/MvApplyHostSupport.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView/MvApplyHostSupport.cs
@@ -216,6 +216,11 @@ public sealed class NativeMvApplyHost : IMvApplyHost
     public int ViewVersion => _projector.ViewVersion;
     public IReadOnlyList<string> LogicalTables => _logicalTables;
 
+    public IReadOnlyList<MvSchemaTableRequirement> GetSchemaRequirements(IMvTableBindings tables) =>
+        _projector is IMvSchemaRequirementsProvider provider
+            ? provider.GetSchemaRequirements(_databaseType, tables)
+            : [];
+
     public async Task<IReadOnlyList<MvSqlStatementDto>> InitializeAsync(IMvTableBindings tables, CancellationToken ct)
     {
         var recordingContext = new RecordingMvInitContext(tables, _databaseType);

--- a/dcb/src/Sekiban.Dcb.MaterializedView/MvCatchUpWorker.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView/MvCatchUpWorker.cs
@@ -88,14 +88,67 @@ public sealed class MvCatchUpWorker : BackgroundService
 
     private async Task InitializeProjectorsAsync(CancellationToken stoppingToken)
     {
-        foreach (var registration in _registrations)
+        while (!stoppingToken.IsCancellationRequested)
         {
-            var host = _hostFactory.Create(registration.ViewName, registration.ViewVersion);
-            await _executor.InitializeAsync(host, _serviceId, stoppingToken).ConfigureAwait(false);
-            _publicationSnapshots[GetProjectorKey(registration)] =
-                MvProjectionStatusSnapshot.Unknown(MvStatus.CatchingUp);
+            try
+            {
+                foreach (var registration in _registrations)
+                {
+                    var host = _hostFactory.Create(registration.ViewName, registration.ViewVersion);
+                    await _executor.InitializeAsync(host, _serviceId, stoppingToken).ConfigureAwait(false);
+                    _publicationSnapshots[GetProjectorKey(registration)] =
+                        MvProjectionStatusSnapshot.Unknown(MvStatus.CatchingUp);
+                }
+
+                return;
+            }
+            catch (MvInitializationException ex) when (
+                _options.InitializationMode == MvInitializationMode.VerifyOnly &&
+                !stoppingToken.IsCancellationRequested)
+            {
+                _logger.LogWarning(
+                    ex,
+                    "Verify-only materialized-view startup is gated until the pre-provisioned schema is compatible; retrying after {RetryDelay}.",
+                    GetVerifyOnlyRetryDelay());
+                foreach (var registration in _registrations)
+                {
+                    var snapshot = MvProjectionStatusSnapshot.Unknown(MvStatus.Faulted);
+                    _publicationSnapshots[GetProjectorKey(registration)] = snapshot;
+                    if (_statusPublisher is not null)
+                    {
+                        try
+                        {
+                            await _statusPublisher.PublishIfDueAsync(
+                                    _serviceId,
+                                    registration.ViewName,
+                                    registration.ViewVersion,
+                                    snapshot,
+                                    MvProjectionStatusPublisherKind.HostedWorker,
+                                    stoppingToken)
+                                .ConfigureAwait(false);
+                        }
+                        catch (Exception statusException) when (statusException is not OperationCanceledException)
+                        {
+                            _logger.LogWarning(
+                                statusException,
+                                "Unable to publish verify-only startup health for {ViewName}/{ViewVersion}.",
+                                registration.ViewName,
+                                registration.ViewVersion);
+                        }
+                    }
+                }
+
+                await Task.Delay(GetVerifyOnlyRetryDelay(), stoppingToken).ConfigureAwait(false);
+            }
         }
     }
+
+    private TimeSpan GetVerifyOnlyRetryDelay() =>
+        _options.VerifyOnlyRetryDelay > TimeSpan.Zero
+            ? _options.VerifyOnlyRetryDelay
+            : _options.PollInterval > TimeSpan.Zero
+                ? _options.PollInterval
+                : TimeSpan.FromSeconds(1);
 
     private async Task<CatchUpCycleResult> RunCatchUpCycleAsync(CancellationToken stoppingToken)
     {

--- a/dcb/src/Sekiban.Dcb.MaterializedView/MvContracts.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView/MvContracts.cs
@@ -230,6 +230,12 @@ public interface IMvApplyHost
     ///     omit this additive member; verify-only then fails closed when the host registers tables.
     /// </summary>
     IReadOnlyList<MvSchemaTableRequirement> GetSchemaRequirements(IMvTableBindings tables) => [];
+
+    /// <summary>
+    ///     Optional versioned form of the declarative verify-only contract. Existing hosts may continue to implement
+    ///     <see cref="GetSchemaRequirements"/>; the executor treats that representation as format version one.
+    /// </summary>
+    MvSchemaContract? GetSchemaContract(IMvTableBindings tables) => null;
 }
 
 public interface IMvApplyHostFactory

--- a/dcb/src/Sekiban.Dcb.MaterializedView/MvContracts.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView/MvContracts.cs
@@ -224,6 +224,12 @@ public interface IMvApplyHost
         IMvApplyQueryPort queryPort,
         string sortableUniqueId,
         CancellationToken ct);
+
+    /// <summary>
+    ///     Returns the provider-neutral schema contract used by verify-only initialization. Existing custom hosts may
+    ///     omit this additive member; verify-only then fails closed when the host registers tables.
+    /// </summary>
+    IReadOnlyList<MvSchemaTableRequirement> GetSchemaRequirements(IMvTableBindings tables) => [];
 }
 
 public interface IMvApplyHostFactory

--- a/dcb/src/Sekiban.Dcb.MaterializedView/MvExecutorBase.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView/MvExecutorBase.cs
@@ -44,6 +44,11 @@ public abstract class MvExecutorBase<TConnection> : IMvExecutor, IMvActivationEx
 
     protected string ConnectionString => _connectionString;
 
+    /// <summary>Provider executors override this so policy decisions carry the concrete database type.</summary>
+    protected virtual MvDbType DatabaseType => MvDbType.Postgres;
+
+    private bool IsVerifyOnly => _options.InitializationMode == MvInitializationMode.VerifyOnly;
+
     // These helpers validate dependencies and move database-neutral workflow only. They never resolve or cache an
     // event store; each provider executor keeps its own factory field and selects its service-scoped source.
     protected static (IEventStore EventStore, IServiceIdProvider ServiceIdProvider) RequireLegacyCompatibilityDependencies(
@@ -163,13 +168,16 @@ public abstract class MvExecutorBase<TConnection> : IMvExecutor, IMvActivationEx
 
         var target = await CaptureTargetCheckpointFromStoreAsync(SelectEventStoreForService(exactServiceId))
             .ConfigureAwait(false);
-        await _registryStore.SetTargetCheckpointAsync(
-                exactServiceId,
-                host.ViewName,
-                host.ViewVersion,
-                target,
-                cancellationToken: cancellationToken)
-            .ConfigureAwait(false);
+        if (!IsVerifyOnly)
+        {
+            await _registryStore.SetTargetCheckpointAsync(
+                    exactServiceId,
+                    host.ViewName,
+                    host.ViewVersion,
+                    target,
+                    cancellationToken: cancellationToken)
+                .ConfigureAwait(false);
+        }
         return target;
     }
 
@@ -185,11 +193,7 @@ public abstract class MvExecutorBase<TConnection> : IMvExecutor, IMvActivationEx
                 cancellationToken,
                 initializeWhenEmpty: false)
             .ConfigureAwait(false);
-        var active = await _registryStore.GetActiveAsync(
-                exactServiceId,
-                host.ViewName,
-                cancellationToken)
-            .ConfigureAwait(false);
+        var active = await ReadActiveAsync(exactServiceId, host.ViewName, cancellationToken).ConfigureAwait(false);
         var (eligibility, request) = MvActivationEligibility.Evaluate(
             exactServiceId,
             host.ViewName,
@@ -199,6 +203,13 @@ public abstract class MvExecutorBase<TConnection> : IMvExecutor, IMvActivationEx
         if (!eligibility.IsEligible || request is null)
         {
             return MvActivationResult.Rejected(eligibility.FailureReason, eligibility.Message);
+        }
+
+        if (IsVerifyOnly)
+        {
+            return MvActivationResult.Rejected(
+                MvActivationFailureReason.ProviderFailure,
+                "Verify-only infrastructure mode never mutates materialized-view registry state.");
         }
 
         try
@@ -248,7 +259,8 @@ public abstract class MvExecutorBase<TConnection> : IMvExecutor, IMvActivationEx
                 bindings,
                 statements,
                 MvSqlStatementPhase.Initialization,
-                cancellationToken)
+                cancellationToken,
+                MvSqlStatementOrigin.ProjectorInitialize)
             .ConfigureAwait(false);
 
         await _registryStore.EnsureInfrastructureAsync(cancellationToken).ConfigureAwait(false);
@@ -383,7 +395,8 @@ public abstract class MvExecutorBase<TConnection> : IMvExecutor, IMvActivationEx
         MvTableBindings bindings,
         IReadOnlyList<MvSqlStatementDto> statements,
         MvSqlStatementPhase phase,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        MvSqlStatementOrigin? origin = null)
     {
         var policy = _options.SqlStatementPolicyMode == MvSqlStatementPolicyMode.Enforced
             ? _options.SqlStatementPolicy
@@ -404,6 +417,10 @@ public abstract class MvExecutorBase<TConnection> : IMvExecutor, IMvActivationEx
                         statement.Sql,
                         statement.Parameters.Select(parameter => parameter with { ValueJson = null }).ToList())
                     {
+                        DatabaseType = DatabaseType,
+                        Origin = origin ?? (phase == MvSqlStatementPhase.Initialization
+                            ? MvSqlStatementOrigin.ProjectorInitialize
+                            : MvSqlStatementOrigin.ProjectorApply),
                         StatementIndex = statementIndex,
                         BatchSize = batch.Count
                     },
@@ -448,6 +465,27 @@ public abstract class MvExecutorBase<TConnection> : IMvExecutor, IMvActivationEx
         }
 
         return _registryStore.GetEntriesAsync(serviceId, viewName, viewVersion, cancellationToken);
+    }
+
+    private Task<MvActiveEntry?> ReadActiveAsync(
+        string serviceId,
+        string viewName,
+        CancellationToken cancellationToken)
+    {
+        if (IsVerifyOnly)
+        {
+            if (_registryStore is not IMvReadOnlyMvInspector inspector)
+            {
+                throw new MvInitializationException(
+                    new MvInitializationFailure(
+                        MvInitializationFailureReason.UnsupportedProviderCapability,
+                        "The configured materialized-view provider does not expose a dedicated read-only active-pointer inspector."));
+            }
+
+            return inspector.ReadActiveAsync(serviceId, viewName, cancellationToken);
+        }
+
+        return _registryStore.GetActiveAsync(serviceId, viewName, cancellationToken);
     }
 
     /// <summary>
@@ -563,6 +601,12 @@ public abstract class MvExecutorBase<TConnection> : IMvExecutor, IMvActivationEx
             return;
         }
 
+        // Verify-only may inspect an existing target, but it is never allowed to create or refresh registry truth.
+        if (IsVerifyOnly)
+        {
+            return;
+        }
+
         var target = await CaptureTargetCheckpointFromStoreAsync(eventStore).ConfigureAwait(false);
         await _registryStore.SetTargetCheckpointAsync(
                 serviceId,
@@ -589,11 +633,7 @@ public abstract class MvExecutorBase<TConnection> : IMvExecutor, IMvActivationEx
                 host.ViewVersion,
                 cancellationToken)
             .ConfigureAwait(false);
-        var active = await _registryStore.GetActiveAsync(
-                serviceId,
-                host.ViewName,
-                cancellationToken)
-            .ConfigureAwait(false);
+        var active = await ReadActiveAsync(serviceId, host.ViewName, cancellationToken).ConfigureAwait(false);
 
         // Retired and faulted rows are terminal lifecycle states. Only the normal catch-up/ready transition may be
         // promoted by this automatic initial-activation path.
@@ -616,6 +656,11 @@ public abstract class MvExecutorBase<TConnection> : IMvExecutor, IMvActivationEx
             readyEntries,
             active);
         if (!preflight.IsEligible)
+        {
+            return entries[0].Status;
+        }
+
+        if (IsVerifyOnly)
         {
             return entries[0].Status;
         }
@@ -700,19 +745,22 @@ public abstract class MvExecutorBase<TConnection> : IMvExecutor, IMvActivationEx
 
         if (batch.Count == 0)
         {
-            await _registryStore.UpdatePositionAsync(
-                    new MvPositionUpdate(
-                        serviceId,
-                        host.ViewName,
-                        host.ViewVersion,
-                        SortableUniqueId.MinValue.Value,
-                        MvApplySource.CatchUp,
-                        AppliedEventVersionDelta: 0)
-                    {
-                        CheckpointTruth = MvCheckpointTruth.KnownZero()
-                    },
-                    cancellationToken: cancellationToken)
-                .ConfigureAwait(false);
+            if (!IsVerifyOnly)
+            {
+                await _registryStore.UpdatePositionAsync(
+                        new MvPositionUpdate(
+                            serviceId,
+                            host.ViewName,
+                            host.ViewVersion,
+                            SortableUniqueId.MinValue.Value,
+                            MvApplySource.CatchUp,
+                            AppliedEventVersionDelta: 0)
+                        {
+                            CheckpointTruth = MvCheckpointTruth.KnownZero()
+                        },
+                        cancellationToken: cancellationToken)
+                    .ConfigureAwait(false);
+            }
             var emptyTruth = currentStatus.CurrentCheckpointTruth.IsKnown &&
                 !currentStatus.CurrentCheckpointTruth.IsKnownZero
                     ? currentStatus.CurrentCheckpointTruth
@@ -788,6 +836,14 @@ public abstract class MvExecutorBase<TConnection> : IMvExecutor, IMvActivationEx
                 cancellationToken)
             .ConfigureAwait(false);
 
+        // Verify-only is an inspection lifecycle. Once the declarative gate has succeeded, an event-apply call is
+        // deliberately a no-op so it cannot open the normal target connection, create a transaction, execute
+        // projector SQL, or commit a view/registry mutation.
+        if (IsVerifyOnly)
+        {
+            return 0;
+        }
+
         var currentPosition = entries
             .Select(entry => entry.CurrentCheckpointTruth.IsKnown ? entry.CurrentCheckpointTruth.PositionValue : null)
             .FirstOrDefault(position => !string.IsNullOrWhiteSpace(position));
@@ -852,7 +908,8 @@ public abstract class MvExecutorBase<TConnection> : IMvExecutor, IMvActivationEx
                 serviceId,
                 host.ViewName,
                 host.ViewVersion,
-                bindings.Tables);
+                bindings.Tables,
+                DatabaseType);
         }
         IReadOnlyList<MvSqlStatementDto> statements;
         try
@@ -870,7 +927,8 @@ public abstract class MvExecutorBase<TConnection> : IMvExecutor, IMvActivationEx
                     bindings,
                     statements,
                     MvSqlStatementPhase.Apply,
-                    cancellationToken)
+                    cancellationToken,
+                    MvSqlStatementOrigin.ProjectorApply)
                 .ConfigureAwait(false);
         }
         catch
@@ -911,16 +969,19 @@ public abstract class MvExecutorBase<TConnection> : IMvExecutor, IMvActivationEx
             return false;
         }
 
-        await _registryStore.UpdatePositionAsync(
-                new MvPositionUpdate(
-                    serviceId,
-                    host.ViewName,
-                    host.ViewVersion,
-                    serializableEvent.SortableUniqueIdValue,
-                    source),
-                transaction,
-                cancellationToken)
-            .ConfigureAwait(false);
+        if (!IsVerifyOnly)
+        {
+            await _registryStore.UpdatePositionAsync(
+                    new MvPositionUpdate(
+                        serviceId,
+                        host.ViewName,
+                        host.ViewVersion,
+                        serializableEvent.SortableUniqueIdValue,
+                        source),
+                    transaction,
+                    cancellationToken)
+                .ConfigureAwait(false);
+        }
         await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
         return true;
     }

--- a/dcb/src/Sekiban.Dcb.MaterializedView/MvExecutorBase.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView/MvExecutorBase.cs
@@ -228,12 +228,96 @@ public abstract class MvExecutorBase<TConnection> : IMvExecutor, IMvActivationEx
         string serviceId,
         CancellationToken cancellationToken)
     {
+        var bindings = new MvTableBindings(host.ViewName, host.ViewVersion, _options);
+        var statements = await host.InitializeAsync(bindings, cancellationToken).ConfigureAwait(false);
+        await AuthorizeStatementsAsync(
+                serviceId,
+                host,
+                bindings,
+                statements,
+                MvSqlStatementPhase.Initialization,
+                cancellationToken)
+            .ConfigureAwait(false);
+
+        if (_options.InitializationMode == MvInitializationMode.VerifyOnly)
+        {
+            var requirements = host.GetSchemaRequirements(bindings);
+            var contractResult = MvSchemaRequirements.ValidateContract(bindings.Tables, requirements);
+            ThrowIfInitializationVerificationFailed(contractResult);
+
+            if (_registryStore is not IMvSchemaVerifier schemaVerifier)
+            {
+                throw new MvInitializationException(
+                    new MvInitializationFailure(
+                        MvInitializationFailureReason.UnsupportedProviderCapability,
+                        "The configured materialized-view provider does not support read-only schema verification."));
+            }
+
+            var verificationResult = await schemaVerifier.VerifySchemaAsync(
+                    [.. MvSchemaRequirements.RegistryTables(), .. requirements],
+                    cancellationToken)
+                .ConfigureAwait(false);
+            ThrowIfInitializationVerificationFailed(verificationResult);
+
+            var existingEntries = await _registryStore.GetEntriesAsync(
+                    serviceId,
+                    host.ViewName,
+                    host.ViewVersion,
+                    cancellationToken)
+                .ConfigureAwait(false);
+            var expectedTables = bindings.Tables.ToDictionary(table => table.LogicalName, StringComparer.Ordinal);
+            var observedLogicalTables = new HashSet<string>(StringComparer.Ordinal);
+            foreach (var entry in existingEntries)
+            {
+                if (!expectedTables.TryGetValue(entry.LogicalTable, out var expectedTable) ||
+                    !string.Equals(entry.PhysicalTable, expectedTable.PhysicalName, StringComparison.Ordinal) ||
+                    !observedLogicalTables.Add(entry.LogicalTable))
+                {
+                    throw new MvInitializationException(
+                        new MvInitializationFailure(
+                            MvInitializationFailureReason.MissingSchemaContract,
+                            $"The existing materialized-view registry binding for logical table '{entry.LogicalTable}' is incompatible with the projector contract.",
+                            entry.LogicalTable,
+                            entry.PhysicalTable));
+                }
+            }
+
+            if (observedLogicalTables.Count == expectedTables.Count)
+            {
+                return;
+            }
+
+            await using var verifyConnection = await OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
+            await using var verifyTransaction = await verifyConnection.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
+            foreach (var table in bindings.Tables)
+            {
+                await _registryStore.RegisterAsync(
+                        new MvRegistryEntry
+                        {
+                            ServiceId = serviceId,
+                            ViewName = host.ViewName,
+                            ViewVersion = host.ViewVersion,
+                            LogicalTable = table.LogicalName,
+                            PhysicalTable = table.PhysicalName,
+                            Status = MvStatus.CatchingUp,
+                            CurrentCheckpointTruth = MvCheckpointTruth.Unknown(MvCheckpointUnknownReason.NotObserved),
+                            TargetCheckpointTruth = MvCheckpointTruth.Unknown(MvCheckpointUnknownReason.NotObserved),
+                            AppliedEventVersion = 0,
+                            LastUpdated = DateTimeOffset.UtcNow
+                        },
+                        verifyTransaction,
+                        cancellationToken)
+                    .ConfigureAwait(false);
+            }
+
+            await verifyTransaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+            return;
+        }
+
         await _registryStore.EnsureInfrastructureAsync(cancellationToken).ConfigureAwait(false);
 
         await using var connection = await OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
         await using var transaction = await connection.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
-        var bindings = new MvTableBindings(host.ViewName, host.ViewVersion, _options);
-        var statements = await host.InitializeAsync(bindings, cancellationToken).ConfigureAwait(false);
         foreach (var statement in statements)
         {
             await ExecuteSqlAsync(
@@ -267,6 +351,53 @@ public abstract class MvExecutorBase<TConnection> : IMvExecutor, IMvActivationEx
         }
 
         await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task AuthorizeStatementsAsync(
+        string serviceId,
+        IMvApplyHost host,
+        MvTableBindings bindings,
+        IReadOnlyList<MvSqlStatementDto> statements,
+        MvSqlStatementPhase phase,
+        CancellationToken cancellationToken)
+    {
+        var policy = _options.SqlStatementPolicy ?? MvAllowAllSqlStatementPolicy.Instance;
+        var tables = bindings.Tables.ToList();
+        foreach (var statement in statements)
+        {
+            var decision = await policy.EvaluateAsync(
+                    new MvSqlStatementContext(
+                        serviceId,
+                        host.ViewName,
+                        host.ViewVersion,
+                        phase,
+                        tables,
+                        statement.Sql,
+                        statement.Parameters),
+                    cancellationToken)
+                .ConfigureAwait(false);
+            if (!decision.IsAllowed)
+            {
+                throw new MvSqlPolicyRejectedException(
+                    new MvSqlPolicyFailure(
+                        decision.Reason ?? "The host SQL statement policy rejected the statement.",
+                        serviceId,
+                        host.ViewName,
+                        host.ViewVersion,
+                        phase));
+            }
+        }
+    }
+
+    private static void ThrowIfInitializationVerificationFailed(MvSchemaVerificationResult result)
+    {
+        if (!result.IsCompatible)
+        {
+            throw new MvInitializationException(
+                result.Failure ?? new MvInitializationFailure(
+                    MvInitializationFailureReason.UnsupportedProviderCapability,
+                    "Materialized-view schema verification failed without a typed reason."));
+        }
     }
 
     protected async Task<MvProjectionStatusSnapshot> GetCurrentStatusAsync(
@@ -672,6 +803,23 @@ public abstract class MvExecutorBase<TConnection> : IMvExecutor, IMvActivationEx
                 serializableEvent.SortableUniqueIdValue,
                 cancellationToken)
             .ConfigureAwait(false);
+        try
+        {
+            await AuthorizeStatementsAsync(
+                    serviceId,
+                    host,
+                    bindings,
+                    statements,
+                    MvSqlStatementPhase.Apply,
+                    cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch
+        {
+            await transaction.RollbackAsync(cancellationToken).ConfigureAwait(false);
+            throw;
+        }
+
         var affectedRows = 0;
         foreach (var statement in statements)
         {

--- a/dcb/src/Sekiban.Dcb.MaterializedView/MvExecutorBase.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView/MvExecutorBase.cs
@@ -15,7 +15,7 @@ namespace Sekiban.Dcb.MaterializedView;
 /// Provider executors retain their own event-store factory and perform service validation/source selection
 /// at each public operation boundary before delegating database work here.
 /// </summary>
-public abstract class MvExecutorBase<TConnection> : IMvExecutor, IMvActivationExecutor
+public abstract class MvExecutorBase<TConnection> : IMvExecutor, IMvActivationExecutor, IMvInitializationVerifier
     where TConnection : DbConnection
 {
     private readonly IMvRegistryStore _registryStore;
@@ -108,6 +108,16 @@ public abstract class MvExecutorBase<TConnection> : IMvExecutor, IMvActivationEx
         CancellationToken cancellationToken = default) =>
         InitializeAtBoundaryAsync(host, serviceId, cancellationToken);
 
+    public async Task<MvSchemaVerificationResult> VerifyInitializationAsync(
+        IMvApplyHost host,
+        string? serviceId = null,
+        CancellationToken cancellationToken = default)
+    {
+        var exactServiceId = ValidateServiceIdAtBoundary(serviceId);
+        var bindings = new MvTableBindings(host.ViewName, host.ViewVersion, _options);
+        return await VerifyOnlyCoreAsync(host, exactServiceId, bindings, cancellationToken).ConfigureAwait(false);
+    }
+
     public Task<int> ApplySerializableEventsAsync(
         IMvApplyHost host,
         IReadOnlyList<SerializableEvent> events,
@@ -145,16 +155,11 @@ public abstract class MvExecutorBase<TConnection> : IMvExecutor, IMvActivationEx
         CancellationToken cancellationToken = default)
     {
         var exactServiceId = ValidateServiceIdAtBoundary(serviceId);
-        var entries = await _registryStore.GetEntriesAsync(
+        await ReadRegistryEntriesAtOperationBoundaryAsync(
+                host,
                 exactServiceId,
-                host.ViewName,
-                host.ViewVersion,
                 cancellationToken)
             .ConfigureAwait(false);
-        if (entries.Count == 0)
-        {
-            await InitializeCoreAsync(host, exactServiceId, cancellationToken).ConfigureAwait(false);
-        }
 
         var target = await CaptureTargetCheckpointFromStoreAsync(SelectEventStoreForService(exactServiceId))
             .ConfigureAwait(false);
@@ -174,11 +179,11 @@ public abstract class MvExecutorBase<TConnection> : IMvExecutor, IMvActivationEx
         CancellationToken cancellationToken = default)
     {
         var exactServiceId = ValidateServiceIdAtBoundary(serviceId);
-        var entries = await _registryStore.GetEntriesAsync(
+        var entries = await ReadRegistryEntriesAtOperationBoundaryAsync(
+                host,
                 exactServiceId,
-                host.ViewName,
-                host.ViewVersion,
-                cancellationToken)
+                cancellationToken,
+                initializeWhenEmpty: false)
             .ConfigureAwait(false);
         var active = await _registryStore.GetActiveAsync(
                 exactServiceId,
@@ -229,6 +234,13 @@ public abstract class MvExecutorBase<TConnection> : IMvExecutor, IMvActivationEx
         CancellationToken cancellationToken)
     {
         var bindings = new MvTableBindings(host.ViewName, host.ViewVersion, _options);
+        if (_options.InitializationMode == MvInitializationMode.VerifyOnly)
+        {
+            var verification = await VerifyOnlyCoreAsync(host, serviceId, bindings, cancellationToken).ConfigureAwait(false);
+            ThrowIfInitializationVerificationFailed(verification);
+            return;
+        }
+
         var statements = await host.InitializeAsync(bindings, cancellationToken).ConfigureAwait(false);
         await AuthorizeStatementsAsync(
                 serviceId,
@@ -238,81 +250,6 @@ public abstract class MvExecutorBase<TConnection> : IMvExecutor, IMvActivationEx
                 MvSqlStatementPhase.Initialization,
                 cancellationToken)
             .ConfigureAwait(false);
-
-        if (_options.InitializationMode == MvInitializationMode.VerifyOnly)
-        {
-            var requirements = host.GetSchemaRequirements(bindings);
-            var contractResult = MvSchemaRequirements.ValidateContract(bindings.Tables, requirements);
-            ThrowIfInitializationVerificationFailed(contractResult);
-
-            if (_registryStore is not IMvSchemaVerifier schemaVerifier)
-            {
-                throw new MvInitializationException(
-                    new MvInitializationFailure(
-                        MvInitializationFailureReason.UnsupportedProviderCapability,
-                        "The configured materialized-view provider does not support read-only schema verification."));
-            }
-
-            var verificationResult = await schemaVerifier.VerifySchemaAsync(
-                    [.. MvSchemaRequirements.RegistryTables(), .. requirements],
-                    cancellationToken)
-                .ConfigureAwait(false);
-            ThrowIfInitializationVerificationFailed(verificationResult);
-
-            var existingEntries = await _registryStore.GetEntriesAsync(
-                    serviceId,
-                    host.ViewName,
-                    host.ViewVersion,
-                    cancellationToken)
-                .ConfigureAwait(false);
-            var expectedTables = bindings.Tables.ToDictionary(table => table.LogicalName, StringComparer.Ordinal);
-            var observedLogicalTables = new HashSet<string>(StringComparer.Ordinal);
-            foreach (var entry in existingEntries)
-            {
-                if (!expectedTables.TryGetValue(entry.LogicalTable, out var expectedTable) ||
-                    !string.Equals(entry.PhysicalTable, expectedTable.PhysicalName, StringComparison.Ordinal) ||
-                    !observedLogicalTables.Add(entry.LogicalTable))
-                {
-                    throw new MvInitializationException(
-                        new MvInitializationFailure(
-                            MvInitializationFailureReason.MissingSchemaContract,
-                            $"The existing materialized-view registry binding for logical table '{entry.LogicalTable}' is incompatible with the projector contract.",
-                            entry.LogicalTable,
-                            entry.PhysicalTable));
-                }
-            }
-
-            if (observedLogicalTables.Count == expectedTables.Count)
-            {
-                return;
-            }
-
-            await using var verifyConnection = await OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
-            await using var verifyTransaction = await verifyConnection.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
-            foreach (var table in bindings.Tables)
-            {
-                await _registryStore.RegisterAsync(
-                        new MvRegistryEntry
-                        {
-                            ServiceId = serviceId,
-                            ViewName = host.ViewName,
-                            ViewVersion = host.ViewVersion,
-                            LogicalTable = table.LogicalName,
-                            PhysicalTable = table.PhysicalName,
-                            Status = MvStatus.CatchingUp,
-                            CurrentCheckpointTruth = MvCheckpointTruth.Unknown(MvCheckpointUnknownReason.NotObserved),
-                            TargetCheckpointTruth = MvCheckpointTruth.Unknown(MvCheckpointUnknownReason.NotObserved),
-                            AppliedEventVersion = 0,
-                            LastUpdated = DateTimeOffset.UtcNow
-                        },
-                        verifyTransaction,
-                        cancellationToken)
-                    .ConfigureAwait(false);
-            }
-
-            await verifyTransaction.CommitAsync(cancellationToken).ConfigureAwait(false);
-            return;
-        }
 
         await _registryStore.EnsureInfrastructureAsync(cancellationToken).ConfigureAwait(false);
 
@@ -353,6 +290,93 @@ public abstract class MvExecutorBase<TConnection> : IMvExecutor, IMvActivationEx
         await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
     }
 
+    private async Task<MvSchemaVerificationResult> VerifyOnlyCoreAsync(
+        IMvApplyHost host,
+        string serviceId,
+        MvTableBindings bindings,
+        CancellationToken cancellationToken)
+    {
+        if (_registryStore is not IMvReadOnlyMvInspector inspector)
+        {
+            return MvSchemaVerificationResult.Failed(
+                MvInitializationFailureReason.UnsupportedProviderCapability,
+                "The configured materialized-view provider does not expose a dedicated read-only inspector.");
+        }
+
+        // The declarative schema provider is the only binding source in VerifyOnly. Calling projector initialization
+        // here would execute arbitrary projector code and would reintroduce the DDL/host side-effect boundary.
+        var contract = host.GetSchemaContract(bindings);
+        if (contract is not null && contract.FormatVersion != MvSchemaContract.CurrentFormatVersion)
+        {
+            return MvSchemaVerificationResult.Failed(
+                MvInitializationFailureReason.SchemaContractUnavailable,
+                $"Materialized-view schema contract format version '{contract.FormatVersion}' is not supported.");
+        }
+
+        var requirements = contract?.Tables ?? host.GetSchemaRequirements(bindings);
+        if (contract is null && bindings.Tables.Count > 0 && requirements.Count == 0)
+        {
+            return MvSchemaVerificationResult.Failed(
+                MvInitializationFailureReason.SchemaContractUnavailable,
+                "Verify-only initialization requires a declarative materialized-view schema contract.");
+        }
+
+        var contractResult = MvSchemaRequirements.ValidateContract(bindings.Tables, requirements);
+        if (!contractResult.IsCompatible)
+        {
+            return contractResult;
+        }
+
+        var verificationResult = await inspector.VerifySchemaAsync(
+                [.. MvSchemaRequirements.RegistryTables(), .. requirements],
+                cancellationToken)
+            .ConfigureAwait(false);
+        if (!verificationResult.IsCompatible)
+        {
+            return verificationResult;
+        }
+
+        var existingEntries = await inspector.ReadRegistryEntriesAsync(
+                serviceId,
+                host.ViewName,
+                host.ViewVersion,
+                cancellationToken)
+            .ConfigureAwait(false);
+        var expectedTables = bindings.Tables.ToDictionary(table => table.LogicalName, StringComparer.Ordinal);
+        var observedLogicalTables = new HashSet<string>(StringComparer.Ordinal);
+        var registryMismatches = new List<MvSchemaMismatch>();
+        foreach (var entry in existingEntries)
+        {
+            if (!expectedTables.TryGetValue(entry.LogicalTable, out var expectedTable) ||
+                !string.Equals(entry.PhysicalTable, expectedTable.PhysicalName, StringComparison.Ordinal) ||
+                !observedLogicalTables.Add(entry.LogicalTable))
+            {
+                registryMismatches.Add(
+                    new MvSchemaMismatch(
+                        MvSchemaMismatchCode.BindingMismatch,
+                        $"The existing materialized-view registry binding for logical table '{entry.LogicalTable}' is incompatible with the projector contract.",
+                        entry.LogicalTable,
+                        entry.PhysicalTable));
+            }
+        }
+
+        foreach (var table in bindings.Tables.Where(table => !observedLogicalTables.Contains(table.LogicalName)))
+        {
+            registryMismatches.Add(
+                new MvSchemaMismatch(
+                    MvSchemaMismatchCode.BindingMismatch,
+                    $"The materialized-view registry has no binding for logical table '{table.LogicalName}'.",
+                    table.LogicalName,
+                    table.PhysicalName));
+        }
+
+        return registryMismatches.Count == 0
+            ? MvSchemaVerificationResult.Compatible()
+            : MvSchemaVerificationResult.FailedWithMismatches(
+                MvInitializationFailureReason.MissingSchemaContract,
+                registryMismatches);
+    }
+
     private async Task AuthorizeStatementsAsync(
         string serviceId,
         IMvApplyHost host,
@@ -361,11 +385,16 @@ public abstract class MvExecutorBase<TConnection> : IMvExecutor, IMvActivationEx
         MvSqlStatementPhase phase,
         CancellationToken cancellationToken)
     {
-        var policy = _options.SqlStatementPolicy ?? MvAllowAllSqlStatementPolicy.Instance;
+        var policy = _options.SqlStatementPolicyMode == MvSqlStatementPolicyMode.Enforced
+            ? _options.SqlStatementPolicy
+            : _options.SqlStatementPolicy ?? MvAllowAllSqlStatementPolicy.Instance;
         var tables = bindings.Tables.ToList();
-        foreach (var statement in statements)
+        var batch = statements.ToList();
+        for (var statementIndex = 0; statementIndex < batch.Count; statementIndex++)
         {
-            var decision = await policy.EvaluateAsync(
+            var statement = batch[statementIndex];
+            await MvSqlPolicyEvaluator.AuthorizeAsync(
+                    policy,
                     new MvSqlStatementContext(
                         serviceId,
                         host.ViewName,
@@ -373,19 +402,13 @@ public abstract class MvExecutorBase<TConnection> : IMvExecutor, IMvActivationEx
                         phase,
                         tables,
                         statement.Sql,
-                        statement.Parameters),
+                        statement.Parameters.Select(parameter => parameter with { ValueJson = null }).ToList())
+                    {
+                        StatementIndex = statementIndex,
+                        BatchSize = batch.Count
+                    },
                     cancellationToken)
                 .ConfigureAwait(false);
-            if (!decision.IsAllowed)
-            {
-                throw new MvSqlPolicyRejectedException(
-                    new MvSqlPolicyFailure(
-                        decision.Reason ?? "The host SQL statement policy rejected the statement.",
-                        serviceId,
-                        host.ViewName,
-                        host.ViewVersion,
-                        phase));
-            }
         }
     }
 
@@ -393,11 +416,74 @@ public abstract class MvExecutorBase<TConnection> : IMvExecutor, IMvActivationEx
     {
         if (!result.IsCompatible)
         {
+            var failure = result.Failure ?? new MvInitializationFailure(
+                MvInitializationFailureReason.UnsupportedProviderCapability,
+                "Materialized-view schema verification failed without a typed reason.");
+            if (result.Mismatches.Count > 0)
+            {
+                failure = failure with { Mismatches = result.Mismatches };
+            }
             throw new MvInitializationException(
-                result.Failure ?? new MvInitializationFailure(
-                    MvInitializationFailureReason.UnsupportedProviderCapability,
-                    "Materialized-view schema verification failed without a typed reason."));
+                failure);
         }
+    }
+
+    private Task<IReadOnlyList<MvRegistryEntry>> ReadRegistryEntriesAsync(
+        string serviceId,
+        string viewName,
+        int viewVersion,
+        CancellationToken cancellationToken)
+    {
+        if (_options.InitializationMode == MvInitializationMode.VerifyOnly)
+        {
+            if (_registryStore is not IMvReadOnlyMvInspector inspector)
+            {
+                throw new MvInitializationException(
+                    new MvInitializationFailure(
+                        MvInitializationFailureReason.UnsupportedProviderCapability,
+                        "The configured materialized-view provider does not expose a dedicated read-only inspector."));
+            }
+
+            return inspector.ReadRegistryEntriesAsync(serviceId, viewName, viewVersion, cancellationToken);
+        }
+
+        return _registryStore.GetEntriesAsync(serviceId, viewName, viewVersion, cancellationToken);
+    }
+
+    /// <summary>
+    ///     All operation paths that may discover an empty registry converge here. VerifyOnly runs the dedicated
+    ///     read-only schema/contract gate before the first registry-row query, so a missing framework table produces a
+    ///     typed failure instead of a provider write/read fallback. Legacy mode retains its lazy initialize behavior.
+    /// </summary>
+    private async Task<IReadOnlyList<MvRegistryEntry>> ReadRegistryEntriesAtOperationBoundaryAsync(
+        IMvApplyHost host,
+        string serviceId,
+        CancellationToken cancellationToken,
+        bool initializeWhenEmpty = true)
+    {
+        if (_options.InitializationMode == MvInitializationMode.VerifyOnly)
+        {
+            await InitializeCoreAsync(host, serviceId, cancellationToken).ConfigureAwait(false);
+        }
+
+        var entries = await ReadRegistryEntriesAsync(
+                serviceId,
+                host.ViewName,
+                host.ViewVersion,
+                cancellationToken)
+            .ConfigureAwait(false);
+        if (entries.Count == 0 && initializeWhenEmpty && _options.InitializationMode != MvInitializationMode.VerifyOnly)
+        {
+            await InitializeCoreAsync(host, serviceId, cancellationToken).ConfigureAwait(false);
+            entries = await ReadRegistryEntriesAsync(
+                    serviceId,
+                    host.ViewName,
+                    host.ViewVersion,
+                    cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        return entries;
     }
 
     protected async Task<MvProjectionStatusSnapshot> GetCurrentStatusAsync(
@@ -405,22 +491,11 @@ public abstract class MvExecutorBase<TConnection> : IMvExecutor, IMvActivationEx
         string serviceId,
         CancellationToken cancellationToken)
     {
-        var entries = await _registryStore.GetEntriesAsync(
+        var entries = await ReadRegistryEntriesAtOperationBoundaryAsync(
+                host,
                 serviceId,
-                host.ViewName,
-                host.ViewVersion,
                 cancellationToken)
             .ConfigureAwait(false);
-        if (entries.Count == 0)
-        {
-            await InitializeCoreAsync(host, serviceId, cancellationToken).ConfigureAwait(false);
-            entries = await _registryStore.GetEntriesAsync(
-                    serviceId,
-                    host.ViewName,
-                    host.ViewVersion,
-                    cancellationToken)
-                .ConfigureAwait(false);
-        }
 
         return MvProjectionStatusSnapshot.FromEntries(entries);
     }
@@ -475,22 +550,11 @@ public abstract class MvExecutorBase<TConnection> : IMvExecutor, IMvActivationEx
         IEventStore eventStore,
         CancellationToken cancellationToken)
     {
-        var entries = await _registryStore.GetEntriesAsync(
+        var entries = await ReadRegistryEntriesAtOperationBoundaryAsync(
+                host,
                 serviceId,
-                host.ViewName,
-                host.ViewVersion,
                 cancellationToken)
             .ConfigureAwait(false);
-        if (entries.Count == 0)
-        {
-            await InitializeCoreAsync(host, serviceId, cancellationToken).ConfigureAwait(false);
-            entries = await _registryStore.GetEntriesAsync(
-                    serviceId,
-                    host.ViewName,
-                    host.ViewVersion,
-                    cancellationToken)
-                .ConfigureAwait(false);
-        }
 
         if (entries.Count == 0 || entries.All(entry =>
                 entry.TargetCheckpointTruth.IsKnown &&
@@ -519,7 +583,7 @@ public abstract class MvExecutorBase<TConnection> : IMvExecutor, IMvActivationEx
         string serviceId,
         CancellationToken cancellationToken)
     {
-        var entries = await _registryStore.GetEntriesAsync(
+        var entries = await ReadRegistryEntriesAsync(
                 serviceId,
                 host.ViewName,
                 host.ViewVersion,
@@ -596,11 +660,6 @@ public abstract class MvExecutorBase<TConnection> : IMvExecutor, IMvActivationEx
         string exactServiceId,
         CancellationToken cancellationToken)
     {
-        if (events.Count == 0)
-        {
-            return Task.FromResult(0);
-        }
-
         return ApplySerializableEventsCoreAsync(
             host,
             events,
@@ -723,22 +782,11 @@ public abstract class MvExecutorBase<TConnection> : IMvExecutor, IMvActivationEx
         MvApplySource source,
         CancellationToken cancellationToken)
     {
-        var entries = await _registryStore.GetEntriesAsync(
+        var entries = await ReadRegistryEntriesAtOperationBoundaryAsync(
+                host,
                 serviceId,
-                host.ViewName,
-                host.ViewVersion,
                 cancellationToken)
             .ConfigureAwait(false);
-        if (entries.Count == 0)
-        {
-            await InitializeCoreAsync(host, serviceId, cancellationToken).ConfigureAwait(false);
-            entries = await _registryStore.GetEntriesAsync(
-                    serviceId,
-                    host.ViewName,
-                    host.ViewVersion,
-                    cancellationToken)
-                .ConfigureAwait(false);
-        }
 
         var currentPosition = entries
             .Select(entry => entry.CurrentCheckpointTruth.IsKnown ? entry.CurrentCheckpointTruth.PositionValue : null)
@@ -796,15 +844,26 @@ public abstract class MvExecutorBase<TConnection> : IMvExecutor, IMvActivationEx
     {
         await using var transaction = await connection.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
         var queryPort = CreateQueryPort(connection, transaction);
-        var statements = await host.ApplyEventAsync(
-                serializableEvent,
-                bindings,
+        if (_options.SqlStatementPolicyMode == MvSqlStatementPolicyMode.Enforced)
+        {
+            queryPort = new MvPolicyEnforcingQueryPort(
                 queryPort,
-                serializableEvent.SortableUniqueIdValue,
-                cancellationToken)
-            .ConfigureAwait(false);
+                _options.SqlStatementPolicy,
+                serviceId,
+                host.ViewName,
+                host.ViewVersion,
+                bindings.Tables);
+        }
+        IReadOnlyList<MvSqlStatementDto> statements;
         try
         {
+            statements = await host.ApplyEventAsync(
+                    serializableEvent,
+                    bindings,
+                    queryPort,
+                    serializableEvent.SortableUniqueIdValue,
+                    cancellationToken)
+                .ConfigureAwait(false);
             await AuthorizeStatementsAsync(
                     serviceId,
                     host,
@@ -816,7 +875,14 @@ public abstract class MvExecutorBase<TConnection> : IMvExecutor, IMvActivationEx
         }
         catch
         {
-            await transaction.RollbackAsync(cancellationToken).ConfigureAwait(false);
+            try
+            {
+                await transaction.RollbackAsync(CancellationToken.None).ConfigureAwait(false);
+            }
+            catch
+            {
+                // Preserve the policy/fault/cancellation outcome. Disposal below still closes the transaction.
+            }
             throw;
         }
 

--- a/dcb/src/Sekiban.Dcb.MaterializedView/MvGenerationCoordinator.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView/MvGenerationCoordinator.cs
@@ -133,6 +133,13 @@ public sealed class MvGenerationCoordinator : IMvGenerationCoordinator
     {
         ArgumentNullException.ThrowIfNull(retainedCandidate);
         var exactServiceId = ValidateServiceId(serviceId);
+        if (_options.InitializationMode == MvInitializationMode.VerifyOnly)
+        {
+            return MvActivationResult.Rejected(
+                MvActivationFailureReason.ProviderFailure,
+                "Verify-only infrastructure mode never mutates materialized-view registry state.");
+        }
+
         var inputRejection = ValidateForcedReverseInput(
             retainedCandidate,
             expectedActiveVersion,
@@ -223,6 +230,12 @@ public sealed class MvGenerationCoordinator : IMvGenerationCoordinator
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(viewName);
         var exactServiceId = ValidateServiceId(serviceId);
+        if (_options.InitializationMode == MvInitializationMode.VerifyOnly &&
+            _registry is IMvReadOnlyMvInspector inspector)
+        {
+            return inspector.ReadActiveAsync(exactServiceId, viewName, cancellationToken);
+        }
+
         return _registry.GetActiveAsync(exactServiceId, viewName, cancellationToken);
     }
 

--- a/dcb/src/Sekiban.Dcb.MaterializedView/MvInitialization.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView/MvInitialization.cs
@@ -6,12 +6,36 @@ public enum MvInitializationMode
     VerifyOnly = 1
 }
 
+/// <summary>
+///     Additive name for the infrastructure ownership mode. <see cref="MvInitializationMode"/> remains the original
+///     public option so existing callers and serialized option values retain their CLR and numeric contract.
+/// </summary>
+public enum MvInfrastructureMode
+{
+    EnsureAndInitialize = 0,
+    VerifyOnly = 1
+}
+
 public enum MvInitializationFailureReason
 {
     MissingSchemaObject = 0,
     IncompatibleSchema = 1,
     MissingSchemaContract = 2,
-    UnsupportedProviderCapability = 3
+    UnsupportedProviderCapability = 3,
+    SchemaContractUnavailable = 4
+}
+
+public enum MvSchemaMismatchCode
+{
+    TableMissing = 0,
+    ColumnMissing = 1,
+    TypeIncompatible = 2,
+    NullabilityMismatch = 3,
+    DefaultMismatch = 4,
+    PrimaryKeyMismatch = 5,
+    BindingMismatch = 6,
+    ContractUnavailable = 7,
+    RequiredIndexMissing = 8
 }
 
 public enum MvSchemaTypeFamily
@@ -33,7 +57,11 @@ public sealed record MvInitializationFailure(
     string Message,
     string? LogicalTable = null,
     string? PhysicalTable = null,
-    string? Column = null);
+    string? Column = null)
+{
+    /// <summary>All deterministic schema mismatches, when verification produced more than one diagnostic.</summary>
+    public IReadOnlyList<MvSchemaMismatch> Mismatches { get; init; } = [];
+}
 
 public sealed class MvInitializationException : InvalidOperationException
 {
@@ -56,6 +84,22 @@ public sealed record MvSchemaTableRequirement(
     string PhysicalTable,
     IReadOnlyList<MvSchemaColumnRequirement> Columns,
     IReadOnlyList<string> PrimaryKeyColumns);
+
+/// <summary>
+///     Versioned, provider-neutral schema contract used by verify-only initialization. The existing table requirement
+///     records remain the wire-compatible representation of each contract table.
+/// </summary>
+public sealed record MvSchemaContract(
+    int FormatVersion,
+    IReadOnlyList<MvSchemaTableRequirement> Tables)
+{
+    public const int CurrentFormatVersion = 1;
+}
+
+public interface IMvSchemaContractProvider
+{
+    MvSchemaContract GetSchemaContract(MvDbType databaseType, IMvTableBindings tables);
+}
 
 /// <summary>
 ///     Optional projector contract describing the schema that verify-only initialization must find.
@@ -84,10 +128,19 @@ public sealed record MvObservedTableSchema(
     IReadOnlyList<MvObservedSchemaColumn> Columns,
     IReadOnlyList<string> PrimaryKeyColumns);
 
+public sealed record MvSchemaMismatch(
+    MvSchemaMismatchCode Code,
+    string Message,
+    string? LogicalTable = null,
+    string? PhysicalTable = null,
+    string? Column = null);
+
 public sealed record MvSchemaVerificationResult(
     bool IsCompatible,
     MvInitializationFailure? Failure)
 {
+    public IReadOnlyList<MvSchemaMismatch> Mismatches { get; init; } = [];
+
     public static MvSchemaVerificationResult Compatible() => new(true, null);
 
     public static MvSchemaVerificationResult Failed(
@@ -99,6 +152,30 @@ public sealed record MvSchemaVerificationResult(
         new(
             false,
             new MvInitializationFailure(reason, message, logicalTable, physicalTable, column));
+
+    public static MvSchemaVerificationResult FailedWithMismatches(
+        MvInitializationFailureReason reason,
+        IReadOnlyList<MvSchemaMismatch> mismatches)
+    {
+        var ordered = mismatches
+            .OrderBy(mismatch => mismatch.Code)
+            .ThenBy(mismatch => mismatch.PhysicalTable, StringComparer.Ordinal)
+            .ThenBy(mismatch => mismatch.LogicalTable, StringComparer.Ordinal)
+            .ThenBy(mismatch => mismatch.Column, StringComparer.Ordinal)
+            .ThenBy(mismatch => mismatch.Message, StringComparer.Ordinal)
+            .ToList();
+        var first = ordered.FirstOrDefault();
+        var failure = new MvInitializationFailure(
+            reason,
+            first?.Message ?? "Materialized-view schema verification failed.",
+            first?.LogicalTable,
+            first?.PhysicalTable,
+            first?.Column)
+        {
+            Mismatches = ordered
+        };
+        return new MvSchemaVerificationResult(false, failure) { Mismatches = ordered };
+    }
 }
 
 /// <summary>
@@ -109,6 +186,31 @@ public interface IMvSchemaVerifier
 {
     Task<MvSchemaVerificationResult> VerifySchemaAsync(
         IReadOnlyList<MvSchemaTableRequirement> requirements,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+///     Dedicated read-only inspection boundary used by verify-only initialization. Implementations must use catalog
+///     reads only; they must not ensure infrastructure, register rows, open a write transaction, or commit.
+/// </summary>
+public interface IMvReadOnlyMvInspector : IMvSchemaVerifier
+{
+    Task<IReadOnlyList<MvRegistryEntry>> ReadRegistryEntriesAsync(
+        string serviceId,
+        string viewName,
+        int viewVersion,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+///     Optional executor capability for an explicit read-only verification request. It is separate from
+///     <see cref="IMvExecutor"/> so existing executor implementors do not acquire a new required member.
+/// </summary>
+public interface IMvInitializationVerifier
+{
+    Task<MvSchemaVerificationResult> VerifyInitializationAsync(
+        IMvApplyHost host,
+        string? serviceId = null,
         CancellationToken cancellationToken = default);
 }
 
@@ -191,111 +293,141 @@ public static class MvSchemaRequirements
         IReadOnlyList<MvSchemaTableRequirement> requirements,
         IReadOnlyDictionary<string, MvObservedTableSchema> observedTables)
     {
-        foreach (var requirement in requirements)
+        var mismatches = new List<MvSchemaMismatch>();
+        foreach (var requirement in requirements
+                     .OrderBy(requirement => requirement.PhysicalTable, StringComparer.Ordinal)
+                     .ThenBy(requirement => requirement.LogicalTable, StringComparer.Ordinal))
         {
             if (!observedTables.TryGetValue(requirement.PhysicalTable, out var observed))
             {
-                return MvSchemaVerificationResult.Failed(
-                    MvInitializationFailureReason.MissingSchemaObject,
-                    $"Required materialized-view table '{requirement.PhysicalTable}' is missing.",
-                    requirement.LogicalTable,
-                    requirement.PhysicalTable);
+                mismatches.Add(
+                    new MvSchemaMismatch(
+                        MvSchemaMismatchCode.TableMissing,
+                        $"Required materialized-view table '{requirement.PhysicalTable}' is missing.",
+                        requirement.LogicalTable,
+                        requirement.PhysicalTable));
+                continue;
             }
 
             var columns = observed.Columns.ToDictionary(column => column.Name, StringComparer.OrdinalIgnoreCase);
-            foreach (var expectedColumn in requirement.Columns)
+            foreach (var expectedColumn in requirement.Columns.OrderBy(column => column.Name, StringComparer.OrdinalIgnoreCase))
             {
                 if (!columns.TryGetValue(expectedColumn.Name, out var actualColumn))
                 {
-                    return MvSchemaVerificationResult.Failed(
-                        MvInitializationFailureReason.MissingSchemaObject,
-                        $"Required column '{expectedColumn.Name}' is missing from materialized-view table '{requirement.PhysicalTable}'.",
-                        requirement.LogicalTable,
-                        requirement.PhysicalTable,
-                        expectedColumn.Name);
+                    mismatches.Add(
+                        new MvSchemaMismatch(
+                            MvSchemaMismatchCode.ColumnMissing,
+                            $"Required column '{expectedColumn.Name}' is missing from materialized-view table '{requirement.PhysicalTable}'.",
+                            requirement.LogicalTable,
+                            requirement.PhysicalTable,
+                            expectedColumn.Name));
+                    continue;
                 }
 
                 if (expectedColumn.TypeFamily != MvSchemaTypeFamily.Any &&
                     actualColumn.TypeFamily != expectedColumn.TypeFamily)
                 {
-                    return MvSchemaVerificationResult.Failed(
-                        MvInitializationFailureReason.IncompatibleSchema,
-                        $"Column '{expectedColumn.Name}' on materialized-view table '{requirement.PhysicalTable}' has an incompatible type.",
-                        requirement.LogicalTable,
-                        requirement.PhysicalTable,
-                        expectedColumn.Name);
+                    mismatches.Add(
+                        new MvSchemaMismatch(
+                            MvSchemaMismatchCode.TypeIncompatible,
+                            $"Column '{expectedColumn.Name}' on materialized-view table '{requirement.PhysicalTable}' has an incompatible type.",
+                            requirement.LogicalTable,
+                            requirement.PhysicalTable,
+                            expectedColumn.Name));
                 }
 
                 if (actualColumn.IsNullable != expectedColumn.IsNullable)
                 {
-                    return MvSchemaVerificationResult.Failed(
-                        MvInitializationFailureReason.IncompatibleSchema,
-                        $"Column '{expectedColumn.Name}' on materialized-view table '{requirement.PhysicalTable}' has incompatible nullability.",
-                        requirement.LogicalTable,
-                        requirement.PhysicalTable,
-                        expectedColumn.Name);
+                    mismatches.Add(
+                        new MvSchemaMismatch(
+                            MvSchemaMismatchCode.NullabilityMismatch,
+                            $"Column '{expectedColumn.Name}' on materialized-view table '{requirement.PhysicalTable}' has incompatible nullability.",
+                            requirement.LogicalTable,
+                            requirement.PhysicalTable,
+                            expectedColumn.Name));
                 }
             }
 
             if (!requirement.PrimaryKeyColumns.SequenceEqual(observed.PrimaryKeyColumns, StringComparer.OrdinalIgnoreCase))
             {
-                return MvSchemaVerificationResult.Failed(
-                    MvInitializationFailureReason.IncompatibleSchema,
-                    $"Materialized-view table '{requirement.PhysicalTable}' has an incompatible primary key.",
-                    requirement.LogicalTable,
-                    requirement.PhysicalTable);
+                mismatches.Add(
+                    new MvSchemaMismatch(
+                        MvSchemaMismatchCode.PrimaryKeyMismatch,
+                        $"Materialized-view table '{requirement.PhysicalTable}' has an incompatible primary key.",
+                        requirement.LogicalTable,
+                        requirement.PhysicalTable));
             }
         }
 
-        return MvSchemaVerificationResult.Compatible();
+        if (mismatches.Count == 0)
+        {
+            return MvSchemaVerificationResult.Compatible();
+        }
+
+        var reason = mismatches.Any(mismatch =>
+                mismatch.Code is MvSchemaMismatchCode.TableMissing or MvSchemaMismatchCode.ColumnMissing)
+            ? MvInitializationFailureReason.MissingSchemaObject
+            : MvInitializationFailureReason.IncompatibleSchema;
+        return MvSchemaVerificationResult.FailedWithMismatches(reason, mismatches);
     }
 
     public static MvSchemaVerificationResult ValidateContract(
         IReadOnlyList<MvTable> tables,
         IReadOnlyList<MvSchemaTableRequirement> requirements)
     {
+        var mismatches = new List<MvSchemaMismatch>();
         if (tables.Count != requirements.Count)
         {
-            return MvSchemaVerificationResult.Failed(
-                MvInitializationFailureReason.MissingSchemaContract,
-                "Verify-only initialization requires one schema requirement for every registered materialized-view table.");
+            mismatches.Add(
+                new MvSchemaMismatch(
+                    MvSchemaMismatchCode.ContractUnavailable,
+                    "Verify-only initialization requires one schema requirement for every registered materialized-view table."));
         }
 
-        var duplicateLogicalTable = requirements
-            .GroupBy(requirement => requirement.LogicalTable, StringComparer.Ordinal)
-            .FirstOrDefault(group => group.Count() > 1);
-        if (duplicateLogicalTable is not null)
+        foreach (var duplicateLogicalTable in requirements
+                     .GroupBy(requirement => requirement.LogicalTable, StringComparer.Ordinal)
+                     .Where(group => group.Count() > 1)
+                     .OrderBy(group => group.Key, StringComparer.Ordinal))
         {
-            return MvSchemaVerificationResult.Failed(
-                MvInitializationFailureReason.MissingSchemaContract,
-                $"Verify-only initialization has duplicate schema requirements for logical table '{duplicateLogicalTable.Key}'.");
+            mismatches.Add(
+                new MvSchemaMismatch(
+                    MvSchemaMismatchCode.BindingMismatch,
+                    $"Verify-only initialization has duplicate schema requirements for logical table '{duplicateLogicalTable.Key}'.",
+                    duplicateLogicalTable.Key));
         }
 
-        var requirementsByLogicalName = requirements.ToDictionary(
-            requirement => requirement.LogicalTable,
-            StringComparer.Ordinal);
-        foreach (var table in tables)
+        var requirementsByLogicalName = requirements
+            .GroupBy(requirement => requirement.LogicalTable, StringComparer.Ordinal)
+            .ToDictionary(group => group.Key, group => group.First(), StringComparer.Ordinal);
+        foreach (var table in tables.OrderBy(table => table.LogicalName, StringComparer.Ordinal))
         {
             if (!requirementsByLogicalName.TryGetValue(table.LogicalName, out var requirement) ||
                 !string.Equals(table.PhysicalName, requirement.PhysicalTable, StringComparison.Ordinal))
             {
-                return MvSchemaVerificationResult.Failed(
-                    MvInitializationFailureReason.MissingSchemaContract,
-                    $"Verify-only initialization has no schema requirement for logical table '{table.LogicalName}'.",
-                    table.LogicalName,
-                    table.PhysicalName);
+                mismatches.Add(
+                    new MvSchemaMismatch(
+                        MvSchemaMismatchCode.BindingMismatch,
+                        $"Verify-only initialization has no schema requirement for logical table '{table.LogicalName}'.",
+                        table.LogicalName,
+                        table.PhysicalName));
+                continue;
             }
 
             if (requirement.Columns.Count == 0 || requirement.PrimaryKeyColumns.Count == 0)
             {
-                return MvSchemaVerificationResult.Failed(
-                    MvInitializationFailureReason.MissingSchemaContract,
-                    $"Verify-only initialization requires columns and a primary key for logical table '{table.LogicalName}'.",
-                    table.LogicalName,
-                    table.PhysicalName);
+                mismatches.Add(
+                    new MvSchemaMismatch(
+                        MvSchemaMismatchCode.ContractUnavailable,
+                        $"Verify-only initialization requires columns and a primary key for logical table '{table.LogicalName}'.",
+                        table.LogicalName,
+                        table.PhysicalName));
             }
         }
 
-        return MvSchemaVerificationResult.Compatible();
+        return mismatches.Count == 0
+            ? MvSchemaVerificationResult.Compatible()
+            : MvSchemaVerificationResult.FailedWithMismatches(
+                MvInitializationFailureReason.MissingSchemaContract,
+                mismatches);
     }
 }

--- a/dcb/src/Sekiban.Dcb.MaterializedView/MvInitialization.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView/MvInitialization.cs
@@ -1,0 +1,301 @@
+namespace Sekiban.Dcb.MaterializedView;
+
+public enum MvInitializationMode
+{
+    CreateOrEnsure = 0,
+    VerifyOnly = 1
+}
+
+public enum MvInitializationFailureReason
+{
+    MissingSchemaObject = 0,
+    IncompatibleSchema = 1,
+    MissingSchemaContract = 2,
+    UnsupportedProviderCapability = 3
+}
+
+public enum MvSchemaTypeFamily
+{
+    Any = 0,
+    String = 1,
+    Integer = 2,
+    Boolean = 3,
+    DateTime = 4,
+    Decimal = 5,
+    FloatingPoint = 6,
+    Binary = 7,
+    Json = 8,
+    Guid = 9
+}
+
+public sealed record MvInitializationFailure(
+    MvInitializationFailureReason Reason,
+    string Message,
+    string? LogicalTable = null,
+    string? PhysicalTable = null,
+    string? Column = null);
+
+public sealed class MvInitializationException : InvalidOperationException
+{
+    public MvInitializationException(MvInitializationFailure failure)
+        : base(failure.Message)
+    {
+        Failure = failure;
+    }
+
+    public MvInitializationFailure Failure { get; }
+}
+
+public sealed record MvSchemaColumnRequirement(
+    string Name,
+    MvSchemaTypeFamily TypeFamily,
+    bool IsNullable);
+
+public sealed record MvSchemaTableRequirement(
+    string LogicalTable,
+    string PhysicalTable,
+    IReadOnlyList<MvSchemaColumnRequirement> Columns,
+    IReadOnlyList<string> PrimaryKeyColumns);
+
+/// <summary>
+///     Optional projector contract describing the schema that verify-only initialization must find.
+///     The contract is provider-neutral; providers map their native metadata to the type families above.
+/// </summary>
+public interface IMvSchemaRequirementsProvider
+{
+    IReadOnlyList<MvSchemaTableRequirement> GetSchemaRequirements(
+        MvDbType databaseType,
+        IMvTableBindings tables);
+}
+
+public sealed record MvObservedSchemaColumn(
+    string TableName,
+    string Name,
+    MvSchemaTypeFamily TypeFamily,
+    bool IsNullable);
+
+public sealed record MvObservedSchemaPrimaryKeyColumn(
+    string TableName,
+    string Name,
+    int Ordinal);
+
+public sealed record MvObservedTableSchema(
+    string Name,
+    IReadOnlyList<MvObservedSchemaColumn> Columns,
+    IReadOnlyList<string> PrimaryKeyColumns);
+
+public sealed record MvSchemaVerificationResult(
+    bool IsCompatible,
+    MvInitializationFailure? Failure)
+{
+    public static MvSchemaVerificationResult Compatible() => new(true, null);
+
+    public static MvSchemaVerificationResult Failed(
+        MvInitializationFailureReason reason,
+        string message,
+        string? logicalTable = null,
+        string? physicalTable = null,
+        string? column = null) =>
+        new(
+            false,
+            new MvInitializationFailure(reason, message, logicalTable, physicalTable, column));
+}
+
+/// <summary>
+///     Provider-owned, read-only metadata verification. Implementations must not create, alter, drop, migrate,
+///     register, or otherwise mutate database objects while evaluating a request.
+/// </summary>
+public interface IMvSchemaVerifier
+{
+    Task<MvSchemaVerificationResult> VerifySchemaAsync(
+        IReadOnlyList<MvSchemaTableRequirement> requirements,
+        CancellationToken cancellationToken = default);
+}
+
+public static class MvSchemaRequirements
+{
+    public static IReadOnlyList<MvSchemaTableRequirement> RegistryTables() =>
+    [
+        new MvSchemaTableRequirement(
+            "sekiban_mv_registry",
+            "sekiban_mv_registry",
+            [
+                new("service_id", MvSchemaTypeFamily.String, false),
+                new("view_name", MvSchemaTypeFamily.String, false),
+                new("view_version", MvSchemaTypeFamily.Integer, false),
+                new("logical_table", MvSchemaTypeFamily.String, false),
+                new("physical_table", MvSchemaTypeFamily.String, false),
+                new("status", MvSchemaTypeFamily.String, false),
+                new("current_position", MvSchemaTypeFamily.String, true),
+                new("target_position", MvSchemaTypeFamily.String, true),
+                new("current_checkpoint_truth", MvSchemaTypeFamily.Any, true),
+                new("target_checkpoint_truth", MvSchemaTypeFamily.Any, true),
+                new("last_sortable_unique_id", MvSchemaTypeFamily.String, true),
+                new("applied_event_version", MvSchemaTypeFamily.Integer, false),
+                new("last_applied_source", MvSchemaTypeFamily.String, true),
+                new("last_applied_at", MvSchemaTypeFamily.DateTime, true),
+                new("last_stream_received_sortable_unique_id", MvSchemaTypeFamily.String, true),
+                new("last_stream_received_at", MvSchemaTypeFamily.DateTime, true),
+                new("last_stream_applied_sortable_unique_id", MvSchemaTypeFamily.String, true),
+                new("last_catch_up_sortable_unique_id", MvSchemaTypeFamily.String, true),
+                new("last_updated", MvSchemaTypeFamily.DateTime, false),
+                new("metadata", MvSchemaTypeFamily.Any, true)
+            ],
+            ["service_id", "view_name", "view_version", "logical_table"]),
+        new MvSchemaTableRequirement(
+            "sekiban_mv_active",
+            "sekiban_mv_active",
+            [
+                new("service_id", MvSchemaTypeFamily.String, false),
+                new("view_name", MvSchemaTypeFamily.String, false),
+                new("active_version", MvSchemaTypeFamily.Integer, false),
+                new("active_generation", MvSchemaTypeFamily.Integer, false),
+                new("activated_at", MvSchemaTypeFamily.DateTime, false),
+                new("switch_kind", MvSchemaTypeFamily.String, false),
+                new("switch_reason", MvSchemaTypeFamily.String, true),
+                new("switched_at_utc", MvSchemaTypeFamily.DateTime, true)
+            ],
+            ["service_id", "view_name"])
+    ];
+
+    public static IReadOnlyDictionary<string, MvObservedTableSchema> Observe(
+        IEnumerable<MvObservedSchemaColumn> columns,
+        IEnumerable<MvObservedSchemaPrimaryKeyColumn> primaryKeyColumns)
+    {
+        var columnGroups = columns
+            .GroupBy(column => column.TableName, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(
+                group => group.Key,
+                group => (IReadOnlyList<MvObservedSchemaColumn>)group.ToList(),
+                StringComparer.OrdinalIgnoreCase);
+        var keyGroups = primaryKeyColumns
+            .GroupBy(column => column.TableName, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(
+                group => group.Key,
+                group => (IReadOnlyList<string>)group
+                    .OrderBy(column => column.Ordinal)
+                    .Select(column => column.Name)
+                    .ToList(),
+                StringComparer.OrdinalIgnoreCase);
+
+        return columnGroups.ToDictionary(
+            pair => pair.Key,
+            pair => new MvObservedTableSchema(
+                pair.Key,
+                pair.Value,
+                keyGroups.TryGetValue(pair.Key, out var keys) ? keys : []),
+            StringComparer.OrdinalIgnoreCase);
+    }
+
+    public static MvSchemaVerificationResult Validate(
+        IReadOnlyList<MvSchemaTableRequirement> requirements,
+        IReadOnlyDictionary<string, MvObservedTableSchema> observedTables)
+    {
+        foreach (var requirement in requirements)
+        {
+            if (!observedTables.TryGetValue(requirement.PhysicalTable, out var observed))
+            {
+                return MvSchemaVerificationResult.Failed(
+                    MvInitializationFailureReason.MissingSchemaObject,
+                    $"Required materialized-view table '{requirement.PhysicalTable}' is missing.",
+                    requirement.LogicalTable,
+                    requirement.PhysicalTable);
+            }
+
+            var columns = observed.Columns.ToDictionary(column => column.Name, StringComparer.OrdinalIgnoreCase);
+            foreach (var expectedColumn in requirement.Columns)
+            {
+                if (!columns.TryGetValue(expectedColumn.Name, out var actualColumn))
+                {
+                    return MvSchemaVerificationResult.Failed(
+                        MvInitializationFailureReason.MissingSchemaObject,
+                        $"Required column '{expectedColumn.Name}' is missing from materialized-view table '{requirement.PhysicalTable}'.",
+                        requirement.LogicalTable,
+                        requirement.PhysicalTable,
+                        expectedColumn.Name);
+                }
+
+                if (expectedColumn.TypeFamily != MvSchemaTypeFamily.Any &&
+                    actualColumn.TypeFamily != expectedColumn.TypeFamily)
+                {
+                    return MvSchemaVerificationResult.Failed(
+                        MvInitializationFailureReason.IncompatibleSchema,
+                        $"Column '{expectedColumn.Name}' on materialized-view table '{requirement.PhysicalTable}' has an incompatible type.",
+                        requirement.LogicalTable,
+                        requirement.PhysicalTable,
+                        expectedColumn.Name);
+                }
+
+                if (actualColumn.IsNullable != expectedColumn.IsNullable)
+                {
+                    return MvSchemaVerificationResult.Failed(
+                        MvInitializationFailureReason.IncompatibleSchema,
+                        $"Column '{expectedColumn.Name}' on materialized-view table '{requirement.PhysicalTable}' has incompatible nullability.",
+                        requirement.LogicalTable,
+                        requirement.PhysicalTable,
+                        expectedColumn.Name);
+                }
+            }
+
+            if (!requirement.PrimaryKeyColumns.SequenceEqual(observed.PrimaryKeyColumns, StringComparer.OrdinalIgnoreCase))
+            {
+                return MvSchemaVerificationResult.Failed(
+                    MvInitializationFailureReason.IncompatibleSchema,
+                    $"Materialized-view table '{requirement.PhysicalTable}' has an incompatible primary key.",
+                    requirement.LogicalTable,
+                    requirement.PhysicalTable);
+            }
+        }
+
+        return MvSchemaVerificationResult.Compatible();
+    }
+
+    public static MvSchemaVerificationResult ValidateContract(
+        IReadOnlyList<MvTable> tables,
+        IReadOnlyList<MvSchemaTableRequirement> requirements)
+    {
+        if (tables.Count != requirements.Count)
+        {
+            return MvSchemaVerificationResult.Failed(
+                MvInitializationFailureReason.MissingSchemaContract,
+                "Verify-only initialization requires one schema requirement for every registered materialized-view table.");
+        }
+
+        var duplicateLogicalTable = requirements
+            .GroupBy(requirement => requirement.LogicalTable, StringComparer.Ordinal)
+            .FirstOrDefault(group => group.Count() > 1);
+        if (duplicateLogicalTable is not null)
+        {
+            return MvSchemaVerificationResult.Failed(
+                MvInitializationFailureReason.MissingSchemaContract,
+                $"Verify-only initialization has duplicate schema requirements for logical table '{duplicateLogicalTable.Key}'.");
+        }
+
+        var requirementsByLogicalName = requirements.ToDictionary(
+            requirement => requirement.LogicalTable,
+            StringComparer.Ordinal);
+        foreach (var table in tables)
+        {
+            if (!requirementsByLogicalName.TryGetValue(table.LogicalName, out var requirement) ||
+                !string.Equals(table.PhysicalName, requirement.PhysicalTable, StringComparison.Ordinal))
+            {
+                return MvSchemaVerificationResult.Failed(
+                    MvInitializationFailureReason.MissingSchemaContract,
+                    $"Verify-only initialization has no schema requirement for logical table '{table.LogicalName}'.",
+                    table.LogicalName,
+                    table.PhysicalName);
+            }
+
+            if (requirement.Columns.Count == 0 || requirement.PrimaryKeyColumns.Count == 0)
+            {
+                return MvSchemaVerificationResult.Failed(
+                    MvInitializationFailureReason.MissingSchemaContract,
+                    $"Verify-only initialization requires columns and a primary key for logical table '{table.LogicalName}'.",
+                    table.LogicalName,
+                    table.PhysicalName);
+            }
+        }
+
+        return MvSchemaVerificationResult.Compatible();
+    }
+}

--- a/dcb/src/Sekiban.Dcb.MaterializedView/MvInitialization.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView/MvInitialization.cs
@@ -35,7 +35,10 @@ public enum MvSchemaMismatchCode
     PrimaryKeyMismatch = 5,
     BindingMismatch = 6,
     ContractUnavailable = 7,
-    RequiredIndexMissing = 8
+    RequiredIndexMissing = 8,
+    GeneratedSemanticsMismatch = 9,
+    SizeMismatch = 10,
+    PrecisionMismatch = 11
 }
 
 public enum MvSchemaTypeFamily
@@ -77,13 +80,36 @@ public sealed class MvInitializationException : InvalidOperationException
 public sealed record MvSchemaColumnRequirement(
     string Name,
     MvSchemaTypeFamily TypeFamily,
-    bool IsNullable);
+    bool IsNullable)
+{
+    /// <summary>Null means that the contract does not constrain the native default.</summary>
+    public string? DefaultSql { get; init; }
+
+    /// <summary>Null means that the contract does not constrain generated-column semantics.</summary>
+    public bool? IsGenerated { get; init; }
+
+    /// <summary>Optional normalized generation expression required when <see cref="IsGenerated"/> is true.</summary>
+    public string? GenerationExpression { get; init; }
+
+    public int? MaxLength { get; init; }
+    public int? Precision { get; init; }
+    public int? Scale { get; init; }
+}
+
+public sealed record MvSchemaIndexRequirement(
+    string Name,
+    IReadOnlyList<string> Columns,
+    bool IsUnique);
 
 public sealed record MvSchemaTableRequirement(
     string LogicalTable,
     string PhysicalTable,
     IReadOnlyList<MvSchemaColumnRequirement> Columns,
-    IReadOnlyList<string> PrimaryKeyColumns);
+    IReadOnlyList<string> PrimaryKeyColumns)
+{
+    /// <summary>Required indexes are matched by ordered columns and uniqueness, not provider-specific names.</summary>
+    public IReadOnlyList<MvSchemaIndexRequirement> Indexes { get; init; } = [];
+}
 
 /// <summary>
 ///     Versioned, provider-neutral schema contract used by verify-only initialization. The existing table requirement
@@ -116,7 +142,15 @@ public sealed record MvObservedSchemaColumn(
     string TableName,
     string Name,
     MvSchemaTypeFamily TypeFamily,
-    bool IsNullable);
+    bool IsNullable)
+{
+    public string? DefaultSql { get; init; }
+    public bool IsGenerated { get; init; }
+    public string? GenerationExpression { get; init; }
+    public int? MaxLength { get; init; }
+    public int? Precision { get; init; }
+    public int? Scale { get; init; }
+}
 
 public sealed record MvObservedSchemaPrimaryKeyColumn(
     string TableName,
@@ -126,7 +160,16 @@ public sealed record MvObservedSchemaPrimaryKeyColumn(
 public sealed record MvObservedTableSchema(
     string Name,
     IReadOnlyList<MvObservedSchemaColumn> Columns,
-    IReadOnlyList<string> PrimaryKeyColumns);
+    IReadOnlyList<string> PrimaryKeyColumns)
+{
+    public IReadOnlyList<MvObservedSchemaIndex> Indexes { get; init; } = [];
+}
+
+public sealed record MvObservedSchemaIndex(
+    string TableName,
+    string Name,
+    IReadOnlyList<string> Columns,
+    bool IsUnique);
 
 public sealed record MvSchemaMismatch(
     MvSchemaMismatchCode Code,
@@ -200,6 +243,13 @@ public interface IMvReadOnlyMvInspector : IMvSchemaVerifier
         string viewName,
         int viewVersion,
         CancellationToken cancellationToken = default);
+
+    /// <summary>Reads the serving pointer through the same provider-owned read-only connection boundary.</summary>
+    Task<MvActiveEntry?> ReadActiveAsync(
+        string serviceId,
+        string viewName,
+        CancellationToken cancellationToken = default) =>
+        throw new NotSupportedException("This read-only materialized-view inspector does not expose the active pointer.");
 }
 
 /// <summary>
@@ -262,7 +312,8 @@ public static class MvSchemaRequirements
 
     public static IReadOnlyDictionary<string, MvObservedTableSchema> Observe(
         IEnumerable<MvObservedSchemaColumn> columns,
-        IEnumerable<MvObservedSchemaPrimaryKeyColumn> primaryKeyColumns)
+        IEnumerable<MvObservedSchemaPrimaryKeyColumn> primaryKeyColumns,
+        IEnumerable<MvObservedSchemaIndex>? indexes = null)
     {
         var columnGroups = columns
             .GroupBy(column => column.TableName, StringComparer.OrdinalIgnoreCase)
@@ -279,13 +330,24 @@ public static class MvSchemaRequirements
                     .Select(column => column.Name)
                     .ToList(),
                 StringComparer.OrdinalIgnoreCase);
+        var indexGroups = (indexes ?? [])
+            .GroupBy(index => index.TableName, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(
+                group => group.Key,
+                group => (IReadOnlyList<MvObservedSchemaIndex>)group
+                    .OrderBy(index => index.Name, StringComparer.OrdinalIgnoreCase)
+                    .ToList(),
+                StringComparer.OrdinalIgnoreCase);
 
         return columnGroups.ToDictionary(
             pair => pair.Key,
             pair => new MvObservedTableSchema(
                 pair.Key,
                 pair.Value,
-                keyGroups.TryGetValue(pair.Key, out var keys) ? keys : []),
+                keyGroups.TryGetValue(pair.Key, out var keys) ? keys : [])
+            {
+                Indexes = indexGroups.TryGetValue(pair.Key, out var tableIndexes) ? tableIndexes : []
+            },
             StringComparer.OrdinalIgnoreCase);
     }
 
@@ -344,6 +406,71 @@ public static class MvSchemaRequirements
                             $"Column '{expectedColumn.Name}' on materialized-view table '{requirement.PhysicalTable}' has incompatible nullability.",
                             requirement.LogicalTable,
                             requirement.PhysicalTable,
+                        expectedColumn.Name));
+                }
+
+                if (expectedColumn.DefaultSql is not null &&
+                    !string.Equals(
+                        NormalizeSqlMetadata(expectedColumn.DefaultSql),
+                        NormalizeSqlMetadata(actualColumn.DefaultSql),
+                        StringComparison.OrdinalIgnoreCase))
+                {
+                    mismatches.Add(
+                        new MvSchemaMismatch(
+                            MvSchemaMismatchCode.DefaultMismatch,
+                            $"Column '{expectedColumn.Name}' on materialized-view table '{requirement.PhysicalTable}' has an incompatible default.",
+                            requirement.LogicalTable,
+                            requirement.PhysicalTable,
+                            expectedColumn.Name));
+                }
+
+                if (expectedColumn.IsGenerated is { } expectedGenerated &&
+                    actualColumn.IsGenerated != expectedGenerated)
+                {
+                    mismatches.Add(
+                        new MvSchemaMismatch(
+                            MvSchemaMismatchCode.GeneratedSemanticsMismatch,
+                            $"Column '{expectedColumn.Name}' on materialized-view table '{requirement.PhysicalTable}' has incompatible generated-column semantics.",
+                            requirement.LogicalTable,
+                            requirement.PhysicalTable,
+                            expectedColumn.Name));
+                }
+
+                if (expectedColumn.GenerationExpression is not null &&
+                    !string.Equals(
+                        NormalizeSqlMetadata(expectedColumn.GenerationExpression),
+                        NormalizeSqlMetadata(actualColumn.GenerationExpression),
+                        StringComparison.OrdinalIgnoreCase))
+                {
+                    mismatches.Add(
+                        new MvSchemaMismatch(
+                            MvSchemaMismatchCode.GeneratedSemanticsMismatch,
+                            $"Column '{expectedColumn.Name}' on materialized-view table '{requirement.PhysicalTable}' has an incompatible generation expression.",
+                            requirement.LogicalTable,
+                            requirement.PhysicalTable,
+                            expectedColumn.Name));
+                }
+
+                if (expectedColumn.MaxLength is { } maxLength && actualColumn.MaxLength != maxLength)
+                {
+                    mismatches.Add(
+                        new MvSchemaMismatch(
+                            MvSchemaMismatchCode.SizeMismatch,
+                            $"Column '{expectedColumn.Name}' on materialized-view table '{requirement.PhysicalTable}' has an incompatible size.",
+                            requirement.LogicalTable,
+                            requirement.PhysicalTable,
+                            expectedColumn.Name));
+                }
+
+                if ((expectedColumn.Precision is { } precision && actualColumn.Precision != precision) ||
+                    (expectedColumn.Scale is { } scale && actualColumn.Scale != scale))
+                {
+                    mismatches.Add(
+                        new MvSchemaMismatch(
+                            MvSchemaMismatchCode.PrecisionMismatch,
+                            $"Column '{expectedColumn.Name}' on materialized-view table '{requirement.PhysicalTable}' has incompatible precision or scale.",
+                            requirement.LogicalTable,
+                            requirement.PhysicalTable,
                             expectedColumn.Name));
                 }
             }
@@ -357,6 +484,22 @@ public static class MvSchemaRequirements
                         requirement.LogicalTable,
                         requirement.PhysicalTable));
             }
+
+            foreach (var expectedIndex in requirement.Indexes.OrderBy(index => index.Name, StringComparer.Ordinal))
+            {
+                var found = observed.Indexes.Any(actualIndex =>
+                    actualIndex.IsUnique == expectedIndex.IsUnique &&
+                    expectedIndex.Columns.SequenceEqual(actualIndex.Columns, StringComparer.OrdinalIgnoreCase));
+                if (!found)
+                {
+                    mismatches.Add(
+                        new MvSchemaMismatch(
+                            MvSchemaMismatchCode.RequiredIndexMissing,
+                            $"Required {(expectedIndex.IsUnique ? "unique " : string.Empty)}index '{expectedIndex.Name}' is missing from materialized-view table '{requirement.PhysicalTable}'.",
+                            requirement.LogicalTable,
+                            requirement.PhysicalTable));
+                }
+            }
         }
 
         if (mismatches.Count == 0)
@@ -369,6 +512,24 @@ public static class MvSchemaRequirements
             ? MvInitializationFailureReason.MissingSchemaObject
             : MvInitializationFailureReason.IncompatibleSchema;
         return MvSchemaVerificationResult.FailedWithMismatches(reason, mismatches);
+    }
+
+    private static string NormalizeSqlMetadata(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return string.Empty;
+        }
+
+        var normalized = string.Join(
+            ' ',
+            value.Trim().TrimEnd(';').Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries));
+        while (normalized.Length >= 2 && normalized[0] == '(' && normalized[^1] == ')')
+        {
+            normalized = normalized[1..^1].Trim();
+        }
+
+        return normalized;
     }
 
     public static MvSchemaVerificationResult ValidateContract(

--- a/dcb/src/Sekiban.Dcb.MaterializedView/MvOptions.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView/MvOptions.cs
@@ -82,6 +82,16 @@ public sealed class MvOptions
     ///     evaluated before execution through a non-raw policy port.
     /// </summary>
     public MvSqlStatementPolicyMode SqlStatementPolicyMode { get; set; } = MvSqlStatementPolicyMode.Legacy;
+
+    /// <summary>
+    ///     Explicit least-privilege SQL Server connection used by the verify-only catalog inspector. The ordinary
+    ///     provider connection remains the writable connection used by legacy/create-and-ensure execution. SQL Server
+    ///     cannot enforce read-only access with ApplicationIntent on a standalone instance, so the principal must
+    ///     have no database/object DML or DDL permissions and enough catalog metadata visibility (for example,
+    ///     database VIEW DEFINITION) for the declared contract. Verify-only fails closed when this restricted
+    ///     inspection capability is not configured or cannot be established.
+    /// </summary>
+    public string? SqlServerInspectionConnectionString { get; set; }
 }
 
 public static class MvSchemaHelper

--- a/dcb/src/Sekiban.Dcb.MaterializedView/MvOptions.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView/MvOptions.cs
@@ -49,6 +49,18 @@ public sealed class MvOptions
     ///     Ordinary multi-service registrations must supply a non-default service id.
     /// </summary>
     public bool AllowDefaultServiceId { get; set; }
+
+    /// <summary>
+    ///     Selects whether initialization may create/ensure schema or may only verify a pre-provisioned schema.
+    ///     The compatibility default preserves the historical create/ensure behavior.
+    /// </summary>
+    public MvInitializationMode InitializationMode { get; set; } = MvInitializationMode.CreateOrEnsure;
+
+    /// <summary>
+    ///     Host-owned policy evaluated for every projector-supplied initialization and apply statement before it is
+    ///     sent to the provider.
+    /// </summary>
+    public IMvSqlStatementPolicy SqlStatementPolicy { get; set; } = MvAllowAllSqlStatementPolicy.Instance;
 }
 
 public static class MvSchemaHelper

--- a/dcb/src/Sekiban.Dcb.MaterializedView/MvOptions.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView/MvOptions.cs
@@ -57,10 +57,31 @@ public sealed class MvOptions
     public MvInitializationMode InitializationMode { get; set; } = MvInitializationMode.CreateOrEnsure;
 
     /// <summary>
+    ///     Delay before a hosted worker retries a failed VerifyOnly contract check. CreateOrEnsure workers do not use
+    ///     this setting. A non-positive value falls back to <see cref="PollInterval"/>.
+    /// </summary>
+    public TimeSpan VerifyOnlyRetryDelay { get; set; } = TimeSpan.FromSeconds(1);
+
+    /// <summary>
+    ///     Additive alias for <see cref="InitializationMode"/> using the infrastructure-ownership terminology.
+    /// </summary>
+    public MvInfrastructureMode InfrastructureMode
+    {
+        get => (MvInfrastructureMode)InitializationMode;
+        set => InitializationMode = (MvInitializationMode)value;
+    }
+
+    /// <summary>
     ///     Host-owned policy evaluated for every projector-supplied initialization and apply statement before it is
     ///     sent to the provider.
     /// </summary>
-    public IMvSqlStatementPolicy SqlStatementPolicy { get; set; } = MvAllowAllSqlStatementPolicy.Instance;
+    public IMvSqlStatementPolicy? SqlStatementPolicy { get; set; } = MvAllowAllSqlStatementPolicy.Instance;
+
+    /// <summary>
+    ///     Selects whether the compatibility raw apply-context surface remains available or every apply query is
+    ///     evaluated before execution through a non-raw policy port.
+    /// </summary>
+    public MvSqlStatementPolicyMode SqlStatementPolicyMode { get; set; } = MvSqlStatementPolicyMode.Legacy;
 }
 
 public static class MvSchemaHelper

--- a/dcb/src/Sekiban.Dcb.MaterializedView/MvSqlStatementPolicy.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView/MvSqlStatementPolicy.cs
@@ -1,9 +1,29 @@
+using System.Security.Cryptography;
+using System.Text;
+
 namespace Sekiban.Dcb.MaterializedView;
+
+public enum MvSqlStatementPolicyMode
+{
+    /// <summary>Preserves the additive compatibility behavior, including raw apply-context access.</summary>
+    Legacy = 0,
+
+    /// <summary>Gates every SQL surface before provider execution and removes raw apply-context access.</summary>
+    Enforced = 1
+}
 
 public enum MvSqlStatementPhase
 {
     Initialization = 0,
     Apply = 1
+}
+
+public enum MvSqlPolicyFailureReason
+{
+    Denied = 0,
+    PolicyUnavailable = 1,
+    PolicyEvaluationFailed = 2,
+    InvalidDecision = 3
 }
 
 public sealed record MvSqlStatementContext(
@@ -13,7 +33,14 @@ public sealed record MvSqlStatementContext(
     MvSqlStatementPhase Phase,
     IReadOnlyList<MvTable> Tables,
     string Sql,
-    IReadOnlyList<MvParam> Parameters);
+    IReadOnlyList<MvParam> Parameters)
+{
+    public MvDbType? DatabaseType { get; init; }
+    public int StatementIndex { get; init; }
+    public int BatchSize { get; init; } = 1;
+    public string SqlSha256 => Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(Sql)));
+    public string SqlFingerprint => SqlSha256;
+}
 
 public readonly record struct MvSqlPolicyDecision(bool IsAllowed, string? Reason)
 {
@@ -49,7 +76,15 @@ public sealed record MvSqlPolicyFailure(
     string ServiceId,
     string ViewName,
     int ViewVersion,
-    MvSqlStatementPhase Phase);
+    MvSqlStatementPhase Phase)
+{
+    public MvSqlPolicyFailureReason FailureReason { get; init; } = MvSqlPolicyFailureReason.Denied;
+    public string? RuleId { get; init; }
+    public int StatementIndex { get; init; }
+    public int BatchSize { get; init; } = 1;
+    public string? SqlSha256 { get; init; }
+    public string? SqlFingerprint => SqlSha256;
+}
 
 public sealed class MvSqlPolicyRejectedException : InvalidOperationException
 {
@@ -62,4 +97,160 @@ public sealed class MvSqlPolicyRejectedException : InvalidOperationException
     }
 
     public MvSqlPolicyFailure Failure { get; }
+}
+
+internal static class MvSqlPolicyEvaluator
+{
+    public static async Task AuthorizeAsync(
+        IMvSqlStatementPolicy? policy,
+        MvSqlStatementContext context,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        if (policy is null)
+        {
+            throw CreateRejected(
+                context,
+                MvSqlPolicyFailureReason.PolicyUnavailable,
+                "No enforced materialized-view SQL statement policy is configured.");
+        }
+
+        MvSqlPolicyDecision decision;
+        try
+        {
+            decision = await policy.EvaluateAsync(context, cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch
+        {
+            throw CreateRejected(
+                context,
+                MvSqlPolicyFailureReason.PolicyEvaluationFailed,
+                "The materialized-view SQL statement policy failed closed while evaluating a statement.");
+        }
+
+        if (decision.IsAllowed && !string.IsNullOrWhiteSpace(decision.Reason))
+        {
+            throw CreateRejected(
+                context,
+                MvSqlPolicyFailureReason.InvalidDecision,
+                "The materialized-view SQL statement policy returned an invalid allow decision.");
+        }
+
+        if (!decision.IsAllowed)
+        {
+            if (string.IsNullOrWhiteSpace(decision.Reason))
+            {
+                throw CreateRejected(
+                    context,
+                    MvSqlPolicyFailureReason.InvalidDecision,
+                    "The materialized-view SQL statement policy returned an invalid deny decision.");
+            }
+
+            throw CreateRejected(context, MvSqlPolicyFailureReason.Denied, decision.Reason);
+        }
+    }
+
+    private static MvSqlPolicyRejectedException CreateRejected(
+        MvSqlStatementContext context,
+        MvSqlPolicyFailureReason reason,
+        string message) =>
+        new(
+            new MvSqlPolicyFailure(
+                message,
+                context.ServiceId,
+                context.ViewName,
+                context.ViewVersion,
+                context.Phase)
+            {
+                FailureReason = reason,
+                StatementIndex = context.StatementIndex,
+                BatchSize = context.BatchSize,
+                SqlSha256 = context.SqlSha256
+            });
+}
+
+/// <summary>
+///     Enforced-mode query port. It deliberately implements only the query-port contract so the native adapter
+///     cannot expose the provider connection or transaction to a projector.
+/// </summary>
+internal sealed class MvPolicyEnforcingQueryPort : IMvApplyQueryPort
+{
+    private readonly IMvApplyQueryPort _inner;
+    private readonly IMvSqlStatementPolicy? _policy;
+    private readonly string _serviceId;
+    private readonly string _viewName;
+    private readonly int _viewVersion;
+    private readonly IReadOnlyList<MvTable> _tables;
+
+    public MvPolicyEnforcingQueryPort(
+        IMvApplyQueryPort inner,
+        IMvSqlStatementPolicy? policy,
+        string serviceId,
+        string viewName,
+        int viewVersion,
+        IReadOnlyList<MvTable> tables)
+    {
+        _inner = inner;
+        _policy = policy;
+        _serviceId = serviceId;
+        _viewName = viewName;
+        _viewVersion = viewVersion;
+        _tables = tables;
+    }
+
+    public async Task<IReadOnlyList<System.Text.Json.JsonElement>> QueryRowsAsync(
+        string sql,
+        IReadOnlyList<MvParam> parameters,
+        CancellationToken ct)
+    {
+        await AuthorizeAsync(sql, parameters, ct).ConfigureAwait(false);
+        return await _inner.QueryRowsAsync(sql, parameters, ct).ConfigureAwait(false);
+    }
+
+    public async Task<System.Text.Json.JsonElement?> QuerySingleOrDefaultAsync(
+        string sql,
+        IReadOnlyList<MvParam> parameters,
+        CancellationToken ct)
+    {
+        await AuthorizeAsync(sql, parameters, ct).ConfigureAwait(false);
+        return await _inner.QuerySingleOrDefaultAsync(sql, parameters, ct).ConfigureAwait(false);
+    }
+
+    public async Task<string?> ExecuteScalarJsonAsync(
+        string sql,
+        IReadOnlyList<MvParam> parameters,
+        CancellationToken ct)
+    {
+        await AuthorizeAsync(sql, parameters, ct).ConfigureAwait(false);
+        return await _inner.ExecuteScalarJsonAsync(sql, parameters, ct).ConfigureAwait(false);
+    }
+
+    internal MvSqlPolicyRejectedException RejectRawAccess(string surface) =>
+        new(
+            new MvSqlPolicyFailure(
+                $"The enforced materialized-view SQL policy does not expose a {surface} to projectors.",
+                _serviceId,
+                _viewName,
+                _viewVersion,
+                MvSqlStatementPhase.Apply));
+
+    private Task AuthorizeAsync(string sql, IReadOnlyList<MvParam> parameters, CancellationToken cancellationToken) =>
+        MvSqlPolicyEvaluator.AuthorizeAsync(
+            _policy,
+            new MvSqlStatementContext(
+                _serviceId,
+                _viewName,
+                _viewVersion,
+                MvSqlStatementPhase.Apply,
+                _tables,
+                sql,
+                MetadataOnly(parameters)),
+            cancellationToken);
+
+    private static IReadOnlyList<MvParam> MetadataOnly(IReadOnlyList<MvParam> parameters) =>
+        parameters.Select(parameter => parameter with { ValueJson = null }).ToList();
 }

--- a/dcb/src/Sekiban.Dcb.MaterializedView/MvSqlStatementPolicy.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView/MvSqlStatementPolicy.cs
@@ -1,0 +1,65 @@
+namespace Sekiban.Dcb.MaterializedView;
+
+public enum MvSqlStatementPhase
+{
+    Initialization = 0,
+    Apply = 1
+}
+
+public sealed record MvSqlStatementContext(
+    string ServiceId,
+    string ViewName,
+    int ViewVersion,
+    MvSqlStatementPhase Phase,
+    IReadOnlyList<MvTable> Tables,
+    string Sql,
+    IReadOnlyList<MvParam> Parameters);
+
+public readonly record struct MvSqlPolicyDecision(bool IsAllowed, string? Reason)
+{
+    public static MvSqlPolicyDecision Allow() => new(true, null);
+
+    public static MvSqlPolicyDecision Reject(string reason) =>
+        new(false, string.IsNullOrWhiteSpace(reason) ? "The host SQL statement policy rejected the statement." : reason);
+}
+
+public interface IMvSqlStatementPolicy
+{
+    ValueTask<MvSqlPolicyDecision> EvaluateAsync(
+        MvSqlStatementContext context,
+        CancellationToken cancellationToken = default);
+}
+
+public sealed class MvAllowAllSqlStatementPolicy : IMvSqlStatementPolicy
+{
+    public static MvAllowAllSqlStatementPolicy Instance { get; } = new();
+
+    private MvAllowAllSqlStatementPolicy()
+    {
+    }
+
+    public ValueTask<MvSqlPolicyDecision> EvaluateAsync(
+        MvSqlStatementContext context,
+        CancellationToken cancellationToken = default) =>
+        ValueTask.FromResult(MvSqlPolicyDecision.Allow());
+}
+
+public sealed record MvSqlPolicyFailure(
+    string Reason,
+    string ServiceId,
+    string ViewName,
+    int ViewVersion,
+    MvSqlStatementPhase Phase);
+
+public sealed class MvSqlPolicyRejectedException : InvalidOperationException
+{
+    public MvSqlPolicyRejectedException(MvSqlPolicyFailure failure)
+        : base(
+            $"The materialized-view SQL statement policy rejected a {failure.Phase} statement for " +
+            $"service '{failure.ServiceId}', view '{failure.ViewName}/{failure.ViewVersion}': {failure.Reason}")
+    {
+        Failure = failure;
+    }
+
+    public MvSqlPolicyFailure Failure { get; }
+}

--- a/dcb/src/Sekiban.Dcb.MaterializedView/MvSqlStatementPolicy.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView/MvSqlStatementPolicy.cs
@@ -18,6 +18,17 @@ public enum MvSqlStatementPhase
     Apply = 1
 }
 
+/// <summary>
+///     Identifies the projector surface that produced a statement. This is additive to the older two-value phase
+///     field, which remains the compatibility grouping used by existing policies.
+/// </summary>
+public enum MvSqlStatementOrigin
+{
+    ProjectorInitialize = 0,
+    ProjectorApply = 1,
+    ProjectorQuery = 2
+}
+
 public enum MvSqlPolicyFailureReason
 {
     Denied = 0,
@@ -36,6 +47,7 @@ public sealed record MvSqlStatementContext(
     IReadOnlyList<MvParam> Parameters)
 {
     public MvDbType? DatabaseType { get; init; }
+    public MvSqlStatementOrigin Origin { get; init; } = MvSqlStatementOrigin.ProjectorApply;
     public int StatementIndex { get; init; }
     public int BatchSize { get; init; } = 1;
     public string SqlSha256 => Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(Sql)));
@@ -44,10 +56,15 @@ public sealed record MvSqlStatementContext(
 
 public readonly record struct MvSqlPolicyDecision(bool IsAllowed, string? Reason)
 {
-    public static MvSqlPolicyDecision Allow() => new(true, null);
+    public string? RuleId { get; init; }
 
-    public static MvSqlPolicyDecision Reject(string reason) =>
-        new(false, string.IsNullOrWhiteSpace(reason) ? "The host SQL statement policy rejected the statement." : reason);
+    public static MvSqlPolicyDecision Allow(string? ruleId = null) => new(true, null) { RuleId = ruleId };
+
+    public static MvSqlPolicyDecision Reject(string reason, string? ruleId = null) =>
+        new(false, string.IsNullOrWhiteSpace(reason) ? "The host SQL statement policy rejected the statement." : reason)
+        {
+            RuleId = ruleId
+        };
 }
 
 public interface IMvSqlStatementPolicy
@@ -80,6 +97,8 @@ public sealed record MvSqlPolicyFailure(
 {
     public MvSqlPolicyFailureReason FailureReason { get; init; } = MvSqlPolicyFailureReason.Denied;
     public string? RuleId { get; init; }
+    public MvSqlStatementOrigin Origin { get; init; }
+    public MvDbType? DatabaseType { get; init; }
     public int StatementIndex { get; init; }
     public int BatchSize { get; init; } = 1;
     public string? SqlSha256 { get; init; }
@@ -137,7 +156,8 @@ internal static class MvSqlPolicyEvaluator
             throw CreateRejected(
                 context,
                 MvSqlPolicyFailureReason.InvalidDecision,
-                "The materialized-view SQL statement policy returned an invalid allow decision.");
+                "The materialized-view SQL statement policy returned an invalid allow decision.",
+                decision.RuleId);
         }
 
         if (!decision.IsAllowed)
@@ -147,17 +167,19 @@ internal static class MvSqlPolicyEvaluator
                 throw CreateRejected(
                     context,
                     MvSqlPolicyFailureReason.InvalidDecision,
-                    "The materialized-view SQL statement policy returned an invalid deny decision.");
+                    "The materialized-view SQL statement policy returned an invalid deny decision.",
+                    decision.RuleId);
             }
 
-            throw CreateRejected(context, MvSqlPolicyFailureReason.Denied, decision.Reason);
+            throw CreateRejected(context, MvSqlPolicyFailureReason.Denied, decision.Reason, decision.RuleId);
         }
     }
 
     private static MvSqlPolicyRejectedException CreateRejected(
         MvSqlStatementContext context,
         MvSqlPolicyFailureReason reason,
-        string message) =>
+        string message,
+        string? ruleId = null) =>
         new(
             new MvSqlPolicyFailure(
                 message,
@@ -167,6 +189,9 @@ internal static class MvSqlPolicyEvaluator
                 context.Phase)
             {
                 FailureReason = reason,
+                RuleId = ruleId,
+                Origin = context.Origin,
+                DatabaseType = context.DatabaseType,
                 StatementIndex = context.StatementIndex,
                 BatchSize = context.BatchSize,
                 SqlSha256 = context.SqlSha256
@@ -185,6 +210,7 @@ internal sealed class MvPolicyEnforcingQueryPort : IMvApplyQueryPort
     private readonly string _viewName;
     private readonly int _viewVersion;
     private readonly IReadOnlyList<MvTable> _tables;
+    private readonly MvDbType? _databaseType;
 
     public MvPolicyEnforcingQueryPort(
         IMvApplyQueryPort inner,
@@ -192,7 +218,8 @@ internal sealed class MvPolicyEnforcingQueryPort : IMvApplyQueryPort
         string serviceId,
         string viewName,
         int viewVersion,
-        IReadOnlyList<MvTable> tables)
+        IReadOnlyList<MvTable> tables,
+        MvDbType? databaseType = null)
     {
         _inner = inner;
         _policy = policy;
@@ -200,6 +227,7 @@ internal sealed class MvPolicyEnforcingQueryPort : IMvApplyQueryPort
         _viewName = viewName;
         _viewVersion = viewVersion;
         _tables = tables;
+        _databaseType = databaseType;
     }
 
     public async Task<IReadOnlyList<System.Text.Json.JsonElement>> QueryRowsAsync(
@@ -236,7 +264,11 @@ internal sealed class MvPolicyEnforcingQueryPort : IMvApplyQueryPort
                 _serviceId,
                 _viewName,
                 _viewVersion,
-                MvSqlStatementPhase.Apply));
+                MvSqlStatementPhase.Apply)
+            {
+                Origin = MvSqlStatementOrigin.ProjectorQuery,
+                DatabaseType = _databaseType
+            });
 
     private Task AuthorizeAsync(string sql, IReadOnlyList<MvParam> parameters, CancellationToken cancellationToken) =>
         MvSqlPolicyEvaluator.AuthorizeAsync(
@@ -248,7 +280,11 @@ internal sealed class MvPolicyEnforcingQueryPort : IMvApplyQueryPort
                 MvSqlStatementPhase.Apply,
                 _tables,
                 sql,
-                MetadataOnly(parameters)),
+                MetadataOnly(parameters))
+            {
+                DatabaseType = _databaseType,
+                Origin = MvSqlStatementOrigin.ProjectorQuery
+            },
             cancellationToken);
 
     private static IReadOnlyList<MvParam> MetadataOnly(IReadOnlyList<MvParam> parameters) =>

--- a/dcb/tests/Sekiban.Dcb.MaterializedView.BinaryConsumer/Program.cs
+++ b/dcb/tests/Sekiban.Dcb.MaterializedView.BinaryConsumer/Program.cs
@@ -1,0 +1,9 @@
+using Sekiban.Dcb.MaterializedView;
+
+var options = new MvOptions
+{
+    ServiceId = "binary-consumer"
+};
+
+Console.WriteLine(
+    $"binary-consumer-ok:{options.ServiceId}:{typeof(IMvExecutor).FullName}");

--- a/dcb/tests/Sekiban.Dcb.MaterializedView.BinaryConsumer/README.md
+++ b/dcb/tests/Sekiban.Dcb.MaterializedView.BinaryConsumer/README.md
@@ -1,0 +1,16 @@
+# Materialized-view binary consumer
+
+This fixture is restored and compiled against the published `Sekiban.Dcb.MaterializedView` **10.13.0** package. The
+compatibility proof then runs the already-built consumer without recompiling it after the current branch's
+`Sekiban.Dcb.MaterializedView.dll` is copied into the output directory:
+
+```sh
+dotnet build dcb/tests/Sekiban.Dcb.MaterializedView.BinaryConsumer/Sekiban.Dcb.MaterializedView.BinaryConsumer.csproj -c Release
+cp dcb/src/Sekiban.Dcb.MaterializedView/bin/Release/net9.0/Sekiban.Dcb.MaterializedView.dll \
+  dcb/tests/Sekiban.Dcb.MaterializedView.BinaryConsumer/bin/Release/net9.0/
+dotnet dcb/tests/Sekiban.Dcb.MaterializedView.BinaryConsumer/bin/Release/net9.0/Sekiban.Dcb.MaterializedView.BinaryConsumer.dll
+```
+
+The output must begin with `binary-consumer-ok:`. The final command deliberately does not invoke `dotnet build` or
+`dotnet run`, so the process proves that the consumer was compiled against the real package reference and executed
+against the current implementation as a binary consumer.

--- a/dcb/tests/Sekiban.Dcb.MaterializedView.BinaryConsumer/Sekiban.Dcb.MaterializedView.BinaryConsumer.csproj
+++ b/dcb/tests/Sekiban.Dcb.MaterializedView.BinaryConsumer/Sekiban.Dcb.MaterializedView.BinaryConsumer.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- This fixture is intentionally compiled against the published v10.13.0 package. -->
+    <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.13.0" />
+  </ItemGroup>
+</Project>

--- a/dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/MultiProviderFixtures.cs
+++ b/dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/MultiProviderFixtures.cs
@@ -27,12 +27,32 @@ using Xunit;
 
 namespace Sekiban.Dcb.MaterializedView.MultiProvider.Tests;
 
-public sealed class CrossProviderWeatherForecastMvV1 : IMaterializedViewProjector
+public sealed class CrossProviderWeatherForecastMvV1 : IMaterializedViewProjector, IMvSchemaRequirementsProvider
 {
     public string ViewName => "WeatherForecastPortable";
     public int ViewVersion => 1;
 
     public MvTable Forecasts { get; private set; } = default!;
+
+    public IReadOnlyList<MvSchemaTableRequirement> GetSchemaRequirements(
+        MvDbType databaseType,
+        IMvTableBindings tables) =>
+    [
+        new MvSchemaTableRequirement(
+            "forecasts",
+            tables.GetPhysicalName("forecasts"),
+            [
+                new("forecast_id", MvSchemaTypeFamily.String, false),
+                new("location", MvSchemaTypeFamily.String, false),
+                new("forecast_date", MvSchemaTypeFamily.DateTime, false),
+                new("temperature_c", MvSchemaTypeFamily.Integer, false),
+                new("summary", MvSchemaTypeFamily.String, true),
+                new("is_deleted", MvSchemaTypeFamily.Boolean, false),
+                new("_last_sortable_unique_id", MvSchemaTypeFamily.String, false),
+                new("_last_applied_at", MvSchemaTypeFamily.DateTime, false)
+            ],
+            ["forecast_id"])
+    ];
 
     public async Task InitializeAsync(IMvInitContext ctx, CancellationToken cancellationToken = default)
     {
@@ -77,6 +97,21 @@ public sealed class CrossProviderWeatherForecastMvV1 : IMaterializedViewProjecto
 
         return new MvSqlStatement(dbType switch
         {
+            MvDbType.Postgres => $"""
+                INSERT INTO {Forecasts.PhysicalName}
+                    (forecast_id, location, forecast_date, temperature_c, summary, is_deleted, _last_sortable_unique_id, _last_applied_at)
+                VALUES
+                    (@ForecastId, @Location, @ForecastDate, @TemperatureC, @Summary, @IsDeleted, @SortableUniqueId, CURRENT_TIMESTAMP)
+                ON CONFLICT (forecast_id) DO UPDATE SET
+                    location = EXCLUDED.location,
+                    forecast_date = EXCLUDED.forecast_date,
+                    temperature_c = EXCLUDED.temperature_c,
+                    summary = EXCLUDED.summary,
+                    is_deleted = EXCLUDED.is_deleted,
+                    _last_sortable_unique_id = EXCLUDED._last_sortable_unique_id,
+                    _last_applied_at = CURRENT_TIMESTAMP
+                WHERE {Forecasts.PhysicalName}._last_sortable_unique_id < EXCLUDED._last_sortable_unique_id;
+                """,
             MvDbType.SqlServer => $"""
                 MERGE {Forecasts.PhysicalName} AS target
                 USING (
@@ -139,6 +174,18 @@ public sealed class CrossProviderWeatherForecastMvV1 : IMaterializedViewProjecto
     private static string CreateTableSql(MvDbType dbType, string tableName) =>
         dbType switch
         {
+            MvDbType.Postgres => $"""
+                CREATE TABLE IF NOT EXISTS {tableName} (
+                    forecast_id VARCHAR(36) NOT NULL PRIMARY KEY,
+                    location VARCHAR(200) NOT NULL,
+                    forecast_date TIMESTAMPTZ NOT NULL,
+                    temperature_c INTEGER NOT NULL,
+                    summary TEXT NULL,
+                    is_deleted BOOLEAN NOT NULL DEFAULT FALSE,
+                    _last_sortable_unique_id VARCHAR(64) NOT NULL,
+                    _last_applied_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+                );
+                """,
             MvDbType.SqlServer => $"""
                 IF OBJECT_ID(N'{tableName}', N'U') IS NULL
                 BEGIN
@@ -184,6 +231,14 @@ public sealed class CrossProviderWeatherForecastMvV1 : IMaterializedViewProjecto
     private MvSqlStatement BuildDelete(MvDbType dbType, Guid forecastId, string sortableUniqueId) =>
         new(dbType switch
         {
+            MvDbType.Postgres => $"""
+                UPDATE {Forecasts.PhysicalName}
+                SET is_deleted = TRUE,
+                    _last_sortable_unique_id = @SortableUniqueId,
+                    _last_applied_at = CURRENT_TIMESTAMP
+                WHERE forecast_id = @ForecastId
+                  AND _last_sortable_unique_id < @SortableUniqueId;
+                """,
             MvDbType.SqlServer => $"""
                 UPDATE {Forecasts.PhysicalName}
                 SET is_deleted = 1,
@@ -256,6 +311,7 @@ public abstract class MultiProviderFixtureBase : IAsyncLifetime
     public string ConnectionStringForTests => ConnectionString;
 
     protected abstract MvDbType DatabaseType { get; }
+    internal MvDbType DatabaseTypeForTests => DatabaseType;
     protected abstract Task<string> CreateConnectionStringAsync();
     protected abstract void RegisterProvider(IServiceCollection services, string connectionString);
     protected abstract DbConnection CreateConnection(string connectionString);

--- a/dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/MultiProviderFixtures.cs
+++ b/dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/MultiProviderFixtures.cs
@@ -716,6 +716,7 @@ public sealed class SqliteMvFixture : MultiProviderFixtureBase
 
     protected override string ResetSql => """
         DROP TABLE IF EXISTS sekiban_mv_weatherforecastportable_v1_forecasts;
+        DROP TABLE IF EXISTS sekiban_mv_policysurface_v1_records;
         DROP TABLE IF EXISTS sekiban_mv_active;
         DROP TABLE IF EXISTS sekiban_mv_registry;
         """;

--- a/dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/MultiProviderFixtures.cs
+++ b/dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/MultiProviderFixtures.cs
@@ -309,6 +309,7 @@ public abstract class MultiProviderFixtureBase : IAsyncLifetime
     // string (the unsafe-window MV harnesses wire their own initializer /
     // catch-up / promoter rather than going through IMvExecutor).
     public string ConnectionStringForTests => ConnectionString;
+    public virtual string? InspectionConnectionStringForTests => null;
 
     protected abstract MvDbType DatabaseType { get; }
     internal MvDbType DatabaseTypeForTests => DatabaseType;
@@ -602,6 +603,9 @@ public sealed class MySqlMvFixture : MultiProviderFixtureBase
 public sealed class SqlServerMvFixture : MultiProviderFixtureBase
 {
     private MsSqlContainer? _container;
+    private string? _inspectionLogin;
+    private string? _inspectionPassword;
+    private string? _inspectionConnectionString;
 
     protected override MvDbType DatabaseType => MvDbType.SqlServer;
 
@@ -611,8 +615,33 @@ public sealed class SqlServerMvFixture : MultiProviderFixtureBase
             .Build();
 
         await _container.StartAsync().ConfigureAwait(false);
-        return _container.GetConnectionString();
+        var connectionString = _container.GetConnectionString();
+        _inspectionLogin = $"mv_inspector_{Guid.NewGuid():N}";
+        _inspectionPassword = "SekibanInspector_9x!";
+        await using (var connection = new SqlConnection(connectionString))
+        {
+            await connection.OpenAsync().ConfigureAwait(false);
+            await connection.ExecuteAsync($"""
+                CREATE LOGIN [{_inspectionLogin}] WITH PASSWORD = '{_inspectionPassword}';
+                CREATE USER [{_inspectionLogin}] FOR LOGIN [{_inspectionLogin}];
+                ALTER ROLE db_datareader ADD MEMBER [{_inspectionLogin}];
+                GRANT VIEW DEFINITION TO [{_inspectionLogin}];
+                """).ConfigureAwait(false);
+        }
+
+        var builder = new SqlConnectionStringBuilder(connectionString)
+        {
+            UserID = _inspectionLogin,
+            Password = _inspectionPassword,
+            IntegratedSecurity = false,
+            ApplicationIntent = ApplicationIntent.ReadWrite,
+            Pooling = false
+        };
+        _inspectionConnectionString = builder.ConnectionString;
+        return connectionString;
     }
+
+    public override string? InspectionConnectionStringForTests => _inspectionConnectionString;
 
     protected override void RegisterProvider(IServiceCollection services, string connectionString)
     {
@@ -622,6 +651,7 @@ public sealed class SqlServerMvFixture : MultiProviderFixtureBase
             options.BatchSize = 100;
             options.SafeWindowMs = 0;
             options.PollInterval = TimeSpan.FromMilliseconds(10);
+            options.SqlServerInspectionConnectionString = _inspectionConnectionString;
         });
         services.AddSekibanDcbMaterializedViewSqlServer(connectionString, registerHostedWorker: false);
     }
@@ -683,6 +713,16 @@ public sealed class SqlServerMvFixture : MultiProviderFixtureBase
         await base.DisposeAsync().ConfigureAwait(false);
         if (_container is not null)
         {
+            if (_inspectionLogin is not null)
+            {
+                await using var connection = new SqlConnection(_container.GetConnectionString());
+                await connection.OpenAsync().ConfigureAwait(false);
+                await connection.ExecuteAsync($"""
+                    IF USER_ID(N'{_inspectionLogin}') IS NOT NULL DROP USER [{_inspectionLogin}];
+                    IF SUSER_ID(N'{_inspectionLogin}') IS NOT NULL DROP LOGIN [{_inspectionLogin}];
+                    """).ConfigureAwait(false);
+            }
+
             await _container.DisposeAsync().ConfigureAwait(false);
         }
     }

--- a/dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/MvVerifyOnlyAndPolicyTests.cs
+++ b/dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/MvVerifyOnlyAndPolicyTests.cs
@@ -1261,8 +1261,28 @@ internal static class MvSchemaMatrixAssertions
                     inspector,
                     requirement with
                     {
+                        Indexes = [new MvSchemaIndexRequirement("ix_schema_matrix_nonunique", ["base_value"], true)]
+                    },
+                    MvSchemaMismatchCode.RequiredIndexMissing)
+                .ConfigureAwait(false);
+            await AssertSingleMismatchAsync(
+                    inspector,
+                    requirement with
+                    {
                         Columns = requirement.Columns
                             .Select(column => column.Name == "generated_value" ? column with { IsGenerated = false } : column)
+                            .ToList()
+                    },
+                    MvSchemaMismatchCode.GeneratedSemanticsMismatch)
+                .ConfigureAwait(false);
+            await AssertSingleMismatchAsync(
+                    inspector,
+                    requirement with
+                    {
+                        Columns = requirement.Columns
+                            .Select(column => column.Name == "generated_value"
+                                ? column with { GenerationExpression = "base_value + 2" }
+                                : column)
                             .ToList()
                     },
                     MvSchemaMismatchCode.GeneratedSemanticsMismatch)
@@ -1336,7 +1356,11 @@ internal static class MvSchemaMatrixAssertions
             ],
             ["id"])
         {
-            Indexes = [new MvSchemaIndexRequirement("ux_schema_matrix", ["width_value", "amount_value"], true)]
+            Indexes =
+            [
+                new MvSchemaIndexRequirement("ux_schema_matrix", ["width_value", "amount_value"], true),
+                new MvSchemaIndexRequirement("ix_schema_matrix_nonunique", ["base_value"], false)
+            ]
         };
 
     private static async Task CreateSchemaAsync(MultiProviderFixtureBase fixture, string tableName)
@@ -1351,9 +1375,10 @@ internal static class MvSchemaMatrixAssertions
                     base_value INTEGER NOT NULL DEFAULT 7,
                     width_value VARCHAR(32) NOT NULL,
                     amount_value DECIMAL(10, 2) NOT NULL,
-                    generated_value INTEGER GENERATED ALWAYS AS (7) STORED
+                    generated_value INTEGER GENERATED ALWAYS AS (base_value + 1) STORED
                 );
                 CREATE UNIQUE INDEX {index} ON {table} (width_value, amount_value);
+                CREATE INDEX ix_{tableName} ON {table} (base_value);
                 """,
             MvDbType.MySql => $"""
                 CREATE TABLE {table} (
@@ -1361,9 +1386,10 @@ internal static class MvSchemaMatrixAssertions
                     base_value INT NOT NULL DEFAULT 7,
                     width_value VARCHAR(32) NOT NULL,
                     amount_value DECIMAL(10, 2) NOT NULL,
-                    generated_value INT GENERATED ALWAYS AS (7) STORED
+                    generated_value INT GENERATED ALWAYS AS (base_value + 1) STORED
                 );
                 CREATE UNIQUE INDEX {index} ON {table} (width_value, amount_value);
+                CREATE INDEX ix_{tableName} ON {table} (base_value);
                 """,
             MvDbType.SqlServer => $"""
                 CREATE TABLE {table} (
@@ -1371,9 +1397,10 @@ internal static class MvSchemaMatrixAssertions
                     base_value INT NOT NULL CONSTRAINT {QuoteIdentifier(fixture.DatabaseTypeForTests, $"df_{tableName}")} DEFAULT 7,
                     width_value VARCHAR(32) NOT NULL,
                     amount_value DECIMAL(10, 2) NOT NULL,
-                    generated_value AS (7) PERSISTED
+                    generated_value AS (ISNULL(base_value + 1, 0)) PERSISTED
                 );
                 CREATE UNIQUE INDEX {index} ON {table} (width_value, amount_value);
+                CREATE INDEX ix_{tableName} ON {table} (base_value);
                 """,
             MvDbType.Sqlite => $"""
                 CREATE TABLE {table} (
@@ -1382,9 +1409,10 @@ internal static class MvSchemaMatrixAssertions
                     width_value VARCHAR(32) NOT NULL,
                     amount_value DECIMAL(10, 2) NOT NULL,
                     unbounded_value TEXT NOT NULL,
-                    generated_value INTEGER GENERATED ALWAYS AS (7) STORED
+                    generated_value INTEGER GENERATED ALWAYS AS (base_value + 1) STORED
                 );
                 CREATE UNIQUE INDEX {index} ON {table} (width_value, amount_value);
+                CREATE INDEX ix_{tableName} ON {table} (base_value);
                 """,
             _ => throw new NotSupportedException()
         };
@@ -1398,7 +1426,7 @@ internal static class MvSchemaMatrixAssertions
         {
             MvDbType.Postgres => "SELECT column_default FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = @TableName AND column_name = 'base_value';",
             MvDbType.MySql => "SELECT column_default FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = @TableName AND column_name = 'base_value';",
-            MvDbType.SqlServer => "SELECT '7';",
+            MvDbType.SqlServer => "SELECT defaults.definition FROM sys.default_constraints AS defaults INNER JOIN sys.columns AS columns ON columns.default_object_id = defaults.object_id INNER JOIN sys.tables AS tables ON tables.object_id = columns.object_id WHERE tables.name = @TableName AND columns.name = 'base_value';",
             MvDbType.Sqlite => "SELECT dflt_value FROM pragma_table_info(@TableName) WHERE name = 'base_value';",
             _ => throw new NotSupportedException()
         };
@@ -1415,8 +1443,8 @@ internal static class MvSchemaMatrixAssertions
         {
             MvDbType.Postgres => "SELECT generation_expression FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = @TableName AND column_name = 'generated_value';",
             MvDbType.MySql => "SELECT generation_expression FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = @TableName AND column_name = 'generated_value';",
-            MvDbType.SqlServer => "SELECT '7';",
-            MvDbType.Sqlite => "SELECT '7';",
+            MvDbType.SqlServer => "SELECT computed_columns.definition FROM sys.computed_columns AS computed_columns INNER JOIN sys.tables AS tables ON tables.object_id = computed_columns.object_id WHERE tables.name = @TableName AND computed_columns.name = 'generated_value';",
+            MvDbType.Sqlite => "SELECT 'base_value + 1';",
             _ => throw new NotSupportedException()
         };
         await using var connection = await OpenCatalogConnectionAsync(fixture).ConfigureAwait(false);

--- a/dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/MvVerifyOnlyAndPolicyTests.cs
+++ b/dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/MvVerifyOnlyAndPolicyTests.cs
@@ -1,4 +1,5 @@
 using System.Data;
+using System.Text.RegularExpressions;
 using Dapper;
 using Dcb.Domain.WithoutResult.Weather;
 using Microsoft.Data.Sqlite;
@@ -40,19 +41,13 @@ public sealed class SqliteMvVerifyOnlyAndPolicyTests(SqliteMvFixture fixture)
             policy,
             rejectEnsureInfrastructure: true);
 
-        await verifyExecutor.InitializeAsync(CreateHost(projector)).ConfigureAwait(false);
+        var verifyHost = new CountingApplyHost(CreateHost(projector), throwOnInitialize: true);
+        await verifyExecutor.InitializeAsync(verifyHost).ConfigureAwait(false);
 
         var schemaVersionAfter = await ReadSchemaVersionAsync().ConfigureAwait(false);
         Assert.Equal(schemaVersionBefore, schemaVersionAfter);
-        var initializationContext = Assert.Single(policy.Contexts);
-        Assert.Equal(MvSqlStatementPhase.Initialization, initializationContext.Phase);
-        Assert.Equal(MultiProviderFixtureBase.ServiceId, initializationContext.ServiceId);
-        Assert.Equal(projector.ViewName, initializationContext.ViewName);
-        Assert.Equal(projector.ViewVersion, initializationContext.ViewVersion);
-        var initializationTable = Assert.Single(initializationContext.Tables);
-        Assert.Equal("forecasts", initializationTable.LogicalName);
-        Assert.Equal(projector.Forecasts.PhysicalName, initializationTable.PhysicalName);
-        Assert.Contains("CREATE TABLE", initializationContext.Sql, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(0, verifyHost.InitializeCalls);
+        Assert.Empty(policy.Contexts);
     }
 
     [SkippableFact]
@@ -130,12 +125,153 @@ public sealed class SqliteMvVerifyOnlyAndPolicyTests(SqliteMvFixture fixture)
     }
 
     [SkippableFact]
+    public async Task VerifyOnly_MissingRegistryBindingFailsClosedWithoutRegistryFallback()
+    {
+        Skip.IfNot(fixture.IsAvailable, fixture.AvailabilityMessage ?? "SQLite fixture is unavailable.");
+        await fixture.ResetAsync().ConfigureAwait(false);
+        var registryStore = fixture.Services.GetRequiredService<IMvRegistryStore>();
+        await registryStore.EnsureInfrastructureAsync().ConfigureAwait(false);
+        var projector = fixture.Services.GetRequiredService<CrossProviderWeatherForecastMvV1>();
+        await fixture.Executor.InitializeAsync(CreateHost(projector)).ConfigureAwait(false);
+
+        await using (var connection = await fixture.OpenConnectionAsync().ConfigureAwait(false))
+        {
+            await connection.ExecuteAsync("DELETE FROM sekiban_mv_registry;").ConfigureAwait(false);
+        }
+
+        var verifyExecutor = CreateExecutor(
+            fixture.ConnectionStringForTests,
+            MvInitializationMode.VerifyOnly,
+            new RecordingPolicy(_ => MvSqlPolicyDecision.Allow()),
+            rejectEnsureInfrastructure: true);
+
+        var exception = await Assert.ThrowsAsync<MvInitializationException>(
+            () => verifyExecutor.InitializeAsync(CreateHost(projector))).ConfigureAwait(false);
+
+        Assert.Equal(MvInitializationFailureReason.MissingSchemaContract, exception.Failure.Reason);
+        await using var checkConnection = await fixture.OpenConnectionAsync().ConfigureAwait(false);
+        Assert.Equal(0, await checkConnection.ExecuteScalarAsync<long>("SELECT COUNT(*) FROM sekiban_mv_registry;"));
+    }
+
+    [SkippableFact]
+    public async Task VerifyOnly_WithoutReadOnlyInspectorFailsBeforeAnyRegistryOrHostIo()
+    {
+        Skip.IfNot(fixture.IsAvailable, fixture.AvailabilityMessage ?? "SQLite fixture is unavailable.");
+        await fixture.ResetAsync().ConfigureAwait(false);
+        var registry = new NoInspectorRegistryStore(fixture.Services.GetRequiredService<IMvRegistryStore>());
+        var executor = new SqliteMvExecutor(
+            fixture.EventStoreFactory,
+            registry,
+            Options.Create(new MvOptions
+            {
+                ServiceId = MultiProviderFixtureBase.ServiceId,
+                InitializationMode = MvInitializationMode.VerifyOnly,
+                SafeWindowMs = 0,
+                BatchSize = 100
+            }),
+            NullLogger<SqliteMvExecutor>.Instance,
+            fixture.ConnectionStringForTests);
+        var projector = fixture.Services.GetRequiredService<CrossProviderWeatherForecastMvV1>();
+        var host = new CountingApplyHost(CreateHost(projector), throwOnInitialize: true);
+
+        var exception = await Assert.ThrowsAsync<MvInitializationException>(
+            () => executor.InitializeAsync(host)).ConfigureAwait(false);
+
+        Assert.Equal(MvInitializationFailureReason.UnsupportedProviderCapability, exception.Failure.Reason);
+        Assert.Equal(0, host.InitializeCalls);
+        Assert.Equal(0, registry.EnsureCalls);
+        Assert.Equal(0, registry.RegisterCalls);
+        Assert.Equal(0, registry.GetEntriesCalls);
+    }
+
+    [SkippableFact]
+    public async Task VerifyOnly_ImplicitEmptyRegistryPathsUseTheSameFailClosedGate()
+    {
+        Skip.IfNot(fixture.IsAvailable, fixture.AvailabilityMessage ?? "SQLite fixture is unavailable.");
+        var pathNames = new[] { "target-capture", "catch-up", "apply" };
+        foreach (var pathName in pathNames)
+        {
+            await fixture.ResetAsync().ConfigureAwait(false);
+            var projector = fixture.Services.GetRequiredService<CrossProviderWeatherForecastMvV1>();
+            await fixture.Executor.InitializeAsync(CreateHost(projector)).ConfigureAwait(false);
+            await using (var connection = await fixture.OpenConnectionAsync().ConfigureAwait(false))
+            {
+                await connection.ExecuteAsync("DELETE FROM sekiban_mv_registry;").ConfigureAwait(false);
+                Assert.Equal(0, await connection.ExecuteScalarAsync<long>(
+                    "SELECT COUNT(*) FROM sekiban_mv_registry;").ConfigureAwait(false));
+            }
+
+            var verifyExecutor = CreateExecutor(
+                fixture.ConnectionStringForTests,
+                MvInitializationMode.VerifyOnly,
+                new RecordingPolicy(_ => MvSqlPolicyDecision.Allow()),
+                rejectEnsureInfrastructure: true);
+            var host = new CountingApplyHost(CreateHost(projector), throwOnInitialize: true);
+
+            var exception = pathName switch
+            {
+                "target-capture" => await Assert.ThrowsAsync<MvInitializationException>(
+                    () => verifyExecutor.CaptureTargetCheckpointAsync(host)).ConfigureAwait(false),
+                "catch-up" => await Assert.ThrowsAsync<MvInitializationException>(
+                    async () => await verifyExecutor.CatchUpOnceAsync(host).ConfigureAwait(false)).ConfigureAwait(false),
+                _ => await Assert.ThrowsAsync<MvInitializationException>(
+                    () => verifyExecutor.ApplySerializableEventsAsync(host, [])).ConfigureAwait(false)
+            };
+
+            Assert.Equal(MvInitializationFailureReason.MissingSchemaContract, exception.Failure.Reason);
+            Assert.Equal(0, host.InitializeCalls);
+            await using var checkConnection = await fixture.OpenConnectionAsync().ConfigureAwait(false);
+            Assert.Equal(0, await checkConnection.ExecuteScalarAsync<long>("SELECT COUNT(*) FROM sekiban_mv_registry;"));
+        }
+    }
+
+    [SkippableFact]
+    public async Task VerifyOnly_ImplicitPathsReportMissingFrameworkSchemaBeforeRegistryRead()
+    {
+        Skip.IfNot(fixture.IsAvailable, fixture.AvailabilityMessage ?? "SQLite fixture is unavailable.");
+        var pathNames = new[] { "target-capture", "catch-up", "apply" };
+        foreach (var pathName in pathNames)
+        {
+            await fixture.ResetAsync().ConfigureAwait(false);
+            var projector = fixture.Services.GetRequiredService<CrossProviderWeatherForecastMvV1>();
+            var verifyExecutor = CreateExecutor(
+                fixture.ConnectionStringForTests,
+                MvInitializationMode.VerifyOnly,
+                new RecordingPolicy(_ => MvSqlPolicyDecision.Allow()),
+                rejectEnsureInfrastructure: true);
+            var host = new CountingApplyHost(CreateHost(projector), throwOnInitialize: true);
+
+            var exception = pathName switch
+            {
+                "target-capture" => await Assert.ThrowsAsync<MvInitializationException>(
+                    () => verifyExecutor.CaptureTargetCheckpointAsync(host)).ConfigureAwait(false),
+                "catch-up" => await Assert.ThrowsAsync<MvInitializationException>(
+                    async () => await verifyExecutor.CatchUpOnceAsync(host).ConfigureAwait(false)).ConfigureAwait(false),
+                _ => await Assert.ThrowsAsync<MvInitializationException>(
+                    () => verifyExecutor.ApplySerializableEventsAsync(host, [])).ConfigureAwait(false)
+            };
+
+            Assert.Equal(MvInitializationFailureReason.MissingSchemaObject, exception.Failure.Reason);
+            Assert.Equal(0, host.InitializeCalls);
+            await using var checkConnection = await fixture.OpenConnectionAsync().ConfigureAwait(false);
+            Assert.Equal(
+                0,
+                await checkConnection.ExecuteScalarAsync<long>(
+                    "SELECT COUNT(*) FROM sqlite_master WHERE name LIKE 'sekiban_mv_%';"));
+        }
+    }
+
+    [SkippableFact]
     public async Task InitializationPolicyRejectsBeforeProviderCommands()
     {
         Skip.IfNot(fixture.IsAvailable, fixture.AvailabilityMessage ?? "SQLite fixture is unavailable.");
         await fixture.ResetAsync().ConfigureAwait(false);
         var policy = new RecordingPolicy(_ => MvSqlPolicyDecision.Reject("DDL is not approved for this host."));
-        var executor = CreateExecutor(fixture.ConnectionStringForTests, MvInitializationMode.CreateOrEnsure, policy);
+        var executor = CreateExecutor(
+            fixture.ConnectionStringForTests,
+            MvInitializationMode.CreateOrEnsure,
+            policy,
+            policyMode: MvSqlStatementPolicyMode.Enforced);
         var projector = fixture.Services.GetRequiredService<CrossProviderWeatherForecastMvV1>();
 
         var exception = await Assert.ThrowsAsync<MvSqlPolicyRejectedException>(
@@ -148,6 +284,54 @@ public sealed class SqliteMvVerifyOnlyAndPolicyTests(SqliteMvFixture fixture)
             0,
             await connection.ExecuteScalarAsync<long>(
                 "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name LIKE 'sekiban_mv_%';"));
+    }
+
+    [SkippableFact]
+    public async Task EnforcedPolicyWithoutRegistrationFailsClosedBeforeProviderCommands()
+    {
+        Skip.IfNot(fixture.IsAvailable, fixture.AvailabilityMessage ?? "SQLite fixture is unavailable.");
+        await fixture.ResetAsync().ConfigureAwait(false);
+        var executor = CreateExecutor(
+            fixture.ConnectionStringForTests,
+            MvInitializationMode.CreateOrEnsure,
+            policy: null,
+            policyMode: MvSqlStatementPolicyMode.Enforced);
+        var projector = fixture.Services.GetRequiredService<CrossProviderWeatherForecastMvV1>();
+
+        var exception = await Assert.ThrowsAsync<MvSqlPolicyRejectedException>(
+            () => executor.InitializeAsync(CreateHost(projector))).ConfigureAwait(false);
+
+        Assert.Equal(MvSqlPolicyFailureReason.PolicyUnavailable, exception.Failure.FailureReason);
+        await using var connection = await fixture.OpenConnectionAsync().ConfigureAwait(false);
+        Assert.Equal(
+            0,
+            await connection.ExecuteScalarAsync<long>(
+                "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name LIKE 'sekiban_mv_%';"));
+    }
+
+    [SkippableFact]
+    public async Task EnforcedPolicyInvalidDecisionFailsClosedBeforeProviderCommands()
+    {
+        Skip.IfNot(fixture.IsAvailable, fixture.AvailabilityMessage ?? "SQLite fixture is unavailable.");
+        await ResetPolicySurfaceAsync().ConfigureAwait(false);
+        var projector = new PolicySurfaceProjector(PolicySurfaceKind.Rows, "SELECT id FROM records");
+        var host = new NativeMvApplyHost(projector, fixture.DomainTypes.EventTypes, MvDbType.Sqlite);
+        var policy = new RecordingPolicy(context =>
+            context.Phase == MvSqlStatementPhase.Initialization
+                ? MvSqlPolicyDecision.Allow()
+                : new MvSqlPolicyDecision(false, null));
+        var executor = CreateExecutor(
+            fixture.ConnectionStringForTests,
+            MvInitializationMode.CreateOrEnsure,
+            policy,
+            policyMode: MvSqlStatementPolicyMode.Enforced);
+
+        await executor.InitializeAsync(host).ConfigureAwait(false);
+        var exception = await Assert.ThrowsAsync<MvSqlPolicyRejectedException>(
+            () => executor.ApplySerializableEventsAsync(host, [CreatePolicyEvent()])).ConfigureAwait(false);
+
+        Assert.Equal(MvSqlPolicyFailureReason.InvalidDecision, exception.Failure.FailureReason);
+        await AssertPolicySurfaceHasNoAppliedEventAsync(projector).ConfigureAwait(false);
     }
 
     [SkippableFact]
@@ -172,7 +356,11 @@ public sealed class SqliteMvVerifyOnlyAndPolicyTests(SqliteMvFixture fixture)
             context.Phase == MvSqlStatementPhase.Apply
                 ? MvSqlPolicyDecision.Reject("Apply is not approved for this host.")
                 : MvSqlPolicyDecision.Allow());
-        var executor = CreateExecutor(fixture.ConnectionStringForTests, MvInitializationMode.CreateOrEnsure, policy);
+        var executor = CreateExecutor(
+            fixture.ConnectionStringForTests,
+            MvInitializationMode.CreateOrEnsure,
+            policy,
+            policyMode: MvSqlStatementPolicyMode.Enforced);
         var forecastId = Guid.CreateVersion7();
         var eventId = Guid.CreateVersion7();
         var eventValue = new Event(
@@ -193,6 +381,8 @@ public sealed class SqliteMvVerifyOnlyAndPolicyTests(SqliteMvFixture fixture)
             () => executor.ApplySerializableEventsAsync(CreateHost(projector), [serializableEvent])).ConfigureAwait(false);
 
         Assert.Equal(MvSqlStatementPhase.Apply, exception.Failure.Phase);
+        Assert.Equal(MvSqlPolicyFailureReason.Denied, exception.Failure.FailureReason);
+        Assert.False(string.IsNullOrWhiteSpace(exception.Failure.SqlSha256));
         var applyContext = Assert.Single(policy.Contexts);
         Assert.Equal(MvSqlStatementPhase.Apply, applyContext.Phase);
         Assert.Equal(MultiProviderFixtureBase.ServiceId, applyContext.ServiceId);
@@ -204,6 +394,7 @@ public sealed class SqliteMvVerifyOnlyAndPolicyTests(SqliteMvFixture fixture)
         Assert.Contains(
             applyContext.Parameters,
             parameter => parameter.Name == "ForecastId" && parameter.Kind == MvParamKind.String);
+        Assert.All(applyContext.Parameters, parameter => Assert.Null(parameter.ValueJson));
         await using var connection = await fixture.OpenConnectionAsync().ConfigureAwait(false);
         Assert.Equal(
             0,
@@ -222,14 +413,232 @@ public sealed class SqliteMvVerifyOnlyAndPolicyTests(SqliteMvFixture fixture)
                 new { ServiceId = MultiProviderFixtureBase.ServiceId }));
     }
 
+    [SkippableTheory]
+    [InlineData("WITH changed AS (UPDATE records SET value = 'x' RETURNING id) SELECT id FROM changed")]
+    [InlineData("/* policy probe */ SELECT id FROM records")]
+    [InlineData("SELECT id FROM records; UPDATE records SET value = 'x'")]
+    public async Task EnforcedPolicyRejectsMutatingCommentedAndMultiStatementQueriesBeforeProvider(
+        string sql)
+    {
+        Skip.IfNot(fixture.IsAvailable, fixture.AvailabilityMessage ?? "SQLite fixture is unavailable.");
+        await ResetPolicySurfaceAsync().ConfigureAwait(false);
+        var projector = new PolicySurfaceProjector(PolicySurfaceKind.Rows, sql);
+        var host = new NativeMvApplyHost(projector, fixture.DomainTypes.EventTypes, MvDbType.Sqlite);
+        var policy = new RecordingPolicy(context =>
+            context.Phase == MvSqlStatementPhase.Initialization
+                ? MvSqlPolicyDecision.Allow()
+                : MvSqlPolicyDecision.Reject("Query shape is not allowlisted."));
+        var executor = CreateExecutor(
+            fixture.ConnectionStringForTests,
+            MvInitializationMode.CreateOrEnsure,
+            policy,
+            policyMode: MvSqlStatementPolicyMode.Enforced);
+
+        await executor.InitializeAsync(host).ConfigureAwait(false);
+        var serializableEvent = CreatePolicyEvent();
+        var exception = await Assert.ThrowsAsync<MvSqlPolicyRejectedException>(
+            () => executor.ApplySerializableEventsAsync(host, [serializableEvent])).ConfigureAwait(false);
+
+        Assert.Equal(MvSqlStatementPhase.Apply, exception.Failure.Phase);
+        var queryContext = Assert.Single(policy.Contexts, context => context.Phase == MvSqlStatementPhase.Apply);
+        Assert.Equal(sql, queryContext.Sql);
+        await using var connection = await fixture.OpenConnectionAsync().ConfigureAwait(false);
+        Assert.Equal(0, await connection.ExecuteScalarAsync<long>($"SELECT COUNT(*) FROM {projector.Records.PhysicalName};"));
+        Assert.Equal(
+            0,
+            await connection.ExecuteScalarAsync<long>(
+                "SELECT applied_event_version FROM sekiban_mv_registry WHERE view_name = 'PolicySurface';"));
+    }
+
+    [SkippableTheory]
+    [InlineData(PolicySurfaceKind.Rows)]
+    [InlineData(PolicySurfaceKind.Single)]
+    [InlineData(PolicySurfaceKind.Scalar)]
+    public async Task EnforcedPolicyGatesEveryQueryPortSurfaceBeforeProviderExecution(PolicySurfaceKind surface)
+    {
+        Skip.IfNot(fixture.IsAvailable, fixture.AvailabilityMessage ?? "SQLite fixture is unavailable.");
+        await ResetPolicySurfaceAsync().ConfigureAwait(false);
+        var projector = new PolicySurfaceProjector(surface, "SELECT id FROM records");
+        var host = new NativeMvApplyHost(projector, fixture.DomainTypes.EventTypes, MvDbType.Sqlite);
+        var policy = new RecordingPolicy(context =>
+            context.Phase == MvSqlStatementPhase.Initialization
+                ? MvSqlPolicyDecision.Allow()
+                : MvSqlPolicyDecision.Reject("Apply query is not approved."));
+        var executor = CreateExecutor(
+            fixture.ConnectionStringForTests,
+            MvInitializationMode.CreateOrEnsure,
+            policy,
+            policyMode: MvSqlStatementPolicyMode.Enforced);
+
+        await executor.InitializeAsync(host).ConfigureAwait(false);
+        await Assert.ThrowsAsync<MvSqlPolicyRejectedException>(
+            () => executor.ApplySerializableEventsAsync(host, [CreatePolicyEvent()])).ConfigureAwait(false);
+
+        Assert.Single(policy.Contexts, context => context.Phase == MvSqlStatementPhase.Apply);
+        await using var connection = await fixture.OpenConnectionAsync().ConfigureAwait(false);
+        Assert.Equal(0, await connection.ExecuteScalarAsync<long>($"SELECT COUNT(*) FROM {projector.Records.PhysicalName};"));
+    }
+
+    [SkippableFact]
+    public async Task EnforcedPolicyRejectsRawConnectionBypassWithoutProviderExecution()
+    {
+        Skip.IfNot(fixture.IsAvailable, fixture.AvailabilityMessage ?? "SQLite fixture is unavailable.");
+        await ResetPolicySurfaceAsync().ConfigureAwait(false);
+        var projector = new PolicySurfaceProjector(PolicySurfaceKind.Raw, "");
+        var host = new NativeMvApplyHost(projector, fixture.DomainTypes.EventTypes, MvDbType.Sqlite);
+        var policy = new RecordingPolicy(context =>
+            context.Phase == MvSqlStatementPhase.Initialization
+                ? MvSqlPolicyDecision.Allow()
+                : MvSqlPolicyDecision.Allow());
+        var executor = CreateExecutor(
+            fixture.ConnectionStringForTests,
+            MvInitializationMode.CreateOrEnsure,
+            policy,
+            policyMode: MvSqlStatementPolicyMode.Enforced);
+
+        await executor.InitializeAsync(host).ConfigureAwait(false);
+        var exception = await Assert.ThrowsAsync<MvSqlPolicyRejectedException>(
+            () => executor.ApplySerializableEventsAsync(host, [CreatePolicyEvent()])).ConfigureAwait(false);
+
+        Assert.Equal(MvSqlStatementPhase.Apply, exception.Failure.Phase);
+        Assert.Contains("raw connection", exception.Failure.Reason, StringComparison.OrdinalIgnoreCase);
+        await using var connection = await fixture.OpenConnectionAsync().ConfigureAwait(false);
+        Assert.Equal(0, await connection.ExecuteScalarAsync<long>($"SELECT COUNT(*) FROM {projector.Records.PhysicalName};"));
+    }
+
+    [SkippableFact]
+    public async Task EnforcedPolicyPreflightsWholeApplyBatchBeforeAnyProviderCommand()
+    {
+        Skip.IfNot(fixture.IsAvailable, fixture.AvailabilityMessage ?? "SQLite fixture is unavailable.");
+        await ResetPolicySurfaceAsync().ConfigureAwait(false);
+        var projector = new PolicySurfaceProjector(PolicySurfaceKind.Batch, "");
+        var host = new NativeMvApplyHost(projector, fixture.DomainTypes.EventTypes, MvDbType.Sqlite);
+        var policy = new RecordingPolicy(context =>
+        {
+            if (context.Phase == MvSqlStatementPhase.Initialization)
+            {
+                return MvSqlPolicyDecision.Allow();
+            }
+
+            return context.Sql.Contains("second", StringComparison.OrdinalIgnoreCase)
+                ? MvSqlPolicyDecision.Reject("The second apply statement is not approved.")
+                : MvSqlPolicyDecision.Allow();
+        });
+        var executor = CreateExecutor(
+            fixture.ConnectionStringForTests,
+            MvInitializationMode.CreateOrEnsure,
+            policy,
+            policyMode: MvSqlStatementPolicyMode.Enforced);
+
+        await executor.InitializeAsync(host).ConfigureAwait(false);
+        var exception = await Assert.ThrowsAsync<MvSqlPolicyRejectedException>(
+            () => executor.ApplySerializableEventsAsync(host, [CreatePolicyEvent()])).ConfigureAwait(false);
+
+        Assert.Equal(MvSqlStatementPhase.Apply, exception.Failure.Phase);
+        Assert.Equal(2, policy.Contexts.Count(context => context.Phase == MvSqlStatementPhase.Apply));
+        Assert.Equal([0, 1], policy.Contexts
+            .Where(context => context.Phase == MvSqlStatementPhase.Apply)
+            .Select(context => context.StatementIndex));
+        Assert.All(
+            policy.Contexts.Where(context => context.Phase == MvSqlStatementPhase.Apply),
+            context => Assert.Equal(2, context.BatchSize));
+        await using var connection = await fixture.OpenConnectionAsync().ConfigureAwait(false);
+        Assert.Equal(0, await connection.ExecuteScalarAsync<long>($"SELECT COUNT(*) FROM {projector.Records.PhysicalName};"));
+        Assert.Equal(
+            0,
+            await connection.ExecuteScalarAsync<long>(
+                "SELECT applied_event_version FROM sekiban_mv_registry WHERE view_name = 'PolicySurface';"));
+    }
+
+    [SkippableFact]
+    public async Task EnforcedPolicyFaultFailsClosedWithDistinctTypedReason()
+    {
+        Skip.IfNot(fixture.IsAvailable, fixture.AvailabilityMessage ?? "SQLite fixture is unavailable.");
+        await ResetPolicySurfaceAsync().ConfigureAwait(false);
+        var projector = new PolicySurfaceProjector(PolicySurfaceKind.Rows, "SELECT id FROM records");
+        var host = new NativeMvApplyHost(projector, fixture.DomainTypes.EventTypes, MvDbType.Sqlite);
+        var policy = new FaultingPolicy();
+        var executor = CreateExecutor(
+            fixture.ConnectionStringForTests,
+            MvInitializationMode.CreateOrEnsure,
+            policy,
+            policyMode: MvSqlStatementPolicyMode.Enforced);
+
+        await executor.InitializeAsync(host).ConfigureAwait(false);
+        var exception = await Assert.ThrowsAsync<MvSqlPolicyRejectedException>(
+            () => executor.ApplySerializableEventsAsync(host, [CreatePolicyEvent()])).ConfigureAwait(false);
+
+        Assert.Equal(MvSqlPolicyFailureReason.PolicyEvaluationFailed, exception.Failure.FailureReason);
+        await AssertPolicySurfaceHasNoAppliedEventAsync(projector).ConfigureAwait(false);
+    }
+
+    [SkippableFact]
+    public async Task EnforcedPolicyCancellationRemainsOperationCanceledAndDoesNotExecute()
+    {
+        Skip.IfNot(fixture.IsAvailable, fixture.AvailabilityMessage ?? "SQLite fixture is unavailable.");
+        await ResetPolicySurfaceAsync().ConfigureAwait(false);
+        var projector = new PolicySurfaceProjector(PolicySurfaceKind.Rows, "SELECT id FROM records");
+        var host = new NativeMvApplyHost(projector, fixture.DomainTypes.EventTypes, MvDbType.Sqlite);
+        using var cancellation = new CancellationTokenSource();
+        var policy = new CancellingPolicy(cancellation);
+        var executor = CreateExecutor(
+            fixture.ConnectionStringForTests,
+            MvInitializationMode.CreateOrEnsure,
+            policy,
+            policyMode: MvSqlStatementPolicyMode.Enforced);
+
+        await executor.InitializeAsync(host).ConfigureAwait(false);
+        await Assert.ThrowsAsync<OperationCanceledException>(
+            () => executor.ApplySerializableEventsAsync(host, [CreatePolicyEvent()], cancellationToken: cancellation.Token))
+            .ConfigureAwait(false);
+
+        await AssertPolicySurfaceHasNoAppliedEventAsync(projector).ConfigureAwait(false);
+    }
+
+    private async Task AssertPolicySurfaceHasNoAppliedEventAsync(PolicySurfaceProjector projector)
+    {
+        await using var connection = await fixture.OpenConnectionAsync().ConfigureAwait(false);
+        Assert.Equal(0, await connection.ExecuteScalarAsync<long>($"SELECT COUNT(*) FROM {projector.Records.PhysicalName};"));
+        Assert.Equal(
+            0,
+            await connection.ExecuteScalarAsync<long>(
+                "SELECT applied_event_version FROM sekiban_mv_registry WHERE view_name = 'PolicySurface';"));
+    }
+
+    private async Task ResetPolicySurfaceAsync()
+    {
+        await fixture.ResetAsync().ConfigureAwait(false);
+        await using var connection = await fixture.OpenConnectionAsync().ConfigureAwait(false);
+        await connection.ExecuteAsync("DROP TABLE IF EXISTS sekiban_mv_policysurface_v1_records;").ConfigureAwait(false);
+    }
+
+    private SerializableEvent CreatePolicyEvent()
+    {
+        var eventId = Guid.CreateVersion7();
+        var eventValue = new Event(
+            new WeatherForecastCreated(
+                Guid.CreateVersion7(),
+                "Tokyo",
+                DateOnly.FromDateTime(DateTime.UtcNow),
+                20,
+                "Sunny"),
+            SortableUniqueId.Generate(DateTime.UtcNow.AddMinutes(-1), eventId),
+            nameof(WeatherForecastCreated),
+            eventId,
+            new EventMetadata("policy-test", "policy-test", "test"),
+            []);
+        return eventValue.ToSerializableEvent(fixture.DomainTypes.EventTypes);
+    }
+
     private NativeMvApplyHost CreateHost(CrossProviderWeatherForecastMvV1 projector) =>
         new(projector, fixture.DomainTypes.EventTypes, MvDbType.Sqlite);
 
     private SqliteMvExecutor CreateExecutor(
         string connectionString,
         MvInitializationMode initializationMode,
-        IMvSqlStatementPolicy policy,
-        bool rejectEnsureInfrastructure = false)
+        IMvSqlStatementPolicy? policy,
+        bool rejectEnsureInfrastructure = false,
+        MvSqlStatementPolicyMode policyMode = MvSqlStatementPolicyMode.Legacy)
     {
         var registry = connectionString == fixture.ConnectionStringForTests
             ? fixture.Services.GetRequiredService<IMvRegistryStore>()
@@ -238,7 +647,7 @@ public sealed class SqliteMvVerifyOnlyAndPolicyTests(SqliteMvFixture fixture)
         {
             registry = new EnsureRejectingRegistryStore(
                 registry,
-                Assert.IsAssignableFrom<IMvSchemaVerifier>(registry));
+                Assert.IsAssignableFrom<IMvReadOnlyMvInspector>(registry));
         }
 
         return new SqliteMvExecutor(
@@ -249,6 +658,7 @@ public sealed class SqliteMvVerifyOnlyAndPolicyTests(SqliteMvFixture fixture)
                 ServiceId = MultiProviderFixtureBase.ServiceId,
                 InitializationMode = initializationMode,
                 SqlStatementPolicy = policy,
+                SqlStatementPolicyMode = policyMode,
                 SafeWindowMs = 0,
                 BatchSize = 100
             }),
@@ -276,9 +686,40 @@ public sealed class SqliteMvVerifyOnlyAndPolicyTests(SqliteMvFixture fixture)
         }
     }
 
+    private sealed class FaultingPolicy : IMvSqlStatementPolicy
+    {
+        public ValueTask<MvSqlPolicyDecision> EvaluateAsync(
+            MvSqlStatementContext context,
+            CancellationToken cancellationToken = default)
+        {
+            if (context.Phase == MvSqlStatementPhase.Apply)
+            {
+                throw new InvalidOperationException("deliberate policy fault");
+            }
+
+            return ValueTask.FromResult(MvSqlPolicyDecision.Allow());
+        }
+    }
+
+    private sealed class CancellingPolicy(CancellationTokenSource cancellation) : IMvSqlStatementPolicy
+    {
+        public ValueTask<MvSqlPolicyDecision> EvaluateAsync(
+            MvSqlStatementContext context,
+            CancellationToken cancellationToken = default)
+        {
+            if (context.Phase == MvSqlStatementPhase.Apply)
+            {
+                cancellation.Cancel();
+                cancellationToken.ThrowIfCancellationRequested();
+            }
+
+            return ValueTask.FromResult(MvSqlPolicyDecision.Allow());
+        }
+    }
+
     private sealed class EnsureRejectingRegistryStore(
         IMvRegistryStore inner,
-        IMvSchemaVerifier schemaVerifier) : IMvRegistryStore, IMvSchemaVerifier
+        IMvReadOnlyMvInspector inspector) : IMvRegistryStore, IMvReadOnlyMvInspector
     {
         public Task EnsureInfrastructureAsync(CancellationToken cancellationToken = default) =>
             throw new InvalidOperationException("Verify-only must not enter EnsureInfrastructureAsync.");
@@ -313,7 +754,14 @@ public sealed class SqliteMvVerifyOnlyAndPolicyTests(SqliteMvFixture fixture)
             string viewName,
             int viewVersion,
             CancellationToken cancellationToken = default) =>
-            inner.GetEntriesAsync(serviceId, viewName, viewVersion, cancellationToken);
+            throw new InvalidOperationException("Verify-only must use the dedicated read-only inspector.");
+
+        public Task<IReadOnlyList<MvRegistryEntry>> ReadRegistryEntriesAsync(
+            string serviceId,
+            string viewName,
+            int viewVersion,
+            CancellationToken cancellationToken = default) =>
+            inspector.ReadRegistryEntriesAsync(serviceId, viewName, viewVersion, cancellationToken);
 
         public Task<MvActiveEntry?> GetActiveAsync(
             string serviceId,
@@ -353,7 +801,168 @@ public sealed class SqliteMvVerifyOnlyAndPolicyTests(SqliteMvFixture fixture)
         public Task<MvSchemaVerificationResult> VerifySchemaAsync(
             IReadOnlyList<MvSchemaTableRequirement> requirements,
             CancellationToken cancellationToken = default) =>
-            schemaVerifier.VerifySchemaAsync(requirements, cancellationToken);
+            inspector.VerifySchemaAsync(requirements, cancellationToken);
+    }
+
+    private sealed class NoInspectorRegistryStore(IMvRegistryStore inner) : IMvRegistryStore
+    {
+        public int EnsureCalls { get; private set; }
+        public int RegisterCalls { get; private set; }
+        public int GetEntriesCalls { get; private set; }
+
+        public Task EnsureInfrastructureAsync(CancellationToken cancellationToken = default)
+        {
+            EnsureCalls++;
+            return inner.EnsureInfrastructureAsync(cancellationToken);
+        }
+
+        public Task RegisterAsync(MvRegistryEntry entry, IDbTransaction? transaction = null, CancellationToken cancellationToken = default)
+        {
+            RegisterCalls++;
+            return inner.RegisterAsync(entry, transaction, cancellationToken);
+        }
+
+        public Task UpdatePositionAsync(MvPositionUpdate update, IDbTransaction? transaction = null, CancellationToken cancellationToken = default) =>
+            inner.UpdatePositionAsync(update, transaction, cancellationToken);
+
+        public Task MarkStreamReceivedAsync(string serviceId, string viewName, int viewVersion, string sortableUniqueId, DateTimeOffset receivedAt, IDbTransaction? transaction = null, CancellationToken cancellationToken = default) =>
+            inner.MarkStreamReceivedAsync(serviceId, viewName, viewVersion, sortableUniqueId, receivedAt, transaction, cancellationToken);
+
+        public Task UpdateStatusAsync(string serviceId, string viewName, int viewVersion, MvStatus status, IDbTransaction? transaction = null, CancellationToken cancellationToken = default) =>
+            inner.UpdateStatusAsync(serviceId, viewName, viewVersion, status, transaction, cancellationToken);
+
+        public Task<IReadOnlyList<MvRegistryEntry>> GetEntriesAsync(string serviceId, string viewName, int viewVersion, CancellationToken cancellationToken = default)
+        {
+            GetEntriesCalls++;
+            return inner.GetEntriesAsync(serviceId, viewName, viewVersion, cancellationToken);
+        }
+
+        public Task<MvActiveEntry?> GetActiveAsync(string serviceId, string viewName, CancellationToken cancellationToken = default) =>
+            inner.GetActiveAsync(serviceId, viewName, cancellationToken);
+
+        public Task SetTargetCheckpointAsync(string serviceId, string viewName, int viewVersion, MvCheckpointTruth targetCheckpointTruth, IDbTransaction? transaction = null, CancellationToken cancellationToken = default) =>
+            inner.SetTargetCheckpointAsync(serviceId, viewName, viewVersion, targetCheckpointTruth, transaction, cancellationToken);
+
+        public Task<MvActivationResult> TryActivateAsync(MvActivationRequest request, IDbTransaction? transaction = null, CancellationToken cancellationToken = default) =>
+            inner.TryActivateAsync(request, transaction, cancellationToken);
+
+        public Task<MvActivationResult> TryForceReverseAsync(MvForcedReverseRequest request, IDbTransaction? transaction = null, CancellationToken cancellationToken = default) =>
+            inner.TryForceReverseAsync(request, transaction, cancellationToken);
+
+        public Task SetActiveAsync(string serviceId, string viewName, int activeVersion, IDbTransaction? transaction = null, CancellationToken cancellationToken = default) =>
+            inner.SetActiveAsync(serviceId, viewName, activeVersion, transaction, cancellationToken);
+    }
+
+}
+
+internal sealed class CountingApplyHost(IMvApplyHost inner, bool throwOnInitialize = false) : IMvApplyHost
+{
+    private readonly bool _throwOnInitialize = throwOnInitialize;
+    public int InitializeCalls { get; private set; }
+    public string ViewName => inner.ViewName;
+    public int ViewVersion => inner.ViewVersion;
+    public IReadOnlyList<string> LogicalTables => inner.LogicalTables;
+
+    public Task<IReadOnlyList<MvSqlStatementDto>> InitializeAsync(
+        IMvTableBindings tables,
+        CancellationToken ct)
+    {
+        InitializeCalls += 1;
+        if (_throwOnInitialize)
+        {
+            throw new InvalidOperationException("Verify-only must not invoke projector initialization.");
+        }
+
+        return inner.InitializeAsync(tables, ct);
+    }
+
+    public Task<IReadOnlyList<MvSqlStatementDto>> ApplyEventAsync(
+        SerializableEvent ev,
+        IMvTableBindings tables,
+        IMvApplyQueryPort queryPort,
+        string sortableUniqueId,
+        CancellationToken ct) =>
+        inner.ApplyEventAsync(ev, tables, queryPort, sortableUniqueId, ct);
+
+    public IReadOnlyList<MvSchemaTableRequirement> GetSchemaRequirements(IMvTableBindings tables) =>
+        inner.GetSchemaRequirements(tables);
+
+    public MvSchemaContract? GetSchemaContract(IMvTableBindings tables) =>
+        inner.GetSchemaContract(tables);
+}
+
+public enum PolicySurfaceKind
+{
+    Rows,
+    Single,
+    Scalar,
+    Raw,
+    Batch
+}
+
+internal sealed class PolicySurfaceProjector(PolicySurfaceKind surface, string sql) :
+    IMaterializedViewProjector,
+    IMvSchemaRequirementsProvider
+{
+    public string ViewName => "PolicySurface";
+    public int ViewVersion => 1;
+    public MvTable Records { get; private set; } = default!;
+
+    public IReadOnlyList<MvSchemaTableRequirement> GetSchemaRequirements(
+        MvDbType databaseType,
+        IMvTableBindings tables) =>
+    [
+        new MvSchemaTableRequirement(
+            "records",
+            tables.GetPhysicalName("records"),
+            [
+                new("id", MvSchemaTypeFamily.String, false),
+                new("value", MvSchemaTypeFamily.String, false)
+            ],
+            ["id"])
+    ];
+
+    public async Task InitializeAsync(IMvInitContext ctx, CancellationToken cancellationToken = default)
+    {
+        Records = ctx.RegisterTable("records");
+        await ctx.ExecuteAsync(
+                $"CREATE TABLE IF NOT EXISTS {Records.PhysicalName} (id TEXT NOT NULL PRIMARY KEY, value TEXT NOT NULL);",
+                cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    public async Task<IReadOnlyList<MvSqlStatement>> ApplyToViewAsync(
+        Event ev,
+        IMvApplyContext ctx,
+        CancellationToken cancellationToken = default)
+    {
+        switch (surface)
+        {
+            case PolicySurfaceKind.Rows:
+                await ctx.QueryRowsAsync(sql, cancellationToken: cancellationToken).ConfigureAwait(false);
+                break;
+            case PolicySurfaceKind.Single:
+                await ctx.QuerySingleOrDefaultRowAsync(sql, cancellationToken: cancellationToken).ConfigureAwait(false);
+                break;
+            case PolicySurfaceKind.Scalar:
+                await ctx.ExecuteScalarAsync<long>(sql, cancellationToken: cancellationToken).ConfigureAwait(false);
+                break;
+            case PolicySurfaceKind.Raw:
+                _ = ctx.Connection;
+                break;
+            case PolicySurfaceKind.Batch:
+                return
+                [
+                    new MvSqlStatement($"INSERT INTO {Records.PhysicalName} (id, value) VALUES ('first', 'first');"),
+                    new MvSqlStatement($"INSERT INTO {Records.PhysicalName} (id, value) VALUES ('second', 'second');")
+                ];
+        }
+
+        return
+        [
+            new MvSqlStatement(
+                $"INSERT INTO {Records.PhysicalName} (id, value) VALUES ('applied', 'applied');")
+        ];
     }
 }
 
@@ -391,27 +1000,48 @@ internal static class MvVerifyOnlyAssertions
         var projector = fixture.Services.GetRequiredService<CrossProviderWeatherForecastMvV1>();
         var host = new NativeMvApplyHost(projector, fixture.DomainTypes.EventTypes, fixture.DatabaseTypeForTests);
         await fixture.Executor.InitializeAsync(host).ConfigureAwait(false);
-
-        var policy = new RecordingPolicy(_ => MvSqlPolicyDecision.Allow());
-        var verifyExecutor = CreateVerifyExecutor(fixture, policy);
-        await verifyExecutor.InitializeAsync(
-                new NativeMvApplyHost(projector, fixture.DomainTypes.EventTypes, fixture.DatabaseTypeForTests))
+        var registryStore = fixture.Services.GetRequiredService<IMvRegistryStore>();
+        var entriesBefore = await registryStore.GetEntriesAsync(
+                MultiProviderFixtureBase.ServiceId,
+                projector.ViewName,
+                projector.ViewVersion)
             .ConfigureAwait(false);
 
-        var initializationContext = Assert.Single(policy.Contexts);
-        Assert.Equal(MvSqlStatementPhase.Initialization, initializationContext.Phase);
-        Assert.Equal(MultiProviderFixtureBase.ServiceId, initializationContext.ServiceId);
-        Assert.Equal(projector.ViewName, initializationContext.ViewName);
-        Assert.Equal(projector.ViewVersion, initializationContext.ViewVersion);
-        var initializationTable = Assert.Single(initializationContext.Tables);
-        Assert.Equal("forecasts", initializationTable.LogicalName);
-        Assert.Equal(projector.Forecasts.PhysicalName, initializationTable.PhysicalName);
-        Assert.Contains("CREATE TABLE", initializationContext.Sql, StringComparison.OrdinalIgnoreCase);
+        var policy = new RecordingPolicy(_ => MvSqlPolicyDecision.Allow());
+        var catalogCommands = new List<string>();
+        var verifyExecutor = CreateVerifyExecutor(fixture, policy, catalogCommands.Add);
+        var verifyHost = new CountingApplyHost(
+            new NativeMvApplyHost(projector, fixture.DomainTypes.EventTypes, fixture.DatabaseTypeForTests));
+        await verifyExecutor.InitializeAsync(
+                verifyHost)
+            .ConfigureAwait(false);
+
+        Assert.Equal(0, verifyHost.InitializeCalls);
+        Assert.Empty(policy.Contexts);
+        Assert.NotEmpty(catalogCommands);
+        Assert.All(catalogCommands, command =>
+        {
+            var normalized = command.TrimStart();
+            Assert.StartsWith("SELECT", normalized, StringComparison.OrdinalIgnoreCase);
+            Assert.False(
+                Regex.IsMatch(
+                    normalized,
+                    @"\b(?:CREATE|ALTER|DROP|INSERT|UPDATE|DELETE)\s",
+                    RegexOptions.IgnoreCase),
+                normalized);
+        });
+        var entriesAfter = await registryStore.GetEntriesAsync(
+                MultiProviderFixtureBase.ServiceId,
+                projector.ViewName,
+                projector.ViewVersion)
+            .ConfigureAwait(false);
+        Assert.Equal(entriesBefore, entriesAfter);
     }
 
     private static IMvExecutor CreateVerifyExecutor(
         MultiProviderFixtureBase fixture,
-        IMvSqlStatementPolicy policy)
+        IMvSqlStatementPolicy policy,
+        Action<string>? catalogCommandRecorder)
     {
         var options = Options.Create(new MvOptions
         {
@@ -426,25 +1056,25 @@ internal static class MvVerifyOnlyAssertions
         {
             MvDbType.Postgres => new PostgresMvExecutor(
                 fixture.EventStoreFactory,
-                new PostgresMvRegistryStore(connectionString),
+                new PostgresMvRegistryStore(connectionString, catalogCommandRecorder),
                 options,
                 NullLogger<PostgresMvExecutor>.Instance,
                 connectionString),
             MvDbType.MySql => new MySqlMvExecutor(
                 fixture.EventStoreFactory,
-                new MySqlMvRegistryStore(connectionString),
+                new MySqlMvRegistryStore(connectionString, catalogCommandRecorder),
                 options,
                 NullLogger<MySqlMvExecutor>.Instance,
                 connectionString),
             MvDbType.SqlServer => new SqlServerMvExecutor(
                 fixture.EventStoreFactory,
-                new SqlServerMvRegistryStore(connectionString),
+                new SqlServerMvRegistryStore(connectionString, catalogCommandRecorder),
                 options,
                 NullLogger<SqlServerMvExecutor>.Instance,
                 connectionString),
             MvDbType.Sqlite => new SqliteMvExecutor(
                 fixture.EventStoreFactory,
-                new SqliteMvRegistryStore(connectionString),
+                new SqliteMvRegistryStore(connectionString, catalogCommandRecorder),
                 options,
                 NullLogger<SqliteMvExecutor>.Instance,
                 connectionString),

--- a/dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/MvVerifyOnlyAndPolicyTests.cs
+++ b/dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/MvVerifyOnlyAndPolicyTests.cs
@@ -1,0 +1,468 @@
+using System.Data;
+using Dapper;
+using Dcb.Domain.WithoutResult.Weather;
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Sekiban.Dcb.Common;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.MaterializedView;
+using Sekiban.Dcb.MaterializedView.MySql;
+using Sekiban.Dcb.MaterializedView.Postgres;
+using Sekiban.Dcb.MaterializedView.Sqlite;
+using Sekiban.Dcb.MaterializedView.SqlServer;
+using Sekiban.Dcb.Storage;
+using Xunit;
+
+namespace Sekiban.Dcb.MaterializedView.MultiProvider.Tests;
+
+[Collection(nameof(SqliteMvCollection))]
+public sealed class SqliteMvVerifyOnlyAndPolicyTests(SqliteMvFixture fixture)
+{
+    [SkippableFact]
+    public async Task VerifyOnly_UsesPreProvisionedSchema_OnReadOnlyConnection_WithoutDdl()
+    {
+        Skip.IfNot(fixture.IsAvailable, fixture.AvailabilityMessage ?? "SQLite fixture is unavailable.");
+        await fixture.ResetAsync().ConfigureAwait(false);
+
+        var projector = fixture.Services.GetRequiredService<CrossProviderWeatherForecastMvV1>();
+        await fixture.Executor.InitializeAsync(CreateHost(projector)).ConfigureAwait(false);
+        var schemaVersionBefore = await ReadSchemaVersionAsync().ConfigureAwait(false);
+        var readOnlyConnectionString = new SqliteConnectionStringBuilder(fixture.ConnectionStringForTests)
+        {
+            Mode = SqliteOpenMode.ReadOnly
+        }.ToString();
+        var policy = new RecordingPolicy(_ => MvSqlPolicyDecision.Allow());
+        var verifyExecutor = CreateExecutor(
+            readOnlyConnectionString,
+            MvInitializationMode.VerifyOnly,
+            policy,
+            rejectEnsureInfrastructure: true);
+
+        await verifyExecutor.InitializeAsync(CreateHost(projector)).ConfigureAwait(false);
+
+        var schemaVersionAfter = await ReadSchemaVersionAsync().ConfigureAwait(false);
+        Assert.Equal(schemaVersionBefore, schemaVersionAfter);
+        var initializationContext = Assert.Single(policy.Contexts);
+        Assert.Equal(MvSqlStatementPhase.Initialization, initializationContext.Phase);
+        Assert.Equal(MultiProviderFixtureBase.ServiceId, initializationContext.ServiceId);
+        Assert.Equal(projector.ViewName, initializationContext.ViewName);
+        Assert.Equal(projector.ViewVersion, initializationContext.ViewVersion);
+        var initializationTable = Assert.Single(initializationContext.Tables);
+        Assert.Equal("forecasts", initializationTable.LogicalName);
+        Assert.Equal(projector.Forecasts.PhysicalName, initializationTable.PhysicalName);
+        Assert.Contains("CREATE TABLE", initializationContext.Sql, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [SkippableFact]
+    public async Task VerifyOnly_MissingTargetFailsBeforeRegistryMutation()
+    {
+        Skip.IfNot(fixture.IsAvailable, fixture.AvailabilityMessage ?? "SQLite fixture is unavailable.");
+        await fixture.ResetAsync().ConfigureAwait(false);
+        var registryStore = fixture.Services.GetRequiredService<IMvRegistryStore>();
+        await registryStore.EnsureInfrastructureAsync().ConfigureAwait(false);
+        var projector = fixture.Services.GetRequiredService<CrossProviderWeatherForecastMvV1>();
+        var verifyExecutor = CreateExecutor(fixture.ConnectionStringForTests, MvInitializationMode.VerifyOnly, new RecordingPolicy(_ => MvSqlPolicyDecision.Allow()));
+
+        var exception = await Assert.ThrowsAsync<MvInitializationException>(
+            () => verifyExecutor.InitializeAsync(CreateHost(projector))).ConfigureAwait(false);
+
+        Assert.Equal(MvInitializationFailureReason.MissingSchemaObject, exception.Failure.Reason);
+        await using var connection = await fixture.OpenConnectionAsync().ConfigureAwait(false);
+        Assert.Equal(0, await connection.ExecuteScalarAsync<long>("SELECT COUNT(*) FROM sekiban_mv_registry;"));
+    }
+
+    [SkippableFact]
+    public async Task VerifyOnly_MissingFrameworkRegistryFailsClosedBeforeAnyMutation()
+    {
+        Skip.IfNot(fixture.IsAvailable, fixture.AvailabilityMessage ?? "SQLite fixture is unavailable.");
+        await fixture.ResetAsync().ConfigureAwait(false);
+        var projector = fixture.Services.GetRequiredService<CrossProviderWeatherForecastMvV1>();
+        var verifyExecutor = CreateExecutor(
+            fixture.ConnectionStringForTests,
+            MvInitializationMode.VerifyOnly,
+            new RecordingPolicy(_ => MvSqlPolicyDecision.Allow()));
+
+        var exception = await Assert.ThrowsAsync<MvInitializationException>(
+            () => verifyExecutor.InitializeAsync(CreateHost(projector))).ConfigureAwait(false);
+
+        Assert.Equal(MvInitializationFailureReason.MissingSchemaObject, exception.Failure.Reason);
+        await using var connection = await fixture.OpenConnectionAsync().ConfigureAwait(false);
+        Assert.Equal(
+            0,
+            await connection.ExecuteScalarAsync<long>(
+                "SELECT COUNT(*) FROM sqlite_master WHERE name LIKE 'sekiban_mv_%';"));
+    }
+
+    [SkippableFact]
+    public async Task VerifyOnly_IncompatibleColumnFailsClosedBeforeRegistryMutation()
+    {
+        Skip.IfNot(fixture.IsAvailable, fixture.AvailabilityMessage ?? "SQLite fixture is unavailable.");
+        await fixture.ResetAsync().ConfigureAwait(false);
+        var registryStore = fixture.Services.GetRequiredService<IMvRegistryStore>();
+        await registryStore.EnsureInfrastructureAsync().ConfigureAwait(false);
+        await using (var connection = await fixture.OpenConnectionAsync().ConfigureAwait(false))
+        {
+            await connection.ExecuteAsync(
+                """
+                CREATE TABLE sekiban_mv_weatherforecastportable_v1_forecasts (
+                    forecast_id TEXT NOT NULL PRIMARY KEY,
+                    location TEXT NOT NULL,
+                    forecast_date TEXT NOT NULL,
+                    temperature_c TEXT NOT NULL,
+                    summary TEXT NULL,
+                    is_deleted INTEGER NOT NULL DEFAULT 0,
+                    _last_sortable_unique_id TEXT NOT NULL,
+                    _last_applied_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+                );
+                """).ConfigureAwait(false);
+        }
+
+        var projector = fixture.Services.GetRequiredService<CrossProviderWeatherForecastMvV1>();
+        var verifyExecutor = CreateExecutor(fixture.ConnectionStringForTests, MvInitializationMode.VerifyOnly, new RecordingPolicy(_ => MvSqlPolicyDecision.Allow()));
+        var exception = await Assert.ThrowsAsync<MvInitializationException>(
+            () => verifyExecutor.InitializeAsync(CreateHost(projector))).ConfigureAwait(false);
+
+        Assert.Equal(MvInitializationFailureReason.IncompatibleSchema, exception.Failure.Reason);
+        await using var checkConnection = await fixture.OpenConnectionAsync().ConfigureAwait(false);
+        Assert.Equal(0, await checkConnection.ExecuteScalarAsync<long>("SELECT COUNT(*) FROM sekiban_mv_registry;"));
+    }
+
+    [SkippableFact]
+    public async Task InitializationPolicyRejectsBeforeProviderCommands()
+    {
+        Skip.IfNot(fixture.IsAvailable, fixture.AvailabilityMessage ?? "SQLite fixture is unavailable.");
+        await fixture.ResetAsync().ConfigureAwait(false);
+        var policy = new RecordingPolicy(_ => MvSqlPolicyDecision.Reject("DDL is not approved for this host."));
+        var executor = CreateExecutor(fixture.ConnectionStringForTests, MvInitializationMode.CreateOrEnsure, policy);
+        var projector = fixture.Services.GetRequiredService<CrossProviderWeatherForecastMvV1>();
+
+        var exception = await Assert.ThrowsAsync<MvSqlPolicyRejectedException>(
+            () => executor.InitializeAsync(CreateHost(projector))).ConfigureAwait(false);
+
+        Assert.Equal(MvSqlStatementPhase.Initialization, exception.Failure.Phase);
+        Assert.Single(policy.Contexts);
+        await using var connection = await fixture.OpenConnectionAsync().ConfigureAwait(false);
+        Assert.Equal(
+            0,
+            await connection.ExecuteScalarAsync<long>(
+                "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name LIKE 'sekiban_mv_%';"));
+    }
+
+    [SkippableFact]
+    public async Task ApplyPolicyRejectsBeforeProviderMutation()
+    {
+        Skip.IfNot(fixture.IsAvailable, fixture.AvailabilityMessage ?? "SQLite fixture is unavailable.");
+        await fixture.ResetAsync().ConfigureAwait(false);
+        var projector = fixture.Services.GetRequiredService<CrossProviderWeatherForecastMvV1>();
+        await fixture.Executor.InitializeAsync(CreateHost(projector)).ConfigureAwait(false);
+        await using (var guardConnection = await fixture.OpenConnectionAsync().ConfigureAwait(false))
+        {
+            await guardConnection.ExecuteAsync(
+                $"""
+                CREATE TRIGGER mv_policy_execution_guard
+                BEFORE INSERT ON {MultiProviderFixtureBase.ForecastTable}
+                BEGIN
+                    SELECT RAISE(ABORT, 'policy test reached provider execution');
+                END;
+                """).ConfigureAwait(false);
+        }
+        var policy = new RecordingPolicy(context =>
+            context.Phase == MvSqlStatementPhase.Apply
+                ? MvSqlPolicyDecision.Reject("Apply is not approved for this host.")
+                : MvSqlPolicyDecision.Allow());
+        var executor = CreateExecutor(fixture.ConnectionStringForTests, MvInitializationMode.CreateOrEnsure, policy);
+        var forecastId = Guid.CreateVersion7();
+        var eventId = Guid.CreateVersion7();
+        var eventValue = new Event(
+            new WeatherForecastCreated(
+                forecastId,
+                "Tokyo",
+                DateOnly.FromDateTime(DateTime.UtcNow),
+                20,
+                "Sunny"),
+            SortableUniqueId.Generate(DateTime.UtcNow.AddMinutes(-1), eventId),
+            nameof(WeatherForecastCreated),
+            eventId,
+            new EventMetadata("policy-test", "policy-test", "test"),
+            []);
+        var serializableEvent = eventValue.ToSerializableEvent(fixture.DomainTypes.EventTypes);
+
+        var exception = await Assert.ThrowsAsync<MvSqlPolicyRejectedException>(
+            () => executor.ApplySerializableEventsAsync(CreateHost(projector), [serializableEvent])).ConfigureAwait(false);
+
+        Assert.Equal(MvSqlStatementPhase.Apply, exception.Failure.Phase);
+        var applyContext = Assert.Single(policy.Contexts);
+        Assert.Equal(MvSqlStatementPhase.Apply, applyContext.Phase);
+        Assert.Equal(MultiProviderFixtureBase.ServiceId, applyContext.ServiceId);
+        Assert.Equal(projector.ViewName, applyContext.ViewName);
+        Assert.Equal(projector.ViewVersion, applyContext.ViewVersion);
+        var applyTable = Assert.Single(applyContext.Tables);
+        Assert.Equal("forecasts", applyTable.LogicalName);
+        Assert.Equal(projector.Forecasts.PhysicalName, applyTable.PhysicalName);
+        Assert.Contains(
+            applyContext.Parameters,
+            parameter => parameter.Name == "ForecastId" && parameter.Kind == MvParamKind.String);
+        await using var connection = await fixture.OpenConnectionAsync().ConfigureAwait(false);
+        Assert.Equal(
+            0,
+            await connection.ExecuteScalarAsync<long>(
+                "SELECT COUNT(*) FROM sekiban_mv_weatherforecastportable_v1_forecasts;"));
+        Assert.Equal(
+            0,
+            await connection.ExecuteScalarAsync<long>(
+                """
+                SELECT applied_event_version
+                FROM sekiban_mv_registry
+                WHERE service_id = @ServiceId
+                  AND view_name = 'WeatherForecastPortable'
+                  AND logical_table = 'forecasts';
+                """,
+                new { ServiceId = MultiProviderFixtureBase.ServiceId }));
+    }
+
+    private NativeMvApplyHost CreateHost(CrossProviderWeatherForecastMvV1 projector) =>
+        new(projector, fixture.DomainTypes.EventTypes, MvDbType.Sqlite);
+
+    private SqliteMvExecutor CreateExecutor(
+        string connectionString,
+        MvInitializationMode initializationMode,
+        IMvSqlStatementPolicy policy,
+        bool rejectEnsureInfrastructure = false)
+    {
+        var registry = connectionString == fixture.ConnectionStringForTests
+            ? fixture.Services.GetRequiredService<IMvRegistryStore>()
+            : new SqliteMvRegistryStore(connectionString);
+        if (rejectEnsureInfrastructure)
+        {
+            registry = new EnsureRejectingRegistryStore(
+                registry,
+                Assert.IsAssignableFrom<IMvSchemaVerifier>(registry));
+        }
+
+        return new SqliteMvExecutor(
+            fixture.EventStoreFactory,
+            registry,
+            Options.Create(new MvOptions
+            {
+                ServiceId = MultiProviderFixtureBase.ServiceId,
+                InitializationMode = initializationMode,
+                SqlStatementPolicy = policy,
+                SafeWindowMs = 0,
+                BatchSize = 100
+            }),
+            NullLogger<SqliteMvExecutor>.Instance,
+            connectionString);
+    }
+
+    private async Task<int> ReadSchemaVersionAsync()
+    {
+        await using var connection = await fixture.OpenConnectionAsync().ConfigureAwait(false);
+        return await connection.ExecuteScalarAsync<int>("PRAGMA schema_version;").ConfigureAwait(false);
+    }
+
+    private sealed class RecordingPolicy(
+        Func<MvSqlStatementContext, MvSqlPolicyDecision> decision) : IMvSqlStatementPolicy
+    {
+        public List<MvSqlStatementContext> Contexts { get; } = [];
+
+        public ValueTask<MvSqlPolicyDecision> EvaluateAsync(
+            MvSqlStatementContext context,
+            CancellationToken cancellationToken = default)
+        {
+            Contexts.Add(context);
+            return ValueTask.FromResult(decision(context));
+        }
+    }
+
+    private sealed class EnsureRejectingRegistryStore(
+        IMvRegistryStore inner,
+        IMvSchemaVerifier schemaVerifier) : IMvRegistryStore, IMvSchemaVerifier
+    {
+        public Task EnsureInfrastructureAsync(CancellationToken cancellationToken = default) =>
+            throw new InvalidOperationException("Verify-only must not enter EnsureInfrastructureAsync.");
+
+        public Task RegisterAsync(MvRegistryEntry entry, IDbTransaction? transaction = null, CancellationToken cancellationToken = default) =>
+            inner.RegisterAsync(entry, transaction, cancellationToken);
+
+        public Task UpdatePositionAsync(MvPositionUpdate update, IDbTransaction? transaction = null, CancellationToken cancellationToken = default) =>
+            inner.UpdatePositionAsync(update, transaction, cancellationToken);
+
+        public Task MarkStreamReceivedAsync(
+            string serviceId,
+            string viewName,
+            int viewVersion,
+            string sortableUniqueId,
+            DateTimeOffset receivedAt,
+            IDbTransaction? transaction = null,
+            CancellationToken cancellationToken = default) =>
+            inner.MarkStreamReceivedAsync(serviceId, viewName, viewVersion, sortableUniqueId, receivedAt, transaction, cancellationToken);
+
+        public Task UpdateStatusAsync(
+            string serviceId,
+            string viewName,
+            int viewVersion,
+            MvStatus status,
+            IDbTransaction? transaction = null,
+            CancellationToken cancellationToken = default) =>
+            inner.UpdateStatusAsync(serviceId, viewName, viewVersion, status, transaction, cancellationToken);
+
+        public Task<IReadOnlyList<MvRegistryEntry>> GetEntriesAsync(
+            string serviceId,
+            string viewName,
+            int viewVersion,
+            CancellationToken cancellationToken = default) =>
+            inner.GetEntriesAsync(serviceId, viewName, viewVersion, cancellationToken);
+
+        public Task<MvActiveEntry?> GetActiveAsync(
+            string serviceId,
+            string viewName,
+            CancellationToken cancellationToken = default) =>
+            inner.GetActiveAsync(serviceId, viewName, cancellationToken);
+
+        public Task SetTargetCheckpointAsync(
+            string serviceId,
+            string viewName,
+            int viewVersion,
+            MvCheckpointTruth targetCheckpointTruth,
+            IDbTransaction? transaction = null,
+            CancellationToken cancellationToken = default) =>
+            inner.SetTargetCheckpointAsync(serviceId, viewName, viewVersion, targetCheckpointTruth, transaction, cancellationToken);
+
+        public Task<MvActivationResult> TryActivateAsync(
+            MvActivationRequest request,
+            IDbTransaction? transaction = null,
+            CancellationToken cancellationToken = default) =>
+            inner.TryActivateAsync(request, transaction, cancellationToken);
+
+        public Task<MvActivationResult> TryForceReverseAsync(
+            MvForcedReverseRequest request,
+            IDbTransaction? transaction = null,
+            CancellationToken cancellationToken = default) =>
+            inner.TryForceReverseAsync(request, transaction, cancellationToken);
+
+        public Task SetActiveAsync(
+            string serviceId,
+            string viewName,
+            int activeVersion,
+            IDbTransaction? transaction = null,
+            CancellationToken cancellationToken = default) =>
+            inner.SetActiveAsync(serviceId, viewName, activeVersion, transaction, cancellationToken);
+
+        public Task<MvSchemaVerificationResult> VerifySchemaAsync(
+            IReadOnlyList<MvSchemaTableRequirement> requirements,
+            CancellationToken cancellationToken = default) =>
+            schemaVerifier.VerifySchemaAsync(requirements, cancellationToken);
+    }
+}
+
+[Collection(nameof(PostgresMvCollection))]
+public sealed class PostgresMvVerifyOnlyTests(PostgresMvFixture fixture)
+{
+    [SkippableFact]
+    public Task VerifyOnly_UsesTheCommonContractAgainstTheRealStore() =>
+        MvVerifyOnlyAssertions.AssertCommonContractAsync(fixture);
+}
+
+[Collection(nameof(MySqlMvCollection))]
+public sealed class MySqlMvVerifyOnlyTests(MySqlMvFixture fixture)
+{
+    [SkippableFact]
+    public Task VerifyOnly_UsesTheCommonContractAgainstTheRealStore() =>
+        MvVerifyOnlyAssertions.AssertCommonContractAsync(fixture);
+}
+
+[Collection(nameof(SqlServerMvCollection))]
+public sealed class SqlServerMvVerifyOnlyTests(SqlServerMvFixture fixture)
+{
+    [SkippableFact]
+    public Task VerifyOnly_UsesTheCommonContractAgainstTheRealStore() =>
+        MvVerifyOnlyAssertions.AssertCommonContractAsync(fixture);
+}
+
+internal static class MvVerifyOnlyAssertions
+{
+    public static async Task AssertCommonContractAsync(MultiProviderFixtureBase fixture)
+    {
+        Skip.IfNot(fixture.IsAvailable, fixture.AvailabilityMessage ?? "Provider fixture is unavailable.");
+        await fixture.ResetAsync().ConfigureAwait(false);
+
+        var projector = fixture.Services.GetRequiredService<CrossProviderWeatherForecastMvV1>();
+        var host = new NativeMvApplyHost(projector, fixture.DomainTypes.EventTypes, fixture.DatabaseTypeForTests);
+        await fixture.Executor.InitializeAsync(host).ConfigureAwait(false);
+
+        var policy = new RecordingPolicy(_ => MvSqlPolicyDecision.Allow());
+        var verifyExecutor = CreateVerifyExecutor(fixture, policy);
+        await verifyExecutor.InitializeAsync(
+                new NativeMvApplyHost(projector, fixture.DomainTypes.EventTypes, fixture.DatabaseTypeForTests))
+            .ConfigureAwait(false);
+
+        var initializationContext = Assert.Single(policy.Contexts);
+        Assert.Equal(MvSqlStatementPhase.Initialization, initializationContext.Phase);
+        Assert.Equal(MultiProviderFixtureBase.ServiceId, initializationContext.ServiceId);
+        Assert.Equal(projector.ViewName, initializationContext.ViewName);
+        Assert.Equal(projector.ViewVersion, initializationContext.ViewVersion);
+        var initializationTable = Assert.Single(initializationContext.Tables);
+        Assert.Equal("forecasts", initializationTable.LogicalName);
+        Assert.Equal(projector.Forecasts.PhysicalName, initializationTable.PhysicalName);
+        Assert.Contains("CREATE TABLE", initializationContext.Sql, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static IMvExecutor CreateVerifyExecutor(
+        MultiProviderFixtureBase fixture,
+        IMvSqlStatementPolicy policy)
+    {
+        var options = Options.Create(new MvOptions
+        {
+            ServiceId = MultiProviderFixtureBase.ServiceId,
+            InitializationMode = MvInitializationMode.VerifyOnly,
+            SqlStatementPolicy = policy,
+            SafeWindowMs = 0,
+            BatchSize = 100
+        });
+        var connectionString = fixture.ConnectionStringForTests;
+        return fixture.DatabaseTypeForTests switch
+        {
+            MvDbType.Postgres => new PostgresMvExecutor(
+                fixture.EventStoreFactory,
+                new PostgresMvRegistryStore(connectionString),
+                options,
+                NullLogger<PostgresMvExecutor>.Instance,
+                connectionString),
+            MvDbType.MySql => new MySqlMvExecutor(
+                fixture.EventStoreFactory,
+                new MySqlMvRegistryStore(connectionString),
+                options,
+                NullLogger<MySqlMvExecutor>.Instance,
+                connectionString),
+            MvDbType.SqlServer => new SqlServerMvExecutor(
+                fixture.EventStoreFactory,
+                new SqlServerMvRegistryStore(connectionString),
+                options,
+                NullLogger<SqlServerMvExecutor>.Instance,
+                connectionString),
+            MvDbType.Sqlite => new SqliteMvExecutor(
+                fixture.EventStoreFactory,
+                new SqliteMvRegistryStore(connectionString),
+                options,
+                NullLogger<SqliteMvExecutor>.Instance,
+                connectionString),
+            _ => throw new NotSupportedException($"Provider '{fixture.DatabaseTypeForTests}' is not supported.")
+        };
+    }
+
+    private sealed class RecordingPolicy(
+        Func<MvSqlStatementContext, MvSqlPolicyDecision> decision) : IMvSqlStatementPolicy
+    {
+        public List<MvSqlStatementContext> Contexts { get; } = [];
+
+        public ValueTask<MvSqlPolicyDecision> EvaluateAsync(
+            MvSqlStatementContext context,
+            CancellationToken cancellationToken = default)
+        {
+            Contexts.Add(context);
+            return ValueTask.FromResult(decision(context));
+        }
+    }
+}

--- a/dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/MvVerifyOnlyAndPolicyTests.cs
+++ b/dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/MvVerifyOnlyAndPolicyTests.cs
@@ -30,16 +30,14 @@ public sealed class SqliteMvVerifyOnlyAndPolicyTests(SqliteMvFixture fixture)
         var projector = fixture.Services.GetRequiredService<CrossProviderWeatherForecastMvV1>();
         await fixture.Executor.InitializeAsync(CreateHost(projector)).ConfigureAwait(false);
         var schemaVersionBefore = await ReadSchemaVersionAsync().ConfigureAwait(false);
-        var readOnlyConnectionString = new SqliteConnectionStringBuilder(fixture.ConnectionStringForTests)
-        {
-            Mode = SqliteOpenMode.ReadOnly
-        }.ToString();
         var policy = new RecordingPolicy(_ => MvSqlPolicyDecision.Allow());
+        var readOnlyConnections = new List<string>();
         var verifyExecutor = CreateExecutor(
-            readOnlyConnectionString,
+            fixture.ConnectionStringForTests,
             MvInitializationMode.VerifyOnly,
             policy,
-            rejectEnsureInfrastructure: true);
+            rejectEnsureInfrastructure: true,
+            readOnlyConnectionRecorder: readOnlyConnections.Add);
 
         var verifyHost = new CountingApplyHost(CreateHost(projector), throwOnInitialize: true);
         await verifyExecutor.InitializeAsync(verifyHost).ConfigureAwait(false);
@@ -48,6 +46,107 @@ public sealed class SqliteMvVerifyOnlyAndPolicyTests(SqliteMvFixture fixture)
         Assert.Equal(schemaVersionBefore, schemaVersionAfter);
         Assert.Equal(0, verifyHost.InitializeCalls);
         Assert.Empty(policy.Contexts);
+        Assert.Contains("sqlite:Mode=ReadOnly", readOnlyConnections);
+    }
+
+    [SkippableFact]
+    public async Task VerifyOnly_CompatibleOperationBoundaries_NeverReachRegistryMutation()
+    {
+        Skip.IfNot(fixture.IsAvailable, fixture.AvailabilityMessage ?? "SQLite fixture is unavailable.");
+        await fixture.ResetAsync().ConfigureAwait(false);
+        var projector = fixture.Services.GetRequiredService<CrossProviderWeatherForecastMvV1>();
+        var host = CreateHost(projector);
+        await fixture.Executor.InitializeAsync(host).ConfigureAwait(false);
+
+        var readOnlyConnections = new List<string>();
+        var realStore = new SqliteMvRegistryStore(
+            fixture.ConnectionStringForTests,
+            catalogCommandRecorder: null,
+            readOnlyConnectionRecorder: readOnlyConnections.Add);
+        await realStore.SetTargetCheckpointAsync(
+                MultiProviderFixtureBase.ServiceId,
+                projector.ViewName,
+                projector.ViewVersion,
+                MvCheckpointTruth.KnownZero(MvCheckpointProvenance.AuthoritativeTargetCapture()))
+            .ConfigureAwait(false);
+        await realStore.UpdatePositionAsync(
+                new MvPositionUpdate(
+                    MultiProviderFixtureBase.ServiceId,
+                    projector.ViewName,
+                    projector.ViewVersion,
+                    SortableUniqueId.MinValue.Value,
+                    MvApplySource.CatchUp,
+                    AppliedEventVersionDelta: 0)
+                {
+                    CheckpointTruth = MvCheckpointTruth.KnownZero()
+                })
+            .ConfigureAwait(false);
+        await realStore.UpdateStatusAsync(
+                MultiProviderFixtureBase.ServiceId,
+                projector.ViewName,
+                projector.ViewVersion,
+                MvStatus.Ready)
+            .ConfigureAwait(false);
+        var guardedRegistry = new EnsureRejectingRegistryStore(
+            Assert.IsAssignableFrom<IMvReadOnlyMvInspector>(realStore));
+        var executor = new SqliteMvExecutor(
+            fixture.EventStoreFactory,
+            guardedRegistry,
+            Options.Create(new MvOptions
+            {
+                ServiceId = MultiProviderFixtureBase.ServiceId,
+                InitializationMode = MvInitializationMode.VerifyOnly,
+                SafeWindowMs = 0,
+                BatchSize = 100
+            }),
+            NullLogger<SqliteMvExecutor>.Instance,
+            fixture.ConnectionStringForTests);
+
+        await executor.InitializeAsync(new CountingApplyHost(host, throwOnInitialize: true)).ConfigureAwait(false);
+        _ = await executor.CaptureTargetCheckpointAsync(host).ConfigureAwait(false);
+        _ = await executor.CatchUpOnceAsync(host).ConfigureAwait(false);
+        var activation = await executor.TryActivateAsync(host).ConfigureAwait(false);
+        var applied = await executor.ApplySerializableEventsAsync(host, [CreatePolicyEvent()]).ConfigureAwait(false);
+        var coordinator = new MvGenerationCoordinator(
+            executor,
+            guardedRegistry,
+            Options.Create(new MvOptions
+            {
+                ServiceId = MultiProviderFixtureBase.ServiceId,
+                InitializationMode = MvInitializationMode.VerifyOnly
+            }));
+        var forcedReverse = await coordinator.ForceReverseAsync(
+                host,
+                expectedActiveVersion: projector.ViewVersion + 1,
+                expectedActiveGeneration: 0,
+                reason: "verify-only mutation probe")
+            .ConfigureAwait(false);
+
+        Assert.Equal(MvActivationFailureReason.ProviderFailure, activation.FailureReason);
+        Assert.Equal(MvActivationFailureReason.ProviderFailure, forcedReverse.FailureReason);
+        Assert.Equal(0, applied);
+        Assert.Equal(0, guardedRegistry.EnsureCalls);
+        Assert.Equal(0, guardedRegistry.RegisterCalls);
+        Assert.Equal(0, guardedRegistry.TargetCheckpointCalls);
+        Assert.Equal(0, guardedRegistry.PositionCalls);
+        Assert.Equal(0, guardedRegistry.StatusCalls);
+        Assert.Equal(0, guardedRegistry.ActivationCalls);
+        Assert.Equal(0, guardedRegistry.ActivePointerCalls);
+        Assert.Contains("sqlite:Mode=ReadOnly", readOnlyConnections);
+
+        await realStore.SetTargetCheckpointAsync(
+                MultiProviderFixtureBase.ServiceId,
+                projector.ViewName,
+                projector.ViewVersion,
+                MvCheckpointTruth.Unknown(MvCheckpointUnknownReason.ReadUnavailable))
+            .ConfigureAwait(false);
+        _ = await executor.CatchUpOnceAsync(host).ConfigureAwait(false);
+        var entriesAfterCatchUp = await realStore.ReadRegistryEntriesAsync(
+                MultiProviderFixtureBase.ServiceId,
+                projector.ViewName,
+                projector.ViewVersion)
+            .ConfigureAwait(false);
+        Assert.All(entriesAfterCatchUp, entry => Assert.True(entry.TargetCheckpointTruth.IsUnknown));
     }
 
     [SkippableFact]
@@ -279,6 +378,8 @@ public sealed class SqliteMvVerifyOnlyAndPolicyTests(SqliteMvFixture fixture)
 
         Assert.Equal(MvSqlStatementPhase.Initialization, exception.Failure.Phase);
         Assert.Single(policy.Contexts);
+        Assert.Equal(MvSqlStatementOrigin.ProjectorInitialize, policy.Contexts[0].Origin);
+        Assert.Equal(MvDbType.Sqlite, policy.Contexts[0].DatabaseType);
         await using var connection = await fixture.OpenConnectionAsync().ConfigureAwait(false);
         Assert.Equal(
             0,
@@ -354,7 +455,7 @@ public sealed class SqliteMvVerifyOnlyAndPolicyTests(SqliteMvFixture fixture)
         }
         var policy = new RecordingPolicy(context =>
             context.Phase == MvSqlStatementPhase.Apply
-                ? MvSqlPolicyDecision.Reject("Apply is not approved for this host.")
+                ? MvSqlPolicyDecision.Reject("Apply is not approved for this host.", "apply-deny-rule")
                 : MvSqlPolicyDecision.Allow());
         var executor = CreateExecutor(
             fixture.ConnectionStringForTests,
@@ -382,6 +483,9 @@ public sealed class SqliteMvVerifyOnlyAndPolicyTests(SqliteMvFixture fixture)
 
         Assert.Equal(MvSqlStatementPhase.Apply, exception.Failure.Phase);
         Assert.Equal(MvSqlPolicyFailureReason.Denied, exception.Failure.FailureReason);
+        Assert.Equal(MvSqlStatementOrigin.ProjectorApply, exception.Failure.Origin);
+        Assert.Equal(MvDbType.Sqlite, exception.Failure.DatabaseType);
+        Assert.Equal("apply-deny-rule", exception.Failure.RuleId);
         Assert.False(string.IsNullOrWhiteSpace(exception.Failure.SqlSha256));
         var applyContext = Assert.Single(policy.Contexts);
         Assert.Equal(MvSqlStatementPhase.Apply, applyContext.Phase);
@@ -442,6 +546,8 @@ public sealed class SqliteMvVerifyOnlyAndPolicyTests(SqliteMvFixture fixture)
         Assert.Equal(MvSqlStatementPhase.Apply, exception.Failure.Phase);
         var queryContext = Assert.Single(policy.Contexts, context => context.Phase == MvSqlStatementPhase.Apply);
         Assert.Equal(sql, queryContext.Sql);
+        Assert.Equal(MvSqlStatementOrigin.ProjectorQuery, queryContext.Origin);
+        Assert.Equal(MvDbType.Sqlite, queryContext.DatabaseType);
         await using var connection = await fixture.OpenConnectionAsync().ConfigureAwait(false);
         Assert.Equal(0, await connection.ExecuteScalarAsync<long>($"SELECT COUNT(*) FROM {projector.Records.PhysicalName};"));
         Assert.Equal(
@@ -502,6 +608,8 @@ public sealed class SqliteMvVerifyOnlyAndPolicyTests(SqliteMvFixture fixture)
 
         Assert.Equal(MvSqlStatementPhase.Apply, exception.Failure.Phase);
         Assert.Contains("raw connection", exception.Failure.Reason, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(MvSqlStatementOrigin.ProjectorQuery, exception.Failure.Origin);
+        Assert.Equal(MvDbType.Sqlite, exception.Failure.DatabaseType);
         await using var connection = await fixture.OpenConnectionAsync().ConfigureAwait(false);
         Assert.Equal(0, await connection.ExecuteScalarAsync<long>($"SELECT COUNT(*) FROM {projector.Records.PhysicalName};"));
     }
@@ -638,15 +746,15 @@ public sealed class SqliteMvVerifyOnlyAndPolicyTests(SqliteMvFixture fixture)
         MvInitializationMode initializationMode,
         IMvSqlStatementPolicy? policy,
         bool rejectEnsureInfrastructure = false,
-        MvSqlStatementPolicyMode policyMode = MvSqlStatementPolicyMode.Legacy)
+        MvSqlStatementPolicyMode policyMode = MvSqlStatementPolicyMode.Legacy,
+        Action<string>? readOnlyConnectionRecorder = null)
     {
-        var registry = connectionString == fixture.ConnectionStringForTests
+        var registry = connectionString == fixture.ConnectionStringForTests && readOnlyConnectionRecorder is null
             ? fixture.Services.GetRequiredService<IMvRegistryStore>()
-            : new SqliteMvRegistryStore(connectionString);
+            : new SqliteMvRegistryStore(connectionString, null, readOnlyConnectionRecorder);
         if (rejectEnsureInfrastructure)
         {
             registry = new EnsureRejectingRegistryStore(
-                registry,
                 Assert.IsAssignableFrom<IMvReadOnlyMvInspector>(registry));
         }
 
@@ -718,17 +826,24 @@ public sealed class SqliteMvVerifyOnlyAndPolicyTests(SqliteMvFixture fixture)
     }
 
     private sealed class EnsureRejectingRegistryStore(
-        IMvRegistryStore inner,
         IMvReadOnlyMvInspector inspector) : IMvRegistryStore, IMvReadOnlyMvInspector
     {
+        public int EnsureCalls;
+        public int RegisterCalls;
+        public int PositionCalls;
+        public int StatusCalls;
+        public int TargetCheckpointCalls;
+        public int ActivationCalls;
+        public int ActivePointerCalls;
+
         public Task EnsureInfrastructureAsync(CancellationToken cancellationToken = default) =>
-            throw new InvalidOperationException("Verify-only must not enter EnsureInfrastructureAsync.");
+            FailMutation(ref EnsureCalls, "EnsureInfrastructureAsync");
 
         public Task RegisterAsync(MvRegistryEntry entry, IDbTransaction? transaction = null, CancellationToken cancellationToken = default) =>
-            inner.RegisterAsync(entry, transaction, cancellationToken);
+            FailMutation(ref RegisterCalls, "RegisterAsync");
 
         public Task UpdatePositionAsync(MvPositionUpdate update, IDbTransaction? transaction = null, CancellationToken cancellationToken = default) =>
-            inner.UpdatePositionAsync(update, transaction, cancellationToken);
+            FailMutation(ref PositionCalls, "UpdatePositionAsync");
 
         public Task MarkStreamReceivedAsync(
             string serviceId,
@@ -738,7 +853,7 @@ public sealed class SqliteMvVerifyOnlyAndPolicyTests(SqliteMvFixture fixture)
             DateTimeOffset receivedAt,
             IDbTransaction? transaction = null,
             CancellationToken cancellationToken = default) =>
-            inner.MarkStreamReceivedAsync(serviceId, viewName, viewVersion, sortableUniqueId, receivedAt, transaction, cancellationToken);
+            FailMutation(ref PositionCalls, "MarkStreamReceivedAsync");
 
         public Task UpdateStatusAsync(
             string serviceId,
@@ -747,7 +862,7 @@ public sealed class SqliteMvVerifyOnlyAndPolicyTests(SqliteMvFixture fixture)
             MvStatus status,
             IDbTransaction? transaction = null,
             CancellationToken cancellationToken = default) =>
-            inner.UpdateStatusAsync(serviceId, viewName, viewVersion, status, transaction, cancellationToken);
+            FailMutation(ref StatusCalls, "UpdateStatusAsync");
 
         public Task<IReadOnlyList<MvRegistryEntry>> GetEntriesAsync(
             string serviceId,
@@ -767,7 +882,13 @@ public sealed class SqliteMvVerifyOnlyAndPolicyTests(SqliteMvFixture fixture)
             string serviceId,
             string viewName,
             CancellationToken cancellationToken = default) =>
-            inner.GetActiveAsync(serviceId, viewName, cancellationToken);
+            throw new InvalidOperationException("Verify-only must use the dedicated read-only active-pointer inspector.");
+
+        public Task<MvActiveEntry?> ReadActiveAsync(
+            string serviceId,
+            string viewName,
+            CancellationToken cancellationToken = default) =>
+            inspector.ReadActiveAsync(serviceId, viewName, cancellationToken);
 
         public Task SetTargetCheckpointAsync(
             string serviceId,
@@ -776,19 +897,19 @@ public sealed class SqliteMvVerifyOnlyAndPolicyTests(SqliteMvFixture fixture)
             MvCheckpointTruth targetCheckpointTruth,
             IDbTransaction? transaction = null,
             CancellationToken cancellationToken = default) =>
-            inner.SetTargetCheckpointAsync(serviceId, viewName, viewVersion, targetCheckpointTruth, transaction, cancellationToken);
+            FailMutation(ref TargetCheckpointCalls, "SetTargetCheckpointAsync");
 
         public Task<MvActivationResult> TryActivateAsync(
             MvActivationRequest request,
             IDbTransaction? transaction = null,
             CancellationToken cancellationToken = default) =>
-            inner.TryActivateAsync(request, transaction, cancellationToken);
+            FailActivation(ref ActivationCalls, "TryActivateAsync");
 
         public Task<MvActivationResult> TryForceReverseAsync(
             MvForcedReverseRequest request,
             IDbTransaction? transaction = null,
             CancellationToken cancellationToken = default) =>
-            inner.TryForceReverseAsync(request, transaction, cancellationToken);
+            FailActivation(ref ActivationCalls, "TryForceReverseAsync");
 
         public Task SetActiveAsync(
             string serviceId,
@@ -796,12 +917,24 @@ public sealed class SqliteMvVerifyOnlyAndPolicyTests(SqliteMvFixture fixture)
             int activeVersion,
             IDbTransaction? transaction = null,
             CancellationToken cancellationToken = default) =>
-            inner.SetActiveAsync(serviceId, viewName, activeVersion, transaction, cancellationToken);
+            FailMutation(ref ActivePointerCalls, "SetActiveAsync");
 
         public Task<MvSchemaVerificationResult> VerifySchemaAsync(
             IReadOnlyList<MvSchemaTableRequirement> requirements,
             CancellationToken cancellationToken = default) =>
             inspector.VerifySchemaAsync(requirements, cancellationToken);
+
+        private static Task FailMutation(ref int counter, string operation)
+        {
+            counter++;
+            throw new InvalidOperationException($"Verify-only registry mutation reached: {operation}.");
+        }
+
+        private static Task<MvActivationResult> FailActivation(ref int counter, string operation)
+        {
+            counter++;
+            throw new InvalidOperationException($"Verify-only registry mutation reached: {operation}.");
+        }
     }
 
     private sealed class NoInspectorRegistryStore(IMvRegistryStore inner) : IMvRegistryStore
@@ -1009,7 +1142,8 @@ internal static class MvVerifyOnlyAssertions
 
         var policy = new RecordingPolicy(_ => MvSqlPolicyDecision.Allow());
         var catalogCommands = new List<string>();
-        var verifyExecutor = CreateVerifyExecutor(fixture, policy, catalogCommands.Add);
+        var readOnlyConnections = new List<string>();
+        var verifyExecutor = CreateVerifyExecutor(fixture, policy, catalogCommands.Add, readOnlyConnections.Add);
         var verifyHost = new CountingApplyHost(
             new NativeMvApplyHost(projector, fixture.DomainTypes.EventTypes, fixture.DatabaseTypeForTests));
         await verifyExecutor.InitializeAsync(
@@ -1019,6 +1153,7 @@ internal static class MvVerifyOnlyAssertions
         Assert.Equal(0, verifyHost.InitializeCalls);
         Assert.Empty(policy.Contexts);
         Assert.NotEmpty(catalogCommands);
+        Assert.Contains(ExpectedReadOnlyMarker(fixture.DatabaseTypeForTests), readOnlyConnections);
         Assert.All(catalogCommands, command =>
         {
             var normalized = command.TrimStart();
@@ -1041,7 +1176,8 @@ internal static class MvVerifyOnlyAssertions
     private static IMvExecutor CreateVerifyExecutor(
         MultiProviderFixtureBase fixture,
         IMvSqlStatementPolicy policy,
-        Action<string>? catalogCommandRecorder)
+        Action<string>? catalogCommandRecorder,
+        Action<string>? readOnlyConnectionRecorder)
     {
         var options = Options.Create(new MvOptions
         {
@@ -1056,31 +1192,40 @@ internal static class MvVerifyOnlyAssertions
         {
             MvDbType.Postgres => new PostgresMvExecutor(
                 fixture.EventStoreFactory,
-                new PostgresMvRegistryStore(connectionString, catalogCommandRecorder),
+                new PostgresMvRegistryStore(connectionString, catalogCommandRecorder, readOnlyConnectionRecorder),
                 options,
                 NullLogger<PostgresMvExecutor>.Instance,
                 connectionString),
             MvDbType.MySql => new MySqlMvExecutor(
                 fixture.EventStoreFactory,
-                new MySqlMvRegistryStore(connectionString, catalogCommandRecorder),
+                new MySqlMvRegistryStore(connectionString, catalogCommandRecorder, readOnlyConnectionRecorder),
                 options,
                 NullLogger<MySqlMvExecutor>.Instance,
                 connectionString),
             MvDbType.SqlServer => new SqlServerMvExecutor(
                 fixture.EventStoreFactory,
-                new SqlServerMvRegistryStore(connectionString, catalogCommandRecorder),
+                new SqlServerMvRegistryStore(connectionString, catalogCommandRecorder, readOnlyConnectionRecorder),
                 options,
                 NullLogger<SqlServerMvExecutor>.Instance,
                 connectionString),
             MvDbType.Sqlite => new SqliteMvExecutor(
                 fixture.EventStoreFactory,
-                new SqliteMvRegistryStore(connectionString, catalogCommandRecorder),
+                new SqliteMvRegistryStore(connectionString, catalogCommandRecorder, readOnlyConnectionRecorder),
                 options,
                 NullLogger<SqliteMvExecutor>.Instance,
                 connectionString),
             _ => throw new NotSupportedException($"Provider '{fixture.DatabaseTypeForTests}' is not supported.")
         };
     }
+
+    private static string ExpectedReadOnlyMarker(MvDbType databaseType) => databaseType switch
+    {
+        MvDbType.Postgres => "postgres:default_transaction_read_only=on",
+        MvDbType.MySql => "mysql:transaction_read_only=on",
+        MvDbType.SqlServer => "sqlserver:ApplicationIntent=ReadOnly",
+        MvDbType.Sqlite => "sqlite:Mode=ReadOnly",
+        _ => throw new ArgumentOutOfRangeException(nameof(databaseType))
+    };
 
     private sealed class RecordingPolicy(
         Func<MvSqlStatementContext, MvSqlPolicyDecision> decision) : IMvSqlStatementPolicy

--- a/dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/MvVerifyOnlyAndPolicyTests.cs
+++ b/dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/MvVerifyOnlyAndPolicyTests.cs
@@ -1,7 +1,9 @@
 using System.Data;
+using System.Data.Common;
 using System.Text.RegularExpressions;
 using Dapper;
 using Dcb.Domain.WithoutResult.Weather;
+using Microsoft.Data.SqlClient;
 using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -1105,6 +1107,10 @@ public sealed class PostgresMvVerifyOnlyTests(PostgresMvFixture fixture)
     [SkippableFact]
     public Task VerifyOnly_UsesTheCommonContractAgainstTheRealStore() =>
         MvVerifyOnlyAssertions.AssertCommonContractAsync(fixture);
+
+    [SkippableFact]
+    public Task SchemaContractMatrix_UsesTheProductionInspector() =>
+        MvSchemaMatrixAssertions.AssertAsync(fixture);
 }
 
 [Collection(nameof(MySqlMvCollection))]
@@ -1113,6 +1119,10 @@ public sealed class MySqlMvVerifyOnlyTests(MySqlMvFixture fixture)
     [SkippableFact]
     public Task VerifyOnly_UsesTheCommonContractAgainstTheRealStore() =>
         MvVerifyOnlyAssertions.AssertCommonContractAsync(fixture);
+
+    [SkippableFact]
+    public Task SchemaContractMatrix_UsesTheProductionInspector() =>
+        MvSchemaMatrixAssertions.AssertAsync(fixture);
 }
 
 [Collection(nameof(SqlServerMvCollection))]
@@ -1121,6 +1131,339 @@ public sealed class SqlServerMvVerifyOnlyTests(SqlServerMvFixture fixture)
     [SkippableFact]
     public Task VerifyOnly_UsesTheCommonContractAgainstTheRealStore() =>
         MvVerifyOnlyAssertions.AssertCommonContractAsync(fixture);
+
+    [SkippableFact]
+    public Task SchemaContractMatrix_UsesTheProductionInspector() =>
+        MvSchemaMatrixAssertions.AssertAsync(fixture);
+
+    [SkippableFact]
+    public async Task VerifyOnlyUsesRestrictedPrincipalAndRejectsRealDml()
+    {
+        Skip.IfNot(fixture.IsAvailable, fixture.AvailabilityMessage ?? "SQL Server fixture is unavailable.");
+        var inspectionConnectionString = fixture.InspectionConnectionStringForTests;
+        Skip.If(string.IsNullOrWhiteSpace(inspectionConnectionString), "SQL Server inspection principal is unavailable.");
+
+        await fixture.ResetAsync().ConfigureAwait(false);
+        var projector = fixture.Services.GetRequiredService<CrossProviderWeatherForecastMvV1>();
+        var host = new NativeMvApplyHost(projector, fixture.DomainTypes.EventTypes, fixture.DatabaseTypeForTests);
+        await fixture.Executor.InitializeAsync(host).ConfigureAwait(false);
+
+        await using var inspectionConnection = new SqlConnection(inspectionConnectionString);
+        await inspectionConnection.OpenAsync().ConfigureAwait(false);
+        var before = await inspectionConnection.ExecuteScalarAsync<int>(
+                $"SELECT COUNT(*) FROM [{projector.Forecasts.PhysicalName}];")
+            .ConfigureAwait(false);
+        var dmlException = await Assert.ThrowsAsync<SqlException>(async () =>
+            await inspectionConnection.ExecuteAsync(
+                    $"INSERT INTO [{projector.Forecasts.PhysicalName}] (forecast_id, location, forecast_date, temperature_c, summary, is_deleted, _last_sortable_unique_id, _last_applied_at) VALUES ('readonly-probe', 'blocked', SYSUTCDATETIME(), 1, NULL, 0, 'readonly-probe', SYSUTCDATETIME());")
+                .ConfigureAwait(false));
+        Assert.Contains(dmlException.Errors.Cast<SqlError>(), error => error.Number == 229);
+        var after = await inspectionConnection.ExecuteScalarAsync<int>(
+                $"SELECT COUNT(*) FROM [{projector.Forecasts.PhysicalName}];")
+            .ConfigureAwait(false);
+        Assert.Equal(before, after);
+
+        var options = new MvOptions();
+        var bindings = new MvTableBindings(projector.ViewName, projector.ViewVersion, options);
+        IReadOnlyList<MvSchemaTableRequirement> requirements =
+        [
+            .. MvSchemaRequirements.RegistryTables(),
+            .. projector.GetSchemaRequirements(MvDbType.SqlServer, bindings)
+        ];
+        var inspector = new SqlServerMvRegistryStore(
+            fixture.ConnectionStringForTests,
+            null,
+            null,
+            inspectionConnectionString);
+        var verification = await inspector.VerifySchemaAsync(requirements).ConfigureAwait(false);
+        Assert.True(verification.IsCompatible, verification.Failure?.Message);
+        var entries = await inspector.ReadRegistryEntriesAsync(
+                MultiProviderFixtureBase.ServiceId,
+                projector.ViewName,
+                projector.ViewVersion)
+            .ConfigureAwait(false);
+        Assert.NotEmpty(entries);
+    }
+}
+
+[Collection(nameof(SqliteMvCollection))]
+public sealed class SqliteMvSchemaMatrixTests(SqliteMvFixture fixture)
+{
+    [SkippableFact]
+    public Task SchemaContractMatrix_UsesTheProductionInspector() =>
+        MvSchemaMatrixAssertions.AssertAsync(fixture);
+}
+
+internal static class MvSchemaMatrixAssertions
+{
+    public static async Task AssertAsync(MultiProviderFixtureBase fixture)
+    {
+        Skip.IfNot(fixture.IsAvailable, fixture.AvailabilityMessage ?? "Provider fixture is unavailable.");
+        await fixture.ResetAsync().ConfigureAwait(false);
+
+        var tableName = $"sekiban_mv_schema_matrix_{Guid.NewGuid():N}";
+        try
+        {
+            await CreateSchemaAsync(fixture, tableName).ConfigureAwait(false);
+            var inspector = fixture.Services.GetRequiredService<IMvRegistryStore>() as IMvReadOnlyMvInspector;
+            Assert.NotNull(inspector);
+            var defaultSql = await ReadDefaultSqlAsync(fixture, tableName).ConfigureAwait(false);
+            var generationExpression = await ReadGenerationExpressionAsync(fixture, tableName).ConfigureAwait(false);
+            var requirement = CreateRequirement(
+                fixture.DatabaseTypeForTests,
+                tableName,
+                defaultSql,
+                generationExpression);
+
+            var compatible = await inspector.VerifySchemaAsync([requirement]).ConfigureAwait(false);
+            Assert.True(compatible.IsCompatible, compatible.Failure?.Message);
+
+            if (fixture.DatabaseTypeForTests == MvDbType.Sqlite)
+            {
+                var unsupported = await inspector.VerifySchemaAsync(
+                        [
+                            new MvSchemaTableRequirement(
+                                "schema_matrix",
+                                tableName,
+                                [
+                                    new("id", MvSchemaTypeFamily.Integer, false),
+                                    new("unbounded_value", MvSchemaTypeFamily.String, false) { MaxLength = 3 }
+                                ],
+                                ["id"])
+                        ])
+                    .ConfigureAwait(false);
+                Assert.False(unsupported.IsCompatible);
+                Assert.Equal(
+                    MvInitializationFailureReason.UnsupportedProviderCapability,
+                    unsupported.Failure?.Reason);
+                Assert.Contains("declared character or binary length", unsupported.Failure?.Message, StringComparison.Ordinal);
+            }
+
+            await AssertSingleMismatchAsync(
+                    inspector,
+                    requirement with
+                    {
+                        Columns = requirement.Columns
+                            .Select(column => column.Name == "base_value" ? column with { DefaultSql = "8" } : column)
+                            .ToList()
+                    },
+                    MvSchemaMismatchCode.DefaultMismatch)
+                .ConfigureAwait(false);
+            await AssertSingleMismatchAsync(
+                    inspector,
+                    requirement with
+                    {
+                        Indexes = [new MvSchemaIndexRequirement("ux_schema_matrix", ["amount_value", "width_value"], true)]
+                    },
+                    MvSchemaMismatchCode.RequiredIndexMissing)
+                .ConfigureAwait(false);
+            await AssertSingleMismatchAsync(
+                    inspector,
+                    requirement with
+                    {
+                        Columns = requirement.Columns
+                            .Select(column => column.Name == "generated_value" ? column with { IsGenerated = false } : column)
+                            .ToList()
+                    },
+                    MvSchemaMismatchCode.GeneratedSemanticsMismatch)
+                .ConfigureAwait(false);
+            await AssertSingleMismatchAsync(
+                    inspector,
+                    requirement with
+                    {
+                        Columns = requirement.Columns
+                            .Select(column => column.Name == "width_value" ? column with { MaxLength = 31 } : column)
+                            .ToList()
+                    },
+                    MvSchemaMismatchCode.SizeMismatch)
+                .ConfigureAwait(false);
+            await AssertSingleMismatchAsync(
+                    inspector,
+                    requirement with
+                    {
+                        Columns = requirement.Columns
+                            .Select(column => column.Name == "amount_value" ? column with { Precision = 9 } : column)
+                            .ToList()
+                    },
+                    MvSchemaMismatchCode.PrecisionMismatch)
+                .ConfigureAwait(false);
+            await AssertSingleMismatchAsync(
+                    inspector,
+                    requirement with
+                    {
+                        Columns = requirement.Columns
+                            .Select(column => column.Name == "amount_value" ? column with { Scale = 1 } : column)
+                            .ToList()
+                    },
+                    MvSchemaMismatchCode.PrecisionMismatch)
+                .ConfigureAwait(false);
+        }
+        finally
+        {
+            await DropSchemaAsync(fixture, tableName).ConfigureAwait(false);
+        }
+    }
+
+    private static async Task AssertSingleMismatchAsync(
+        IMvReadOnlyMvInspector inspector,
+        MvSchemaTableRequirement requirement,
+        MvSchemaMismatchCode expectedCode)
+    {
+        var result = await inspector.VerifySchemaAsync([requirement]).ConfigureAwait(false);
+        Assert.False(result.IsCompatible);
+        Assert.Equal([expectedCode], result.Mismatches.Select(mismatch => mismatch.Code));
+        Assert.Equal([expectedCode], result.Failure?.Mismatches.Select(mismatch => mismatch.Code));
+    }
+
+    private static MvSchemaTableRequirement CreateRequirement(
+        MvDbType databaseType,
+        string tableName,
+        string defaultSql,
+        string generationExpression) =>
+        new(
+            "schema_matrix",
+            tableName,
+            [
+                new("id", MvSchemaTypeFamily.Integer, false),
+                new("base_value", MvSchemaTypeFamily.Integer, false) { DefaultSql = defaultSql },
+                new("width_value", MvSchemaTypeFamily.String, false) { MaxLength = 32 },
+                new("amount_value", MvSchemaTypeFamily.Decimal, false) { Precision = 10, Scale = 2 },
+                new("generated_value", MvSchemaTypeFamily.Integer, databaseType != MvDbType.SqlServer)
+                {
+                    IsGenerated = true,
+                    GenerationExpression = generationExpression
+                }
+            ],
+            ["id"])
+        {
+            Indexes = [new MvSchemaIndexRequirement("ux_schema_matrix", ["width_value", "amount_value"], true)]
+        };
+
+    private static async Task CreateSchemaAsync(MultiProviderFixtureBase fixture, string tableName)
+    {
+        var table = QuoteIdentifier(fixture.DatabaseTypeForTests, tableName);
+        var index = QuoteIdentifier(fixture.DatabaseTypeForTests, $"ux_{tableName}");
+        var sql = fixture.DatabaseTypeForTests switch
+        {
+            MvDbType.Postgres => $"""
+                CREATE TABLE {table} (
+                    id INTEGER NOT NULL PRIMARY KEY,
+                    base_value INTEGER NOT NULL DEFAULT 7,
+                    width_value VARCHAR(32) NOT NULL,
+                    amount_value DECIMAL(10, 2) NOT NULL,
+                    generated_value INTEGER GENERATED ALWAYS AS (7) STORED
+                );
+                CREATE UNIQUE INDEX {index} ON {table} (width_value, amount_value);
+                """,
+            MvDbType.MySql => $"""
+                CREATE TABLE {table} (
+                    id INT NOT NULL PRIMARY KEY,
+                    base_value INT NOT NULL DEFAULT 7,
+                    width_value VARCHAR(32) NOT NULL,
+                    amount_value DECIMAL(10, 2) NOT NULL,
+                    generated_value INT GENERATED ALWAYS AS (7) STORED
+                );
+                CREATE UNIQUE INDEX {index} ON {table} (width_value, amount_value);
+                """,
+            MvDbType.SqlServer => $"""
+                CREATE TABLE {table} (
+                    id INT NOT NULL PRIMARY KEY,
+                    base_value INT NOT NULL CONSTRAINT {QuoteIdentifier(fixture.DatabaseTypeForTests, $"df_{tableName}")} DEFAULT 7,
+                    width_value VARCHAR(32) NOT NULL,
+                    amount_value DECIMAL(10, 2) NOT NULL,
+                    generated_value AS (7) PERSISTED
+                );
+                CREATE UNIQUE INDEX {index} ON {table} (width_value, amount_value);
+                """,
+            MvDbType.Sqlite => $"""
+                CREATE TABLE {table} (
+                    id INTEGER NOT NULL PRIMARY KEY,
+                    base_value INTEGER NOT NULL DEFAULT 7,
+                    width_value VARCHAR(32) NOT NULL,
+                    amount_value DECIMAL(10, 2) NOT NULL,
+                    unbounded_value TEXT NOT NULL,
+                    generated_value INTEGER GENERATED ALWAYS AS (7) STORED
+                );
+                CREATE UNIQUE INDEX {index} ON {table} (width_value, amount_value);
+                """,
+            _ => throw new NotSupportedException()
+        };
+        await using var connection = await fixture.OpenConnectionAsync().ConfigureAwait(false);
+        await connection.ExecuteAsync(sql).ConfigureAwait(false);
+    }
+
+    private static async Task<string> ReadDefaultSqlAsync(MultiProviderFixtureBase fixture, string tableName)
+    {
+        var sql = fixture.DatabaseTypeForTests switch
+        {
+            MvDbType.Postgres => "SELECT column_default FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = @TableName AND column_name = 'base_value';",
+            MvDbType.MySql => "SELECT column_default FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = @TableName AND column_name = 'base_value';",
+            MvDbType.SqlServer => "SELECT '7';",
+            MvDbType.Sqlite => "SELECT dflt_value FROM pragma_table_info(@TableName) WHERE name = 'base_value';",
+            _ => throw new NotSupportedException()
+        };
+        await using var connection = await OpenCatalogConnectionAsync(fixture).ConfigureAwait(false);
+        return await connection.ExecuteScalarAsync<string?>(sql, new { TableName = tableName }).ConfigureAwait(false) ??
+            throw new InvalidOperationException($"Schema matrix default metadata was not found for '{tableName}'.");
+    }
+
+    private static async Task<string> ReadGenerationExpressionAsync(
+        MultiProviderFixtureBase fixture,
+        string tableName)
+    {
+        var sql = fixture.DatabaseTypeForTests switch
+        {
+            MvDbType.Postgres => "SELECT generation_expression FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = @TableName AND column_name = 'generated_value';",
+            MvDbType.MySql => "SELECT generation_expression FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = @TableName AND column_name = 'generated_value';",
+            MvDbType.SqlServer => "SELECT '7';",
+            MvDbType.Sqlite => "SELECT '7';",
+            _ => throw new NotSupportedException()
+        };
+        await using var connection = await OpenCatalogConnectionAsync(fixture).ConfigureAwait(false);
+        return await connection.ExecuteScalarAsync<string?>(sql, new { TableName = tableName }).ConfigureAwait(false) ??
+            throw new InvalidOperationException($"Schema matrix generated metadata was not found for '{tableName}'.");
+    }
+
+    private static async Task<DbConnection> OpenCatalogConnectionAsync(MultiProviderFixtureBase fixture)
+    {
+        if (fixture.DatabaseTypeForTests == MvDbType.SqlServer &&
+            !string.IsNullOrWhiteSpace(fixture.InspectionConnectionStringForTests))
+        {
+            var inspectionConnection = new SqlConnection(fixture.InspectionConnectionStringForTests);
+            await inspectionConnection.OpenAsync().ConfigureAwait(false);
+            return inspectionConnection;
+        }
+
+        return await fixture.OpenConnectionAsync().ConfigureAwait(false);
+    }
+
+    private static async Task DropSchemaAsync(MultiProviderFixtureBase fixture, string tableName)
+    {
+        if (!fixture.IsAvailable)
+        {
+            return;
+        }
+
+        var table = QuoteIdentifier(fixture.DatabaseTypeForTests, tableName);
+        var index = QuoteIdentifier(fixture.DatabaseTypeForTests, $"ux_{tableName}");
+        var sql = fixture.DatabaseTypeForTests switch
+        {
+            MvDbType.Postgres => $"DROP INDEX IF EXISTS {index}; DROP TABLE IF EXISTS {table};",
+            MvDbType.MySql => $"DROP TABLE IF EXISTS {table};",
+            MvDbType.SqlServer => $"IF OBJECT_ID(N'{tableName}', N'U') IS NOT NULL DROP TABLE {table};",
+            MvDbType.Sqlite => $"DROP TABLE IF EXISTS {table};",
+            _ => throw new NotSupportedException()
+        };
+        await using var connection = await fixture.OpenConnectionAsync().ConfigureAwait(false);
+        await connection.ExecuteAsync(sql).ConfigureAwait(false);
+    }
+
+    private static string QuoteIdentifier(MvDbType databaseType, string identifier) => databaseType switch
+    {
+        MvDbType.MySql => $"`{identifier}`",
+        MvDbType.SqlServer => $"[{identifier}]",
+        _ => $"\"{identifier}\""
+    };
 }
 
 internal static class MvVerifyOnlyAssertions
@@ -1204,7 +1547,11 @@ internal static class MvVerifyOnlyAssertions
                 connectionString),
             MvDbType.SqlServer => new SqlServerMvExecutor(
                 fixture.EventStoreFactory,
-                new SqlServerMvRegistryStore(connectionString, catalogCommandRecorder, readOnlyConnectionRecorder),
+                new SqlServerMvRegistryStore(
+                    connectionString,
+                    catalogCommandRecorder,
+                    readOnlyConnectionRecorder,
+                    fixture.InspectionConnectionStringForTests),
                 options,
                 NullLogger<SqlServerMvExecutor>.Instance,
                 connectionString),
@@ -1222,7 +1569,7 @@ internal static class MvVerifyOnlyAssertions
     {
         MvDbType.Postgres => "postgres:default_transaction_read_only=on",
         MvDbType.MySql => "mysql:transaction_read_only=on",
-        MvDbType.SqlServer => "sqlserver:ApplicationIntent=ReadOnly",
+        MvDbType.SqlServer => "sqlserver:restricted-inspection-principal",
         MvDbType.Sqlite => "sqlite:Mode=ReadOnly",
         _ => throw new ArgumentOutOfRangeException(nameof(databaseType))
     };

--- a/dcb/tests/Sekiban.Dcb.MaterializedView.Tests/MaterializedViewUnitTests.cs
+++ b/dcb/tests/Sekiban.Dcb.MaterializedView.Tests/MaterializedViewUnitTests.cs
@@ -164,6 +164,32 @@ public class MaterializedViewUnitTests
     }
 
     [Fact]
+    public async Task CatchUpWorker_VerifyOnlyGatesCatchUpUntilLaterVerificationSucceeds()
+    {
+        var executor = new FakeMvExecutor(initializationFailuresBeforeSuccess: 1);
+        var hostFactory = new FakeApplyHostFactory(new FakeApplyHost("Fake", 1));
+        using var worker = new MvCatchUpWorker(
+            hostFactory,
+            executor,
+            Options.Create(new MvOptions
+            {
+                ServiceId = "worker-test",
+                InitializationMode = MvInitializationMode.VerifyOnly,
+                VerifyOnlyRetryDelay = TimeSpan.FromMilliseconds(5),
+                PollInterval = TimeSpan.FromMilliseconds(5)
+            }),
+            NullLogger<MvCatchUpWorker>.Instance);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+        await worker.StartAsync(cts.Token);
+        await SpinWaitAsync(() => executor.CatchUpCalls > 0, cts.Token);
+        await worker.StopAsync(CancellationToken.None);
+
+        Assert.Equal(2, executor.InitializeCalls);
+        Assert.True(executor.CatchUpCalls > 0);
+    }
+
+    [Fact]
     public void CatchUpWorker_RejectsMissingOrImplicitDefaultServiceBeforeStarting()
     {
         var hostFactory = new FakeApplyHostFactory(new FakeApplyHost("Fake", 1));
@@ -413,8 +439,9 @@ public class MaterializedViewUnitTests
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => GetEnumerator();
     }
 
-    private sealed class FakeMvExecutor : IMvExecutor
+    private sealed class FakeMvExecutor(int initializationFailuresBeforeSuccess = 0) : IMvExecutor
     {
+        private int _initializationFailuresRemaining = initializationFailuresBeforeSuccess;
         public int InitializeCalls { get; private set; }
         public int CatchUpCalls { get; private set; }
         public List<string?> ServiceIds { get; } = [];
@@ -426,6 +453,16 @@ public class MaterializedViewUnitTests
         {
             InitializeCalls++;
             ServiceIds.Add(serviceId);
+            if (_initializationFailuresRemaining > 0)
+            {
+                _initializationFailuresRemaining--;
+                return Task.FromException(
+                    new MvInitializationException(
+                        new MvInitializationFailure(
+                            MvInitializationFailureReason.MissingSchemaObject,
+                            "schema is not ready")));
+            }
+
             return Task.CompletedTask;
         }
 
@@ -444,6 +481,14 @@ public class MaterializedViewUnitTests
             IReadOnlyList<SerializableEvent> events,
             string? serviceId = null,
             CancellationToken cancellationToken = default) => Task.FromResult(0);
+    }
+
+    private static async Task SpinWaitAsync(Func<bool> predicate, CancellationToken cancellationToken)
+    {
+        while (!predicate())
+        {
+            await Task.Delay(5, cancellationToken);
+        }
     }
 
     private sealed class FakeApplyHostFactory : IMvApplyHostFactory

--- a/dcb/tests/Sekiban.Dcb.MaterializedView.Tests/MvInitializationCompatibilityTests.cs
+++ b/dcb/tests/Sekiban.Dcb.MaterializedView.Tests/MvInitializationCompatibilityTests.cs
@@ -1,0 +1,76 @@
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.MaterializedView;
+using Xunit;
+
+namespace Sekiban.Dcb.MaterializedView.Tests;
+
+public sealed class MvInitializationCompatibilityTests
+{
+    [Fact]
+    public void NewOptionsKeepTheCreateEnsureAndAllowAllCompatibilityDefaults()
+    {
+        var options = new MvOptions();
+
+        Assert.Equal(MvInitializationMode.CreateOrEnsure, options.InitializationMode);
+        Assert.Same(MvAllowAllSqlStatementPolicy.Instance, options.SqlStatementPolicy);
+    }
+
+    [Fact]
+    public void LegacyApplyHostGetsAnEmptyAdditiveSchemaContract()
+    {
+        var host = new LegacyHost();
+        var bindings = new MvTableBindings(host.ViewName, host.ViewVersion, new MvOptions());
+
+        Assert.Empty(((IMvApplyHost)host).GetSchemaRequirements(bindings));
+    }
+
+    [Fact]
+    public void DuplicateSchemaRequirementsFailClosedWithATypedFailure()
+    {
+        var result = MvSchemaRequirements.ValidateContract(
+            [new MvTable("orders", "orders_table", "OrderView", 1)],
+            [
+                new MvSchemaTableRequirement("orders", "orders_table", [new("id", MvSchemaTypeFamily.String, false)], ["id"]),
+                new MvSchemaTableRequirement("orders", "orders_table_2", [new("id", MvSchemaTypeFamily.String, false)], ["id"])
+            ]);
+
+        Assert.False(result.IsCompatible);
+        Assert.Equal(MvInitializationFailureReason.MissingSchemaContract, result.Failure?.Reason);
+    }
+
+    [Fact]
+    public void PolicyFailureDoesNotCopySqlOrParameterValues()
+    {
+        var exception = new MvSqlPolicyRejectedException(
+            new MvSqlPolicyFailure(
+                "blocked",
+                "orders",
+                "OrderView",
+                1,
+                MvSqlStatementPhase.Apply));
+
+        Assert.DoesNotContain("SELECT", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("secret", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(MvSqlStatementPhase.Apply, exception.Failure.Phase);
+    }
+
+    private sealed class LegacyHost : IMvApplyHost
+    {
+        public string ViewName => "Legacy";
+        public int ViewVersion => 1;
+        public IReadOnlyList<string> LogicalTables => [];
+
+        public Task<IReadOnlyList<MvSqlStatementDto>> InitializeAsync(
+            IMvTableBindings tables,
+            CancellationToken ct) =>
+            Task.FromResult<IReadOnlyList<MvSqlStatementDto>>([]);
+
+        public Task<IReadOnlyList<MvSqlStatementDto>> ApplyEventAsync(
+            SerializableEvent ev,
+            IMvTableBindings tables,
+            IMvApplyQueryPort queryPort,
+            string sortableUniqueId,
+            CancellationToken ct) =>
+            Task.FromResult<IReadOnlyList<MvSqlStatementDto>>([]);
+    }
+}

--- a/dcb/tests/Sekiban.Dcb.MaterializedView.Tests/MvInitializationCompatibilityTests.cs
+++ b/dcb/tests/Sekiban.Dcb.MaterializedView.Tests/MvInitializationCompatibilityTests.cs
@@ -116,6 +116,71 @@ public sealed class MvInitializationCompatibilityTests
     }
 
     [Fact]
+    public void SchemaVerificationCoversDefaultsIndexesGeneratedSemanticsAndPrecision()
+    {
+        var requirements = new[]
+        {
+            new MvSchemaTableRequirement(
+                "orders",
+                "orders_table",
+                [
+                    new("id", MvSchemaTypeFamily.Decimal, false)
+                    {
+                        DefaultSql = "0",
+                        IsGenerated = false,
+                        MaxLength = 10,
+                        Precision = 10,
+                        Scale = 2
+                    }
+                ],
+                ["id"])
+            {
+                Indexes = [new MvSchemaIndexRequirement("orders_id_unique", ["id"], true)]
+            }
+        };
+        var observed = MvSchemaRequirements.Observe(
+            [
+                new MvObservedSchemaColumn("orders_table", "id", MvSchemaTypeFamily.Decimal, false)
+                {
+                    DefaultSql = "1",
+                    IsGenerated = true,
+                    MaxLength = 9,
+                    Precision = 9,
+                    Scale = 1
+                }
+            ],
+            [new MvObservedSchemaPrimaryKeyColumn("orders_table", "id", 1)]);
+
+        var mismatch = MvSchemaRequirements.Validate(requirements, observed);
+
+        Assert.Equal(
+            [
+                MvSchemaMismatchCode.DefaultMismatch,
+                MvSchemaMismatchCode.RequiredIndexMissing,
+                MvSchemaMismatchCode.GeneratedSemanticsMismatch,
+                MvSchemaMismatchCode.SizeMismatch,
+                MvSchemaMismatchCode.PrecisionMismatch
+            ],
+            mismatch.Mismatches.Select(item => item.Code));
+
+        var compatibleObserved = MvSchemaRequirements.Observe(
+            [
+                new MvObservedSchemaColumn("orders_table", "id", MvSchemaTypeFamily.Decimal, false)
+                {
+                    DefaultSql = "( 0 );",
+                    IsGenerated = false,
+                    MaxLength = 10,
+                    Precision = 10,
+                    Scale = 2
+                }
+            ],
+            [new MvObservedSchemaPrimaryKeyColumn("orders_table", "id", 1)],
+            [new MvObservedSchemaIndex("orders_table", "orders_id_unique_native", ["id"], true)]);
+
+        Assert.True(MvSchemaRequirements.Validate(requirements, compatibleObserved).IsCompatible);
+    }
+
+    [Fact]
     public void PolicyFailureDoesNotCopySqlOrParameterValues()
     {
         var exception = new MvSqlPolicyRejectedException(

--- a/dcb/tests/Sekiban.Dcb.MaterializedView.Tests/MvInitializationCompatibilityTests.cs
+++ b/dcb/tests/Sekiban.Dcb.MaterializedView.Tests/MvInitializationCompatibilityTests.cs
@@ -24,6 +24,26 @@ public sealed class MvInitializationCompatibilityTests
     }
 
     [Fact]
+    public async Task SqlServerVerifyOnlyFailsClosedWithoutAnExplicitInspectionPrincipal()
+    {
+        var catalogCommands = new List<string>();
+        var store = new SqlServerMvRegistryStore("Server=unused;Database=unused", catalogCommands.Add);
+        var result = await store.VerifySchemaAsync(
+                [
+                    new MvSchemaTableRequirement(
+                        "orders",
+                        "orders_table",
+                        [new("id", MvSchemaTypeFamily.Integer, false)],
+                        ["id"])
+                ]);
+
+        Assert.False(result.IsCompatible);
+        Assert.Equal(MvInitializationFailureReason.UnsupportedProviderCapability, result.Failure?.Reason);
+        Assert.Contains("explicit least-privilege", result.Failure?.Message, StringComparison.Ordinal);
+        Assert.Empty(catalogCommands);
+    }
+
+    [Fact]
     public void LegacyApplyHostGetsAnEmptyAdditiveSchemaContract()
     {
         var host = new LegacyHost();

--- a/dcb/tests/Sekiban.Dcb.MaterializedView.Tests/MvInitializationCompatibilityTests.cs
+++ b/dcb/tests/Sekiban.Dcb.MaterializedView.Tests/MvInitializationCompatibilityTests.cs
@@ -1,5 +1,11 @@
 using Sekiban.Dcb.Events;
 using Sekiban.Dcb.MaterializedView;
+using Sekiban.Dcb.MaterializedView.MySql;
+using Sekiban.Dcb.MaterializedView.Postgres;
+using Sekiban.Dcb.MaterializedView.SqlServer;
+using Sekiban.Dcb.MaterializedView.Sqlite;
+using Sekiban.Dcb.Storage;
+using System.Reflection;
 using Xunit;
 
 namespace Sekiban.Dcb.MaterializedView.Tests;
@@ -12,7 +18,9 @@ public sealed class MvInitializationCompatibilityTests
         var options = new MvOptions();
 
         Assert.Equal(MvInitializationMode.CreateOrEnsure, options.InitializationMode);
+        Assert.Equal(MvInfrastructureMode.EnsureAndInitialize, options.InfrastructureMode);
         Assert.Same(MvAllowAllSqlStatementPolicy.Instance, options.SqlStatementPolicy);
+        Assert.Equal(MvSqlStatementPolicyMode.Legacy, options.SqlStatementPolicyMode);
     }
 
     [Fact]
@@ -22,6 +30,32 @@ public sealed class MvInitializationCompatibilityTests
         var bindings = new MvTableBindings(host.ViewName, host.ViewVersion, new MvOptions());
 
         Assert.Empty(((IMvApplyHost)host).GetSchemaRequirements(bindings));
+        Assert.Null(((IMvApplyHost)host).GetSchemaContract(bindings));
+    }
+
+    [Fact]
+    public void InitializationVerificationIsAnAdditiveCapabilityAndProviderConstructorsRemainPinned()
+    {
+        Assert.NotNull(typeof(IMvInitializationVerifier).GetMethod("VerifyInitializationAsync"));
+        Assert.All(
+            new[] { typeof(PostgresMvExecutor), typeof(MySqlMvExecutor), typeof(SqlServerMvExecutor), typeof(SqliteMvExecutor) },
+            executorType =>
+            {
+                Assert.Contains(
+                    executorType.GetConstructors(BindingFlags.Instance | BindingFlags.Public),
+                    constructor => constructor.GetParameters().Length == 5 &&
+                                   constructor.GetParameters()[0].ParameterType == typeof(IEventStoreFactory));
+                Assert.Contains(
+                    executorType.GetConstructors(BindingFlags.Instance | BindingFlags.Public),
+                    constructor => constructor.GetParameters().Length == 6 &&
+                                   constructor.GetParameters()[0].ParameterType == typeof(IEventStore));
+            });
+        Assert.All(
+            new[] { typeof(PostgresMvRegistryStore), typeof(MySqlMvRegistryStore), typeof(SqlServerMvRegistryStore), typeof(SqliteMvRegistryStore) },
+            storeType => Assert.Contains(
+                storeType.GetConstructors(BindingFlags.Instance | BindingFlags.Public),
+                constructor => constructor.GetParameters().Length == 1 &&
+                               constructor.GetParameters()[0].ParameterType == typeof(string)));
     }
 
     [Fact]
@@ -36,6 +70,49 @@ public sealed class MvInitializationCompatibilityTests
 
         Assert.False(result.IsCompatible);
         Assert.Equal(MvInitializationFailureReason.MissingSchemaContract, result.Failure?.Reason);
+    }
+
+    [Fact]
+    public void SchemaVerificationReportsAllMismatchesInDeterministicOrder()
+    {
+        var requirements = new[]
+        {
+            new MvSchemaTableRequirement(
+                "orders",
+                "orders_table",
+                [
+                    new("id", MvSchemaTypeFamily.String, false),
+                    new("amount", MvSchemaTypeFamily.Integer, false)
+                ],
+                ["id"]),
+            new MvSchemaTableRequirement(
+                "lines",
+                "lines_table",
+                [new("id", MvSchemaTypeFamily.String, false)],
+                ["id"])
+        };
+        var observed = MvSchemaRequirements.Observe(
+            [
+                new MvObservedSchemaColumn("orders_table", "id", MvSchemaTypeFamily.Integer, true),
+                new MvObservedSchemaColumn("orders_table", "amount", MvSchemaTypeFamily.String, false)
+            ],
+            []);
+
+        var first = MvSchemaRequirements.Validate(requirements, observed);
+        var second = MvSchemaRequirements.Validate(requirements.AsEnumerable().Reverse().ToArray(), observed);
+
+        Assert.False(first.IsCompatible);
+        Assert.Equal(
+            [
+                MvSchemaMismatchCode.TableMissing,
+                MvSchemaMismatchCode.TypeIncompatible,
+                MvSchemaMismatchCode.TypeIncompatible,
+                MvSchemaMismatchCode.NullabilityMismatch,
+                MvSchemaMismatchCode.PrimaryKeyMismatch
+            ],
+            first.Mismatches.Select(mismatch => mismatch.Code));
+        Assert.Equal(first.Mismatches, second.Mismatches);
+        Assert.Equal(first.Mismatches, first.Failure?.Mismatches);
     }
 
     [Fact]

--- a/docs/dcb_llm/13_common_issues.md
+++ b/docs/dcb_llm/13_common_issues.md
@@ -510,3 +510,15 @@ operational requirement.
 **10.13.0 release note.** DCB executor-generated `SortableUniqueId` values are now monotonic under host-clock rollback
 and are seeded lazily from the per-service store head after restart. Public legacy constructors and static signatures,
 the 30-digit format, and random-suffix semantics remain compatible.
+
+## Verify-only materialized-view startup and SQL policy — dcb-v10.14.0 (SEK-G32)
+
+`MvInitializationMode.VerifyOnly` is the explicit BYO-database path. It verifies a versioned declarative schema contract
+and pre-provisioned registry bindings through a read-only provider inspector. It never ensures infrastructure, invokes
+projector initialization, executes fallback DDL, or seeds registry rows. The four provider inspectors use catalog reads;
+the SQLite verifier uses a read-only metadata path and does not run the normal session PRAGMAs.
+
+`MvSqlStatementPolicyMode.Enforced` is opt-in. It preflights every initialization/apply batch and gates rows, single-row,
+and scalar query ports before provider execution. It removes raw connection/transaction access from the projector while
+`Legacy` remains the compatibility default. Missing, throwing, invalid, or denying policies fail closed with typed safe
+reasons, and cancellation remains cancellation. Hosted workers retry verification and do not fall back to schema ensure.

--- a/docs/dcb_llm/13_common_issues.md
+++ b/docs/dcb_llm/13_common_issues.md
@@ -516,7 +516,12 @@ the 30-digit format, and random-suffix semantics remain compatible.
 `MvInitializationMode.VerifyOnly` is the explicit BYO-database path. It verifies a versioned declarative schema contract
 and pre-provisioned registry bindings through a read-only provider inspector. It never ensures infrastructure, invokes
 projector initialization, executes fallback DDL, or seeds registry rows. The four provider inspectors use catalog reads;
-the SQLite verifier uses a read-only metadata path and does not run the normal session PRAGMAs.
+the SQLite verifier uses a read-only metadata path and does not run the normal session PRAGMAs. SQL Server requires
+`MvOptions.SqlServerInspectionConnectionString` to name a distinct least-privilege inspection principal; it must have
+no database/object write permission and enough non-writing catalog metadata visibility (such as database `VIEW
+DEFINITION`) for the schema contract. Verify-only returns typed `UnsupportedProviderCapability` before catalog reads
+when that principal is absent or cannot establish the capability. `ApplicationIntent=ReadOnly` is not used as a
+standalone-instance enforcement mechanism.
 
 `MvSqlStatementPolicyMode.Enforced` is opt-in. It preflights every initialization/apply batch and gates rows, single-row,
 and scalar query ports before provider execution. It removes raw connection/transaction access from the projector while

--- a/docs/dcb_llm/20_materialized_view.md
+++ b/docs/dcb_llm/20_materialized_view.md
@@ -263,6 +263,15 @@ the projector tables, including the registry binding rows. A missing or incompat
 never seeded automatically. The zero-DDL guarantee covers Sekiban-owned connections; arbitrary user/projector code is
 outside that process boundary.
 
+Verify-only remains isolated after the schema gate succeeds. Target-checkpoint capture, empty-history catch-up, status
+refresh, activation, and event-apply paths cannot call a mutating registry API; registry writes are not a success-path
+fallback. The executor and Orleans grain also avoid normal projector initialization, subscriptions, refresh timers, and
+write-oriented registry connections in this mode. The dedicated inspector owns its read-only route: SQLite opens with
+`Mode=ReadOnly`, PostgreSQL uses `default_transaction_read_only=on`, MySQL starts a read-only transaction session, and
+SQL Server requests `ApplicationIntent=ReadOnly`. Registry entries, the active pointer, and catalog metadata are read
+through that inspector only. The provider catalog allowlist is read-only; SQLite metadata uses table-valued PRAGMA
+catalog functions rather than mutating PRAGMA statements.
+
 Projectors that support verify-only initialization describe their target schema with the additive, format-versioned
 `MvSchemaContract`/`IMvSchemaRequirementsProvider` contract (format version `1`):
 
@@ -285,16 +294,24 @@ public IReadOnlyList<MvSchemaTableRequirement> GetSchemaRequirements(
 ];
 ```
 
-The verifier reports all mismatches in deterministic order. The provider-neutral type families and primary-key/nullability checks are mapped to native metadata by PostgreSQL,
-MySQL, SQL Server, and SQLite. A missing table/column, incompatible type/nullability/key, missing schema contract, or
+The verifier reports all mismatches in deterministic order. In addition to type, nullability, and primary-key shape, the
+contract can describe normalized defaults, required indexes (ordered columns and uniqueness), generated-column
+semantics and expression, character size, and numeric precision/scale. The provider-neutral checks are mapped to native
+metadata by PostgreSQL, MySQL, SQL Server, and SQLite. A missing table/column, incompatible type/nullability/key or
+metadata, missing schema contract, or
 unsupported metadata capability throws the typed `MvInitializationException` with an
 `MvInitializationFailureReason`. These failures happen before event reads, view writes, registry mutation, catch-up,
 or activation. A host that has not opted into the schema contract therefore fails closed in verify-only mode.
 
+The compatibility proof includes a binary consumer restored against the published `10.13.0` package and then run
+without recompilation against the branch assembly; see
+[`Sekiban.Dcb.MaterializedView.BinaryConsumer`](../../dcb/tests/Sekiban.Dcb.MaterializedView.BinaryConsumer/README.md).
+
 Every projector-supplied initialization and apply statement is also presented to the host-owned
 `IMvSqlStatementPolicy` before provider execution. `MvSqlStatementContext` contains the exact service id, view name and
-version, `Initialization` or `Apply` phase, logical/physical table bindings, SQL text, and parameter metadata. A policy
-returns `MvSqlPolicyDecision.Allow()` or `Reject(reason)`:
+version, `Initialization` or `Apply` phase, the exact `ProjectorInitialize`/`ProjectorApply`/`ProjectorQuery` origin,
+provider `DatabaseType`, logical/physical table bindings, SQL text, and parameter metadata. A policy can return an
+optional rule id with `MvSqlPolicyDecision.Allow(ruleId)` or `Reject(reason, ruleId)`:
 
 ```csharp
 public sealed class MyHostSqlPolicy : IMvSqlStatementPolicy
@@ -311,10 +328,11 @@ public sealed class MyHostSqlPolicy : IMvSqlStatementPolicy
 }
 ```
 
-Rejection is typed as `MvSqlPolicyRejectedException`; its safe failure contains the service/view/version and phase, but
-does not copy SQL or parameter values into the failure. Initialization rejection occurs before `EnsureInfrastructureAsync`
-or a provider command. Apply rejection rolls back the event transaction before any projector statement or registry
-checkpoint is committed. In `Legacy` mode, existing raw `Connection`/`Transaction` access remains source-compatible.
+Rejection is typed as `MvSqlPolicyRejectedException`; its safe failure contains the service/view/version, phase, exact
+origin, provider, rule id, statement index/batch size, and SQL fingerprint, but does not copy SQL or parameter values
+into the failure. Initialization rejection occurs before `EnsureInfrastructureAsync` or a provider command. Apply
+rejection rolls back the event transaction before any projector statement or registry checkpoint is committed. In
+`Legacy` mode, existing raw `Connection`/`Transaction` access remains source-compatible.
 Hosts that need a hard SQL boundary opt into `Enforced` mode:
 
 ```csharp

--- a/docs/dcb_llm/20_materialized_view.md
+++ b/docs/dcb_llm/20_materialized_view.md
@@ -255,14 +255,16 @@ builder.Services.AddSekibanDcbMaterializedView(options =>
 });
 ```
 
-In verify-only mode, the projector is run in a recording context so its logical/physical table bindings and statements
-can be inspected without executing projector SQL. The executor never calls `EnsureInfrastructureAsync`, executes
-`CREATE`, `ALTER`, `DROP`, migration, registry-schema, or fallback DDL, or silently switches to create mode. The
-provider performs read-only metadata checks for the two registry tables and every projector table. Existing registry
-rows are read after verification; a missing registry row may be registered only after the schema proof succeeds.
+Verify-only derives its bindings and required schema from the declarative contract before it enters the projector
+initialization path. It calls the provider's dedicated `IMvReadOnlyMvInspector` for catalog and registry reads only;
+`IMvApplyHost.InitializeAsync`, `EnsureInfrastructureAsync`, normal write connections, registration, transactions, and
+commits are not fallback paths. A compatible deployment must therefore provision both framework registry tables and
+the projector tables, including the registry binding rows. A missing or incompatible binding is a typed failure and is
+never seeded automatically. The zero-DDL guarantee covers Sekiban-owned connections; arbitrary user/projector code is
+outside that process boundary.
 
-Projectors that support verify-only initialization describe their target schema with the additive
-`IMvSchemaRequirementsProvider` contract:
+Projectors that support verify-only initialization describe their target schema with the additive, format-versioned
+`MvSchemaContract`/`IMvSchemaRequirementsProvider` contract (format version `1`):
 
 ```csharp
 public IReadOnlyList<MvSchemaTableRequirement> GetSchemaRequirements(
@@ -283,7 +285,7 @@ public IReadOnlyList<MvSchemaTableRequirement> GetSchemaRequirements(
 ];
 ```
 
-The provider-neutral type families and primary-key/nullability checks are mapped to native metadata by PostgreSQL,
+The verifier reports all mismatches in deterministic order. The provider-neutral type families and primary-key/nullability checks are mapped to native metadata by PostgreSQL,
 MySQL, SQL Server, and SQLite. A missing table/column, incompatible type/nullability/key, missing schema contract, or
 unsupported metadata capability throws the typed `MvInitializationException` with an
 `MvInitializationFailureReason`. These failures happen before event reads, view writes, registry mutation, catch-up,
@@ -312,8 +314,25 @@ public sealed class MyHostSqlPolicy : IMvSqlStatementPolicy
 Rejection is typed as `MvSqlPolicyRejectedException`; its safe failure contains the service/view/version and phase, but
 does not copy SQL or parameter values into the failure. Initialization rejection occurs before `EnsureInfrastructureAsync`
 or a provider command. Apply rejection rolls back the event transaction before any projector statement or registry
-checkpoint is committed. The default `MvAllowAllSqlStatementPolicy` preserves existing behavior when no host policy is
-configured.
+checkpoint is committed. In `Legacy` mode, existing raw `Connection`/`Transaction` access remains source-compatible.
+Hosts that need a hard SQL boundary opt into `Enforced` mode:
+
+```csharp
+options.SqlStatementPolicyMode = MvSqlStatementPolicyMode.Enforced;
+```
+
+Enforced mode wraps `QueryRowsAsync`, `QuerySingleOrDefaultAsync`, and `ExecuteScalarJsonAsync` before the provider
+port, removes raw connection/transaction exposure, and preflights every statement in an initialization or apply batch
+before the first statement executes. Missing policy, policy faults, invalid decisions, and denials fail closed with
+typed reasons; cancellation remains `OperationCanceledException`. SQL is treated as opaque text by the runtime, so a
+host allowlist must reject mutating CTEs, comments, or multi-statement text according to its own policy.
+
+The hosted worker uses the same central initialization gate. In verify-only mode it publishes a faulted verification
+status, waits for the configured retry interval, and remains stopped until a later verification succeeds; it never
+falls back to ensure mode.
+
+The package default remains `CreateOrEnsure` plus `Legacy` and `MvAllowAllSqlStatementPolicy`, preserving existing
+callers that do not opt into the new boundary.
 
 ## Idempotency and Ordering
 

--- a/docs/dcb_llm/20_materialized_view.md
+++ b/docs/dcb_llm/20_materialized_view.md
@@ -268,9 +268,15 @@ refresh, activation, and event-apply paths cannot call a mutating registry API; 
 fallback. The executor and Orleans grain also avoid normal projector initialization, subscriptions, refresh timers, and
 write-oriented registry connections in this mode. The dedicated inspector owns its read-only route: SQLite opens with
 `Mode=ReadOnly`, PostgreSQL uses `default_transaction_read_only=on`, MySQL starts a read-only transaction session, and
-SQL Server requests `ApplicationIntent=ReadOnly`. Registry entries, the active pointer, and catalog metadata are read
-through that inspector only. The provider catalog allowlist is read-only; SQLite metadata uses table-valued PRAGMA
-catalog functions rather than mutating PRAGMA statements.
+SQL Server uses an explicit inspection principal. Registry entries, the active pointer, and catalog metadata are read
+through that inspector only. SQL Server does not use `ApplicationIntent=ReadOnly` as an enforcement mechanism on a
+standalone instance: configure `MvOptions.SqlServerInspectionConnectionString` with a distinct least-privilege
+inspection principal (for example, a database user in `db_datareader` with no DML or DDL permissions plus the
+non-writing catalog metadata visibility needed by the contract, such as database `VIEW DEFINITION`). Verify-only
+fails with a typed `UnsupportedProviderCapability` failure before catalog inspection when that capability is absent or
+cannot be established. The provider catalog allowlist is read-only; SQLite metadata uses table-valued PRAGMA catalog
+functions rather than mutating PRAGMA statements, and derives declared lengths/precision/scale and generated
+expressions where SQLite exposes them.
 
 Projectors that support verify-only initialization describe their target schema with the additive, format-versioned
 `MvSchemaContract`/`IMvSchemaRequirementsProvider` contract (format version `1`):

--- a/docs/dcb_llm/20_materialized_view.md
+++ b/docs/dcb_llm/20_materialized_view.md
@@ -242,6 +242,79 @@ Projector responsibilities:
 - `ApplyToViewAsync`
   Translate one event into one or more SQL statements.
 
+## Pre-Provisioned Schema and Host-Owned SQL Policy
+
+Initialization keeps the historical `CreateOrEnsure` behavior by default. Hosts that provision database objects through
+deployment migrations can select `VerifyOnly`:
+
+```csharp
+builder.Services.AddSekibanDcbMaterializedView(options =>
+{
+    options.InitializationMode = MvInitializationMode.VerifyOnly;
+    options.SqlStatementPolicy = MyHostSqlPolicy.Instance;
+});
+```
+
+In verify-only mode, the projector is run in a recording context so its logical/physical table bindings and statements
+can be inspected without executing projector SQL. The executor never calls `EnsureInfrastructureAsync`, executes
+`CREATE`, `ALTER`, `DROP`, migration, registry-schema, or fallback DDL, or silently switches to create mode. The
+provider performs read-only metadata checks for the two registry tables and every projector table. Existing registry
+rows are read after verification; a missing registry row may be registered only after the schema proof succeeds.
+
+Projectors that support verify-only initialization describe their target schema with the additive
+`IMvSchemaRequirementsProvider` contract:
+
+```csharp
+public IReadOnlyList<MvSchemaTableRequirement> GetSchemaRequirements(
+    MvDbType databaseType,
+    IMvTableBindings tables) =>
+[
+    new(
+        "forecasts",
+        tables.GetPhysicalName("forecasts"),
+        [
+            new("forecast_id", MvSchemaTypeFamily.Guid, false),
+            new("location", MvSchemaTypeFamily.String, false),
+            new("forecast_date", MvSchemaTypeFamily.DateTime, false),
+            new("temperature_c", MvSchemaTypeFamily.Integer, false),
+            new("summary", MvSchemaTypeFamily.String, true)
+        ],
+        ["forecast_id"])
+];
+```
+
+The provider-neutral type families and primary-key/nullability checks are mapped to native metadata by PostgreSQL,
+MySQL, SQL Server, and SQLite. A missing table/column, incompatible type/nullability/key, missing schema contract, or
+unsupported metadata capability throws the typed `MvInitializationException` with an
+`MvInitializationFailureReason`. These failures happen before event reads, view writes, registry mutation, catch-up,
+or activation. A host that has not opted into the schema contract therefore fails closed in verify-only mode.
+
+Every projector-supplied initialization and apply statement is also presented to the host-owned
+`IMvSqlStatementPolicy` before provider execution. `MvSqlStatementContext` contains the exact service id, view name and
+version, `Initialization` or `Apply` phase, logical/physical table bindings, SQL text, and parameter metadata. A policy
+returns `MvSqlPolicyDecision.Allow()` or `Reject(reason)`:
+
+```csharp
+public sealed class MyHostSqlPolicy : IMvSqlStatementPolicy
+{
+    public static MyHostSqlPolicy Instance { get; } = new();
+
+    public ValueTask<MvSqlPolicyDecision> EvaluateAsync(
+        MvSqlStatementContext context,
+        CancellationToken cancellationToken = default) =>
+        ValueTask.FromResult(
+            context.Phase == MvSqlStatementPhase.Initialization
+                ? MvSqlPolicyDecision.Reject("Initialization SQL is migration-owned.")
+                : MvSqlPolicyDecision.Allow());
+}
+```
+
+Rejection is typed as `MvSqlPolicyRejectedException`; its safe failure contains the service/view/version and phase, but
+does not copy SQL or parameter values into the failure. Initialization rejection occurs before `EnsureInfrastructureAsync`
+or a provider command. Apply rejection rolls back the event transaction before any projector statement or registry
+checkpoint is committed. The default `MvAllowAllSqlStatementPolicy` preserves existing behavior when no host policy is
+configured.
+
 ## Idempotency and Ordering
 
 Materialized views must be safe to replay. The usual pattern is:

--- a/docs/dcb_llm_ja/13_common_issues.md
+++ b/docs/dcb_llm_ja/13_common_issues.md
@@ -474,7 +474,10 @@ semantics は互換のままです。
 `MvInitializationMode.VerifyOnly` は BYO database 用の明示的な経路です。version 付きの宣言的 schema contract と事前に
 用意した registry binding を read-only provider inspector で検証します。infrastructure ensure、projector 初期化、fallback DDL、
 registry row の自動 seed は行いません。4 provider の inspector は catalog read を使い、SQLite verifier は read-only metadata 経路で
-通常の session PRAGMA を実行しません。
+通常の session PRAGMA を実行しません。SQL Server は `MvOptions.SqlServerInspectionConnectionString` に独立した最小権限の
+inspection principal を要求します。DML/DDL の write permission を持たず、`VIEW DEFINITION` など契約に必要な非書込み
+metadata visibility を確立できない場合は、catalog read 前に `UnsupportedProviderCapability` の型付き failure を返します。
+standalone instance の強制能力として `ApplicationIntent=ReadOnly` は使いません。
 
 `MvSqlStatementPolicyMode.Enforced` は opt-in です。initialization/apply batch の全件を provider 実行前に preflight し、rows・single-row・
 scalar query port も gate します。projector への raw connection / transaction 公開を止めますが、`Legacy` は互換既定値のままです。

--- a/docs/dcb_llm_ja/13_common_issues.md
+++ b/docs/dcb_llm_ja/13_common_issues.md
@@ -468,3 +468,15 @@ allocator は同一ホストの巻き戻りによるイベント欠落を防ぎ�
 **10.13.0 リリースノート**。DCB executor が生成する `SortableUniqueId` はホスト時刻の巻き戻り下でも単調増加し、再起動後は
 service ごとの store head から lazy seed されます。従来の公開 constructor と static signature、30桁 format、random suffix
 semantics は互換のままです。
+
+## verify-only の materialized-view 起動と SQL policy — dcb-v10.14.0 (SEK-G32)
+
+`MvInitializationMode.VerifyOnly` は BYO database 用の明示的な経路です。version 付きの宣言的 schema contract と事前に
+用意した registry binding を read-only provider inspector で検証します。infrastructure ensure、projector 初期化、fallback DDL、
+registry row の自動 seed は行いません。4 provider の inspector は catalog read を使い、SQLite verifier は read-only metadata 経路で
+通常の session PRAGMA を実行しません。
+
+`MvSqlStatementPolicyMode.Enforced` は opt-in です。initialization/apply batch の全件を provider 実行前に preflight し、rows・single-row・
+scalar query port も gate します。projector への raw connection / transaction 公開を止めますが、`Legacy` は互換既定値のままです。
+policy の未登録・throw・invalid・deny は typed safe reason 付きで fail-closed し、cancellation は cancellation のままです。hosted worker
+は verification を retry し、schema ensure へ fallback しません。

--- a/docs/dcb_llm_ja/20_materialized_view.md
+++ b/docs/dcb_llm_ja/20_materialized_view.md
@@ -245,6 +245,77 @@ public sealed class WeatherForecastMvV1 : IMaterializedViewProjector
 - `ApplyToViewAsync`
   1 イベントを 1 個以上の SQL 文へ変換
 
+## 事前プロビジョニングしたスキーマとホスト所有 SQL ポリシー
+
+初期化の既定値は、従来互換の `CreateOrEnsure` です。deployment migration などで DB オブジェクトを管理する
+ホストは `VerifyOnly` を選択できます。
+
+```csharp
+builder.Services.AddSekibanDcbMaterializedView(options =>
+{
+    options.InitializationMode = MvInitializationMode.VerifyOnly;
+    options.SqlStatementPolicy = MyHostSqlPolicy.Instance;
+});
+```
+
+verify-only では projector を recording context で実行し、logical / physical table binding と SQL 文を記録します。
+projector の SQL は実行されません。executor は `EnsureInfrastructureAsync` を呼ばず、`CREATE`、`ALTER`、`DROP`、
+migration、registry schema、fallback DDL を実行せず、create mode へ暗黙に切り替えることもありません。provider は
+registry の 2 テーブルと projector の各テーブルについて read-only の metadata 検証を行います。既存の registry
+row は検証後に読み取り、registry row が不足している場合に限り、schema proof 成功後に登録できます。
+
+verify-only に対応する projector は、追加された `IMvSchemaRequirementsProvider` 契約で target schema を宣言します。
+
+```csharp
+public IReadOnlyList<MvSchemaTableRequirement> GetSchemaRequirements(
+    MvDbType databaseType,
+    IMvTableBindings tables) =>
+[
+    new(
+        "forecasts",
+        tables.GetPhysicalName("forecasts"),
+        [
+            new("forecast_id", MvSchemaTypeFamily.Guid, false),
+            new("location", MvSchemaTypeFamily.String, false),
+            new("forecast_date", MvSchemaTypeFamily.DateTime, false),
+            new("temperature_c", MvSchemaTypeFamily.Integer, false),
+            new("summary", MvSchemaTypeFamily.String, true)
+        ],
+        ["forecast_id"])
+];
+```
+
+provider-neutral な type family と primary key / nullability の検証は、PostgreSQL、MySQL、SQL Server、SQLite の native
+metadata へそれぞれ変換して実行されます。table / column の不足、type・nullability・key の不一致、schema contract
+不足、metadata capability 非対応は、型付き `MvInitializationException` と `MvInitializationFailureReason` になります。
+これらは event read、view write、registry mutation、catch-up、activation より前に発生します。そのため schema contract
+を実装していない host も verify-only では fail-closed になります。
+
+projector が返すすべての initialization / apply SQL 文は、provider 実行前に host 所有の
+`IMvSqlStatementPolicy` へ渡されます。`MvSqlStatementContext` には正確な service id、view name / version、
+`Initialization` または `Apply` phase、logical / physical table binding、SQL text、parameter metadata が含まれます。
+policy は `MvSqlPolicyDecision.Allow()` または `Reject(reason)` を返します。
+
+```csharp
+public sealed class MyHostSqlPolicy : IMvSqlStatementPolicy
+{
+    public static MyHostSqlPolicy Instance { get; } = new();
+
+    public ValueTask<MvSqlPolicyDecision> EvaluateAsync(
+        MvSqlStatementContext context,
+        CancellationToken cancellationToken = default) =>
+        ValueTask.FromResult(
+            context.Phase == MvSqlStatementPhase.Initialization
+                ? MvSqlPolicyDecision.Reject("Initialization SQL is migration-owned.")
+                : MvSqlPolicyDecision.Allow());
+}
+```
+
+拒否は型付き `MvSqlPolicyRejectedException` になります。safe failure には service / view / version と phase だけが含まれ、
+SQL や parameter value はコピーされません。initialization の拒否は `EnsureInfrastructureAsync` や provider command より
+前に起きます。apply の拒否は projector SQL や registry checkpoint を commit する前に event transaction を rollback します。
+host policy を設定しない場合は `MvAllowAllSqlStatementPolicy` が従来の動作を維持します。
+
 ## 順序保証と冪等性
 
 マテリアライズドビューはリプレイ可能である必要があります。基本パターンは次の通りです。

--- a/docs/dcb_llm_ja/20_materialized_view.md
+++ b/docs/dcb_llm_ja/20_materialized_view.md
@@ -269,9 +269,14 @@ VerifyOnly は schema gate 成功後も隔離されたままです。target chec
 activation、event apply の各経路から registry の mutating API へ到達せず、成功後の fallback write もありません。
 executor と Orleans Grain は、この mode では通常の projector 初期化、subscription、refresh timer、書込み用 registry 接続を開始しません。
 専用 inspector 自身が read-only 経路を選びます。SQLite は `Mode=ReadOnly`、PostgreSQL は
-`default_transaction_read_only=on`、MySQL は read-only transaction session、SQL Server は
-`ApplicationIntent=ReadOnly` を使用します。registry entry、active pointer、catalog metadata は inspector 経由だけで読み取り、
-provider の catalog allowlist は read-only です。SQLite の metadata は書込みを伴う PRAGMA ではなく table-valued PRAGMA catalog function を使います。
+`default_transaction_read_only=on`、MySQL は read-only transaction session を使用します。SQL Server は専用の
+inspection principal を使用し、standalone instance で `ApplicationIntent=ReadOnly` を強制能力として扱いません。
+`MvOptions.SqlServerInspectionConnectionString` に独立した最小権限の inspection principal（例えば DML/DDL 権限を
+持たない `db_datareader` 相当の database user と、`VIEW DEFINITION` など契約に必要な非書込み metadata 権限）を
+設定します。この capability が未設定または確立できない場合、catalog inspection 前に
+`UnsupportedProviderCapability` の型付き failure で停止します。registry entry、active pointer、catalog metadata は inspector
+経由だけで読み取り、provider の catalog allowlist は read-only です。SQLite の metadata は書込みを伴う PRAGMA ではなく
+table-valued PRAGMA catalog function を使い、取得可能な declared length、precision/scale、generated expression を導出します。
 
 verify-only に対応する projector は、format version `1` の追加された `MvSchemaContract` /
 `IMvSchemaRequirementsProvider` 契約で target schema を宣言します。

--- a/docs/dcb_llm_ja/20_materialized_view.md
+++ b/docs/dcb_llm_ja/20_materialized_view.md
@@ -258,13 +258,15 @@ builder.Services.AddSekibanDcbMaterializedView(options =>
 });
 ```
 
-verify-only では projector を recording context で実行し、logical / physical table binding と SQL 文を記録します。
-projector の SQL は実行されません。executor は `EnsureInfrastructureAsync` を呼ばず、`CREATE`、`ALTER`、`DROP`、
-migration、registry schema、fallback DDL を実行せず、create mode へ暗黙に切り替えることもありません。provider は
-registry の 2 テーブルと projector の各テーブルについて read-only の metadata 検証を行います。既存の registry
-row は検証後に読み取り、registry row が不足している場合に限り、schema proof 成功後に登録できます。
+verify-only は projector の初期化経路へ入る前に、宣言的な contract から binding と必要 schema を導出します。
+provider の専用 `IMvReadOnlyMvInspector` で catalog と registry を読むだけであり、
+`IMvApplyHost.InitializeAsync`、`EnsureInfrastructureAsync`、通常の書込み接続、registration、transaction、commit
+は fallback になりません。したがって deployment 側で framework の registry 2 テーブル、projector table、registry
+binding row まで用意します。binding の不足や不一致は型付きエラーで停止し、自動 seed は行いません。zero-DDL の保証は
+Sekiban が所有する接続の境界に限られ、任意の user/projector code はこのプロセス境界の外です。
 
-verify-only に対応する projector は、追加された `IMvSchemaRequirementsProvider` 契約で target schema を宣言します。
+verify-only に対応する projector は、format version `1` の追加された `MvSchemaContract` /
+`IMvSchemaRequirementsProvider` 契約で target schema を宣言します。
 
 ```csharp
 public IReadOnlyList<MvSchemaTableRequirement> GetSchemaRequirements(
@@ -285,7 +287,7 @@ public IReadOnlyList<MvSchemaTableRequirement> GetSchemaRequirements(
 ];
 ```
 
-provider-neutral な type family と primary key / nullability の検証は、PostgreSQL、MySQL、SQL Server、SQLite の native
+verifier は mismatch を deterministic な順序で全件報告します。provider-neutral な type family と primary key / nullability の検証は、PostgreSQL、MySQL、SQL Server、SQLite の native
 metadata へそれぞれ変換して実行されます。table / column の不足、type・nullability・key の不一致、schema contract
 不足、metadata capability 非対応は、型付き `MvInitializationException` と `MvInitializationFailureReason` になります。
 これらは event read、view write、registry mutation、catch-up、activation より前に発生します。そのため schema contract
@@ -314,7 +316,24 @@ public sealed class MyHostSqlPolicy : IMvSqlStatementPolicy
 拒否は型付き `MvSqlPolicyRejectedException` になります。safe failure には service / view / version と phase だけが含まれ、
 SQL や parameter value はコピーされません。initialization の拒否は `EnsureInfrastructureAsync` や provider command より
 前に起きます。apply の拒否は projector SQL や registry checkpoint を commit する前に event transaction を rollback します。
-host policy を設定しない場合は `MvAllowAllSqlStatementPolicy` が従来の動作を維持します。
+`Legacy` mode では既存の raw `Connection` / `Transaction` access を source-compatible に維持します。SQL 境界を強制する
+host は `Enforced` mode を選びます。
+
+```csharp
+options.SqlStatementPolicyMode = MvSqlStatementPolicyMode.Enforced;
+```
+
+Enforced mode は `QueryRowsAsync`、`QuerySingleOrDefaultAsync`、`ExecuteScalarJsonAsync` の provider port の前で policy を
+評価し、raw connection / transaction を projector に公開しません。initialization / apply batch は最初の SQL を実行する前に
+全 statement を preflight します。policy の未登録、fault、invalid decision、deny は typed reason 付きで fail-closed し、
+cancellation は `OperationCanceledException` のままです。runtime は SQL の先頭 keyword で判断しないため、mutating CTE、comment、
+multi-statement text の許可可否は host の allowlist が決めます。
+
+hosted worker も同じ中央 initialization gate を使います。verify-only では verification failure を faulted status として公開し、
+retry interval 後に再試行します。成功するまで worker は停止し、ensure mode へ fallback しません。
+
+package の既定値は `CreateOrEnsure`、`Legacy`、`MvAllowAllSqlStatementPolicy` のままであり、新しい境界を選ばない既存 caller の
+動作を維持します。
 
 ## 順序保証と冪等性
 

--- a/docs/dcb_llm_ja/20_materialized_view.md
+++ b/docs/dcb_llm_ja/20_materialized_view.md
@@ -265,6 +265,14 @@ provider の専用 `IMvReadOnlyMvInspector` で catalog と registry を読む�
 binding row まで用意します。binding の不足や不一致は型付きエラーで停止し、自動 seed は行いません。zero-DDL の保証は
 Sekiban が所有する接続の境界に限られ、任意の user/projector code はこのプロセス境界の外です。
 
+VerifyOnly は schema gate 成功後も隔離されたままです。target checkpoint の capture、空履歴の catch-up、status refresh、
+activation、event apply の各経路から registry の mutating API へ到達せず、成功後の fallback write もありません。
+executor と Orleans Grain は、この mode では通常の projector 初期化、subscription、refresh timer、書込み用 registry 接続を開始しません。
+専用 inspector 自身が read-only 経路を選びます。SQLite は `Mode=ReadOnly`、PostgreSQL は
+`default_transaction_read_only=on`、MySQL は read-only transaction session、SQL Server は
+`ApplicationIntent=ReadOnly` を使用します。registry entry、active pointer、catalog metadata は inspector 経由だけで読み取り、
+provider の catalog allowlist は read-only です。SQLite の metadata は書込みを伴う PRAGMA ではなく table-valued PRAGMA catalog function を使います。
+
 verify-only に対応する projector は、format version `1` の追加された `MvSchemaContract` /
 `IMvSchemaRequirementsProvider` 契約で target schema を宣言します。
 
@@ -287,16 +295,23 @@ public IReadOnlyList<MvSchemaTableRequirement> GetSchemaRequirements(
 ];
 ```
 
-verifier は mismatch を deterministic な順序で全件報告します。provider-neutral な type family と primary key / nullability の検証は、PostgreSQL、MySQL、SQL Server、SQLite の native
-metadata へそれぞれ変換して実行されます。table / column の不足、type・nullability・key の不一致、schema contract
+verifier は mismatch を deterministic な順序で全件報告します。type、nullability、primary key に加えて、正規化した
+default、必要な index（列順と unique 性）、generated column の意味と式、文字列サイズ、numeric の precision / scale も contract で表現できます。
+provider-neutral な検証は PostgreSQL、MySQL、SQL Server、SQLite の native metadata へそれぞれ変換して実行されます。
+table / column の不足、type・nullability・key・metadata の不一致、schema contract
 不足、metadata capability 非対応は、型付き `MvInitializationException` と `MvInitializationFailureReason` になります。
 これらは event read、view write、registry mutation、catch-up、activation より前に発生します。そのため schema contract
 を実装していない host も verify-only では fail-closed になります。
 
+互換性の proof には公開済み `10.13.0` package を参照して restore / build した binary consumer を含めています。
+branch の assembly を出力先へ差し替えた後、再コンパイルなしで実行します。詳細は
+[`Sekiban.Dcb.MaterializedView.BinaryConsumer`](../../dcb/tests/Sekiban.Dcb.MaterializedView.BinaryConsumer/README.md) を参照してください。
+
 projector が返すすべての initialization / apply SQL 文は、provider 実行前に host 所有の
 `IMvSqlStatementPolicy` へ渡されます。`MvSqlStatementContext` には正確な service id、view name / version、
-`Initialization` または `Apply` phase、logical / physical table binding、SQL text、parameter metadata が含まれます。
-policy は `MvSqlPolicyDecision.Allow()` または `Reject(reason)` を返します。
+`Initialization` または `Apply` phase、正確な `ProjectorInitialize` / `ProjectorApply` / `ProjectorQuery` origin、
+provider の `DatabaseType`、logical / physical table binding、SQL text、parameter metadata が含まれます。
+policy は optional な rule id を付けて `MvSqlPolicyDecision.Allow(ruleId)` または `Reject(reason, ruleId)` を返せます。
 
 ```csharp
 public sealed class MyHostSqlPolicy : IMvSqlStatementPolicy
@@ -313,9 +328,10 @@ public sealed class MyHostSqlPolicy : IMvSqlStatementPolicy
 }
 ```
 
-拒否は型付き `MvSqlPolicyRejectedException` になります。safe failure には service / view / version と phase だけが含まれ、
-SQL や parameter value はコピーされません。initialization の拒否は `EnsureInfrastructureAsync` や provider command より
-前に起きます。apply の拒否は projector SQL や registry checkpoint を commit する前に event transaction を rollback します。
+拒否は型付き `MvSqlPolicyRejectedException` になります。safe failure には service / view / version、phase、正確な origin、
+provider、rule id、statement index / batch size、SQL fingerprint が含まれますが、SQL や parameter value はコピーされません。
+initialization の拒否は `EnsureInfrastructureAsync` や provider command より前に起きます。apply の拒否は projector SQL や
+registry checkpoint を commit する前に event transaction を rollback します。
 `Legacy` mode では既存の raw `Connection` / `Transaction` access を source-compatible に維持します。SQL 境界を強制する
 host は `Enforced` mode を選びます。
 


### PR DESCRIPTION
Closes #1125

## Implementation

- Completed the single VerifyOnly gate before projector initialization. VerifyOnly derives bindings only from the declarative contract, never calls `host.InitializeAsync`, and never enters ensure, normal open, registration, transaction, commit, target capture persistence, status mutation, activation, stream subscription, refresh timers, or event-apply writes.
- Closed the remaining implicit paths: target capture, empty-history catch-up/checkpoint capture, status/activation, stream event apply, Orleans grain orchestration, and generation-coordinator forced reverse all fail closed before registry mutation. VerifyOnly event apply is an inspection no-op after the schema gate and cannot open a normal target connection or transaction.
- Made each provider's `IMvReadOnlyMvInspector` implementation own the read-only route: SQLite `Mode=ReadOnly` and table-valued PRAGMA catalog functions; PostgreSQL `default_transaction_read_only=on`; MySQL read-only transaction session; SQL Server an explicit least-privilege inspection connection.
- SQL Server no longer treats `ApplicationIntent=ReadOnly` as enforcement. `MvOptions.SqlServerInspectionConnectionString` is required for VerifyOnly. The inspector opens that connection, verifies a distinct principal with database `SELECT` and `VIEW DEFINITION`, rejects any database/object write permission, and returns typed `UnsupportedProviderCapability` before catalog inspection when the capability cannot be established. Legacy writable paths remain unchanged.
- Extended `MvSchemaContract`/requirements and deterministic verification to defaults, required indexes (ordered columns and uniqueness), generated semantics/expressions, size, and precision/scale with typed fail-closed mismatch diagnostics.
- Removed the SQLite S2077 dynamic SQL hotspot with static catalog SQL, parameterized table-valued PRAGMAs, strict contract-derived identifier validation, and faithful derivation of declared lengths, precision/scale, and generated expressions. Required dimensions that SQLite cannot faithfully inspect return precise typed `UnsupportedProviderCapability` failures.
- Preserved the enforced SQL policy boundary and enriched its context/failure with exact origin, provider, rule id, phase, batch/statement index, and SQL fingerprint. Query rows/single/scalar, raw bypass, mutating CTE/comment/multi-statement shapes, complete batch preflight, fault, and cancellation remain covered.
- Added the EN/JA documentation updates and retained the binary consumer fixture restored against the published `Sekiban.Dcb.MaterializedView` `10.13.0` package.

## Validation

Production-path real-store VerifyOnly/policy and schema matrix:

- `dotnet test dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests.csproj --no-build --no-restore -f net9.0 --filter 'FullyQualifiedName~MvVerifyOnly|FullyQualifiedName~SchemaMatrix'` — **31/31 passed**.
- Same focused production-path command with `-f net10.0` — **31/31 passed**.
- The four-provider real-store proof starts schema creation and ordinary writes with the normal write-capable fixture connection. VerifyOnly uses only the production inspector route; catalog inspection commands are recorded as reads, projector initialization and SQL policy are not invoked, and registry entries before/after are equal. The SQL Server test uses a separate inspector principal with `db_datareader` plus non-writing `VIEW DEFINITION`; an actual INSERT through that connection is rejected with SQL error 229 and the real table row count is unchanged.
- The production-inspector mismatch matrix runs against real PostgreSQL, MySQL, SQL Server, and SQLite stores. For every provider it proves compatible pass, isolated default mismatch (`DefaultMismatch`), ordered/unique index mismatch (`RequiredIndexMissing`), generated semantics mismatch (`GeneratedSemanticsMismatch`), width mismatch (`SizeMismatch`), precision mismatch (`PrecisionMismatch`), and scale mismatch (`PrecisionMismatch`). SQLite additionally proves an unbounded declared type requested with a bounded contract returns `UnsupportedProviderCapability` with the precise unsupported-dimension message.
- SQLite real-store VerifyOnly separately exercises successful initialization, target capture, catch-up with a non-authoritative target, activation eligibility, status/checkpoint observation, and event apply. Rejecting registry counters fail on every mutating API; all counters remain zero and the target remains unchanged after catch-up. The VerifyOnly host initialization count is zero.

Affected MV and compatibility suites:

- `dotnet test dcb/tests/Sekiban.Dcb.MaterializedView.Tests/Sekiban.Dcb.MaterializedView.Tests.csproj --no-build --no-restore -f net9.0` — **78/78 passed**.
- Same core MV command with `-f net10.0` — **78/78 passed**.
- `dotnet test dcb/tests/Sekiban.Dcb.MaterializedView.Postgres.Tests/Sekiban.Dcb.MaterializedView.Postgres.Tests.csproj --no-build --no-restore -f net9.0 --filter FullyQualifiedName~MaterializedViewPostgresTests` — **7/7 passed**.
- Same Postgres real-store command with `-f net10.0` — **7/7 passed**.
- Binary consumer: compiled against the actual published `10.13.0` package and ran without source recompilation: `binary-consumer-ok:binary-consumer:Sekiban.Dcb.MaterializedView.IMvExecutor`.
- `git diff --check` and EN/JA documentation contract checks passed.

## Mutation-kill evidence

Each decisive mutation was applied to the production path, the named test was run to failure, and the original implementation was restored before the final runs:

- Removing VerifyOnly target-capture and catch-up checkpoint guards failed at the registry update (`SetTargetCheckpointAsync`). Removing activation or event-apply guards failed the zero-mutation counters, proving normal target open/transaction/apply was reintroduced.
- Reintroducing SQL Server's writable-connection `ApplicationIntent=ReadOnly` fallback made all three SQL Server production tests fail at the restricted capability check; this kills the fake-read-only route.
- Removing SQLite generation-expression mapping failed with `SQLite pragma metadata identifies a generated column, but its generation expression could not be derived from sqlite_master.` Removing width mapping failed with `SQLite cannot faithfully inspect the required declared character or binary length.` Removing precision/scale mapping failed with `SQLite cannot faithfully inspect the required declared numeric precision and scale.`
- Removing SQLite default mapping failed with the expected `DefaultMismatch`. Reversing PostgreSQL catalog index ordinality failed the real-store matrix with `RequiredIndexMissing`.
- Bypassing enforced raw/query policy, phase/origin labeling, and first-statement-only/post-execution batch checking fails the corresponding policy tests. All mutations were restored.

The unfiltered Orleans-hosted Postgres run was attempted separately; its environment-only Orleans `TestClusterPortAllocator` path hit `System.OverflowException` in `BsdIPGlobalProperties.GetTcpConnections` while allocating TCP listener pairs. The affected production-path real-store filters above pass independently.

Exact head: `7c5cb72f6dd15d15eedcc44da164962accdfb1a7`


## Final rereview round 2 matrix repair

- Added a real non-unique index to every provider schema fixture and added it to the declarative contract as IsUnique=false. The matching contract passes; an isolated IsUnique=true requirement returns exactly RequiredIndexMissing. The existing ordered-column mismatch remains a separate exact RequiredIndexMissing case.
- Replaced the constant generated expression with a non-constant expression derived from base_value for PostgreSQL, MySQL, SQLite, and SQL Server (ISNULL(base_value + 1, 0) preserves SQL Server computed-column nullability). The matching contract passes; changing only the expression to base_value + 2 returns exactly GeneratedSemanticsMismatch.
- Both new cases use the production IMvReadOnlyMvInspector against real PostgreSQL, MySQL, SQL Server, and SQLite stores. The shared assertion checks the complete deterministic code list in both result.Mismatches and result.Failure.Mismatches. SQL Server expected default/expression values now come from the real system catalog; SQLite keeps faithful expression derivation.
- Final matrix result: SchemaContractMatrix_UsesTheProductionInspector 4/4 passed on both net9.0 and net10.0; focused MV/policy/schema suite 31/31 passed on both frameworks.

## Final matrix mutation-kill evidence

Each mutation was applied to the provider production inspector, the real-store matrix test was run to red, and the mutation was restored before final validation:

- PostgreSQL, MySQL, SQL Server, and SQLite uniqueness observation forced to true: each failed with the exact RequiredIndexMissing for ix_schema_matrix_nonunique.
- PostgreSQL, MySQL, SQL Server, and SQLite generation-expression observation forced to literal 7: each failed with the exact incompatible generation-expression / GeneratedSemanticsMismatch result.

Final validation after restoration: core MV 78/78 on net9.0 and net10.0; Postgres real-store affected suite 7/7 on net9.0 and net10.0; git diff --check passed. The final pushed head is 4cbf1f6801e42743878167a1e2cf19cbdf374d34.
