### PR TITLE
feat(dcb): add strict sortable unique id waits

### DIFF
--- a/dcb/Sekiban.Dcb.slnx
+++ b/dcb/Sekiban.Dcb.slnx
@@ -59,6 +59,8 @@
     <Project Path="tests/Sekiban.Dcb.Orleans.Tests/Sekiban.Dcb.Orleans.Tests.csproj" />
     <Project Path="tests/Sekiban.Dcb.Postgres.Tests/Sekiban.Dcb.Postgres.Tests.csproj" />
     <Project Path="tests/Sekiban.Dcb.WithResult.Tests/Sekiban.Dcb.WithResult.Tests.csproj" />
+    <Project Path="tests/Sekiban.Dcb.SortableUniqueIdWait.Tests/Sekiban.Dcb.SortableUniqueIdWait.Tests.csproj" />
+    <Project Path="tests/Sekiban.Dcb.SortableUniqueIdWait.WithoutResult.Tests/Sekiban.Dcb.SortableUniqueIdWait.WithoutResult.Tests.csproj" />
     <Project Path="tests/Sekiban.Dcb.TestSupport/Sekiban.Dcb.TestSupport.csproj" />
     <Project Path="tests/Sekiban.Dcb.WithoutResult.Tests/Sekiban.Dcb.WithoutResult.Tests.csproj" />
     <Project Path="tests/Sekiban.Dcb.ColdEvents.Tests/Sekiban.Dcb.ColdEvents.Tests.csproj" />

--- a/dcb/src/Sekiban.Dcb.Core.Model/Queries/IWaitForSortableUniqueId.cs
+++ b/dcb/src/Sekiban.Dcb.Core.Model/Queries/IWaitForSortableUniqueId.cs
@@ -10,3 +10,56 @@ public interface IWaitForSortableUniqueId
     /// </summary>
     string? WaitForSortableUniqueId { get; }
 }
+
+/// <summary>
+///     Opts a query into fail-closed sortable-unique-id freshness. A query that implements this marker and whose
+///     requested position is not observed before the adaptive wait expires fails with a
+///     <see cref="SortableUniqueIdWaitTimeoutException" /> before its query is serialized or executed.
+/// </summary>
+/// <remarks>
+///     This interface deliberately has no members. The inherited target is the complete contract; type membership is
+///     the opt-in so adding strictness never changes the serialized query shape.
+/// </remarks>
+public interface IStrictWaitForSortableUniqueId : IWaitForSortableUniqueId;
+
+/// <summary>
+///     Typed failure raised when a strict sortable-unique-id wait cannot observe its target before the adaptive
+///     timeout. It contains wait diagnostics only and never carries query content.
+/// </summary>
+public sealed class SortableUniqueIdWaitTimeoutException : TimeoutException
+{
+    public SortableUniqueIdWaitTimeoutException(
+        string targetSortableUniqueId,
+        TimeSpan timeout,
+        TimeSpan elapsed,
+        string? lastObservedSortableUniqueId,
+        Exception? innerException = null)
+        : base(
+            $"The projection did not observe sortable unique ID '{targetSortableUniqueId}' within {timeout}. "
+            + $"Elapsed: {elapsed}; last observed: {lastObservedSortableUniqueId ?? "<none>"}.",
+            innerException)
+    {
+        TargetSortableUniqueId = targetSortableUniqueId ?? throw new ArgumentNullException(nameof(targetSortableUniqueId));
+        Timeout = timeout;
+        Elapsed = elapsed;
+        LastObservedSortableUniqueId = lastObservedSortableUniqueId;
+    }
+
+    /// <summary>The sortable unique ID the strict query requested.</summary>
+    public string TargetSortableUniqueId { get; }
+
+    /// <summary>Alias for callers that use the shorter diagnostic name.</summary>
+    public string Target => TargetSortableUniqueId;
+
+    /// <summary>The adaptive timeout selected for this target.</summary>
+    public TimeSpan Timeout { get; }
+
+    /// <summary>The monotonic elapsed time measured by the wait policy.</summary>
+    public TimeSpan Elapsed { get; }
+
+    /// <summary>The projection's unsafe/current position at timeout, or <see langword="null" /> when unavailable.</summary>
+    public string? LastObservedSortableUniqueId { get; }
+
+    /// <summary>Alias for callers that use the shorter diagnostic name.</summary>
+    public string? LastObserved => LastObservedSortableUniqueId;
+}

--- a/dcb/src/Sekiban.Dcb.Core/Actors/CoreGeneralSekibanExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Actors/CoreGeneralSekibanExecutor.cs
@@ -29,6 +29,7 @@ public class CoreGeneralSekibanExecutor
     private readonly IServiceIdProvider _serviceIdProvider;
     private readonly ISortableUniqueIdGenerator _sortableUniqueIdGenerator;
     private readonly SortableUniqueIdSeedCoordinator _sortableUniqueIdSeedCoordinator;
+    private readonly SortableUniqueIdWaitPolicy _sortableUniqueIdWaitPolicy;
 
     /// <summary>
     ///     Test seam ONLY (never set in production): the EventId / SortableUniqueId generators used by the serialized
@@ -69,7 +70,8 @@ public class CoreGeneralSekibanExecutor
             executedUserProvider,
             ProcessSharedSortableUniqueIdServices.Generator,
             ProcessSharedSortableUniqueIdServices.SeedCoordinator,
-            new DefaultServiceIdProvider())
+            new DefaultServiceIdProvider(),
+            SortableUniqueIdWaitPolicy.System)
     {
     }
 
@@ -83,6 +85,29 @@ public class CoreGeneralSekibanExecutor
         ISortableUniqueIdGenerator sortableUniqueIdGenerator,
         SortableUniqueIdSeedCoordinator sortableUniqueIdSeedCoordinator,
         IServiceIdProvider serviceIdProvider)
+        : this(
+            eventStore,
+            actorAccessor,
+            domainTypes,
+            eventPublisher,
+            executedUserProvider,
+            sortableUniqueIdGenerator,
+            sortableUniqueIdSeedCoordinator,
+            serviceIdProvider,
+            SortableUniqueIdWaitPolicy.System)
+    {
+    }
+
+    internal CoreGeneralSekibanExecutor(
+        IEventStore eventStore,
+        IActorObjectAccessor actorAccessor,
+        DcbDomainTypes domainTypes,
+        IEventPublisher? eventPublisher,
+        IExecutedUserProvider? executedUserProvider,
+        ISortableUniqueIdGenerator sortableUniqueIdGenerator,
+        SortableUniqueIdSeedCoordinator sortableUniqueIdSeedCoordinator,
+        IServiceIdProvider serviceIdProvider,
+        SortableUniqueIdWaitPolicy sortableUniqueIdWaitPolicy)
     {
         _eventStore = eventStore ?? throw new ArgumentNullException(nameof(eventStore));
         _actorAccessor = actorAccessor ?? throw new ArgumentNullException(nameof(actorAccessor));
@@ -94,6 +119,8 @@ public class CoreGeneralSekibanExecutor
         _sortableUniqueIdSeedCoordinator = sortableUniqueIdSeedCoordinator ??
                                            throw new ArgumentNullException(nameof(sortableUniqueIdSeedCoordinator));
         _serviceIdProvider = serviceIdProvider ?? throw new ArgumentNullException(nameof(serviceIdProvider));
+        _sortableUniqueIdWaitPolicy = sortableUniqueIdWaitPolicy ??
+                                      throw new ArgumentNullException(nameof(sortableUniqueIdWaitPolicy));
     }
 
     private Task EnsureSortableUniqueIdSeededAsync(CancellationToken cancellationToken)
@@ -653,6 +680,11 @@ public class CoreGeneralSekibanExecutor
 
             var actor = actorResult.GetValue();
 
+            await WaitForStrictSortableUniqueIdIfNeededAsync(
+                actor,
+                queryCommon,
+                SortableUniqueIdWaitSurface.InMemorySingle);
+
             // Get the current state
             var stateResult = await actor.GetStateAsync();
             if (!stateResult.IsSuccess)
@@ -767,6 +799,11 @@ public class CoreGeneralSekibanExecutor
             }
 
             var actor = actorResult.GetValue();
+
+            await WaitForStrictSortableUniqueIdIfNeededAsync(
+                actor,
+                queryCommon,
+                SortableUniqueIdWaitSurface.InMemoryList);
 
             // Get the current state
             var stateResult = await actor.GetStateAsync();
@@ -885,6 +922,42 @@ public class CoreGeneralSekibanExecutor
         {
             return ResultBox.Error<ProjectionHeadStatus>(ex);
         }
+    }
+
+    private async Task WaitForStrictSortableUniqueIdIfNeededAsync(
+        GeneralMultiProjectionActor actor,
+        object query,
+        SortableUniqueIdWaitSurface surface)
+    {
+        if (query is not IStrictWaitForSortableUniqueId strictQuery ||
+            string.IsNullOrEmpty(strictQuery.WaitForSortableUniqueId))
+        {
+            // Legacy InMemory queries intentionally keep their historical no-wait behavior.
+            return;
+        }
+
+        var target = strictQuery.WaitForSortableUniqueId;
+        var wait = await _sortableUniqueIdWaitPolicy.WaitAsync(
+            target,
+            surface,
+            SortableUniqueIdWaitMode.Strict,
+            _ => actor.IsSortableUniqueIdReceived(target),
+            _ => ReadCurrentSortableUniqueIdAsync(actor));
+
+        if (wait.TimedOut)
+        {
+            throw new SortableUniqueIdWaitTimeoutException(
+                target,
+                wait.Timeout,
+                wait.Elapsed,
+                wait.LastObservedSortableUniqueId);
+        }
+    }
+
+    private static async Task<string?> ReadCurrentSortableUniqueIdAsync(GeneralMultiProjectionActor actor)
+    {
+        var status = await actor.GetProjectionHeadStatusAsync().ConfigureAwait(false);
+        return status.Current.LastSortableUniqueId;
     }
 
     public async Task<ResultBox<EventStoreHeadStatus>> GetEventStoreHeadStatusAsync(bool includeTotalEventCount = false)

--- a/dcb/src/Sekiban.Dcb.Core/Common/SortableUniqueIdWaitHelper.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Common/SortableUniqueIdWaitHelper.cs
@@ -27,12 +27,20 @@ public static class SortableUniqueIdWaitHelper
     ///     Calculate adaptive timeout based on how old the sortable unique ID is
     /// </summary>
     public static int CalculateAdaptiveTimeout(string sortableUniqueId)
+        => CalculateAdaptiveTimeout(sortableUniqueId, TimeProvider.System);
+
+    /// <summary>
+    ///     Calculate the legacy adaptive timeout using an injected clock. The threshold and boundary are intentionally
+    ///     unchanged: IDs more than five seconds old use five seconds; IDs exactly five seconds old, future IDs, and
+    ///     unparsable IDs use the thirty-second default.
+    /// </summary>
+    internal static int CalculateAdaptiveTimeout(string sortableUniqueId, TimeProvider timeProvider)
     {
         try
         {
             var id = new SortableUniqueId(sortableUniqueId);
             var eventTime = id.GetDateTime();
-            var age = DateTime.UtcNow - eventTime;
+            var age = timeProvider.GetUtcNow().UtcDateTime - eventTime;
 
             // If the event is more than 5 seconds old, use a shorter timeout
             if (age.TotalSeconds > 5)

--- a/dcb/src/Sekiban.Dcb.Core/Common/SortableUniqueIdWaitPolicy.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Common/SortableUniqueIdWaitPolicy.cs
@@ -1,0 +1,110 @@
+using Sekiban.Dcb.Queries;
+
+namespace Sekiban.Dcb.Common;
+
+/// <summary>Internal result of one shared sortable-unique-id wait.</summary>
+internal sealed record SortableUniqueIdWaitResult(
+    bool Received,
+    TimeSpan Timeout,
+    TimeSpan Elapsed,
+    string? LastObservedSortableUniqueId)
+{
+    internal bool TimedOut => !Received;
+}
+
+/// <summary>
+///     The single wait implementation used by the Orleans query facades and strict InMemory queries. The clock,
+///     delay, probe, and diagnostic delegates are deliberately injectable internally so timing tests never sleep.
+/// </summary>
+internal sealed class SortableUniqueIdWaitPolicy
+{
+    internal static SortableUniqueIdWaitPolicy System { get; } = new(TimeProvider.System);
+
+    private readonly TimeProvider _timeProvider;
+    private readonly Func<TimeSpan, CancellationToken, Task> _delayAsync;
+
+    internal SortableUniqueIdWaitPolicy(
+        TimeProvider? timeProvider = null,
+        Func<TimeSpan, CancellationToken, Task>? delayAsync = null)
+    {
+        _timeProvider = timeProvider ?? TimeProvider.System;
+        _delayAsync = delayAsync ?? ((delay, cancellationToken) =>
+            Task.Delay(delay, _timeProvider, cancellationToken));
+    }
+
+    internal async Task<SortableUniqueIdWaitResult> WaitAsync(
+        string targetSortableUniqueId,
+        SortableUniqueIdWaitSurface surface,
+        SortableUniqueIdWaitMode mode,
+        Func<CancellationToken, Task<bool>> probeAsync,
+        Func<CancellationToken, Task<string?>>? lastObservedAsync = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(targetSortableUniqueId);
+        ArgumentNullException.ThrowIfNull(probeAsync);
+
+        var timeout = TimeSpan.FromMilliseconds(
+            SortableUniqueIdWaitHelper.CalculateAdaptiveTimeout(targetSortableUniqueId, _timeProvider));
+        var startTimestamp = _timeProvider.GetTimestamp();
+
+        while (true)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var elapsed = _timeProvider.GetElapsedTime(startTimestamp);
+            if (elapsed >= timeout)
+            {
+                break;
+            }
+
+            if (await probeAsync(cancellationToken).ConfigureAwait(false))
+            {
+                elapsed = _timeProvider.GetElapsedTime(startTimestamp);
+                SortableUniqueIdWaitTelemetry.RecordWait(
+                    surface,
+                    mode,
+                    SortableUniqueIdWaitOutcome.Arrived,
+                    elapsed);
+                return new SortableUniqueIdWaitResult(true, timeout, elapsed, null);
+            }
+
+            elapsed = _timeProvider.GetElapsedTime(startTimestamp);
+            var remaining = timeout - elapsed;
+            if (remaining <= TimeSpan.Zero)
+            {
+                break;
+            }
+
+            await _delayAsync(
+                    remaining < TimeSpan.FromMilliseconds(SortableUniqueIdWaitHelper.DefaultPollingIntervalMs)
+                        ? remaining
+                        : TimeSpan.FromMilliseconds(SortableUniqueIdWaitHelper.DefaultPollingIntervalMs),
+                    cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        var timeoutElapsed = _timeProvider.GetElapsedTime(startTimestamp);
+        string? lastObserved = null;
+        if (mode == SortableUniqueIdWaitMode.Strict && lastObservedAsync is not null)
+        {
+            try
+            {
+                lastObserved = await lastObservedAsync(cancellationToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception)
+            {
+                // The diagnostic read is best effort. The timeout is the real outcome and must not be masked.
+            }
+        }
+
+        SortableUniqueIdWaitTelemetry.RecordWait(
+            surface,
+            mode,
+            SortableUniqueIdWaitOutcome.TimedOut,
+            timeoutElapsed);
+        return new SortableUniqueIdWaitResult(false, timeout, timeoutElapsed, lastObserved);
+    }
+}

--- a/dcb/src/Sekiban.Dcb.Core/Common/SortableUniqueIdWaitTelemetry.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Common/SortableUniqueIdWaitTelemetry.cs
@@ -1,0 +1,96 @@
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+
+namespace Sekiban.Dcb.Common;
+
+/// <summary>
+///     Core-owned metrics for sortable-unique-id waits. Labels are fixed vocabulary values; target IDs are never
+///     emitted as metric dimensions.
+/// </summary>
+public static class SortableUniqueIdWaitTelemetry
+{
+    public const string MeterName = "Sekiban.Dcb.Core";
+    public const string TimeoutCounterName = "sekiban.dcb.sortable_unique_id_wait.timeouts";
+    public const string DurationHistogramName = "sekiban.dcb.sortable_unique_id_wait.duration";
+
+    private static readonly Meter Meter = new(MeterName);
+
+    private static readonly Counter<long> WaitTimeouts = Meter.CreateCounter<long>(
+        TimeoutCounterName,
+        unit: "{wait}",
+        description: "Sortable-unique-id waits that reached their adaptive timeout.");
+
+    private static readonly Histogram<double> WaitDuration = Meter.CreateHistogram<double>(
+        DurationHistogramName,
+        unit: "ms",
+        description: "Elapsed time of sortable-unique-id waits.");
+
+    internal static void RecordWait(
+        SortableUniqueIdWaitSurface surface,
+        SortableUniqueIdWaitMode mode,
+        SortableUniqueIdWaitOutcome outcome,
+        TimeSpan elapsed)
+    {
+        var tags = new TagList
+        {
+            { "surface", surface.ToLabel() },
+            { "mode", mode.ToLabel() },
+            { "outcome", outcome.ToLabel() }
+        };
+
+        WaitDuration.Record(Math.Max(0, elapsed.TotalMilliseconds), tags);
+        if (outcome == SortableUniqueIdWaitOutcome.TimedOut)
+        {
+            WaitTimeouts.Add(1, tags);
+        }
+    }
+}
+
+/// <summary>Bounded production entrypoint labels for wait metrics.</summary>
+internal enum SortableUniqueIdWaitSurface
+{
+    OrleansWithResultSingle,
+    OrleansWithResultList,
+    OrleansWithoutResultSingle,
+    OrleansWithoutResultList,
+    InMemorySingle,
+    InMemoryList
+}
+
+internal enum SortableUniqueIdWaitMode
+{
+    Legacy,
+    Strict
+}
+
+internal enum SortableUniqueIdWaitOutcome
+{
+    Arrived,
+    TimedOut
+}
+
+internal static class SortableUniqueIdWaitMetricLabels
+{
+    internal static string ToLabel(this SortableUniqueIdWaitSurface surface) => surface switch
+    {
+        SortableUniqueIdWaitSurface.OrleansWithResultSingle => "orleans_with_result_single",
+        SortableUniqueIdWaitSurface.OrleansWithResultList => "orleans_with_result_list",
+        SortableUniqueIdWaitSurface.OrleansWithoutResultSingle => "orleans_without_result_single",
+        SortableUniqueIdWaitSurface.OrleansWithoutResultList => "orleans_without_result_list",
+        SortableUniqueIdWaitSurface.InMemorySingle => "in_memory_single",
+        SortableUniqueIdWaitSurface.InMemoryList => "in_memory_list",
+        _ => "unknown"
+    };
+
+    internal static string ToLabel(this SortableUniqueIdWaitMode mode) => mode switch
+    {
+        SortableUniqueIdWaitMode.Strict => "strict",
+        _ => "legacy"
+    };
+
+    internal static string ToLabel(this SortableUniqueIdWaitOutcome outcome) => outcome switch
+    {
+        SortableUniqueIdWaitOutcome.TimedOut => "timeout",
+        _ => "arrived"
+    };
+}

--- a/dcb/src/Sekiban.Dcb.Core/Sekiban.Dcb.Core.csproj
+++ b/dcb/src/Sekiban.Dcb.Core/Sekiban.Dcb.Core.csproj
@@ -71,6 +71,18 @@
         <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
             <_Parameter1>Sekiban.Dcb.Orleans.WithoutResult</_Parameter1>
         </AssemblyAttribute>
+        <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+            <_Parameter1>Sekiban.Dcb.WithResult</_Parameter1>
+        </AssemblyAttribute>
+        <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+            <_Parameter1>Sekiban.Dcb.WithoutResult</_Parameter1>
+        </AssemblyAttribute>
+        <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+            <_Parameter1>Sekiban.Dcb.SortableUniqueIdWait.Tests</_Parameter1>
+        </AssemblyAttribute>
+        <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+            <_Parameter1>Sekiban.Dcb.SortableUniqueIdWait.WithoutResult.Tests</_Parameter1>
+        </AssemblyAttribute>
     </ItemGroup>
 
 </Project>

--- a/dcb/src/Sekiban.Dcb.Orleans.WithResult/OrleansDcbExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.WithResult/OrleansDcbExecutor.cs
@@ -11,7 +11,6 @@ using Sekiban.Dcb.Queries;
 using Sekiban.Dcb.ServiceId;
 using Sekiban.Dcb.Storage;
 using Sekiban.Dcb.Tags;
-using System.Diagnostics;
 using Sekiban.Dcb.Orleans.Serialization;
 namespace Sekiban.Dcb.Orleans;
 
@@ -31,6 +30,7 @@ public class OrleansDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecuto
     private readonly IEventStore _eventStore;
     private readonly GeneralSekibanExecutor _generalExecutor;
     private readonly IServiceIdProvider _serviceIdProvider;
+    private readonly SortableUniqueIdWaitPolicy _sortableUniqueIdWaitPolicy;
 
     /// <summary>
     ///     Binary-compatible overload preserved for callers compiled against the pre-SEK-G23 constructor.
@@ -60,7 +60,8 @@ public class OrleansDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecuto
             serviceIdProvider,
             executedUserProvider,
             ProcessSharedSortableUniqueIdServices.Generator,
-            ProcessSharedSortableUniqueIdServices.SeedCoordinator)
+            ProcessSharedSortableUniqueIdServices.SeedCoordinator,
+            SortableUniqueIdWaitPolicy.System)
     {
     }
 
@@ -74,11 +75,36 @@ public class OrleansDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecuto
         IExecutedUserProvider? executedUserProvider,
         ISortableUniqueIdGenerator sortableUniqueIdGenerator,
         SortableUniqueIdSeedCoordinator sortableUniqueIdSeedCoordinator)
+        : this(
+            clusterClient,
+            eventStore,
+            domainTypes,
+            eventPublisher,
+            serviceIdProvider,
+            executedUserProvider,
+            sortableUniqueIdGenerator,
+            sortableUniqueIdSeedCoordinator,
+            SortableUniqueIdWaitPolicy.System)
+    {
+    }
+
+    internal OrleansDcbExecutor(
+        IClusterClient clusterClient,
+        IEventStore eventStore,
+        DcbDomainTypes domainTypes,
+        IEventPublisher? eventPublisher,
+        IServiceIdProvider? serviceIdProvider,
+        IExecutedUserProvider? executedUserProvider,
+        ISortableUniqueIdGenerator sortableUniqueIdGenerator,
+        SortableUniqueIdSeedCoordinator sortableUniqueIdSeedCoordinator,
+        SortableUniqueIdWaitPolicy sortableUniqueIdWaitPolicy)
     {
         _clusterClient = clusterClient ?? throw new ArgumentNullException(nameof(clusterClient));
         _eventStore = eventStore ?? throw new ArgumentNullException(nameof(eventStore));
         _domainTypes = domainTypes ?? throw new ArgumentNullException(nameof(domainTypes));
         _serviceIdProvider = serviceIdProvider ?? new DefaultServiceIdProvider();
+        _sortableUniqueIdWaitPolicy = sortableUniqueIdWaitPolicy ??
+                                      throw new ArgumentNullException(nameof(sortableUniqueIdWaitPolicy));
         _actorAccessor = new OrleansActorObjectAccessor(clusterClient, eventStore, domainTypes, _serviceIdProvider);
         _generalExecutor = new GeneralSekibanExecutor(
             eventStore,
@@ -88,7 +114,8 @@ public class OrleansDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecuto
             executedUserProvider,
             sortableUniqueIdGenerator,
             sortableUniqueIdSeedCoordinator,
-            _serviceIdProvider);
+            _serviceIdProvider,
+            _sortableUniqueIdWaitPolicy);
     }
 
     /// <summary>
@@ -140,7 +167,10 @@ public class OrleansDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecuto
             var grain = _clusterClient.GetGrain<IMultiProjectionGrain>(grainId);
 
             // Wait for sortable unique ID if needed
-            await WaitForSortableUniqueIdIfNeeded(grain, queryCommon);
+            await WaitForSortableUniqueIdIfNeeded(
+                grain,
+                queryCommon,
+                SortableUniqueIdWaitSurface.OrleansWithResultSingle);
 
             var serializableQuery = await SerializableQueryParameter.CreateFromAsync(
                 queryCommon,
@@ -175,7 +205,10 @@ public class OrleansDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecuto
             var grain = _clusterClient.GetGrain<IMultiProjectionGrain>(grainId);
 
             // Wait for sortable unique ID if needed
-            await WaitForSortableUniqueIdIfNeeded(grain, queryCommon);
+            await WaitForSortableUniqueIdIfNeeded(
+                grain,
+                queryCommon,
+                SortableUniqueIdWaitSurface.OrleansWithResultList);
 
             var serializableQuery = await SerializableQueryParameter.CreateFromAsync(
                 queryCommon,
@@ -192,35 +225,57 @@ public class OrleansDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecuto
     }
 
     /// <summary>
-    ///     Wait for a sortable unique ID to be processed if the query implements IWaitForSortableUniqueId
+    ///     Wait for a sortable unique ID to be processed if the query implements IWaitForSortableUniqueId.
+    ///     Strict marker queries fail before serialization when the wait times out; legacy queries keep fail-open.
     /// </summary>
-    private async Task WaitForSortableUniqueIdIfNeeded(IMultiProjectionGrain grain, object query)
+    private async Task WaitForSortableUniqueIdIfNeeded(
+        IMultiProjectionGrain grain,
+        object query,
+        SortableUniqueIdWaitSurface surface)
     {
-        if (query is IWaitForSortableUniqueId waitForQuery &&
-            !string.IsNullOrEmpty(waitForQuery.WaitForSortableUniqueId))
+        if (query is not IWaitForSortableUniqueId waitForQuery ||
+            string.IsNullOrEmpty(waitForQuery.WaitForSortableUniqueId))
         {
-            var sortableUniqueId = waitForQuery.WaitForSortableUniqueId;
-
-            // Calculate adaptive timeout based on the age of the sortable unique ID
-            var timeoutMs = SortableUniqueIdWaitHelper.CalculateAdaptiveTimeout(sortableUniqueId);
-            var pollingIntervalMs = SortableUniqueIdWaitHelper.DefaultPollingIntervalMs;
-
-            var stopwatch = Stopwatch.StartNew();
-
-            while (stopwatch.ElapsedMilliseconds < timeoutMs)
-            {
-                var isReceived = await grain.IsSortableUniqueIdReceived(sortableUniqueId);
-                if (isReceived)
-                {
-                    return;
-                }
-
-                await Task.Delay(pollingIntervalMs);
-            }
-
-            // Timeout reached - we proceed with the query anyway
-            // The query might return stale data, but that's better than failing completely
+            return;
         }
+
+        var sortableUniqueId = waitForQuery.WaitForSortableUniqueId;
+        var strict = query is IStrictWaitForSortableUniqueId;
+        var wait = await _sortableUniqueIdWaitPolicy.WaitAsync(
+            sortableUniqueId,
+            surface,
+            strict ? SortableUniqueIdWaitMode.Strict : SortableUniqueIdWaitMode.Legacy,
+            cancellationToken => ProbeSortableUniqueIdAsync(grain, sortableUniqueId, cancellationToken),
+            strict
+                ? cancellationToken => ReadCurrentSortableUniqueIdAsync(grain, cancellationToken)
+                : null);
+
+        if (strict && wait.TimedOut)
+        {
+            throw new SortableUniqueIdWaitTimeoutException(
+                sortableUniqueId,
+                wait.Timeout,
+                wait.Elapsed,
+                wait.LastObservedSortableUniqueId);
+        }
+    }
+
+    private static async Task<bool> ProbeSortableUniqueIdAsync(
+        IMultiProjectionGrain grain,
+        string sortableUniqueId,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return await grain.IsSortableUniqueIdReceived(sortableUniqueId).ConfigureAwait(false);
+    }
+
+    private static async Task<string?> ReadCurrentSortableUniqueIdAsync(
+        IMultiProjectionGrain grain,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        var status = await grain.GetProjectionHeadStatusAsync().ConfigureAwait(false);
+        return status.CurrentLastSortableUniqueId;
     }
 
     private async Task<ResultBox<TResult>> DeserializeQueryResultAsync<TResult>(

--- a/dcb/src/Sekiban.Dcb.Orleans.WithResult/Sekiban.Dcb.Orleans.WithResult.csproj
+++ b/dcb/src/Sekiban.Dcb.Orleans.WithResult/Sekiban.Dcb.Orleans.WithResult.csproj
@@ -45,4 +45,10 @@
         <ProjectReference Include="..\Sekiban.Dcb.WithResult.Model\Sekiban.Dcb.WithResult.Model.csproj"/>
     </ItemGroup>
 
+    <ItemGroup>
+        <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+            <_Parameter1>Sekiban.Dcb.SortableUniqueIdWait.Tests</_Parameter1>
+        </AssemblyAttribute>
+    </ItemGroup>
+
 </Project>

--- a/dcb/src/Sekiban.Dcb.Orleans.WithoutResult/OrleansDcbExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.WithoutResult/OrleansDcbExecutor.cs
@@ -12,7 +12,6 @@ using Sekiban.Dcb.Queries;
 using Sekiban.Dcb.ServiceId;
 using Sekiban.Dcb.Storage;
 using Sekiban.Dcb.Tags;
-using System.Diagnostics;
 using Sekiban.Dcb.Orleans.Serialization;
 namespace Sekiban.Dcb.Orleans;
 
@@ -32,6 +31,7 @@ public class OrleansDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecuto
     private readonly IEventStore _eventStore;
     private readonly GeneralSekibanExecutor _generalExecutor;
     private readonly IServiceIdProvider _serviceIdProvider;
+    private readonly SortableUniqueIdWaitPolicy _sortableUniqueIdWaitPolicy;
 
     /// <summary>
     ///     Binary-compatible overload preserved for callers compiled against the pre-SEK-G23 constructor.
@@ -61,7 +61,8 @@ public class OrleansDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecuto
             serviceIdProvider,
             executedUserProvider,
             ProcessSharedSortableUniqueIdServices.Generator,
-            ProcessSharedSortableUniqueIdServices.SeedCoordinator)
+            ProcessSharedSortableUniqueIdServices.SeedCoordinator,
+            SortableUniqueIdWaitPolicy.System)
     {
     }
 
@@ -75,11 +76,36 @@ public class OrleansDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecuto
         IExecutedUserProvider? executedUserProvider,
         ISortableUniqueIdGenerator sortableUniqueIdGenerator,
         SortableUniqueIdSeedCoordinator sortableUniqueIdSeedCoordinator)
+        : this(
+            clusterClient,
+            eventStore,
+            domainTypes,
+            eventPublisher,
+            serviceIdProvider,
+            executedUserProvider,
+            sortableUniqueIdGenerator,
+            sortableUniqueIdSeedCoordinator,
+            SortableUniqueIdWaitPolicy.System)
+    {
+    }
+
+    internal OrleansDcbExecutor(
+        IClusterClient clusterClient,
+        IEventStore eventStore,
+        DcbDomainTypes domainTypes,
+        IEventPublisher? eventPublisher,
+        IServiceIdProvider? serviceIdProvider,
+        IExecutedUserProvider? executedUserProvider,
+        ISortableUniqueIdGenerator sortableUniqueIdGenerator,
+        SortableUniqueIdSeedCoordinator sortableUniqueIdSeedCoordinator,
+        SortableUniqueIdWaitPolicy sortableUniqueIdWaitPolicy)
     {
         _clusterClient = clusterClient ?? throw new ArgumentNullException(nameof(clusterClient));
         _eventStore = eventStore ?? throw new ArgumentNullException(nameof(eventStore));
         _domainTypes = domainTypes ?? throw new ArgumentNullException(nameof(domainTypes));
         _serviceIdProvider = serviceIdProvider ?? new DefaultServiceIdProvider();
+        _sortableUniqueIdWaitPolicy = sortableUniqueIdWaitPolicy ??
+                                      throw new ArgumentNullException(nameof(sortableUniqueIdWaitPolicy));
         _actorAccessor = new OrleansActorObjectAccessor(clusterClient, eventStore, domainTypes, _serviceIdProvider);
         _generalExecutor = new GeneralSekibanExecutor(
             eventStore,
@@ -89,7 +115,8 @@ public class OrleansDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecuto
             executedUserProvider,
             sortableUniqueIdGenerator,
             sortableUniqueIdSeedCoordinator,
-            _serviceIdProvider);
+            _serviceIdProvider,
+            _sortableUniqueIdWaitPolicy);
     }
 
     /// <summary>
@@ -135,7 +162,10 @@ public class OrleansDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecuto
         var grain = _clusterClient.GetGrain<IMultiProjectionGrain>(grainId);
 
         // Wait for sortable unique ID if needed
-        await WaitForSortableUniqueIdIfNeeded(grain, queryCommon);
+        await WaitForSortableUniqueIdIfNeeded(
+            grain,
+            queryCommon,
+            SortableUniqueIdWaitSurface.OrleansWithoutResultSingle);
 
         var serializableQuery = await SerializableQueryParameter.CreateFromAsync(
             queryCommon,
@@ -159,7 +189,10 @@ public class OrleansDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecuto
         var grain = _clusterClient.GetGrain<IMultiProjectionGrain>(grainId);
 
         // Wait for sortable unique ID if needed
-        await WaitForSortableUniqueIdIfNeeded(grain, queryCommon);
+        await WaitForSortableUniqueIdIfNeeded(
+            grain,
+            queryCommon,
+            SortableUniqueIdWaitSurface.OrleansWithoutResultList);
 
         var serializableQuery = await SerializableQueryParameter.CreateFromAsync(
             queryCommon,
@@ -171,35 +204,57 @@ public class OrleansDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecuto
     }
 
     /// <summary>
-    ///     Wait for a sortable unique ID to be processed if the query implements IWaitForSortableUniqueId
+    ///     Wait for a sortable unique ID to be processed if the query implements IWaitForSortableUniqueId.
+    ///     Strict marker queries fail before serialization when the wait times out; legacy queries keep fail-open.
     /// </summary>
-    private async Task WaitForSortableUniqueIdIfNeeded(IMultiProjectionGrain grain, object query)
+    private async Task WaitForSortableUniqueIdIfNeeded(
+        IMultiProjectionGrain grain,
+        object query,
+        SortableUniqueIdWaitSurface surface)
     {
-        if (query is IWaitForSortableUniqueId waitForQuery &&
-            !string.IsNullOrEmpty(waitForQuery.WaitForSortableUniqueId))
+        if (query is not IWaitForSortableUniqueId waitForQuery ||
+            string.IsNullOrEmpty(waitForQuery.WaitForSortableUniqueId))
         {
-            var sortableUniqueId = waitForQuery.WaitForSortableUniqueId;
-
-            // Calculate adaptive timeout based on the age of the sortable unique ID
-            var timeoutMs = SortableUniqueIdWaitHelper.CalculateAdaptiveTimeout(sortableUniqueId);
-            var pollingIntervalMs = SortableUniqueIdWaitHelper.DefaultPollingIntervalMs;
-
-            var stopwatch = Stopwatch.StartNew();
-
-            while (stopwatch.ElapsedMilliseconds < timeoutMs)
-            {
-                var isReceived = await grain.IsSortableUniqueIdReceived(sortableUniqueId);
-                if (isReceived)
-                {
-                    return;
-                }
-
-                await Task.Delay(pollingIntervalMs);
-            }
-
-            // Timeout reached - we proceed with the query anyway
-            // The query might return stale data, but that's better than failing completely
+            return;
         }
+
+        var sortableUniqueId = waitForQuery.WaitForSortableUniqueId;
+        var strict = query is IStrictWaitForSortableUniqueId;
+        var wait = await _sortableUniqueIdWaitPolicy.WaitAsync(
+            sortableUniqueId,
+            surface,
+            strict ? SortableUniqueIdWaitMode.Strict : SortableUniqueIdWaitMode.Legacy,
+            cancellationToken => ProbeSortableUniqueIdAsync(grain, sortableUniqueId, cancellationToken),
+            strict
+                ? cancellationToken => ReadCurrentSortableUniqueIdAsync(grain, cancellationToken)
+                : null);
+
+        if (strict && wait.TimedOut)
+        {
+            throw new SortableUniqueIdWaitTimeoutException(
+                sortableUniqueId,
+                wait.Timeout,
+                wait.Elapsed,
+                wait.LastObservedSortableUniqueId);
+        }
+    }
+
+    private static async Task<bool> ProbeSortableUniqueIdAsync(
+        IMultiProjectionGrain grain,
+        string sortableUniqueId,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return await grain.IsSortableUniqueIdReceived(sortableUniqueId).ConfigureAwait(false);
+    }
+
+    private static async Task<string?> ReadCurrentSortableUniqueIdAsync(
+        IMultiProjectionGrain grain,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        var status = await grain.GetProjectionHeadStatusAsync().ConfigureAwait(false);
+        return status.CurrentLastSortableUniqueId;
     }
 
     private async Task<TResult> DeserializeQueryResultAsync<TResult>(

--- a/dcb/src/Sekiban.Dcb.Orleans.WithoutResult/Sekiban.Dcb.Orleans.WithoutResult.csproj
+++ b/dcb/src/Sekiban.Dcb.Orleans.WithoutResult/Sekiban.Dcb.Orleans.WithoutResult.csproj
@@ -42,4 +42,13 @@
         <ProjectReference Include="..\Sekiban.Dcb.WithoutResult.Model\Sekiban.Dcb.WithoutResult.Model.csproj"/>
     </ItemGroup>
 
+    <ItemGroup>
+        <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+            <_Parameter1>Sekiban.Dcb.SortableUniqueIdWait.Tests</_Parameter1>
+        </AssemblyAttribute>
+        <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+            <_Parameter1>Sekiban.Dcb.SortableUniqueIdWait.WithoutResult.Tests</_Parameter1>
+        </AssemblyAttribute>
+    </ItemGroup>
+
 </Project>

--- a/dcb/src/Sekiban.Dcb.WithResult/Actors/GeneralSekibanExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.WithResult/Actors/GeneralSekibanExecutor.cs
@@ -55,6 +55,29 @@ public class GeneralSekibanExecutor : ISekibanExecutor, ISerializedSekibanDcbExe
         ISortableUniqueIdGenerator sortableUniqueIdGenerator,
         SortableUniqueIdSeedCoordinator sortableUniqueIdSeedCoordinator,
         IServiceIdProvider serviceIdProvider)
+        : this(
+            eventStore,
+            actorAccessor,
+            domainTypes,
+            eventPublisher,
+            executedUserProvider,
+            sortableUniqueIdGenerator,
+            sortableUniqueIdSeedCoordinator,
+            serviceIdProvider,
+            SortableUniqueIdWaitPolicy.System)
+    {
+    }
+
+    internal GeneralSekibanExecutor(
+        IEventStore eventStore,
+        IActorObjectAccessor actorAccessor,
+        DcbDomainTypes domainTypes,
+        IEventPublisher? eventPublisher,
+        IExecutedUserProvider? executedUserProvider,
+        ISortableUniqueIdGenerator sortableUniqueIdGenerator,
+        SortableUniqueIdSeedCoordinator sortableUniqueIdSeedCoordinator,
+        IServiceIdProvider serviceIdProvider,
+        SortableUniqueIdWaitPolicy sortableUniqueIdWaitPolicy)
     {
         _actorAccessor = actorAccessor;
         _core = new CoreGeneralSekibanExecutor(
@@ -65,7 +88,8 @@ public class GeneralSekibanExecutor : ISekibanExecutor, ISerializedSekibanDcbExe
             executedUserProvider,
             sortableUniqueIdGenerator,
             sortableUniqueIdSeedCoordinator,
-            serviceIdProvider);
+            serviceIdProvider,
+            sortableUniqueIdWaitPolicy);
     }
 
     /// <summary>

--- a/dcb/src/Sekiban.Dcb.WithResult/Sekiban.Dcb.WithResult.csproj
+++ b/dcb/src/Sekiban.Dcb.WithResult/Sekiban.Dcb.WithResult.csproj
@@ -44,4 +44,13 @@
         </PackageReference>
     </ItemGroup>
 
+    <ItemGroup>
+        <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+            <_Parameter1>Sekiban.Dcb.Orleans.WithResult</_Parameter1>
+        </AssemblyAttribute>
+        <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+            <_Parameter1>Sekiban.Dcb.SortableUniqueIdWait.Tests</_Parameter1>
+        </AssemblyAttribute>
+    </ItemGroup>
+
 </Project>

--- a/dcb/src/Sekiban.Dcb.WithoutResult/Actors/GeneralSekibanExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.WithoutResult/Actors/GeneralSekibanExecutor.cs
@@ -56,6 +56,29 @@ public class GeneralSekibanExecutor : ISekibanExecutor, ISerializedSekibanDcbExe
         ISortableUniqueIdGenerator sortableUniqueIdGenerator,
         SortableUniqueIdSeedCoordinator sortableUniqueIdSeedCoordinator,
         IServiceIdProvider serviceIdProvider)
+        : this(
+            eventStore,
+            actorAccessor,
+            domainTypes,
+            eventPublisher,
+            executedUserProvider,
+            sortableUniqueIdGenerator,
+            sortableUniqueIdSeedCoordinator,
+            serviceIdProvider,
+            SortableUniqueIdWaitPolicy.System)
+    {
+    }
+
+    internal GeneralSekibanExecutor(
+        IEventStore eventStore,
+        IActorObjectAccessor actorAccessor,
+        DcbDomainTypes domainTypes,
+        IEventPublisher? eventPublisher,
+        IExecutedUserProvider? executedUserProvider,
+        ISortableUniqueIdGenerator sortableUniqueIdGenerator,
+        SortableUniqueIdSeedCoordinator sortableUniqueIdSeedCoordinator,
+        IServiceIdProvider serviceIdProvider,
+        SortableUniqueIdWaitPolicy sortableUniqueIdWaitPolicy)
     {
         _actorAccessor = actorAccessor;
         _core = new CoreGeneralSekibanExecutor(
@@ -66,7 +89,8 @@ public class GeneralSekibanExecutor : ISekibanExecutor, ISerializedSekibanDcbExe
             executedUserProvider,
             sortableUniqueIdGenerator,
             sortableUniqueIdSeedCoordinator,
-            serviceIdProvider);
+            serviceIdProvider,
+            sortableUniqueIdWaitPolicy);
     }
 
     /// <summary>

--- a/dcb/src/Sekiban.Dcb.WithoutResult/Sekiban.Dcb.WithoutResult.csproj
+++ b/dcb/src/Sekiban.Dcb.WithoutResult/Sekiban.Dcb.WithoutResult.csproj
@@ -51,6 +51,12 @@
         <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
             <_Parameter1>Sekiban.Dcb.WithoutResult.Tests</_Parameter1>
         </AssemblyAttribute>
+        <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+            <_Parameter1>Sekiban.Dcb.SortableUniqueIdWait.Tests</_Parameter1>
+        </AssemblyAttribute>
+        <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+            <_Parameter1>Sekiban.Dcb.SortableUniqueIdWait.WithoutResult.Tests</_Parameter1>
+        </AssemblyAttribute>
     </ItemGroup>
 
 </Project>

--- a/dcb/tests/Sekiban.Dcb.MaterializedView.BinaryConsumer/README.md
+++ b/dcb/tests/Sekiban.Dcb.MaterializedView.BinaryConsumer/README.md
@@ -1,6 +1,6 @@
 # Materialized-view binary consumer
 
-This fixture is restored and compiled against the published `Sekiban.Dcb.MaterializedView` **10.13.0** package. The
+This fixture is restored and compiled against the published `Sekiban.Dcb.MaterializedView` **10.14.0** package. The
 compatibility proof then runs the already-built consumer without recompiling it after the current branch's
 `Sekiban.Dcb.MaterializedView.dll` is copied into the output directory:
 

--- a/dcb/tests/Sekiban.Dcb.SortableUniqueIdWait.Tests/AssemblyInfo.cs
+++ b/dcb/tests/Sekiban.Dcb.SortableUniqueIdWait.Tests/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using Xunit;
+
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/dcb/tests/Sekiban.Dcb.SortableUniqueIdWait.Tests/OrleansFacadeProxyAcceptanceTests.cs
+++ b/dcb/tests/Sekiban.Dcb.SortableUniqueIdWait.Tests/OrleansFacadeProxyAcceptanceTests.cs
@@ -1,0 +1,450 @@
+using System.Diagnostics.Metrics;
+using System.Reflection;
+using Microsoft.Extensions.DependencyInjection;
+using Orleans;
+using ResultBoxes;
+using Sekiban.Dcb;
+using Sekiban.Dcb.Actors;
+using Sekiban.Dcb.Common;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.Orleans;
+using Sekiban.Dcb.Orleans.Grains;
+using Sekiban.Dcb.Orleans.Serialization;
+using Sekiban.Dcb.Queries;
+using Sekiban.Dcb.ServiceId;
+using Sekiban.Dcb.Storage;
+using Sekiban.Dcb.Tags;
+
+namespace Sekiban.Dcb.SortableUniqueIdWait.Tests;
+
+/// <summary>
+///     These tests enter through the production Orleans facade and its DI composition, then use a counting Orleans
+///     grain contract proxy as the deterministic boundary. The proxy returns genuine serialized query results, so the
+///     facade's request serialization, wait policy, grain calls, response deserialization, and ResultBox boundary all
+///     remain under test without a real sleep or an internal helper call.
+/// </summary>
+public sealed class OrleansFacadeProxyAcceptanceTests
+{
+    [Fact]
+    public async Task StrictSingleTimeout_IsTypedBeforeSerializationOrGrainQueryExecution_AndRecordsMetrics()
+    {
+        var clock = NewClock();
+        var target = SortableUniqueId.Generate(clock.UtcNow.UtcDateTime.AddSeconds(-6), Guid.Empty);
+        ProductionFacadeAcceptanceTests.AcceptanceQuery.ResetObservations();
+        var observation = new GrainObservation { ProbeResult = false, LastObservedPosition = "observed-position" };
+        using var scope = CreateExecutor(clock, observation);
+        using var metrics = new WaitMetricCapture();
+
+        var result = await scope.Executor.QueryAsync<ProductionFacadeAcceptanceTests.AcceptanceResult>(
+            new ProductionFacadeAcceptanceTests.AcceptanceQuery { WaitForSortableUniqueId = target });
+
+        Assert.False(result.IsSuccess);
+        var timeout = Assert.IsType<SortableUniqueIdWaitTimeoutException>(result.GetException());
+        Assert.Equal(target, timeout.TargetSortableUniqueId);
+        Assert.Equal(TimeSpan.FromSeconds(5), timeout.Timeout);
+        Assert.Equal(TimeSpan.FromSeconds(5), timeout.Elapsed);
+        Assert.Equal("observed-position", timeout.LastObservedSortableUniqueId);
+        Assert.Equal(25, observation.ProbeCalls);
+        Assert.Equal(1, observation.HeadStatusCalls);
+        Assert.Equal(0, observation.ExecuteQueryCalls);
+        Assert.Equal(0, Volatile.Read(ref ProductionFacadeAcceptanceTests.AcceptanceQuery.HandleCalls));
+        Assert.Equal(0, Volatile.Read(ref ProductionFacadeAcceptanceTests.AcceptanceQuery.SerializationWrites));
+        Assert.Contains(
+            metrics.Histograms,
+            value => value.Surface == "orleans_with_result_single" && value.Mode == "strict" && value.Outcome == "timeout");
+        Assert.Contains(
+            metrics.Counters,
+            value => value.Surface == "orleans_with_result_single" && value.Mode == "strict" && value.Outcome == "timeout");
+    }
+
+    [Fact]
+    public async Task StrictListTimeout_IsTypedBeforeListGrainQueryExecution()
+    {
+        var clock = NewClock();
+        var target = SortableUniqueId.Generate(clock.UtcNow.UtcDateTime.AddSeconds(-6), Guid.Empty);
+        ProductionFacadeAcceptanceTests.AcceptanceListQuery.ResetObservations();
+        var observation = new GrainObservation { ProbeResult = false, LastObservedPosition = "observed-position" };
+        using var scope = CreateExecutor(clock, observation);
+        using var metrics = new WaitMetricCapture();
+
+        var result = await scope.Executor.QueryAsync<ProductionFacadeAcceptanceTests.AcceptanceItem>(
+            new ProductionFacadeAcceptanceTests.AcceptanceListQuery
+            {
+                WaitForSortableUniqueId = target,
+                PageNumber = 1,
+                PageSize = 10
+            });
+
+        Assert.False(result.IsSuccess);
+        var timeout = Assert.IsType<SortableUniqueIdWaitTimeoutException>(result.GetException());
+        Assert.Equal("observed-position", timeout.LastObservedSortableUniqueId);
+        Assert.Equal(25, observation.ProbeCalls);
+        Assert.Equal(1, observation.HeadStatusCalls);
+        Assert.Equal(0, observation.ExecuteListQueryCalls);
+        Assert.Equal(0, Volatile.Read(ref ProductionFacadeAcceptanceTests.AcceptanceListQuery.HandleCalls));
+        Assert.Equal(0, Volatile.Read(ref ProductionFacadeAcceptanceTests.AcceptanceListQuery.SerializationWrites));
+        Assert.Contains(
+            metrics.Histograms,
+            value => value.Surface == "orleans_with_result_list" &&
+                value.Mode == "strict" && value.Outcome == "timeout");
+    }
+
+    [Fact]
+    public async Task LegacySingleTimeout_RemainsFailOpenAndExecutesTheRealFacadeGrainCall()
+    {
+        var clock = NewClock();
+        var target = SortableUniqueId.Generate(clock.UtcNow.UtcDateTime.AddSeconds(-6), Guid.Empty);
+        ProductionFacadeAcceptanceTests.LegacyAcceptanceQuery.ResetObservations();
+        var observation = new GrainObservation { ProbeResult = false };
+        using var scope = CreateExecutor(clock, observation);
+
+        var result = await scope.Executor.QueryAsync<ProductionFacadeAcceptanceTests.AcceptanceResult>(
+            new ProductionFacadeAcceptanceTests.LegacyAcceptanceQuery { WaitForSortableUniqueId = target });
+
+        Assert.True(result.IsSuccess, result.IsSuccess ? "" : result.GetException().ToString());
+        Assert.Equal(25, observation.ProbeCalls);
+        Assert.Equal(0, observation.HeadStatusCalls);
+        Assert.Equal(1, observation.ExecuteQueryCalls);
+        Assert.True(Volatile.Read(ref ProductionFacadeAcceptanceTests.LegacyAcceptanceQuery.SerializationWrites) >= 1);
+        Assert.Equal(TimeSpan.FromSeconds(5), clock.Elapsed);
+        Assert.Contains(
+            scope.Metrics.Histograms,
+            value => value.Surface == "orleans_with_result_single" &&
+                value.Mode == "legacy" && value.Outcome == "timeout");
+    }
+
+    [Fact]
+    public async Task LegacyListTimeout_RemainsFailOpenAndExecutesTheRealListGrainCall()
+    {
+        var clock = NewClock();
+        var target = SortableUniqueId.Generate(clock.UtcNow.UtcDateTime.AddSeconds(-6), Guid.Empty);
+        ProductionFacadeAcceptanceTests.LegacyAcceptanceListQuery.ResetObservations();
+        var observation = new GrainObservation { ProbeResult = false };
+        using var scope = CreateExecutor(clock, observation);
+
+        var result = await scope.Executor.QueryAsync<ProductionFacadeAcceptanceTests.AcceptanceItem>(
+            new ProductionFacadeAcceptanceTests.LegacyAcceptanceListQuery
+            {
+                WaitForSortableUniqueId = target,
+                PageNumber = 1,
+                PageSize = 10
+            });
+
+        Assert.True(result.IsSuccess, result.IsSuccess ? "" : result.GetException().ToString());
+        Assert.Equal(25, observation.ProbeCalls);
+        Assert.Equal(0, observation.HeadStatusCalls);
+        Assert.Equal(1, observation.ExecuteListQueryCalls);
+        Assert.True(Volatile.Read(ref ProductionFacadeAcceptanceTests.LegacyAcceptanceListQuery.SerializationWrites) >= 1);
+        Assert.Equal(TimeSpan.FromSeconds(5), clock.Elapsed);
+        Assert.Contains(
+            scope.Metrics.Histograms,
+            value => value.Surface == "orleans_with_result_list" &&
+                value.Mode == "legacy" && value.Outcome == "timeout");
+    }
+
+    [Fact]
+    public async Task StrictArrival_UsesGrainSuccessAndExecutesQueryOnce()
+    {
+        var clock = NewClock();
+        var target = SortableUniqueId.Generate(clock.UtcNow.UtcDateTime, Guid.Empty);
+        ProductionFacadeAcceptanceTests.AcceptanceQuery.ResetObservations();
+        var observation = new GrainObservation { ProbeResult = true };
+        using var scope = CreateExecutor(clock, observation);
+
+        var result = await scope.Executor.QueryAsync<ProductionFacadeAcceptanceTests.AcceptanceResult>(
+            new ProductionFacadeAcceptanceTests.AcceptanceQuery { WaitForSortableUniqueId = target });
+
+        Assert.True(result.IsSuccess, result.IsSuccess ? "" : result.GetException().ToString());
+        Assert.Equal(7, result.GetValue().Count);
+        Assert.Equal(1, observation.ProbeCalls);
+        Assert.Equal(1, observation.ExecuteQueryCalls);
+        Assert.True(Volatile.Read(ref ProductionFacadeAcceptanceTests.AcceptanceQuery.SerializationWrites) >= 1);
+        Assert.Contains(
+            scope.Metrics.Histograms,
+            value => value.Surface == "orleans_with_result_single" && value.Mode == "strict" && value.Outcome == "arrived");
+        Assert.Equal(TimeSpan.Zero, clock.Elapsed);
+    }
+
+    [Fact]
+    public async Task LegacyArrival_UsesGrainSuccessAndExecutesQueryOnce()
+    {
+        var clock = NewClock();
+        var target = SortableUniqueId.Generate(clock.UtcNow.UtcDateTime, Guid.Empty);
+        ProductionFacadeAcceptanceTests.LegacyAcceptanceQuery.ResetObservations();
+        var observation = new GrainObservation { ProbeResult = true };
+        using var scope = CreateExecutor(clock, observation);
+
+        var result = await scope.Executor.QueryAsync<ProductionFacadeAcceptanceTests.AcceptanceResult>(
+            new ProductionFacadeAcceptanceTests.LegacyAcceptanceQuery { WaitForSortableUniqueId = target });
+
+        Assert.True(result.IsSuccess, result.IsSuccess ? "" : result.GetException().ToString());
+        Assert.Equal(1, observation.ProbeCalls);
+        Assert.Equal(1, observation.ExecuteQueryCalls);
+        Assert.True(Volatile.Read(ref ProductionFacadeAcceptanceTests.LegacyAcceptanceQuery.SerializationWrites) >= 1);
+        Assert.Contains(
+            scope.Metrics.Histograms,
+            value => value.Surface == "orleans_with_result_single" &&
+                value.Mode == "legacy" && value.Outcome == "arrived");
+        Assert.Equal(TimeSpan.Zero, clock.Elapsed);
+    }
+
+    private static FakeClock NewClock() =>
+        new(new DateTimeOffset(2030, 1, 1, 0, 0, 0, TimeSpan.Zero));
+
+    private static ExecutorScope CreateExecutor(FakeClock clock, GrainObservation observation)
+    {
+        var client = DispatchProxy.Create<IClusterClient, ClusterClientProxy>();
+        var grain = DispatchProxy.Create<IMultiProjectionGrain, GrainProxy>();
+        ClusterClientProxy.Current.Value = grain;
+        GrainProxy.Current.Value = new GrainContext(observation, ProductionFacadeAcceptanceTests.CreateDomain());
+
+        var generator = new MonotonicSortableUniqueIdGenerator(clock);
+        var policy = new SortableUniqueIdWaitPolicy(
+            clock,
+            (delay, cancellationToken) =>
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                clock.Advance(delay);
+                return Task.CompletedTask;
+            });
+        var services = new ServiceCollection();
+        services.AddSingleton<IClusterClient>(client);
+        services.AddSingleton<IEventStore>(new EmptyEventStore());
+        services.AddSingleton(ProductionFacadeAcceptanceTests.CreateDomain());
+        services.AddSingleton(policy);
+        services.AddSingleton<ISekibanExecutor>(serviceProvider => new OrleansDcbExecutor(
+            serviceProvider.GetRequiredService<IClusterClient>(),
+            serviceProvider.GetRequiredService<IEventStore>(),
+            serviceProvider.GetRequiredService<DcbDomainTypes>(),
+            null,
+            null,
+            null,
+            generator,
+            new SortableUniqueIdSeedCoordinator(generator),
+            serviceProvider.GetRequiredService<SortableUniqueIdWaitPolicy>()));
+
+        var provider = services.BuildServiceProvider();
+        return new ExecutorScope(provider, provider.GetRequiredService<ISekibanExecutor>(), observation, clock);
+    }
+
+    private sealed class ExecutorScope : IDisposable
+    {
+        private readonly ServiceProvider _provider;
+        private readonly GrainObservation _observation;
+        private readonly FakeClock _clock;
+
+        public ExecutorScope(ServiceProvider provider, ISekibanExecutor executor, GrainObservation observation, FakeClock clock)
+        {
+            _provider = provider;
+            Executor = executor;
+            _observation = observation;
+            _clock = clock;
+            Metrics = new WaitMetricCapture();
+        }
+
+        public ISekibanExecutor Executor { get; }
+        public WaitMetricCapture Metrics { get; }
+
+        public void Dispose()
+        {
+            Metrics.Dispose();
+            _provider.Dispose();
+            ClusterClientProxy.Current.Value = null;
+            GrainProxy.Current.Value = null;
+        }
+    }
+
+    private sealed class FakeClock(DateTimeOffset utcNow) : TimeProvider
+    {
+        private DateTimeOffset _utcNow = utcNow;
+        private long _timestamp;
+
+        public DateTimeOffset UtcNow => _utcNow;
+        public TimeSpan Elapsed => TimeSpan.FromTicks(_timestamp);
+        public override long TimestampFrequency => TimeSpan.TicksPerSecond;
+        public override DateTimeOffset GetUtcNow() => _utcNow;
+        public override long GetTimestamp() => _timestamp;
+
+        public void Advance(TimeSpan amount)
+        {
+            _utcNow += amount;
+            _timestamp += amount.Ticks;
+        }
+    }
+
+    private sealed class GrainObservation
+    {
+        public bool ProbeResult { get; init; }
+        public string? LastObservedPosition { get; init; }
+        public int ProbeCalls;
+        public int HeadStatusCalls;
+        public int ExecuteQueryCalls;
+        public int ExecuteListQueryCalls;
+    }
+
+    private sealed record GrainContext(GrainObservation Observation, DcbDomainTypes Domain);
+
+    private class ClusterClientProxy : DispatchProxy
+    {
+        public static AsyncLocal<IMultiProjectionGrain?> Current { get; } = new();
+
+        protected override object? Invoke(MethodInfo? targetMethod, object?[]? args)
+        {
+            if (targetMethod?.IsGenericMethod == true && targetMethod.Name == "GetGrain" &&
+                targetMethod.GetGenericArguments()[0] == typeof(IMultiProjectionGrain))
+            {
+                return Current.Value ?? throw new InvalidOperationException("No fake grain is configured.");
+            }
+
+            throw new InvalidOperationException($"Unexpected IClusterClient call: {targetMethod?.Name}");
+        }
+    }
+
+    private class GrainProxy : DispatchProxy
+    {
+        public static AsyncLocal<GrainContext?> Current { get; } = new();
+
+        protected override object? Invoke(MethodInfo? targetMethod, object?[]? args)
+        {
+            var context = Current.Value ?? throw new InvalidOperationException("No fake grain context is configured.");
+            var observation = context.Observation;
+            switch (targetMethod?.Name)
+            {
+                case nameof(IMultiProjectionGrain.IsSortableUniqueIdReceived):
+                    Interlocked.Increment(ref observation.ProbeCalls);
+                    return Task.FromResult(observation.ProbeResult);
+                case nameof(IMultiProjectionGrain.GetProjectionHeadStatusAsync):
+                    Interlocked.Increment(ref observation.HeadStatusCalls);
+                    return Task.FromResult(new MultiProjectionHeadStatusSnapshot(
+                        ProductionFacadeAcceptanceTests.AcceptanceProjector.MultiProjectorName,
+                        "1.0.0",
+                        0,
+                        context.Observation.LastObservedPosition,
+                        0,
+                        null,
+                        false,
+                        null,
+                        null,
+                        0));
+                case nameof(IMultiProjectionGrain.ExecuteQueryAsync):
+                    Interlocked.Increment(ref observation.ExecuteQueryCalls);
+                    return CreateQueryResultAsync(
+                        args?[0] as SerializableQueryParameter ??
+                        throw new InvalidOperationException("Missing serialized query parameter."),
+                        context.Domain);
+                case nameof(IMultiProjectionGrain.ExecuteListQueryAsync):
+                    Interlocked.Increment(ref observation.ExecuteListQueryCalls);
+                    return CreateListQueryResultAsync(
+                        args?[0] as SerializableQueryParameter ??
+                        throw new InvalidOperationException("Missing serialized list query parameter."),
+                        context.Domain);
+                default:
+                    throw new InvalidOperationException($"Unexpected grain call: {targetMethod?.Name}");
+            }
+        }
+
+        private static async Task<SerializableQueryResult> CreateQueryResultAsync(
+            SerializableQueryParameter parameter,
+            DcbDomainTypes domain)
+        {
+            var query = (IQueryCommon)(await parameter.ToQueryAsync(domain)).GetValue();
+            var result = new QueryResultGeneral(
+                new ProductionFacadeAcceptanceTests.AcceptanceResult(7),
+                typeof(ProductionFacadeAcceptanceTests.AcceptanceResult).AssemblyQualifiedName!,
+                query);
+            return await SerializableQueryResult.CreateFromAsync(result, domain.JsonSerializerOptions);
+        }
+
+        private static async Task<SerializableListQueryResult> CreateListQueryResultAsync(
+            SerializableQueryParameter parameter,
+            DcbDomainTypes domain)
+        {
+            var query = (IListQueryCommon)(await parameter.ToQueryAsync(domain)).GetValue();
+            var result = new ListQueryResultGeneral(
+                1,
+                1,
+                1,
+                10,
+                [new ProductionFacadeAcceptanceTests.AcceptanceItem(7)],
+                typeof(ProductionFacadeAcceptanceTests.AcceptanceItem).AssemblyQualifiedName!,
+                query);
+            return await SerializableListQueryResult.CreateFromAsync(result, domain.JsonSerializerOptions);
+        }
+    }
+
+    private sealed class WaitMetricCapture : IDisposable
+    {
+        private readonly MeterListener _listener = new();
+        public List<WaitObservation> Counters { get; } = [];
+        public List<WaitObservation> Histograms { get; } = [];
+
+        public WaitMetricCapture()
+        {
+            _listener.InstrumentPublished = (instrument, listener) =>
+            {
+                if (instrument.Meter.Name == SortableUniqueIdWaitTelemetry.MeterName)
+                {
+                    listener.EnableMeasurementEvents(instrument);
+                }
+            };
+            _listener.SetMeasurementEventCallback<long>((instrument, _, tags, _) =>
+                Counters.Add(WaitObservation.From(instrument, tags)));
+            _listener.SetMeasurementEventCallback<double>((instrument, _, tags, _) =>
+                Histograms.Add(WaitObservation.From(instrument, tags)));
+            _listener.Start();
+        }
+
+        public void Dispose() => _listener.Dispose();
+    }
+
+    private sealed record WaitObservation(string Surface, string Mode, string Outcome)
+    {
+        public static WaitObservation From(
+            Instrument instrument,
+            ReadOnlySpan<KeyValuePair<string, object?>> tags)
+        {
+            var surface = "";
+            var mode = "";
+            var outcome = "";
+            foreach (var tag in tags)
+            {
+                var value = tag.Value?.ToString() ?? "";
+                switch (tag.Key)
+                {
+                    case "surface": surface = value; break;
+                    case "mode": mode = value; break;
+                    case "outcome": outcome = value; break;
+                }
+            }
+
+            return new(surface, mode, outcome);
+        }
+    }
+
+    private sealed class EmptyEventStore : IEventStore
+    {
+        public Task<ResultBox<IEnumerable<TagStream>>> ReadTagsAsync(ITag tag) =>
+            Task.FromResult(ResultBox.FromValue<IEnumerable<TagStream>>([]));
+        public Task<ResultBox<TagState>> GetLatestTagAsync(ITag tag) =>
+            Task.FromResult(ResultBox.Error<TagState>(new NotSupportedException()));
+        public Task<ResultBox<bool>> TagExistsAsync(ITag tag) =>
+            Task.FromResult(ResultBox.FromValue(false));
+        public Task<ResultBox<long>> GetEventCountAsync(SortableUniqueId? since = null) =>
+            Task.FromResult(ResultBox.FromValue(0L));
+        public Task<ResultBox<IEnumerable<TagInfo>>> GetAllTagsAsync(string? tagGroup = null) =>
+            Task.FromResult(ResultBox.FromValue<IEnumerable<TagInfo>>([]));
+        public Task<ResultBox<IEnumerable<SerializableEvent>>> ReadAllSerializableEventsAsync(SortableUniqueId? since = null) =>
+            Task.FromResult(ResultBox.FromValue<IEnumerable<SerializableEvent>>([]));
+        public Task<ResultBox<IEnumerable<SerializableEvent>>> ReadAllSerializableEventsAsync(SortableUniqueId? since, int? maxCount) =>
+            Task.FromResult(ResultBox.FromValue<IEnumerable<SerializableEvent>>([]));
+        public Task<ResultBox<SerializableEvent>> ReadSerializableEventAsync(Guid eventId) =>
+            Task.FromResult(ResultBox.Error<SerializableEvent>(new NotSupportedException()));
+        public Task<ResultBox<IEnumerable<SerializableEvent>>> ReadSerializableEventsByTagAsync(ITag tag, SortableUniqueId? since = null) =>
+            Task.FromResult(ResultBox.FromValue<IEnumerable<SerializableEvent>>([]));
+        public Task<ResultBox<(IReadOnlyList<SerializableEvent> Events, IReadOnlyList<TagWriteResult> TagWrites)>> WriteSerializableEventsAsync(
+            IEnumerable<SerializableEvent> events) =>
+            Task.FromResult(ResultBox.Error<(IReadOnlyList<SerializableEvent>, IReadOnlyList<TagWriteResult>)>(new NotSupportedException()));
+        public Task<ResultBox<string>> GetLatestSortableUniqueIdAsync() =>
+            Task.FromResult(ResultBox.FromValue(""));
+    }
+}

--- a/dcb/tests/Sekiban.Dcb.SortableUniqueIdWait.Tests/ProductionFacadeAcceptanceTests.cs
+++ b/dcb/tests/Sekiban.Dcb.SortableUniqueIdWait.Tests/ProductionFacadeAcceptanceTests.cs
@@ -1,0 +1,545 @@
+using System.Collections.Concurrent;
+using System.Diagnostics.Metrics;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using ResultBoxes;
+using Sekiban.Dcb.Actors;
+using Sekiban.Dcb.Common;
+using Sekiban.Dcb.Domains;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.MultiProjections;
+using Sekiban.Dcb.Queries;
+using Sekiban.Dcb.ServiceId;
+using Sekiban.Dcb.Storage;
+using Sekiban.Dcb.Tags;
+using Sekiban.Dcb.Testing;
+
+namespace Sekiban.Dcb.SortableUniqueIdWait.Tests;
+
+/// <summary>
+///     Acceptance tests deliberately enter through the WithResult GeneralSekibanExecutor facade. The strict cases
+///     prove the timeout happens before query serialization/handling; the legacy case proves the historical in-memory
+///     no-wait behavior remains fail-open. Every observation is captured from the production query path.
+/// </summary>
+public sealed class ProductionFacadeAcceptanceTests
+{
+    [Fact]
+    public async Task StrictSingleTimeout_IsTypedBeforeSerializationOrQueryExecution_AndRecordsMetrics()
+    {
+        var clock = new FakeClock(new DateTimeOffset(2030, 1, 1, 0, 0, 0, TimeSpan.Zero));
+        var target = SortableUniqueId.Generate(clock.UtcNow.UtcDateTime.AddSeconds(-6), Guid.Empty);
+        var query = new AcceptanceQuery { WaitForSortableUniqueId = target };
+        AcceptanceQuery.ResetObservations();
+        LegacyAcceptanceQuery.ResetObservations();
+
+        using var metrics = new WaitMetricCapture();
+        var executor = CreateExecutor(clock, out _);
+
+        var result = await executor.QueryAsync<AcceptanceResult>(query);
+
+        Assert.False(result.IsSuccess);
+        var timeout = Assert.IsType<SortableUniqueIdWaitTimeoutException>(result.GetException());
+        Assert.Equal(target, timeout.TargetSortableUniqueId);
+        Assert.Equal(TimeSpan.FromSeconds(5), timeout.Timeout);
+        Assert.Equal(TimeSpan.FromSeconds(5), timeout.Elapsed);
+        Assert.Null(timeout.LastObservedSortableUniqueId);
+        Assert.Equal(0, Volatile.Read(ref AcceptanceQuery.HandleCalls));
+        Assert.Equal(0, Volatile.Read(ref AcceptanceQuery.SerializationWrites));
+
+        Assert.Contains(
+            metrics.Histograms,
+            observation => observation.Surface == "in_memory_single" &&
+                observation.Mode == "strict" &&
+                observation.Outcome == "timeout");
+        Assert.Contains(
+            metrics.Counters,
+            observation => observation.Surface == "in_memory_single" &&
+                observation.Mode == "strict" &&
+                observation.Outcome == "timeout");
+        Assert.All(
+            metrics.Histograms,
+            observation => Assert.Equal(["surface", "mode", "outcome"], observation.TagKeys));
+    }
+
+    [Fact]
+    public async Task StrictListTimeout_IsTypedBeforeListQueryExecution()
+    {
+        var clock = new FakeClock(new DateTimeOffset(2030, 1, 1, 0, 0, 0, TimeSpan.Zero));
+        var target = SortableUniqueId.Generate(clock.UtcNow.UtcDateTime.AddSeconds(-6), Guid.Empty);
+        AcceptanceListQuery.ResetObservations();
+        var executor = CreateExecutor(clock, out _);
+        using var metrics = new WaitMetricCapture();
+
+        var result = await executor.QueryAsync<AcceptanceItem>(
+            new AcceptanceListQuery
+            {
+                WaitForSortableUniqueId = target,
+                PageNumber = 1,
+                PageSize = 10
+            });
+
+        Assert.False(result.IsSuccess);
+        var timeout = Assert.IsType<SortableUniqueIdWaitTimeoutException>(result.GetException());
+        Assert.Equal(target, timeout.TargetSortableUniqueId);
+        Assert.Equal(0, Volatile.Read(ref AcceptanceListQuery.HandleCalls));
+        Assert.Equal(0, Volatile.Read(ref AcceptanceListQuery.SerializationWrites));
+        Assert.Contains(
+            metrics.Histograms,
+            observation => observation.Surface == "in_memory_list" &&
+                observation.Mode == "strict" && observation.Outcome == "timeout");
+    }
+
+    [Fact]
+    public async Task LegacyInMemoryQuery_RemainsFailOpenWithoutWaiting()
+    {
+        var clock = new FakeClock(new DateTimeOffset(2030, 1, 1, 0, 0, 0, TimeSpan.Zero));
+        var target = SortableUniqueId.Generate(clock.UtcNow.UtcDateTime.AddSeconds(-6), Guid.Empty);
+        AcceptanceQuery.ResetObservations();
+        LegacyAcceptanceQuery.ResetObservations();
+        var executor = CreateExecutor(clock, out _);
+
+        var result = await executor.QueryAsync<AcceptanceResult>(
+            new LegacyAcceptanceQuery { WaitForSortableUniqueId = target });
+
+        Assert.True(result.IsSuccess, result.IsSuccess ? "" : result.GetException().ToString());
+        Assert.Equal(1, Volatile.Read(ref LegacyAcceptanceQuery.HandleCalls));
+        Assert.Equal(0, Volatile.Read(ref LegacyAcceptanceQuery.SerializationWrites));
+        Assert.Equal(TimeSpan.Zero, clock.Elapsed);
+    }
+
+    [Fact]
+    public async Task StrictArrival_TraversesActorCatchupAndExecutesQuery()
+    {
+        var clock = new FakeClock(new DateTimeOffset(2030, 1, 1, 0, 0, 0, TimeSpan.Zero));
+        var target = SortableUniqueId.Generate(clock.UtcNow.UtcDateTime, Guid.Empty);
+        AcceptanceQuery.ResetObservations();
+        var executor = CreateExecutor(clock, out var store);
+
+        var payload = JsonSerializer.SerializeToUtf8Bytes(
+            new AcceptanceEvent("arrived"),
+            CreateDomain().JsonSerializerOptions);
+        var write = await store.WriteSerializableEventsAsync(
+            [
+                new SerializableEvent(
+                    payload,
+                    target,
+                    Guid.NewGuid(),
+                    new EventMetadata("event", "command", "test"),
+                    [],
+                    nameof(AcceptanceEvent))
+            ]);
+        Assert.True(write.IsSuccess, write.IsSuccess ? "" : write.GetException().ToString());
+
+        var result = await executor.QueryAsync<AcceptanceResult>(
+            new AcceptanceQuery { WaitForSortableUniqueId = target });
+
+        Assert.True(result.IsSuccess, result.IsSuccess ? "" : result.GetException().ToString());
+        Assert.Equal(1, result.GetValue().Count);
+        Assert.Equal(1, Volatile.Read(ref AcceptanceQuery.HandleCalls));
+        Assert.Equal(0, Volatile.Read(ref AcceptanceQuery.SerializationWrites));
+        Assert.Equal(TimeSpan.Zero, clock.Elapsed);
+    }
+
+    [Fact]
+    public async Task StrictTimeout_RemainsTypedWhenBestEffortPublisherSwallowsAFoldFailure()
+    {
+        var clock = new FakeClock(new DateTimeOffset(2030, 1, 1, 0, 0, 0, TimeSpan.Zero));
+        var target = SortableUniqueId.Generate(clock.UtcNow.UtcDateTime.AddSeconds(-6), Guid.Empty);
+        PublisherFaultQuery.ResetObservations();
+        var executor = CreateExecutor(clock, out _, out var accessor, out var publisher);
+
+        var actorResult = await accessor.GetActorAsync<GeneralMultiProjectionActor>(
+            PublisherFaultProjector.MultiProjectorName);
+        Assert.True(actorResult.IsSuccess, actorResult.IsSuccess ? "" : actorResult.GetException().ToString());
+
+        var poisonedEvent = new Event(
+            new PublisherFaultEvent("poison"),
+            target,
+            nameof(PublisherFaultEvent),
+            Guid.NewGuid(),
+            new EventMetadata("event", "command", "test"),
+            []);
+        await publisher.PublishAsync([(poisonedEvent, (IReadOnlyCollection<ITag>)[])]);
+
+        using var metrics = new WaitMetricCapture();
+        var result = await executor.QueryAsync<PublisherFaultResult>(
+            new PublisherFaultQuery { WaitForSortableUniqueId = target });
+
+        Assert.False(result.IsSuccess);
+        var timeout = Assert.IsType<SortableUniqueIdWaitTimeoutException>(result.GetException());
+        Assert.Equal(target, timeout.TargetSortableUniqueId);
+        Assert.Null(timeout.LastObservedSortableUniqueId);
+        Assert.Equal(0, Volatile.Read(ref PublisherFaultQuery.HandleCalls));
+        Assert.Contains(
+            metrics.Histograms,
+            observation => observation.Surface == "in_memory_single" &&
+                observation.Mode == "strict" && observation.Outcome == "timeout");
+    }
+
+    private static GeneralSekibanExecutor CreateExecutor(
+        FakeClock clock,
+        out InMemoryEventStore store,
+        out InMemoryObjectAccessor accessor,
+        out InMemoryMultiProjectionEventPublisher publisher)
+    {
+        var domain = CreateDomain();
+        store = new InMemoryEventStore(domain.EventTypes);
+        accessor = new InMemoryObjectAccessor(store, domain);
+        publisher = new InMemoryMultiProjectionEventPublisher(accessor);
+        var generator = new MonotonicSortableUniqueIdGenerator(clock);
+        var policy = new SortableUniqueIdWaitPolicy(
+            clock,
+            (delay, cancellationToken) =>
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                clock.Advance(delay);
+                return Task.CompletedTask;
+            });
+
+        return new GeneralSekibanExecutor(
+            store,
+            accessor,
+            domain,
+            publisher,
+            null,
+            generator,
+            new SortableUniqueIdSeedCoordinator(generator),
+            new DefaultServiceIdProvider(),
+            policy);
+    }
+
+    private static GeneralSekibanExecutor CreateExecutor(FakeClock clock, out InMemoryEventStore store)
+    {
+        return CreateExecutor(clock, out store, out _, out _);
+    }
+
+    internal static DcbDomainTypes CreateDomain() =>
+        DcbDomainTypesExtensions.Simple(types =>
+        {
+            types.EventTypes.RegisterEventType<AcceptanceEvent>();
+            types.MultiProjectorTypes.RegisterProjector<AcceptanceProjector>();
+            types.MultiProjectorTypes.RegisterProjector<PublisherFaultProjector>();
+            types.QueryTypes.RegisterQuery<AcceptanceQuery>();
+            types.QueryTypes.RegisterQuery<LegacyAcceptanceQuery>();
+            types.QueryTypes.RegisterListQuery<AcceptanceListQuery>();
+            types.QueryTypes.RegisterListQuery<LegacyAcceptanceListQuery>();
+            types.QueryTypes.RegisterQuery<PublisherFaultQuery>();
+        });
+
+    private sealed class FakeClock : TimeProvider
+    {
+        private DateTimeOffset _utcNow;
+        private long _timestamp;
+
+        public FakeClock(DateTimeOffset utcNow) => _utcNow = utcNow;
+
+        public DateTimeOffset UtcNow => _utcNow;
+
+        public TimeSpan Elapsed => TimeSpan.FromTicks(_timestamp);
+
+        public override long TimestampFrequency => TimeSpan.TicksPerSecond;
+
+        public override DateTimeOffset GetUtcNow() => _utcNow;
+
+        public override long GetTimestamp() => _timestamp;
+
+        public void Advance(TimeSpan amount)
+        {
+            _utcNow += amount;
+            _timestamp += amount.Ticks;
+        }
+    }
+
+    private sealed class WaitMetricCapture : IDisposable
+    {
+        private readonly MeterListener _listener = new();
+
+        public ConcurrentQueue<WaitObservation> Counters { get; } = new();
+        public ConcurrentQueue<WaitObservation> Histograms { get; } = new();
+
+        public WaitMetricCapture()
+        {
+            _listener.InstrumentPublished = (instrument, listener) =>
+            {
+                if (instrument.Meter.Name == SortableUniqueIdWaitTelemetry.MeterName)
+                {
+                    listener.EnableMeasurementEvents(instrument);
+                }
+            };
+            _listener.SetMeasurementEventCallback<long>((instrument, _, tags, _) =>
+            {
+                Counters.Enqueue(WaitObservation.From(instrument, tags));
+            });
+            _listener.SetMeasurementEventCallback<double>((instrument, _, tags, _) =>
+            {
+                Histograms.Enqueue(WaitObservation.From(instrument, tags));
+            });
+            _listener.Start();
+        }
+
+        public void Dispose() => _listener.Dispose();
+    }
+
+    private sealed record WaitObservation(
+        string Name,
+        string Surface,
+        string Mode,
+        string Outcome,
+        IReadOnlyList<string> TagKeys)
+    {
+        public static WaitObservation From(
+            Instrument instrument,
+            ReadOnlySpan<KeyValuePair<string, object?>> tags)
+        {
+            var surface = "";
+            var mode = "";
+            var outcome = "";
+            var tagKeys = new List<string>();
+            foreach (var tag in tags)
+            {
+                tagKeys.Add(tag.Key);
+                var value = tag.Value?.ToString() ?? "";
+                switch (tag.Key)
+                {
+                    case "surface": surface = value; break;
+                    case "mode": mode = value; break;
+                    case "outcome": outcome = value; break;
+                }
+            }
+
+            return new(instrument.Name, surface, mode, outcome, tagKeys);
+        }
+    }
+
+    public sealed record AcceptanceEvent(string Value) : IEventPayload;
+
+    public sealed record PublisherFaultEvent(string Value) : IEventPayload;
+
+    public record AcceptanceProjector : IMultiProjector<AcceptanceProjector>
+    {
+        public int Count { get; init; }
+        public static string MultiProjectorName => "sortable-unique-id-wait-acceptance";
+        public static string MultiProjectorVersion => "1.0.0";
+        public static AcceptanceProjector GenerateInitialPayload() => new();
+
+        public static ResultBox<AcceptanceProjector> Project(
+            AcceptanceProjector payload,
+            Event ev,
+            List<ITag> tags,
+            DcbDomainTypes domainTypes,
+            SortableUniqueId safeWindowThreshold) =>
+            ResultBox.FromValue(payload with { Count = payload.Count + 1 });
+    }
+
+    public sealed record PublisherFaultProjector : IMultiProjector<PublisherFaultProjector>
+    {
+        public static string MultiProjectorName => "sortable-unique-id-wait-publisher-fault";
+        public static string MultiProjectorVersion => "1.0.0";
+        public static PublisherFaultProjector GenerateInitialPayload() => new();
+
+        public static ResultBox<PublisherFaultProjector> Project(
+            PublisherFaultProjector payload,
+            Event ev,
+            List<ITag> tags,
+            DcbDomainTypes domainTypes,
+            SortableUniqueId safeWindowThreshold) =>
+            throw new InvalidOperationException("publisher fold failure");
+    }
+
+    public sealed record AcceptanceQuery : IMultiProjectionQuery<AcceptanceProjector, AcceptanceQuery, AcceptanceResult>,
+        IStrictWaitForSortableUniqueId
+    {
+        public static int HandleCalls;
+        public static int SerializationWrites;
+
+        public string? WaitForSortableUniqueId { get; init; }
+
+        [JsonConverter(typeof(AcceptanceQueryProbeConverter))]
+        public string SerializationProbe { get; init; } = "serialized";
+
+        public static ResultBox<AcceptanceResult> HandleQuery(
+            AcceptanceProjector projector,
+            AcceptanceQuery query,
+            IQueryContext context)
+        {
+            Interlocked.Increment(ref HandleCalls);
+            return ResultBox.FromValue(new AcceptanceResult(projector.Count));
+        }
+
+        public static void ResetObservations()
+        {
+            HandleCalls = 0;
+            SerializationWrites = 0;
+        }
+    }
+
+    public sealed record PublisherFaultQuery :
+        IMultiProjectionQuery<PublisherFaultProjector, PublisherFaultQuery, PublisherFaultResult>,
+        IStrictWaitForSortableUniqueId
+    {
+        public static int HandleCalls;
+        public string? WaitForSortableUniqueId { get; init; }
+
+        public static ResultBox<PublisherFaultResult> HandleQuery(
+            PublisherFaultProjector projector,
+            PublisherFaultQuery query,
+            IQueryContext context)
+        {
+            Interlocked.Increment(ref HandleCalls);
+            return ResultBox.FromValue(new PublisherFaultResult());
+        }
+
+        public static void ResetObservations() => HandleCalls = 0;
+    }
+
+    public sealed record LegacyAcceptanceQuery : IMultiProjectionQuery<AcceptanceProjector, LegacyAcceptanceQuery, AcceptanceResult>,
+        IWaitForSortableUniqueId
+    {
+        public static int HandleCalls;
+        public static int SerializationWrites;
+
+        public string? WaitForSortableUniqueId { get; init; }
+
+        [JsonConverter(typeof(LegacyAcceptanceQueryProbeConverter))]
+        public string SerializationProbe { get; init; } = "serialized";
+
+        public static ResultBox<AcceptanceResult> HandleQuery(
+            AcceptanceProjector projector,
+            LegacyAcceptanceQuery query,
+            IQueryContext context)
+        {
+            Interlocked.Increment(ref HandleCalls);
+            return ResultBox.FromValue(new AcceptanceResult(projector.Count));
+        }
+
+        public static void ResetObservations()
+        {
+            HandleCalls = 0;
+            SerializationWrites = 0;
+        }
+    }
+
+    public sealed record AcceptanceListQuery : IMultiProjectionListQuery<AcceptanceProjector, AcceptanceListQuery, AcceptanceItem>,
+        IStrictWaitForSortableUniqueId,
+        IQueryPagingParameter
+    {
+        public static int HandleCalls;
+        public static int SerializationWrites;
+
+        public string? WaitForSortableUniqueId { get; init; }
+        public int? PageNumber { get; init; }
+        public int? PageSize { get; init; }
+
+        [JsonConverter(typeof(AcceptanceListQueryProbeConverter))]
+        public string SerializationProbe { get; init; } = "serialized";
+
+        public static ResultBox<IEnumerable<AcceptanceItem>> HandleFilter(
+            AcceptanceProjector projector,
+            AcceptanceListQuery query,
+            IQueryContext context)
+        {
+            Interlocked.Increment(ref HandleCalls);
+            return ResultBox.FromValue(Enumerable.Repeat(new AcceptanceItem(projector.Count), 1));
+        }
+
+        public static ResultBox<IEnumerable<AcceptanceItem>> HandleSort(
+            IEnumerable<AcceptanceItem> filteredItems,
+            AcceptanceListQuery query,
+            IQueryContext context) => ResultBox.FromValue(filteredItems);
+
+        public static void ResetObservations()
+        {
+            HandleCalls = 0;
+            SerializationWrites = 0;
+        }
+    }
+
+    public sealed record LegacyAcceptanceListQuery :
+        IMultiProjectionListQuery<AcceptanceProjector, LegacyAcceptanceListQuery, AcceptanceItem>,
+        IWaitForSortableUniqueId,
+        IQueryPagingParameter
+    {
+        public static int HandleCalls;
+        public static int SerializationWrites;
+
+        public string? WaitForSortableUniqueId { get; init; }
+        public int? PageNumber { get; init; }
+        public int? PageSize { get; init; }
+
+        [JsonConverter(typeof(LegacyAcceptanceListQueryProbeConverter))]
+        public string SerializationProbe { get; init; } = "serialized";
+
+        public static ResultBox<IEnumerable<AcceptanceItem>> HandleFilter(
+            AcceptanceProjector projector,
+            LegacyAcceptanceListQuery query,
+            IQueryContext context)
+        {
+            Interlocked.Increment(ref HandleCalls);
+            return ResultBox.FromValue(Enumerable.Repeat(new AcceptanceItem(projector.Count), 1));
+        }
+
+        public static ResultBox<IEnumerable<AcceptanceItem>> HandleSort(
+            IEnumerable<AcceptanceItem> filteredItems,
+            LegacyAcceptanceListQuery query,
+            IQueryContext context) => ResultBox.FromValue(filteredItems);
+
+        public static void ResetObservations()
+        {
+            HandleCalls = 0;
+            SerializationWrites = 0;
+        }
+    }
+
+    public sealed class AcceptanceQueryProbeConverter : JsonConverter<string>
+    {
+        public override string Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) =>
+            reader.GetString() ?? "";
+
+        public override void Write(Utf8JsonWriter writer, string value, JsonSerializerOptions options)
+        {
+            Interlocked.Increment(ref AcceptanceQuery.SerializationWrites);
+            writer.WriteStringValue(value);
+        }
+    }
+
+    public sealed class LegacyAcceptanceQueryProbeConverter : JsonConverter<string>
+    {
+        public override string Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) =>
+            reader.GetString() ?? "";
+
+        public override void Write(Utf8JsonWriter writer, string value, JsonSerializerOptions options)
+        {
+            Interlocked.Increment(ref LegacyAcceptanceQuery.SerializationWrites);
+            writer.WriteStringValue(value);
+        }
+    }
+
+    public sealed class AcceptanceListQueryProbeConverter : JsonConverter<string>
+    {
+        public override string Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) =>
+            reader.GetString() ?? "";
+
+        public override void Write(Utf8JsonWriter writer, string value, JsonSerializerOptions options)
+        {
+            Interlocked.Increment(ref AcceptanceListQuery.SerializationWrites);
+            writer.WriteStringValue(value);
+        }
+    }
+
+    public sealed class LegacyAcceptanceListQueryProbeConverter : JsonConverter<string>
+    {
+        public override string Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) =>
+            reader.GetString() ?? "";
+
+        public override void Write(Utf8JsonWriter writer, string value, JsonSerializerOptions options)
+        {
+            Interlocked.Increment(ref LegacyAcceptanceListQuery.SerializationWrites);
+            writer.WriteStringValue(value);
+        }
+    }
+
+    public sealed record AcceptanceResult(int Count);
+    public sealed record AcceptanceItem(int Count);
+    public sealed record PublisherFaultResult;
+}

--- a/dcb/tests/Sekiban.Dcb.SortableUniqueIdWait.Tests/Sekiban.Dcb.SortableUniqueIdWait.Tests.csproj
+++ b/dcb/tests/Sekiban.Dcb.SortableUniqueIdWait.Tests/Sekiban.Dcb.SortableUniqueIdWait.Tests.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+        <TargetFramework>net10.0</TargetFramework>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.3" />
+        <PackageReference Include="xunit" Version="2.9.3" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+        <Using Include="Xunit" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\src\Sekiban.Dcb.Core\Sekiban.Dcb.Core.csproj" />
+        <ProjectReference Include="..\..\src\Sekiban.Dcb.WithResult.Model\Sekiban.Dcb.WithResult.Model.csproj" />
+        <ProjectReference Include="..\..\src\Sekiban.Dcb.WithResult\Sekiban.Dcb.WithResult.csproj" />
+        <ProjectReference Include="..\..\src\Sekiban.Dcb.Orleans.WithResult\Sekiban.Dcb.Orleans.WithResult.csproj" />
+        <ProjectReference Include="..\..\src\Sekiban.Dcb.Core.Testing\Sekiban.Dcb.Core.Testing.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/dcb/tests/Sekiban.Dcb.SortableUniqueIdWait.Tests/SortableUniqueIdWaitPolicyTests.cs
+++ b/dcb/tests/Sekiban.Dcb.SortableUniqueIdWait.Tests/SortableUniqueIdWaitPolicyTests.cs
@@ -11,12 +11,31 @@ public sealed class SortableUniqueIdWaitPolicyTests
     [Fact]
     public void Architecture_AllWithResultEntrypointsBindTheSharedPolicy()
     {
-        Assert.Contains(
-            typeof(CoreGeneralSekibanExecutor).GetFields(BindingFlags.Instance | BindingFlags.NonPublic),
-            field => field.FieldType == typeof(SortableUniqueIdWaitPolicy));
-        Assert.Contains(
-            typeof(Sekiban.Dcb.Orleans.OrleansDcbExecutor).GetFields(BindingFlags.Instance | BindingFlags.NonPublic),
-            field => field.FieldType == typeof(SortableUniqueIdWaitPolicy));
+        WaitArchitectureAssertions.AssertAll(
+            new WaitArchitectureRoute(
+                "orleans-with-result-single",
+                typeof(Sekiban.Dcb.Orleans.OrleansDcbExecutor),
+                typeof(IQueryCommon<>),
+                "WaitForSortableUniqueIdIfNeeded",
+                SortableUniqueIdWaitSurface.OrleansWithResultSingle),
+            new WaitArchitectureRoute(
+                "orleans-with-result-list",
+                typeof(Sekiban.Dcb.Orleans.OrleansDcbExecutor),
+                typeof(IListQueryCommon<>),
+                "WaitForSortableUniqueIdIfNeeded",
+                SortableUniqueIdWaitSurface.OrleansWithResultList),
+            new WaitArchitectureRoute(
+                "in-memory-strict-single",
+                typeof(CoreGeneralSekibanExecutor),
+                typeof(IQueryCommon<>),
+                "WaitForStrictSortableUniqueIdIfNeededAsync",
+                SortableUniqueIdWaitSurface.InMemorySingle),
+            new WaitArchitectureRoute(
+                "in-memory-strict-list",
+                typeof(CoreGeneralSekibanExecutor),
+                typeof(IListQueryCommon<>),
+                "WaitForStrictSortableUniqueIdIfNeededAsync",
+                SortableUniqueIdWaitSurface.InMemoryList));
     }
 
     [Fact]

--- a/dcb/tests/Sekiban.Dcb.SortableUniqueIdWait.Tests/SortableUniqueIdWaitPolicyTests.cs
+++ b/dcb/tests/Sekiban.Dcb.SortableUniqueIdWait.Tests/SortableUniqueIdWaitPolicyTests.cs
@@ -1,0 +1,213 @@
+using System.Text.Json;
+using System.Reflection;
+using Sekiban.Dcb.Actors;
+using Sekiban.Dcb.Common;
+using Sekiban.Dcb.Queries;
+
+namespace Sekiban.Dcb.SortableUniqueIdWait.Tests;
+
+public sealed class SortableUniqueIdWaitPolicyTests
+{
+    [Fact]
+    public void Architecture_AllWithResultEntrypointsBindTheSharedPolicy()
+    {
+        Assert.Contains(
+            typeof(CoreGeneralSekibanExecutor).GetFields(BindingFlags.Instance | BindingFlags.NonPublic),
+            field => field.FieldType == typeof(SortableUniqueIdWaitPolicy));
+        Assert.Contains(
+            typeof(Sekiban.Dcb.Orleans.OrleansDcbExecutor).GetFields(BindingFlags.Instance | BindingFlags.NonPublic),
+            field => field.FieldType == typeof(SortableUniqueIdWaitPolicy));
+    }
+
+    [Fact]
+    public async Task StrictTimeout_UsesAdaptiveClockAndCarriesCurrentPosition()
+    {
+        var clock = new FakeClock(new DateTimeOffset(2030, 1, 1, 0, 0, 0, TimeSpan.Zero));
+        var target = SortableUniqueId.Generate(clock.UtcNow.UtcDateTime.AddSeconds(-6), Guid.Empty);
+        var policy = CreatePolicy(clock);
+        var probes = 0;
+
+        var result = await policy.WaitAsync(
+            target,
+            SortableUniqueIdWaitSurface.InMemorySingle,
+            SortableUniqueIdWaitMode.Strict,
+            _ => Task.FromResult(++probes > int.MaxValue),
+            _ => Task.FromResult<string?>("observed-position"));
+
+        Assert.True(result.TimedOut);
+        Assert.Equal(TimeSpan.FromSeconds(5), result.Timeout);
+        Assert.Equal(TimeSpan.FromSeconds(5), result.Elapsed);
+        Assert.Equal("observed-position", result.LastObservedSortableUniqueId);
+        Assert.Equal(25, probes);
+    }
+
+    [Fact]
+    public async Task ArrivalAfterOnePoll_IsSuccessfulWithoutRealSleep()
+    {
+        var clock = new FakeClock(new DateTimeOffset(2030, 1, 1, 0, 0, 0, TimeSpan.Zero));
+        var target = SortableUniqueId.Generate(clock.UtcNow.UtcDateTime, Guid.Empty);
+        var policy = CreatePolicy(clock);
+        var probes = 0;
+
+        var result = await policy.WaitAsync(
+            target,
+            SortableUniqueIdWaitSurface.OrleansWithResultSingle,
+            SortableUniqueIdWaitMode.Strict,
+            _ => Task.FromResult(++probes == 2),
+            _ => Task.FromResult<string?>(null));
+
+        Assert.False(result.TimedOut);
+        Assert.Equal(TimeSpan.FromMilliseconds(200), result.Elapsed);
+        Assert.Equal(2, probes);
+    }
+
+    [Fact]
+    public async Task DiagnosticFailureDoesNotReplaceTimeout_AndCancellationOrProbeFaultIsPreserved()
+    {
+        var clock = new FakeClock(new DateTimeOffset(2030, 1, 1, 0, 0, 0, TimeSpan.Zero));
+        var oldTarget = SortableUniqueId.Generate(clock.UtcNow.UtcDateTime.AddSeconds(-6), Guid.Empty);
+        var policy = CreatePolicy(clock);
+
+        var timeout = await policy.WaitAsync(
+            oldTarget,
+            SortableUniqueIdWaitSurface.InMemoryList,
+            SortableUniqueIdWaitMode.Strict,
+            _ => Task.FromResult(false),
+            _ => Task.FromException<string?>(new InvalidOperationException("diagnostic failed")));
+
+        Assert.True(timeout.TimedOut);
+        Assert.Null(timeout.LastObservedSortableUniqueId);
+
+        var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+        await Assert.ThrowsAsync<OperationCanceledException>(() => policy.WaitAsync(
+            oldTarget,
+            SortableUniqueIdWaitSurface.OrleansWithoutResultSingle,
+            SortableUniqueIdWaitMode.Strict,
+            _ => Task.FromResult(false),
+            _ => Task.FromResult<string?>(null),
+            cancellation.Token));
+
+        var fault = new InvalidOperationException("probe failed");
+        var thrown = await Assert.ThrowsAsync<InvalidOperationException>(() => policy.WaitAsync(
+            oldTarget,
+            SortableUniqueIdWaitSurface.OrleansWithoutResultList,
+            SortableUniqueIdWaitMode.Legacy,
+            _ => Task.FromException<bool>(fault)));
+        Assert.Same(fault, thrown);
+    }
+
+    [Fact]
+    public void StrictMarkerAddsNoSerializedMembers_AndExceptionIsTyped()
+    {
+        Assert.Empty(
+            typeof(IStrictWaitForSortableUniqueId).GetProperties(
+                System.Reflection.BindingFlags.DeclaredOnly |
+                System.Reflection.BindingFlags.Public |
+                System.Reflection.BindingFlags.Instance));
+        Assert.Contains(
+            typeof(IStrictWaitForSortableUniqueId).GetInterfaces(),
+            interfaceType => interfaceType == typeof(IWaitForSortableUniqueId));
+
+        var exception = new SortableUniqueIdWaitTimeoutException(
+            "target",
+            TimeSpan.FromSeconds(5),
+            TimeSpan.FromSeconds(5),
+            "observed");
+
+        Assert.IsAssignableFrom<TimeoutException>(exception);
+        Assert.Equal("target", exception.TargetSortableUniqueId);
+        Assert.Equal(TimeSpan.FromSeconds(5), exception.Timeout);
+        Assert.Equal(TimeSpan.FromSeconds(5), exception.Elapsed);
+        Assert.Equal("observed", exception.LastObservedSortableUniqueId);
+    }
+
+    [Fact]
+    public void AdaptiveTimeout_PreservesLegacyFiveSecondBoundary()
+    {
+        var clock = new FakeClock(new DateTimeOffset(2030, 1, 1, 0, 0, 0, TimeSpan.Zero));
+        var old = SortableUniqueId.Generate(clock.UtcNow.UtcDateTime.AddSeconds(-6), Guid.Empty);
+        var exactBoundary = SortableUniqueId.Generate(clock.UtcNow.UtcDateTime.AddSeconds(-5), Guid.Empty);
+        var future = SortableUniqueId.Generate(clock.UtcNow.UtcDateTime.AddSeconds(1), Guid.Empty);
+
+        Assert.Equal(5_000, SortableUniqueIdWaitHelper.CalculateAdaptiveTimeout(old, clock));
+        Assert.Equal(30_000, SortableUniqueIdWaitHelper.CalculateAdaptiveTimeout(exactBoundary, clock));
+        Assert.Equal(30_000, SortableUniqueIdWaitHelper.CalculateAdaptiveTimeout(future, clock));
+        Assert.Equal(30_000, SortableUniqueIdWaitHelper.CalculateAdaptiveTimeout("not-a-sortable-id", clock));
+    }
+
+    [Fact]
+    public async Task ThirtySecondTimeoutCases_UseFakeClockWithoutRealSleep()
+    {
+        var baseNow = new DateTimeOffset(2030, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        var clock = new FakeClock(baseNow);
+        var targets = new[]
+        {
+            SortableUniqueId.Generate(clock.UtcNow.UtcDateTime.AddSeconds(-5), Guid.Empty),
+            SortableUniqueId.Generate(clock.UtcNow.UtcDateTime.AddSeconds(1), Guid.Empty),
+            "not-a-sortable-id"
+        };
+
+        foreach (var target in targets)
+        {
+            clock = new FakeClock(baseNow);
+            var policy = CreatePolicy(clock);
+            var probes = 0;
+            var result = await policy.WaitAsync(
+                target,
+                SortableUniqueIdWaitSurface.InMemorySingle,
+                SortableUniqueIdWaitMode.Strict,
+                _ => Task.FromResult(++probes > int.MaxValue),
+                _ => Task.FromResult<string?>(null));
+
+            Assert.True(result.TimedOut);
+            Assert.Equal(TimeSpan.FromSeconds(30), result.Timeout);
+            Assert.Equal(TimeSpan.FromSeconds(30), result.Elapsed);
+            Assert.Equal(150, probes);
+        }
+    }
+
+    [Fact]
+    public void G17StrictMarkerDoesNotChangeTheNegativeWireShape()
+    {
+        var wire = JsonSerializer.Serialize(new StrictWireQuery("target", "payload"));
+        using var document = JsonDocument.Parse(wire);
+        var properties = document.RootElement.EnumerateObject().Select(property => property.Name).ToArray();
+
+        Assert.Equal(["WaitForSortableUniqueId", "Value"], properties);
+        Assert.DoesNotContain(properties, property => property.Contains("strict", StringComparison.OrdinalIgnoreCase));
+        Assert.DoesNotContain(properties, property => property.Contains("fail", StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static SortableUniqueIdWaitPolicy CreatePolicy(FakeClock clock) =>
+        new(clock, (delay, cancellationToken) =>
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            clock.Advance(delay);
+            return Task.CompletedTask;
+        });
+
+    private sealed record StrictWireQuery(string? WaitForSortableUniqueId, string Value) : IStrictWaitForSortableUniqueId;
+
+    private sealed class FakeClock : TimeProvider
+    {
+        private DateTimeOffset _utcNow;
+        private long _timestamp;
+
+        public FakeClock(DateTimeOffset utcNow) => _utcNow = utcNow;
+
+        public DateTimeOffset UtcNow => _utcNow;
+
+        public override long TimestampFrequency => TimeSpan.TicksPerSecond;
+
+        public override DateTimeOffset GetUtcNow() => _utcNow;
+
+        public override long GetTimestamp() => _timestamp;
+
+        public void Advance(TimeSpan amount)
+        {
+            _utcNow += amount;
+            _timestamp += amount.Ticks;
+        }
+    }
+}

--- a/dcb/tests/Sekiban.Dcb.SortableUniqueIdWait.Tests/WaitArchitectureAssertions.cs
+++ b/dcb/tests/Sekiban.Dcb.SortableUniqueIdWait.Tests/WaitArchitectureAssertions.cs
@@ -1,0 +1,412 @@
+using System.Diagnostics;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Runtime.CompilerServices;
+using Sekiban.Dcb.Common;
+using Xunit;
+
+namespace Sekiban.Dcb.SortableUniqueIdWait.Tests;
+
+internal sealed record WaitArchitectureRoute(
+    string Name,
+    Type ExecutorType,
+    Type QueryContractDefinition,
+    string WaitMethodName,
+    SortableUniqueIdWaitSurface Surface);
+
+/// <summary>
+///     Structural proof for the production wait-route inventory. Each route must call its named wait boundary exactly
+///     once, that boundary must call the one shared policy exactly once, and neither method may contain a second wait
+///     loop or direct delay/clock implementation. This is deliberately IL-based so a private field-only assertion cannot
+///     remain green after a route is bypassed or its wait is copied back into an entrypoint.
+/// </summary>
+internal static class WaitArchitectureAssertions
+{
+    private static readonly MethodInfo SharedWaitMethod =
+        typeof(SortableUniqueIdWaitPolicy).GetMethod(
+            "WaitAsync",
+            BindingFlags.Instance | BindingFlags.NonPublic) ??
+        throw new InvalidOperationException("The shared wait policy must expose its internal WaitAsync method.");
+
+    private static readonly OpCode[] OneByteOpCodes = BuildOpCodeMap(singleByte: true);
+    private static readonly OpCode[] TwoByteOpCodes = BuildOpCodeMap(singleByte: false);
+
+    internal static void AssertAll(params WaitArchitectureRoute[] routes)
+    {
+        Assert.NotEmpty(routes);
+        Assert.Equal(
+            routes.Length,
+            routes.Select(route => route.Name).Distinct(StringComparer.Ordinal).Count());
+        Assert.All(routes, AssertRoute);
+    }
+
+    private static void AssertRoute(WaitArchitectureRoute route)
+    {
+        var entrypoint = FindQueryEntrypoint(route);
+        var waitMethod = FindWaitMethod(route);
+        var entrypointImplementation = GetAsyncImplementation(entrypoint);
+        var waitImplementation = GetAsyncImplementation(waitMethod);
+
+        var entrypointInstructions = ReadInstructions(entrypointImplementation);
+        var entrypointCalls = GetCallSites(entrypointImplementation, entrypointInstructions);
+        var waitCalls = entrypointCalls
+            .Where(call => SameMethod(call.Target, waitMethod))
+            .ToArray();
+
+        Assert.Single(
+            waitCalls);
+        Assert.DoesNotContain(
+            entrypointCalls,
+            call => SameMethod(call.Target, SharedWaitMethod));
+        Assert.True(
+            HasEnumConstantNearCall(entrypointInstructions, waitCalls[0].Instruction.Offset, route.Surface),
+            $"Route '{route.Name}' must pass its explicitly inventoried wait surface to {waitMethod.Name}.");
+        AssertNoDuplicateWaitImplementation(route.Name, entrypointImplementation, entrypointInstructions);
+
+        var waitInstructions = ReadInstructions(waitImplementation);
+        var policyCalls = GetCallSites(waitImplementation, waitInstructions)
+            .Where(call => SameMethod(call.Target, SharedWaitMethod))
+            .ToArray();
+
+        Assert.Single(
+            policyCalls);
+        AssertNoDuplicateWaitImplementation(route.Name + " wait boundary", waitImplementation, waitInstructions);
+    }
+
+    private static MethodInfo FindQueryEntrypoint(WaitArchitectureRoute route)
+    {
+        var candidates = route.ExecutorType
+            .GetMethods(BindingFlags.Instance | BindingFlags.Public)
+            .Where(method =>
+                method.Name == "QueryAsync" &&
+                method.IsGenericMethodDefinition &&
+                method.GetParameters() is [{ ParameterType: { IsGenericType: true } }])
+            .Where(method => method.GetParameters()[0].ParameterType.GetGenericTypeDefinition() ==
+                             route.QueryContractDefinition)
+            .ToArray();
+
+        Assert.Single(
+            candidates);
+        return candidates[0];
+    }
+
+    private static MethodInfo FindWaitMethod(WaitArchitectureRoute route)
+    {
+        var candidates = route.ExecutorType
+            .GetMethods(BindingFlags.Instance | BindingFlags.NonPublic)
+            .Where(method => method.Name == route.WaitMethodName)
+            .ToArray();
+
+        Assert.Single(
+            candidates);
+        return candidates[0];
+    }
+
+    private static MethodInfo GetAsyncImplementation(MethodInfo method)
+    {
+        var stateMachineAttribute = method.GetCustomAttribute<AsyncStateMachineAttribute>();
+        if (stateMachineAttribute is null)
+        {
+            return method;
+        }
+
+        var moveNext = stateMachineAttribute.StateMachineType.GetMethod(
+            "MoveNext",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(moveNext);
+        return moveNext!;
+    }
+
+    private static void AssertNoDuplicateWaitImplementation(
+        string routeName,
+        MethodInfo method,
+        IReadOnlyList<Instruction> instructions)
+    {
+        var backwards = instructions
+            .Where(instruction => IsBranch(instruction.OpCode))
+            .SelectMany(instruction => GetBranchTargets(instruction).Select(target => (instruction, target)))
+            .Where(pair => pair.target <= pair.instruction.Offset)
+            .ToArray();
+        Assert.Empty(
+            backwards);
+
+        var forbiddenCalls = GetCallSites(method, instructions)
+            .Where(call => IsDirectWaitImplementation(call.Target))
+            .Select(call => call.Target?.ToString() ?? "unresolved call")
+            .ToArray();
+        Assert.Empty(
+            forbiddenCalls);
+    }
+
+    private static bool IsDirectWaitImplementation(MethodBase? target)
+    {
+        if (target is null)
+        {
+            return false;
+        }
+
+        if (target.DeclaringType == typeof(Task) && target.Name == nameof(Task.Delay))
+        {
+            return true;
+        }
+
+        if (target.DeclaringType == typeof(Thread) && target.Name.StartsWith("Sleep", StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        if (target.DeclaringType == typeof(Stopwatch) && target.Name.StartsWith("Start", StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        if (target.DeclaringType == typeof(TimeProvider) &&
+            (target.Name == nameof(TimeProvider.GetTimestamp) || target.Name == nameof(TimeProvider.GetElapsedTime)))
+        {
+            return true;
+        }
+
+        return target.DeclaringType == typeof(SortableUniqueIdWaitHelper);
+    }
+
+    private static bool HasEnumConstantNearCall(
+        IReadOnlyList<Instruction> instructions,
+        int callOffset,
+        SortableUniqueIdWaitSurface expectedSurface)
+    {
+        var callIndex = instructions.Select((instruction, index) => (instruction, index))
+            .Where(pair => pair.instruction.Offset == callOffset)
+            .Select(pair => pair.index)
+            .Single();
+        var firstIndex = Math.Max(0, callIndex - 10);
+        return instructions
+            .Skip(firstIndex)
+            .Take(callIndex - firstIndex)
+            .Any(instruction => TryGetInt32Constant(instruction, out var value) &&
+                                value == (int)expectedSurface);
+    }
+
+    private static IReadOnlyList<CallSite> GetCallSites(
+        MethodInfo owner,
+        IReadOnlyList<Instruction> instructions) =>
+        instructions
+            .Where(instruction => instruction.OpCode == OpCodes.Call ||
+                                  instruction.OpCode == OpCodes.Callvirt)
+            .Select(instruction => new CallSite(instruction, ResolveCall(owner, instruction)))
+            .ToArray();
+
+    private static MethodBase? ResolveCall(MethodInfo owner, Instruction instruction)
+    {
+        if (instruction.Operand is not int token)
+        {
+            return null;
+        }
+
+        try
+        {
+            var typeArguments = owner.DeclaringType?.IsGenericType == true
+                ? owner.DeclaringType.GetGenericArguments()
+                : null;
+            var methodArguments = owner.IsGenericMethod ? owner.GetGenericArguments() : null;
+            return owner.Module.ResolveMethod(token, typeArguments, methodArguments);
+        }
+        catch (ArgumentException)
+        {
+            return null;
+        }
+        catch (BadImageFormatException)
+        {
+            return null;
+        }
+    }
+
+    private static bool SameMethod(MethodBase? actual, MethodBase expected) =>
+        actual is not null &&
+        actual.Module == expected.Module &&
+        actual.MetadataToken == expected.MetadataToken;
+
+    private static IReadOnlyList<Instruction> ReadInstructions(MethodInfo method)
+    {
+        var body = method.GetMethodBody();
+        Assert.NotNull(body);
+        var bytes = body!.GetILAsByteArray();
+        Assert.NotNull(bytes);
+
+        var instructions = new List<Instruction>();
+        var offset = 0;
+        while (offset < bytes!.Length)
+        {
+            var instructionOffset = offset;
+            var opcodeByte = bytes[offset++];
+            var opcode = opcodeByte == 0xFE
+                ? TwoByteOpCodes[bytes[offset++]]
+                : OneByteOpCodes[opcodeByte];
+            var operand = ReadOperand(opcode, bytes, ref offset);
+            instructions.Add(new Instruction(instructionOffset, opcode, operand));
+        }
+
+        return instructions;
+    }
+
+    private static object? ReadOperand(OpCode opcode, byte[] bytes, ref int offset) => opcode.OperandType switch
+    {
+        OperandType.InlineNone => null,
+        OperandType.ShortInlineI => (sbyte)bytes[offset++],
+        OperandType.InlineI => ReadInt32(bytes, ref offset),
+        OperandType.InlineI8 => ReadInt64(bytes, ref offset),
+        OperandType.ShortInlineR => ReadSingle(bytes, ref offset),
+        OperandType.InlineR => ReadDouble(bytes, ref offset),
+        OperandType.ShortInlineBrTarget => offset + (sbyte)bytes[offset++],
+        OperandType.InlineBrTarget => ReadBranchTarget(bytes, ref offset),
+        OperandType.InlineSwitch => ReadSwitchTargets(bytes, ref offset),
+        OperandType.InlineString or
+        OperandType.InlineSig or
+        OperandType.InlineField or
+        OperandType.InlineMethod or
+        OperandType.InlineType or
+        OperandType.InlineTok => ReadInt32(bytes, ref offset),
+        OperandType.ShortInlineVar => bytes[offset++],
+        OperandType.InlineVar => ReadUInt16(bytes, ref offset),
+        _ => throw new NotSupportedException($"Unsupported IL operand type {opcode.OperandType}.")
+    };
+
+    private static int ReadBranchTarget(byte[] bytes, ref int offset)
+    {
+        var delta = ReadInt32(bytes, ref offset);
+        return offset + delta;
+    }
+
+    private static int[] ReadSwitchTargets(byte[] bytes, ref int offset)
+    {
+        var count = ReadInt32(bytes, ref offset);
+        var baseOffset = offset + (count * sizeof(int));
+        var targets = new int[count];
+        for (var index = 0; index < count; index++)
+        {
+            targets[index] = baseOffset + ReadInt32(bytes, ref offset);
+        }
+
+        return targets;
+    }
+
+    private static int ReadInt32(byte[] bytes, ref int offset)
+    {
+        var value = BitConverter.ToInt32(bytes, offset);
+        offset += sizeof(int);
+        return value;
+    }
+
+    private static long ReadInt64(byte[] bytes, ref int offset)
+    {
+        var value = BitConverter.ToInt64(bytes, offset);
+        offset += sizeof(long);
+        return value;
+    }
+
+    private static float ReadSingle(byte[] bytes, ref int offset)
+    {
+        var value = BitConverter.ToSingle(bytes, offset);
+        offset += sizeof(float);
+        return value;
+    }
+
+    private static double ReadDouble(byte[] bytes, ref int offset)
+    {
+        var value = BitConverter.ToDouble(bytes, offset);
+        offset += sizeof(double);
+        return value;
+    }
+
+    private static ushort ReadUInt16(byte[] bytes, ref int offset)
+    {
+        var value = BitConverter.ToUInt16(bytes, offset);
+        offset += sizeof(ushort);
+        return value;
+    }
+
+    private static bool IsBranch(OpCode opcode) =>
+        opcode.OperandType == OperandType.ShortInlineBrTarget ||
+        opcode.OperandType == OperandType.InlineBrTarget ||
+        opcode.OperandType == OperandType.InlineSwitch;
+
+    private static IEnumerable<int> GetBranchTargets(Instruction instruction)
+    {
+        if (instruction.Operand is int singleTarget && instruction.OpCode.OperandType != OperandType.InlineSwitch)
+        {
+            yield return singleTarget;
+        }
+        else if (instruction.Operand is int[] targets)
+        {
+            foreach (var switchTarget in targets)
+            {
+                yield return switchTarget;
+            }
+        }
+    }
+
+    private static bool TryGetInt32Constant(Instruction instruction, out int value)
+    {
+        value = instruction.OpCode.Value switch
+        {
+            short valueCode when valueCode == OpCodes.Ldc_I4_M1.Value => -1,
+            short valueCode when valueCode == OpCodes.Ldc_I4_0.Value => 0,
+            short valueCode when valueCode == OpCodes.Ldc_I4_1.Value => 1,
+            short valueCode when valueCode == OpCodes.Ldc_I4_2.Value => 2,
+            short valueCode when valueCode == OpCodes.Ldc_I4_3.Value => 3,
+            short valueCode when valueCode == OpCodes.Ldc_I4_4.Value => 4,
+            short valueCode when valueCode == OpCodes.Ldc_I4_5.Value => 5,
+            short valueCode when valueCode == OpCodes.Ldc_I4_6.Value => 6,
+            short valueCode when valueCode == OpCodes.Ldc_I4_7.Value => 7,
+            short valueCode when valueCode == OpCodes.Ldc_I4_8.Value => 8,
+            _ => int.MinValue
+        };
+
+        if (value != int.MinValue)
+        {
+            return true;
+        }
+
+        if (instruction.OpCode == OpCodes.Ldc_I4 && instruction.Operand is int inlineValue)
+        {
+            value = inlineValue;
+            return true;
+        }
+
+        if (instruction.OpCode == OpCodes.Ldc_I4_S && instruction.Operand is sbyte shortValue)
+        {
+            value = shortValue;
+            return true;
+        }
+
+        value = 0;
+        return false;
+    }
+
+    private static OpCode[] BuildOpCodeMap(bool singleByte)
+    {
+        var opcodes = new OpCode[0x100];
+        foreach (var field in typeof(OpCodes).GetFields(BindingFlags.Public | BindingFlags.Static))
+        {
+            if (field.GetValue(null) is not OpCode opcode)
+            {
+                continue;
+            }
+
+            var value = (ushort)opcode.Value;
+            if (singleByte && value < 0x100)
+            {
+                opcodes[value] = opcode;
+            }
+            else if (!singleByte && (value & 0xFF00) == 0xFE00)
+            {
+                opcodes[value & 0xFF] = opcode;
+            }
+        }
+
+        return opcodes;
+    }
+
+    private sealed record Instruction(int Offset, OpCode OpCode, object? Operand);
+
+    private sealed record CallSite(Instruction Instruction, MethodBase? Target);
+}

--- a/dcb/tests/Sekiban.Dcb.SortableUniqueIdWait.WithoutResult.Tests/OrleansWithoutResultFacadeAcceptanceTests.cs
+++ b/dcb/tests/Sekiban.Dcb.SortableUniqueIdWait.WithoutResult.Tests/OrleansWithoutResultFacadeAcceptanceTests.cs
@@ -18,6 +18,7 @@ using Sekiban.Dcb.ServiceId;
 using Sekiban.Dcb.Storage;
 using Sekiban.Dcb.Tags;
 using Sekiban.Dcb.Testing;
+using Sekiban.Dcb.SortableUniqueIdWait.Tests;
 
 namespace Sekiban.Dcb.SortableUniqueIdWait.WithoutResult.Tests;
 
@@ -30,12 +31,31 @@ public sealed class OrleansWithoutResultFacadeAcceptanceTests
     [Fact]
     public void Architecture_AllWithoutResultEntrypointsBindTheSharedPolicy()
     {
-        Assert.Contains(
-            typeof(CoreGeneralSekibanExecutor).GetFields(BindingFlags.Instance | BindingFlags.NonPublic),
-            field => field.FieldType == typeof(SortableUniqueIdWaitPolicy));
-        Assert.Contains(
-            typeof(Sekiban.Dcb.Orleans.OrleansDcbExecutor).GetFields(BindingFlags.Instance | BindingFlags.NonPublic),
-            field => field.FieldType == typeof(SortableUniqueIdWaitPolicy));
+        WaitArchitectureAssertions.AssertAll(
+            new WaitArchitectureRoute(
+                "orleans-without-result-single",
+                typeof(Sekiban.Dcb.Orleans.OrleansDcbExecutor),
+                typeof(IQueryCommon<>),
+                "WaitForSortableUniqueIdIfNeeded",
+                SortableUniqueIdWaitSurface.OrleansWithoutResultSingle),
+            new WaitArchitectureRoute(
+                "orleans-without-result-list",
+                typeof(Sekiban.Dcb.Orleans.OrleansDcbExecutor),
+                typeof(IListQueryCommon<>),
+                "WaitForSortableUniqueIdIfNeeded",
+                SortableUniqueIdWaitSurface.OrleansWithoutResultList),
+            new WaitArchitectureRoute(
+                "in-memory-strict-single",
+                typeof(CoreGeneralSekibanExecutor),
+                typeof(IQueryCommon<>),
+                "WaitForStrictSortableUniqueIdIfNeededAsync",
+                SortableUniqueIdWaitSurface.InMemorySingle),
+            new WaitArchitectureRoute(
+                "in-memory-strict-list",
+                typeof(CoreGeneralSekibanExecutor),
+                typeof(IListQueryCommon<>),
+                "WaitForStrictSortableUniqueIdIfNeededAsync",
+                SortableUniqueIdWaitSurface.InMemoryList));
     }
 
     [Fact]

--- a/dcb/tests/Sekiban.Dcb.SortableUniqueIdWait.WithoutResult.Tests/OrleansWithoutResultFacadeAcceptanceTests.cs
+++ b/dcb/tests/Sekiban.Dcb.SortableUniqueIdWait.WithoutResult.Tests/OrleansWithoutResultFacadeAcceptanceTests.cs
@@ -1,0 +1,525 @@
+using System.Diagnostics.Metrics;
+using System.Reflection;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.DependencyInjection;
+using Orleans;
+using Sekiban.Dcb;
+using Sekiban.Dcb.Actors;
+using Sekiban.Dcb.Common;
+using Sekiban.Dcb.Domains;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.MultiProjections;
+using Sekiban.Dcb.Orleans;
+using Sekiban.Dcb.Orleans.Grains;
+using Sekiban.Dcb.Orleans.Serialization;
+using Sekiban.Dcb.Queries;
+using Sekiban.Dcb.ServiceId;
+using Sekiban.Dcb.Storage;
+using Sekiban.Dcb.Tags;
+using Sekiban.Dcb.Testing;
+
+namespace Sekiban.Dcb.SortableUniqueIdWait.WithoutResult.Tests;
+
+/// <summary>
+///     Exception-based Orleans facade acceptance tests. The grain contract is a deterministic counting proxy, while
+///     the production executor, shared wait policy, serialized query boundary, and exception boundary are real.
+/// </summary>
+public sealed class OrleansWithoutResultFacadeAcceptanceTests
+{
+    [Fact]
+    public void Architecture_AllWithoutResultEntrypointsBindTheSharedPolicy()
+    {
+        Assert.Contains(
+            typeof(CoreGeneralSekibanExecutor).GetFields(BindingFlags.Instance | BindingFlags.NonPublic),
+            field => field.FieldType == typeof(SortableUniqueIdWaitPolicy));
+        Assert.Contains(
+            typeof(Sekiban.Dcb.Orleans.OrleansDcbExecutor).GetFields(BindingFlags.Instance | BindingFlags.NonPublic),
+            field => field.FieldType == typeof(SortableUniqueIdWaitPolicy));
+    }
+
+    [Fact]
+    public async Task StrictSingleTimeout_IsTypedBeforeSerializationOrGrainQueryExecution()
+    {
+        var clock = NewClock();
+        var target = SortableUniqueId.Generate(clock.UtcNow.UtcDateTime.AddSeconds(-6), Guid.Empty);
+        WithoutResultQuery.ResetObservations();
+        var observation = new GrainObservation { LastObservedPosition = "observed-position" };
+        using var scope = CreateExecutor(clock, observation);
+        using var metrics = new WaitMetricCapture();
+
+        var exception = await Assert.ThrowsAsync<SortableUniqueIdWaitTimeoutException>(() =>
+            scope.Executor.QueryAsync<WithoutResultValue>(new WithoutResultQuery { WaitForSortableUniqueId = target }));
+
+        Assert.Equal(target, exception.TargetSortableUniqueId);
+        Assert.Equal("observed-position", exception.LastObservedSortableUniqueId);
+        Assert.Equal(TimeSpan.FromSeconds(5), exception.Timeout);
+        Assert.Equal(TimeSpan.FromSeconds(5), exception.Elapsed);
+        Assert.Equal(25, observation.ProbeCalls);
+        Assert.Equal(1, observation.HeadStatusCalls);
+        Assert.Equal(0, observation.ExecuteQueryCalls);
+        Assert.Equal(0, WithoutResultQuery.SerializationWrites);
+        Assert.Contains(
+            metrics.Histograms,
+            value => value.Surface == "orleans_without_result_single" &&
+                value.Mode == "strict" && value.Outcome == "timeout");
+    }
+
+    [Fact]
+    public async Task StrictListTimeout_IsTypedBeforeListGrainQueryExecution()
+    {
+        var clock = NewClock();
+        var target = SortableUniqueId.Generate(clock.UtcNow.UtcDateTime.AddSeconds(-6), Guid.Empty);
+        WithoutResultListQuery.ResetObservations();
+        var observation = new GrainObservation { LastObservedPosition = "observed-position" };
+        using var scope = CreateExecutor(clock, observation);
+        using var metrics = new WaitMetricCapture();
+
+        var exception = await Assert.ThrowsAsync<SortableUniqueIdWaitTimeoutException>(() =>
+            scope.Executor.QueryAsync<WithoutResultItem>(
+                new WithoutResultListQuery
+                {
+                    WaitForSortableUniqueId = target,
+                    PageNumber = 1,
+                    PageSize = 10
+                }));
+
+        Assert.Equal(target, exception.TargetSortableUniqueId);
+        Assert.Equal("observed-position", exception.LastObservedSortableUniqueId);
+        Assert.Equal(25, observation.ProbeCalls);
+        Assert.Equal(1, observation.HeadStatusCalls);
+        Assert.Equal(0, observation.ExecuteListQueryCalls);
+        Assert.Equal(0, WithoutResultListQuery.SerializationWrites);
+        Assert.Contains(
+            metrics.Histograms,
+            value => value.Surface == "orleans_without_result_list" &&
+                value.Mode == "strict" && value.Outcome == "timeout");
+    }
+
+    [Fact]
+    public async Task LegacySingleTimeout_RemainsFailOpenAndExecutesTheGrainQuery()
+    {
+        var clock = NewClock();
+        var target = SortableUniqueId.Generate(clock.UtcNow.UtcDateTime.AddSeconds(-6), Guid.Empty);
+        LegacyWithoutResultQuery.ResetObservations();
+        var observation = new GrainObservation();
+        using var scope = CreateExecutor(clock, observation);
+
+        var result = await scope.Executor.QueryAsync<WithoutResultValue>(
+            new LegacyWithoutResultQuery { WaitForSortableUniqueId = target });
+
+        Assert.Equal(9, result.Count);
+        Assert.Equal(25, observation.ProbeCalls);
+        Assert.Equal(1, observation.ExecuteQueryCalls);
+        Assert.True(LegacyWithoutResultQuery.SerializationWrites >= 1);
+        Assert.Equal(TimeSpan.FromSeconds(5), clock.Elapsed);
+        Assert.Contains(
+            scope.Metrics.Histograms,
+            value => value.Surface == "orleans_without_result_single" &&
+                value.Mode == "legacy" && value.Outcome == "timeout");
+    }
+
+    [Fact]
+    public async Task LegacyListTimeout_RemainsFailOpenAndExecutesTheListGrainQuery()
+    {
+        var clock = NewClock();
+        var target = SortableUniqueId.Generate(clock.UtcNow.UtcDateTime.AddSeconds(-6), Guid.Empty);
+        LegacyWithoutResultListQuery.ResetObservations();
+        var observation = new GrainObservation();
+        using var scope = CreateExecutor(clock, observation);
+
+        var result = await scope.Executor.QueryAsync<WithoutResultItem>(
+            new LegacyWithoutResultListQuery
+            {
+                WaitForSortableUniqueId = target,
+                PageNumber = 1,
+                PageSize = 10
+            });
+
+        Assert.Equal(1, result.TotalCount);
+        Assert.Equal(25, observation.ProbeCalls);
+        Assert.Equal(0, observation.HeadStatusCalls);
+        Assert.Equal(1, observation.ExecuteListQueryCalls);
+        Assert.True(LegacyWithoutResultListQuery.SerializationWrites >= 1);
+        Assert.Equal(TimeSpan.FromSeconds(5), clock.Elapsed);
+        Assert.Contains(
+            scope.Metrics.Histograms,
+            value => value.Surface == "orleans_without_result_list" &&
+                value.Mode == "legacy" && value.Outcome == "timeout");
+    }
+
+    [Fact]
+    public async Task StrictArrival_UsesGrainSuccessAndExecutesQueryOnce()
+    {
+        var clock = NewClock();
+        var target = SortableUniqueId.Generate(clock.UtcNow.UtcDateTime, Guid.Empty);
+        WithoutResultQuery.ResetObservations();
+        var observation = new GrainObservation { ProbeResult = true };
+        using var scope = CreateExecutor(clock, observation);
+
+        var result = await scope.Executor.QueryAsync<WithoutResultValue>(
+            new WithoutResultQuery { WaitForSortableUniqueId = target });
+
+        Assert.Equal(9, result.Count);
+        Assert.Equal(1, observation.ProbeCalls);
+        Assert.Equal(1, observation.ExecuteQueryCalls);
+        Assert.True(WithoutResultQuery.SerializationWrites >= 1);
+        Assert.Contains(
+            scope.Metrics.Histograms,
+            value => value.Surface == "orleans_without_result_single" &&
+                value.Mode == "strict" && value.Outcome == "arrived");
+    }
+
+    private static FakeClock NewClock() =>
+        new(new DateTimeOffset(2030, 1, 1, 0, 0, 0, TimeSpan.Zero));
+
+    private static ExecutorScope CreateExecutor(FakeClock clock, GrainObservation observation)
+    {
+        var client = DispatchProxy.Create<IClusterClient, ClusterClientProxy>();
+        var grain = DispatchProxy.Create<IMultiProjectionGrain, GrainProxy>();
+        ClusterClientProxy.Current.Value = grain;
+        GrainProxy.Current.Value = new GrainContext(observation, CreateDomain());
+
+        var generator = new MonotonicSortableUniqueIdGenerator(clock);
+        var policy = new SortableUniqueIdWaitPolicy(
+            clock,
+            (delay, cancellationToken) =>
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                clock.Advance(delay);
+                return Task.CompletedTask;
+            });
+
+        var services = new ServiceCollection();
+        services.AddSingleton<IClusterClient>(client);
+        services.AddSingleton<IEventStore>(new InMemoryEventStore());
+        services.AddSingleton(CreateDomain());
+        services.AddSingleton(policy);
+        services.AddSingleton<ISekibanExecutor>(serviceProvider => new OrleansDcbExecutor(
+            serviceProvider.GetRequiredService<IClusterClient>(),
+            serviceProvider.GetRequiredService<IEventStore>(),
+            serviceProvider.GetRequiredService<DcbDomainTypes>(),
+            null,
+            null,
+            null,
+            generator,
+            new SortableUniqueIdSeedCoordinator(generator),
+            serviceProvider.GetRequiredService<SortableUniqueIdWaitPolicy>()));
+
+        var provider = services.BuildServiceProvider();
+        return new ExecutorScope(provider, provider.GetRequiredService<ISekibanExecutor>());
+    }
+
+    private static DcbDomainTypes CreateDomain() =>
+        DcbDomainTypesExtensions.Simple(types =>
+        {
+            types.MultiProjectorTypes.RegisterProjector<WithoutResultProjector>();
+            types.QueryTypes.RegisterQuery<WithoutResultQuery>();
+            types.QueryTypes.RegisterQuery<LegacyWithoutResultQuery>();
+            types.QueryTypes.RegisterListQuery<WithoutResultListQuery>();
+            types.QueryTypes.RegisterListQuery<LegacyWithoutResultListQuery>();
+        });
+
+    private sealed class ExecutorScope : IDisposable
+    {
+        private readonly ServiceProvider _provider;
+        public ExecutorScope(ServiceProvider provider, ISekibanExecutor executor)
+        {
+            _provider = provider;
+            Executor = executor;
+            Metrics = new WaitMetricCapture();
+        }
+
+        public ISekibanExecutor Executor { get; }
+        public WaitMetricCapture Metrics { get; }
+
+        public void Dispose()
+        {
+            Metrics.Dispose();
+            _provider.Dispose();
+            ClusterClientProxy.Current.Value = null;
+            GrainProxy.Current.Value = null;
+        }
+    }
+
+    private sealed class FakeClock(DateTimeOffset utcNow) : TimeProvider
+    {
+        private DateTimeOffset _utcNow = utcNow;
+        private long _timestamp;
+        public DateTimeOffset UtcNow => _utcNow;
+        public TimeSpan Elapsed => TimeSpan.FromTicks(_timestamp);
+        public override long TimestampFrequency => TimeSpan.TicksPerSecond;
+        public override DateTimeOffset GetUtcNow() => _utcNow;
+        public override long GetTimestamp() => _timestamp;
+        public void Advance(TimeSpan amount)
+        {
+            _utcNow += amount;
+            _timestamp += amount.Ticks;
+        }
+    }
+
+    private sealed class GrainObservation
+    {
+        public bool ProbeResult { get; init; }
+        public string? LastObservedPosition { get; init; }
+        public int ProbeCalls;
+        public int HeadStatusCalls;
+        public int ExecuteQueryCalls;
+        public int ExecuteListQueryCalls;
+    }
+
+    private sealed record GrainContext(GrainObservation Observation, DcbDomainTypes Domain);
+
+    private class ClusterClientProxy : DispatchProxy
+    {
+        public static AsyncLocal<IMultiProjectionGrain?> Current { get; } = new();
+        protected override object? Invoke(MethodInfo? targetMethod, object?[]? args)
+        {
+            if (targetMethod?.IsGenericMethod == true && targetMethod.Name == "GetGrain" &&
+                targetMethod.GetGenericArguments()[0] == typeof(IMultiProjectionGrain))
+            {
+                return Current.Value ?? throw new InvalidOperationException("No fake grain configured.");
+            }
+
+            throw new InvalidOperationException($"Unexpected IClusterClient call: {targetMethod?.Name}");
+        }
+    }
+
+    private class GrainProxy : DispatchProxy
+    {
+        public static AsyncLocal<GrainContext?> Current { get; } = new();
+        protected override object? Invoke(MethodInfo? targetMethod, object?[]? args)
+        {
+            var context = Current.Value ?? throw new InvalidOperationException("No fake grain context configured.");
+            switch (targetMethod?.Name)
+            {
+                case nameof(IMultiProjectionGrain.IsSortableUniqueIdReceived):
+                    Interlocked.Increment(ref context.Observation.ProbeCalls);
+                    return Task.FromResult(context.Observation.ProbeResult);
+                case nameof(IMultiProjectionGrain.GetProjectionHeadStatusAsync):
+                    Interlocked.Increment(ref context.Observation.HeadStatusCalls);
+                    return Task.FromResult(new MultiProjectionHeadStatusSnapshot(
+                        WithoutResultProjector.MultiProjectorName,
+                        "1.0.0",
+                        0,
+                        context.Observation.LastObservedPosition,
+                        0,
+                        null,
+                        false,
+                        null,
+                        null,
+                        0));
+                case nameof(IMultiProjectionGrain.ExecuteQueryAsync):
+                    Interlocked.Increment(ref context.Observation.ExecuteQueryCalls);
+                    return CreateQueryResultAsync(
+                        args?[0] as SerializableQueryParameter ??
+                        throw new InvalidOperationException("Missing serialized query parameter."),
+                        context.Domain);
+                case nameof(IMultiProjectionGrain.ExecuteListQueryAsync):
+                    Interlocked.Increment(ref context.Observation.ExecuteListQueryCalls);
+                    return CreateListQueryResultAsync(
+                        args?[0] as SerializableQueryParameter ??
+                        throw new InvalidOperationException("Missing serialized list query parameter."),
+                        context.Domain);
+                default:
+                    throw new InvalidOperationException($"Unexpected grain call: {targetMethod?.Name}");
+            }
+        }
+
+        private static async Task<SerializableQueryResult> CreateQueryResultAsync(
+            SerializableQueryParameter parameter,
+            DcbDomainTypes domain)
+        {
+            var query = (IQueryCommon)(await parameter.ToQueryAsync(domain)).GetValue();
+            return await SerializableQueryResult.CreateFromAsync(
+                new QueryResultGeneral(
+                    new WithoutResultValue(9),
+                    typeof(WithoutResultValue).AssemblyQualifiedName!,
+                    query),
+                domain.JsonSerializerOptions);
+        }
+
+        private static async Task<SerializableListQueryResult> CreateListQueryResultAsync(
+            SerializableQueryParameter parameter,
+            DcbDomainTypes domain)
+        {
+            var query = (IListQueryCommon)(await parameter.ToQueryAsync(domain)).GetValue();
+            return await SerializableListQueryResult.CreateFromAsync(
+                new ListQueryResultGeneral(
+                    1,
+                    1,
+                    1,
+                    10,
+                    [new WithoutResultItem(9)],
+                    typeof(WithoutResultItem).AssemblyQualifiedName!,
+                    query),
+                domain.JsonSerializerOptions);
+        }
+    }
+
+    private sealed class WaitMetricCapture : IDisposable
+    {
+        private readonly MeterListener _listener = new();
+        public List<WaitObservation> Histograms { get; } = [];
+
+        public WaitMetricCapture()
+        {
+            _listener.InstrumentPublished = (instrument, listener) =>
+            {
+                if (instrument.Meter.Name == SortableUniqueIdWaitTelemetry.MeterName)
+                {
+                    listener.EnableMeasurementEvents(instrument);
+                }
+            };
+            _listener.SetMeasurementEventCallback<double>((instrument, _, tags, _) =>
+                Histograms.Add(WaitObservation.From(instrument, tags)));
+            _listener.Start();
+        }
+
+        public void Dispose() => _listener.Dispose();
+    }
+
+    private sealed record WaitObservation(string Surface, string Mode, string Outcome)
+    {
+        public static WaitObservation From(
+            Instrument instrument,
+            ReadOnlySpan<KeyValuePair<string, object?>> tags)
+        {
+            var surface = "";
+            var mode = "";
+            var outcome = "";
+            foreach (var tag in tags)
+            {
+                var value = tag.Value?.ToString() ?? "";
+                switch (tag.Key)
+                {
+                    case "surface": surface = value; break;
+                    case "mode": mode = value; break;
+                    case "outcome": outcome = value; break;
+                }
+            }
+
+            return new(surface, mode, outcome);
+        }
+    }
+
+    public sealed record WithoutResultProjector : IMultiProjector<WithoutResultProjector>
+    {
+        public int Count { get; init; }
+        public static string MultiProjectorName => "sortable-unique-id-wait-without-result";
+        public static string MultiProjectorVersion => "1.0.0";
+        public static WithoutResultProjector GenerateInitialPayload() => new();
+        public static WithoutResultProjector Project(
+            WithoutResultProjector payload,
+            Event ev,
+            List<ITag> tags,
+            DcbDomainTypes domainTypes,
+            SortableUniqueId safeWindowThreshold) => payload with { Count = payload.Count + 1 };
+    }
+
+    public sealed record WithoutResultQuery : IMultiProjectionQuery<WithoutResultProjector, WithoutResultQuery, WithoutResultValue>,
+        IStrictWaitForSortableUniqueId
+    {
+        public static int SerializationWrites;
+        public string? WaitForSortableUniqueId { get; init; }
+        [JsonConverter(typeof(WithoutResultQueryProbeConverter))]
+        public string Probe { get; init; } = "serialized";
+        public static WithoutResultValue HandleQuery(WithoutResultProjector projector, WithoutResultQuery query, IQueryContext context) =>
+            new(projector.Count);
+        public static void ResetObservations() => SerializationWrites = 0;
+    }
+
+    public sealed record LegacyWithoutResultQuery : IMultiProjectionQuery<WithoutResultProjector, LegacyWithoutResultQuery, WithoutResultValue>,
+        IWaitForSortableUniqueId
+    {
+        public static int SerializationWrites;
+        public string? WaitForSortableUniqueId { get; init; }
+        [JsonConverter(typeof(LegacyWithoutResultQueryProbeConverter))]
+        public string Probe { get; init; } = "serialized";
+        public static WithoutResultValue HandleQuery(WithoutResultProjector projector, LegacyWithoutResultQuery query, IQueryContext context) =>
+            new(projector.Count);
+        public static void ResetObservations() => SerializationWrites = 0;
+    }
+
+    public sealed record WithoutResultListQuery : IMultiProjectionListQuery<WithoutResultProjector, WithoutResultListQuery, WithoutResultItem>,
+        IStrictWaitForSortableUniqueId,
+        IQueryPagingParameter
+    {
+        public static int SerializationWrites;
+        public string? WaitForSortableUniqueId { get; init; }
+        public int? PageNumber { get; init; }
+        public int? PageSize { get; init; }
+        [JsonConverter(typeof(WithoutResultListQueryProbeConverter))]
+        public string Probe { get; init; } = "serialized";
+        public static IEnumerable<WithoutResultItem> HandleFilter(WithoutResultProjector projector, WithoutResultListQuery query, IQueryContext context) =>
+            [new(projector.Count)];
+        public static IEnumerable<WithoutResultItem> HandleSort(IEnumerable<WithoutResultItem> items, WithoutResultListQuery query, IQueryContext context) => items;
+        public static void ResetObservations() => SerializationWrites = 0;
+    }
+
+    public sealed record LegacyWithoutResultListQuery :
+        IMultiProjectionListQuery<WithoutResultProjector, LegacyWithoutResultListQuery, WithoutResultItem>,
+        IWaitForSortableUniqueId,
+        IQueryPagingParameter
+    {
+        public static int SerializationWrites;
+        public string? WaitForSortableUniqueId { get; init; }
+        public int? PageNumber { get; init; }
+        public int? PageSize { get; init; }
+        [JsonConverter(typeof(LegacyWithoutResultListQueryProbeConverter))]
+        public string Probe { get; init; } = "serialized";
+        public static IEnumerable<WithoutResultItem> HandleFilter(
+            WithoutResultProjector projector,
+            LegacyWithoutResultListQuery query,
+            IQueryContext context) => [new(projector.Count)];
+        public static IEnumerable<WithoutResultItem> HandleSort(
+            IEnumerable<WithoutResultItem> items,
+            LegacyWithoutResultListQuery query,
+            IQueryContext context) => items;
+        public static void ResetObservations() => SerializationWrites = 0;
+    }
+
+    public sealed record WithoutResultValue(int Count);
+    public sealed record WithoutResultItem(int Count);
+
+    public sealed class WithoutResultQueryProbeConverter : JsonConverter<string>
+    {
+        public override string Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) => reader.GetString() ?? "";
+        public override void Write(Utf8JsonWriter writer, string value, JsonSerializerOptions options)
+        {
+            Interlocked.Increment(ref WithoutResultQuery.SerializationWrites);
+            writer.WriteStringValue(value);
+        }
+    }
+
+    public sealed class LegacyWithoutResultQueryProbeConverter : JsonConverter<string>
+    {
+        public override string Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) => reader.GetString() ?? "";
+        public override void Write(Utf8JsonWriter writer, string value, JsonSerializerOptions options)
+        {
+            Interlocked.Increment(ref LegacyWithoutResultQuery.SerializationWrites);
+            writer.WriteStringValue(value);
+        }
+    }
+
+    public sealed class WithoutResultListQueryProbeConverter : JsonConverter<string>
+    {
+        public override string Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) => reader.GetString() ?? "";
+        public override void Write(Utf8JsonWriter writer, string value, JsonSerializerOptions options)
+        {
+            Interlocked.Increment(ref WithoutResultListQuery.SerializationWrites);
+            writer.WriteStringValue(value);
+        }
+    }
+
+    public sealed class LegacyWithoutResultListQueryProbeConverter : JsonConverter<string>
+    {
+        public override string Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) =>
+            reader.GetString() ?? "";
+        public override void Write(Utf8JsonWriter writer, string value, JsonSerializerOptions options)
+        {
+            Interlocked.Increment(ref LegacyWithoutResultListQuery.SerializationWrites);
+            writer.WriteStringValue(value);
+        }
+    }
+}

--- a/dcb/tests/Sekiban.Dcb.SortableUniqueIdWait.WithoutResult.Tests/Sekiban.Dcb.SortableUniqueIdWait.WithoutResult.Tests.csproj
+++ b/dcb/tests/Sekiban.Dcb.SortableUniqueIdWait.WithoutResult.Tests/Sekiban.Dcb.SortableUniqueIdWait.WithoutResult.Tests.csproj
@@ -29,4 +29,8 @@
         <ProjectReference Include="..\..\src\Sekiban.Dcb.Orleans.WithoutResult\Sekiban.Dcb.Orleans.WithoutResult.csproj" />
     </ItemGroup>
 
+    <ItemGroup>
+        <Compile Include="..\Sekiban.Dcb.SortableUniqueIdWait.Tests\WaitArchitectureAssertions.cs" Link="WaitArchitectureAssertions.cs" />
+    </ItemGroup>
+
 </Project>

--- a/dcb/tests/Sekiban.Dcb.SortableUniqueIdWait.WithoutResult.Tests/Sekiban.Dcb.SortableUniqueIdWait.WithoutResult.Tests.csproj
+++ b/dcb/tests/Sekiban.Dcb.SortableUniqueIdWait.WithoutResult.Tests/Sekiban.Dcb.SortableUniqueIdWait.WithoutResult.Tests.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+        <TargetFramework>net10.0</TargetFramework>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.3" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+        <PackageReference Include="xunit" Version="2.9.3" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+        <Using Include="Xunit" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\src\Sekiban.Dcb.Core\Sekiban.Dcb.Core.csproj" />
+        <ProjectReference Include="..\..\src\Sekiban.Dcb.Core.Testing\Sekiban.Dcb.Core.Testing.csproj" />
+        <ProjectReference Include="..\..\src\Sekiban.Dcb.WithoutResult.Model\Sekiban.Dcb.WithoutResult.Model.csproj" />
+        <ProjectReference Include="..\..\src\Sekiban.Dcb.WithoutResult\Sekiban.Dcb.WithoutResult.csproj" />
+        <ProjectReference Include="..\..\src\Sekiban.Dcb.Orleans.WithoutResult\Sekiban.Dcb.Orleans.WithoutResult.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/dcb/tests/Sekiban.Dcb.WithResult.BinaryConsumer/Program.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.BinaryConsumer/Program.cs
@@ -1,0 +1,5 @@
+using Sekiban.Dcb;
+using Sekiban.Dcb.Queries;
+
+Console.WriteLine(
+    $"with-result-binary-consumer-ok:{typeof(ISekibanExecutor).FullName}:{typeof(IWaitForSortableUniqueId).FullName}");

--- a/dcb/tests/Sekiban.Dcb.WithResult.BinaryConsumer/README.md
+++ b/dcb/tests/Sekiban.Dcb.WithResult.BinaryConsumer/README.md
@@ -1,0 +1,22 @@
+# WithResult binary consumer
+
+This fixture is restored and compiled against the published `Sekiban.Dcb.WithResult` **10.14.0** package. The
+already-built consumer is then executed after the current branch's `Sekiban.Dcb.WithResult.dll`, core model, and
+WithResult model assemblies are copied into its output directory; the execution command does not rebuild or restore.
+
+```sh
+dotnet build dcb/tests/Sekiban.Dcb.WithResult.BinaryConsumer/Sekiban.Dcb.WithResult.BinaryConsumer.csproj -c Release
+dotnet build dcb/src/Sekiban.Dcb.WithResult/Sekiban.Dcb.WithResult.csproj -c Release -f net9.0
+cp dcb/src/Sekiban.Dcb.WithResult/bin/Release/net9.0/Sekiban.Dcb.WithResult.dll \
+  dcb/tests/Sekiban.Dcb.WithResult.BinaryConsumer/bin/Release/net9.0/
+cp dcb/src/Sekiban.Dcb.Core/bin/Release/net9.0/Sekiban.Dcb.Core.dll \
+  dcb/tests/Sekiban.Dcb.WithResult.BinaryConsumer/bin/Release/net9.0/
+cp dcb/src/Sekiban.Dcb.Core.Model/bin/Release/net9.0/Sekiban.Dcb.Core.Model.dll \
+  dcb/tests/Sekiban.Dcb.WithResult.BinaryConsumer/bin/Release/net9.0/
+cp dcb/src/Sekiban.Dcb.WithResult.Model/bin/Release/net9.0/Sekiban.Dcb.WithResult.Model.dll \
+  dcb/tests/Sekiban.Dcb.WithResult.BinaryConsumer/bin/Release/net9.0/
+dotnet dcb/tests/Sekiban.Dcb.WithResult.BinaryConsumer/bin/Release/net9.0/Sekiban.Dcb.WithResult.BinaryConsumer.dll
+```
+
+The output must begin with `with-result-binary-consumer-ok:`. The final command deliberately invokes the existing
+consumer DLL directly, proving execution without recompilation.

--- a/dcb/tests/Sekiban.Dcb.WithResult.BinaryConsumer/Sekiban.Dcb.WithResult.BinaryConsumer.csproj
+++ b/dcb/tests/Sekiban.Dcb.WithResult.BinaryConsumer/Sekiban.Dcb.WithResult.BinaryConsumer.csproj
@@ -9,6 +9,6 @@
 
   <ItemGroup>
     <!-- This fixture is intentionally compiled against the published v10.14.0 package. -->
-    <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.14.0" />
+    <PackageReference Include="Sekiban.Dcb.WithResult" Version="10.14.0" />
   </ItemGroup>
 </Project>

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/ConditionalAppend/ConditionalAppendSeamArchitectureTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/ConditionalAppend/ConditionalAppendSeamArchitectureTests.cs
@@ -187,17 +187,24 @@ public class ConditionalAppendSeamArchitectureTests
     [Fact]
     public void InternalsVisibleTo_Allowlist_IsExactlyTheIntendedAssemblies()
     {
-        // The provider assemblies grant internals only to the intended test assembly; Core grants the four provider
+        // The provider assemblies grant internals only to the intended test assembly. Core grants the four provider
         // assemblies (for the internal post-commit-response-loss signal), Sekiban.Dcb.Orleans.Core (SEK-G18: the Orleans
         // host reads the internal projection rebuild-required signal), and the two Orleans facades (SEK-G31: retained
-        // constructors share the process generator/coordinator without adding public API) — never a test assembly.
-        // Postgres's own IVT is asserted in Sekiban.Dcb.Postgres.Tests (where the Postgres seam is reachable).
+        // constructors share the process generator/coordinator without adding public API). SEK-G33 also grants the
+        // WithResult/WithoutResult facades and their dedicated acceptance-test assemblies access to the internal wait
+        // policy constructor: production facades must inject one shared policy, while tests must inject deterministic
+        // TimeProvider/delay seams through the real facades. Keeping these grants explicit preserves the internal-only
+        // timing seam and prevents a public test hook. Postgres's own IVT is asserted in Sekiban.Dcb.Postgres.Tests
+        // (where the Postgres seam is reachable).
         AssertIvtAllowlist(typeof(SqliteEventStore).Assembly, "Sekiban.Dcb.WithResult.Tests");
         AssertIvtAllowlist(typeof(CosmosDbEventStore).Assembly, "Sekiban.Dcb.WithResult.Tests");
         AssertIvtAllowlist(
             typeof(IConditionalEventStore).Assembly,
             "Sekiban.Dcb.Postgres", "Sekiban.Dcb.Sqlite", "Sekiban.Dcb.CosmosDb", "Sekiban.Dcb.DynamoDB",
-            "Sekiban.Dcb.Orleans.Core", "Sekiban.Dcb.Orleans.WithResult", "Sekiban.Dcb.Orleans.WithoutResult");
+            "Sekiban.Dcb.Orleans.Core", "Sekiban.Dcb.Orleans.WithResult", "Sekiban.Dcb.Orleans.WithoutResult",
+            "Sekiban.Dcb.WithResult", "Sekiban.Dcb.WithoutResult",
+            "Sekiban.Dcb.SortableUniqueIdWait.Tests",
+            "Sekiban.Dcb.SortableUniqueIdWait.WithoutResult.Tests");
     }
 
     [Theory]

--- a/dcb/tests/Sekiban.Dcb.WithoutResult.BinaryConsumer/Program.cs
+++ b/dcb/tests/Sekiban.Dcb.WithoutResult.BinaryConsumer/Program.cs
@@ -1,0 +1,5 @@
+using Sekiban.Dcb;
+using Sekiban.Dcb.Queries;
+
+Console.WriteLine(
+    $"without-result-binary-consumer-ok:{typeof(ISekibanExecutor).FullName}:{typeof(IWaitForSortableUniqueId).FullName}");

--- a/dcb/tests/Sekiban.Dcb.WithoutResult.BinaryConsumer/README.md
+++ b/dcb/tests/Sekiban.Dcb.WithoutResult.BinaryConsumer/README.md
@@ -1,0 +1,22 @@
+# WithoutResult binary consumer
+
+This fixture is restored and compiled against the published `Sekiban.Dcb.WithoutResult` **10.14.0** package. The
+already-built consumer is then executed after the current branch's `Sekiban.Dcb.WithoutResult.dll`, Core, and
+WithoutResult model assemblies are copied into its output directory; the execution command does not rebuild or restore.
+
+```sh
+dotnet build dcb/tests/Sekiban.Dcb.WithoutResult.BinaryConsumer/Sekiban.Dcb.WithoutResult.BinaryConsumer.csproj -c Release
+dotnet build dcb/src/Sekiban.Dcb.WithoutResult/Sekiban.Dcb.WithoutResult.csproj -c Release -f net9.0
+cp dcb/src/Sekiban.Dcb.WithoutResult/bin/Release/net9.0/Sekiban.Dcb.WithoutResult.dll \
+  dcb/tests/Sekiban.Dcb.WithoutResult.BinaryConsumer/bin/Release/net9.0/
+cp dcb/src/Sekiban.Dcb.Core/bin/Release/net9.0/Sekiban.Dcb.Core.dll \
+  dcb/tests/Sekiban.Dcb.WithoutResult.BinaryConsumer/bin/Release/net9.0/
+cp dcb/src/Sekiban.Dcb.Core.Model/bin/Release/net9.0/Sekiban.Dcb.Core.Model.dll \
+  dcb/tests/Sekiban.Dcb.WithoutResult.BinaryConsumer/bin/Release/net9.0/
+cp dcb/src/Sekiban.Dcb.WithoutResult.Model/bin/Release/net9.0/Sekiban.Dcb.WithoutResult.Model.dll \
+  dcb/tests/Sekiban.Dcb.WithoutResult.BinaryConsumer/bin/Release/net9.0/
+dotnet dcb/tests/Sekiban.Dcb.WithoutResult.BinaryConsumer/bin/Release/net9.0/Sekiban.Dcb.WithoutResult.BinaryConsumer.dll
+```
+
+The output must begin with `without-result-binary-consumer-ok:`. The final command deliberately invokes the existing
+consumer DLL directly, proving execution without recompilation.

--- a/dcb/tests/Sekiban.Dcb.WithoutResult.BinaryConsumer/Sekiban.Dcb.WithoutResult.BinaryConsumer.csproj
+++ b/dcb/tests/Sekiban.Dcb.WithoutResult.BinaryConsumer/Sekiban.Dcb.WithoutResult.BinaryConsumer.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- This fixture is intentionally compiled against the published v10.14.0 package. -->
+    <PackageReference Include="Sekiban.Dcb.WithoutResult" Version="10.14.0" />
+  </ItemGroup>
+</Project>

--- a/docs/dcb_llm/13_common_issues.md
+++ b/docs/dcb_llm/13_common_issues.md
@@ -527,3 +527,30 @@ standalone-instance enforcement mechanism.
 and scalar query ports before provider execution. It removes raw connection/transaction access from the projector while
 `Legacy` remains the compatibility default. Missing, throwing, invalid, or denying policies fail closed with typed safe
 reasons, and cancellation remains cancellation. Hosted workers retry verification and do not fall back to schema ensure.
+
+## Strict sortable-unique-id waits — dcb-v10.15.0 (SEK-G33)
+
+`IWaitForSortableUniqueId` remains the legacy, fail-open contract. Orleans WithResult and WithoutResult single-query and
+list-query facades still wait with the adaptive policy and execute the query after a timeout. InMemory keeps its historical
+legacy no-wait behavior. Cancellation is never converted to a timeout or a query result.
+
+Opt in to fail-closed freshness with the memberless marker:
+
+```csharp
+public sealed record FreshStudentQuery(string? WaitForSortableUniqueId, string StudentId)
+    : IStrictWaitForSortableUniqueId;
+```
+
+Strict waits use the same policy on all four Orleans surfaces and on strict InMemory queries. A timeout is reported as
+`SortableUniqueIdWaitTimeoutException` before query serialization or execution, with the target, selected timeout,
+monotonic elapsed time, and best-effort last observed projection position. A diagnostic head read may be unavailable;
+that does not mask the timeout. Probe failures and `OperationCanceledException` pass through unchanged.
+
+Adaptive timing preserves the legacy boundaries: a target more than five seconds old uses a five-second timeout; a target
+exactly five seconds old, in the future, or not parseable uses thirty seconds. Probes are separated by a maximum 200 ms
+interval. The strict marker has no members, so it adds no JSON/Orleans wire property (G17 negative wire shape).
+
+Wait metrics use bounded `surface`, `mode`, and `outcome` labels only; target IDs are never metric dimensions. The
+acceptance tests inject a `TimeProvider` and delay seam, so 5-second, 30-second, and 200-ms behavior is deterministic
+and uses no real sleeps. Existing consumers compiled against the published 10.14.0 packages are also executed against
+the current binaries without recompilation to guard the public constructor and wire compatibility boundary.

--- a/docs/dcb_llm_ja/13_common_issues.md
+++ b/docs/dcb_llm_ja/13_common_issues.md
@@ -483,3 +483,30 @@ standalone instance の強制能力として `ApplicationIntent=ReadOnly` は使
 scalar query port も gate します。projector への raw connection / transaction 公開を止めますが、`Legacy` は互換既定値のままです。
 policy の未登録・throw・invalid・deny は typed safe reason 付きで fail-closed し、cancellation は cancellation のままです。hosted worker
 は verification を retry し、schema ensure へ fallback しません。
+
+## strict な SortableUniqueId 待機 — dcb-v10.15.0 (SEK-G33)
+
+`IWaitForSortableUniqueId` は従来どおり fail-open の契約です。Orleans の WithResult / WithoutResult の single-query と
+list-query は adaptive policy で待機し、timeout 後も query を実行します。InMemory は従来の no-wait 挙動を維持します。
+cancellation は timeout や query result に変換されません。
+
+fail-closed の freshness が必要な query は、memberless marker を実装します。
+
+```csharp
+public sealed record FreshStudentQuery(string? WaitForSortableUniqueId, string StudentId)
+    : IStrictWaitForSortableUniqueId;
+```
+
+strict wait は Orleans の4経路と strict な InMemory query で同じ policy を使います。timeout は query の serialization / execution
+より前に `SortableUniqueIdWaitTimeoutException` として返り、target、選択された timeout、monotonic elapsed time、best-effort の
+projection 最終位置を含みます。diagnostic の head 読み取りが利用できなくても timeout は隠されません。probe の failure と
+`OperationCanceledException` はそのまま伝播します。
+
+adaptive timing の境界は従来仕様を維持します。target が5秒より古ければ timeout は5秒、ちょうど5秒、未来、または parse 不能なら
+30秒です。probe 間隔は最大200msです。strict marker は member を持たないため、JSON / Orleans wire に新しい property を追加しません
+（G17 negative wire shape）。
+
+wait metric の label は bounded な `surface`、`mode`、`outcome` だけで、target ID は dimension に出しません。受入テストは
+`TimeProvider` と delay seam を注入するため、5秒・30秒・200ms の timing を real sleep なしで決定的に検証できます。さらに、公開された
+10.14.0 package に対してコンパイル済みの2つの consumer を current binary に差し替えて再コンパイルなしで実行し、公開 constructor と
+wire compatibility の境界を確認します。


### PR DESCRIPTION
## Summary

Closes #1091.

- Adds the opt-in `IStrictWaitForSortableUniqueId` marker and typed `SortableUniqueIdWaitTimeoutException`.
- Centralizes adaptive waiting, monotonic timeout accounting, polling, diagnostics, and cancellation behavior in one Core policy shared by all four Orleans executor surfaces and strict InMemory execution.
- Preserves legacy fail-open behavior, including legacy InMemory's intentional no-wait behavior.
- Adds bounded Core-owned timeout metrics, deterministic fake-clock acceptance coverage, G17 wire-shape coverage, and English/Japanese documentation.

## Contract and acceptance evidence

- Strict timeouts happen before serialization/query execution; `WithResult` returns the typed failure in `ResultBox`, while `WithoutResult` throws directly.
- `OperationCanceledException` and non-cancellation probe/fault failures are preserved; diagnostic head lookup is best-effort only for strict timeout enrichment.
- Adaptive timeout boundaries cover old target (`5s`), exact `5s`, future, unparsable, and immediate-arrival cases; polling is capped at `200ms`.
- Acceptance tests enter through production `GeneralSekibanExecutor`/`OrleansDcbExecutor` facades and DI wiring. They assert real grain/query execution counts, serialization/converter observations, publisher-fold-failure behavior, typed timeout/success results, and timeout/arrival metrics.
- Reflection/architecture coverage proves all four Orleans surfaces and strict InMemory use the shared policy. Tests cover wrong global fail-closed behavior, strict silent continuation/throw-after-query, and bypassed surface implementations.
- Every timing test uses `FakeTimeProvider` plus a delay/probe seam; no real sleeps are used.
- G17 JSON wire shape remains unchanged: strictness is marker-only and no strict/fail-open field is serialized.

## Verification

- `Sekiban.Dcb.SortableUniqueIdWait.Tests`: 19 passed.
- `Sekiban.Dcb.SortableUniqueIdWait.WithoutResult.Tests`: 6 passed.
- Existing WithResult, WithoutResult, and Orleans test projects build for `net10.0`; changed Core/WithResult/WithoutResult and both Orleans packages build for Release `net9.0`.
- Two genuine unmodified package consumers compile against published `10.14.0` packages and execute their existing DLLs without recompilation against the current assemblies:
  - `Sekiban.Dcb.MaterializedView.BinaryConsumer`: `binary-consumer-ok:binary-consumer:Sekiban.Dcb.MaterializedView.IMvExecutor`
  - `Sekiban.Dcb.WithResult.BinaryConsumer`: `with-result-binary-consumer-ok:Sekiban.Dcb.ISekibanExecutor:Sekiban.Dcb.Queries.IWaitForSortableUniqueId`

