### PR TITLE
SEK-G35: recover projection status heartbeats

### DIFF
--- a/dcb/src/Sekiban.Dcb.Core/Actors/IProjectionStatusReader.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Actors/IProjectionStatusReader.cs
@@ -36,6 +36,17 @@ public interface ISerializedProjectionStatusReader
         ProjectionStatusReadRequest? request = null,
         CancellationToken cancellationToken = default);
 
+    /// <summary>
+    ///     Optional V2 serialized observation surface. Existing implementers remain binary compatible; implementations
+    ///     that do not support V2 report a typed unsupported-version error rather than changing V1 behavior.
+    /// </summary>
+    Task<ResultBox<byte[]>> ReadSerializedV2Async(
+        ProjectionStatusReadRequest? request = null,
+        CancellationToken cancellationToken = default) =>
+        Task.FromResult(ResultBox.Error<byte[]>(
+            new UnsupportedSerializedProjectionStatusVersionException(
+                SerializedProjectionStatusEnvelopeV2.CurrentVersion)));
+
     Task<ResultBox<byte[]>> GetSerializedSnapshotsAsync(
         ProjectionStatusReadRequest? request = null,
         CancellationToken cancellationToken = default) =>

--- a/dcb/src/Sekiban.Dcb.Core/Actors/ProjectionStatusReader.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Actors/ProjectionStatusReader.cs
@@ -62,9 +62,12 @@ public sealed class ProjectionStatusReader : IProjectionStatusReader
                     new UnauthorizedAccessException("Projection status ServiceId is owned by the server."));
             }
 
+            var expectedProjectorVersion = string.IsNullOrWhiteSpace(request?.ExpectedProjectorVersion)
+                ? null
+                : request!.ExpectedProjectorVersion;
             var rowsResult = await _statusStore.ListAsync(
                 request?.ProjectorName,
-                request?.ProjectorVersion,
+                expectedProjectorVersion is null ? request?.ProjectorVersion : null,
                 cancellationToken).ConfigureAwait(false);
             if (!rowsResult.IsSuccess)
             {
@@ -173,6 +176,11 @@ public sealed class ProjectionStatusReader : IProjectionStatusReader
                         IsFaulted = faulted,
                         FaultMessage = row.FaultMessage,
                         IsFresh = rowFresh,
+                        ExpectedProjectorVersion = expectedProjectorVersion,
+                        VersionDisposition = ResolveVersionDisposition(
+                            expectedProjectorVersion,
+                            row.ProjectorVersion,
+                            rowFresh),
                         SwitchKind = row.SwitchKind,
                         SwitchReason = row.SwitchReason,
                         SwitchedAtUtc = row.SwitchedAtUtc
@@ -194,6 +202,22 @@ public sealed class ProjectionStatusReader : IProjectionStatusReader
         {
             return ResultBox.Error<IReadOnlyList<ProjectionStatusSnapshot>>(ex);
         }
+    }
+
+    private static ProjectionStatusVersionDisposition ResolveVersionDisposition(
+        string? expectedProjectorVersion,
+        string observedProjectorVersion,
+        bool rowFresh)
+    {
+        if (!rowFresh)
+        {
+            return ProjectionStatusVersionDisposition.StaleOrOrphan;
+        }
+
+        return expectedProjectorVersion is not null &&
+               !string.Equals(expectedProjectorVersion, observedProjectorVersion, StringComparison.Ordinal)
+            ? ProjectionStatusVersionDisposition.VersionMismatch
+            : ProjectionStatusVersionDisposition.Current;
     }
 }
 
@@ -241,7 +265,8 @@ public sealed class SerializedProjectionStatusReader : ISerializedProjectionStat
         }
 
         var version = discriminator.GetValue();
-        if (version != SerializedProjectionStatusRequestEnvelopeV1.CurrentVersion)
+        if (version != SerializedProjectionStatusRequestEnvelopeV1.CurrentVersion &&
+            version != SerializedProjectionStatusRequestEnvelopeV2.CurrentVersion)
         {
             return ResultBox.Error<byte[]>(
                 new UnsupportedSerializedProjectionStatusVersionException(version));
@@ -249,18 +274,32 @@ public sealed class SerializedProjectionStatusReader : ISerializedProjectionStat
 
         try
         {
-            // Phase 2: bind only the already-discriminated V1 shape. Unknown fields, wrong-typed filters, and null
-            // roots are shape errors, never version errors.
-            var envelope = JsonSerializer.Deserialize<SerializedProjectionStatusRequestEnvelopeV1>(
+            if (version == SerializedProjectionStatusRequestEnvelopeV1.CurrentVersion)
+            {
+                // Phase 2: bind only the already-discriminated V1 shape. Unknown fields, wrong-typed filters, and null
+                // roots are shape errors, never version errors. This branch intentionally retains the frozen V1 path.
+                var envelope = JsonSerializer.Deserialize<SerializedProjectionStatusRequestEnvelopeV1>(
+                    utf8Json.Span,
+                    RequestJsonOptions);
+                if (envelope is null)
+                {
+                    return ResultBox.Error<byte[]>(
+                        new SerializedProjectionStatusShapeException("Projection status request envelope is null."));
+                }
+
+                return await ReadSerializedAsync(envelope.ToRequest(), cancellationToken).ConfigureAwait(false);
+            }
+
+            var v2Envelope = JsonSerializer.Deserialize<SerializedProjectionStatusRequestEnvelopeV2>(
                 utf8Json.Span,
                 RequestJsonOptions);
-            if (envelope is null)
+            if (v2Envelope is null)
             {
                 return ResultBox.Error<byte[]>(
                     new SerializedProjectionStatusShapeException("Projection status request envelope is null."));
             }
 
-            return await ReadSerializedAsync(envelope.ToRequest(), cancellationToken).ConfigureAwait(false);
+            return await ReadSerializedV2Async(v2Envelope.ToRequest(), cancellationToken).ConfigureAwait(false);
         }
         catch (JsonException ex)
         {
@@ -290,10 +329,36 @@ public sealed class SerializedProjectionStatusReader : ISerializedProjectionStat
         return ResultBox.FromValue(JsonSerializer.SerializeToUtf8Bytes(envelope, JsonOptions));
     }
 
+    /// <summary>
+    ///     Serializes V2 status observations. V1 remains frozen; V2 is the opt-in surface that includes expected versus
+    ///     observed projector versions and the stale/orphan classification for every row.
+    /// </summary>
+    public async Task<ResultBox<byte[]>> ReadSerializedV2Async(
+        ProjectionStatusReadRequest? request = null,
+        CancellationToken cancellationToken = default)
+    {
+        var result = await _reader.ReadAsync(request, cancellationToken).ConfigureAwait(false);
+        if (!result.IsSuccess)
+        {
+            return ResultBox.Error<byte[]>(result.GetException());
+        }
+
+        var envelope = SerializedProjectionStatusEnvelopeV2.Create(
+            _serviceIdProvider.GetCurrentServiceId(),
+            result.GetValue());
+        return ResultBox.FromValue(JsonSerializer.SerializeToUtf8Bytes(envelope, JsonOptions));
+    }
+
     /// <summary>Serializes the canonical V1 request vector used by endpoints and wire-contract tests.</summary>
     public static byte[] SerializeRequest(ProjectionStatusReadRequest? request = null) =>
         JsonSerializer.SerializeToUtf8Bytes(
             SerializedProjectionStatusRequestEnvelopeV1.Create(request),
+            RequestJsonOptions);
+
+    /// <summary>Serializes a V2 request with its optional expected-version observation.</summary>
+    public static byte[] SerializeRequestV2(ProjectionStatusReadRequest? request = null) =>
+        JsonSerializer.SerializeToUtf8Bytes(
+            SerializedProjectionStatusRequestEnvelopeV2.Create(request),
             RequestJsonOptions);
 
     public static ResultBox<SerializedProjectionStatusEnvelopeV1> Deserialize(ReadOnlySpan<byte> payload)
@@ -348,6 +413,64 @@ public sealed class SerializedProjectionStatusReader : ISerializedProjectionStat
         catch (Exception ex) when (ex is InvalidOperationException or NotSupportedException or OverflowException)
         {
             return ResultBox.Error<SerializedProjectionStatusEnvelopeV1>(
+                new SerializedProjectionStatusShapeException(ex.Message));
+        }
+    }
+
+    /// <summary>Strictly deserializes a V2 status envelope without changing the frozen V1 parser.</summary>
+    public static ResultBox<SerializedProjectionStatusEnvelopeV2> DeserializeV2(ReadOnlySpan<byte> payload)
+    {
+        try
+        {
+            using var document = JsonDocument.Parse(payload.ToArray());
+            if (document.RootElement.ValueKind != JsonValueKind.Object)
+            {
+                return ResultBox.Error<SerializedProjectionStatusEnvelopeV2>(
+                    new SerializedProjectionStatusShapeException("Projection status envelope root must be an object."));
+            }
+
+            var versionResult = ReadVersion(document.RootElement);
+            if (!versionResult.IsSuccess)
+            {
+                return ResultBox.Error<SerializedProjectionStatusEnvelopeV2>(versionResult.GetException());
+            }
+
+            var version = versionResult.GetValue();
+            if (version != SerializedProjectionStatusEnvelopeV2.CurrentVersion)
+            {
+                return ResultBox.Error<SerializedProjectionStatusEnvelopeV2>(
+                    new UnsupportedSerializedProjectionStatusVersionException(version));
+            }
+
+            var envelope = JsonSerializer.Deserialize<SerializedProjectionStatusEnvelopeV2>(payload, JsonOptions);
+            if (envelope is null || string.IsNullOrWhiteSpace(envelope.ServiceId) || envelope.Snapshots is null ||
+                envelope.Snapshots.Any(snapshot => snapshot is null || snapshot.Snapshot is null ||
+                    string.IsNullOrWhiteSpace(snapshot.Snapshot.ProjectorName) ||
+                    string.IsNullOrWhiteSpace(snapshot.Snapshot.ProjectorVersion) ||
+                    string.IsNullOrWhiteSpace(snapshot.Snapshot.ClusterId) ||
+                    string.IsNullOrWhiteSpace(snapshot.Snapshot.ActivationId) ||
+                    string.IsNullOrWhiteSpace(snapshot.Snapshot.Consistency) ||
+                    string.IsNullOrWhiteSpace(snapshot.ObservedProjectorVersion) ||
+                    !Enum.IsDefined(typeof(ProjectionStatusVersionDisposition), snapshot.VersionDisposition)))
+            {
+                return ResultBox.Error<SerializedProjectionStatusEnvelopeV2>(
+                    new SerializedProjectionStatusShapeException("Projection status envelope has an invalid V2 shape."));
+            }
+
+            return ResultBox.FromValue(envelope);
+        }
+        catch (UnsupportedSerializedProjectionStatusVersionException ex)
+        {
+            return ResultBox.Error<SerializedProjectionStatusEnvelopeV2>(ex);
+        }
+        catch (JsonException ex)
+        {
+            return ResultBox.Error<SerializedProjectionStatusEnvelopeV2>(
+                new SerializedProjectionStatusShapeException(ex.Message));
+        }
+        catch (Exception ex) when (ex is InvalidOperationException or NotSupportedException or OverflowException)
+        {
+            return ResultBox.Error<SerializedProjectionStatusEnvelopeV2>(
                 new SerializedProjectionStatusShapeException(ex.Message));
         }
     }

--- a/dcb/src/Sekiban.Dcb.Core/InMemory/InMemoryMultiProjectionStateStore.cs
+++ b/dcb/src/Sekiban.Dcb.Core/InMemory/InMemoryMultiProjectionStateStore.cs
@@ -112,8 +112,12 @@ public class InMemoryMultiProjectionStateStore :
             {
                 return Task.FromResult(ResultBox.FromValue(
                     ProjectionStatusWriteResult.Rejected(
+                        heartbeat,
+                        expectedSequence,
                         current,
-                        $"Heartbeat CAS rejected: expected sequence {expectedSequence}, current sequence {currentSequence}.")));
+                        current is null && expectedSequence > 0
+                            ? ProjectionStatusConflictReason.RowAbsent
+                            : null)));
             }
 
             _statusRows[key] = heartbeat;

--- a/dcb/src/Sekiban.Dcb.Core/ProjectionStatus/ProjectionStatusModels.cs
+++ b/dcb/src/Sekiban.Dcb.Core/ProjectionStatus/ProjectionStatusModels.cs
@@ -61,6 +61,25 @@ public sealed record ProjectionStatusSnapshot(
     [JsonIgnore]
     public IReadOnlyList<string> ConflictActivations =>
         ConflictingActivationIds ?? Array.Empty<string>();
+
+    /// <summary>
+    ///     The projector version the caller expected to observe. It is intentionally excluded from V1 serialization;
+    ///     the V2 envelope carries it together with <see cref="VersionDisposition"/>.
+    /// </summary>
+    [JsonIgnore]
+    public string? ExpectedProjectorVersion { get; init; }
+
+    /// <summary>The version physically observed on this row. <see cref="ProjectorVersion"/> remains the V1 name.</summary>
+    [JsonIgnore]
+    public string ObservedProjectorVersion => ProjectorVersion;
+
+    /// <summary>Whether this row is current, a fresh different-version row, or stale/orphaned.</summary>
+    [JsonIgnore]
+    public ProjectionStatusVersionDisposition VersionDisposition { get; init; } = ProjectionStatusVersionDisposition.Current;
+
+    /// <summary>True when the row is no longer fresh and cannot be presented as the sole current row.</summary>
+    [JsonIgnore]
+    public bool IsStaleOrOrphan => VersionDisposition == ProjectionStatusVersionDisposition.StaleOrOrphan;
 }
 
 /// <summary>
@@ -188,6 +207,55 @@ public enum ProjectionStatusWriteOutcome
     Conflict = 1
 }
 
+/// <summary>Provider-neutral classification for a rejected projection-status compare-and-set write.</summary>
+public enum ProjectionStatusConflictReason
+{
+    RowAbsent = 0,
+    RowAlreadyExists = 1,
+    SequenceMismatch = 2,
+    ProviderPreconditionFailed = 3
+}
+
+/// <summary>
+///     Typed, secret-free diagnostics for a rejected projection-status write. The physical row identity is the
+///     service/projector/version/cluster tuple; ActivationId remains row data and is included only as observed data.
+/// </summary>
+public sealed record ProjectionStatusWriteConflict(
+    ProjectionStatusConflictReason Reason,
+    long ExpectedSequence,
+    long? ObservedSequence,
+    string ExpectedProjectorVersion,
+    string? ObservedProjectorVersion,
+    string ExpectedActivationId,
+    string? ObservedActivationId,
+    string? ProviderCondition = null)
+{
+    /// <summary>Compatibility text derived solely from the typed payload.</summary>
+    public string ToCompatibilityReason() => Reason switch
+    {
+        ProjectionStatusConflictReason.RowAbsent =>
+            $"Heartbeat CAS rejected: expected sequence {ExpectedSequence}, row is absent.",
+        ProjectionStatusConflictReason.RowAlreadyExists =>
+            $"Heartbeat CAS rejected: expected sequence {ExpectedSequence}, row already exists.",
+        ProjectionStatusConflictReason.SequenceMismatch => ObservedSequence.HasValue
+            ? $"Heartbeat CAS rejected: expected sequence {ExpectedSequence}, current sequence {ObservedSequence.Value}."
+            : $"Heartbeat CAS rejected: expected sequence {ExpectedSequence}, current sequence is unavailable.",
+        ProjectionStatusConflictReason.ProviderPreconditionFailed =>
+            "Heartbeat CAS rejected by provider precondition.",
+        _ => "Heartbeat CAS rejected."
+    };
+}
+
+/// <summary>
+///     The physical heartbeat identity pinned for one projection activation. It is captured from registered projector
+///     metadata and must never be rebuilt from mutable persisted projection state.
+/// </summary>
+public sealed record ProjectionStatusWriterIdentity(
+    string ServiceId,
+    string ProjectorName,
+    string ProjectorVersion,
+    string ClusterId);
+
 /// <summary>
 ///     Result of a heartbeat CAS.  A conflict is a normal stale-writer result and must be surfaced to the reader or
 ///     caller; it is never converted into an unconditional last-write-wins update.
@@ -200,11 +268,83 @@ public sealed record ProjectionStatusWriteResult(
     public bool Committed => Outcome == ProjectionStatusWriteOutcome.Committed;
     public bool Conflict => Outcome == ProjectionStatusWriteOutcome.Conflict;
 
+    /// <summary>
+    ///     Structured diagnostics for a rejected write. The legacy <see cref="ConflictReason"/> text remains for
+    ///     source and binary compatibility and is derived from this payload for new provider paths.
+    /// </summary>
+    public ProjectionStatusWriteConflict? ConflictDetails { get; init; }
+
+    /// <summary>Alias for callers that describe <see cref="ConflictDetails"/> as a payload.</summary>
+    [JsonIgnore]
+    public ProjectionStatusWriteConflict? ConflictPayload => ConflictDetails;
+
     public static ProjectionStatusWriteResult Success(ProjectionStatusHeartbeat row) =>
         new(ProjectionStatusWriteOutcome.Committed, row);
 
     public static ProjectionStatusWriteResult Rejected(ProjectionStatusHeartbeat? current, string reason) =>
         new(ProjectionStatusWriteOutcome.Conflict, current, reason);
+
+    /// <summary>
+    ///     Creates a provider-neutral rejection while retaining the established three-argument record constructor and
+    ///     string compatibility surface. Providers may force <paramref name="reason"/> when a native precondition
+    ///     failure is observed after a reread.
+    /// </summary>
+    public static ProjectionStatusWriteResult Rejected(
+        ProjectionStatusHeartbeat expected,
+        long expectedSequence,
+        ProjectionStatusHeartbeat? current,
+        ProjectionStatusConflictReason? reason = null,
+        string? providerCondition = null)
+    {
+        ArgumentNullException.ThrowIfNull(expected);
+        var resolvedReason = reason ?? Classify(expected, expectedSequence, current);
+        var details = new ProjectionStatusWriteConflict(
+            resolvedReason,
+            expectedSequence,
+            current?.Sequence,
+            expected.ProjectorVersion,
+            current?.ProjectorVersion,
+            expected.ActivationId,
+            current?.ActivationId,
+            providerCondition);
+        return new ProjectionStatusWriteResult(
+            ProjectionStatusWriteOutcome.Conflict,
+            current,
+            details.ToCompatibilityReason())
+        {
+            ConflictDetails = details
+        };
+    }
+
+    private static ProjectionStatusConflictReason Classify(
+        ProjectionStatusHeartbeat expected,
+        long expectedSequence,
+        ProjectionStatusHeartbeat? current)
+    {
+        if (current is null)
+        {
+            return expectedSequence > 0
+                ? ProjectionStatusConflictReason.RowAbsent
+                : ProjectionStatusConflictReason.ProviderPreconditionFailed;
+        }
+
+        if (expectedSequence == 0)
+        {
+            return ProjectionStatusConflictReason.RowAlreadyExists;
+        }
+
+        return current.Sequence != expectedSequence || expected.Sequence <= current.Sequence
+            ? ProjectionStatusConflictReason.SequenceMismatch
+            : ProjectionStatusConflictReason.ProviderPreconditionFailed;
+    }
+}
+
+/// <summary>How a passive reader classified a row relative to its expected version and freshness boundary.</summary>
+public enum ProjectionStatusVersionDisposition
+{
+    Current = 0,
+    VersionMismatch = 1,
+    StaleOrOrphan = 2
 }
 
 /// <summary>Configuration for the passive projection status registry and read-side sampling.</summary>
@@ -255,7 +395,15 @@ public class ProjectionStatusRegistryOptions : ProjectionStatusOptions
 public sealed record ProjectionStatusReadRequest(
     string? ServiceId = null,
     string? ProjectorName = null,
-    string? ProjectorVersion = null);
+    string? ProjectorVersion = null)
+{
+    /// <summary>
+    ///     Expected active version used for classification, not filtering. When supplied, the reader keeps rows from
+    ///     other versions visible so rolling deployments and expired orphans can be diagnosed rather than rejected.
+    /// </summary>
+    [JsonIgnore]
+    public string? ExpectedProjectorVersion { get; init; }
+}
 
 /// <summary>Version-one request envelope for the serialized passive status boundary.</summary>
 public sealed record SerializedProjectionStatusRequestEnvelopeV1(
@@ -289,6 +437,62 @@ public sealed record SerializedProjectionStatusEnvelopeV1(
         string serviceId,
         IReadOnlyList<ProjectionStatusSnapshot> snapshots) =>
         new(CurrentVersion, serviceId, snapshots);
+}
+
+/// <summary>Version-two request envelope that adds an expected-version observation without changing V1 vectors.</summary>
+public sealed record SerializedProjectionStatusRequestEnvelopeV2(
+    int Version,
+    string? ServiceId,
+    string? ProjectorName,
+    string? ProjectorVersion,
+    string? ExpectedProjectorVersion)
+{
+    public const int CurrentVersion = 2;
+
+    public static SerializedProjectionStatusRequestEnvelopeV2 Create(ProjectionStatusReadRequest? request) =>
+        new(
+            CurrentVersion,
+            request?.ServiceId,
+            request?.ProjectorName,
+            request?.ProjectorVersion,
+            request?.ExpectedProjectorVersion);
+
+    public ProjectionStatusReadRequest ToRequest() =>
+        new(ServiceId, ProjectorName, ProjectorVersion)
+        {
+            ExpectedProjectorVersion = ExpectedProjectorVersion
+        };
+}
+
+/// <summary>V2 wrapper for a V1-shaped snapshot plus explicit version-observation diagnostics.</summary>
+public sealed record SerializedProjectionStatusSnapshotV2(
+    ProjectionStatusSnapshot Snapshot,
+    string? ExpectedProjectorVersion,
+    string ObservedProjectorVersion,
+    ProjectionStatusVersionDisposition VersionDisposition,
+    bool IsStaleOrOrphan)
+{
+    public static SerializedProjectionStatusSnapshotV2 Create(ProjectionStatusSnapshot snapshot) =>
+        new(
+            snapshot,
+            snapshot.ExpectedProjectorVersion,
+            snapshot.ObservedProjectorVersion,
+            snapshot.VersionDisposition,
+            snapshot.IsStaleOrOrphan);
+}
+
+/// <summary>Version-two serialized passive status envelope with version-disposition diagnostics.</summary>
+public sealed record SerializedProjectionStatusEnvelopeV2(
+    int Version,
+    string ServiceId,
+    IReadOnlyList<SerializedProjectionStatusSnapshotV2> Snapshots)
+{
+    public const int CurrentVersion = 2;
+
+    public static SerializedProjectionStatusEnvelopeV2 Create(
+        string serviceId,
+        IReadOnlyList<ProjectionStatusSnapshot> snapshots) =>
+        new(CurrentVersion, serviceId, snapshots.Select(SerializedProjectionStatusSnapshotV2.Create).ToArray());
 }
 
 /// <summary>Typed errors used by the serialized status boundary before any store read is attempted.</summary>

--- a/dcb/src/Sekiban.Dcb.CosmosDb/CosmosProjectionStatusStore.cs
+++ b/dcb/src/Sekiban.Dcb.CosmosDb/CosmosProjectionStatusStore.cs
@@ -55,8 +55,9 @@ public partial class CosmosMultiProjectionStateStore
                 {
                     var current = await ReadStatusAsync(container, partitionValue, id, cancellationToken).ConfigureAwait(false);
                     return ResultBox.FromValue(ProjectionStatusWriteResult.Rejected(
-                        current,
-                        "Heartbeat CAS rejected: activation row already exists."));
+                        heartbeat,
+                        expectedSequence,
+                        current));
                 }
             }
 
@@ -64,16 +65,19 @@ public partial class CosmosMultiProjectionStateStore
             if (currentDoc is null)
             {
                 return ResultBox.FromValue(ProjectionStatusWriteResult.Rejected(
+                    heartbeat,
+                    expectedSequence,
                     null,
-                    $"Heartbeat CAS rejected: expected sequence {expectedSequence}, row is absent."));
+                    ProjectionStatusConflictReason.RowAbsent));
             }
 
             if (!string.Equals(currentDoc.DocumentType, ProjectionStatusDocumentType, StringComparison.Ordinal) ||
                 currentDoc.Sequence != expectedSequence || heartbeat.Sequence <= currentDoc.Sequence)
             {
                 return ResultBox.FromValue(ProjectionStatusWriteResult.Rejected(
-                    currentDoc.ToStatusHeartbeat(),
-                    $"Heartbeat CAS rejected: expected sequence {expectedSequence}, current sequence {currentDoc.Sequence}."));
+                    heartbeat,
+                    expectedSequence,
+                    currentDoc.ToStatusHeartbeat()));
             }
 
             doc.ETag = currentDoc.ETag;
@@ -91,8 +95,10 @@ public partial class CosmosMultiProjectionStateStore
             {
                 var current = await ReadStatusAsync(container, partitionValue, id, cancellationToken).ConfigureAwait(false);
                 return ResultBox.FromValue(ProjectionStatusWriteResult.Rejected(
+                    heartbeat,
+                    expectedSequence,
                     current,
-                    "Heartbeat CAS rejected by provider ETag."));
+                    providerCondition: "conditional-replace"));
             }
         }
         catch (Exception ex)

--- a/dcb/src/Sekiban.Dcb.DynamoDB/DynamoProjectionStatusStore.cs
+++ b/dcb/src/Sekiban.Dcb.DynamoDB/DynamoProjectionStatusStore.cs
@@ -94,8 +94,10 @@ public partial class DynamoMultiProjectionStateStore
                     heartbeat,
                     cancellationToken).ConfigureAwait(false);
                 return ResultBox.FromValue(ProjectionStatusWriteResult.Rejected(
+                    heartbeat,
+                    expectedSequence,
                     current?.ToStatusHeartbeat(),
-                    "The projection status heartbeat sequence was stale or the activation already exists."));
+                    providerCondition: "conditional-put"));
             }
         }
         catch (Exception ex)

--- a/dcb/src/Sekiban.Dcb.MaterializedView/MvProjectionStatusPublication.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView/MvProjectionStatusPublication.cs
@@ -253,9 +253,15 @@ public sealed class MvProjectionStatusPublisher
             return;
         }
 
-        // Rebase from the provider-observed token. The next dedicated tick can replace an older process activation,
-        // while that older writer is fenced because its expected sequence is then stale.
-        if (write.Current is { } current && current.Sequence > fence.Sequence)
+        // A missing row after an update attempt is a rebase, not an implicit same-operation create. Keep the physical
+        // identity and reset only this local fence; the next publication remains provider-conditional expected=0.
+        if (write.ConflictDetails?.Reason == ProjectionStatusConflictReason.RowAbsent && expected > 0)
+        {
+            fence.Sequence = 0;
+        }
+        // Otherwise adopt the provider-observed fence exactly. This covers an existing-row create race, a stale writer,
+        // and provider precondition failures without turning any path into a last-write-wins overwrite.
+        else if (write.Current is { } current)
         {
             fence.Sequence = current.Sequence;
         }

--- a/dcb/src/Sekiban.Dcb.Orleans.Core/Grains/MultiProjectionGrain.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.Core/Grains/MultiProjectionGrain.cs
@@ -74,6 +74,7 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
     private readonly IProjectionStatusStore? _projectionStatusStore;
     private readonly ProjectionStatusOptions _projectionStatusOptions;
     private readonly string _activationId = Guid.CreateVersion7().ToString("N");
+    private ProjectionStatusWriterIdentity? _projectionStatusWriterIdentity;
     private long _projectionStatusSequence;
     private int _projectionStatusDirty = 1;
     private int _projectionStatusWriteInProgress;
@@ -2193,7 +2194,8 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
                 mergedOptions,
                 _logger);
 
-            var projectorVersion = _host.GetProjectorVersion();
+            CaptureProjectionStatusWriterIdentity(projectorName);
+            var projectorVersion = _projectionStatusWriterIdentity!.ProjectorVersion;
             bool restoredFromExternalStore = false;
 
             // SEK-G18 #6: a durable RebuildRequired marker means the persisted/external checkpoint may be the stale
@@ -2724,7 +2726,54 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
         _catchUpProgress = new CatchUpProgress { IsActive = false };
 
         _host = _actorHostFactory.Create(GetProjectorName(), _mergedActorOptions ?? DefaultActorOptions, _logger);
+        VerifyPinnedProjectionStatusWriterIdentityAfterHostRecreation();
         _firstQueryGate.Arm();
+    }
+
+    private void CaptureProjectionStatusWriterIdentity(string projectorName)
+    {
+        var host = _host ?? throw new InvalidOperationException("Projection status identity requires an actor host.");
+        var identity = new ProjectionStatusWriterIdentity(
+            _serviceId,
+            projectorName,
+            host.GetProjectorVersion(),
+            string.IsNullOrWhiteSpace(_projectionStatusOptions.ClusterId)
+                ? ProjectionStatusOptions.DefaultClusterId
+                : _projectionStatusOptions.ClusterId);
+
+        if (_projectionStatusWriterIdentity is null)
+        {
+            _projectionStatusWriterIdentity = identity;
+            return;
+        }
+
+        if (!Equals(_projectionStatusWriterIdentity, identity))
+        {
+            _logger.LogWarning(
+                "Projection status writer identity was already pinned; retaining {PinnedProjectorVersion} instead of {ObservedProjectorVersion}: {ProjectorName}",
+                _projectionStatusWriterIdentity.ProjectorVersion,
+                identity.ProjectorVersion,
+                projectorName);
+        }
+    }
+
+    private void VerifyPinnedProjectionStatusWriterIdentityAfterHostRecreation()
+    {
+        if (_projectionStatusWriterIdentity is not { } pinned || _host is null)
+        {
+            _logger.LogWarning("Projection host was recreated before a projection status writer identity was pinned: {ProjectorName}", GetProjectorName());
+            return;
+        }
+
+        var recreatedVersion = _host.GetProjectorVersion();
+        if (!string.Equals(pinned.ProjectorVersion, recreatedVersion, StringComparison.Ordinal))
+        {
+            _logger.LogWarning(
+                "Projection host recreation reported version {ObservedProjectorVersion}; retaining activation-pinned status version {PinnedProjectorVersion}: {ProjectorName}",
+                recreatedVersion,
+                pinned.ProjectorVersion,
+                pinned.ProjectorName);
+        }
     }
 
     // Clears the persisted fault descriptor AND the derived projection checkpoint on the candidate, so catch-up rebuilds
@@ -2786,7 +2835,14 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
                 return;
             }
 
-            var projectorName = GetProjectorName();
+            var writerIdentity = _projectionStatusWriterIdentity;
+            if (writerIdentity is null)
+            {
+                _logger.LogDebug("Projection status writer identity has not been captured: {ProjectorName}", GetProjectorName());
+                return;
+            }
+
+            var projectorName = writerIdentity.ProjectorName;
             var sequence = Volatile.Read(ref _projectionStatusSequence) + 1;
             string? lastAppliedPosition;
             string? lastTraversedPosition;
@@ -2797,12 +2853,10 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
             }
 
             var heartbeat = new ProjectionStatusHeartbeat(
-                _serviceId,
-                projectorName,
-                _stateStore.Committed.ProjectorVersion ?? _host?.GetProjectorVersion() ?? string.Empty,
-                string.IsNullOrWhiteSpace(_projectionStatusOptions.ClusterId)
-                    ? ProjectionStatusOptions.DefaultClusterId
-                    : _projectionStatusOptions.ClusterId,
+                writerIdentity.ServiceId,
+                writerIdentity.ProjectorName,
+                writerIdentity.ProjectorVersion,
+                writerIdentity.ClusterId,
                 _activationId,
                 sequence,
                 _eventsProcessed,
@@ -2820,9 +2874,10 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
                 ? _projectionStatusOptions.HeartbeatWriteTimeout
                 : TimeSpan.FromSeconds(5);
             using var writeTimeoutCts = new CancellationTokenSource(writeTimeout);
+            var expectedSequence = Volatile.Read(ref _projectionStatusSequence);
             var writeResult = await _projectionStatusStore.UpsertAsync(
                 heartbeat,
-                Volatile.Read(ref _projectionStatusSequence),
+                expectedSequence,
                 writeTimeoutCts.Token).ConfigureAwait(false);
             if (!writeResult.IsSuccess)
             {
@@ -2840,16 +2895,22 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
             var outcome = writeResult.GetValue();
             if (outcome.Committed)
             {
-                Volatile.Write(ref _projectionStatusSequence, sequence);
+                Volatile.Write(ref _projectionStatusSequence, outcome.Current?.Sequence ?? sequence);
                 Interlocked.Exchange(ref _projectionStatusDirty, 0);
                 _projectionStatusFailureAttempt = 0;
                 _projectionStatusNextAttemptUtc = DateTimeOffset.MinValue;
             }
             else
             {
-                // Another writer for this activation owns the newer sequence.  Re-base without replacing its row;
-                // the next timer tick will attempt the next sequence using the provider's observed token.
-                if (outcome.Current is { Sequence: var currentSequence } && currentSequence > sequence - 1)
+                // A missing row after an update attempt is a rebase, not an implicit create. Reset only the local fence;
+                // the scheduled next operation will still use the provider-conditional expected=0 create path.
+                if (outcome.ConflictDetails?.Reason == ProjectionStatusConflictReason.RowAbsent && expectedSequence > 0)
+                {
+                    Volatile.Write(ref _projectionStatusSequence, 0);
+                }
+                // Every other observed row is a normal CAS rebase. Adopt its exact sequence even when it moved backward
+                // relative to this activation's stale local fence; the physical identity remains activation-pinned.
+                else if (outcome.Current is { Sequence: var currentSequence })
                 {
                     Volatile.Write(ref _projectionStatusSequence, currentSequence);
                 }

--- a/dcb/src/Sekiban.Dcb.Postgres/PostgresProjectionStatusStore.cs
+++ b/dcb/src/Sekiban.Dcb.Postgres/PostgresProjectionStatusStore.cs
@@ -74,6 +74,13 @@ public partial class PostgresMultiProjectionStateStore
                        @applied_event_count, @last_applied_sortable_unique_id, @last_traversed_sortable_unique_id, @recorded_at_utc,
                        @phase, @lease_expires_at_utc, @is_faulted, @fault_message, @switch_kind, @switch_reason, @switched_at_utc
                 WHERE @expected_sequence = 0
+                   OR EXISTS (
+                       SELECT 1
+                       FROM dcb_projection_statuses
+                       WHERE service_id = @service_id
+                         AND projector_name = @projector_name
+                         AND projector_version = @projector_version
+                         AND cluster_id = @cluster_id)
                 ON CONFLICT (service_id, projector_name, projector_version, cluster_id)
                 DO UPDATE SET
                     activation_id = EXCLUDED.activation_id,
@@ -130,8 +137,12 @@ public partial class PostgresMultiProjectionStateStore
                 heartbeat.ClusterId,
                 cancellationToken).ConfigureAwait(false);
             return ResultBox.FromValue(ProjectionStatusWriteResult.Rejected(
+                heartbeat,
+                expectedSequence,
                 current,
-                $"Heartbeat CAS rejected: expected sequence {expectedSequence}."));
+                current is null && expectedSequence > 0
+                    ? ProjectionStatusConflictReason.RowAbsent
+                    : null));
         }
         catch (Exception ex)
         {
@@ -162,8 +173,10 @@ public partial class PostgresMultiProjectionStateStore
                        switch_kind, switch_reason, switched_at_utc
                 FROM dcb_projection_statuses
                 WHERE service_id = @service_id
-                  AND (@projector_name IS NULL OR projector_name = @projector_name)
-                  AND (@projector_version IS NULL OR projector_version = @projector_version)
+                  AND (CAST(@projector_name AS varchar) IS NULL
+                       OR projector_name = CAST(@projector_name AS varchar))
+                  AND (CAST(@projector_version AS varchar) IS NULL
+                       OR projector_version = CAST(@projector_version AS varchar))
                 ORDER BY projector_name, projector_version, cluster_id, activation_id;
                 """;
             AddParameter(command, "service_id", CurrentServiceId);

--- a/dcb/src/Sekiban.Dcb.Sqlite/SqliteProjectionStatusStore.cs
+++ b/dcb/src/Sekiban.Dcb.Sqlite/SqliteProjectionStatusStore.cs
@@ -106,6 +106,13 @@ public partial class SqliteMultiProjectionStateStore
                        @appliedEventCount, @lastAppliedSortableUniqueId, @lastTraversedSortableUniqueId, @recordedAtUtc,
                        @phase, @leaseExpiresAtUtc, @isFaulted, @faultMessage, @switchKind, @switchReason, @switchedAtUtc
                 WHERE @expectedSequence = 0
+                   OR EXISTS (
+                       SELECT 1
+                       FROM dcb_projection_statuses
+                       WHERE ServiceId = @serviceId
+                         AND ProjectorName = @projectorName
+                         AND ProjectorVersion = @projectorVersion
+                         AND ClusterId = @clusterId)
                 ON CONFLICT(ServiceId, ProjectorName, ProjectorVersion, ClusterId)
                 DO UPDATE SET
                     ActivationId = excluded.ActivationId,
@@ -152,13 +159,18 @@ public partial class SqliteMultiProjectionStateStore
                 return ResultBox.FromValue(ProjectionStatusWriteResult.Success(ReadHeartbeat(reader)));
             }
 
+            await reader.DisposeAsync().ConfigureAwait(false);
             var current = await ReadCurrentHeartbeatAsync(
                 connection,
                 heartbeat,
                 cancellationToken).ConfigureAwait(false);
             return ResultBox.FromValue(ProjectionStatusWriteResult.Rejected(
+                heartbeat,
+                expectedSequence,
                 current,
-                $"Heartbeat CAS rejected: expected sequence {expectedSequence}."));
+                current is null && expectedSequence > 0
+                    ? ProjectionStatusConflictReason.RowAbsent
+                    : null));
         }
         catch (Exception ex)
         {

--- a/dcb/tests/Sekiban.Dcb.MaterializedView.Tests/MvProjectionStatusPublicationTests.cs
+++ b/dcb/tests/Sekiban.Dcb.MaterializedView.Tests/MvProjectionStatusPublicationTests.cs
@@ -135,6 +135,76 @@ public class MvProjectionStatusPublicationTests
     }
 
     [Fact]
+    public async Task Publisher_RebasesExternalRowLossAndCompetingCreate_UsingTheRealStoreContract()
+    {
+        // Exercise the production publisher against the actual in-memory status store. This proves both that an absent
+        // expected>0 update does not create in the same operation and that the later expected=0 create remains conditional
+        // when another writer wins the race.
+        var serviceIdProvider = new FixedServiceIdProvider(ServiceId);
+        var store = new InMemoryMultiProjectionStateStore(serviceIdProvider);
+        var publisher = new MvProjectionStatusPublisher(
+            store,
+            StatusOptions(),
+            NullLogger<MvProjectionStatusPublisher>.Instance);
+        var snapshot = new MvProjectionStatusSnapshot(MvCheckpointTruth.KnownZero(), MvStatus.Active, 1);
+
+        await publisher.PublishSwitchAsync(
+            ServiceId,
+            ViewName,
+            ViewVersion,
+            snapshot,
+            MvProjectionStatusPublisherKind.HostedWorker);
+        Assert.Equal(1, Assert.Single((await store.ListAsync()).GetValue()).Sequence);
+
+        // The second production write has expected=1. Removing the row must leave the store empty after that write.
+        store.Clear();
+        await publisher.PublishSwitchAsync(
+            ServiceId,
+            ViewName,
+            ViewVersion,
+            snapshot,
+            MvProjectionStatusPublisherKind.HostedWorker);
+        Assert.Empty((await store.ListAsync()).GetValue());
+
+        var identity = MvProjectionStatusIdentity.Create(ViewName, ViewVersion);
+        var competingCreate = new ProjectionStatusHeartbeat(
+            ServiceId,
+            identity.ProjectorName,
+            identity.ProjectorVersion,
+            "test-cluster:mv:hosted",
+            "competing-activation",
+            1,
+            1,
+            null,
+            null,
+            DateTimeOffset.UtcNow)
+        {
+            Phase = ProjectionStatusPhases.Active
+        };
+        Assert.True((await store.UpsertAsync(competingCreate, 0)).GetValue().Committed);
+
+        // The publisher's conditional create loses, observes RowAlreadyExists, and only rebases its fence.
+        await publisher.PublishSwitchAsync(
+            ServiceId,
+            ViewName,
+            ViewVersion,
+            snapshot,
+            MvProjectionStatusPublisherKind.HostedWorker);
+        var afterConflict = Assert.Single((await store.ListAsync()).GetValue());
+        Assert.Equal("competing-activation", afterConflict.ActivationId);
+        Assert.Equal(1, afterConflict.Sequence);
+
+        // A later operation uses the rebased expected=1 update route and advances normally.
+        await publisher.PublishSwitchAsync(
+            ServiceId,
+            ViewName,
+            ViewVersion,
+            snapshot,
+            MvProjectionStatusPublisherKind.HostedWorker);
+        Assert.Equal(2, Assert.Single((await store.ListAsync()).GetValue()).Sequence);
+    }
+
+    [Fact]
     public async Task Publication_ValidatesExactServiceBeforeAnyIo_AndDoesNoStatusIoWhenDisabled()
     {
         var invalidStore = new ObservingStatusStore(new FixedServiceIdProvider(ServiceId));

--- a/dcb/tests/Sekiban.Dcb.Orleans.Tests/MultiProjectionGrainPersistPolicyTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Orleans.Tests/MultiProjectionGrainPersistPolicyTests.cs
@@ -174,12 +174,93 @@ public class MultiProjectionGrainPersistPolicyTests
                 ["v1", "safe-001", 11])));
     }
 
+    [Fact]
+    public async Task ProjectionStatusHeartbeat_PinsHostVersionAndRebasesMissingRowsWithoutUnconditionalCreate()
+    {
+        // This deliberately invokes the production grain writer against the real in-memory status store. A fake result
+        // cannot prove the two regression boundaries: persisted state changing inside an activation must not change the
+        // physical key, and an expected>0 write to a removed row must not create in the same operation.
+        var host = new MutableProjectionActorHost("registered-v1");
+        var hostFactory = new MutableProjectionActorHostFactory(host);
+        var serviceIdProvider = new FixedServiceIdProvider("svc");
+        var statusStore = new Sekiban.Dcb.Testing.InMemoryMultiProjectionStateStore(serviceIdProvider);
+        var grain = CreateGrain(
+            state: new MultiProjectionGrainState { ProjectorVersion = "mutable-v1" },
+            actorHostFactory: hostFactory,
+            projectionStatusStore: statusStore,
+            projectionStatusOptions: new ProjectionStatusOptions
+            {
+                ClusterId = "test-cluster",
+                HeartbeatWriteTimeout = TimeSpan.FromSeconds(1)
+            });
+
+        SetPrivateField(grain, "_serviceId", "svc");
+        SetPrivateField(grain, "_grainKey", "projection");
+        SetPrivateField(grain, "_projectorName", "projection");
+        SetPrivateField(grain, "_host", host);
+        InvokePrivate(grain, "CaptureProjectionStatusWriterIdentity", ["projection"]);
+
+        await InvokePrivateTaskAsync(grain, "WriteProjectionStatusHeartbeatAsync");
+        var first = Assert.Single((await statusStore.ListAsync("projection", "registered-v1")).GetValue());
+        Assert.Equal(1, first.Sequence);
+        Assert.Equal("registered-v1", first.ProjectorVersion);
+
+        var coordinated = Assert.IsType<CoordinatedGrainStateStore>(GetPrivateField(grain, "_stateStore"));
+        await coordinated.ExecuteWriteAsync(
+            GrainStateWriteKind.MetadataMaintenance,
+            state => state.ProjectorVersion = "mutable-v2");
+
+        // Recreating the host with different registered metadata verifies/logs disagreement but must retain the pin.
+        host.ProjectorVersion = "registered-v2";
+        InvokePrivate(grain, "RecreateHostForFullRebuild");
+        var pinned = Assert.IsType<ProjectionStatusWriterIdentity>(
+            GetPrivateField(grain, "_projectionStatusWriterIdentity"));
+        Assert.Equal("registered-v1", pinned.ProjectorVersion);
+
+        await InvokePrivateTaskAsync(grain, "WriteProjectionStatusHeartbeatAsync");
+        var advanced = Assert.Single((await statusStore.ListAsync("projection", "registered-v1")).GetValue());
+        Assert.Equal(2, advanced.Sequence);
+        Assert.Empty((await statusStore.ListAsync("projection", "mutable-v2")).GetValue());
+
+        // Simulate external row loss. The expected=2 write must report RowAbsent and only reset the local fence; no
+        // unconditional insert is allowed in this operation.
+        statusStore.Clear();
+        await InvokePrivateTaskAsync(grain, "WriteProjectionStatusHeartbeatAsync");
+        Assert.Empty((await statusStore.ListAsync("projection", "registered-v1")).GetValue());
+        Assert.Equal(0L, GetPrivateField<long>(grain, "_projectionStatusSequence"));
+
+        // A competing writer can win the later conditional create. The grain must adopt that fence, then use the
+        // reachable expected=1 update path, while still writing the activation-pinned v1 identity.
+        var competing = first with
+        {
+            ActivationId = "competing-activation",
+            Sequence = 1,
+            RecordedAtUtc = DateTimeOffset.UtcNow
+        };
+        Assert.True((await statusStore.UpsertAsync(competing, 0)).GetValue().Committed);
+        SetPrivateField(grain, "_projectionStatusNextAttemptUtc", DateTimeOffset.MinValue);
+        await InvokePrivateTaskAsync(grain, "WriteProjectionStatusHeartbeatAsync");
+        var afterCreateRace = Assert.Single((await statusStore.ListAsync("projection", "registered-v1")).GetValue());
+        Assert.Equal("competing-activation", afterCreateRace.ActivationId);
+        Assert.Equal(1, afterCreateRace.Sequence);
+        Assert.Equal(1L, GetPrivateField<long>(grain, "_projectionStatusSequence"));
+
+        SetPrivateField(grain, "_projectionStatusNextAttemptUtc", DateTimeOffset.MinValue);
+        await InvokePrivateTaskAsync(grain, "WriteProjectionStatusHeartbeatAsync");
+        var recovered = Assert.Single((await statusStore.ListAsync("projection", "registered-v1")).GetValue());
+        Assert.Equal(2, recovered.Sequence);
+        Assert.Empty((await statusStore.ListAsync("projection", "mutable-v2")).GetValue());
+    }
+
     private static MultiProjectionGrain CreateGrain(
         GeneralMultiProjectionActorOptions? options = null,
-        MultiProjectionGrainState? state = null) =>
+        MultiProjectionGrainState? state = null,
+        IProjectionActorHostFactory? actorHostFactory = null,
+        IProjectionStatusStore? projectionStatusStore = null,
+        ProjectionStatusOptions? projectionStatusOptions = null) =>
         new(
             new TestPersistentState<MultiProjectionGrainState>(state ?? new MultiProjectionGrainState()),
-            new StubProjectionActorHostFactory(),
+            actorHostFactory ?? new StubProjectionActorHostFactory(),
             new StubEventStore(),
             new DefaultOrleansEventSubscriptionResolver(),
             multiProjectionStateStore: null,
@@ -188,7 +269,9 @@ public class MultiProjectionGrainPersistPolicyTests
             tempFileSnapshotManager: null,
             logger: NullLogger<MultiProjectionGrain>.Instance,
             eventStoreFactory: null,
-            serviceIdProvider: new DefaultServiceIdProvider());
+            serviceIdProvider: new DefaultServiceIdProvider(),
+            projectionStatusStore: projectionStatusStore,
+            projectionStatusOptions: projectionStatusOptions);
 
     private static object? InvokePrivate(object target, string methodName, object?[]? args = null)
     {
@@ -202,6 +285,31 @@ public class MultiProjectionGrainPersistPolicyTests
         var property = target.GetType().GetProperty(propertyName, BindingFlags.Instance | BindingFlags.Public);
         Assert.NotNull(property);
         return Assert.IsType<T>(property!.GetValue(target));
+    }
+
+    private static object? GetPrivateField(object target, string fieldName)
+    {
+        var field = target.GetType().GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(field);
+        return field!.GetValue(target);
+    }
+
+    private static T GetPrivateField<T>(object target, string fieldName) =>
+        Assert.IsType<T>(GetPrivateField(target, fieldName));
+
+    private static void SetPrivateField(object target, string fieldName, object? value)
+    {
+        var field = target.GetType().GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(field);
+        field!.SetValue(target, value);
+    }
+
+    private static async Task InvokePrivateTaskAsync(object target, string methodName)
+    {
+        var method = target.GetType().GetMethod(methodName, BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(method);
+        var task = Assert.IsAssignableFrom<Task>(method!.Invoke(target, null));
+        await task;
     }
 
     private sealed class TestPersistentState<T> : IPersistentState<T> where T : new()
@@ -230,7 +338,15 @@ public class MultiProjectionGrainPersistPolicyTests
             Microsoft.Extensions.Logging.ILogger? logger = null) => new StubProjectionActorHost();
     }
 
-    private sealed class StubProjectionActorHost : IProjectionActorHost
+    private sealed class MutableProjectionActorHostFactory(MutableProjectionActorHost host) : IProjectionActorHostFactory
+    {
+        public IProjectionActorHost Create(
+            string projectorName,
+            GeneralMultiProjectionActorOptions? options = null,
+            Microsoft.Extensions.Logging.ILogger? logger = null) => host;
+    }
+
+    private class StubProjectionActorHost : IProjectionActorHost
     {
         public Task AddSerializableEventsAsync(IReadOnlyList<SerializableEvent> events, bool finishedCatchUp = true) =>
             throw new NotSupportedException();
@@ -278,13 +394,25 @@ public class MultiProjectionGrainPersistPolicyTests
         public Task<bool> IsSortableUniqueIdReceivedAsync(string sortableUniqueId) => throw new NotSupportedException();
         public long EstimateStateSizeBytes(bool includeUnsafeDetails) => throw new NotSupportedException();
         public string PeekCurrentSafeWindowThreshold() => throw new NotSupportedException();
-        public string GetProjectorVersion() => throw new NotSupportedException();
+        public virtual string GetProjectorVersion() => "registered-v1";
 
         public Task<ResultBox<bool>> RewriteSnapshotVersionAsync(
             Stream source,
             Stream target,
             string newVersion,
             CancellationToken cancellationToken) => throw new NotSupportedException();
+    }
+
+    private sealed class MutableProjectionActorHost(string projectorVersion) : StubProjectionActorHost
+    {
+        public string ProjectorVersion { get; set; } = projectorVersion;
+
+        public override string GetProjectorVersion() => ProjectorVersion;
+    }
+
+    private sealed class FixedServiceIdProvider(string serviceId) : IServiceIdProvider
+    {
+        public string GetCurrentServiceId() => serviceId;
     }
 
     private sealed class StubEventStore : IEventStore

--- a/dcb/tests/Sekiban.Dcb.Postgres.Tests/PostgresProjectionStatusStoreTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Postgres.Tests/PostgresProjectionStatusStoreTests.cs
@@ -1,0 +1,110 @@
+using Microsoft.EntityFrameworkCore;
+using Sekiban.Dcb;
+using Sekiban.Dcb.Postgres;
+using Sekiban.Dcb.ServiceId;
+using Xunit;
+
+namespace Sekiban.Dcb.Postgres.Tests;
+
+/// <summary>
+///     Real PostgreSQL proof for SEK-G35. The statement must reach its conflict/update arm for an existing row while
+///     still rejecting an expected&gt;0 write when the row is absent; a simplified unconditional INSERT is not acceptable.
+/// </summary>
+[Collection("PostgresTests")]
+public sealed class PostgresProjectionStatusStoreTests : IAsyncLifetime
+{
+    private readonly PostgresTestFixture _fixture;
+
+    public PostgresProjectionStatusStoreTests(PostgresTestFixture fixture) => _fixture = fixture;
+
+    public async Task InitializeAsync()
+    {
+        await using var context = await _fixture.DbContextFactory.CreateDbContextAsync();
+        await context.Database.ExecuteSqlRawAsync("DROP TABLE IF EXISTS dcb_projection_statuses");
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public async Task CasMatrix_UsesReachableUpdateAndConditionalCreateAgainstRealPostgres()
+    {
+        var store = new PostgresMultiProjectionStateStore(
+            _fixture.DbContextFactory,
+            new FixedServiceIdProvider("svc"));
+        var first = Heartbeat("activation-a", 1);
+
+        var created = await store.UpsertAsync(first, 0);
+        var updated = await store.UpsertAsync(first with { Sequence = 2, AppliedEventCount = 2 }, 1);
+        var staleCreate = await store.UpsertAsync(first with { Sequence = 3 }, 0);
+
+        Assert.True(created.IsSuccess);
+        Assert.True(created.GetValue().Committed);
+        Assert.True(updated.IsSuccess);
+        Assert.True(updated.GetValue().Committed);
+        Assert.Equal(2, updated.GetValue().Current!.Sequence);
+        Assert.Equal(2, updated.GetValue().Current!.AppliedEventCount);
+        Assert.True(staleCreate.IsSuccess);
+        var createRaceConflict = Assert.IsType<ProjectionStatusWriteConflict>(staleCreate.GetValue().ConflictDetails);
+        Assert.Equal(ProjectionStatusConflictReason.RowAlreadyExists, createRaceConflict.Reason);
+        Assert.Equal(0, createRaceConflict.ExpectedSequence);
+        Assert.Equal(2, createRaceConflict.ObservedSequence);
+        Assert.Equal(first.ProjectorVersion, createRaceConflict.ExpectedProjectorVersion);
+        Assert.Equal(first.ProjectorVersion, createRaceConflict.ObservedProjectorVersion);
+        Assert.Equal(createRaceConflict.ToCompatibilityReason(), staleCreate.GetValue().ConflictReason);
+        Assert.DoesNotContain("activation row already exists", staleCreate.GetValue().ConflictReason!, StringComparison.OrdinalIgnoreCase);
+
+        var staleUpdate = await store.UpsertAsync(first with { Sequence = 3 }, 1);
+        Assert.True(staleUpdate.IsSuccess);
+        var staleUpdateConflict = Assert.IsType<ProjectionStatusWriteConflict>(staleUpdate.GetValue().ConflictDetails);
+        Assert.Equal(ProjectionStatusConflictReason.SequenceMismatch, staleUpdateConflict.Reason);
+        Assert.Equal(1, staleUpdateConflict.ExpectedSequence);
+        Assert.Equal(2, staleUpdateConflict.ObservedSequence);
+
+        var missing = first with { ClusterId = "missing", Sequence = 2 };
+        var absent = await store.UpsertAsync(missing, 1);
+        Assert.True(absent.IsSuccess);
+        var absentConflict = Assert.IsType<ProjectionStatusWriteConflict>(absent.GetValue().ConflictDetails);
+        Assert.Equal(ProjectionStatusConflictReason.RowAbsent, absentConflict.Reason);
+        Assert.Equal(1, absentConflict.ExpectedSequence);
+        Assert.Null(absent.GetValue().Current);
+        Assert.Null(absentConflict.ObservedSequence);
+        Assert.Equal(missing.ProjectorVersion, absentConflict.ExpectedProjectorVersion);
+        Assert.Null(absentConflict.ObservedProjectorVersion);
+        var listedAfterAbsentWrite = await store.ListAsync();
+        Assert.True(
+            listedAfterAbsentWrite.IsSuccess,
+            listedAfterAbsentWrite.IsSuccess ? string.Empty : listedAfterAbsentWrite.GetException().ToString());
+        Assert.DoesNotContain(listedAfterAbsentWrite.GetValue(), row => row.ClusterId == "missing");
+
+        // A later conditional create can race. The loser observes RowAlreadyExists and must not overwrite the winner.
+        var competitor = missing with { ActivationId = "competitor", Sequence = 1 };
+        Assert.True((await store.UpsertAsync(competitor, 0)).GetValue().Committed);
+        var losingCreate = await store.UpsertAsync(missing with { ActivationId = "retrying", Sequence = 1 }, 0);
+        Assert.True(losingCreate.IsSuccess);
+        Assert.Equal(
+            ProjectionStatusConflictReason.RowAlreadyExists,
+            Assert.IsType<ProjectionStatusWriteConflict>(losingCreate.GetValue().ConflictDetails).Reason);
+        Assert.Equal("competitor", losingCreate.GetValue().Current!.ActivationId);
+
+        var afterRebase = await store.UpsertAsync(missing with { ActivationId = "retrying", Sequence = 2 }, 1);
+        Assert.True(afterRebase.IsSuccess);
+        Assert.True(afterRebase.GetValue().Committed);
+        Assert.Equal(2, afterRebase.GetValue().Current!.Sequence);
+    }
+
+    private static ProjectionStatusHeartbeat Heartbeat(string activationId, long sequence) =>
+        new(
+            "svc",
+            "status-projector",
+            "v1",
+            "cluster-a",
+            activationId,
+            sequence,
+            sequence,
+            null,
+            null,
+            DateTimeOffset.UtcNow)
+        {
+            Phase = ProjectionStatusPhases.Active
+        };
+}

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/ProjectionStatusRegistryTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/ProjectionStatusRegistryTests.cs
@@ -234,6 +234,81 @@ public sealed class ProjectionStatusRegistryTests
     }
 
     [Fact]
+    public async Task Reader_ExposesRollingVersionsInV2WhileLeavingV1VectorsFrozen()
+    {
+        var provider = new MutableServiceIdProvider("alpha");
+        var statusStore = new CoreInMemoryMultiProjectionStateStore(provider);
+        var eventStore = new CoreInMemoryEventStore(DomainType.GetDomainTypes().EventTypes, provider);
+        var now = DateTimeOffset.UtcNow;
+
+        await statusStore.UpsertAsync(CreateHeartbeat("fresh-v1", 1, now) with
+        {
+            ProjectorVersion = "v1",
+            Phase = ProjectionStatusPhases.Active,
+            LeaseExpiresAtUtc = now.AddMinutes(1)
+        }, 0);
+        await statusStore.UpsertAsync(CreateHeartbeat("fresh-v2", 1, now) with
+        {
+            ProjectorVersion = "v2",
+            Phase = ProjectionStatusPhases.Active,
+            LeaseExpiresAtUtc = now.AddMinutes(1)
+        }, 0);
+        await statusStore.UpsertAsync(CreateHeartbeat("expired-v0", 1, now.AddMinutes(-10)) with
+        {
+            ProjectorVersion = "v0",
+            Phase = ProjectionStatusPhases.Active,
+            LeaseExpiresAtUtc = now.AddMinutes(-1)
+        }, 0);
+
+        var request = new ProjectionStatusReadRequest(ProjectorName: "students")
+        {
+            ExpectedProjectorVersion = "v2"
+        };
+        var reader = new ProjectionStatusReader(
+            statusStore,
+            eventStore,
+            provider,
+            new ProjectionStatusOptions { FreshnessWindow = TimeSpan.FromMinutes(2), SamplingWindow = TimeSpan.Zero });
+        var snapshots = (await reader.ReadAsync(request)).GetValue();
+
+        var current = Assert.Single(snapshots, snapshot => snapshot.ProjectorVersion == "v2");
+        Assert.Equal("v2", current.ExpectedProjectorVersion);
+        Assert.Equal("v2", current.ObservedProjectorVersion);
+        Assert.Equal(ProjectionStatusVersionDisposition.Current, current.VersionDisposition);
+
+        var freshDifferentVersion = Assert.Single(snapshots, snapshot => snapshot.ProjectorVersion == "v1");
+        Assert.Equal(ProjectionStatusVersionDisposition.VersionMismatch, freshDifferentVersion.VersionDisposition);
+        Assert.False(freshDifferentVersion.IsStaleOrOrphan);
+
+        var expiredOrphan = Assert.Single(snapshots, snapshot => snapshot.ProjectorVersion == "v0");
+        Assert.Equal(ProjectionStatusVersionDisposition.StaleOrOrphan, expiredOrphan.VersionDisposition);
+        Assert.True(expiredOrphan.IsStaleOrOrphan);
+        Assert.False(expiredOrphan.IsCaughtUp);
+
+        var serialized = new SerializedProjectionStatusReader(reader, provider);
+        var v2 = await serialized.AcceptAsync(SerializedProjectionStatusReader.SerializeRequestV2(request));
+        Assert.True(v2.IsSuccess);
+        var envelope = SerializedProjectionStatusReader.DeserializeV2(v2.GetValue());
+        Assert.True(envelope.IsSuccess);
+        Assert.Equal(2, envelope.GetValue().Version);
+        Assert.Contains(envelope.GetValue().Snapshots, snapshot =>
+            snapshot.ObservedProjectorVersion == "v0" &&
+            snapshot.VersionDisposition == ProjectionStatusVersionDisposition.StaleOrOrphan &&
+            snapshot.IsStaleOrOrphan);
+    }
+
+    [Fact]
+    public void ProjectionStatusPublicApi_RetainsLegacyClrConstructors()
+    {
+        Assert.NotNull(typeof(ProjectionStatusWriteResult).GetConstructor(
+            [typeof(ProjectionStatusWriteOutcome), typeof(ProjectionStatusHeartbeat), typeof(string)]));
+        Assert.NotNull(typeof(ProjectionStatusReadRequest).GetConstructor(
+            [typeof(string), typeof(string), typeof(string)]));
+        Assert.NotNull(typeof(SerializedProjectionStatusEnvelopeV1).GetConstructor(
+            [typeof(int), typeof(string), typeof(IReadOnlyList<ProjectionStatusSnapshot>)]));
+    }
+
+    [Fact]
     public async Task Reader_ReusesOneDenominatorPerServiceWindow_AndAggregatesDistinctCursors()
     {
         var provider = new MutableServiceIdProvider("alpha");
@@ -318,25 +393,14 @@ public sealed class ProjectionStatusRegistryTests
     }
 
     [Fact]
-    public async Task SqliteStatusStore_AutoCreatesTable_AndRejectsStaleSequence()
+    public async Task SqliteStatusStore_UsesReachableUpdateRouteAndFailsClosedForAbsentExpectedSequence()
     {
         var path = Path.Combine(Path.GetTempPath(), $"sekiban-projection-status-{Guid.NewGuid():N}.db");
         try
         {
             var provider = new MutableServiceIdProvider("alpha");
             var store = new SqliteMultiProjectionStateStore(path, serviceIdProvider: provider);
-            var heartbeat = CreateHeartbeat("activation-a", 1, DateTimeOffset.UtcNow);
-
-            var committed = await store.UpsertAsync(heartbeat, 0);
-            var stale = await store.UpsertAsync(heartbeat with { Sequence = 2 }, 0);
-            var rows = await store.ListAsync("students", "v1");
-
-            Assert.True(committed.IsSuccess);
-            Assert.True(committed.GetValue().Committed);
-            Assert.True(stale.IsSuccess);
-            Assert.True(stale.GetValue().Conflict);
-            Assert.True(rows.IsSuccess);
-            Assert.Single(rows.GetValue());
+            await AssertProjectionStatusCasContractAsync(store);
         }
         finally
         {
@@ -345,6 +409,46 @@ public sealed class ProjectionStatusRegistryTests
                 File.Delete(path);
             }
         }
+    }
+
+    [Fact]
+    public async Task InMemoryStatusStore_UsesTheSharedFailClosedCasContract()
+    {
+        await AssertProjectionStatusCasContractAsync(
+            new CoreInMemoryMultiProjectionStateStore(new MutableServiceIdProvider("alpha")));
+    }
+
+    [Fact]
+    public async Task CosmosStatusStore_UsesTheSharedFailClosedCasContract()
+    {
+        var client = new InMemoryCosmosClient();
+        var options = new CosmosDbEventStoreOptions
+        {
+            MultiProjectionStatesContainerName = "multiProjectionStates"
+        };
+        var store = new CosmosMultiProjectionStateStore(
+            new CosmosDbContext(client, "test-db", options: options),
+            new MutableServiceIdProvider("alpha"),
+            new DefaultCosmosContainerResolver(options));
+
+        await AssertProjectionStatusCasContractAsync(store);
+    }
+
+    [Fact]
+    public async Task DynamoStatusStore_UsesTheSharedFailClosedCasContract()
+    {
+        var client = DispatchProxy.Create<IAmazonDynamoDB, MixedDynamoDb>();
+        var store = new DynamoMultiProjectionStateStore(
+            new DynamoDbContext(
+                client,
+                Options.Create(new DynamoDbEventStoreOptions
+                {
+                    AutoCreateTables = false,
+                    ProjectionStatesTableName = "states"
+                })),
+            new MutableServiceIdProvider("alpha"));
+
+        await AssertProjectionStatusCasContractAsync(store);
     }
 
     [Fact]
@@ -536,6 +640,85 @@ public sealed class ProjectionStatusRegistryTests
             null,
             null,
             recordedAtUtc);
+
+    /// <summary>
+    ///     Shared provider matrix for the public status-store contract. Each invocation drives the production store,
+    ///     including its native conditional create/update operation; it is deliberately not a mocked write result.
+    /// </summary>
+    private static async Task AssertProjectionStatusCasContractAsync(IProjectionStatusStore store)
+    {
+        var first = CreateHeartbeat("activation-a", 1, DateTimeOffset.UtcNow);
+        var created = await store.UpsertAsync(first, 0);
+        Assert.True(created.IsSuccess, created.IsSuccess ? string.Empty : created.GetException().ToString());
+        Assert.True(created.GetValue().Committed);
+
+        var updatedHeartbeat = first with { Sequence = 2, AppliedEventCount = 2 };
+        var updated = await store.UpsertAsync(updatedHeartbeat, 1);
+        Assert.True(updated.IsSuccess, updated.IsSuccess ? string.Empty : updated.GetException().ToString());
+        Assert.True(updated.GetValue().Committed);
+        Assert.Equal(2, updated.GetValue().Current!.Sequence);
+        Assert.Equal(2, updated.GetValue().Current!.AppliedEventCount);
+        var rowsAfterUpdate = await store.ListAsync("students", "v1");
+        Assert.True(rowsAfterUpdate.IsSuccess, rowsAfterUpdate.IsSuccess ? string.Empty : rowsAfterUpdate.GetException().ToString());
+        var rowAfterUpdate = Assert.Single(rowsAfterUpdate.GetValue());
+        Assert.Equal(2, rowAfterUpdate.Sequence);
+        Assert.Equal(2, rowAfterUpdate.AppliedEventCount);
+
+        var createRace = await store.UpsertAsync(first with { Sequence = 3 }, 0);
+        Assert.True(createRace.IsSuccess, createRace.IsSuccess ? string.Empty : createRace.GetException().ToString());
+        var createRaceConflict = Assert.IsType<ProjectionStatusWriteConflict>(createRace.GetValue().ConflictDetails);
+        Assert.Equal(ProjectionStatusConflictReason.RowAlreadyExists, createRaceConflict.Reason);
+        Assert.Equal(0, createRaceConflict.ExpectedSequence);
+        Assert.Equal(2, createRaceConflict.ObservedSequence);
+        Assert.Equal(first.ProjectorVersion, createRaceConflict.ExpectedProjectorVersion);
+        Assert.Equal(first.ProjectorVersion, createRaceConflict.ObservedProjectorVersion);
+        Assert.Equal(createRaceConflict.ToCompatibilityReason(), createRace.GetValue().ConflictReason);
+        Assert.DoesNotContain("activation row already exists", createRace.GetValue().ConflictReason!, StringComparison.OrdinalIgnoreCase);
+
+        var staleUpdate = await store.UpsertAsync(first with { Sequence = 3 }, 1);
+        Assert.True(staleUpdate.IsSuccess, staleUpdate.IsSuccess ? string.Empty : staleUpdate.GetException().ToString());
+        Assert.True(staleUpdate.GetValue().Conflict, staleUpdate.GetValue().ToString());
+        var staleUpdateConflict = Assert.IsType<ProjectionStatusWriteConflict>(staleUpdate.GetValue().ConflictDetails);
+        Assert.Equal(ProjectionStatusConflictReason.SequenceMismatch, staleUpdateConflict.Reason);
+        Assert.Equal(1, staleUpdateConflict.ExpectedSequence);
+        Assert.Equal(2, staleUpdateConflict.ObservedSequence);
+
+        var missing = first with { ClusterId = "missing-cluster", Sequence = 2 };
+        var absent = await store.UpsertAsync(missing, 1);
+        Assert.True(absent.IsSuccess, absent.IsSuccess ? string.Empty : absent.GetException().ToString());
+        var absentConflict = Assert.IsType<ProjectionStatusWriteConflict>(absent.GetValue().ConflictDetails);
+        Assert.Equal(ProjectionStatusConflictReason.RowAbsent, absentConflict.Reason);
+        Assert.Equal(1, absentConflict.ExpectedSequence);
+        Assert.Null(absentConflict.ObservedSequence);
+        Assert.Equal(missing.ProjectorVersion, absentConflict.ExpectedProjectorVersion);
+        Assert.Null(absentConflict.ObservedProjectorVersion);
+
+        var afterAbsent = await store.ListAsync("students", "v1");
+        Assert.True(afterAbsent.IsSuccess, afterAbsent.IsSuccess ? string.Empty : afterAbsent.GetException().ToString());
+        Assert.DoesNotContain(afterAbsent.GetValue(), row => row.ClusterId == "missing-cluster");
+
+        // A later, still-conditional create can lose a race. It must report the winner rather than overwrite it.
+        var competingCreate = missing with { ActivationId = "competing", Sequence = 1 };
+        var competitor = await store.UpsertAsync(competingCreate, 0);
+        Assert.True(competitor.IsSuccess, competitor.IsSuccess ? string.Empty : competitor.GetException().ToString());
+        Assert.True(competitor.GetValue().Committed);
+
+        var losingCreate = await store.UpsertAsync(
+            missing with { ActivationId = "retrying", Sequence = 1 },
+            0);
+        Assert.True(losingCreate.IsSuccess, losingCreate.IsSuccess ? string.Empty : losingCreate.GetException().ToString());
+        var losingConflict = Assert.IsType<ProjectionStatusWriteConflict>(losingCreate.GetValue().ConflictDetails);
+        Assert.Equal(ProjectionStatusConflictReason.RowAlreadyExists, losingConflict.Reason);
+        Assert.Equal(1, losingConflict.ObservedSequence);
+        Assert.Equal("competing", losingConflict.ObservedActivationId);
+
+        var rebasedUpdate = await store.UpsertAsync(
+            missing with { ActivationId = "retrying", Sequence = 2 },
+            1);
+        Assert.True(rebasedUpdate.IsSuccess, rebasedUpdate.IsSuccess ? string.Empty : rebasedUpdate.GetException().ToString());
+        Assert.True(rebasedUpdate.GetValue().Committed);
+        Assert.Equal(2, rebasedUpdate.GetValue().Current!.Sequence);
+    }
 
     private static MultiProjectionStateWriteRequest CreateProjectionWriteRequest() => new(
         "students",
@@ -839,8 +1022,9 @@ public sealed class ProjectionStatusRegistryTests
                 var expectedNumber = long.TryParse(expected.N, out var expectedN) ? expectedN : 0;
                 var matches = comparison[1] switch
                 {
-                    "=" => string.Equals(actual.N, expected.N, StringComparison.Ordinal) ||
-                        string.Equals(actual.S, expected.S, StringComparison.Ordinal),
+                    "=" => actual.N is not null || expected.N is not null
+                        ? string.Equals(actual.N, expected.N, StringComparison.Ordinal)
+                        : string.Equals(actual.S, expected.S, StringComparison.Ordinal),
                     "<" => actualNumber < expectedNumber,
                     _ => false
                 };

--- a/docs/dcb_llm/11_storage_providers.md
+++ b/docs/dcb_llm/11_storage_providers.md
@@ -176,6 +176,25 @@ app.MapGet("/ops/projection-status", async (ISerializedProjectionStatusReader re
 Never use `AllowAnonymous` for this surface. `ISerializedSekibanDcbExecutor` remains untouched. This is the
 dcb-v10.10.0 release-note entry for SEK-G24.
 
+### Projection-status heartbeat recovery (SEK-G35 / dcb-v10.16.0)
+
+Projection-status heartbeats now pin the full writer identity at activation: service, projector name, projector
+version, and cluster. A host rebuild during a rolling deployment continues to write the version captured by that
+activation instead of silently moving the row to the newly registered host version. A new activation naturally uses
+the new version.
+
+The expected-sequence CAS remains fail-closed on every provider. In particular, PostgreSQL and SQLite no longer have
+an unreachable update path after the initial insert: an update is attempted only when the physical row exists, and a
+missing row with a nonzero expected sequence is rejected. The next scheduled heartbeat rebases its local fence and
+may perform the normal sequence-zero create; it never inserts unconditionally in the same failed operation. Cosmos
+DB continues to use its pinned document identity and provider preconditions for the same contract.
+
+The original serialized V1 envelope is frozen. Operators that need rolling-deployment diagnostics can request the
+additive V2 reader envelope, which reports the expected and observed projector versions and whether a row is current,
+version-mismatched, or stale/orphaned. These diagnostics are observational: no provider automatically deletes rows
+from older versions or other clusters. Apply an explicit retention policy only after confirming that the rows are no
+longer useful for rollout or incident analysis.
+
 ## Consistency Contract
 
 This section documents the actual atomicity guarantees of `IEventStore.WriteSerializableEventsAsync` / `WriteEventsAsync` per provider. The two-phase Cosmos write design itself is unchanged; what has changed is how a failure of that write is handled.

--- a/docs/dcb_llm/13_common_issues.md
+++ b/docs/dcb_llm/13_common_issues.md
@@ -572,3 +572,22 @@ no-post-authorization-execution boundary.
 **Migration note.** Existing `CreateOrEnsure`, public CLR signatures, and enum values 0/1 remain compatible. Move only
 deliberate pre-provisioned execution hosts to `VerifyAndExecute`, provide an enforced policy, and grant their runtime
 role DML rather than DDL. A 10.14.1-built binary consumer and an additions-only public API comparison run in CI.
+
+## Projection-status heartbeats stay live across row loss and rolling versions — dcb-v10.16.0 (SEK-G35)
+
+Projection-status heartbeat writes now keep an activation-pinned writer identity. Recreating an actor host during a
+rolling deployment does not move an existing activation from its original projector version to the newly registered
+one. The next activation is the intentional boundary at which the new version begins to write.
+
+All providers retain a fail-closed expected-sequence CAS. Since dcb-v10.10.0, PostgreSQL and SQLite had an unreachable
+update path; it is now a reachable guarded update, so a missing row with `expectedSequence > 0` is rejected rather
+than becoming an unconditional insert. The producer rebases its local fence after that conflict and lets a later
+scheduled operation use the ordinary sequence-zero create path. Before this release, Cosmos DB could derive a different
+document identity after snapshot-derived committed-version metadata changed within a live activation, leaving every
+expected-sequence update pointed at an absent row and freezing the heartbeat. Its activation-pinned physical identity
+and conditional replacement behavior now prevent that failure. Rows from older versions or other clusters are
+diagnostics, not garbage collection candidates: no automatic deletion is performed.
+
+The serialized V1 status envelope and public CLR constructors remain compatible. The additive V2 status protocol is
+the opt-in path for expected-versus-observed projector-version diagnostics and reports `Current`, `VersionMismatch`,
+or `StaleOrOrphan` without changing V1 golden payloads.

--- a/docs/dcb_llm_ja/11_storage_providers.md
+++ b/docs/dcb_llm_ja/11_storage_providers.md
@@ -172,6 +172,24 @@ provider から決まり、ホストの endpoint は既定で deny としてく�
 例えば `RequireAuthorization("ProjectionStatusOperator")` を指定します。`AllowAnonymous` は使わず、既存の
 `ISerializedSekibanDcbExecutor` は変更しません。これは dcb-v10.10.0 の SEK-G24 release note です。
 
+### projection-status heartbeat の回復 (SEK-G35 / dcb-v10.16.0)
+
+projection-status heartbeat は activation 時点で writer identity 全体（service、projector 名、projector version、cluster）を
+固定します。rolling deployment 中に host を再作成しても、その activation は新しく登録された host version へ行を暗黙に移さず、
+固定された version に書き続けます。新しい activation は自然に新しい version を使用します。
+
+expected-sequence CAS はすべての provider で fail-closed のままです。特に PostgreSQL と SQLite は初回 insert 後に update
+経路が到達不能になることがなくなり、physical row が存在するときだけ update を試みます。expected sequence が非ゼロなのに
+行がない場合は拒否されます。次の scheduled heartbeat が local fence を rebase した後、通常の sequence-zero create を
+試みることはありますが、失敗した同じ operation で無条件 insert を行うことはありません。Cosmos DB も固定された document
+identity と provider precondition により同じ契約を守ります。
+
+既存の serialized V1 envelope は凍結されたままです。rolling deployment の診断が必要な operator は、追加された V2 reader
+envelope を使用できます。V2 は expected/observed projector version と、行が current、version mismatch、または
+stale/orphan のどれかを返します。これらは observation のための情報であり、provider が旧 version や他 cluster の行を
+自動削除することはありません。rollout や incident analysis に不要になったことを確認してから、明示的な retention policy を
+適用してください。
+
 ---
 
 ## 設定のポイント

--- a/docs/dcb_llm_ja/13_common_issues.md
+++ b/docs/dcb_llm_ja/13_common_issues.md
@@ -527,3 +527,21 @@ allow、reject、checkpoint/active-pointer の atomicity、および authorizati
 **移行メモ。** 既存の `CreateOrEnsure`、公開 CLR signature、enum value 0/1 は互換のままです。意図的に事前プロビジョニング済みの
 execution host だけを `VerifyAndExecute` へ移し、Enforced policy と DDL ではなく DML を付与した runtime role を設定してください。
 10.14.1 で build した binary consumer と additions-only の public API 比較も CI で実行します。
+
+## projection-status heartbeat は行消失と rolling version をまたいで継続する — dcb-v10.16.0 (SEK-G35)
+
+projection-status heartbeat の書き込みは activation に固定した writer identity を保持します。rolling deployment 中に
+actor host を再作成しても、既存 activation が元の projector version から新しく登録された version へ移ることはありません。
+新しい version が書き始める意図的な境界は次の activation です。
+
+すべての provider は fail-closed な expected-sequence CAS を維持します。dcb-v10.10.0 以降の PostgreSQL と SQLite では
+update 経路が到達不能でしたが、現在は到達可能な guarded update 経路を使うため、`expectedSequence > 0` で行がない場合は、
+無条件 insert にはならず拒否されます。producer はその conflict の後に local fence を rebase し、後続の scheduled operation で
+通常の sequence-zero create 経路を使います。この release より前の Cosmos DB は、live activation の内部で snapshot 由来の
+committed-version metadata が変化すると別の document identity を導出することがあり、expected-sequence update が常に absent 行を
+指して heartbeat が凍結していました。activation に固定した physical document identity と conditional replacement がこの失敗を
+防ぎます。旧 version や別 cluster の行は診断情報であり、garbage collection の対象ではありません。自動削除は行いません。
+
+serialized V1 status envelope と公開 CLR constructor の互換性は維持されます。追加された V2 status protocol は
+expected と observed projector version の診断に opt-in する経路で、V1 golden payload を変更せずに `Current`、
+`VersionMismatch`、`StaleOrOrphan` を返します。


### PR DESCRIPTION
## Summary

- Pin each grain activation to its host-provided projection-status identity and make both writers rebase safely after a missing row.
- Repair the fail-closed SQLite/PostgreSQL update route and return structured, provider-neutral CAS conflict diagnostics.
- Add V2 rolling-version status diagnostics while preserving V1 vectors and CLR signatures, with provider, writer, reader, and documentation coverage.

Closes #1134
Fixes #1133

## Verification

- dotnet build dcb/Sekiban.Dcb.slnx --artifacts-path /private/tmp/sek-g35-build.YAusWE -m:1
- Focused projection-status test suites on net9.0 and net10.0, including the real PostgreSQL Testcontainers matrix.