### PR TITLE
SEK-G36: expose projection status row timestamp and version match

### DIFF
--- a/dcb/src/Sekiban.Dcb.Core/Actors/ProjectionStatusReader.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Actors/ProjectionStatusReader.cs
@@ -176,7 +176,9 @@ public sealed class ProjectionStatusReader : IProjectionStatusReader
                         IsFaulted = faulted,
                         FaultMessage = row.FaultMessage,
                         IsFresh = rowFresh,
+                        RecordedAtUtc = row.RecordedAtUtc,
                         ExpectedProjectorVersion = expectedProjectorVersion,
+                        VersionMatch = ResolveVersionMatch(expectedProjectorVersion, row.ProjectorVersion),
                         VersionDisposition = ResolveVersionDisposition(
                             expectedProjectorVersion,
                             row.ProjectorVersion,
@@ -219,6 +221,15 @@ public sealed class ProjectionStatusReader : IProjectionStatusReader
             ? ProjectionStatusVersionDisposition.VersionMismatch
             : ProjectionStatusVersionDisposition.Current;
     }
+
+    private static ProjectionStatusVersionMatch ResolveVersionMatch(
+        string? expectedProjectorVersion,
+        string observedProjectorVersion) =>
+        string.IsNullOrWhiteSpace(expectedProjectorVersion)
+            ? ProjectionStatusVersionMatch.Unknown
+            : string.Equals(expectedProjectorVersion, observedProjectorVersion, StringComparison.Ordinal)
+                ? ProjectionStatusVersionMatch.Match
+                : ProjectionStatusVersionMatch.Mismatch;
 }
 
 /// <summary>
@@ -451,7 +462,8 @@ public sealed class SerializedProjectionStatusReader : ISerializedProjectionStat
                     string.IsNullOrWhiteSpace(snapshot.Snapshot.ActivationId) ||
                     string.IsNullOrWhiteSpace(snapshot.Snapshot.Consistency) ||
                     string.IsNullOrWhiteSpace(snapshot.ObservedProjectorVersion) ||
-                    !Enum.IsDefined(typeof(ProjectionStatusVersionDisposition), snapshot.VersionDisposition)))
+                    !Enum.IsDefined(typeof(ProjectionStatusVersionDisposition), snapshot.VersionDisposition) ||
+                    !Enum.IsDefined(typeof(ProjectionStatusVersionMatch), snapshot.VersionMatch)))
             {
                 return ResultBox.Error<SerializedProjectionStatusEnvelopeV2>(
                     new SerializedProjectionStatusShapeException("Projection status envelope has an invalid V2 shape."));

--- a/dcb/src/Sekiban.Dcb.Core/ProjectionStatus/ProjectionStatusModels.cs
+++ b/dcb/src/Sekiban.Dcb.Core/ProjectionStatus/ProjectionStatusModels.cs
@@ -43,6 +43,20 @@ public sealed record ProjectionStatusSnapshot(
     /// <summary>Whether this row satisfied the freshness/lease predicate at sampling time.</summary>
     public bool IsFresh { get; init; }
 
+    /// <summary>
+    ///     Timestamp committed with this row's heartbeat. This is intentionally distinct from
+    ///     <see cref="SampledAtUtc"/>, which identifies when the reader sampled its best-effort observation.
+    /// </summary>
+    [JsonIgnore]
+    public DateTimeOffset? RecordedAtUtc { get; init; }
+
+    /// <summary>
+    ///     Independent comparison of the caller's expected projector version and the version observed on this row.
+    ///     This does not fold freshness into the result; use <see cref="IsFresh"/> separately.
+    /// </summary>
+    [JsonIgnore]
+    public ProjectionStatusVersionMatch VersionMatch { get; init; } = ProjectionStatusVersionMatch.Unknown;
+
     /// <summary>Optional active-pointer transition classification supplied by an MV publisher.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? SwitchKind { get; init; }
@@ -347,6 +361,17 @@ public enum ProjectionStatusVersionDisposition
     StaleOrOrphan = 2
 }
 
+/// <summary>
+///     Independent comparison of an expected projector version and the version physically observed on a status row.
+///     Freshness remains a separate axis.
+/// </summary>
+public enum ProjectionStatusVersionMatch
+{
+    Unknown = 0,
+    Match = 1,
+    Mismatch = 2
+}
+
 /// <summary>Configuration for the passive projection status registry and read-side sampling.</summary>
 public class ProjectionStatusOptions
 {
@@ -472,13 +497,26 @@ public sealed record SerializedProjectionStatusSnapshotV2(
     ProjectionStatusVersionDisposition VersionDisposition,
     bool IsStaleOrOrphan)
 {
+    /// <summary>
+    ///     Timestamp committed with the row, surfaced outside the V1-shaped nested snapshot so V1 payloads remain
+    ///     frozen. It is not synthesized from <see cref="ProjectionStatusSnapshot.SampledAtUtc"/>.
+    /// </summary>
+    public DateTimeOffset? RecordedAtUtc { get; init; }
+
+    /// <summary>Expected-versus-observed version comparison, independent of freshness.</summary>
+    public ProjectionStatusVersionMatch VersionMatch { get; init; } = ProjectionStatusVersionMatch.Unknown;
+
     public static SerializedProjectionStatusSnapshotV2 Create(ProjectionStatusSnapshot snapshot) =>
         new(
             snapshot,
             snapshot.ExpectedProjectorVersion,
             snapshot.ObservedProjectorVersion,
             snapshot.VersionDisposition,
-            snapshot.IsStaleOrOrphan);
+            snapshot.IsStaleOrOrphan)
+        {
+            RecordedAtUtc = snapshot.RecordedAtUtc,
+            VersionMatch = snapshot.VersionMatch
+        };
 }
 
 /// <summary>Version-two serialized passive status envelope with version-disposition diagnostics.</summary>

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/ProjectionStatusRegistryTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/ProjectionStatusRegistryTests.cs
@@ -2,6 +2,7 @@ using Amazon.DynamoDBv2;
 using Amazon.DynamoDBv2.Model;
 using System.Text;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using System.Reflection;
 using Microsoft.Extensions.Options;
 using Dcb.Domain;
@@ -115,7 +116,10 @@ public sealed class ProjectionStatusRegistryTests
             eventStore,
             provider,
             new ProjectionStatusOptions { FreshnessWindow = TimeSpan.FromMinutes(5) });
-        var result = await reader.ReadAsync();
+        var result = await reader.ReadAsync(new ProjectionStatusReadRequest
+        {
+            ExpectedProjectorVersion = "v1"
+        });
 
         Assert.True(result.IsSuccess);
         var snapshots = result.GetValue();
@@ -123,6 +127,8 @@ public sealed class ProjectionStatusRegistryTests
         Assert.All(snapshots, snapshot =>
         {
             Assert.True(snapshot.HasConflict);
+            Assert.True(snapshot.IsFresh);
+            Assert.Equal(ProjectionStatusVersionMatch.Match, snapshot.VersionMatch);
             Assert.Equal(new[] { "activation-b", "activation-c" }, snapshot.ConflictActivations);
         });
     }
@@ -222,7 +228,9 @@ public sealed class ProjectionStatusRegistryTests
             LeaseExpiresAtUtc = DateTimeOffset.Parse("2026-01-01T00:01:00+00:00"),
             IsFaulted = false,
             FaultMessage = null,
-            IsFresh = true
+            IsFresh = true,
+            RecordedAtUtc = DateTimeOffset.Parse("2026-01-01T00:00:30+00:00"),
+            VersionMatch = ProjectionStatusVersionMatch.Match
         };
         var adapter = new SerializedProjectionStatusReader(new FixedStatusReader(snapshot), new MutableServiceIdProvider("server-service"));
         var response = await adapter.ReadSerializedAsync();
@@ -274,13 +282,19 @@ public sealed class ProjectionStatusRegistryTests
         var current = Assert.Single(snapshots, snapshot => snapshot.ProjectorVersion == "v2");
         Assert.Equal("v2", current.ExpectedProjectorVersion);
         Assert.Equal("v2", current.ObservedProjectorVersion);
+        Assert.Equal(now, current.RecordedAtUtc);
+        Assert.Equal(ProjectionStatusVersionMatch.Match, current.VersionMatch);
         Assert.Equal(ProjectionStatusVersionDisposition.Current, current.VersionDisposition);
 
         var freshDifferentVersion = Assert.Single(snapshots, snapshot => snapshot.ProjectorVersion == "v1");
+        Assert.True(freshDifferentVersion.IsFresh);
+        Assert.Equal(ProjectionStatusVersionMatch.Mismatch, freshDifferentVersion.VersionMatch);
         Assert.Equal(ProjectionStatusVersionDisposition.VersionMismatch, freshDifferentVersion.VersionDisposition);
         Assert.False(freshDifferentVersion.IsStaleOrOrphan);
 
         var expiredOrphan = Assert.Single(snapshots, snapshot => snapshot.ProjectorVersion == "v0");
+        Assert.False(expiredOrphan.IsFresh);
+        Assert.Equal(ProjectionStatusVersionMatch.Mismatch, expiredOrphan.VersionMatch);
         Assert.Equal(ProjectionStatusVersionDisposition.StaleOrOrphan, expiredOrphan.VersionDisposition);
         Assert.True(expiredOrphan.IsStaleOrOrphan);
         Assert.False(expiredOrphan.IsCaughtUp);
@@ -291,21 +305,206 @@ public sealed class ProjectionStatusRegistryTests
         var envelope = SerializedProjectionStatusReader.DeserializeV2(v2.GetValue());
         Assert.True(envelope.IsSuccess);
         Assert.Equal(2, envelope.GetValue().Version);
+        var serializedCurrent = Assert.Single(
+            envelope.GetValue().Snapshots,
+            snapshot => snapshot.ObservedProjectorVersion == "v2");
+        Assert.Equal(now, serializedCurrent.RecordedAtUtc);
+        Assert.Equal(ProjectionStatusVersionMatch.Match, serializedCurrent.VersionMatch);
+
+        using var v2Document = JsonDocument.Parse(v2.GetValue());
+        var v2CurrentJson = v2Document.RootElement.GetProperty("snapshots")
+            .EnumerateArray()
+            .Single(snapshot => snapshot.GetProperty("observedProjectorVersion").GetString() == "v2");
+        Assert.Equal(now, v2CurrentJson.GetProperty("recordedAtUtc").GetDateTimeOffset());
+        Assert.Equal((int)ProjectionStatusVersionMatch.Match, v2CurrentJson.GetProperty("versionMatch").GetInt32());
+        Assert.False(v2CurrentJson.GetProperty("snapshot").TryGetProperty("recordedAtUtc", out _));
+        Assert.False(v2CurrentJson.GetProperty("snapshot").TryGetProperty("versionMatch", out _));
         Assert.Contains(envelope.GetValue().Snapshots, snapshot =>
             snapshot.ObservedProjectorVersion == "v0" &&
             snapshot.VersionDisposition == ProjectionStatusVersionDisposition.StaleOrOrphan &&
             snapshot.IsStaleOrOrphan);
     }
 
+    public static IEnumerable<object?[]> VersionMatchFreshnessMatrix()
+    {
+        var now = DateTimeOffset.UtcNow;
+        var freshLease = now.AddMinutes(5);
+        var oldRecordedAt = now.AddMinutes(-5);
+        var expiredLease = now.AddMinutes(-5);
+
+        yield return [
+            "fresh-unknown", null, now, freshLease, true,
+            ProjectionStatusVersionMatch.Unknown, ProjectionStatusVersionDisposition.Current
+        ];
+        yield return [
+            "fresh-equal", "v1", now, freshLease, true,
+            ProjectionStatusVersionMatch.Match, ProjectionStatusVersionDisposition.Current
+        ];
+        yield return [
+            "fresh-unequal", "v2", now, freshLease, true,
+            ProjectionStatusVersionMatch.Mismatch, ProjectionStatusVersionDisposition.VersionMismatch
+        ];
+
+        // Stale because its committed row timestamp is outside the freshness window, even though its lease is live.
+        yield return [
+            "stale-recorded-at-unknown", null, oldRecordedAt, freshLease, false,
+            ProjectionStatusVersionMatch.Unknown, ProjectionStatusVersionDisposition.StaleOrOrphan
+        ];
+        // This stale+equal cell kills a resolver that returns StaleOrOrphan before comparing versions.
+        yield return [
+            "stale-recorded-at-equal", "v1", oldRecordedAt, freshLease, false,
+            ProjectionStatusVersionMatch.Match, ProjectionStatusVersionDisposition.StaleOrOrphan
+        ];
+        // This stale+unequal cell is stale through the independent lease predicate, not through RecordedAtUtc.
+        yield return [
+            "stale-expired-lease-unequal", "v2", now, expiredLease, false,
+            ProjectionStatusVersionMatch.Mismatch, ProjectionStatusVersionDisposition.StaleOrOrphan
+        ];
+    }
+
+    [Theory]
+    [MemberData(nameof(VersionMatchFreshnessMatrix))]
+    public async Task Reader_ResolvesVersionMatchIndependentlyAcrossTheSixCellFreshnessMatrix(
+        string cellName,
+        string? expectedProjectorVersion,
+        DateTimeOffset recordedAtUtc,
+        DateTimeOffset? leaseExpiresAtUtc,
+        bool isFresh,
+        ProjectionStatusVersionMatch versionMatch,
+        ProjectionStatusVersionDisposition versionDisposition)
+    {
+        await AssertVersionMatchCellAsync(
+            expectedProjectorVersion,
+            recordedAtUtc,
+            leaseExpiresAtUtc,
+            isFresh,
+            versionMatch,
+            versionDisposition,
+            cellName);
+    }
+
+    [Fact]
+    public async Task Reader_UsesUnknownForBlankExpectedVersionsAndOrdinalVersionMatching()
+    {
+        var now = DateTimeOffset.UtcNow;
+        var freshLease = now.AddMinutes(5);
+
+        await AssertVersionMatchCellAsync(
+            expectedProjectorVersion: string.Empty,
+            recordedAtUtc: now,
+            leaseExpiresAtUtc: freshLease,
+            isFresh: true,
+            versionMatch: ProjectionStatusVersionMatch.Unknown,
+            versionDisposition: ProjectionStatusVersionDisposition.Current);
+        await AssertVersionMatchCellAsync(
+            expectedProjectorVersion: " \t ",
+            recordedAtUtc: now,
+            leaseExpiresAtUtc: freshLease,
+            isFresh: true,
+            versionMatch: ProjectionStatusVersionMatch.Unknown,
+            versionDisposition: ProjectionStatusVersionDisposition.Current);
+        await AssertVersionMatchCellAsync(
+            expectedProjectorVersion: "v1",
+            recordedAtUtc: now,
+            leaseExpiresAtUtc: freshLease,
+            isFresh: true,
+            versionMatch: ProjectionStatusVersionMatch.Match,
+            versionDisposition: ProjectionStatusVersionDisposition.Current);
+        await AssertVersionMatchCellAsync(
+            expectedProjectorVersion: "V1",
+            recordedAtUtc: now,
+            leaseExpiresAtUtc: freshLease,
+            isFresh: true,
+            versionMatch: ProjectionStatusVersionMatch.Mismatch,
+            versionDisposition: ProjectionStatusVersionDisposition.VersionMismatch);
+        await AssertVersionMatchCellAsync(
+            expectedProjectorVersion: "v2",
+            recordedAtUtc: now,
+            leaseExpiresAtUtc: freshLease,
+            isFresh: true,
+            versionMatch: ProjectionStatusVersionMatch.Mismatch,
+            versionDisposition: ProjectionStatusVersionDisposition.VersionMismatch);
+    }
+
+    [Fact]
+    public async Task SerializedV2_UsesAdditiveVersionMatchAndReadsPreG36PayloadDefaults()
+    {
+        var recordedAtUtc = DateTimeOffset.Parse("2026-01-01T00:00:30+00:00");
+        var snapshot = new ProjectionStatusSnapshot(
+            "students",
+            "v1",
+            "cluster-a",
+            "activation-a",
+            7,
+            3,
+            "0001",
+            "0002",
+            4,
+            0,
+            DateTimeOffset.Parse("2026-01-01T00:00:00+00:00"),
+            ProjectionStatusSnapshot.BestEffortConsistency,
+            true)
+        {
+            IsFresh = true,
+            RecordedAtUtc = recordedAtUtc,
+            ExpectedProjectorVersion = "v1",
+            VersionMatch = ProjectionStatusVersionMatch.Match
+        };
+        var adapter = new SerializedProjectionStatusReader(
+            new FixedStatusReader(snapshot),
+            new MutableServiceIdProvider("server-service"));
+
+        var serialized = await adapter.ReadSerializedV2Async();
+        Assert.True(serialized.IsSuccess);
+        var json = Encoding.UTF8.GetString(serialized.GetValue());
+        Assert.Contains("\"recordedAtUtc\":\"2026-01-01T00:00:30+00:00\"", json);
+        Assert.Contains("\"versionMatch\":1", json);
+
+        var preG36Json = JsonNode.Parse(serialized.GetValue())!.AsObject();
+        var preG36Wrapper = preG36Json["snapshots"]!.AsArray()[0]!.AsObject();
+        preG36Wrapper.Remove("recordedAtUtc");
+        preG36Wrapper.Remove("versionMatch");
+        var preG36 = SerializedProjectionStatusReader.DeserializeV2(
+            Encoding.UTF8.GetBytes(preG36Json.ToJsonString()));
+
+        Assert.True(preG36.IsSuccess);
+        var restored = Assert.Single(preG36.GetValue().Snapshots);
+        Assert.Null(restored.RecordedAtUtc);
+        Assert.Equal(ProjectionStatusVersionMatch.Unknown, restored.VersionMatch);
+        Assert.Null(restored.Snapshot.RecordedAtUtc);
+        Assert.Equal(ProjectionStatusVersionMatch.Unknown, restored.Snapshot.VersionMatch);
+
+        var undefinedVersionMatch = SerializedProjectionStatusReader.DeserializeV2(
+            Encoding.UTF8.GetBytes(json.Replace("\"versionMatch\":1", "\"versionMatch\":99", StringComparison.Ordinal)));
+        Assert.False(undefinedVersionMatch.IsSuccess);
+        Assert.IsType<SerializedProjectionStatusShapeException>(undefinedVersionMatch.GetException());
+    }
+
     [Fact]
     public void ProjectionStatusPublicApi_RetainsLegacyClrConstructors()
     {
+        Assert.Equal(0, (int)ProjectionStatusVersionDisposition.Current);
+        Assert.Equal(1, (int)ProjectionStatusVersionDisposition.VersionMismatch);
+        Assert.Equal(2, (int)ProjectionStatusVersionDisposition.StaleOrOrphan);
         Assert.NotNull(typeof(ProjectionStatusWriteResult).GetConstructor(
             [typeof(ProjectionStatusWriteOutcome), typeof(ProjectionStatusHeartbeat), typeof(string)]));
         Assert.NotNull(typeof(ProjectionStatusReadRequest).GetConstructor(
             [typeof(string), typeof(string), typeof(string)]));
         Assert.NotNull(typeof(SerializedProjectionStatusEnvelopeV1).GetConstructor(
             [typeof(int), typeof(string), typeof(IReadOnlyList<ProjectionStatusSnapshot>)]));
+        AssertRecordConstructorAndDeconstruct(
+            typeof(ProjectionStatusSnapshot),
+            [
+                typeof(string), typeof(string), typeof(string), typeof(string), typeof(long), typeof(long),
+                typeof(string), typeof(string), typeof(long), typeof(long), typeof(DateTimeOffset), typeof(string),
+                typeof(bool), typeof(bool), typeof(IReadOnlyList<string>)
+            ]);
+        AssertRecordConstructorAndDeconstruct(
+            typeof(SerializedProjectionStatusSnapshotV2),
+            [
+                typeof(ProjectionStatusSnapshot), typeof(string), typeof(string),
+                typeof(ProjectionStatusVersionDisposition), typeof(bool)
+            ]);
     }
 
     [Fact]
@@ -401,6 +600,69 @@ public sealed class ProjectionStatusRegistryTests
             var provider = new MutableServiceIdProvider("alpha");
             var store = new SqliteMultiProjectionStateStore(path, serviceIdProvider: provider);
             await AssertProjectionStatusCasContractAsync(store);
+        }
+        finally
+        {
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task SqliteStatusStore_StateBearingDoItTwicePersistsExactRecordedTimestampsAndSequences()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"sekiban-projection-status-timestamps-{Guid.NewGuid():N}.db");
+        try
+        {
+            var provider = new MutableServiceIdProvider("alpha");
+            var store = new SqliteMultiProjectionStateStore(path, serviceIdProvider: provider);
+            var eventStore = new CoreInMemoryEventStore(DomainType.GetDomainTypes().EventTypes, provider);
+            var reader = new ProjectionStatusReader(
+                store,
+                eventStore,
+                provider,
+                new ProjectionStatusOptions
+                {
+                    FreshnessWindow = TimeSpan.FromMinutes(30),
+                    SamplingWindow = TimeSpan.Zero
+                });
+            var t1 = DateTimeOffset.UtcNow.AddMinutes(-10);
+            var t2 = t1.AddMinutes(1);
+            var firstHeartbeat = CreateHeartbeat("writer-a", 1, t1) with
+            {
+                Phase = ProjectionStatusPhases.Active,
+                LeaseExpiresAtUtc = DateTimeOffset.UtcNow.AddMinutes(5)
+            };
+
+            var firstWrite = await store.UpsertAsync(firstHeartbeat, 0);
+            Assert.True(firstWrite.IsSuccess, firstWrite.IsSuccess ? string.Empty : firstWrite.GetException().ToString());
+            Assert.True(firstWrite.GetValue().Committed);
+            var persistedFirst = Assert.Single((await store.ListAsync("students", "v1")).GetValue());
+            Assert.Equal(1, persistedFirst.Sequence);
+            Assert.Equal(t1, persistedFirst.RecordedAtUtc);
+            var firstSnapshot = Assert.Single((await reader.ReadAsync()).GetValue());
+            Assert.Equal(1, firstSnapshot.Sequence);
+            Assert.Equal(t1, firstSnapshot.RecordedAtUtc);
+            Assert.NotEqual(t1, firstSnapshot.SampledAtUtc);
+
+            var secondHeartbeat = firstHeartbeat with
+            {
+                Sequence = 2,
+                AppliedEventCount = 2,
+                RecordedAtUtc = t2
+            };
+            var secondWrite = await store.UpsertAsync(secondHeartbeat, 1);
+            Assert.True(secondWrite.IsSuccess, secondWrite.IsSuccess ? string.Empty : secondWrite.GetException().ToString());
+            Assert.True(secondWrite.GetValue().Committed);
+            var persistedSecond = Assert.Single((await store.ListAsync("students", "v1")).GetValue());
+            Assert.Equal(2, persistedSecond.Sequence);
+            Assert.Equal(t2, persistedSecond.RecordedAtUtc);
+            var secondSnapshot = Assert.Single((await reader.ReadAsync()).GetValue());
+            Assert.Equal(2, secondSnapshot.Sequence);
+            Assert.Equal(t2, secondSnapshot.RecordedAtUtc);
+            Assert.NotEqual(t2, secondSnapshot.SampledAtUtc);
         }
         finally
         {
@@ -640,6 +902,69 @@ public sealed class ProjectionStatusRegistryTests
             null,
             null,
             recordedAtUtc);
+
+    private static async Task AssertVersionMatchCellAsync(
+        string? expectedProjectorVersion,
+        DateTimeOffset recordedAtUtc,
+        DateTimeOffset? leaseExpiresAtUtc,
+        bool isFresh,
+        ProjectionStatusVersionMatch versionMatch,
+        ProjectionStatusVersionDisposition versionDisposition,
+        string? cellName = null)
+    {
+        var provider = new MutableServiceIdProvider("alpha");
+        var statusStore = new CoreInMemoryMultiProjectionStateStore(provider);
+        var eventStore = new CoreInMemoryEventStore(DomainType.GetDomainTypes().EventTypes, provider);
+        var heartbeat = CreateHeartbeat("activation-a", 1, recordedAtUtc) with
+        {
+            Phase = ProjectionStatusPhases.Active,
+            LeaseExpiresAtUtc = leaseExpiresAtUtc
+        };
+        var write = await statusStore.UpsertAsync(heartbeat, 0);
+        Assert.True(write.IsSuccess, write.IsSuccess ? string.Empty : write.GetException().ToString());
+        Assert.True(write.GetValue().Committed);
+
+        var reader = new ProjectionStatusReader(
+            statusStore,
+            eventStore,
+            provider,
+            new ProjectionStatusOptions
+            {
+                FreshnessWindow = TimeSpan.FromMinutes(2),
+                SamplingWindow = TimeSpan.Zero
+            });
+        var request = new ProjectionStatusReadRequest(ProjectorName: "students")
+        {
+            ExpectedProjectorVersion = expectedProjectorVersion
+        };
+        var result = await reader.ReadAsync(request);
+
+        Assert.True(
+            result.IsSuccess,
+            result.IsSuccess
+                ? string.Empty
+                : $"{cellName ?? "version-match cell"}: {result.GetException()}");
+        var snapshot = Assert.Single(result.GetValue());
+        Assert.Equal(recordedAtUtc, snapshot.RecordedAtUtc);
+        Assert.Equal(isFresh, snapshot.IsFresh);
+        Assert.Equal(versionMatch, snapshot.VersionMatch);
+        Assert.Equal(versionDisposition, snapshot.VersionDisposition);
+        Assert.Equal(
+            versionDisposition == ProjectionStatusVersionDisposition.StaleOrOrphan,
+            snapshot.IsStaleOrOrphan);
+    }
+
+    private static void AssertRecordConstructorAndDeconstruct(Type recordType, Type[] parameterTypes)
+    {
+        var constructor = recordType.GetConstructor(parameterTypes);
+        Assert.NotNull(constructor);
+        Assert.Equal(parameterTypes.Length, constructor.GetParameters().Length);
+
+        var deconstruct = recordType.GetMethod(
+            "Deconstruct",
+            parameterTypes.Select(parameterType => parameterType.MakeByRefType()).ToArray());
+        Assert.NotNull(deconstruct);
+    }
 
     /// <summary>
     ///     Shared provider matrix for the public status-store contract. Each invocation drives the production store,

--- a/docs/dcb_llm/11_storage_providers.md
+++ b/docs/dcb_llm/11_storage_providers.md
@@ -205,22 +205,29 @@ are surfaced by the additive V2 wrapper, whose nested `Snapshot` remains V1-shap
 
 Use this five-step consumer rule:
 
-1. Supply `ExpectedProjectorVersion` only when the caller has an expected version to compare. Until the V2
-   `ProjectorVersion` versus `ExpectedProjectorVersion` request-precedence rule is specified, do not set both
-   request properties together.
-2. Inspect `VersionMatch` independently of freshness: null, empty, or whitespace expected values are `Unknown`;
+1. Use `VersionMatch` to identify expected-version candidates, independently of freshness: null, empty, or
+   whitespace expected values are `Unknown`;
    equality is ordinal and case-sensitive; all other values are `Mismatch`.
-3. Inspect `IsFresh` separately. It is true only when both the committed `RecordedAtUtc` is inside the freshness
+2. Use `IsFresh` to report liveness separately. It is true only when both the committed `RecordedAtUtc` is inside the freshness
    window and the optional lease has not expired.
-4. Retain every observation and existing conflict signal while applying the caller's own authority rule. A fresh
-   mismatch is still a fresh observation, and two fresh matched rows are still a conflict.
-5. Escalate, select, retain, or clean up only through explicit consumer policy. A stale mismatch is an orphan
-   *candidate*, never a deletion authorization; dcb does not fold, filter, declare `IsOrphan`, or delete rows.
+3. When the expected version is `Unknown`, preserve all candidates: do not infer an expectation, fold rows, or
+   select one candidate.
+4. Preserve same-version observations across clusters and honor the existing conflict signal; do not select one by
+   timestamp. A fresh mismatch is still a fresh observation, and two fresh matched rows are still a conflict.
+5. Use `RecordedAtUtc` for age display and diagnosis, never as a replacement for expected-version selection. It is
+   not a cross-row tie breaker.
+
+Request-property caution: supply `ExpectedProjectorVersion` only when the caller has an expected version to compare.
+The V2 `ProjectorVersion` versus `ExpectedProjectorVersion` request-precedence rule is intentionally pending, so do
+not set both request properties together.
+
+Escalate, select, retain, or clean up only through explicit consumer policy. A stale mismatch is an orphan
+*candidate*, never a deletion authorization; dcb does not fold, filter, declare `IsOrphan`, or delete rows.
 
 Three tempting shortcuts are not authority rules: do not take the ordinal maximum `ProjectorVersion` (`1.0.9` sorts
-above `1.0.10`); do not take the maximum `Sequence` (it is a per-row CAS fence and can be higher on an orphan); and
-do not take the largest `LastAppliedSortableUniqueId` (a current new version can still be catching up). Use the two
-independent axes and the caller's explicit policy instead.
+above `1.0.10`); do not take the maximum `Sequence` (it is a per-row CAS fence, not comparable across rows: observed
+in aic dev, orphan `5884` > current `1583`); and do not take the largest `LastAppliedSortableUniqueId` (a current new
+version can still be catching up). Use the two independent axes and the caller's explicit policy instead.
 
 ## Consistency Contract
 

--- a/docs/dcb_llm/11_storage_providers.md
+++ b/docs/dcb_llm/11_storage_providers.md
@@ -195,6 +195,33 @@ version-mismatched, or stale/orphaned. These diagnostics are observational: no p
 from older versions or other clusters. Apply an explicit retention policy only after confirming that the rows are no
 longer useful for rollout or incident analysis.
 
+### Row timestamp and independent version match (SEK-G36 / dcb-v10.17.0)
+
+`ProjectionStatusSnapshot.RecordedAtUtc` is the exact timestamp committed with the heartbeat row. It is not derived
+from `SampledAtUtc`, which remains only the reader's best-effort observation time, and it is not a cross-row tie
+breaker. The in-process snapshot exposes both `RecordedAtUtc` and the independent
+`ProjectionStatusVersionMatch` (`Unknown = 0`, `Match = 1`, `Mismatch = 2`). V1 bytes remain frozen: the new facts
+are surfaced by the additive V2 wrapper, whose nested `Snapshot` remains V1-shaped.
+
+Use this five-step consumer rule:
+
+1. Supply `ExpectedProjectorVersion` only when the caller has an expected version to compare. Until the V2
+   `ProjectorVersion` versus `ExpectedProjectorVersion` request-precedence rule is specified, do not set both
+   request properties together.
+2. Inspect `VersionMatch` independently of freshness: null, empty, or whitespace expected values are `Unknown`;
+   equality is ordinal and case-sensitive; all other values are `Mismatch`.
+3. Inspect `IsFresh` separately. It is true only when both the committed `RecordedAtUtc` is inside the freshness
+   window and the optional lease has not expired.
+4. Retain every observation and existing conflict signal while applying the caller's own authority rule. A fresh
+   mismatch is still a fresh observation, and two fresh matched rows are still a conflict.
+5. Escalate, select, retain, or clean up only through explicit consumer policy. A stale mismatch is an orphan
+   *candidate*, never a deletion authorization; dcb does not fold, filter, declare `IsOrphan`, or delete rows.
+
+Three tempting shortcuts are not authority rules: do not take the ordinal maximum `ProjectorVersion` (`1.0.9` sorts
+above `1.0.10`); do not take the maximum `Sequence` (it is a per-row CAS fence and can be higher on an orphan); and
+do not take the largest `LastAppliedSortableUniqueId` (a current new version can still be catching up). Use the two
+independent axes and the caller's explicit policy instead.
+
 ## Consistency Contract
 
 This section documents the actual atomicity guarantees of `IEventStore.WriteSerializableEventsAsync` / `WriteEventsAsync` per provider. The two-phase Cosmos write design itself is unchanged; what has changed is how a failure of that write is handled.

--- a/docs/dcb_llm/13_common_issues.md
+++ b/docs/dcb_llm/13_common_issues.md
@@ -591,3 +591,16 @@ diagnostics, not garbage collection candidates: no automatic deletion is perform
 The serialized V1 status envelope and public CLR constructors remain compatible. The additive V2 status protocol is
 the opt-in path for expected-versus-observed projector-version diagnostics and reports `Current`, `VersionMismatch`,
 or `StaleOrOrphan` without changing V1 golden payloads.
+
+## Projection-status rows expose their committed timestamp and version-match axis — dcb-v10.17.0 (SEK-G36)
+
+The passive reader now returns the exact row `RecordedAtUtc` and an independent `VersionMatch` observation. V1 JSON,
+the 15-parameter `ProjectionStatusSnapshot` constructor and deconstructor, and the 5-parameter V2 wrapper constructor
+and deconstructor remain compatible. The V2 wrapper carries the new timestamp and `Unknown` / `Match` / `Mismatch`
+axis while its nested snapshot stays V1-shaped.
+
+`VersionDisposition` deliberately keeps its legacy freshness-first behavior: a stale row is still
+`StaleOrOrphan`. `VersionMatch` reports equality independently, so stale equal and stale unequal rows are no longer
+indistinguishable to the consumer. `IsFresh` still requires both a recent committed timestamp and a live optional
+lease. A stale mismatch remains an orphan candidate, not a deletion authorization, and dcb still performs no
+selection, folding, retention, or cleanup policy.

--- a/docs/dcb_llm_ja/11_storage_providers.md
+++ b/docs/dcb_llm_ja/11_storage_providers.md
@@ -199,22 +199,30 @@ V1 の byte は凍結されたままです。新しい事実は加法的な V2 w
 
 consumer は次の 5 ステップに従ってください。
 
-1. caller が比較すべき expected version を持つときだけ `ExpectedProjectorVersion` を指定します。V2 の
-   `ProjectorVersion` と `ExpectedProjectorVersion` の request precedence は未決定なので、両方の request property を同時に
-   設定しないでください。
-2. freshness とは独立に `VersionMatch` を確認します。expected が null、空文字、または whitespace なら `Unknown` です。
+1. freshness とは独立に `VersionMatch` で expected-version の候補を確認します。expected が null、空文字、または
+   whitespace なら `Unknown` です。
    equality は ordinal かつ case-sensitive で、それ以外は `Mismatch` です。
-3. `IsFresh` は別の軸として確認します。commit された `RecordedAtUtc` が freshness window 内にあり、かつ optional lease が
+2. `IsFresh` で生存性を別立てに報告します。commit された `RecordedAtUtc` が freshness window 内にあり、かつ optional lease が
    expire していない場合にだけ true になります。
-4. caller 自身の authority rule を適用するときも、すべての observation と既存の conflict signal を保持します。fresh mismatch
-   は依然として fresh な observation であり、fresh matched row が 2 行なら依然として conflict です。
-5. escalation、selection、retention、cleanup は明示的な consumer policy でのみ行います。stale mismatch は orphan
-   *candidate* にすぎず、削除の authorization ではありません。dcb は行を fold、filter、`IsOrphan` 判定、削除しません。
+3. expected version が `Unknown` のときは、すべての候補を保持します。期待値を推測したり、行を fold したり、1 件を
+   selection したりしないでください。
+4. 同一 version の cluster をまたぐ observation を保持し、既存の conflict signal を尊重します。timestamp で 1 件を選びません。
+   fresh mismatch は依然として fresh な observation であり、fresh matched row が 2 行なら依然として conflict です。
+5. `RecordedAtUtc` は経過時間の表示と診断に使い、expected-version による selection の代替にしません。行どうしの
+   tie breaker でもありません。
+
+request property に関する注意: caller が比較すべき expected version を持つときだけ `ExpectedProjectorVersion` を指定します。
+V2 の `ProjectorVersion` と `ExpectedProjectorVersion` の request precedence は意図的に保留されているため、両方の request
+property を同時に設定しないでください。
+
+escalation、selection、retention、cleanup は明示的な consumer policy でのみ行います。stale mismatch は orphan
+*candidate* にすぎず、削除の authorization ではありません。dcb は行を fold、filter、`IsOrphan` 判定、削除しません。
 
 次の 3 つの近道は authority rule ではありません。ordinal の最大 `ProjectorVersion` を選ばないでください
-(`1.0.9` は `1.0.10` より大きく並びます)。最大 `Sequence` も選ばないでください（これは行ごとの CAS fence であり、orphan の
-値の方が大きいことがあります）。最大の `LastAppliedSortableUniqueId` も選ばないでください（新しい current version はまだ
-catch-up 中であることがあります）。2 つの独立した軸と caller の明示的な policy を使ってください。
+(`1.0.9` は `1.0.10` より大きく並びます)。最大 `Sequence` も選ばないでください（これは行ごとの CAS fence で、行どうしでは
+比較できません。aic dev で観測された実例は orphan `5884` > current `1583` です）。最大の
+`LastAppliedSortableUniqueId` も選ばないでください（新しい current version はまだ catch-up 中であることがあります）。2 つの
+独立した軸と caller の明示的な policy を使ってください。
 
 ---
 

--- a/docs/dcb_llm_ja/11_storage_providers.md
+++ b/docs/dcb_llm_ja/11_storage_providers.md
@@ -190,6 +190,32 @@ stale/orphan のどれかを返します。これらは observation のための
 自動削除することはありません。rollout や incident analysis に不要になったことを確認してから、明示的な retention policy を
 適用してください。
 
+### 行タイムスタンプと独立した version match (SEK-G36 / dcb-v10.17.0)
+
+`ProjectionStatusSnapshot.RecordedAtUtc` は heartbeat 行とともに commit された正確なタイムスタンプです。reader の
+best-effort な観測時刻である `SampledAtUtc` から導出されるものではなく、行どうしの tie breaker にも使いません。in-process
+snapshot は `RecordedAtUtc` と独立した `ProjectionStatusVersionMatch` (`Unknown = 0`、`Match = 1`、`Mismatch = 2`) を公開します。
+V1 の byte は凍結されたままです。新しい事実は加法的な V2 wrapper から公開され、入れ子の `Snapshot` は V1 形状のままです。
+
+consumer は次の 5 ステップに従ってください。
+
+1. caller が比較すべき expected version を持つときだけ `ExpectedProjectorVersion` を指定します。V2 の
+   `ProjectorVersion` と `ExpectedProjectorVersion` の request precedence は未決定なので、両方の request property を同時に
+   設定しないでください。
+2. freshness とは独立に `VersionMatch` を確認します。expected が null、空文字、または whitespace なら `Unknown` です。
+   equality は ordinal かつ case-sensitive で、それ以外は `Mismatch` です。
+3. `IsFresh` は別の軸として確認します。commit された `RecordedAtUtc` が freshness window 内にあり、かつ optional lease が
+   expire していない場合にだけ true になります。
+4. caller 自身の authority rule を適用するときも、すべての observation と既存の conflict signal を保持します。fresh mismatch
+   は依然として fresh な observation であり、fresh matched row が 2 行なら依然として conflict です。
+5. escalation、selection、retention、cleanup は明示的な consumer policy でのみ行います。stale mismatch は orphan
+   *candidate* にすぎず、削除の authorization ではありません。dcb は行を fold、filter、`IsOrphan` 判定、削除しません。
+
+次の 3 つの近道は authority rule ではありません。ordinal の最大 `ProjectorVersion` を選ばないでください
+(`1.0.9` は `1.0.10` より大きく並びます)。最大 `Sequence` も選ばないでください（これは行ごとの CAS fence であり、orphan の
+値の方が大きいことがあります）。最大の `LastAppliedSortableUniqueId` も選ばないでください（新しい current version はまだ
+catch-up 中であることがあります）。2 つの独立した軸と caller の明示的な policy を使ってください。
+
 ---
 
 ## 設定のポイント

--- a/docs/dcb_llm_ja/13_common_issues.md
+++ b/docs/dcb_llm_ja/13_common_issues.md
@@ -545,3 +545,14 @@ committed-version metadata が変化すると別の document identity を導出�
 serialized V1 status envelope と公開 CLR constructor の互換性は維持されます。追加された V2 status protocol は
 expected と observed projector version の診断に opt-in する経路で、V1 golden payload を変更せずに `Current`、
 `VersionMismatch`、`StaleOrOrphan` を返します。
+
+## projection-status 行が commit 済みタイムスタンプと version-match 軸を公開する — dcb-v10.17.0 (SEK-G36)
+
+受動 reader は正確な行の `RecordedAtUtc` と独立した `VersionMatch` observation を返すようになりました。V1 JSON、15 parameter
+の `ProjectionStatusSnapshot` constructor / deconstructor、5 parameter の V2 wrapper constructor / deconstructor は互換性を
+維持します。V2 wrapper が新しい timestamp と `Unknown` / `Match` / `Mismatch` 軸を保持し、入れ子の snapshot は V1 形状のままです。
+
+`VersionDisposition` は意図的に既存の freshness-first 挙動を維持します。stale な行は引き続き `StaleOrOrphan` です。
+`VersionMatch` は equality を独立して返すため、stale equal 行と stale unequal 行を consumer が区別できます。`IsFresh` は
+recent な commit 済み timestamp と live な optional lease の両方を引き続き必要とします。stale mismatch は orphan candidate であって
+削除の authorization ではありません。dcb は selection、folding、retention、cleanup policy を実行しません。


### PR DESCRIPTION
Closes #1136

## Summary

- Expose each committed heartbeat-row `RecordedAtUtc` and a freshness-independent `VersionMatch` axis on the in-process snapshot and additive V2 wrapper.
- Preserve the legacy freshness-first `VersionDisposition`, V1 JSON vectors, positional record constructors, and deconstructors.
- Add EN/JA dcb-v10.17.0 consumer guidance: five-step authority rule, three unsafe shortcuts, pending request-precedence note, and no deletion authorization.

## Compatibility and wire behavior

- `ProjectionStatusSnapshot` retains its 15-parameter constructor/deconstructor; `SerializedProjectionStatusSnapshotV2` retains its 5-parameter constructor/deconstructor. New members are non-positional init properties.
- V1 request/response bytes remain identical and contain neither new field. The V2 nested snapshot remains V1-shaped.
- Pre-G36 V2 payloads deserialize with `RecordedAtUtc = null` and `VersionMatch = Unknown`; undefined numeric version-match values are rejected.

## Verification

- `dotnet test dcb/tests/Sekiban.Dcb.WithResult.Tests/Sekiban.Dcb.WithResult.Tests.csproj -c Release -f net9.0 --verbosity minimal` — 1,043 passed.
- `dotnet test dcb/tests/Sekiban.Dcb.WithResult.Tests/Sekiban.Dcb.WithResult.Tests.csproj -c Release -f net10.0 --verbosity minimal` — 1,043 passed.
- Targeted API/reflection/serialization/matrix/state gate subset passed 10/10 on both net9.0 and net10.0.
- Scoped `dotnet format whitespace --verify-no-changes` passed for all touched C# files; docs invariant checks and `git diff --check` passed.

## Real-store and mutation-kill evidence

- The SQLite production-path Do-It-Twice test writes the same writer identity at exact `t1` / sequence 1 and then exact `t2` / sequence 2; it asserts both persisted-store rows and reader snapshots transition `1 -> 2` and `t1 -> t2`, while `SampledAtUtc` remains distinct.
- A stale-first version-match mutation failed exactly the `stale-recorded-at-equal` (`Match` expected) and `stale-expired-lease-unequal` (`Mismatch` expected) matrix cells: 2 failed / 4 passed.
- A cached-first-timestamp mutation failed the second-read `t2` assertion (actual `t1`), and a `SampledAtUtc` substitution mutation failed the first-read exact `t1` assertion. Both mutations were immediately restored.
