### PR TITLE
SEK-G34: fail-closed MV transitions and verified execution

### DIFF
--- a/.github/workflows/run_test_dcb.yml
+++ b/.github/workflows/run_test_dcb.yml
@@ -25,6 +25,10 @@ on:
       - 'dcb/src/Sekiban.Dcb.Postgres.MigrationHost/**'
       - 'dcb/tests/Sekiban.Dcb.Orleans.Tests/**'
       - 'dcb/tests/Sekiban.Dcb.Postgres.Tests/**'
+      - 'dcb/tests/Sekiban.Dcb.MaterializedView.BinaryConsumer/**'
+      - 'dcb/tests/Sekiban.Dcb.MaterializedView.ApiSurfaceVerifier/**'
+      - 'dcb/tests/Sekiban.Dcb.MaterializedView.NewVersionConsumer/**'
+      - 'dcb/tests/Sekiban.Dcb.MaterializedView.Tests/**'
       - 'dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/**'
       - 'dcb/tests/Sekiban.Dcb.WithResult.Tests/**'
       - 'dcb/tests/Sekiban.Dcb.WithoutResult.Tests/**'
@@ -69,8 +73,20 @@ jobs:
           dotnet test dcb/tests/Sekiban.Dcb.WithResult.Tests/Sekiban.Dcb.WithResult.Tests.csproj -c Release --no-build -f net9.0 --verbosity normal --collect:"XPlat Code Coverage" -- RunConfiguration.MaxCpuCount=1
           dotnet test dcb/tests/Sekiban.Dcb.WithoutResult.Tests/Sekiban.Dcb.WithoutResult.Tests.csproj -c Release --no-build -f net9.0 --verbosity normal --collect:"XPlat Code Coverage" -- RunConfiguration.MaxCpuCount=1
           dotnet test dcb/tests/Sekiban.Dcb.Postgres.Tests/Sekiban.Dcb.Postgres.Tests.csproj -c Release --no-build -f net9.0 --verbosity normal --collect:"XPlat Code Coverage" -- RunConfiguration.MaxCpuCount=1
+          dotnet test dcb/tests/Sekiban.Dcb.MaterializedView.Tests/Sekiban.Dcb.MaterializedView.Tests.csproj -c Release --no-build -f net9.0 --verbosity normal --collect:"XPlat Code Coverage" -- RunConfiguration.MaxCpuCount=1
           dotnet test dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests.csproj -c Release --no-build -f net9.0 --verbosity normal --collect:"XPlat Code Coverage" -- RunConfiguration.MaxCpuCount=1
           dotnet test dcb/tests/Sekiban.Dcb.BlobStorage.AzureStorage.Unit/Sekiban.Dcb.BlobStorage.AzureStorage.Unit.csproj -c Release --no-build -f net9.0 --verbosity normal --collect:"XPlat Code Coverage" -- RunConfiguration.MaxCpuCount=1
+
+      - name: Verify 10.14.1 materialized-view binary consumer without rebuild
+        run: |
+          dotnet build dcb/tests/Sekiban.Dcb.MaterializedView.BinaryConsumer/Sekiban.Dcb.MaterializedView.BinaryConsumer.csproj -c Release --no-restore -f net9.0
+          dotnet dcb/tests/Sekiban.Dcb.MaterializedView.ApiSurfaceVerifier/bin/Release/net9.0/Sekiban.Dcb.MaterializedView.ApiSurfaceVerifier.dll dcb/tests/Sekiban.Dcb.MaterializedView.BinaryConsumer/bin/Release/net9.0/Sekiban.Dcb.MaterializedView.dll dcb/src/Sekiban.Dcb.MaterializedView/bin/Release/net9.0/Sekiban.Dcb.MaterializedView.dll
+          cp dcb/src/Sekiban.Dcb.MaterializedView/bin/Release/net9.0/Sekiban.Dcb.MaterializedView.dll dcb/tests/Sekiban.Dcb.MaterializedView.BinaryConsumer/bin/Release/net9.0/
+          dotnet dcb/tests/Sekiban.Dcb.MaterializedView.BinaryConsumer/bin/Release/net9.0/Sekiban.Dcb.MaterializedView.BinaryConsumer.dll
+
+      - name: Verify current materialized-view consumer
+        run: |
+          dotnet dcb/tests/Sekiban.Dcb.MaterializedView.NewVersionConsumer/bin/Release/net9.0/Sekiban.Dcb.MaterializedView.NewVersionConsumer.dll
 
   dcbTestsNet10:
     runs-on: ubuntu-latest
@@ -106,5 +122,6 @@ jobs:
           dotnet test dcb/tests/Sekiban.Dcb.WithResult.Tests/Sekiban.Dcb.WithResult.Tests.csproj -c Release --no-build -f net10.0 --verbosity normal --collect:"XPlat Code Coverage" -- RunConfiguration.MaxCpuCount=1
           dotnet test dcb/tests/Sekiban.Dcb.WithoutResult.Tests/Sekiban.Dcb.WithoutResult.Tests.csproj -c Release --no-build -f net10.0 --verbosity normal --collect:"XPlat Code Coverage" -- RunConfiguration.MaxCpuCount=1
           dotnet test dcb/tests/Sekiban.Dcb.Postgres.Tests/Sekiban.Dcb.Postgres.Tests.csproj -c Release --no-build -f net10.0 --verbosity normal --collect:"XPlat Code Coverage" -- RunConfiguration.MaxCpuCount=1
+          dotnet test dcb/tests/Sekiban.Dcb.MaterializedView.Tests/Sekiban.Dcb.MaterializedView.Tests.csproj -c Release --no-build -f net10.0 --verbosity normal --collect:"XPlat Code Coverage" -- RunConfiguration.MaxCpuCount=1
           dotnet test dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests.csproj -c Release --no-build -f net10.0 --verbosity normal --collect:"XPlat Code Coverage" -- RunConfiguration.MaxCpuCount=1
           dotnet test dcb/tests/Sekiban.Dcb.BlobStorage.AzureStorage.Unit/Sekiban.Dcb.BlobStorage.AzureStorage.Unit.csproj -c Release --no-build -f net10.0 --verbosity normal --collect:"XPlat Code Coverage" -- RunConfiguration.MaxCpuCount=1

--- a/Sekiban.slnx
+++ b/Sekiban.slnx
@@ -92,6 +92,9 @@
   </Folder>
   <Folder Name="/dcb/tests/">
     <Project Path="dcb/tests/Sekiban.Dcb.BlobStorage.AzureStorage.Unit/Sekiban.Dcb.BlobStorage.AzureStorage.Unit.csproj" />
+    <Project Path="dcb/tests/Sekiban.Dcb.MaterializedView.ApiSurfaceVerifier/Sekiban.Dcb.MaterializedView.ApiSurfaceVerifier.csproj" />
+    <Project Path="dcb/tests/Sekiban.Dcb.MaterializedView.BinaryConsumer/Sekiban.Dcb.MaterializedView.BinaryConsumer.csproj" />
+    <Project Path="dcb/tests/Sekiban.Dcb.MaterializedView.NewVersionConsumer/Sekiban.Dcb.MaterializedView.NewVersionConsumer.csproj" />
     <Project Path="dcb/tests/Sekiban.Dcb.MaterializedView.Tests/Sekiban.Dcb.MaterializedView.Tests.csproj" />
     <Project Path="dcb/tests/Sekiban.Dcb.MaterializedView.Postgres.Tests/Sekiban.Dcb.MaterializedView.Postgres.Tests.csproj" />
     <Project Path="dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests.csproj" />

--- a/dcb/src/Sekiban.Dcb.MaterializedView.MySql/MySqlMvExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.MySql/MySqlMvExecutor.cs
@@ -52,6 +52,7 @@ public sealed class MySqlMvExecutor : MvExecutorBase<MySqlConnection>, IMvExecut
         CancellationToken cancellationToken = default)
     {
         var exactServiceId = ValidateServiceIdAtBoundary(serviceId);
+        EnsureCatchUpIsAllowedAtBoundary(host, exactServiceId);
         return await CatchUpFromStoreAsync(
                 host,
                 exactServiceId,

--- a/dcb/src/Sekiban.Dcb.MaterializedView.Orleans/MaterializedViewGrain.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.Orleans/MaterializedViewGrain.cs
@@ -28,8 +28,6 @@ public sealed class MaterializedViewGrain : Grain, IMaterializedViewGrain
     private readonly IMvRegistryStore _registryStore;
     private readonly IEventSubscriptionResolver _subscriptionResolver;
 
-    private bool IsVerifyOnly => _options.InitializationMode == MvInitializationMode.VerifyOnly;
-
     private readonly List<SerializableEvent> _pendingStreamEvents = [];
     private IAsyncStream<SerializableEvent>? _stream;
     private StreamSubscriptionHandle<SerializableEvent>? _streamHandle;
@@ -58,6 +56,15 @@ public sealed class MaterializedViewGrain : Grain, IMaterializedViewGrain
     private string? _lastProgressSortableUniqueId;
     private long _catchUpBatchSkipCount;
     private bool _statusMarkedCatchingUp;
+
+    private MvModeCapabilities ResolveCapabilities(MvTransition transition)
+    {
+        ResolveIdentity();
+        return MvModeCapabilities.ResolveAndValidate(
+            _options,
+            transition,
+            new MvTransitionIdentity(_serviceId!, _viewName!, _viewVersion));
+    }
 
     public MaterializedViewGrain(
         IMvApplyHostFactory hostFactory,
@@ -93,6 +100,7 @@ public sealed class MaterializedViewGrain : Grain, IMaterializedViewGrain
     public override async Task OnActivateAsync(CancellationToken cancellationToken)
     {
         ResolveIdentity();
+        _ = ResolveCapabilities(MvTransition.Initialize);
         await PrepareStreamAsync();
         await base.OnActivateAsync(cancellationToken);
     }
@@ -119,12 +127,13 @@ public sealed class MaterializedViewGrain : Grain, IMaterializedViewGrain
             return;
         }
 
+        var capabilities = ResolveCapabilities(MvTransition.Initialize);
         ResolveHost();
         await _executor.InitializeAsync(_host!, _serviceId, CancellationToken.None);
-        if (IsVerifyOnly)
+        if (!capabilities.AllowsLifecycleDml)
         {
-            // Verify-only is an inspection lifecycle, not a catch-up lifecycle. Do not subscribe, capture a target,
-            // mark status, apply events, or let a timer reach registry mutations after the schema gate succeeds.
+            // A verification-only lifecycle does not subscribe, capture a target, mark status, apply events, or let
+            // a timer reach registry mutations after the schema gate succeeds.
             _started = true;
             return;
         }
@@ -152,12 +161,15 @@ public sealed class MaterializedViewGrain : Grain, IMaterializedViewGrain
 
     public async Task RefreshAsync()
     {
-        await EnsureStartedAsync();
-
-        if (IsVerifyOnly)
+        var capabilities = ResolveCapabilities(MvTransition.Refresh);
+        if (!capabilities.AllowsLifecycleDml)
         {
-            return;
+            throw MvModeCapabilities.CreateRefusal(
+                _options.InitializationMode,
+                MvTransition.Refresh,
+                new MvTransitionIdentity(_serviceId!, _viewName!, _viewVersion));
         }
+        await EnsureStartedAsync();
 
         // Activate catch-up for any callers that explicitly request a refresh.
         if (!_isCatchUpActive)
@@ -404,7 +416,8 @@ public sealed class MaterializedViewGrain : Grain, IMaterializedViewGrain
     /// </summary>
     private async Task<bool> RunCatchUpTickAsync(bool ignoreImmediateFlag, CancellationToken cancellationToken)
     {
-        if (IsVerifyOnly)
+        var capabilities = ResolveCapabilities(MvTransition.CatchUp);
+        if (!capabilities.AllowsProjectorApply || !capabilities.AllowsLifecycleDml)
         {
             return false;
         }
@@ -520,7 +533,8 @@ public sealed class MaterializedViewGrain : Grain, IMaterializedViewGrain
 
     private async Task CompleteCatchUpAsync(CancellationToken cancellationToken)
     {
-        if (IsVerifyOnly)
+        var capabilities = ResolveCapabilities(MvTransition.CatchUp);
+        if (!capabilities.AllowsLifecycleDml)
         {
             return;
         }
@@ -728,7 +742,8 @@ public sealed class MaterializedViewGrain : Grain, IMaterializedViewGrain
 
     internal async Task OnStreamBatchAsync(IEnumerable<SerializableEvent> events)
     {
-        if (IsVerifyOnly)
+        var capabilities = ResolveCapabilities(MvTransition.Apply);
+        if (!capabilities.AllowsProjectorApply)
         {
             return;
         }
@@ -792,7 +807,8 @@ public sealed class MaterializedViewGrain : Grain, IMaterializedViewGrain
     private async Task RefreshPositionFromRegistryAsync(CancellationToken cancellationToken)
     {
         ResolveHost();
-        var entries = IsVerifyOnly && _registryStore is IMvReadOnlyMvInspector inspector
+        var capabilities = ResolveCapabilities(MvTransition.VerifyInitialization);
+        var entries = capabilities.UsesReadOnlyInspection && _registryStore is IMvReadOnlyMvInspector inspector
             ? await inspector.ReadRegistryEntriesAsync(_serviceId!, _host!.ViewName, _host.ViewVersion, cancellationToken)
             : await _registryStore.GetEntriesAsync(_serviceId!, _host!.ViewName, _host.ViewVersion, cancellationToken);
         _publicationSnapshot = MvProjectionStatusSnapshot.FromEntries(entries);

--- a/dcb/src/Sekiban.Dcb.MaterializedView.Postgres/PostgresMvExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.Postgres/PostgresMvExecutor.cs
@@ -52,6 +52,7 @@ public sealed class PostgresMvExecutor : MvExecutorBase<NpgsqlConnection>, IMvEx
         CancellationToken cancellationToken = default)
     {
         var exactServiceId = ValidateServiceIdAtBoundary(serviceId);
+        EnsureCatchUpIsAllowedAtBoundary(host, exactServiceId);
         return await CatchUpFromStoreAsync(
                 host,
                 exactServiceId,

--- a/dcb/src/Sekiban.Dcb.MaterializedView.SqlServer/SqlServerMvExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.SqlServer/SqlServerMvExecutor.cs
@@ -52,6 +52,7 @@ public sealed class SqlServerMvExecutor : MvExecutorBase<SqlConnection>, IMvExec
         CancellationToken cancellationToken = default)
     {
         var exactServiceId = ValidateServiceIdAtBoundary(serviceId);
+        EnsureCatchUpIsAllowedAtBoundary(host, exactServiceId);
         return await CatchUpFromStoreAsync(
                 host,
                 exactServiceId,

--- a/dcb/src/Sekiban.Dcb.MaterializedView.Sqlite/SqliteMvExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView.Sqlite/SqliteMvExecutor.cs
@@ -52,6 +52,7 @@ public sealed class SqliteMvExecutor : MvExecutorBase<SqliteConnection>, IMvExec
         CancellationToken cancellationToken = default)
     {
         var exactServiceId = ValidateServiceIdAtBoundary(serviceId);
+        EnsureCatchUpIsAllowedAtBoundary(host, exactServiceId);
         return await CatchUpFromStoreAsync(
                 host,
                 exactServiceId,

--- a/dcb/src/Sekiban.Dcb.MaterializedView/AssemblyInfo.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Sekiban.Dcb.MaterializedView.Orleans")]

--- a/dcb/src/Sekiban.Dcb.MaterializedView/AssemblyInfo.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView/AssemblyInfo.cs
@@ -1,3 +1,4 @@
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Sekiban.Dcb.MaterializedView.Orleans")]
+[assembly: InternalsVisibleTo("Sekiban.Dcb.MaterializedView.MultiProvider.Tests")]

--- a/dcb/src/Sekiban.Dcb.MaterializedView/MvActivation.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView/MvActivation.cs
@@ -17,7 +17,8 @@ public enum MvActivationFailureReason
     ExpectedActiveConflict = 11,
     ExpectedGenerationConflict = 12,
     ConcurrentSuperseded = 13,
-    ProviderFailure = 14
+    ProviderFailure = 14,
+    TransitionNotAllowed = 15
 }
 
 /// <summary>Provider-neutral result of evaluating a candidate before any active-pointer mutation.</summary>

--- a/dcb/src/Sekiban.Dcb.MaterializedView/MvCatchUpWorker.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView/MvCatchUpWorker.cs
@@ -71,6 +71,16 @@ public sealed class MvCatchUpWorker : BackgroundService
     {
         await InitializeProjectorsAsync(stoppingToken).ConfigureAwait(false);
 
+        var capabilities = MvModeCapabilities.ResolveAndValidate(
+            _options,
+            MvTransition.CatchUp,
+            MvTransitionIdentity.Unknown);
+        if (!capabilities.AllowsProjectorApply || !capabilities.AllowsLifecycleDml)
+        {
+            _logger.LogInformation("Materialized-view worker verified the pre-provisioned contract and will not run a mutating catch-up lifecycle.");
+            return;
+        }
+
         while (!stoppingToken.IsCancellationRequested)
         {
             var cycle = await RunCatchUpCycleAsync(stoppingToken).ConfigureAwait(false);
@@ -103,13 +113,17 @@ public sealed class MvCatchUpWorker : BackgroundService
                 return;
             }
             catch (MvInitializationException ex) when (
-                _options.InitializationMode == MvInitializationMode.VerifyOnly &&
+                MvModeCapabilities.ResolveAndValidate(
+                        _options,
+                        MvTransition.Initialize,
+                        MvTransitionIdentity.Unknown)
+                    .RequiresVerification &&
                 !stoppingToken.IsCancellationRequested)
             {
                 _logger.LogWarning(
                     ex,
-                    "Verify-only materialized-view startup is gated until the pre-provisioned schema is compatible; retrying after {RetryDelay}.",
-                    GetVerifyOnlyRetryDelay());
+                    "Verification-mode materialized-view startup is gated until the pre-provisioned schema is compatible; retrying after {RetryDelay}.",
+                    GetVerificationRetryDelay());
                 foreach (var registration in _registrations)
                 {
                     var snapshot = MvProjectionStatusSnapshot.Unknown(MvStatus.Faulted);
@@ -138,12 +152,12 @@ public sealed class MvCatchUpWorker : BackgroundService
                     }
                 }
 
-                await Task.Delay(GetVerifyOnlyRetryDelay(), stoppingToken).ConfigureAwait(false);
+                await Task.Delay(GetVerificationRetryDelay(), stoppingToken).ConfigureAwait(false);
             }
         }
     }
 
-    private TimeSpan GetVerifyOnlyRetryDelay() =>
+    private TimeSpan GetVerificationRetryDelay() =>
         _options.VerifyOnlyRetryDelay > TimeSpan.Zero
             ? _options.VerifyOnlyRetryDelay
             : _options.PollInterval > TimeSpan.Zero

--- a/dcb/src/Sekiban.Dcb.MaterializedView/MvExecutionObserver.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView/MvExecutionObserver.cs
@@ -1,0 +1,12 @@
+namespace Sekiban.Dcb.MaterializedView;
+
+/// <summary>
+///     Internal diagnostic seam for execution-path proofs. Notifications happen at the provider-command and successful
+///     commit boundaries and never participate in authorization or execution decisions.
+/// </summary>
+internal interface IMvExecutionObserver
+{
+    void OnProjectorCommandExecutionAttempt(string sql);
+
+    void OnTransactionCommitted();
+}

--- a/dcb/src/Sekiban.Dcb.MaterializedView/MvExecutorBase.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView/MvExecutorBase.cs
@@ -23,6 +23,7 @@ public abstract class MvExecutorBase<TConnection> : IMvExecutor, IMvActivationEx
     private readonly MvOptions _options;
     private readonly string _connectionString;
     private readonly IServiceIdProvider? _legacyServiceIdProvider;
+    private readonly IMvExecutionObserver? _executionObserver;
 
     protected MvExecutorBase(
         IMvRegistryStore registryStore,
@@ -36,6 +37,7 @@ public abstract class MvExecutorBase<TConnection> : IMvExecutor, IMvActivationEx
         _options = options.Value;
         _connectionString = connectionString;
         _legacyServiceIdProvider = legacyServiceIdProvider;
+        _executionObserver = _options.ExecutionObserver;
     }
 
     protected IMvRegistryStore RegistryStore => _registryStore;
@@ -46,6 +48,11 @@ public abstract class MvExecutorBase<TConnection> : IMvExecutor, IMvActivationEx
 
     /// <summary>Provider executors override this so policy decisions carry the concrete database type.</summary>
     protected virtual MvDbType DatabaseType => MvDbType.Postgres;
+
+    private void RecordProjectorCommandExecutionAttempt(string sql) =>
+        _executionObserver?.OnProjectorCommandExecutionAttempt(sql);
+
+    private void RecordTransactionCommitted() => _executionObserver?.OnTransactionCommitted();
 
     private MvModeCapabilities ResolveCapabilities(
         IMvApplyHost host,
@@ -326,6 +333,7 @@ public abstract class MvExecutorBase<TConnection> : IMvExecutor, IMvActivationEx
         await using var transaction = await connection.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
         foreach (var statement in statements)
         {
+            RecordProjectorCommandExecutionAttempt(statement.Sql);
             await ExecuteSqlAsync(
                     connection,
                     statement.Sql,
@@ -357,6 +365,7 @@ public abstract class MvExecutorBase<TConnection> : IMvExecutor, IMvActivationEx
         }
 
         await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+        RecordTransactionCommitted();
     }
 
     private async Task<MvSchemaVerificationResult> VerifyOnlyCoreAsync(
@@ -1040,6 +1049,7 @@ public abstract class MvExecutorBase<TConnection> : IMvExecutor, IMvActivationEx
             var affectedRows = 0;
             foreach (var statement in item.Statements)
             {
+                RecordProjectorCommandExecutionAttempt(statement.Sql);
                 affectedRows += await ExecuteSqlAsync(
                         connection,
                         statement.Sql,
@@ -1074,6 +1084,7 @@ public abstract class MvExecutorBase<TConnection> : IMvExecutor, IMvActivationEx
         }
 
         await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+        RecordTransactionCommitted();
         return appliedEvents;
     }
 
@@ -1130,6 +1141,7 @@ public abstract class MvExecutorBase<TConnection> : IMvExecutor, IMvActivationEx
         var affectedRows = 0;
         foreach (var statement in statements)
         {
+            RecordProjectorCommandExecutionAttempt(statement.Sql);
             affectedRows += await ExecuteSqlAsync(
                     connection,
                     statement.Sql,
@@ -1168,6 +1180,7 @@ public abstract class MvExecutorBase<TConnection> : IMvExecutor, IMvActivationEx
                 cancellationToken)
             .ConfigureAwait(false);
         await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+        RecordTransactionCommitted();
         return true;
     }
 

--- a/dcb/src/Sekiban.Dcb.MaterializedView/MvExecutorBase.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView/MvExecutorBase.cs
@@ -47,7 +47,38 @@ public abstract class MvExecutorBase<TConnection> : IMvExecutor, IMvActivationEx
     /// <summary>Provider executors override this so policy decisions carry the concrete database type.</summary>
     protected virtual MvDbType DatabaseType => MvDbType.Postgres;
 
-    private bool IsVerifyOnly => _options.InitializationMode == MvInitializationMode.VerifyOnly;
+    private MvModeCapabilities ResolveCapabilities(
+        IMvApplyHost host,
+        string serviceId,
+        MvTransition transition) =>
+        MvModeCapabilities.ResolveAndValidate(
+            _options,
+            transition,
+            new MvTransitionIdentity(serviceId, host.ViewName, host.ViewVersion));
+
+    private static void ThrowIfProjectorApplyIsNotAllowed(
+        MvModeCapabilities capabilities,
+        MvInitializationMode mode,
+        MvTransition transition,
+        MvTransitionIdentity identity)
+    {
+        if (!capabilities.AllowsProjectorApply)
+        {
+            throw MvModeCapabilities.CreateRefusal(mode, transition, identity);
+        }
+    }
+
+    private static void ThrowIfLifecycleDmlIsNotAllowed(
+        MvModeCapabilities capabilities,
+        MvInitializationMode mode,
+        MvTransition transition,
+        MvTransitionIdentity identity)
+    {
+        if (!capabilities.AllowsLifecycleDml)
+        {
+            throw MvModeCapabilities.CreateRefusal(mode, transition, identity);
+        }
+    }
 
     // These helpers validate dependencies and move database-neutral workflow only. They never resolve or cache an
     // event store; each provider executor keeps its own factory field and selects its service-scoped source.
@@ -87,25 +118,37 @@ public abstract class MvExecutorBase<TConnection> : IMvExecutor, IMvActivationEx
     protected Task InitializeAtBoundaryAsync(
         IMvApplyHost host,
         string? requestedServiceId,
-        CancellationToken cancellationToken) =>
-        InitializeCoreAsync(
-            host,
-            ValidateServiceId(requestedServiceId, _legacyServiceIdProvider, GetType().Name),
-            cancellationToken);
+        CancellationToken cancellationToken)
+    {
+        var serviceId = ValidateServiceId(requestedServiceId, _legacyServiceIdProvider, GetType().Name);
+        _ = ResolveCapabilities(host, serviceId, MvTransition.Initialize);
+        return InitializeCoreAsync(host, serviceId, cancellationToken);
+    }
 
     protected Task<int> ApplySerializableEventsAtBoundaryAsync(
         IMvApplyHost host,
         IReadOnlyList<SerializableEvent> events,
         string? requestedServiceId,
-        CancellationToken cancellationToken) =>
-        ApplyStreamEventsAtBoundaryAsync(
-            host,
-            events,
-            ValidateServiceId(requestedServiceId, _legacyServiceIdProvider, GetType().Name),
-            cancellationToken);
+        CancellationToken cancellationToken)
+    {
+        var serviceId = ValidateServiceId(requestedServiceId, _legacyServiceIdProvider, GetType().Name);
+        var identity = new MvTransitionIdentity(serviceId, host.ViewName, host.ViewVersion);
+        var capabilities = ResolveCapabilities(host, serviceId, MvTransition.Apply);
+        ThrowIfProjectorApplyIsNotAllowed(capabilities, _options.InitializationMode, MvTransition.Apply, identity);
+        return ApplyStreamEventsAtBoundaryAsync(host, events, serviceId, cancellationToken);
+    }
 
     protected string ValidateServiceIdAtBoundary(string? requestedServiceId) =>
         ValidateServiceId(requestedServiceId, _legacyServiceIdProvider, GetType().Name);
+
+    /// <summary>Provider executors call this before selecting an event store for a catch-up command.</summary>
+    protected void EnsureCatchUpIsAllowedAtBoundary(IMvApplyHost host, string serviceId)
+    {
+        var identity = new MvTransitionIdentity(serviceId, host.ViewName, host.ViewVersion);
+        var capabilities = ResolveCapabilities(host, serviceId, MvTransition.CatchUp);
+        ThrowIfProjectorApplyIsNotAllowed(capabilities, _options.InitializationMode, MvTransition.CatchUp, identity);
+        ThrowIfLifecycleDmlIsNotAllowed(capabilities, _options.InitializationMode, MvTransition.CatchUp, identity);
+    }
 
     public Task InitializeAsync(
         IMvApplyHost host,
@@ -119,6 +162,7 @@ public abstract class MvExecutorBase<TConnection> : IMvExecutor, IMvActivationEx
         CancellationToken cancellationToken = default)
     {
         var exactServiceId = ValidateServiceIdAtBoundary(serviceId);
+        _ = ResolveCapabilities(host, exactServiceId, MvTransition.VerifyInitialization);
         var bindings = new MvTableBindings(host.ViewName, host.ViewVersion, _options);
         return await VerifyOnlyCoreAsync(host, exactServiceId, bindings, cancellationToken).ConfigureAwait(false);
     }
@@ -160,6 +204,13 @@ public abstract class MvExecutorBase<TConnection> : IMvExecutor, IMvActivationEx
         CancellationToken cancellationToken = default)
     {
         var exactServiceId = ValidateServiceIdAtBoundary(serviceId);
+        var identity = new MvTransitionIdentity(exactServiceId, host.ViewName, host.ViewVersion);
+        var capabilities = ResolveCapabilities(host, exactServiceId, MvTransition.CaptureTargetCheckpoint);
+        ThrowIfLifecycleDmlIsNotAllowed(
+            capabilities,
+            _options.InitializationMode,
+            MvTransition.CaptureTargetCheckpoint,
+            identity);
         await ReadRegistryEntriesAtOperationBoundaryAsync(
                 host,
                 exactServiceId,
@@ -168,16 +219,13 @@ public abstract class MvExecutorBase<TConnection> : IMvExecutor, IMvActivationEx
 
         var target = await CaptureTargetCheckpointFromStoreAsync(SelectEventStoreForService(exactServiceId))
             .ConfigureAwait(false);
-        if (!IsVerifyOnly)
-        {
-            await _registryStore.SetTargetCheckpointAsync(
-                    exactServiceId,
-                    host.ViewName,
-                    host.ViewVersion,
-                    target,
-                    cancellationToken: cancellationToken)
-                .ConfigureAwait(false);
-        }
+        await _registryStore.SetTargetCheckpointAsync(
+                exactServiceId,
+                host.ViewName,
+                host.ViewVersion,
+                target,
+                cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
         return target;
     }
 
@@ -187,6 +235,13 @@ public abstract class MvExecutorBase<TConnection> : IMvExecutor, IMvActivationEx
         CancellationToken cancellationToken = default)
     {
         var exactServiceId = ValidateServiceIdAtBoundary(serviceId);
+        var identity = new MvTransitionIdentity(exactServiceId, host.ViewName, host.ViewVersion);
+        var capabilities = ResolveCapabilities(host, exactServiceId, MvTransition.Activate);
+        if (!capabilities.AllowsLifecycleDml)
+        {
+            var refusal = MvModeCapabilities.CreateRefusal(_options.InitializationMode, MvTransition.Activate, identity);
+            return MvActivationResult.Rejected(MvActivationFailureReason.TransitionNotAllowed, refusal.Message);
+        }
         var entries = await ReadRegistryEntriesAtOperationBoundaryAsync(
                 host,
                 exactServiceId,
@@ -203,13 +258,6 @@ public abstract class MvExecutorBase<TConnection> : IMvExecutor, IMvActivationEx
         if (!eligibility.IsEligible || request is null)
         {
             return MvActivationResult.Rejected(eligibility.FailureReason, eligibility.Message);
-        }
-
-        if (IsVerifyOnly)
-        {
-            return MvActivationResult.Rejected(
-                MvActivationFailureReason.ProviderFailure,
-                "Verify-only infrastructure mode never mutates materialized-view registry state.");
         }
 
         try
@@ -244,12 +292,21 @@ public abstract class MvExecutorBase<TConnection> : IMvExecutor, IMvActivationEx
         string serviceId,
         CancellationToken cancellationToken)
     {
+        var capabilities = ResolveCapabilities(host, serviceId, MvTransition.Initialize);
         var bindings = new MvTableBindings(host.ViewName, host.ViewVersion, _options);
-        if (_options.InitializationMode == MvInitializationMode.VerifyOnly)
+        if (capabilities.RequiresVerification)
         {
             var verification = await VerifyOnlyCoreAsync(host, serviceId, bindings, cancellationToken).ConfigureAwait(false);
             ThrowIfInitializationVerificationFailed(verification);
             return;
+        }
+
+        if (!capabilities.AllowsInfrastructureEnsure)
+        {
+            throw MvModeCapabilities.CreateRefusal(
+                _options.InitializationMode,
+                MvTransition.Initialize,
+                new MvTransitionIdentity(serviceId, host.ViewName, host.ViewVersion));
         }
 
         var statements = await host.InitializeAsync(bindings, cancellationToken).ConfigureAwait(false);
@@ -451,7 +508,11 @@ public abstract class MvExecutorBase<TConnection> : IMvExecutor, IMvActivationEx
         int viewVersion,
         CancellationToken cancellationToken)
     {
-        if (_options.InitializationMode == MvInitializationMode.VerifyOnly)
+        var capabilities = MvModeCapabilities.ResolveAndValidate(
+            _options,
+            MvTransition.VerifyInitialization,
+            new MvTransitionIdentity(serviceId, viewName, viewVersion));
+        if (capabilities.UsesReadOnlyInspection)
         {
             if (_registryStore is not IMvReadOnlyMvInspector inspector)
             {
@@ -472,7 +533,11 @@ public abstract class MvExecutorBase<TConnection> : IMvExecutor, IMvActivationEx
         string viewName,
         CancellationToken cancellationToken)
     {
-        if (IsVerifyOnly)
+        var capabilities = MvModeCapabilities.ResolveAndValidate(
+            _options,
+            MvTransition.VerifyInitialization,
+            new MvTransitionIdentity(serviceId, viewName, -1));
+        if (capabilities.UsesReadOnlyInspection)
         {
             if (_registryStore is not IMvReadOnlyMvInspector inspector)
             {
@@ -499,7 +564,8 @@ public abstract class MvExecutorBase<TConnection> : IMvExecutor, IMvActivationEx
         CancellationToken cancellationToken,
         bool initializeWhenEmpty = true)
     {
-        if (_options.InitializationMode == MvInitializationMode.VerifyOnly)
+        var capabilities = ResolveCapabilities(host, serviceId, MvTransition.Initialize);
+        if (capabilities.RequiresVerification)
         {
             await InitializeCoreAsync(host, serviceId, cancellationToken).ConfigureAwait(false);
         }
@@ -510,7 +576,7 @@ public abstract class MvExecutorBase<TConnection> : IMvExecutor, IMvActivationEx
                 host.ViewVersion,
                 cancellationToken)
             .ConfigureAwait(false);
-        if (entries.Count == 0 && initializeWhenEmpty && _options.InitializationMode != MvInitializationMode.VerifyOnly)
+        if (entries.Count == 0 && initializeWhenEmpty && capabilities.AllowsInfrastructureEnsure)
         {
             await InitializeCoreAsync(host, serviceId, cancellationToken).ConfigureAwait(false);
             entries = await ReadRegistryEntriesAsync(
@@ -601,11 +667,12 @@ public abstract class MvExecutorBase<TConnection> : IMvExecutor, IMvActivationEx
             return;
         }
 
-        // Verify-only may inspect an existing target, but it is never allowed to create or refresh registry truth.
-        if (IsVerifyOnly)
-        {
-            return;
-        }
+        var capabilities = ResolveCapabilities(host, serviceId, MvTransition.CatchUp);
+        ThrowIfLifecycleDmlIsNotAllowed(
+            capabilities,
+            _options.InitializationMode,
+            MvTransition.CatchUp,
+            new MvTransitionIdentity(serviceId, host.ViewName, host.ViewVersion));
 
         var target = await CaptureTargetCheckpointFromStoreAsync(eventStore).ConfigureAwait(false);
         await _registryStore.SetTargetCheckpointAsync(
@@ -627,6 +694,11 @@ public abstract class MvExecutorBase<TConnection> : IMvExecutor, IMvActivationEx
         string serviceId,
         CancellationToken cancellationToken)
     {
+        var capabilities = ResolveCapabilities(host, serviceId, MvTransition.Activate);
+        if (!capabilities.AllowsLifecycleDml)
+        {
+            return MvStatus.CatchingUp;
+        }
         var entries = await ReadRegistryEntriesAsync(
                 serviceId,
                 host.ViewName,
@@ -656,11 +728,6 @@ public abstract class MvExecutorBase<TConnection> : IMvExecutor, IMvActivationEx
             readyEntries,
             active);
         if (!preflight.IsEligible)
-        {
-            return entries[0].Status;
-        }
-
-        if (IsVerifyOnly)
         {
             return entries[0].Status;
         }
@@ -720,6 +787,12 @@ public abstract class MvExecutorBase<TConnection> : IMvExecutor, IMvActivationEx
         MvProjectionStatusSnapshot currentStatus,
         CancellationToken cancellationToken)
     {
+        var capabilities = ResolveCapabilities(host, serviceId, MvTransition.CatchUp);
+        ThrowIfLifecycleDmlIsNotAllowed(
+            capabilities,
+            _options.InitializationMode,
+            MvTransition.CatchUp,
+            new MvTransitionIdentity(serviceId, host.ViewName, host.ViewVersion));
         if (!readResult.IsSuccess)
         {
             var exception = readResult.GetException();
@@ -745,7 +818,14 @@ public abstract class MvExecutorBase<TConnection> : IMvExecutor, IMvActivationEx
 
         if (batch.Count == 0)
         {
-            if (!IsVerifyOnly)
+            var emptyTruth = currentStatus.CurrentCheckpointTruth.IsKnown &&
+                !currentStatus.CurrentCheckpointTruth.IsKnownZero
+                    ? currentStatus.CurrentCheckpointTruth
+                    : MvCheckpointTruth.KnownZero();
+            // An empty read only establishes known-zero when no authoritative current checkpoint exists. Replaying
+            // an already caught-up projection must be a pure observation: writing MinValue here would update the
+            // registry timestamp and can make a valid non-zero checkpoint look like a silent-zero transition.
+            if (!currentStatus.CurrentCheckpointTruth.IsKnown)
             {
                 await _registryStore.UpdatePositionAsync(
                         new MvPositionUpdate(
@@ -756,15 +836,11 @@ public abstract class MvExecutorBase<TConnection> : IMvExecutor, IMvActivationEx
                             MvApplySource.CatchUp,
                             AppliedEventVersionDelta: 0)
                         {
-                            CheckpointTruth = MvCheckpointTruth.KnownZero()
+                            CheckpointTruth = emptyTruth
                         },
                         cancellationToken: cancellationToken)
                     .ConfigureAwait(false);
             }
-            var emptyTruth = currentStatus.CurrentCheckpointTruth.IsKnown &&
-                !currentStatus.CurrentCheckpointTruth.IsKnownZero
-                    ? currentStatus.CurrentCheckpointTruth
-                    : MvCheckpointTruth.KnownZero();
             return new MvCatchUpResult(0, false)
             {
                 ProjectionStatus = currentStatus with
@@ -830,19 +906,19 @@ public abstract class MvExecutorBase<TConnection> : IMvExecutor, IMvActivationEx
         MvApplySource source,
         CancellationToken cancellationToken)
     {
+        var transition = source == MvApplySource.CatchUp ? MvTransition.CatchUp : MvTransition.Apply;
+        var identity = new MvTransitionIdentity(serviceId, host.ViewName, host.ViewVersion);
+        var capabilities = ResolveCapabilities(host, serviceId, transition);
+        ThrowIfProjectorApplyIsNotAllowed(capabilities, _options.InitializationMode, transition, identity);
+        if (source == MvApplySource.CatchUp)
+        {
+            ThrowIfLifecycleDmlIsNotAllowed(capabilities, _options.InitializationMode, transition, identity);
+        }
         var entries = await ReadRegistryEntriesAtOperationBoundaryAsync(
                 host,
                 serviceId,
                 cancellationToken)
             .ConfigureAwait(false);
-
-        // Verify-only is an inspection lifecycle. Once the declarative gate has succeeded, an event-apply call is
-        // deliberately a no-op so it cannot open the normal target connection, create a transaction, execute
-        // projector SQL, or commit a view/registry mutation.
-        if (IsVerifyOnly)
-        {
-            return 0;
-        }
 
         var currentPosition = entries
             .Select(entry => entry.CurrentCheckpointTruth.IsKnown ? entry.CurrentCheckpointTruth.PositionValue : null)
@@ -862,6 +938,19 @@ public abstract class MvExecutorBase<TConnection> : IMvExecutor, IMvActivationEx
             return 0;
         }
 
+        if (capabilities.RequiresWholeBatchPolicyAuthorization)
+        {
+            return await ApplyVerifiedExecutionBatchAsync(
+                    host,
+                    serviceId,
+                    CreateBindings(host, entries),
+                    orderedEvents,
+                    source,
+                    capabilities,
+                    cancellationToken)
+                .ConfigureAwait(false);
+        }
+
         await using var connection = await OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
         var appliedEvents = 0;
         var bindings = CreateBindings(host, entries);
@@ -875,6 +964,7 @@ public abstract class MvExecutorBase<TConnection> : IMvExecutor, IMvActivationEx
                     serializableEvent,
                     currentPosition,
                     source,
+                    capabilities,
                     cancellationToken)
                 .ConfigureAwait(false);
             if (!applied)
@@ -888,6 +978,105 @@ public abstract class MvExecutorBase<TConnection> : IMvExecutor, IMvActivationEx
         return appliedEvents;
     }
 
+    /// <summary>
+    ///     Mode 2 is the execution path for a pre-provisioned database. Every projector statement in the requested
+    ///     event batch is produced and authorized before the first DML or registry update is executed. This makes a
+    ///     later policy denial atomic: no earlier event in the batch can have committed a row or checkpoint.
+    /// </summary>
+    private async Task<int> ApplyVerifiedExecutionBatchAsync(
+        IMvApplyHost host,
+        string serviceId,
+        MvTableBindings bindings,
+        IReadOnlyList<SerializableEvent> events,
+        MvApplySource source,
+        MvModeCapabilities capabilities,
+        CancellationToken cancellationToken)
+    {
+        await using var connection = await OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using var transaction = await connection.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
+        var queryPort = new MvPolicyEnforcingQueryPort(
+            CreateQueryPort(connection, transaction),
+            _options.SqlStatementPolicy,
+            serviceId,
+            host.ViewName,
+            host.ViewVersion,
+            bindings.Tables,
+            DatabaseType);
+        var prepared = new List<(SerializableEvent Event, IReadOnlyList<MvSqlStatementDto> Statements)>();
+
+        try
+        {
+            foreach (var serializableEvent in events)
+            {
+                var statements = await host.ApplyEventAsync(
+                        serializableEvent,
+                        bindings,
+                        queryPort,
+                        serializableEvent.SortableUniqueIdValue,
+                        cancellationToken)
+                    .ConfigureAwait(false);
+                prepared.Add((serializableEvent, statements));
+            }
+
+            await AuthorizeStatementsAsync(
+                    serviceId,
+                    host,
+                    bindings,
+                    prepared.SelectMany(item => item.Statements).ToList(),
+                    MvSqlStatementPhase.Apply,
+                    cancellationToken,
+                    MvSqlStatementOrigin.ProjectorApply)
+                .ConfigureAwait(false);
+        }
+        catch
+        {
+            await RollbackPreservingFailureAsync(transaction).ConfigureAwait(false);
+            throw;
+        }
+
+        var appliedEvents = 0;
+        foreach (var item in prepared)
+        {
+            var affectedRows = 0;
+            foreach (var statement in item.Statements)
+            {
+                affectedRows += await ExecuteSqlAsync(
+                        connection,
+                        statement.Sql,
+                        statement.Parameters,
+                        transaction,
+                        cancellationToken)
+                    .ConfigureAwait(false);
+            }
+
+            if (source == MvApplySource.Stream && item.Statements.Count > 0 && affectedRows == 0)
+            {
+                await transaction.RollbackAsync(cancellationToken).ConfigureAwait(false);
+                return 0;
+            }
+
+            ThrowIfLifecycleDmlIsNotAllowed(
+                capabilities,
+                _options.InitializationMode,
+                source == MvApplySource.CatchUp ? MvTransition.CatchUp : MvTransition.Apply,
+                new MvTransitionIdentity(serviceId, host.ViewName, host.ViewVersion));
+            await _registryStore.UpdatePositionAsync(
+                    new MvPositionUpdate(
+                        serviceId,
+                        host.ViewName,
+                        host.ViewVersion,
+                        item.Event.SortableUniqueIdValue,
+                        source),
+                    transaction,
+                    cancellationToken)
+                .ConfigureAwait(false);
+            appliedEvents++;
+        }
+
+        await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+        return appliedEvents;
+    }
+
     private async Task<bool> ApplySerializableEventAsync(
         TConnection connection,
         IMvApplyHost host,
@@ -896,6 +1085,7 @@ public abstract class MvExecutorBase<TConnection> : IMvExecutor, IMvActivationEx
         SerializableEvent serializableEvent,
         string? currentPosition,
         MvApplySource source,
+        MvModeCapabilities capabilities,
         CancellationToken cancellationToken)
     {
         await using var transaction = await connection.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
@@ -933,14 +1123,7 @@ public abstract class MvExecutorBase<TConnection> : IMvExecutor, IMvActivationEx
         }
         catch
         {
-            try
-            {
-                await transaction.RollbackAsync(CancellationToken.None).ConfigureAwait(false);
-            }
-            catch
-            {
-                // Preserve the policy/fault/cancellation outcome. Disposal below still closes the transaction.
-            }
+            await RollbackPreservingFailureAsync(transaction).ConfigureAwait(false);
             throw;
         }
 
@@ -969,19 +1152,21 @@ public abstract class MvExecutorBase<TConnection> : IMvExecutor, IMvActivationEx
             return false;
         }
 
-        if (!IsVerifyOnly)
-        {
-            await _registryStore.UpdatePositionAsync(
-                    new MvPositionUpdate(
-                        serviceId,
-                        host.ViewName,
-                        host.ViewVersion,
-                        serializableEvent.SortableUniqueIdValue,
-                        source),
-                    transaction,
-                    cancellationToken)
-                .ConfigureAwait(false);
-        }
+        ThrowIfLifecycleDmlIsNotAllowed(
+            capabilities,
+            _options.InitializationMode,
+            source == MvApplySource.CatchUp ? MvTransition.CatchUp : MvTransition.Apply,
+            new MvTransitionIdentity(serviceId, host.ViewName, host.ViewVersion));
+        await _registryStore.UpdatePositionAsync(
+                new MvPositionUpdate(
+                    serviceId,
+                    host.ViewName,
+                    host.ViewVersion,
+                    serializableEvent.SortableUniqueIdValue,
+                    source),
+                transaction,
+                cancellationToken)
+            .ConfigureAwait(false);
         await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
         return true;
     }
@@ -995,6 +1180,18 @@ public abstract class MvExecutorBase<TConnection> : IMvExecutor, IMvActivationEx
         }
 
         return bindings;
+    }
+
+    private static async Task RollbackPreservingFailureAsync(DbTransaction transaction)
+    {
+        try
+        {
+            await transaction.RollbackAsync(CancellationToken.None).ConfigureAwait(false);
+        }
+        catch
+        {
+            // Preserve the policy/fault/cancellation outcome. Disposal still closes the transaction.
+        }
     }
 
     protected static Dictionary<string, object?> ToParameterDictionary(IReadOnlyList<MvParam> parameters)

--- a/dcb/src/Sekiban.Dcb.MaterializedView/MvGenerationCoordinator.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView/MvGenerationCoordinator.cs
@@ -70,6 +70,15 @@ public sealed class MvGenerationCoordinator : IMvGenerationCoordinator
         ArgumentNullException.ThrowIfNull(candidate);
         ValidateCandidate(candidate);
         var exactServiceId = ValidateServiceId(serviceId);
+        var identity = new MvTransitionIdentity(exactServiceId, candidate.ViewName, candidate.ViewVersion);
+        var capabilities = MvModeCapabilities.ResolveAndValidate(_options, MvTransition.CaptureTargetCheckpoint, identity);
+        if (!capabilities.AllowsLifecycleDml)
+        {
+            throw MvModeCapabilities.CreateRefusal(
+                _options.InitializationMode,
+                MvTransition.CaptureTargetCheckpoint,
+                identity);
+        }
         await InLaneAsync(
             exactServiceId,
             candidate.ViewName,
@@ -91,6 +100,13 @@ public sealed class MvGenerationCoordinator : IMvGenerationCoordinator
         ArgumentNullException.ThrowIfNull(candidate);
         ValidateCandidate(candidate);
         var exactServiceId = ValidateServiceId(serviceId);
+        var identity = new MvTransitionIdentity(exactServiceId, candidate.ViewName, candidate.ViewVersion);
+        var capabilities = MvModeCapabilities.ResolveAndValidate(_options, MvTransition.Activate, identity);
+        if (!capabilities.AllowsLifecycleDml)
+        {
+            var refusal = MvModeCapabilities.CreateRefusal(_options.InitializationMode, MvTransition.Activate, identity);
+            return MvActivationResult.Rejected(MvActivationFailureReason.TransitionNotAllowed, refusal.Message);
+        }
         return await InLaneAsync(
             exactServiceId,
             candidate.ViewName,
@@ -133,11 +149,15 @@ public sealed class MvGenerationCoordinator : IMvGenerationCoordinator
     {
         ArgumentNullException.ThrowIfNull(retainedCandidate);
         var exactServiceId = ValidateServiceId(serviceId);
-        if (_options.InitializationMode == MvInitializationMode.VerifyOnly)
+        var identity = new MvTransitionIdentity(
+            exactServiceId,
+            retainedCandidate.ViewName,
+            retainedCandidate.ViewVersion);
+        var capabilities = MvModeCapabilities.ResolveAndValidate(_options, MvTransition.ForceReverse, identity);
+        if (!capabilities.AllowsLifecycleDml)
         {
-            return MvActivationResult.Rejected(
-                MvActivationFailureReason.ProviderFailure,
-                "Verify-only infrastructure mode never mutates materialized-view registry state.");
+            var refusal = MvModeCapabilities.CreateRefusal(_options.InitializationMode, MvTransition.ForceReverse, identity);
+            return MvActivationResult.Rejected(MvActivationFailureReason.TransitionNotAllowed, refusal.Message);
         }
 
         var inputRejection = ValidateForcedReverseInput(
@@ -230,8 +250,11 @@ public sealed class MvGenerationCoordinator : IMvGenerationCoordinator
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(viewName);
         var exactServiceId = ValidateServiceId(serviceId);
-        if (_options.InitializationMode == MvInitializationMode.VerifyOnly &&
-            _registry is IMvReadOnlyMvInspector inspector)
+        var capabilities = MvModeCapabilities.ResolveAndValidate(
+            _options,
+            MvTransition.VerifyInitialization,
+            new MvTransitionIdentity(exactServiceId, viewName, -1));
+        if (capabilities.UsesReadOnlyInspection && _registry is IMvReadOnlyMvInspector inspector)
         {
             return inspector.ReadActiveAsync(exactServiceId, viewName, cancellationToken);
         }

--- a/dcb/src/Sekiban.Dcb.MaterializedView/MvInitialization.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView/MvInitialization.cs
@@ -3,7 +3,8 @@ namespace Sekiban.Dcb.MaterializedView;
 public enum MvInitializationMode
 {
     CreateOrEnsure = 0,
-    VerifyOnly = 1
+    VerifyOnly = 1,
+    VerifyAndExecute = 2
 }
 
 /// <summary>
@@ -13,7 +14,8 @@ public enum MvInitializationMode
 public enum MvInfrastructureMode
 {
     EnsureAndInitialize = 0,
-    VerifyOnly = 1
+    VerifyOnly = 1,
+    VerifyAndExecute = 2
 }
 
 public enum MvInitializationFailureReason

--- a/dcb/src/Sekiban.Dcb.MaterializedView/MvModeCapabilities.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView/MvModeCapabilities.cs
@@ -1,0 +1,160 @@
+namespace Sekiban.Dcb.MaterializedView;
+
+/// <summary>
+///     Public operation boundary used when a materialized-view mode refuses a command. The values deliberately
+///     describe a caller-visible operation rather than a provider implementation detail.
+/// </summary>
+public enum MvTransition
+{
+    Initialize = 0,
+    VerifyInitialization = 1,
+    Apply = 2,
+    CatchUp = 3,
+    CaptureTargetCheckpoint = 4,
+    Activate = 5,
+    ForceReverse = 6,
+    Refresh = 7
+}
+
+/// <summary>Typed reason for a materialized-view transition refusal.</summary>
+public enum MvTransitionNotAllowedReason
+{
+    VerifyOnly = 0,
+    UnknownMode = 1,
+    VerifiedExecutionPolicyRequired = 2
+}
+
+/// <summary>Secret-free identity attached to a transition failure.</summary>
+public sealed record MvTransitionIdentity(string ServiceId, string ViewName, int ViewVersion)
+{
+    public static MvTransitionIdentity Unknown { get; } = new("unknown", "unknown", -1);
+}
+
+/// <summary>
+///     Raised before any store, event-store, connection, or projector work when a command cannot mutate in the
+///     configured materialized-view mode.
+/// </summary>
+public class MvTransitionNotAllowedException : InvalidOperationException
+{
+    public MvTransitionNotAllowedException(
+        MvInitializationMode mode,
+        MvTransition transition,
+        MvTransitionNotAllowedReason reason,
+        MvTransitionIdentity identity)
+        : base(CreateMessage(mode, transition, reason, identity))
+    {
+        Mode = mode;
+        Transition = transition;
+        Reason = reason;
+        Identity = identity;
+    }
+
+    /// <summary>The configured public initialization mode, including an unrecognized numeric value when applicable.</summary>
+    public MvInitializationMode Mode { get; }
+
+    /// <summary>The command that was refused.</summary>
+    public MvTransition Transition { get; }
+
+    /// <summary>The typed refusal reason.</summary>
+    public MvTransitionNotAllowedReason Reason { get; }
+
+    /// <summary>The exact service/view identity supplied at the public boundary.</summary>
+    public MvTransitionIdentity Identity { get; }
+
+    public string ServiceId => Identity.ServiceId;
+    public string ViewName => Identity.ViewName;
+    public int ViewVersion => Identity.ViewVersion;
+
+    private static string CreateMessage(
+        MvInitializationMode mode,
+        MvTransition transition,
+        MvTransitionNotAllowedReason reason,
+        MvTransitionIdentity identity) =>
+        $"Materialized-view transition '{transition}' is not allowed in mode '{(int)mode}' " +
+        $"for service '{identity.ServiceId}', view '{identity.ViewName}/{identity.ViewVersion}' ({reason}).";
+}
+
+/// <summary>
+///     A mode-2 configuration failure. It is also a transition refusal so callers that already handle
+///     <see cref="MvTransitionNotAllowedException"/> retain a single typed boundary.
+/// </summary>
+public sealed class MvVerifiedExecutionConfigurationException : MvTransitionNotAllowedException
+{
+    public MvVerifiedExecutionConfigurationException(
+        MvInitializationMode mode,
+        MvTransition transition,
+        MvTransitionIdentity identity)
+        : base(mode, transition, MvTransitionNotAllowedReason.VerifiedExecutionPolicyRequired, identity)
+    {
+    }
+}
+
+/// <summary>
+///     The sole mode-to-capability mapping. Callers must resolve it at a public boundary before touching a store,
+///     host, event source, or provider connection; unknown numeric enum values therefore fail closed.
+/// </summary>
+internal sealed record MvModeCapabilities(
+    bool RequiresVerification,
+    bool AllowsInfrastructureEnsure,
+    bool AllowsProjectorApply,
+    bool AllowsLifecycleDml)
+{
+    public bool UsesReadOnlyInspection => RequiresVerification && !AllowsLifecycleDml;
+
+    /// <summary>
+    ///     Mode 2 has no infrastructure ownership but does execute projector DML. Its explicit policy precondition
+    ///     lets the executor authorize the complete batch before the first DML/registry command is sent.
+    /// </summary>
+    public bool RequiresWholeBatchPolicyAuthorization => RequiresVerification && AllowsProjectorApply;
+
+    public static MvModeCapabilities Resolve(
+        MvInitializationMode mode,
+        MvTransition transition,
+        MvTransitionIdentity identity) =>
+        mode switch
+        {
+            MvInitializationMode.CreateOrEnsure => new(
+                RequiresVerification: false,
+                AllowsInfrastructureEnsure: true,
+                AllowsProjectorApply: true,
+                AllowsLifecycleDml: true),
+            MvInitializationMode.VerifyOnly => new(
+                RequiresVerification: true,
+                AllowsInfrastructureEnsure: false,
+                AllowsProjectorApply: false,
+                AllowsLifecycleDml: false),
+            MvInitializationMode.VerifyAndExecute => new(
+                RequiresVerification: true,
+                AllowsInfrastructureEnsure: false,
+                AllowsProjectorApply: true,
+                AllowsLifecycleDml: true),
+            _ => throw new MvTransitionNotAllowedException(
+                mode,
+                transition,
+                MvTransitionNotAllowedReason.UnknownMode,
+                identity)
+        };
+
+    public static MvModeCapabilities ResolveAndValidate(
+        MvOptions options,
+        MvTransition transition,
+        MvTransitionIdentity identity)
+    {
+        var capabilities = Resolve(options.InitializationMode, transition, identity);
+        if (capabilities.RequiresWholeBatchPolicyAuthorization &&
+            (options.SqlStatementPolicyMode != MvSqlStatementPolicyMode.Enforced ||
+             options.SqlStatementPolicy is null ||
+             ReferenceEquals(options.SqlStatementPolicy, MvAllowAllSqlStatementPolicy.Instance)))
+        {
+            throw new MvVerifiedExecutionConfigurationException(options.InitializationMode, transition, identity);
+        }
+
+        return capabilities;
+    }
+
+    public static MvTransitionNotAllowedException CreateRefusal(
+        MvInitializationMode mode,
+        MvTransition transition,
+        MvTransitionIdentity identity) =>
+        new(mode, transition, MvTransitionNotAllowedReason.VerifyOnly, identity);
+}

--- a/dcb/src/Sekiban.Dcb.MaterializedView/MvOptions.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView/MvOptions.cs
@@ -51,14 +51,17 @@ public sealed class MvOptions
     public bool AllowDefaultServiceId { get; set; }
 
     /// <summary>
-    ///     Selects whether initialization may create/ensure schema or may only verify a pre-provisioned schema.
-    ///     The compatibility default preserves the historical create/ensure behavior.
+    ///     Selects infrastructure ownership and execution capability. <see cref="MvInitializationMode.VerifyOnly"/>
+    ///     verifies a pre-provisioned schema and refuses mutating commands; <see cref="MvInitializationMode.VerifyAndExecute"/>
+    ///     verifies first and then permits DML only with an explicit enforced policy. The compatibility default
+    ///     preserves historical create/ensure behavior.
     /// </summary>
     public MvInitializationMode InitializationMode { get; set; } = MvInitializationMode.CreateOrEnsure;
 
     /// <summary>
-    ///     Delay before a hosted worker retries a failed VerifyOnly contract check. CreateOrEnsure workers do not use
-    ///     this setting. A non-positive value falls back to <see cref="PollInterval"/>.
+    ///     Delay before a hosted worker retries a failed pre-provisioned-schema contract check in either verification
+    ///     mode (<see cref="MvInitializationMode.VerifyOnly"/> or <see cref="MvInitializationMode.VerifyAndExecute"/>).
+    ///     CreateOrEnsure workers do not use this setting. A non-positive value falls back to <see cref="PollInterval"/>.
     /// </summary>
     public TimeSpan VerifyOnlyRetryDelay { get; set; } = TimeSpan.FromSeconds(1);
 

--- a/dcb/src/Sekiban.Dcb.MaterializedView/MvOptions.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView/MvOptions.cs
@@ -95,6 +95,9 @@ public sealed class MvOptions
     ///     inspection capability is not configured or cannot be established.
     /// </summary>
     public string? SqlServerInspectionConnectionString { get; set; }
+
+    /// <summary>Internal test-only observation of projector execution and successful transaction commits.</summary>
+    internal IMvExecutionObserver? ExecutionObserver { get; set; }
 }
 
 public static class MvSchemaHelper

--- a/dcb/tests/Sekiban.Dcb.MaterializedView.ApiSurfaceVerifier/ApiSurface.cs
+++ b/dcb/tests/Sekiban.Dcb.MaterializedView.ApiSurfaceVerifier/ApiSurface.cs
@@ -1,0 +1,91 @@
+using System.Reflection;
+
+namespace Sekiban.Dcb.MaterializedView.ApiSurfaceVerifier;
+
+internal static class ApiSurface
+{
+    private const BindingFlags DeclaredVisible =
+        BindingFlags.DeclaredOnly | BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic;
+
+    public static IReadOnlyDictionary<string, HashSet<string>> Read(Assembly assembly) =>
+        assembly.GetExportedTypes()
+            .OrderBy(type => type.FullName, StringComparer.Ordinal)
+            .ToDictionary(
+                TypeKey,
+                Members,
+                StringComparer.Ordinal);
+
+    private static string TypeKey(Type type) => type.FullName ?? type.Name;
+
+    private static HashSet<string> Members(Type type)
+    {
+        var members = new HashSet<string>(StringComparer.Ordinal)
+        {
+            $"type:{type.Attributes}",
+            $"base:{TypeKey(type.BaseType ?? typeof(void))}"
+        };
+
+        foreach (var constructor in type.GetConstructors(DeclaredVisible).Where(IsVisible))
+        {
+            members.Add($"ctor:{Parameters(constructor.GetParameters())}");
+        }
+
+        foreach (var method in type.GetMethods(DeclaredVisible).Where(IsVisible))
+        {
+            members.Add(
+                $"method:{method.Name}`{method.GetGenericArguments().Length}:{TypeKey(method.ReturnType)}:{Parameters(method.GetParameters())}");
+        }
+
+        foreach (var property in type.GetProperties(DeclaredVisible))
+        {
+            var getter = property.GetMethod;
+            var setter = property.SetMethod;
+            if ((getter is null || !IsVisible(getter)) && (setter is null || !IsVisible(setter)))
+            {
+                continue;
+            }
+
+            members.Add(
+                $"property:{property.Name}:{TypeKey(property.PropertyType)}:{Parameters(property.GetIndexParameters())}:" +
+                $"get={Access(getter)}:set={Access(setter)}");
+        }
+
+        foreach (var field in type.GetFields(DeclaredVisible).Where(IsVisible))
+        {
+            var constantValue = field.IsLiteral ? field.GetRawConstantValue() : null;
+            members.Add($"field:{field.Name}:{TypeKey(field.FieldType)}:{field.IsLiteral}:{constantValue}");
+        }
+
+        foreach (var @event in type.GetEvents(DeclaredVisible))
+        {
+            var add = @event.AddMethod;
+            var remove = @event.RemoveMethod;
+            if ((add is null || !IsVisible(add)) && (remove is null || !IsVisible(remove)))
+            {
+                continue;
+            }
+
+            members.Add($"event:{@event.Name}:{TypeKey(@event.EventHandlerType ?? typeof(void))}:add={Access(add)}:remove={Access(remove)}");
+        }
+
+        return members;
+    }
+
+    private static string Parameters(IEnumerable<ParameterInfo> parameters) =>
+        string.Join(",", parameters.Select(parameter =>
+            $"{TypeKey(parameter.ParameterType)}:{parameter.Attributes}"));
+
+    private static bool IsVisible(MethodBase member) => member.IsPublic || member.IsFamily || member.IsFamilyOrAssembly;
+
+    private static bool IsVisible(FieldInfo field) => field.IsPublic || field.IsFamily || field.IsFamilyOrAssembly;
+
+    private static string Access(MethodBase? member) => member is null
+        ? "none"
+        : member.IsPublic
+            ? "public"
+            : member.IsFamily
+                ? "protected"
+                : member.IsFamilyOrAssembly
+                    ? "protected-internal"
+                    : "hidden";
+}

--- a/dcb/tests/Sekiban.Dcb.MaterializedView.ApiSurfaceVerifier/Program.cs
+++ b/dcb/tests/Sekiban.Dcb.MaterializedView.ApiSurfaceVerifier/Program.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using Sekiban.Dcb.MaterializedView.ApiSurfaceVerifier;
 
 if (args.Length != 2)
 {
@@ -67,92 +68,4 @@ static MetadataLoadContext CreateMetadataContext(string assemblyPath, string fal
             }
         }
     }
-}
-
-internal static class ApiSurface
-{
-    private const BindingFlags DeclaredVisible =
-        BindingFlags.DeclaredOnly | BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic;
-
-    public static IReadOnlyDictionary<string, HashSet<string>> Read(Assembly assembly) =>
-        assembly.GetExportedTypes()
-            .OrderBy(type => type.FullName, StringComparer.Ordinal)
-            .ToDictionary(
-                TypeKey,
-                Members,
-                StringComparer.Ordinal);
-
-    private static string TypeKey(Type type) => type.FullName ?? type.Name;
-
-    private static HashSet<string> Members(Type type)
-    {
-        var members = new HashSet<string>(StringComparer.Ordinal)
-        {
-            $"type:{type.Attributes}",
-            $"base:{TypeKey(type.BaseType ?? typeof(void))}"
-        };
-
-        foreach (var constructor in type.GetConstructors(DeclaredVisible).Where(IsVisible))
-        {
-            members.Add($"ctor:{Parameters(constructor.GetParameters())}");
-        }
-
-        foreach (var method in type.GetMethods(DeclaredVisible).Where(IsVisible))
-        {
-            members.Add(
-                $"method:{method.Name}`{method.GetGenericArguments().Length}:{TypeKey(method.ReturnType)}:{Parameters(method.GetParameters())}");
-        }
-
-        foreach (var property in type.GetProperties(DeclaredVisible))
-        {
-            var getter = property.GetMethod;
-            var setter = property.SetMethod;
-            if ((getter is null || !IsVisible(getter)) && (setter is null || !IsVisible(setter)))
-            {
-                continue;
-            }
-
-            members.Add(
-                $"property:{property.Name}:{TypeKey(property.PropertyType)}:{Parameters(property.GetIndexParameters())}:" +
-                $"get={Access(getter)}:set={Access(setter)}");
-        }
-
-        foreach (var field in type.GetFields(DeclaredVisible).Where(IsVisible))
-        {
-            var constantValue = field.IsLiteral ? field.GetRawConstantValue() : null;
-            members.Add($"field:{field.Name}:{TypeKey(field.FieldType)}:{field.IsLiteral}:{constantValue}");
-        }
-
-        foreach (var @event in type.GetEvents(DeclaredVisible))
-        {
-            var add = @event.AddMethod;
-            var remove = @event.RemoveMethod;
-            if ((add is null || !IsVisible(add)) && (remove is null || !IsVisible(remove)))
-            {
-                continue;
-            }
-
-            members.Add($"event:{@event.Name}:{TypeKey(@event.EventHandlerType ?? typeof(void))}:add={Access(add)}:remove={Access(remove)}");
-        }
-
-        return members;
-    }
-
-    private static string Parameters(IEnumerable<ParameterInfo> parameters) =>
-        string.Join(",", parameters.Select(parameter =>
-            $"{TypeKey(parameter.ParameterType)}:{parameter.Attributes}"));
-
-    private static bool IsVisible(MethodBase member) => member.IsPublic || member.IsFamily || member.IsFamilyOrAssembly;
-
-    private static bool IsVisible(FieldInfo field) => field.IsPublic || field.IsFamily || field.IsFamilyOrAssembly;
-
-    private static string Access(MethodBase? member) => member is null
-        ? "none"
-        : member.IsPublic
-            ? "public"
-            : member.IsFamily
-                ? "protected"
-                : member.IsFamilyOrAssembly
-                    ? "protected-internal"
-                    : "hidden";
 }

--- a/dcb/tests/Sekiban.Dcb.MaterializedView.ApiSurfaceVerifier/Program.cs
+++ b/dcb/tests/Sekiban.Dcb.MaterializedView.ApiSurfaceVerifier/Program.cs
@@ -1,0 +1,158 @@
+using System.Reflection;
+
+if (args.Length != 2)
+{
+    throw new ArgumentException("Usage: <baseline-assembly-path> <candidate-assembly-path>.");
+}
+
+var baselinePath = Path.GetFullPath(args[0]);
+var candidatePath = Path.GetFullPath(args[1]);
+if (!File.Exists(baselinePath) || !File.Exists(candidatePath))
+{
+    throw new FileNotFoundException("Both baseline and candidate assemblies must exist.");
+}
+
+using var baselineContext = CreateMetadataContext(baselinePath, candidatePath);
+using var candidateContext = CreateMetadataContext(candidatePath, baselinePath);
+var baseline = baselineContext.LoadFromAssemblyPath(baselinePath);
+var candidate = candidateContext.LoadFromAssemblyPath(candidatePath);
+
+var baselineSurface = ApiSurface.Read(baseline);
+var candidateSurface = ApiSurface.Read(candidate);
+var removedTypes = baselineSurface.Keys.Except(candidateSurface.Keys, StringComparer.Ordinal).OrderBy(value => value).ToList();
+var removedMembers = baselineSurface
+    .SelectMany(type => type.Value.Except(candidateSurface.GetValueOrDefault(type.Key, []), StringComparer.Ordinal)
+        .Select(member => $"{type.Key}::{member}"))
+    .OrderBy(value => value)
+    .ToList();
+if (removedTypes.Count != 0 || removedMembers.Count != 0)
+{
+    var removed = string.Join(Environment.NewLine, removedTypes.Concat(removedMembers));
+    throw new InvalidOperationException($"The candidate removes public API from the baseline:{Environment.NewLine}{removed}");
+}
+
+Console.WriteLine($"api-surface-additions-only-ok:{baselineSurface.Count}:{candidateSurface.Count}");
+
+static MetadataLoadContext CreateMetadataContext(string assemblyPath, string fallbackAssemblyPath)
+{
+    var trustedPlatformAssemblies = ((string?)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES"))
+        ?.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries)
+        ?? [];
+    var assemblyDirectory = Path.GetDirectoryName(assemblyPath)
+        ?? throw new ArgumentException("The assembly path must have a parent directory.", nameof(assemblyPath));
+    var fallbackDirectory = Path.GetDirectoryName(fallbackAssemblyPath)
+        ?? throw new ArgumentException("The fallback assembly path must have a parent directory.", nameof(fallbackAssemblyPath));
+    var resolverPaths = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+    AddAssemblies(Directory.EnumerateFiles(assemblyDirectory, "*.dll"));
+    AddAssemblies(Directory.EnumerateFiles(fallbackDirectory, "*.dll"));
+    AddAssemblies(trustedPlatformAssemblies);
+    AddAssemblies([assemblyPath]);
+    return new MetadataLoadContext(new PathAssemblyResolver(resolverPaths.Values));
+
+    void AddAssemblies(IEnumerable<string> paths)
+    {
+        foreach (var path in paths)
+        {
+            try
+            {
+                var name = AssemblyName.GetAssemblyName(path).Name;
+                if (!string.IsNullOrWhiteSpace(name))
+                {
+                    _ = resolverPaths.TryAdd(name, path);
+                }
+            }
+            catch (BadImageFormatException)
+            {
+                // Native support libraries are not part of the managed public API surface.
+            }
+        }
+    }
+}
+
+internal static class ApiSurface
+{
+    private const BindingFlags DeclaredVisible =
+        BindingFlags.DeclaredOnly | BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic;
+
+    public static IReadOnlyDictionary<string, HashSet<string>> Read(Assembly assembly) =>
+        assembly.GetExportedTypes()
+            .OrderBy(type => type.FullName, StringComparer.Ordinal)
+            .ToDictionary(
+                TypeKey,
+                Members,
+                StringComparer.Ordinal);
+
+    private static string TypeKey(Type type) => type.FullName ?? type.Name;
+
+    private static HashSet<string> Members(Type type)
+    {
+        var members = new HashSet<string>(StringComparer.Ordinal)
+        {
+            $"type:{type.Attributes}",
+            $"base:{TypeKey(type.BaseType ?? typeof(void))}"
+        };
+
+        foreach (var constructor in type.GetConstructors(DeclaredVisible).Where(IsVisible))
+        {
+            members.Add($"ctor:{Parameters(constructor.GetParameters())}");
+        }
+
+        foreach (var method in type.GetMethods(DeclaredVisible).Where(IsVisible))
+        {
+            members.Add(
+                $"method:{method.Name}`{method.GetGenericArguments().Length}:{TypeKey(method.ReturnType)}:{Parameters(method.GetParameters())}");
+        }
+
+        foreach (var property in type.GetProperties(DeclaredVisible))
+        {
+            var getter = property.GetMethod;
+            var setter = property.SetMethod;
+            if ((getter is null || !IsVisible(getter)) && (setter is null || !IsVisible(setter)))
+            {
+                continue;
+            }
+
+            members.Add(
+                $"property:{property.Name}:{TypeKey(property.PropertyType)}:{Parameters(property.GetIndexParameters())}:" +
+                $"get={Access(getter)}:set={Access(setter)}");
+        }
+
+        foreach (var field in type.GetFields(DeclaredVisible).Where(IsVisible))
+        {
+            var constantValue = field.IsLiteral ? field.GetRawConstantValue() : null;
+            members.Add($"field:{field.Name}:{TypeKey(field.FieldType)}:{field.IsLiteral}:{constantValue}");
+        }
+
+        foreach (var @event in type.GetEvents(DeclaredVisible))
+        {
+            var add = @event.AddMethod;
+            var remove = @event.RemoveMethod;
+            if ((add is null || !IsVisible(add)) && (remove is null || !IsVisible(remove)))
+            {
+                continue;
+            }
+
+            members.Add($"event:{@event.Name}:{TypeKey(@event.EventHandlerType ?? typeof(void))}:add={Access(add)}:remove={Access(remove)}");
+        }
+
+        return members;
+    }
+
+    private static string Parameters(IEnumerable<ParameterInfo> parameters) =>
+        string.Join(",", parameters.Select(parameter =>
+            $"{TypeKey(parameter.ParameterType)}:{parameter.Attributes}"));
+
+    private static bool IsVisible(MethodBase member) => member.IsPublic || member.IsFamily || member.IsFamilyOrAssembly;
+
+    private static bool IsVisible(FieldInfo field) => field.IsPublic || field.IsFamily || field.IsFamilyOrAssembly;
+
+    private static string Access(MethodBase? member) => member is null
+        ? "none"
+        : member.IsPublic
+            ? "public"
+            : member.IsFamily
+                ? "protected"
+                : member.IsFamilyOrAssembly
+                    ? "protected-internal"
+                    : "hidden";
+}

--- a/dcb/tests/Sekiban.Dcb.MaterializedView.ApiSurfaceVerifier/README.md
+++ b/dcb/tests/Sekiban.Dcb.MaterializedView.ApiSurfaceVerifier/README.md
@@ -1,0 +1,5 @@
+# Materialized-view API surface verifier
+
+The verifier compares the public/protected API exposed by the published 10.14.1 assembly and the current net9
+assembly. It fails if a baseline type, member, enum value, or visible signature is removed or changed; newly added
+API is allowed. CI runs it next to the compiled-and-not-rebuilt 10.14.1 binary consumer.

--- a/dcb/tests/Sekiban.Dcb.MaterializedView.ApiSurfaceVerifier/Sekiban.Dcb.MaterializedView.ApiSurfaceVerifier.csproj
+++ b/dcb/tests/Sekiban.Dcb.MaterializedView.ApiSurfaceVerifier/Sekiban.Dcb.MaterializedView.ApiSurfaceVerifier.csproj
@@ -8,7 +8,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- This fixture is intentionally compiled against the published v10.14.1 package. -->
-    <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.14.1" />
+    <PackageReference Include="System.Reflection.MetadataLoadContext" Version="10.0.3" />
   </ItemGroup>
 </Project>

--- a/dcb/tests/Sekiban.Dcb.MaterializedView.BinaryConsumer/Program.cs
+++ b/dcb/tests/Sekiban.Dcb.MaterializedView.BinaryConsumer/Program.cs
@@ -5,5 +5,24 @@ var options = new MvOptions
     ServiceId = "binary-consumer"
 };
 
+var initializationModeZero = MvInitializationMode.CreateOrEnsure;
+var initializationModeOne = MvInitializationMode.VerifyOnly;
+var infrastructureModeZero = MvInfrastructureMode.EnsureAndInitialize;
+var infrastructureModeOne = MvInfrastructureMode.VerifyOnly;
+var initializationProperty = new MvOptions { InitializationMode = initializationModeOne };
+var infrastructureProperty = new MvOptions { InfrastructureMode = infrastructureModeOne };
+if ((int)initializationModeZero != 0 || (int)initializationModeOne != 1 ||
+    (int)infrastructureModeZero != 0 || (int)infrastructureModeOne != 1 ||
+    initializationProperty.InitializationMode != MvInitializationMode.VerifyOnly ||
+    infrastructureProperty.InfrastructureMode != MvInfrastructureMode.VerifyOnly)
+{
+    throw new InvalidOperationException("The 10.14.1 materialized-view mode/property contract changed.");
+}
+
+Func<IMvExecutor, IMvApplyHost, Task<int>> applySignature =
+    static (executor, host) => executor.ApplySerializableEventsAsync(host, []);
+Func<IMvActivationExecutor, IMvApplyHost, Task<MvCheckpointTruth>> captureSignature =
+    static (executor, host) => executor.CaptureTargetCheckpointAsync(host);
+
 Console.WriteLine(
-    $"binary-consumer-ok:{options.ServiceId}:{typeof(IMvExecutor).FullName}");
+    $"binary-consumer-ok:{options.ServiceId}:{typeof(IMvExecutor).FullName}:{applySignature.Method.ReturnType.Name}:{captureSignature.Method.ReturnType.Name}");

--- a/dcb/tests/Sekiban.Dcb.MaterializedView.BinaryConsumer/README.md
+++ b/dcb/tests/Sekiban.Dcb.MaterializedView.BinaryConsumer/README.md
@@ -1,6 +1,6 @@
 # Materialized-view binary consumer
 
-This fixture is restored and compiled against the published `Sekiban.Dcb.MaterializedView` **10.14.0** package. The
+This fixture is restored and compiled against the published `Sekiban.Dcb.MaterializedView` **10.14.1** package. The
 compatibility proof then runs the already-built consumer without recompiling it after the current branch's
 `Sekiban.Dcb.MaterializedView.dll` is copied into the output directory:
 
@@ -11,6 +11,8 @@ cp dcb/src/Sekiban.Dcb.MaterializedView/bin/Release/net9.0/Sekiban.Dcb.Materiali
 dotnet dcb/tests/Sekiban.Dcb.MaterializedView.BinaryConsumer/bin/Release/net9.0/Sekiban.Dcb.MaterializedView.BinaryConsumer.dll
 ```
 
-The output must begin with `binary-consumer-ok:`. The final command deliberately does not invoke `dotnet build` or
-`dotnet run`, so the process proves that the consumer was compiled against the real package reference and executed
-against the current implementation as a binary consumer.
+The fixture references both preserved mode values (0/1), both `MvOptions` mode properties, and the preserved
+apply/capture method signatures. The output must begin with `binary-consumer-ok:`. The final command deliberately does
+not invoke `dotnet build` or `dotnet run`, so the process proves that the consumer was compiled against the real package
+reference and executed against the current implementation as a binary consumer. CI also runs the adjacent
+additions-only API-surface verifier and the current-version consumer for value 2 and the typed refusal API.

--- a/dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/MvVerifyOnlyAndPolicyTests.cs
+++ b/dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/MvVerifyOnlyAndPolicyTests.cs
@@ -1059,6 +1059,39 @@ internal sealed class CountingApplyHost(IMvApplyHost inner, bool throwOnInitiali
         inner.GetSchemaContract(tables);
 }
 
+/// <summary>
+///     Adds a projector-emitted DDL statement after the real projector INSERT. Mode 2 must authorize the complete
+///     batch before either statement reaches the provider, so the second statement is a direct wrong-ordering probe.
+/// </summary>
+internal sealed class DdlAppendingApplyHost(IMvApplyHost inner, string deniedDdl) : IMvApplyHost
+{
+    public string ViewName => inner.ViewName;
+    public int ViewVersion => inner.ViewVersion;
+    public IReadOnlyList<string> LogicalTables => inner.LogicalTables;
+
+    public Task<IReadOnlyList<MvSqlStatementDto>> InitializeAsync(
+        IMvTableBindings tables,
+        CancellationToken ct) =>
+        inner.InitializeAsync(tables, ct);
+
+    public async Task<IReadOnlyList<MvSqlStatementDto>> ApplyEventAsync(
+        SerializableEvent ev,
+        IMvTableBindings tables,
+        IMvApplyQueryPort queryPort,
+        string sortableUniqueId,
+        CancellationToken ct)
+    {
+        var statements = await inner.ApplyEventAsync(ev, tables, queryPort, sortableUniqueId, ct).ConfigureAwait(false);
+        return [.. statements, new MvSqlStatementDto(deniedDdl, [])];
+    }
+
+    public IReadOnlyList<MvSchemaTableRequirement> GetSchemaRequirements(IMvTableBindings tables) =>
+        inner.GetSchemaRequirements(tables);
+
+    public MvSchemaContract? GetSchemaContract(IMvTableBindings tables) =>
+        inner.GetSchemaContract(tables);
+}
+
 public enum PolicySurfaceKind
 {
     Rows,
@@ -1256,9 +1289,94 @@ public sealed class PostgresMvVerifyOnlyTests(PostgresMvFixture fixture)
                 return rows.ToArray();
             }
 
+            async Task<string[]> SnapshotSchemaFingerprintAsync()
+            {
+                var rows = await ownerConnection.QueryAsync<string>(
+                        """
+                        WITH schema_objects AS (
+                            SELECT
+                                'relation' AS object_kind,
+                                schema_namespace.nspname AS schema_name,
+                                relation.relname AS object_name,
+                                json_build_object(
+                                    'kind', relation.relkind,
+                                    'persistence', relation.relpersistence,
+                                    'view_definition', CASE
+                                        WHEN relation.relkind IN ('v', 'm') THEN pg_get_viewdef(relation.oid, true)
+                                        ELSE NULL
+                                    END)::text AS definition
+                            FROM pg_class AS relation
+                            INNER JOIN pg_namespace AS schema_namespace ON schema_namespace.oid = relation.relnamespace
+                            WHERE schema_namespace.nspname = current_schema()
+                              AND relation.relkind IN ('r', 'p', 'v', 'm', 'S', 'f')
+
+                            UNION ALL
+
+                            SELECT
+                                'column',
+                                schema_namespace.nspname,
+                                relation.relname || '.' || attribute.attname,
+                                json_build_object(
+                                    'position', attribute.attnum,
+                                    'type', format_type(attribute.atttypid, attribute.atttypmod),
+                                    'not_null', attribute.attnotnull,
+                                    'default', pg_get_expr(default_value.adbin, default_value.adrelid),
+                                    'identity', attribute.attidentity,
+                                    'generated', attribute.attgenerated)::text
+                            FROM pg_attribute AS attribute
+                            INNER JOIN pg_class AS relation ON relation.oid = attribute.attrelid
+                            INNER JOIN pg_namespace AS schema_namespace ON schema_namespace.oid = relation.relnamespace
+                            LEFT JOIN pg_attrdef AS default_value
+                                ON default_value.adrelid = attribute.attrelid
+                               AND default_value.adnum = attribute.attnum
+                            WHERE schema_namespace.nspname = current_schema()
+                              AND relation.relkind IN ('r', 'p', 'v', 'm', 'S', 'f')
+                              AND attribute.attnum > 0
+                              AND NOT attribute.attisdropped
+
+                            UNION ALL
+
+                            SELECT
+                                'constraint',
+                                schema_namespace.nspname,
+                                relation.relname || '.' || constraint_item.conname,
+                                pg_get_constraintdef(constraint_item.oid, true)
+                            FROM pg_constraint AS constraint_item
+                            INNER JOIN pg_class AS relation ON relation.oid = constraint_item.conrelid
+                            INNER JOIN pg_namespace AS schema_namespace ON schema_namespace.oid = relation.relnamespace
+                            WHERE schema_namespace.nspname = current_schema()
+
+                            UNION ALL
+
+                            SELECT
+                                'index',
+                                schema_namespace.nspname,
+                                relation.relname || '.' || index_relation.relname,
+                                pg_get_indexdef(index_relation.oid)
+                            FROM pg_index AS index_item
+                            INNER JOIN pg_class AS relation ON relation.oid = index_item.indrelid
+                            INNER JOIN pg_class AS index_relation ON index_relation.oid = index_item.indexrelid
+                            INNER JOIN pg_namespace AS schema_namespace ON schema_namespace.oid = relation.relnamespace
+                            WHERE schema_namespace.nspname = current_schema()
+                        )
+                        SELECT row_to_json(fingerprint)::text
+                        FROM (
+                            SELECT object_kind, schema_name, object_name, definition
+                            FROM schema_objects
+                            ORDER BY object_kind, schema_name, object_name, definition
+                        ) AS fingerprint;
+                        """)
+                    .ConfigureAwait(false);
+                return rows.ToArray();
+            }
+
             var allowPolicy = new ObservingPolicy(readRows, _ => MvSqlPolicyDecision.Allow());
-            var allowExecutor = CreateVerifyAndExecuteExecutor(restrictedConnectionString, allowPolicy);
+            var allowExecutionAudit = new ExecutionAudit();
+            var allowExecutor = CreateVerifyAndExecuteExecutor(restrictedConnectionString, allowPolicy, allowExecutionAudit);
             await allowExecutor.InitializeAsync(host).ConfigureAwait(false);
+            allowExecutionAudit.Reset();
+            var schemaBeforeAllow = await SnapshotSchemaFingerprintAsync().ConfigureAwait(false);
+            Assert.NotEmpty(schemaBeforeAllow);
 
             var emptyApply = await allowExecutor.ApplySerializableEventsAsync(host, []).ConfigureAwait(false);
             Assert.Equal(0, emptyApply);
@@ -1273,7 +1391,7 @@ public sealed class PostgresMvVerifyOnlyTests(PostgresMvFixture fixture)
             Assert.All(allowPolicy.ObservedRowsBeforeApply, count => Assert.Equal(0, count));
             Assert.DoesNotContain(
                 allowPolicy.ApplyContexts,
-                context => Regex.IsMatch(context.Sql, @"^\s*(CREATE|ALTER|DROP)\b", RegexOptions.IgnoreCase));
+                context => IsDdlStatement(context.Sql));
             Assert.Equal(1, readRows());
 
             var beforeLifecycle = await ownerRegistry.GetEntriesAsync(
@@ -1310,18 +1428,29 @@ public sealed class PostgresMvVerifyOnlyTests(PostgresMvFixture fixture)
             Assert.Equal(registryBeforeReplay, await SnapshotRegistryAsync().ConfigureAwait(false));
             Assert.Equal(activeBeforeReplay, await SnapshotActiveAsync().ConfigureAwait(false));
             Assert.Equal(2, readRows());
+            Assert.Equal(schemaBeforeAllow, await SnapshotSchemaFingerprintAsync().ConfigureAwait(false));
+            Assert.Equal(0, allowPolicy.ApplyContexts.Count(context => IsDdlStatement(context.Sql)));
+            Assert.Equal(0, allowExecutionAudit.ProjectorCommandExecutionAttempts.Count(IsDdlStatement));
+            Assert.Equal(2, allowExecutionAudit.ProjectorCommandExecutionAttempts.Count);
+            Assert.Equal(2, allowExecutionAudit.TransactionCommitCount);
 
             var registryBeforeReject = await SnapshotRegistryAsync().ConfigureAwait(false);
             var activeBeforeReject = await SnapshotActiveAsync().ConfigureAwait(false);
             var projectionRowsBeforeReject = await SnapshotProjectionRowsAsync().ConfigureAwait(false);
+            var schemaBeforeReject = await SnapshotSchemaFingerprintAsync().ConfigureAwait(false);
             var rowsBeforeReject = projectionRowsBeforeReject.LongLength;
             var denySecondPolicy = new ObservingPolicy(
                 readRows,
                 context => context.StatementIndex == 1
                     ? MvSqlPolicyDecision.Reject("second statement is intentionally denied", "g34-deny-second")
                     : MvSqlPolicyDecision.Allow());
-            var rejectExecutor = CreateVerifyAndExecuteExecutor(restrictedConnectionString, denySecondPolicy);
+            var denySecondExecutionAudit = new ExecutionAudit();
+            var rejectExecutor = CreateVerifyAndExecuteExecutor(
+                restrictedConnectionString,
+                denySecondPolicy,
+                denySecondExecutionAudit);
             await rejectExecutor.InitializeAsync(host).ConfigureAwait(false);
+            denySecondExecutionAudit.Reset();
 
             var rejection = await Assert.ThrowsAsync<MvSqlPolicyRejectedException>(
                 () => rejectExecutor.ApplySerializableEventsAsync(
@@ -1339,6 +1468,78 @@ public sealed class PostgresMvVerifyOnlyTests(PostgresMvFixture fixture)
             Assert.Equal(projectionRowsBeforeReject, await SnapshotProjectionRowsAsync().ConfigureAwait(false));
             Assert.Equal(registryBeforeReject, await SnapshotRegistryAsync().ConfigureAwait(false));
             Assert.Equal(activeBeforeReject, await SnapshotActiveAsync().ConfigureAwait(false));
+            Assert.Equal(schemaBeforeReject, await SnapshotSchemaFingerprintAsync().ConfigureAwait(false));
+            Assert.Empty(denySecondExecutionAudit.ProjectorCommandExecutionAttempts);
+            Assert.Equal(0, denySecondExecutionAudit.TransactionCommitCount);
+
+            var registryBeforeDenyAll = await SnapshotRegistryAsync().ConfigureAwait(false);
+            var activeBeforeDenyAll = await SnapshotActiveAsync().ConfigureAwait(false);
+            var projectionRowsBeforeDenyAll = await SnapshotProjectionRowsAsync().ConfigureAwait(false);
+            var schemaBeforeDenyAll = await SnapshotSchemaFingerprintAsync().ConfigureAwait(false);
+            var denyAllPolicy = new ObservingPolicy(
+                readRows,
+                _ => MvSqlPolicyDecision.Reject("all mode-2 projector commands are intentionally denied", "g34-deny-all"));
+            var denyAllExecutionAudit = new ExecutionAudit();
+            var denyAllExecutor = CreateVerifyAndExecuteExecutor(
+                restrictedConnectionString,
+                denyAllPolicy,
+                denyAllExecutionAudit);
+            await denyAllExecutor.InitializeAsync(host).ConfigureAwait(false);
+            denyAllExecutionAudit.Reset();
+
+            var denyAllRejection = await Assert.ThrowsAsync<MvSqlPolicyRejectedException>(
+                () => denyAllExecutor.ApplySerializableEventsAsync(
+                    host,
+                    [CreateEvent(fixture, DateTime.UtcNow.AddMinutes(1))])).ConfigureAwait(false);
+
+            Assert.Equal(MvSqlPolicyFailureReason.Denied, denyAllRejection.Failure.FailureReason);
+            Assert.Single(denyAllPolicy.ApplyContexts);
+            Assert.Equal(0, denyAllPolicy.ApplyContexts[0].StatementIndex);
+            Assert.Equal(1, denyAllPolicy.ApplyContexts[0].BatchSize);
+            Assert.All(denyAllPolicy.ObservedRowsBeforeApply, count => Assert.Equal(rowsBeforeReject, count));
+            Assert.Empty(denyAllExecutionAudit.ProjectorCommandExecutionAttempts);
+            Assert.Equal(0, denyAllExecutionAudit.TransactionCommitCount);
+            Assert.Equal(projectionRowsBeforeDenyAll, await SnapshotProjectionRowsAsync().ConfigureAwait(false));
+            Assert.Equal(registryBeforeDenyAll, await SnapshotRegistryAsync().ConfigureAwait(false));
+            Assert.Equal(activeBeforeDenyAll, await SnapshotActiveAsync().ConfigureAwait(false));
+            Assert.Equal(schemaBeforeDenyAll, await SnapshotSchemaFingerprintAsync().ConfigureAwait(false));
+
+            var registryBeforeDdlDeny = await SnapshotRegistryAsync().ConfigureAwait(false);
+            var activeBeforeDdlDeny = await SnapshotActiveAsync().ConfigureAwait(false);
+            var projectionRowsBeforeDdlDeny = await SnapshotProjectionRowsAsync().ConfigureAwait(false);
+            var schemaBeforeDdlDeny = await SnapshotSchemaFingerprintAsync().ConfigureAwait(false);
+            var deniedDdlTable = $"g34_policy_denied_{Guid.NewGuid():N}";
+            var ddlDenyHost = new DdlAppendingApplyHost(host, $"CREATE TABLE {deniedDdlTable} (id INT);");
+            var ddlDenyPolicy = new ObservingPolicy(
+                readRows,
+                context => IsDdlStatement(context.Sql)
+                    ? MvSqlPolicyDecision.Reject("DDL is intentionally denied before provider execution", "g34-deny-ddl")
+                    : MvSqlPolicyDecision.Allow());
+            var ddlDenyExecutionAudit = new ExecutionAudit();
+            var ddlDenyExecutor = CreateVerifyAndExecuteExecutor(
+                restrictedConnectionString,
+                ddlDenyPolicy,
+                ddlDenyExecutionAudit);
+            await ddlDenyExecutor.InitializeAsync(ddlDenyHost).ConfigureAwait(false);
+            ddlDenyExecutionAudit.Reset();
+
+            var ddlDenyRejection = await Assert.ThrowsAsync<MvSqlPolicyRejectedException>(
+                () => ddlDenyExecutor.ApplySerializableEventsAsync(
+                    ddlDenyHost,
+                    [CreateEvent(fixture, DateTime.UtcNow.AddMinutes(2))])).ConfigureAwait(false);
+
+            Assert.Equal(MvSqlPolicyFailureReason.Denied, ddlDenyRejection.Failure.FailureReason);
+            Assert.Equal(2, ddlDenyPolicy.ApplyContexts.Count);
+            Assert.Equal([0, 1], ddlDenyPolicy.ApplyContexts.Select(context => context.StatementIndex));
+            Assert.False(IsDdlStatement(ddlDenyPolicy.ApplyContexts[0].Sql));
+            Assert.True(IsDdlStatement(ddlDenyPolicy.ApplyContexts[1].Sql));
+            Assert.All(ddlDenyPolicy.ObservedRowsBeforeApply, count => Assert.Equal(rowsBeforeReject, count));
+            Assert.Empty(ddlDenyExecutionAudit.ProjectorCommandExecutionAttempts);
+            Assert.Equal(0, ddlDenyExecutionAudit.TransactionCommitCount);
+            Assert.Equal(projectionRowsBeforeDdlDeny, await SnapshotProjectionRowsAsync().ConfigureAwait(false));
+            Assert.Equal(registryBeforeDdlDeny, await SnapshotRegistryAsync().ConfigureAwait(false));
+            Assert.Equal(activeBeforeDdlDeny, await SnapshotActiveAsync().ConfigureAwait(false));
+            Assert.Equal(schemaBeforeDdlDeny, await SnapshotSchemaFingerprintAsync().ConfigureAwait(false));
         }
         finally
         {
@@ -1353,21 +1554,27 @@ public sealed class PostgresMvVerifyOnlyTests(PostgresMvFixture fixture)
 
     private PostgresMvExecutor CreateVerifyAndExecuteExecutor(
         string connectionString,
-        IMvSqlStatementPolicy policy) =>
-        new(
+        IMvSqlStatementPolicy policy,
+        IMvExecutionObserver? executionObserver = null)
+    {
+        var registryStore = new PostgresMvRegistryStore(connectionString);
+        var options = Options.Create(new MvOptions
+        {
+            ServiceId = MultiProviderFixtureBase.ServiceId,
+            InitializationMode = MvInitializationMode.VerifyAndExecute,
+            SqlStatementPolicyMode = MvSqlStatementPolicyMode.Enforced,
+            SqlStatementPolicy = policy,
+            SafeWindowMs = 0,
+            BatchSize = 100,
+            ExecutionObserver = executionObserver
+        });
+        return new PostgresMvExecutor(
             fixture.EventStoreFactory,
-            new PostgresMvRegistryStore(connectionString),
-            Options.Create(new MvOptions
-            {
-                ServiceId = MultiProviderFixtureBase.ServiceId,
-                InitializationMode = MvInitializationMode.VerifyAndExecute,
-                SqlStatementPolicyMode = MvSqlStatementPolicyMode.Enforced,
-                SqlStatementPolicy = policy,
-                SafeWindowMs = 0,
-                BatchSize = 100
-            }),
+            registryStore,
+            options,
             NullLogger<PostgresMvExecutor>.Instance,
             connectionString);
+    }
 
     private static SerializableEvent CreateEvent(PostgresMvFixture fixture, DateTime timestamp)
     {
@@ -1405,6 +1612,26 @@ public sealed class PostgresMvVerifyOnlyTests(PostgresMvFixture fixture)
             }
 
             return ValueTask.FromResult(decision(context));
+        }
+    }
+
+    private static bool IsDdlStatement(string sql) =>
+        Regex.IsMatch(sql, @"^\s*(CREATE|ALTER|DROP)\b", RegexOptions.IgnoreCase);
+
+    private sealed class ExecutionAudit : IMvExecutionObserver
+    {
+        public List<string> ProjectorCommandExecutionAttempts { get; } = [];
+        public int TransactionCommitCount { get; private set; }
+
+        public void OnProjectorCommandExecutionAttempt(string sql) =>
+            ProjectorCommandExecutionAttempts.Add(sql);
+
+        public void OnTransactionCommitted() => TransactionCommitCount++;
+
+        public void Reset()
+        {
+            ProjectorCommandExecutionAttempts.Clear();
+            TransactionCommitCount = 0;
         }
     }
 }

--- a/dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/MvVerifyOnlyAndPolicyTests.cs
+++ b/dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/MvVerifyOnlyAndPolicyTests.cs
@@ -1,5 +1,6 @@
 using System.Data;
 using System.Data.Common;
+using System.Reflection;
 using System.Text.RegularExpressions;
 using Dapper;
 using Dcb.Domain.WithoutResult.Weather;
@@ -8,10 +9,12 @@ using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
+using Npgsql;
 using Sekiban.Dcb.Common;
 using Sekiban.Dcb.Events;
 using Sekiban.Dcb.MaterializedView;
 using Sekiban.Dcb.MaterializedView.MySql;
+using Sekiban.Dcb.MaterializedView.Orleans;
 using Sekiban.Dcb.MaterializedView.Postgres;
 using Sekiban.Dcb.MaterializedView.Sqlite;
 using Sekiban.Dcb.MaterializedView.SqlServer;
@@ -105,10 +108,13 @@ public sealed class SqliteMvVerifyOnlyAndPolicyTests(SqliteMvFixture fixture)
             fixture.ConnectionStringForTests);
 
         await executor.InitializeAsync(new CountingApplyHost(host, throwOnInitialize: true)).ConfigureAwait(false);
-        _ = await executor.CaptureTargetCheckpointAsync(host).ConfigureAwait(false);
-        _ = await executor.CatchUpOnceAsync(host).ConfigureAwait(false);
+        var capture = await Assert.ThrowsAsync<MvTransitionNotAllowedException>(
+            () => executor.CaptureTargetCheckpointAsync(host)).ConfigureAwait(false);
+        var catchUp = await Assert.ThrowsAsync<MvTransitionNotAllowedException>(
+            () => executor.CatchUpOnceAsync(host)).ConfigureAwait(false);
         var activation = await executor.TryActivateAsync(host).ConfigureAwait(false);
-        var applied = await executor.ApplySerializableEventsAsync(host, [CreatePolicyEvent()]).ConfigureAwait(false);
+        var apply = await Assert.ThrowsAsync<MvTransitionNotAllowedException>(
+            () => executor.ApplySerializableEventsAsync(host, [CreatePolicyEvent()])).ConfigureAwait(false);
         var coordinator = new MvGenerationCoordinator(
             executor,
             guardedRegistry,
@@ -117,6 +123,9 @@ public sealed class SqliteMvVerifyOnlyAndPolicyTests(SqliteMvFixture fixture)
                 ServiceId = MultiProviderFixtureBase.ServiceId,
                 InitializationMode = MvInitializationMode.VerifyOnly
             }));
+        var prepare = await Assert.ThrowsAsync<MvTransitionNotAllowedException>(
+            () => coordinator.PrepareGenerationAsync(host));
+        var switchResult = await coordinator.SwitchAsync(host).ConfigureAwait(false);
         var forcedReverse = await coordinator.ForceReverseAsync(
                 host,
                 expectedActiveVersion: projector.ViewVersion + 1,
@@ -124,9 +133,13 @@ public sealed class SqliteMvVerifyOnlyAndPolicyTests(SqliteMvFixture fixture)
                 reason: "verify-only mutation probe")
             .ConfigureAwait(false);
 
-        Assert.Equal(MvActivationFailureReason.ProviderFailure, activation.FailureReason);
-        Assert.Equal(MvActivationFailureReason.ProviderFailure, forcedReverse.FailureReason);
-        Assert.Equal(0, applied);
+        Assert.Equal(MvTransition.CaptureTargetCheckpoint, capture.Transition);
+        Assert.Equal(MvTransition.CatchUp, catchUp.Transition);
+        Assert.Equal(MvTransition.Apply, apply.Transition);
+        Assert.Equal(MvTransition.CaptureTargetCheckpoint, prepare.Transition);
+        Assert.Equal(MvActivationFailureReason.TransitionNotAllowed, activation.FailureReason);
+        Assert.Equal(MvActivationFailureReason.TransitionNotAllowed, switchResult.FailureReason);
+        Assert.Equal(MvActivationFailureReason.TransitionNotAllowed, forcedReverse.FailureReason);
         Assert.Equal(0, guardedRegistry.EnsureCalls);
         Assert.Equal(0, guardedRegistry.RegisterCalls);
         Assert.Equal(0, guardedRegistry.TargetCheckpointCalls);
@@ -136,19 +149,6 @@ public sealed class SqliteMvVerifyOnlyAndPolicyTests(SqliteMvFixture fixture)
         Assert.Equal(0, guardedRegistry.ActivePointerCalls);
         Assert.Contains("sqlite:Mode=ReadOnly", readOnlyConnections);
 
-        await realStore.SetTargetCheckpointAsync(
-                MultiProviderFixtureBase.ServiceId,
-                projector.ViewName,
-                projector.ViewVersion,
-                MvCheckpointTruth.Unknown(MvCheckpointUnknownReason.ReadUnavailable))
-            .ConfigureAwait(false);
-        _ = await executor.CatchUpOnceAsync(host).ConfigureAwait(false);
-        var entriesAfterCatchUp = await realStore.ReadRegistryEntriesAsync(
-                MultiProviderFixtureBase.ServiceId,
-                projector.ViewName,
-                projector.ViewVersion)
-            .ConfigureAwait(false);
-        Assert.All(entriesAfterCatchUp, entry => Assert.True(entry.TargetCheckpointTruth.IsUnknown));
     }
 
     [SkippableFact]
@@ -286,7 +286,7 @@ public sealed class SqliteMvVerifyOnlyAndPolicyTests(SqliteMvFixture fixture)
     }
 
     [SkippableFact]
-    public async Task VerifyOnly_ImplicitEmptyRegistryPathsUseTheSameFailClosedGate()
+    public async Task VerifyOnly_MutatingBoundariesRefuseBeforeSchemaOrRegistryAccess()
     {
         Skip.IfNot(fixture.IsAvailable, fixture.AvailabilityMessage ?? "SQLite fixture is unavailable.");
         var pathNames = new[] { "target-capture", "catch-up", "apply" };
@@ -311,15 +311,15 @@ public sealed class SqliteMvVerifyOnlyAndPolicyTests(SqliteMvFixture fixture)
 
             var exception = pathName switch
             {
-                "target-capture" => await Assert.ThrowsAsync<MvInitializationException>(
+                "target-capture" => await Assert.ThrowsAsync<MvTransitionNotAllowedException>(
                     () => verifyExecutor.CaptureTargetCheckpointAsync(host)).ConfigureAwait(false),
-                "catch-up" => await Assert.ThrowsAsync<MvInitializationException>(
+                "catch-up" => await Assert.ThrowsAsync<MvTransitionNotAllowedException>(
                     async () => await verifyExecutor.CatchUpOnceAsync(host).ConfigureAwait(false)).ConfigureAwait(false),
-                _ => await Assert.ThrowsAsync<MvInitializationException>(
+                _ => await Assert.ThrowsAsync<MvTransitionNotAllowedException>(
                     () => verifyExecutor.ApplySerializableEventsAsync(host, [])).ConfigureAwait(false)
             };
 
-            Assert.Equal(MvInitializationFailureReason.MissingSchemaContract, exception.Failure.Reason);
+            Assert.Equal(MvTransitionNotAllowedReason.VerifyOnly, exception.Reason);
             Assert.Equal(0, host.InitializeCalls);
             await using var checkConnection = await fixture.OpenConnectionAsync().ConfigureAwait(false);
             Assert.Equal(0, await checkConnection.ExecuteScalarAsync<long>("SELECT COUNT(*) FROM sekiban_mv_registry;"));
@@ -327,7 +327,7 @@ public sealed class SqliteMvVerifyOnlyAndPolicyTests(SqliteMvFixture fixture)
     }
 
     [SkippableFact]
-    public async Task VerifyOnly_ImplicitPathsReportMissingFrameworkSchemaBeforeRegistryRead()
+    public async Task VerifyOnly_MutatingBoundariesRefuseEvenWhenFrameworkSchemaIsMissing()
     {
         Skip.IfNot(fixture.IsAvailable, fixture.AvailabilityMessage ?? "SQLite fixture is unavailable.");
         var pathNames = new[] { "target-capture", "catch-up", "apply" };
@@ -344,15 +344,15 @@ public sealed class SqliteMvVerifyOnlyAndPolicyTests(SqliteMvFixture fixture)
 
             var exception = pathName switch
             {
-                "target-capture" => await Assert.ThrowsAsync<MvInitializationException>(
+                "target-capture" => await Assert.ThrowsAsync<MvTransitionNotAllowedException>(
                     () => verifyExecutor.CaptureTargetCheckpointAsync(host)).ConfigureAwait(false),
-                "catch-up" => await Assert.ThrowsAsync<MvInitializationException>(
+                "catch-up" => await Assert.ThrowsAsync<MvTransitionNotAllowedException>(
                     async () => await verifyExecutor.CatchUpOnceAsync(host).ConfigureAwait(false)).ConfigureAwait(false),
-                _ => await Assert.ThrowsAsync<MvInitializationException>(
+                _ => await Assert.ThrowsAsync<MvTransitionNotAllowedException>(
                     () => verifyExecutor.ApplySerializableEventsAsync(host, [])).ConfigureAwait(false)
             };
 
-            Assert.Equal(MvInitializationFailureReason.MissingSchemaObject, exception.Failure.Reason);
+            Assert.Equal(MvTransitionNotAllowedReason.VerifyOnly, exception.Reason);
             Assert.Equal(0, host.InitializeCalls);
             await using var checkConnection = await fixture.OpenConnectionAsync().ConfigureAwait(false);
             Assert.Equal(
@@ -360,6 +360,32 @@ public sealed class SqliteMvVerifyOnlyAndPolicyTests(SqliteMvFixture fixture)
                 await checkConnection.ExecuteScalarAsync<long>(
                     "SELECT COUNT(*) FROM sqlite_master WHERE name LIKE 'sekiban_mv_%';"));
         }
+    }
+
+    [Fact]
+    public async Task VerifyOnly_PublicRefreshRefusesBeforeItCanReachGrainDependencies()
+    {
+        var grain = new MaterializedViewGrain(
+            hostFactory: null!,
+            executor: null!,
+            registryStore: null!,
+            subscriptionResolver: null!,
+            options: Options.Create(new MvOptions
+            {
+                ServiceId = "g34-refresh",
+                InitializationMode = MvInitializationMode.VerifyOnly
+            }),
+            logger: NullLogger<MaterializedViewGrain>.Instance);
+        SetPrivateField(grain, "_grainKey", "g34-refresh|RefreshView|1");
+        SetPrivateField(grain, "_serviceId", "g34-refresh");
+        SetPrivateField(grain, "_viewName", "RefreshView");
+        SetPrivateField(grain, "_viewVersion", 1);
+
+        var refusal = await Assert.ThrowsAsync<MvTransitionNotAllowedException>(
+            () => grain.RefreshAsync());
+
+        Assert.Equal(MvTransition.Refresh, refusal.Transition);
+        Assert.Equal(MvTransitionNotAllowedReason.VerifyOnly, refusal.Reason);
     }
 
     [SkippableFact]
@@ -740,6 +766,13 @@ public sealed class SqliteMvVerifyOnlyAndPolicyTests(SqliteMvFixture fixture)
         return eventValue.ToSerializableEvent(fixture.DomainTypes.EventTypes);
     }
 
+    private static void SetPrivateField<T>(MaterializedViewGrain grain, string fieldName, T value)
+    {
+        var field = typeof(MaterializedViewGrain).GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(field);
+        field!.SetValue(grain, value);
+    }
+
     private NativeMvApplyHost CreateHost(CrossProviderWeatherForecastMvV1 projector) =>
         new(projector, fixture.DomainTypes.EventTypes, MvDbType.Sqlite);
 
@@ -1111,6 +1144,269 @@ public sealed class PostgresMvVerifyOnlyTests(PostgresMvFixture fixture)
     [SkippableFact]
     public Task SchemaContractMatrix_UsesTheProductionInspector() =>
         MvSchemaMatrixAssertions.AssertAsync(fixture);
+
+    [SkippableFact]
+    public async Task VerifyAndExecute_UsesDdlDeniedRoleForProductionDmlAndFailsAtomicallyOnPolicyReject()
+    {
+        Skip.IfNot(fixture.IsAvailable, fixture.AvailabilityMessage ?? "PostgreSQL fixture is unavailable.");
+        await fixture.ResetAsync().ConfigureAwait(false);
+
+        var projector = fixture.Services.GetRequiredService<CrossProviderWeatherForecastMvV1>();
+        var host = new NativeMvApplyHost(projector, fixture.DomainTypes.EventTypes, MvDbType.Postgres);
+        await fixture.Executor.InitializeAsync(host).ConfigureAwait(false);
+
+        var roleName = $"g34_exec_{Guid.NewGuid():N}";
+        var rolePassword = Guid.NewGuid().ToString("N");
+        try
+        {
+            await using var ownerConnection = new NpgsqlConnection(fixture.ConnectionStringForTests);
+            await ownerConnection.OpenAsync().ConfigureAwait(false);
+            var ownerRole = await ownerConnection.ExecuteScalarAsync<string>("SELECT current_user;").ConfigureAwait(false);
+            await ownerConnection.ExecuteAsync($"""
+                REVOKE CREATE ON SCHEMA public FROM PUBLIC;
+                GRANT CREATE ON SCHEMA public TO {ownerRole};
+                CREATE ROLE {roleName} LOGIN PASSWORD '{rolePassword}' NOSUPERUSER NOCREATEDB NOCREATEROLE NOINHERIT;
+                GRANT CONNECT ON DATABASE sekiban_mv_test TO {roleName};
+                GRANT USAGE ON SCHEMA public TO {roleName};
+                GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO {roleName};
+                GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO {roleName};
+                REVOKE CREATE ON SCHEMA public FROM {roleName};
+                """).ConfigureAwait(false);
+
+            var restrictedBuilder = new NpgsqlConnectionStringBuilder(fixture.ConnectionStringForTests)
+            {
+                Username = roleName,
+                Password = rolePassword,
+                Pooling = false
+            };
+            var restrictedConnectionString = restrictedBuilder.ConnectionString;
+            await using (var restrictedConnection = new NpgsqlConnection(restrictedConnectionString))
+            {
+                await restrictedConnection.OpenAsync().ConfigureAwait(false);
+                var create = await Assert.ThrowsAsync<PostgresException>(
+                    () => restrictedConnection.ExecuteAsync($"CREATE TABLE g34_create_probe_{Guid.NewGuid():N} (id INT);")).ConfigureAwait(false);
+                var alter = await Assert.ThrowsAsync<PostgresException>(
+                    () => restrictedConnection.ExecuteAsync($"ALTER TABLE {projector.Forecasts.PhysicalName} ADD COLUMN g34_alter_probe INT;")).ConfigureAwait(false);
+                var drop = await Assert.ThrowsAsync<PostgresException>(
+                    () => restrictedConnection.ExecuteAsync($"DROP TABLE {projector.Forecasts.PhysicalName};")).ConfigureAwait(false);
+                Assert.Equal("42501", create.SqlState);
+                Assert.Equal("42501", alter.SqlState);
+                Assert.Equal("42501", drop.SqlState);
+            }
+
+            var readRows = () => ownerConnection.ExecuteScalar<long>($"SELECT COUNT(*) FROM {projector.Forecasts.PhysicalName};");
+            var ownerRegistry = fixture.Services.GetRequiredService<IMvRegistryStore>();
+            async Task<string[]> SnapshotRegistryAsync()
+            {
+                var rows = await ownerConnection.QueryAsync<string>(
+                        """
+                        SELECT row_to_json(snapshot)::text
+                        FROM (
+                            SELECT *
+                            FROM sekiban_mv_registry
+                            WHERE service_id = @ServiceId
+                              AND view_name = @ViewName
+                              AND view_version = @ViewVersion
+                            ORDER BY logical_table
+                        ) AS snapshot;
+                        """,
+                        new
+                        {
+                            ServiceId = MultiProviderFixtureBase.ServiceId,
+                            projector.ViewName,
+                            projector.ViewVersion
+                        })
+                    .ConfigureAwait(false);
+                return rows.ToArray();
+            }
+
+            async Task<string[]> SnapshotActiveAsync()
+            {
+                var rows = await ownerConnection.QueryAsync<string>(
+                        """
+                        SELECT row_to_json(snapshot)::text
+                        FROM (
+                            SELECT *
+                            FROM sekiban_mv_active
+                            WHERE service_id = @ServiceId
+                              AND view_name = @ViewName
+                        ) AS snapshot;
+                        """,
+                        new
+                        {
+                            ServiceId = MultiProviderFixtureBase.ServiceId,
+                            projector.ViewName
+                        })
+                    .ConfigureAwait(false);
+                return rows.ToArray();
+            }
+
+            async Task<string[]> SnapshotProjectionRowsAsync()
+            {
+                var rows = await ownerConnection.QueryAsync<string>(
+                        $"""
+                        SELECT row_to_json(snapshot)::text
+                        FROM (
+                            SELECT *
+                            FROM {projector.Forecasts.PhysicalName}
+                            ORDER BY forecast_id
+                        ) AS snapshot;
+                        """)
+                    .ConfigureAwait(false);
+                return rows.ToArray();
+            }
+
+            var allowPolicy = new ObservingPolicy(readRows, _ => MvSqlPolicyDecision.Allow());
+            var allowExecutor = CreateVerifyAndExecuteExecutor(restrictedConnectionString, allowPolicy);
+            await allowExecutor.InitializeAsync(host).ConfigureAwait(false);
+
+            var emptyApply = await allowExecutor.ApplySerializableEventsAsync(host, []).ConfigureAwait(false);
+            Assert.Equal(0, emptyApply);
+
+            var applied = await allowExecutor.ApplySerializableEventsAsync(
+                    host,
+                    [CreateEvent(fixture, DateTime.UtcNow.AddMinutes(-2))])
+                .ConfigureAwait(false);
+            Assert.Equal(1, applied);
+            Assert.Single(allowPolicy.ApplyContexts);
+            Assert.Equal(MvSqlStatementPhase.Apply, allowPolicy.ApplyContexts[0].Phase);
+            Assert.All(allowPolicy.ObservedRowsBeforeApply, count => Assert.Equal(0, count));
+            Assert.DoesNotContain(
+                allowPolicy.ApplyContexts,
+                context => Regex.IsMatch(context.Sql, @"^\s*(CREATE|ALTER|DROP)\b", RegexOptions.IgnoreCase));
+            Assert.Equal(1, readRows());
+
+            var beforeLifecycle = await ownerRegistry.GetEntriesAsync(
+                    MultiProviderFixtureBase.ServiceId,
+                    projector.ViewName,
+                    projector.ViewVersion)
+                .ConfigureAwait(false);
+            var sourceEvent = CreateEvent(fixture, DateTime.UtcNow.AddSeconds(-30));
+            var writeSource = await fixture.EventStore.WriteSerializableEventsAsync([sourceEvent]).ConfigureAwait(false);
+            Assert.True(writeSource.IsSuccess);
+            var target = await allowExecutor.CaptureTargetCheckpointAsync(host).ConfigureAwait(false);
+            Assert.True(target.IsKnown);
+            var firstCatchUp = await allowExecutor.CatchUpOnceAsync(host).ConfigureAwait(false);
+            Assert.Equal(1, firstCatchUp.AppliedEvents);
+            var afterFirstCatchUp = await ownerRegistry.GetEntriesAsync(
+                    MultiProviderFixtureBase.ServiceId,
+                    projector.ViewName,
+                    projector.ViewVersion)
+                .ConfigureAwait(false);
+            Assert.Equal(
+                beforeLifecycle.Single().AppliedEventVersion + 1,
+                afterFirstCatchUp.Single().AppliedEventVersion);
+            _ = await allowExecutor.CatchUpOnceAsync(host).ConfigureAwait(false);
+            var activeAfterFirstCas = await ownerRegistry.GetActiveAsync(
+                    MultiProviderFixtureBase.ServiceId,
+                    projector.ViewName)
+                .ConfigureAwait(false);
+            Assert.NotNull(activeAfterFirstCas);
+            Assert.Equal(projector.ViewVersion, activeAfterFirstCas.ActiveVersion);
+            var registryBeforeReplay = await SnapshotRegistryAsync().ConfigureAwait(false);
+            var activeBeforeReplay = await SnapshotActiveAsync().ConfigureAwait(false);
+            var replay = await allowExecutor.CatchUpOnceAsync(host).ConfigureAwait(false);
+            Assert.Equal(0, replay.AppliedEvents);
+            Assert.Equal(registryBeforeReplay, await SnapshotRegistryAsync().ConfigureAwait(false));
+            Assert.Equal(activeBeforeReplay, await SnapshotActiveAsync().ConfigureAwait(false));
+            Assert.Equal(2, readRows());
+
+            var registryBeforeReject = await SnapshotRegistryAsync().ConfigureAwait(false);
+            var activeBeforeReject = await SnapshotActiveAsync().ConfigureAwait(false);
+            var projectionRowsBeforeReject = await SnapshotProjectionRowsAsync().ConfigureAwait(false);
+            var rowsBeforeReject = projectionRowsBeforeReject.LongLength;
+            var denySecondPolicy = new ObservingPolicy(
+                readRows,
+                context => context.StatementIndex == 1
+                    ? MvSqlPolicyDecision.Reject("second statement is intentionally denied", "g34-deny-second")
+                    : MvSqlPolicyDecision.Allow());
+            var rejectExecutor = CreateVerifyAndExecuteExecutor(restrictedConnectionString, denySecondPolicy);
+            await rejectExecutor.InitializeAsync(host).ConfigureAwait(false);
+
+            var rejection = await Assert.ThrowsAsync<MvSqlPolicyRejectedException>(
+                () => rejectExecutor.ApplySerializableEventsAsync(
+                    host,
+                    [
+                        CreateEvent(fixture, DateTime.UtcNow.AddMinutes(-1)),
+                        CreateEvent(fixture, DateTime.UtcNow)
+                    ])).ConfigureAwait(false);
+
+            Assert.Equal(MvSqlPolicyFailureReason.Denied, rejection.Failure.FailureReason);
+            Assert.Equal(rowsBeforeReject, readRows());
+            Assert.All(denySecondPolicy.ObservedRowsBeforeApply, count => Assert.Equal(rowsBeforeReject, count));
+            Assert.Equal(2, denySecondPolicy.ApplyContexts.Count);
+            Assert.Equal([0, 1], denySecondPolicy.ApplyContexts.Select(context => context.StatementIndex));
+            Assert.Equal(projectionRowsBeforeReject, await SnapshotProjectionRowsAsync().ConfigureAwait(false));
+            Assert.Equal(registryBeforeReject, await SnapshotRegistryAsync().ConfigureAwait(false));
+            Assert.Equal(activeBeforeReject, await SnapshotActiveAsync().ConfigureAwait(false));
+        }
+        finally
+        {
+            NpgsqlConnection.ClearAllPools();
+            await using var cleanupConnection = new NpgsqlConnection(fixture.ConnectionStringForTests);
+            await cleanupConnection.OpenAsync().ConfigureAwait(false);
+            await cleanupConnection.ExecuteAsync($"DROP OWNED BY {roleName};").ConfigureAwait(false);
+            await cleanupConnection.ExecuteAsync($"DROP ROLE IF EXISTS {roleName};").ConfigureAwait(false);
+            await cleanupConnection.ExecuteAsync("GRANT CREATE ON SCHEMA public TO PUBLIC;").ConfigureAwait(false);
+        }
+    }
+
+    private PostgresMvExecutor CreateVerifyAndExecuteExecutor(
+        string connectionString,
+        IMvSqlStatementPolicy policy) =>
+        new(
+            fixture.EventStoreFactory,
+            new PostgresMvRegistryStore(connectionString),
+            Options.Create(new MvOptions
+            {
+                ServiceId = MultiProviderFixtureBase.ServiceId,
+                InitializationMode = MvInitializationMode.VerifyAndExecute,
+                SqlStatementPolicyMode = MvSqlStatementPolicyMode.Enforced,
+                SqlStatementPolicy = policy,
+                SafeWindowMs = 0,
+                BatchSize = 100
+            }),
+            NullLogger<PostgresMvExecutor>.Instance,
+            connectionString);
+
+    private static SerializableEvent CreateEvent(PostgresMvFixture fixture, DateTime timestamp)
+    {
+        var eventId = Guid.CreateVersion7();
+        var value = new Event(
+            new WeatherForecastCreated(
+                Guid.CreateVersion7(),
+                "Tokyo",
+                DateOnly.FromDateTime(timestamp),
+                20,
+                "Sunny"),
+            SortableUniqueId.Generate(timestamp, eventId),
+            nameof(WeatherForecastCreated),
+            eventId,
+            new EventMetadata("g34", "g34", "test"),
+            []);
+        return value.ToSerializableEvent(fixture.DomainTypes.EventTypes);
+    }
+
+    private sealed class ObservingPolicy(
+        Func<long> readRows,
+        Func<MvSqlStatementContext, MvSqlPolicyDecision> decision) : IMvSqlStatementPolicy
+    {
+        public List<MvSqlStatementContext> ApplyContexts { get; } = [];
+        public List<long> ObservedRowsBeforeApply { get; } = [];
+
+        public ValueTask<MvSqlPolicyDecision> EvaluateAsync(
+            MvSqlStatementContext context,
+            CancellationToken cancellationToken = default)
+        {
+            if (context.Phase == MvSqlStatementPhase.Apply)
+            {
+                ApplyContexts.Add(context);
+                ObservedRowsBeforeApply.Add(readRows());
+            }
+
+            return ValueTask.FromResult(decision(context));
+        }
+    }
 }
 
 [Collection(nameof(MySqlMvCollection))]

--- a/dcb/tests/Sekiban.Dcb.MaterializedView.NewVersionConsumer/Program.cs
+++ b/dcb/tests/Sekiban.Dcb.MaterializedView.NewVersionConsumer/Program.cs
@@ -1,0 +1,26 @@
+using Sekiban.Dcb.MaterializedView;
+
+var options = new MvOptions
+{
+    InitializationMode = MvInitializationMode.VerifyAndExecute
+};
+options.InfrastructureMode = MvInfrastructureMode.VerifyAndExecute;
+
+if ((int)options.InitializationMode != 2 ||
+    (int)options.InfrastructureMode != 2)
+{
+    throw new InvalidOperationException("The VerifyAndExecute mode value must remain additive at 2.");
+}
+
+var refusal = new MvVerifiedExecutionConfigurationException(
+    options.InitializationMode,
+    MvTransition.Apply,
+    new MvTransitionIdentity("new-version-consumer", "Orders", 1));
+if (refusal is not MvTransitionNotAllowedException ||
+    refusal.Reason != MvTransitionNotAllowedReason.VerifiedExecutionPolicyRequired ||
+    refusal.Transition != MvTransition.Apply)
+{
+    throw new InvalidOperationException("The VerifyAndExecute typed refusal contract changed.");
+}
+
+Console.WriteLine($"new-version-consumer-ok:{(int)options.InitializationMode}:{refusal.Reason}");

--- a/dcb/tests/Sekiban.Dcb.MaterializedView.NewVersionConsumer/README.md
+++ b/dcb/tests/Sekiban.Dcb.MaterializedView.NewVersionConsumer/README.md
@@ -1,0 +1,8 @@
+# Materialized-view new-version consumer
+
+This consumer is compiled against the current source and proves the additive public value
+`VerifyAndExecute = 2` through both `MvOptions` mode properties. It also consumes the public
+`MvVerifiedExecutionConfigurationException` / `MvTransitionNotAllowedException` refusal surface.
+
+The execution-path and no-side-effect guarantees are covered by the Materialized View unit and
+real-PostgreSQL tests; this fixture protects the public API shape available to a newly compiled consumer.

--- a/dcb/tests/Sekiban.Dcb.MaterializedView.NewVersionConsumer/Sekiban.Dcb.MaterializedView.NewVersionConsumer.csproj
+++ b/dcb/tests/Sekiban.Dcb.MaterializedView.NewVersionConsumer/Sekiban.Dcb.MaterializedView.NewVersionConsumer.csproj
@@ -8,7 +8,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- This fixture is intentionally compiled against the published v10.14.1 package. -->
-    <PackageReference Include="Sekiban.Dcb.MaterializedView" Version="10.14.1" />
+    <ProjectReference Include="../../src/Sekiban.Dcb.MaterializedView/Sekiban.Dcb.MaterializedView.csproj" />
   </ItemGroup>
 </Project>

--- a/dcb/tests/Sekiban.Dcb.MaterializedView.Tests/MaterializedViewUnitTests.cs
+++ b/dcb/tests/Sekiban.Dcb.MaterializedView.Tests/MaterializedViewUnitTests.cs
@@ -164,7 +164,7 @@ public class MaterializedViewUnitTests
     }
 
     [Fact]
-    public async Task CatchUpWorker_VerifyOnlyGatesCatchUpUntilLaterVerificationSucceeds()
+    public async Task CatchUpWorker_VerifyOnlyRetriesVerificationThenStopsBeforeCatchUp()
     {
         var executor = new FakeMvExecutor(initializationFailuresBeforeSuccess: 1);
         var hostFactory = new FakeApplyHostFactory(new FakeApplyHost("Fake", 1));
@@ -182,11 +182,11 @@ public class MaterializedViewUnitTests
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
         await worker.StartAsync(cts.Token);
-        await SpinWaitAsync(() => executor.CatchUpCalls > 0, cts.Token);
+        await SpinWaitAsync(() => executor.InitializeCalls >= 2, cts.Token);
         await worker.StopAsync(CancellationToken.None);
 
         Assert.Equal(2, executor.InitializeCalls);
-        Assert.True(executor.CatchUpCalls > 0);
+        Assert.Equal(0, executor.CatchUpCalls);
     }
 
     [Fact]

--- a/dcb/tests/Sekiban.Dcb.MaterializedView.Tests/MvExecutorServiceBoundaryTests.cs
+++ b/dcb/tests/Sekiban.Dcb.MaterializedView.Tests/MvExecutorServiceBoundaryTests.cs
@@ -148,6 +148,98 @@ public sealed class MvExecutorServiceBoundaryTests
                            constructor.GetParameters()[0].ParameterType == typeof(IEventStoreFactory));
     }
 
+    [Fact]
+    public async Task VerifyAndExecuteRequiresAnExplicitEnforcedPolicyBeforeAnyHostOrStoreWork()
+    {
+        var invalidOptions = new[]
+        {
+            new MvOptions
+            {
+                ServiceId = "mode-two",
+                InitializationMode = MvInitializationMode.VerifyAndExecute
+            },
+            new MvOptions
+            {
+                ServiceId = "mode-two",
+                InitializationMode = MvInitializationMode.VerifyAndExecute,
+                SqlStatementPolicyMode = MvSqlStatementPolicyMode.Enforced,
+                SqlStatementPolicy = null
+            },
+            new MvOptions
+            {
+                ServiceId = "mode-two",
+                InitializationMode = MvInitializationMode.VerifyAndExecute,
+                SqlStatementPolicyMode = MvSqlStatementPolicyMode.Enforced,
+                SqlStatementPolicy = MvAllowAllSqlStatementPolicy.Instance
+            },
+            new MvOptions
+            {
+                ServiceId = "mode-two",
+                InitializationMode = MvInitializationMode.VerifyAndExecute,
+                SqlStatementPolicyMode = MvSqlStatementPolicyMode.Legacy,
+                SqlStatementPolicy = new ExplicitAllowPolicy()
+            }
+        };
+
+        foreach (var options in invalidOptions)
+        {
+            var sourceFactory = new ThrowingEventStoreFactory();
+            var registry = new CountingRegistryStore();
+            var host = new BoundaryHost();
+            var executor = new SqliteMvExecutor(
+                sourceFactory,
+                registry,
+                Options.Create(options),
+                NullLogger<SqliteMvExecutor>.Instance,
+                "Data Source=unused");
+
+            var configuration = await Assert.ThrowsAsync<MvVerifiedExecutionConfigurationException>(
+                () => executor.InitializeAsync(host));
+
+            Assert.Equal(MvTransition.Initialize, configuration.Transition);
+            Assert.Equal(MvTransitionNotAllowedReason.VerifiedExecutionPolicyRequired, configuration.Reason);
+            Assert.Equal(0, host.InitializeCalls);
+            Assert.Equal(0, registry.EnsureCalls);
+            Assert.Equal(0, sourceFactory.CreateCalls);
+        }
+    }
+
+    [Fact]
+    public async Task UnknownModeFailsClosedBeforeAnyHostOrStoreWork()
+    {
+        var sourceFactory = new ThrowingEventStoreFactory();
+        var registry = new CountingRegistryStore();
+        var host = new BoundaryHost();
+        var executor = new SqliteMvExecutor(
+            sourceFactory,
+            registry,
+            Options.Create(new MvOptions
+            {
+                ServiceId = "unknown-mode",
+                InitializationMode = (MvInitializationMode)99
+            }),
+            NullLogger<SqliteMvExecutor>.Instance,
+            "Data Source=unused");
+
+        var refusal = await Assert.ThrowsAsync<MvTransitionNotAllowedException>(
+            () => executor.InitializeAsync(host));
+
+        await Assert.ThrowsAsync<MvTransitionNotAllowedException>(
+            () => executor.ApplySerializableEventsAsync(host, []));
+        await Assert.ThrowsAsync<MvTransitionNotAllowedException>(
+            () => executor.CatchUpOnceAsync(host));
+        var activationExecutor = Assert.IsAssignableFrom<IMvActivationExecutor>(executor);
+        await Assert.ThrowsAsync<MvTransitionNotAllowedException>(
+            () => activationExecutor.CaptureTargetCheckpointAsync(host));
+        await Assert.ThrowsAsync<MvTransitionNotAllowedException>(
+            () => activationExecutor.TryActivateAsync(host));
+
+        Assert.Equal(MvTransitionNotAllowedReason.UnknownMode, refusal.Reason);
+        Assert.Equal(0, host.InitializeCalls);
+        Assert.Equal(0, registry.EnsureCalls);
+        Assert.Equal(0, sourceFactory.CreateCalls);
+    }
+
     private sealed class ThrowingEventStoreFactory : IEventStoreFactory
     {
         public int CreateCalls { get; private set; }
@@ -193,12 +285,16 @@ public sealed class MvExecutorServiceBoundaryTests
 
     private sealed class BoundaryHost : IMvApplyHost
     {
+        public int InitializeCalls { get; private set; }
         public string ViewName => "Boundary";
         public int ViewVersion => 1;
         public IReadOnlyList<string> LogicalTables => ["main"];
 
-        public Task<IReadOnlyList<MvSqlStatementDto>> InitializeAsync(IMvTableBindings tables, CancellationToken ct) =>
-            Task.FromResult<IReadOnlyList<MvSqlStatementDto>>([]);
+        public Task<IReadOnlyList<MvSqlStatementDto>> InitializeAsync(IMvTableBindings tables, CancellationToken ct)
+        {
+            InitializeCalls++;
+            return Task.FromResult<IReadOnlyList<MvSqlStatementDto>>([]);
+        }
 
         public Task<IReadOnlyList<MvSqlStatementDto>> ApplyEventAsync(
             SerializableEvent ev,
@@ -207,5 +303,13 @@ public sealed class MvExecutorServiceBoundaryTests
             string sortableUniqueId,
             CancellationToken ct) =>
             Task.FromResult<IReadOnlyList<MvSqlStatementDto>>([]);
+    }
+
+    private sealed class ExplicitAllowPolicy : IMvSqlStatementPolicy
+    {
+        public ValueTask<MvSqlPolicyDecision> EvaluateAsync(
+            MvSqlStatementContext context,
+            CancellationToken cancellationToken = default) =>
+            ValueTask.FromResult(MvSqlPolicyDecision.Allow());
     }
 }

--- a/dcb/tests/Sekiban.Dcb.MaterializedView.Tests/MvInitializationCompatibilityTests.cs
+++ b/dcb/tests/Sekiban.Dcb.MaterializedView.Tests/MvInitializationCompatibilityTests.cs
@@ -24,6 +24,63 @@ public sealed class MvInitializationCompatibilityTests
     }
 
     [Fact]
+    public void VerifyAndExecuteIsAnAdditivePublicModeWithTypedRefusalSurface()
+    {
+        var options = new MvOptions
+        {
+            InitializationMode = MvInitializationMode.VerifyAndExecute
+        };
+
+        Assert.Equal(2, (int)options.InitializationMode);
+        Assert.Equal(MvInfrastructureMode.VerifyAndExecute, options.InfrastructureMode);
+        Assert.Equal(2, (int)options.InfrastructureMode);
+
+        var exception = new MvTransitionNotAllowedException(
+            MvInitializationMode.VerifyOnly,
+            MvTransition.Apply,
+            MvTransitionNotAllowedReason.VerifyOnly,
+            new MvTransitionIdentity("orders", "OrderView", 2));
+        Assert.Equal(MvTransition.Apply, exception.Transition);
+        Assert.Equal("orders", exception.ServiceId);
+        Assert.DoesNotContain("connection", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void ModeDependentBranchesAreCentralizedInTheCapabilityMapping()
+    {
+        var repositoryRoot = FindRepositoryRoot();
+        var sourceRoot = Path.Combine(repositoryRoot, "dcb", "src");
+        var mappingPath = Path.Combine(sourceRoot, "Sekiban.Dcb.MaterializedView", "MvModeCapabilities.cs");
+        var mapping = File.ReadAllText(mappingPath);
+
+        Assert.Contains("mode switch", mapping, StringComparison.Ordinal);
+        Assert.Contains("MvInitializationMode.CreateOrEnsure", mapping, StringComparison.Ordinal);
+        Assert.Contains("MvInitializationMode.VerifyOnly", mapping, StringComparison.Ordinal);
+        Assert.Contains("MvInitializationMode.VerifyAndExecute", mapping, StringComparison.Ordinal);
+
+        var boundaryFiles = new[]
+        {
+            Path.Combine(sourceRoot, "Sekiban.Dcb.MaterializedView", "MvExecutorBase.cs"),
+            Path.Combine(sourceRoot, "Sekiban.Dcb.MaterializedView", "MvGenerationCoordinator.cs"),
+            Path.Combine(sourceRoot, "Sekiban.Dcb.MaterializedView", "MvCatchUpWorker.cs"),
+            Path.Combine(sourceRoot, "Sekiban.Dcb.MaterializedView.Orleans", "MaterializedViewGrain.cs")
+        };
+        Assert.All(boundaryFiles, path => Assert.Contains("MvModeCapabilities", File.ReadAllText(path), StringComparison.Ordinal));
+
+        var modeSources = Directory.EnumerateFiles(sourceRoot, "*.cs", SearchOption.AllDirectories)
+            .Where(path => Path.GetFileName(path) != "MvModeCapabilities.cs")
+            .Where(path => Path.GetDirectoryName(path)!.Contains("Sekiban.Dcb.MaterializedView", StringComparison.Ordinal))
+            .ToList();
+        Assert.All(modeSources, path =>
+        {
+            var source = File.ReadAllText(path);
+            Assert.DoesNotContain("IsVerifyOnly", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("InitializationMode == MvInitializationMode", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("InitializationMode != MvInitializationMode", source, StringComparison.Ordinal);
+        });
+    }
+
+    [Fact]
     public async Task SqlServerVerifyOnlyFailsClosedWithoutAnExplicitInspectionPrincipal()
     {
         var catalogCommands = new List<string>();
@@ -234,5 +291,21 @@ public sealed class MvInitializationCompatibilityTests
             string sortableUniqueId,
             CancellationToken ct) =>
             Task.FromResult<IReadOnlyList<MvSqlStatementDto>>([]);
+    }
+
+    private static string FindRepositoryRoot()
+    {
+        foreach (var start in new[] { Directory.GetCurrentDirectory(), AppContext.BaseDirectory })
+        {
+            for (var candidate = new DirectoryInfo(start); candidate is not null; candidate = candidate.Parent)
+            {
+                if (File.Exists(Path.Combine(candidate.FullName, "Sekiban.slnx")))
+                {
+                    return candidate.FullName;
+                }
+            }
+        }
+
+        throw new DirectoryNotFoundException("Could not locate the Sekiban repository root for the capability architecture assertion.");
     }
 }

--- a/docs/dcb_llm/13_common_issues.md
+++ b/docs/dcb_llm/13_common_issues.md
@@ -554,3 +554,21 @@ Wait metrics use bounded `surface`, `mode`, and `outcome` labels only; target ID
 acceptance tests inject a `TimeProvider` and delay seam, so 5-second, 30-second, and 200-ms behavior is deterministic
 and uses no real sleeps. Existing consumers compiled against the published 10.14.0 packages are also executed against
 the current binaries without recompilation to guard the public constructor and wire compatibility boundary.
+
+## Materialized-view verified execution and honest refusals — dcb-v10.15.0 (SEK-G34)
+
+`VerifyOnly` is now an observation-only mode with honest command results: event apply, catch-up (including an empty
+batch), checkpoint capture, lifecycle promotion, and public refresh fail with the secret-free typed
+`MvTransitionNotAllowedException`; activation and forced reverse return
+`MvActivationFailureReason.TransitionNotAllowed`. A zero result in this mode is no longer a plausible success value.
+
+Hosts that provision schema separately and need a worker to execute use the additive
+`MvInitializationMode.VerifyAndExecute = 2`. It verifies the existing schema and registry bindings, never performs
+DDL/ensure/seed work, and permits projector and lifecycle DML only with an explicit non-allow-all
+`MvSqlStatementPolicyMode.Enforced` policy. The full event batch is authorized before its first DML or registry
+command. A real PostgreSQL DDL-denied-role proof covers allow, reject, checkpoint/active-pointer atomicity, and the
+no-post-authorization-execution boundary.
+
+**Migration note.** Existing `CreateOrEnsure`, public CLR signatures, and enum values 0/1 remain compatible. Move only
+deliberate pre-provisioned execution hosts to `VerifyAndExecute`, provide an enforced policy, and grant their runtime
+role DML rather than DDL. A 10.14.1-built binary consumer and an additions-only public API comparison run in CI.

--- a/docs/dcb_llm/20_materialized_view.md
+++ b/docs/dcb_llm/20_materialized_view.md
@@ -263,10 +263,12 @@ the projector tables, including the registry binding rows. A missing or incompat
 never seeded automatically. The zero-DDL guarantee covers Sekiban-owned connections; arbitrary user/projector code is
 outside that process boundary.
 
-Verify-only remains isolated after the schema gate succeeds. Target-checkpoint capture, empty-history catch-up, status
-refresh, activation, and event-apply paths cannot call a mutating registry API; registry writes are not a success-path
-fallback. The executor and Orleans grain also avoid normal projector initialization, subscriptions, refresh timers, and
-write-oriented registry connections in this mode. The dedicated inspector owns its read-only route: SQLite opens with
+Verify-only remains isolated after the schema gate succeeds. Target-checkpoint capture, empty-history catch-up, public
+refresh, and event-apply are mutating commands and fail at their public boundary with the secret-free typed
+`MvTransitionNotAllowedException`; activation and forced reverse return
+`MvActivationFailureReason.TransitionNotAllowed`. Observations remain legal reads. Registry writes are not a
+success-path fallback. The executor and Orleans grain also avoid normal projector initialization, subscriptions,
+refresh timers, and write-oriented registry connections in this mode. The dedicated inspector owns its read-only route: SQLite opens with
 `Mode=ReadOnly`, PostgreSQL uses `default_transaction_read_only=on`, MySQL starts a read-only transaction session, and
 SQL Server uses an explicit inspection principal. Registry entries, the active pointer, and catalog metadata are read
 through that inspector only. SQL Server does not use `ApplicationIntent=ReadOnly` as an enforcement mechanism on a
@@ -277,6 +279,43 @@ fails with a typed `UnsupportedProviderCapability` failure before catalog inspec
 cannot be established. The provider catalog allowlist is read-only; SQLite metadata uses table-valued PRAGMA catalog
 functions rather than mutating PRAGMA statements, and derives declared lengths/precision/scale and generated
 expressions where SQLite exposes them.
+
+### VerifyAndExecute (pre-provisioned execution)
+
+`VerifyAndExecute = 2` is the mode for a host that owns schema deployment but wants the normal materialized-view
+lifecycle to execute against that already-provisioned database. It performs the same declarative schema verification as
+`VerifyOnly`, but it never creates/ensures infrastructure or seeds registry bindings. It then permits projector DML,
+checkpoint/status updates, and the active-pointer CAS only through an explicit enforced policy:
+
+```csharp
+builder.Services.AddSekibanDcbMaterializedView(options =>
+{
+    options.InitializationMode = MvInitializationMode.VerifyAndExecute;
+    options.SqlStatementPolicyMode = MvSqlStatementPolicyMode.Enforced;
+    options.SqlStatementPolicy = MyHostSqlPolicy.Instance;
+});
+```
+
+An absent policy, `Legacy` policy mode, or the compatibility allow-all policy produces the typed
+`MvVerifiedExecutionConfigurationException` before a store, source, connection, or projector is touched. Unknown
+numeric mode values also fail closed before work starts. The mode matrix is intentionally small:
+
+| Mode | Verify schema | Ensure / DDL / registry seed | Projector DML | Lifecycle DML |
+| --- | --- | --- | --- | --- |
+| `CreateOrEnsure` (0) | no | yes | yes | yes |
+| `VerifyOnly` (1) | yes | no | typed refusal | typed refusal |
+| `VerifyAndExecute` (2) | yes | no | yes, `Enforced` + explicit policy | yes, `Enforced` + explicit policy |
+
+For PostgreSQL, provision objects with an owner/migration role and grant the runtime role only the required DML and
+catalog visibility; do not grant schema creation or object ownership. A typical deployment grants `USAGE` on the
+schema plus `SELECT`, `INSERT`, `UPDATE`, and `DELETE` on the named MV and framework-registry tables (and sequence
+usage where applicable), while `CREATE`, `ALTER`, and `DROP` remain denied. The integration proof uses such a real
+PostgreSQL role and negative controls for all three DDL verbs. No connection strings, passwords, SQL values, or other
+secrets are emitted as evidence.
+
+In mode 2, the executor collects and authorizes the whole apply batch before its first projector DML or registry
+command. A policy rejection therefore leaves view rows, registry checkpoint/status, and the active pointer unchanged;
+a deny test is expected to become red if a future implementation executes before authorization.
 
 Projectors that support verify-only initialization describe their target schema with the additive, format-versioned
 `MvSchemaContract`/`IMvSchemaRequirementsProvider` contract (format version `1`):
@@ -309,7 +348,7 @@ unsupported metadata capability throws the typed `MvInitializationException` wit
 `MvInitializationFailureReason`. These failures happen before event reads, view writes, registry mutation, catch-up,
 or activation. A host that has not opted into the schema contract therefore fails closed in verify-only mode.
 
-The compatibility proof includes a binary consumer restored against the published `10.13.0` package and then run
+The compatibility proof includes a binary consumer restored against the published `10.14.1` package and then run
 without recompilation against the branch assembly; see
 [`Sekiban.Dcb.MaterializedView.BinaryConsumer`](../../dcb/tests/Sekiban.Dcb.MaterializedView.BinaryConsumer/README.md).
 
@@ -347,13 +386,21 @@ options.SqlStatementPolicyMode = MvSqlStatementPolicyMode.Enforced;
 
 Enforced mode wraps `QueryRowsAsync`, `QuerySingleOrDefaultAsync`, and `ExecuteScalarJsonAsync` before the provider
 port, removes raw connection/transaction exposure, and preflights every statement in an initialization or apply batch
-before the first statement executes. Missing policy, policy faults, invalid decisions, and denials fail closed with
+before the first statement executes. `VerifyAndExecute` additionally makes this an all-or-nothing whole-event-batch
+boundary. Missing policy, policy faults, invalid decisions, and denials fail closed with
 typed reasons; cancellation remains `OperationCanceledException`. SQL is treated as opaque text by the runtime, so a
 host allowlist must reject mutating CTEs, comments, or multi-statement text according to its own policy.
 
 The hosted worker uses the same central initialization gate. In verify-only mode it publishes a faulted verification
-status, waits for the configured retry interval, and remains stopped until a later verification succeeds; it never
-falls back to ensure mode.
+status and waits for the configured retry interval until verification succeeds; after success it stops instead of
+silently entering a mutating catch-up lifecycle. It never falls back to ensure mode.
+
+### dcb-v10.15.0 migration note
+
+`VerifyOnly` command calls that previously appeared to succeed with zero work now fail typed. Hosts that need a
+pre-provisioned worker to execute must deliberately move to `VerifyAndExecute`, supply an enforced non-allow-all
+policy, and grant only DML to its database role. Existing `CreateOrEnsure`, existing CLR method signatures, and enum
+values 0/1 remain unchanged.
 
 The package default remains `CreateOrEnsure` plus `Legacy` and `MvAllowAllSqlStatementPolicy`, preserving existing
 callers that do not opt into the new boundary.

--- a/docs/dcb_llm_ja/13_common_issues.md
+++ b/docs/dcb_llm_ja/13_common_issues.md
@@ -510,3 +510,20 @@ wait metric の label は bounded な `surface`、`mode`、`outcome` だけで�
 `TimeProvider` と delay seam を注入するため、5秒・30秒・200ms の timing を real sleep なしで決定的に検証できます。さらに、公開された
 10.14.0 package に対してコンパイル済みの2つの consumer を current binary に差し替えて再コンパイルなしで実行し、公開 constructor と
 wire compatibility の境界を確認します。
+
+## materialized-view の verified execution と正直な拒否 — dcb-v10.15.0 (SEK-G34)
+
+`VerifyOnly` は observation-only mode になり、command の結果も正直になります。event apply、catch-up（empty batch を含む）、
+checkpoint capture、lifecycle promotion、public refresh は secret-free な型付き
+`MvTransitionNotAllowedException` で拒否されます。activation と forced reverse は
+`MvActivationFailureReason.TransitionNotAllowed` を返します。この mode の zero result は、もっともらしい成功値ではありません。
+
+schema を別に provision し worker を実行したい host は、追加された
+`MvInitializationMode.VerifyAndExecute = 2` を使用します。既存の schema と registry binding を verify し、DDL / ensure / seed は
+行いません。明示的な non-allow-all の `MvSqlStatementPolicyMode.Enforced` policy がある場合だけ projector と lifecycle の DML を
+許可します。最初の DML / registry command より前に event batch 全体を authorize します。実 PostgreSQL の DDL-denied-role proof は
+allow、reject、checkpoint/active-pointer の atomicity、および authorization 後の実行がないことを確認します。
+
+**移行メモ。** 既存の `CreateOrEnsure`、公開 CLR signature、enum value 0/1 は互換のままです。意図的に事前プロビジョニング済みの
+execution host だけを `VerifyAndExecute` へ移し、Enforced policy と DDL ではなく DML を付与した runtime role を設定してください。
+10.14.1 で build した binary consumer と additions-only の public API 比較も CI で実行します。

--- a/docs/dcb_llm_ja/20_materialized_view.md
+++ b/docs/dcb_llm_ja/20_materialized_view.md
@@ -265,8 +265,11 @@ provider の専用 `IMvReadOnlyMvInspector` で catalog と registry を読む�
 binding row まで用意します。binding の不足や不一致は型付きエラーで停止し、自動 seed は行いません。zero-DDL の保証は
 Sekiban が所有する接続の境界に限られ、任意の user/projector code はこのプロセス境界の外です。
 
-VerifyOnly は schema gate 成功後も隔離されたままです。target checkpoint の capture、空履歴の catch-up、status refresh、
-activation、event apply の各経路から registry の mutating API へ到達せず、成功後の fallback write もありません。
+VerifyOnly は schema gate 成功後も隔離されたままです。target checkpoint の capture、空履歴の catch-up、public refresh、
+event apply は mutating command なので、public boundary で secret-free な型付き
+`MvTransitionNotAllowedException` として拒否されます。activation と forced reverse は
+`MvActivationFailureReason.TransitionNotAllowed` を返します。observation は正当な read のままです。registry の mutating API
+へ到達せず、成功後の fallback write もありません。
 executor と Orleans Grain は、この mode では通常の projector 初期化、subscription、refresh timer、書込み用 registry 接続を開始しません。
 専用 inspector 自身が read-only 経路を選びます。SQLite は `Mode=ReadOnly`、PostgreSQL は
 `default_transaction_read_only=on`、MySQL は read-only transaction session を使用します。SQL Server は専用の
@@ -277,6 +280,41 @@ inspection principal を使用し、standalone instance で `ApplicationIntent=R
 `UnsupportedProviderCapability` の型付き failure で停止します。registry entry、active pointer、catalog metadata は inspector
 経由だけで読み取り、provider の catalog allowlist は read-only です。SQLite の metadata は書込みを伴う PRAGMA ではなく
 table-valued PRAGMA catalog function を使い、取得可能な declared length、precision/scale、generated expression を導出します。
+
+### VerifyAndExecute（事前プロビジョニング済み実行）
+
+`VerifyAndExecute = 2` は、schema deployment を host が所有しつつ、事前に用意した database に対して通常の
+materialized-view lifecycle を実行する mode です。`VerifyOnly` と同じ declarative schema verification を行いますが、
+infrastructure の ensure、DDL、registry binding の seed は行いません。projector DML、checkpoint/status 更新、
+active-pointer CAS は明示的な Enforced policy がある場合だけ許可されます。
+
+```csharp
+builder.Services.AddSekibanDcbMaterializedView(options =>
+{
+    options.InitializationMode = MvInitializationMode.VerifyAndExecute;
+    options.SqlStatementPolicyMode = MvSqlStatementPolicyMode.Enforced;
+    options.SqlStatementPolicy = MyHostSqlPolicy.Instance;
+});
+```
+
+policy の未設定、`Legacy` policy mode、互換 allow-all policy は、store/source/connection/projector より前に型付き
+`MvVerifiedExecutionConfigurationException` になります。未知の numeric mode も作業前に fail-closed です。
+
+| Mode | schema verify | ensure / DDL / registry seed | projector DML | lifecycle DML |
+| --- | --- | --- | --- | --- |
+| `CreateOrEnsure` (0) | なし | 可 | 可 | 可 |
+| `VerifyOnly` (1) | あり | 不可 | 型付き拒否 | 型付き拒否 |
+| `VerifyAndExecute` (2) | あり | 不可 | `Enforced` + 明示 policy 時のみ可 | `Enforced` + 明示 policy 時のみ可 |
+
+PostgreSQL では object を owner/migration role で provision し、runtime role には必要な DML と catalog visibility
+だけを grant します。schema の CREATE と object ownership は grant しません。通常は schema の `USAGE` と、MV および
+framework registry table への `SELECT` / `INSERT` / `UPDATE` / `DELETE`（必要なら sequence usage）だけを付与し、
+`CREATE` / `ALTER` / `DROP` は拒否します。integration proof は実際にこの DDL-denied role を使い、3 つの DDL verb の
+negative control も確認します。evidence には connection string、password、SQL value などの secret を出力しません。
+
+mode 2 は最初の projector DML / registry command より前に apply batch 全体を collect して authorize します。policy deny の
+場合は view row、registry checkpoint/status、active pointer が変わりません。将来の実装が authorization より先に実行すると、
+この deny test は red になります。
 
 verify-only に対応する projector は、format version `1` の追加された `MvSchemaContract` /
 `IMvSchemaRequirementsProvider` 契約で target schema を宣言します。
@@ -308,7 +346,7 @@ table / column の不足、type・nullability・key・metadata の不一致、sc
 これらは event read、view write、registry mutation、catch-up、activation より前に発生します。そのため schema contract
 を実装していない host も verify-only では fail-closed になります。
 
-互換性の proof には公開済み `10.13.0` package を参照して restore / build した binary consumer を含めています。
+互換性の proof には公開済み `10.14.1` package を参照して restore / build した binary consumer を含めています。
 branch の assembly を出力先へ差し替えた後、再コンパイルなしで実行します。詳細は
 [`Sekiban.Dcb.MaterializedView.BinaryConsumer`](../../dcb/tests/Sekiban.Dcb.MaterializedView.BinaryConsumer/README.md) を参照してください。
 
@@ -346,12 +384,18 @@ options.SqlStatementPolicyMode = MvSqlStatementPolicyMode.Enforced;
 
 Enforced mode は `QueryRowsAsync`、`QuerySingleOrDefaultAsync`、`ExecuteScalarJsonAsync` の provider port の前で policy を
 評価し、raw connection / transaction を projector に公開しません。initialization / apply batch は最初の SQL を実行する前に
-全 statement を preflight します。policy の未登録、fault、invalid decision、deny は typed reason 付きで fail-closed し、
+全 statement を preflight します。`VerifyAndExecute` では event batch 全体の all-or-nothing boundary も追加されます。policy の未登録、fault、invalid decision、deny は typed reason 付きで fail-closed し、
 cancellation は `OperationCanceledException` のままです。runtime は SQL の先頭 keyword で判断しないため、mutating CTE、comment、
 multi-statement text の許可可否は host の allowlist が決めます。
 
 hosted worker も同じ中央 initialization gate を使います。verify-only では verification failure を faulted status として公開し、
-retry interval 後に再試行します。成功するまで worker は停止し、ensure mode へ fallback しません。
+retry interval 後に再試行します。verification 成功後は mutating catch-up lifecycle に入らず停止します。ensure mode へ fallback しません。
+
+### dcb-v10.15.0 migration note
+
+以前に zero work で成功したように見えた `VerifyOnly` の command call は、型付き failure になります。事前プロビジョニング済み
+worker を実行したい host は、意図的に `VerifyAndExecute` へ移行し、Enforced の non-allow-all policy と DML 限定の
+database role を設定してください。既存の `CreateOrEnsure`、CLR method signature、enum value 0/1 は変更しません。
 
 package の既定値は `CreateOrEnsure`、`Legacy`、`MvAllowAllSqlStatementPolicy` のままであり、新しい境界を選ばない既存 caller の
 動作を維持します。


### PR DESCRIPTION
## Summary

- Implements the frozen SEK-G34 three-mode capability mapping and typed VerifyOnly command refusals.
- Solves #1130 silent-zero behavior: forbidden VerifyOnly commands fail typed before store or host work.
- Solves #1129 verified-execution: mode 2 verifies pre-provisioned schema, then runs policy-authorized DML with a real PostgreSQL DDL-denied-role proof.

## Verification

- Real PostgreSQL DDL-denied-role allow/reject proof; reject snapshots preserve rows, registry, status, and active pointer.
- 10.14.1 binary consumer runs without rebuild; additions-only API verifier and current mode-2 consumer are wired into CI.

Closes #1131
Closes #1130
Closes #1129