### PR TITLE
fix(dcb): make catch-up checkpoints advance on fetched events

### DIFF
--- a/dcb/src/Sekiban.Dcb.Orleans.Core/Grains/CatchUpPositionContracts.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.Core/Grains/CatchUpPositionContracts.cs
@@ -82,8 +82,10 @@ internal sealed record CatchUpInvocationResult(
     SortableUniqueId? AuthoritativeReachedPosition);
 
 internal readonly record struct CatchUpBatchResult(
-    int ProcessedCount,
-    SortableUniqueId? AuthoritativeReadCursor);
+    int FetchedCount,
+    int AppliedCount,
+    SortableUniqueId? LastFetchedPosition,
+    SortableUniqueId? LastAppliedPosition);
 
 internal enum CatchUpProductionHookPoint
 {

--- a/dcb/src/Sekiban.Dcb.Orleans.Core/Grains/MultiProjectionGrain.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.Core/Grains/MultiProjectionGrain.cs
@@ -34,6 +34,11 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
     private const string EmptyLogValue = "empty";
     private const int CatchUpEventTypeSummaryTopN = 5;
     private const long CatchUpInformationElapsedThresholdMs = 1000;
+    private const int HotCatchUpPersistMaxFetchedEvents = 5_000;
+    private static readonly TimeSpan HotCatchUpPersistMaxInterval = TimeSpan.FromMinutes(5);
+    private const string PersistOutcomeNotAttempted = "not_attempted";
+    private const string PersistOutcomeDurableWrite = "durable_write";
+    private const string PersistOutcomeNoDurableWrite = "no_durable_write";
     private const int DefaultSnapshotEnvelopeSizeLimitBytes = 2 * 1024 * 1024;
     private const int SnapshotEnvelopeBase64ExpansionNumerator = 3;
     private const int SnapshotEnvelopeBase64ExpansionDenominator = 4;
@@ -211,8 +216,36 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
     private bool _hybridCatchUpCheckLogged;
     private HybridReadBatchMetadata? _lastHybridReadBatchMetadata;
     private long _eventsProcessedSinceLastCatchUpPersist;
+    private long _eventsFetchedSinceLastCatchUpPersist;
     private DateTime _lastCatchUpPersistUtc = DateTime.UtcNow;
+    private bool? _lastCatchUpUsedCold;
     private long _catchUpBatchSkipCount;
+    private string _lastPersistOutcome = PersistOutcomeNotAttempted;
+
+    private void ResetCatchUpPersistWindow(bool resetReadPath = false)
+    {
+        _eventsProcessedSinceLastCatchUpPersist = 0;
+        _eventsFetchedSinceLastCatchUpPersist = 0;
+        _lastCatchUpPersistUtc = DateTime.UtcNow;
+        if (resetReadPath)
+        {
+            _lastCatchUpUsedCold = null;
+        }
+    }
+
+    private void ObserveCatchUpReadPath(HybridReadBatchMetadata? metadata)
+    {
+        var usedCold = metadata?.UsedCold == true;
+        if (_lastCatchUpUsedCold.HasValue && _lastCatchUpUsedCold.Value != usedCold)
+        {
+            // A cold-to-hot (or hot-to-cold) transition starts a new logical catch-up window. The applied count,
+            // fetched count, and elapsed-time fallback must move together; carrying only one of them makes the next
+            // threshold dependent on the previous storage path.
+            ResetCatchUpPersistWindow();
+        }
+
+        _lastCatchUpUsedCold = usedCold;
+    }
 
     private sealed record PersistPolicySettings(
         int PersistBatchSize,
@@ -247,7 +280,10 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
         int SegmentCount,
         bool PersistTriggered,
         string PersistReason,
-        string EventTypeSummary);
+        string EventTypeSummary)
+    {
+        public string PersistOutcome { get; init; } = PersistOutcomeNotAttempted;
+    }
 
     private sealed record PersistCheckpoint(
         string ProjectorVersion,
@@ -454,7 +490,7 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
         _logger.Log(
             logLevel,
             MultiProjectionLogEvents.CatchUpBatchSummary,
-            "[{ProjectorName}] Catch-up batch summary. BatchNumber={BatchNumber}, StartPosition={StartPosition}, CurrentPosition={CurrentPosition}, LastAppliedPosition={LastAppliedPosition}, TargetPosition={TargetPosition}, RequestedMaxCount={RequestedMaxCount}, FetchedCount={FetchedCount}, FilteredCount={FilteredCount}, AppliedCount={AppliedCount}, PendingStreamEventsBefore={PendingStreamEventsBefore}, PendingStreamEventsAfter={PendingStreamEventsAfter}, ReadElapsedMs={ReadElapsedMs}, ApplyElapsedMs={ApplyElapsedMs}, PersistElapsedMs={PersistElapsedMs}, SafePromotionElapsedMs={SafePromotionElapsedMs}, TotalElapsedMs={TotalElapsedMs}, ReadSource={ReadSource}, ColdEventsRead={ColdEventsRead}, HotEventsRead={HotEventsRead}, ReachedColdSegmentBoundary={ReachedColdSegmentBoundary}, SegmentCount={SegmentCount}, PersistTriggered={PersistTriggered}, PersistReason={PersistReason}, EventTypeSummary={EventTypeSummary}",
+            "[{ProjectorName}] Catch-up batch summary. BatchNumber={BatchNumber}, StartPosition={StartPosition}, CurrentPosition={CurrentPosition}, LastAppliedPosition={LastAppliedPosition}, TargetPosition={TargetPosition}, RequestedMaxCount={RequestedMaxCount}, FetchedCount={FetchedCount}, FilteredCount={FilteredCount}, AppliedCount={AppliedCount}, PendingStreamEventsBefore={PendingStreamEventsBefore}, PendingStreamEventsAfter={PendingStreamEventsAfter}, ReadElapsedMs={ReadElapsedMs}, ApplyElapsedMs={ApplyElapsedMs}, PersistElapsedMs={PersistElapsedMs}, SafePromotionElapsedMs={SafePromotionElapsedMs}, TotalElapsedMs={TotalElapsedMs}, ReadSource={ReadSource}, ColdEventsRead={ColdEventsRead}, HotEventsRead={HotEventsRead}, ReachedColdSegmentBoundary={ReachedColdSegmentBoundary}, SegmentCount={SegmentCount}, PersistTriggered={PersistTriggered}, PersistReason={PersistReason}, PersistOutcome={PersistOutcome}, EventTypeSummary={EventTypeSummary}",
             projectorName,
             telemetry.BatchNumber,
             telemetry.StartPosition,
@@ -479,6 +515,7 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
             telemetry.SegmentCount,
             telemetry.PersistTriggered,
             telemetry.PersistReason,
+            telemetry.PersistOutcome,
             telemetry.EventTypeSummary);
     }
 
@@ -1299,6 +1336,7 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
 
     public async Task<ResultBox<bool>> PersistStateAsync()
     {
+        _lastPersistOutcome = PersistOutcomeNotAttempted;
         try
         {
             var startUtc = DateTime.UtcNow;
@@ -1306,6 +1344,7 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
 
             if (_host == null)
             {
+                _lastPersistOutcome = PersistOutcomeNoDurableWrite;
                 return ResultBox.Error<bool>(new InvalidOperationException("Projection host not initialized"));
             }
 
@@ -1335,6 +1374,7 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
             var shortCircuit = TryShortCircuitPersist(projectorName, checkpoint);
             if (shortCircuit is not null)
             {
+                _lastPersistOutcome = PersistOutcomeNoDurableWrite;
                 return shortCircuit;
             }
 
@@ -1355,6 +1395,7 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
             {
                 _lastError = snapshotWriteResult.GetException().Message;
                 _logger.LogWarning("[{ProjectorName}] {LastError}", projectorName, _lastError);
+                _lastPersistOutcome = PersistOutcomeNoDurableWrite;
                 return ResultBox.FromValue(false);
             }
 
@@ -1504,12 +1545,16 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
                 TryCompactAfterLargePersist(projectorName, envelopeSize);
             }
 
+            _lastPersistOutcome = externalStoreSaved
+                ? PersistOutcomeDurableWrite
+                : PersistOutcomeNoDurableWrite;
             return ResultBox.FromValue(true);
         }
         catch (Exception ex)
         {
             _lastError = $"Persistence failed: {ex.Message}";
             _logger.LogError(ex, "[{ProjectorName}] Persistence failed", GetProjectorName());
+            _lastPersistOutcome = PersistOutcomeNoDurableWrite;
             return ResultBox.Error<bool>(ex);
         }
     }
@@ -1539,6 +1584,7 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
                 {
                     _lastError = writeResult.GetException().Message;
                     _logger.LogWarning("[{ProjectorName}] Streaming snapshot write failed: {Error}", projectorName, _lastError);
+                    _lastPersistOutcome = PersistOutcomeNoDurableWrite;
                     return ResultBox.FromValue(false);
                 }
 
@@ -1612,6 +1658,9 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
                     TryCompactAfterLargePersist(projectorName, tempFileSize);
                 }
 
+                _lastPersistOutcome = externalStoreSaved
+                    ? PersistOutcomeDurableWrite
+                    : PersistOutcomeNoDurableWrite;
                 return ResultBox.FromValue(true);
             }
             catch
@@ -1625,6 +1674,7 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
         {
             _lastError = $"Streaming persistence failed: {ex.Message}";
             _logger.LogError(ex, "[{ProjectorName}] Streaming persistence failed", projectorName);
+            _lastPersistOutcome = PersistOutcomeNoDurableWrite;
             return ResultBox.Error<bool>(ex);
         }
         finally
@@ -2022,10 +2072,10 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
             await CatchUpProductionTestHooks.PublishAsync(
                 CatchUpProductionHookPoint.InvocationEnteredGate,
                 new CatchUpProductionObservation(_serviceId, projectorName, _catchUpProgress.StartLease, null));
+            RecoverStaleCatchUpIfNeeded(projectorName);
             var inheritedStart = forceEvenIfCatchUpActive && _catchUpProgress.IsActive
                 ? _catchUpProgress.StartLease
                 : null;
-            RecoverStaleCatchUpIfNeeded(projectorName);
             if (_catchUpProgress.IsActive && !forceEvenIfCatchUpActive)
             {
                 _logger.LogDebug(
@@ -2067,6 +2117,12 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
             };
             ResetHybridCatchUpLogging();
             ResetCatchUpFailureTracking();
+            if (inheritedStart is null)
+            {
+                // A fresh invocation owns a new logical window. A forced first-query invocation with an inherited
+                // active run deliberately keeps the prior window's applied/fetched/time progress.
+                ResetCatchUpPersistWindow(resetReadPath: true);
+            }
             _catchUpBatchSkipCount = 0;
 
             MoveBufferedStreamEventsToPending(currentPosition);
@@ -2077,13 +2133,13 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
                 for (var i = 0; i < maxRefreshBatches && _catchUpProgress.IsActive; i++)
                 {
                     var batch = await ProcessSingleCatchUpBatch();
-                    if (batch.AuthoritativeReadCursor is { } batchCursor &&
+                    if (batch.LastFetchedPosition is { } batchCursor &&
                         (invocationReached is null || batchCursor.IsLaterThan(invocationReached)))
                     {
                         invocationReached = batchCursor;
                     }
 
-                    if (batch.ProcessedCount == 0)
+                    if (batch.FetchedCount == 0)
                     {
                         _catchUpProgress.ConsecutiveEmptyBatches++;
                         if (_catchUpProgress.ConsecutiveEmptyBatches >= MaxConsecutiveEmptyBatches)
@@ -2724,6 +2780,7 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
         _catchUpTimer?.Dispose();
         _catchUpTimer = null;
         _catchUpProgress = new CatchUpProgress { IsActive = false };
+        ResetCatchUpPersistWindow(resetReadPath: true);
 
         _host = _actorHostFactory.Create(GetProjectorName(), _mergedActorOptions ?? DefaultActorOptions, _logger);
         VerifyPinnedProjectionStatusWriterIdentityAfterHostRecreation();
@@ -3676,8 +3733,7 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
             };
             ResetHybridCatchUpLogging();
             ResetCatchUpFailureTracking();
-            _eventsProcessedSinceLastCatchUpPersist = 0;
-            _lastCatchUpPersistUtc = DateTime.UtcNow;
+            ResetCatchUpPersistWindow(resetReadPath: true);
             _catchUpBatchSkipCount = 0;
 
             MoveBufferedStreamEventsToPending(currentPosition);
@@ -3779,7 +3835,7 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
             var batch = await ProcessSingleCatchUpBatch();
             ResetCatchUpFailureTracking();
 
-            if (batch.ProcessedCount == 0)
+            if (batch.FetchedCount == 0)
             {
                 _catchUpProgress.ConsecutiveEmptyBatches++;
                 if (_catchUpProgress.ConsecutiveEmptyBatches >= MaxConsecutiveEmptyBatches)
@@ -3807,7 +3863,7 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
 
     private async Task<CatchUpBatchResult> ProcessSingleCatchUpBatch()
     {
-        if (_host == null) return new CatchUpBatchResult(0, null);
+        if (_host == null) return new CatchUpBatchResult(0, 0, null, null);
         _catchUpProgress.LastAttempt = DateTime.UtcNow;
         return await ProcessSerializableBatch();
     }
@@ -3932,7 +3988,7 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
             // failure must not be lost: the first-query barrier reads this to fail closed with the original exception
             // rather than treat a failed read as "caught up to an empty tail".
             _catchUpReadException = exception;
-            return new CatchUpBatchResult(0, null);
+            return new CatchUpBatchResult(0, 0, null, null);
         }
 
         _logger.LogDebug(
@@ -3970,7 +4026,7 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
                     PersistTriggered: false,
                     PersistReason: "none",
                     EventTypeSummary: EmptyLogValue));
-            return new CatchUpBatchResult(0, _catchUpProgress.CurrentPosition);
+            return new CatchUpBatchResult(0, 0, _catchUpProgress.CurrentPosition, null);
         }
 
         UpdateTargetPosition(events[^1].SortableUniqueIdValue);
@@ -3982,38 +4038,27 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
         var filteredCount = Math.Max(0, events.Count - filtered.Count);
         if (filtered.Count == 0)
         {
-            _catchUpProgress.CurrentPosition = new SortableUniqueId(events[^1].SortableUniqueIdValue);
-            MarkProjectionStatusDirty(events[^1].SortableUniqueIdValue);
-            LogCatchUpBatchSummary(
-                projectorName,
-                new CatchUpBatchTelemetry(
-                    BatchNumber: batchNumber,
-                    StartPosition: startPosition,
-                    CurrentPosition: _catchUpProgress.CurrentPosition?.Value ?? events[^1].SortableUniqueIdValue,
-                    LastAppliedPosition: EmptyLogValue,
-                    TargetPosition: _catchUpProgress.TargetPosition?.Value ?? events[^1].SortableUniqueIdValue,
-                    RequestedMaxCount: batchSize,
-                    FetchedCount: events.Count,
-                    FilteredCount: filteredCount,
-                    AppliedCount: 0,
-                    PendingStreamEventsBefore: pendingStreamEventsBefore,
-                    PendingStreamEventsAfter: _pendingStreamEvents.Count,
-                    ReadElapsedMs: readStopwatch.ElapsedMilliseconds,
-                    ApplyElapsedMs: 0,
-                    PersistElapsedMs: 0,
-                    SafePromotionElapsedMs: 0,
-                    TotalElapsedMs: readStopwatch.ElapsedMilliseconds,
-                    ReadSource: hybridReadBatchMetadata?.Source ?? (isHybridCatchUp ? "hybrid_unknown" : catchUpStore.GetType().Name),
-                    ColdEventsRead: hybridReadBatchMetadata?.ColdEventsRead ?? 0,
-                    HotEventsRead: hybridReadBatchMetadata?.HotEventsRead ?? 0,
-                    ReachedColdSegmentBoundary: hybridReadBatchMetadata?.ReachedColdSegmentBoundary ?? false,
-                    SegmentCount: hybridReadBatchMetadata?.SegmentCount ?? 0,
-                    PersistTriggered: false,
-                    PersistReason: "none",
-                    EventTypeSummary: EmptyLogValue));
+            await UpdateCatchUpProgressAfterBatch(
+                batchNumber,
+                startPosition,
+                Array.Empty<Guid>(),
+                events[^1].SortableUniqueIdValue,
+                null,
+                batchSize,
+                fetchedCount: events.Count,
+                filteredCount,
+                appliedCount: 0,
+                readElapsedMs: readStopwatch.ElapsedMilliseconds,
+                applyElapsedMs: 0,
+                pendingStreamEventsBefore,
+                hybridCatchUpStore,
+                hybridReadBatchMetadata,
+                BuildCatchUpEventTypeSummary(events.Select(e => e.EventPayloadName)));
             return new CatchUpBatchResult(
+                events.Count,
                 0,
-                new SortableUniqueId(events[^1].SortableUniqueIdValue));
+                new SortableUniqueId(events[^1].SortableUniqueIdValue),
+                null);
         }
 
         var applyStopwatch = System.Diagnostics.Stopwatch.StartNew();
@@ -4038,6 +4083,7 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
             batchNumber,
             startPosition,
             filtered.Select(e => e.Id),
+            events[^1].SortableUniqueIdValue,
             filtered[^1].SortableUniqueIdValue,
             batchSize,
             fetchedCount: events.Count,
@@ -4051,8 +4097,10 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
             BuildCatchUpEventTypeSummary(filtered.Select(e => e.EventPayloadName)));
 
         return new CatchUpBatchResult(
+            events.Count,
             filtered.Count,
-            new SortableUniqueId(events[^1].SortableUniqueIdValue));
+            new SortableUniqueId(events[^1].SortableUniqueIdValue),
+            new SortableUniqueId(filtered[^1].SortableUniqueIdValue));
     }
 
     private async Task<CatchUpBatchResult> ProcessStreamingSerializableBatch(
@@ -4065,7 +4113,7 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
     {
         if (_host == null)
         {
-            return new CatchUpBatchResult(0, null);
+            return new CatchUpBatchResult(0, 0, null, null);
         }
 
         var processedIds = new List<Guid>(Math.Min(batchSize, StreamingCatchUpApplyChunkSize * 2));
@@ -4158,7 +4206,7 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
                 // Match the enumerable path: the resilient background reader may retry later, but a first-query
                 // invocation must retain and rethrow this exact provider exception when its cursor did not reach head.
                 _catchUpReadException = exception;
-                return new CatchUpBatchResult(0, null);
+                return new CatchUpBatchResult(0, 0, null, null);
             }
             if (fetchedCount == 0)
             {
@@ -4189,52 +4237,42 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
                         PersistTriggered: false,
                         PersistReason: "none",
                         EventTypeSummary: EmptyLogValue));
-                return new CatchUpBatchResult(0, _catchUpProgress.CurrentPosition);
+                return new CatchUpBatchResult(0, 0, _catchUpProgress.CurrentPosition, null);
             }
 
             await FlushBufferAsync();
             var filteredCount = Math.Max(0, fetchedCount - appliedCount);
             if (appliedCount == 0)
             {
-                _catchUpProgress.CurrentPosition = new SortableUniqueId(lastFetchedSortableUniqueId!);
-                MarkProjectionStatusDirty(lastFetchedSortableUniqueId!);
-                LogCatchUpBatchSummary(
-                    projectorName,
-                    new CatchUpBatchTelemetry(
-                        BatchNumber: batchNumber,
-                        StartPosition: startPosition,
-                        CurrentPosition: _catchUpProgress.CurrentPosition?.Value ?? lastFetchedSortableUniqueId!,
-                        LastAppliedPosition: EmptyLogValue,
-                        TargetPosition: _catchUpProgress.TargetPosition?.Value ?? lastFetchedSortableUniqueId!,
-                        RequestedMaxCount: batchSize,
-                        FetchedCount: fetchedCount,
-                        FilteredCount: filteredCount,
-                        AppliedCount: 0,
-                        PendingStreamEventsBefore: pendingStreamEventsBefore,
-                        PendingStreamEventsAfter: _pendingStreamEvents.Count,
-                        ReadElapsedMs: readElapsedMs,
-                        ApplyElapsedMs: applyElapsedMs,
-                        PersistElapsedMs: 0,
-                        SafePromotionElapsedMs: 0,
-                        TotalElapsedMs: readElapsedMs + applyElapsedMs,
-                        ReadSource: hybridReadBatchMetadata?.Source ?? (isHybridCatchUp ? "hybrid_unknown" : streamingCatchUpStore.GetType().Name),
-                        ColdEventsRead: hybridReadBatchMetadata?.ColdEventsRead ?? 0,
-                        HotEventsRead: hybridReadBatchMetadata?.HotEventsRead ?? 0,
-                        ReachedColdSegmentBoundary: hybridReadBatchMetadata?.ReachedColdSegmentBoundary ?? false,
-                        SegmentCount: hybridReadBatchMetadata?.SegmentCount ?? 0,
-                        PersistTriggered: false,
-                        PersistReason: "none",
-                        EventTypeSummary: EmptyLogValue));
+                await UpdateCatchUpProgressAfterBatch(
+                    batchNumber,
+                    startPosition,
+                    Array.Empty<Guid>(),
+                    lastFetchedSortableUniqueId!,
+                    null,
+                    batchSize,
+                    fetchedCount,
+                    filteredCount,
+                    appliedCount: 0,
+                    readElapsedMs,
+                    applyElapsedMs,
+                    pendingStreamEventsBefore,
+                    hybridCatchUpStore,
+                    hybridReadBatchMetadata,
+                    BuildCatchUpEventTypeSummary(eventTypeNames));
                 return new CatchUpBatchResult(
+                    fetchedCount,
                     0,
-                    new SortableUniqueId(lastFetchedSortableUniqueId!));
+                    new SortableUniqueId(lastFetchedSortableUniqueId!),
+                    null);
             }
 
             await UpdateCatchUpProgressAfterBatch(
                 batchNumber,
                 startPosition,
                 processedIds,
-                lastProcessedSortableUniqueId!,
+                lastFetchedSortableUniqueId!,
+                lastProcessedSortableUniqueId,
                 batchSize,
                 fetchedCount,
                 filteredCount,
@@ -4256,10 +4294,14 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
         }
 
         return new CatchUpBatchResult(
+            fetchedCount,
             appliedCount,
             lastFetchedSortableUniqueId is null
                 ? _catchUpProgress.CurrentPosition
-                : new SortableUniqueId(lastFetchedSortableUniqueId));
+                : new SortableUniqueId(lastFetchedSortableUniqueId),
+            lastProcessedSortableUniqueId is null
+                ? null
+                : new SortableUniqueId(lastProcessedSortableUniqueId));
     }
 
     private int ResolveCatchUpBatchSize(HybridEventStore? hybridCatchUpStore)
@@ -4329,7 +4371,8 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
         int batchNumber,
         string startPosition,
         IEnumerable<Guid> processedIds,
-        string lastSortableUniqueIdValue,
+        string lastFetchedSortableUniqueIdValue,
+        string? lastAppliedSortableUniqueIdValue,
         int requestedMaxCount,
         int fetchedCount,
         int filteredCount,
@@ -4343,10 +4386,12 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
     {
         var projectorName = GetProjectorName();
 
+        ObserveCatchUpReadPath(hybridReadBatchMetadata);
         _catchUpProgress.BatchesProcessed++;
-        _catchUpProgress.HadNewEvents = true;
+        _catchUpProgress.HadNewEvents |= appliedCount > 0;
         _eventsProcessed += appliedCount;
         _eventsProcessedSinceLastCatchUpPersist += appliedCount;
+        _eventsFetchedSinceLastCatchUpPersist += fetchedCount;
         _lastHybridReadBatchMetadata = hybridReadBatchMetadata;
 
         foreach (var id in processedIds)
@@ -4354,19 +4399,28 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
             TrackProcessedEventId(id);
         }
 
-        _catchUpProgress.CurrentPosition = new SortableUniqueId(lastSortableUniqueIdValue);
-        MarkProjectionStatusDirty(lastSortableUniqueIdValue, lastSortableUniqueIdValue);
+        _catchUpProgress.CurrentPosition = new SortableUniqueId(lastFetchedSortableUniqueIdValue);
+        MarkProjectionStatusDirty(lastFetchedSortableUniqueIdValue, lastAppliedSortableUniqueIdValue);
 
         var persistDecision = GetCatchUpPersistDecision(hybridCatchUpStore, hybridReadBatchMetadata);
         long persistElapsedMs = 0;
+        var persistOutcome = PersistOutcomeNotAttempted;
         if (persistDecision.ShouldPersist)
         {
             var persistStopwatch = System.Diagnostics.Stopwatch.StartNew();
-            await PersistStateAsync();
-            persistStopwatch.Stop();
-            persistElapsedMs = persistStopwatch.ElapsedMilliseconds;
-            _eventsProcessedSinceLastCatchUpPersist = 0;
-            _lastCatchUpPersistUtc = DateTime.UtcNow;
+            try
+            {
+                await PersistStateAsync();
+                persistOutcome = _lastPersistOutcome;
+            }
+            finally
+            {
+                persistStopwatch.Stop();
+                persistElapsedMs = persistStopwatch.ElapsedMilliseconds;
+                // A completed persist attempt, including a short-circuit or failed ResultBox, closes this logical
+                // threshold window. Applied, fetched, and time tracking must reset as one unit.
+                ResetCatchUpPersistWindow();
+            }
         }
 
         var totalElapsedMs = readElapsedMs + applyElapsedMs + persistElapsedMs;
@@ -4375,9 +4429,9 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
             new CatchUpBatchTelemetry(
                 BatchNumber: batchNumber,
                 StartPosition: startPosition,
-                CurrentPosition: _catchUpProgress.CurrentPosition?.Value ?? lastSortableUniqueIdValue,
-                LastAppliedPosition: lastSortableUniqueIdValue,
-                TargetPosition: _catchUpProgress.TargetPosition?.Value ?? lastSortableUniqueIdValue,
+                CurrentPosition: _catchUpProgress.CurrentPosition?.Value ?? lastFetchedSortableUniqueIdValue,
+                LastAppliedPosition: lastAppliedSortableUniqueIdValue ?? EmptyLogValue,
+                TargetPosition: _catchUpProgress.TargetPosition?.Value ?? lastFetchedSortableUniqueIdValue,
                 RequestedMaxCount: requestedMaxCount,
                 FetchedCount: fetchedCount,
                 FilteredCount: filteredCount,
@@ -4396,7 +4450,10 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
                 SegmentCount: hybridReadBatchMetadata?.SegmentCount ?? 0,
                 PersistTriggered: persistDecision.ShouldPersist,
                 PersistReason: persistDecision.Reason,
-                EventTypeSummary: eventTypeSummary));
+                EventTypeSummary: eventTypeSummary)
+            {
+                PersistOutcome = persistOutcome
+            });
 
         if (_catchUpProgress.BatchesProcessed % 10 == 0)
         {
@@ -4418,8 +4475,13 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
         HybridEventStore? hybridCatchUpStore,
         HybridReadBatchMetadata? hybridReadBatchMetadata)
     {
-        if (hybridCatchUpStore is not null && hybridReadBatchMetadata?.UsedCold == true)
+        if (hybridReadBatchMetadata?.UsedCold == true)
         {
+            if (hybridCatchUpStore is null)
+            {
+                return new CatchUpPersistDecision(false, "none");
+            }
+
             if (hybridCatchUpStore.ShouldPersistSnapshotOnColdSegmentBoundary()
                 && hybridReadBatchMetadata.ReachedColdSegmentBoundary)
             {
@@ -4436,12 +4498,27 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
                 return new CatchUpPersistDecision(true, "max_interval_since_last_persist");
             }
 
+            if (_eventsFetchedSinceLastCatchUpPersist >= hybridCatchUpStore.GetCatchUpPersistMaxEventsWithoutSnapshot())
+            {
+                return new CatchUpPersistDecision(true, "fetched_count_checkpoint");
+            }
+
             return new CatchUpPersistDecision(false, "none");
         }
 
-        if (_eventsProcessed > 0 && _eventsProcessed % 5000 == 0)
+        if (_eventsProcessed > 0 && _eventsProcessed % HotCatchUpPersistMaxFetchedEvents == 0)
         {
             return new CatchUpPersistDecision(true, "event_count_checkpoint");
+        }
+
+        if (_eventsFetchedSinceLastCatchUpPersist >= HotCatchUpPersistMaxFetchedEvents)
+        {
+            return new CatchUpPersistDecision(true, "fetched_count_checkpoint");
+        }
+
+        if (DateTime.UtcNow - _lastCatchUpPersistUtc >= HotCatchUpPersistMaxInterval)
+        {
+            return new CatchUpPersistDecision(true, "time_checkpoint");
         }
 
         return new CatchUpPersistDecision(false, "none");
@@ -4506,6 +4583,7 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
         finally
         {
             _catchUpProgress.IsActive = false;
+            ResetCatchUpPersistWindow(resetReadPath: true);
             ResetCatchUpFailureTracking();
             EndCatchUpDeactivationDelay();
         }

--- a/dcb/tests/Sekiban.Dcb.Orleans.Tests/MinimalOrleansTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Orleans.Tests/MinimalOrleansTests.cs
@@ -43,6 +43,10 @@ public class MinimalOrleansTests : IAsyncLifetime
         builder.Options.ClusterId = $"TestCluster-{uniqueId}";
         builder.Options.ServiceId = $"TestService-{uniqueId}";
         // Use real networking with explicit fixed ports to avoid client assuming 30000 while silo chooses dynamic port.
+        var portBase = 20_000 + (Environment.ProcessId % 5_000) * 4;
+        builder.PortAllocator = new FixedPortAllocator(portBase, portBase + 100);
+        builder.Options.BaseSiloPort = portBase;
+        builder.Options.BaseGatewayPort = portBase + 1;
         builder.AddSiloBuilderConfigurator<TestSiloConfigurator>();
 
         _cluster = builder.Build();
@@ -417,6 +421,63 @@ public class MinimalOrleansTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task Hot_fetched_checkpoint_is_committed_and_consumed_by_fresh_activation()
+    {
+        var grain = _client.GetGrain<IMultiProjectionGrain>(PersistenceTestMulti.MultiProjectorName);
+        var baseTick = DateTime.UtcNow.AddMinutes(-2).Ticks;
+        var firstEvents = Enumerable.Range(0, 123)
+            .Select(index => CreatePersistenceEvent(baseTick + index, index))
+            .ToList();
+
+        await grain.SeedEventsAsync(ToSerializableEvents(firstEvents));
+        await WaitUntilCatchUpIdleAsync(grain);
+        await grain.RefreshAsync();
+        var initialPersistResult = await grain.PersistStateAsync();
+        Assert.True(initialPersistResult.IsSuccess);
+
+        var c0Result = await SharedStateStore.GetLatestForVersionAsync(
+            PersistenceTestMulti.MultiProjectorName,
+            PersistenceTestMulti.MultiProjectorVersion);
+        Assert.True(c0Result.IsSuccess);
+        Assert.True(c0Result.GetValue().HasValue);
+        var c0 = c0Result.GetValue().GetValue();
+        Assert.Equal(123, c0.EventsProcessed);
+
+        // Start at an arbitrary residue so the legacy exact modulo trigger cannot fire on the tenth 500-event batch.
+        var secondEvents = Enumerable.Range(0, 5_000)
+            .Select(index => CreatePersistenceEvent(baseTick + 123 + index, 123 + index))
+            .ToList();
+        await WaitUntilCatchUpIdleAsync(grain);
+        await grain.SeedEventsAsync(ToSerializableEvents(secondEvents));
+        await grain.RefreshAsync();
+
+        var c1Result = await SharedStateStore.GetLatestForVersionAsync(
+            PersistenceTestMulti.MultiProjectorName,
+            PersistenceTestMulti.MultiProjectorVersion);
+        Assert.True(c1Result.IsSuccess);
+        Assert.True(c1Result.GetValue().HasValue);
+        var c1 = c1Result.GetValue().GetValue();
+        Assert.Equal(5_123, c1.EventsProcessed);
+        Assert.True(
+            string.Compare(c1.LastSortableUniqueId, c0.LastSortableUniqueId, StringComparison.Ordinal) > 0,
+            $"Expected C1 {c1.LastSortableUniqueId} to be after C0 {c0.LastSortableUniqueId}.");
+
+        // The next activation must consume the committed restart cursor as its authoritative exclusive read position.
+        await grain.RequestDeactivationAsync();
+        SharedEventStore.ClearReadAllEventsTracking();
+        var freshGrain = _client.GetGrain<IMultiProjectionGrain>(PersistenceTestMulti.MultiProjectorName);
+        await freshGrain.GetStatusAsync();
+        await WaitUntilAsync(
+            () => SharedEventStore.ReadAllSerializableEventSinceValues.Count > 0,
+            TimeSpan.FromSeconds(10));
+
+        var firstFreshRead = SharedEventStore.ReadAllSerializableEventSinceValues[0];
+        Assert.Equal(c1.LastSortableUniqueId, firstFreshRead);
+        var freshStatus = await freshGrain.GetStatusAsync();
+        Assert.True(freshStatus.EventsProcessed >= c1.EventsProcessed);
+    }
+
+    [Fact]
     public async Task Orleans_Should_Isolate_TagConsistentGrain_By_ServiceId()
     {
         var tagId = "order:123";
@@ -529,6 +590,13 @@ public class MinimalOrleansTests : IAsyncLifetime
         }
     }
 
+    private sealed class FixedPortAllocator(int baseSiloPort, int baseGatewayPort) : ITestClusterPortAllocator
+    {
+        public (int, int) AllocateConsecutivePortPairs(int numPorts) => (baseSiloPort, baseGatewayPort);
+
+        public void Dispose() { }
+    }
+
 
     private record EmptyTestMultiProjector : IMultiProjector<EmptyTestMultiProjector>
     {
@@ -603,6 +671,15 @@ public class MinimalOrleansTests : IAsyncLifetime
 
     private record TestProjectionEvent(int Value) : IEventPayload;
 
+    private static Event CreatePersistenceEvent(long tick, int value) => new(
+        new TestProjectionEvent(value),
+        new SortableUniqueId(
+            SortableUniqueId.GetTickString(tick) + SortableUniqueId.GetIdString(Guid.Empty)),
+        nameof(TestProjectionEvent),
+        Guid.CreateVersion7(),
+        new EventMetadata(Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), "persistence-test"),
+        new List<string>());
+
     private static CountingInMemoryEventStore CreateSharedEventStore()
     {
         var eventTypes = new SimpleEventTypes();
@@ -616,6 +693,7 @@ public class MinimalOrleansTests : IAsyncLifetime
         private readonly object _lock = new();
         private readonly List<int?> _readAllEventsMaxCounts = new();
         private readonly List<int?> _readAllSerializableEventsMaxCounts = new();
+        private readonly List<string?> _readAllSerializableEventSinceValues = new();
 
         public CountingInMemoryEventStore(IEventTypes eventTypes)
         {
@@ -647,6 +725,17 @@ public class MinimalOrleansTests : IAsyncLifetime
             }
         }
 
+        public IReadOnlyList<string?> ReadAllSerializableEventSinceValues
+        {
+            get
+            {
+                lock (_lock)
+                {
+                    return _readAllSerializableEventSinceValues.ToList();
+                }
+            }
+        }
+
         public void Clear() => _inner.Clear();
 
         public void ClearReadAllEventsTracking()
@@ -657,6 +746,7 @@ public class MinimalOrleansTests : IAsyncLifetime
                 _readAllEventsMaxCounts.Clear();
                 ReadAllSerializableEventsCallCount = 0;
                 _readAllSerializableEventsMaxCounts.Clear();
+                _readAllSerializableEventSinceValues.Clear();
             }
         }
 
@@ -682,6 +772,7 @@ public class MinimalOrleansTests : IAsyncLifetime
             {
                 ReadAllSerializableEventsCallCount++;
                 _readAllSerializableEventsMaxCounts.Add(maxCount);
+                _readAllSerializableEventSinceValues.Add(since?.Value);
             }
 
             return _inner.ReadAllSerializableEventsAsync(since, maxCount);
@@ -807,6 +898,22 @@ public class MinimalOrleansTests : IAsyncLifetime
         }
 
         Assert.True(predicate(), $"Condition was not met within {timeout}.");
+    }
+
+    private static async Task WaitUntilCatchUpIdleAsync(IMultiProjectionGrain grain)
+    {
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(10);
+        while (DateTime.UtcNow < deadline)
+        {
+            if (!(await grain.GetCatchUpStatusAsync()).IsActive)
+            {
+                return;
+            }
+
+            await Task.Delay(20);
+        }
+
+        Assert.False((await grain.GetCatchUpStatusAsync()).IsActive, "Catch-up did not become idle in time.");
     }
 
     private static void ResetStatusOptions()

--- a/dcb/tests/Sekiban.Dcb.Orleans.Tests/MinimalOrleansTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Orleans.Tests/MinimalOrleansTests.cs
@@ -1,5 +1,7 @@
 using System.Collections.Concurrent;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Orleans.Streams;
 using Orleans.TestingHost;
 using ResultBoxes;
 using Sekiban.Dcb;
@@ -48,6 +50,7 @@ public class MinimalOrleansTests : IAsyncLifetime
         builder.Options.BaseSiloPort = portBase;
         builder.Options.BaseGatewayPort = portBase + 1;
         builder.AddSiloBuilderConfigurator<TestSiloConfigurator>();
+        builder.AddClientBuilderConfigurator<TestClientConfigurator>();
 
         _cluster = builder.Build();
         await _cluster.DeployAsync();
@@ -478,6 +481,105 @@ public class MinimalOrleansTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task Hot_fetched_checkpoint_for_stream_preapplied_range_is_durable_and_consumed_by_fresh_activation()
+    {
+        var grain = _client.GetGrain<IMultiProjectionGrain>(PersistenceTestMulti.MultiProjectorName);
+        var baseTick = DateTime.UtcNow.AddMinutes(-2).Ticks;
+        var firstEvents = Enumerable.Range(0, 123)
+            .Select(index => CreatePersistenceEvent(baseTick + index, index))
+            .ToList();
+
+        await grain.GetStatusAsync();
+        await grain.SeedEventsAsync(ToSerializableEvents(firstEvents));
+        await grain.RefreshAsync();
+        await WaitUntilCatchUpIdleAsync(grain);
+        var initialPersistResult = await grain.PersistStateAsync();
+        Assert.True(initialPersistResult.IsSuccess);
+
+        var c0Result = await SharedStateStore.GetLatestForVersionAsync(
+            PersistenceTestMulti.MultiProjectorName,
+            PersistenceTestMulti.MultiProjectorVersion);
+        Assert.True(c0Result.IsSuccess);
+        Assert.True(c0Result.GetValue().HasValue);
+        var c0 = c0Result.GetValue().GetValue();
+        Assert.Equal(123, c0.EventsProcessed);
+
+        // Deliver the range through the production stream subscription before it exists in the authoritative store.
+        // The old sortable timestamps make the stream-applied host state eligible for safe-window promotion; delivery
+        // alone is not treated as durable evidence.
+        var streamBaseTick = DateTime.UtcNow.AddSeconds(-5).Ticks;
+        var secondEvents = Enumerable.Range(0, 5_000)
+            .Select(index => CreatePersistenceEvent(streamBaseTick + index, 123 + index))
+            .ToList();
+        var secondSerializableEvents = ToSerializableEvents(secondEvents);
+        var stream = _client
+            .GetStreamProvider("EventStreamProvider")
+            .GetStream<SerializableEvent>(StreamId.Create(
+                ServiceIdGrainKey.BuildStreamNamespace("AllEvents", DefaultServiceIdProvider.DefaultServiceId),
+                Guid.Empty));
+
+        await stream.OnNextBatchAsync(secondSerializableEvents);
+
+        await WaitUntilEventsProcessedAsync(
+            grain,
+            c0.EventsProcessed + secondSerializableEvents.Count,
+            TimeSpan.FromSeconds(30));
+        var streamedStatus = await grain.GetStatusAsync();
+        Assert.Equal(5_123, streamedStatus.EventsProcessed);
+
+        // Put the exact stream-delivered events into the authoritative store only after stream application has finished.
+        // The subsequent refresh must therefore fetch a non-empty range whose every event is already ID-filtered.
+        var writeResult = await SharedEventStore.WriteSerializableEventsAsync(secondSerializableEvents);
+        Assert.True(writeResult.IsSuccess, writeResult.IsSuccess ? string.Empty : writeResult.GetException().ToString());
+        SharedEventStore.ClearReadAllEventsTracking();
+        var firstReadStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseFirstRead = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        SharedEventStore.GateNextSerializableRead(firstReadStarted, releaseFirstRead);
+        var refreshTask = grain.RefreshAsync();
+        await firstReadStarted.Task.WaitAsync(TimeSpan.FromSeconds(10));
+        // The range was unsafe when the refresh captured its C0 start. Let the normal safe-window threshold make it
+        // eligible before releasing the first authoritative batch; PersistStateAsync must then promote it at the
+        // fetched-count checkpoint.
+        await Task.Delay(TimeSpan.FromSeconds(18));
+        releaseFirstRead.TrySetResult();
+        await refreshTask;
+        await WaitUntilCatchUpIdleAsync(grain);
+
+        var c1Result = await SharedStateStore.GetLatestForVersionAsync(
+            PersistenceTestMulti.MultiProjectorName,
+            PersistenceTestMulti.MultiProjectorVersion);
+        Assert.True(c1Result.IsSuccess);
+        Assert.True(c1Result.GetValue().HasValue);
+        var c1 = c1Result.GetValue().GetValue();
+
+        // These assertions use the committed restart record and the activation-local processed count. They do not
+        // infer durability from the catch-up telemetry's PersistTriggered flag.
+        Assert.Equal(5_123, streamedStatus.EventsProcessed);
+        Assert.Equal(5_123, c1.EventsProcessed);
+        Assert.Equal(secondSerializableEvents[^1].SortableUniqueIdValue, c1.LastSortableUniqueId);
+        Assert.True(
+            string.Compare(c1.LastSortableUniqueId, c0.LastSortableUniqueId, StringComparison.Ordinal) > 0,
+            $"Expected durable C1 {c1.LastSortableUniqueId} to be after C0 {c0.LastSortableUniqueId}.");
+
+        // A genuinely fresh activation must consume the committed C1, not the ephemeral ID cache from the previous
+        // activation. Its first authoritative read is recorded by the real event store.
+        await grain.RequestDeactivationAsync();
+        SharedEventStore.ClearReadAllEventsTracking();
+        var freshGrain = _client.GetGrain<IMultiProjectionGrain>(PersistenceTestMulti.MultiProjectorName);
+        await freshGrain.GetStatusAsync();
+        await WaitUntilAsync(
+            () => SharedEventStore.ReadAllSerializableEventSinceValues.Count > 0,
+            TimeSpan.FromSeconds(10));
+
+        var firstFreshRead = SharedEventStore.ReadAllSerializableEventSinceValues[0];
+        // ReadAllSerializableEventsAsync treats `since` as an exclusive cursor, so this proves the returned
+        // authoritative range begins strictly after committed C1 rather than replaying the committed tail.
+        Assert.Equal(c1.LastSortableUniqueId, firstFreshRead);
+        var freshStatus = await freshGrain.GetStatusAsync();
+        Assert.True(freshStatus.EventsProcessed >= c1.EventsProcessed);
+    }
+
+    [Fact]
     public async Task Orleans_Should_Isolate_TagConsistentGrain_By_ServiceId()
     {
         var tagId = "order:123";
@@ -597,6 +699,14 @@ public class MinimalOrleansTests : IAsyncLifetime
         public void Dispose() { }
     }
 
+    private sealed class TestClientConfigurator : IClientBuilderConfigurator
+    {
+        public void Configure(IConfiguration configuration, IClientBuilder clientBuilder)
+        {
+            clientBuilder.AddMemoryStreams("EventStreamProvider");
+        }
+    }
+
 
     private record EmptyTestMultiProjector : IMultiProjector<EmptyTestMultiProjector>
     {
@@ -694,6 +804,9 @@ public class MinimalOrleansTests : IAsyncLifetime
         private readonly List<int?> _readAllEventsMaxCounts = new();
         private readonly List<int?> _readAllSerializableEventsMaxCounts = new();
         private readonly List<string?> _readAllSerializableEventSinceValues = new();
+        private TaskCompletionSource? _nextSerializableReadStarted;
+        private TaskCompletionSource? _nextSerializableReadRelease;
+        private bool _nextSerializableReadGated;
 
         public CountingInMemoryEventStore(IEventTypes eventTypes)
         {
@@ -750,6 +863,18 @@ public class MinimalOrleansTests : IAsyncLifetime
             }
         }
 
+        public void GateNextSerializableRead(
+            TaskCompletionSource readStarted,
+            TaskCompletionSource releaseRead)
+        {
+            lock (_lock)
+            {
+                _nextSerializableReadStarted = readStarted;
+                _nextSerializableReadRelease = releaseRead;
+                _nextSerializableReadGated = true;
+            }
+        }
+
         public Task<ResultBox<IEnumerable<Event>>> ReadAllEventsAsync(SortableUniqueId? since = null, int? maxCount = null)
         {
             lock (_lock)
@@ -764,7 +889,7 @@ public class MinimalOrleansTests : IAsyncLifetime
         public Task<ResultBox<IEnumerable<SerializableEvent>>> ReadAllSerializableEventsAsync(SortableUniqueId? since = null)
             => ReadAllSerializableEventsAsync(since, maxCount: null);
 
-        public Task<ResultBox<IEnumerable<SerializableEvent>>> ReadAllSerializableEventsAsync(
+        public async Task<ResultBox<IEnumerable<SerializableEvent>>> ReadAllSerializableEventsAsync(
             SortableUniqueId? since,
             int? maxCount)
         {
@@ -775,7 +900,27 @@ public class MinimalOrleansTests : IAsyncLifetime
                 _readAllSerializableEventSinceValues.Add(since?.Value);
             }
 
-            return _inner.ReadAllSerializableEventsAsync(since, maxCount);
+            TaskCompletionSource? readStarted = null;
+            TaskCompletionSource? releaseRead = null;
+            lock (_lock)
+            {
+                if (_nextSerializableReadGated)
+                {
+                    _nextSerializableReadGated = false;
+                    readStarted = _nextSerializableReadStarted;
+                    releaseRead = _nextSerializableReadRelease;
+                    _nextSerializableReadStarted = null;
+                    _nextSerializableReadRelease = null;
+                }
+            }
+
+            if (readStarted is not null && releaseRead is not null)
+            {
+                readStarted.TrySetResult();
+                await releaseRead.Task;
+            }
+
+            return await _inner.ReadAllSerializableEventsAsync(since, maxCount);
         }
 
         public Task<ResultBox<IEnumerable<Event>>> ReadEventsByTagAsync(ITag tag, SortableUniqueId? since = null) =>
@@ -914,6 +1059,27 @@ public class MinimalOrleansTests : IAsyncLifetime
         }
 
         Assert.False((await grain.GetCatchUpStatusAsync()).IsActive, "Catch-up did not become idle in time.");
+    }
+
+    private static async Task WaitUntilEventsProcessedAsync(
+        IMultiProjectionGrain grain,
+        long expectedEventsProcessed,
+        TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            if ((await grain.GetStatusAsync()).EventsProcessed >= expectedEventsProcessed)
+            {
+                return;
+            }
+
+            await Task.Delay(20);
+        }
+
+        Assert.True(
+            (await grain.GetStatusAsync()).EventsProcessed >= expectedEventsProcessed,
+            $"Expected at least {expectedEventsProcessed} stream-applied events within {timeout}.");
     }
 
     private static void ResetStatusOptions()

--- a/dcb/tests/Sekiban.Dcb.Orleans.Tests/MultiProjectionGrainCatchUpProductionPathTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Orleans.Tests/MultiProjectionGrainCatchUpProductionPathTests.cs
@@ -81,15 +81,20 @@ public sealed class MultiProjectionGrainCatchUpProductionPathTests
 
         // Synthetic case: the activation-local ID cache says the range was seen, but the host safe checkpoint stays at
         // C0 and no durable snapshot contains those effects.
-        var syntheticStore = new ProductionCatchUpEventStore();
+        var unchangedC0Record = new RecordingPersistentState<MultiProjectionGrainState> { State = c0State };
+        var syntheticStore = new ProductionCatchUpEventStore(persistentState: unchangedC0Record);
         var syntheticHost = new ProductionCatchUpProjectionHost
         {
+            ProjectionStartPosition = c0,
             SafeVersion = 1,
             SafePosition = c0
         };
-        var syntheticGrain = CreateGrain(syntheticStore, syntheticHost, c0State);
+        var syntheticGrain = CreateGrain(syntheticStore, syntheticHost, persistentState: unchangedC0Record);
+        var authoritativeEventIds = syntheticStore.Events.Select(ev => ev.Id).ToArray();
+        var expectedFreshProjection = DeterministicMaterializedProjection.From(c0, authoritativeEventIds);
 
-        Assert.Equal(syntheticStore.Events.Count, GetPrivateField<HashSet<Guid>>(syntheticGrain, "_processedEventIds").Count);
+        Assert.Equal(authoritativeEventIds.Length, GetPrivateField<HashSet<Guid>>(syntheticGrain, "_processedEventIds").Count);
+        Assert.Equal(authoritativeEventIds.Length, authoritativeEventIds.Distinct().Count());
         await syntheticGrain.RefreshAsync();
 
         Assert.Equal(c0, syntheticStore.ReadSinceValues[0]);
@@ -100,27 +105,42 @@ public sealed class MultiProjectionGrainCatchUpProductionPathTests
         Assert.Equal("no_durable_write", GetPrivateField<string>(syntheticGrain, "_lastPersistOutcome"));
         Assert.Equal(c0, syntheticStore.PersistentState.State.LastSortableUniqueId);
         Assert.Equal(c0, c0State.LastSortableUniqueId); // traversal never became the committed restart cursor
+        Assert.Empty(syntheticHost.AppliedEventIds);
+        Assert.Equal(
+            DeterministicMaterializedProjection.From(c0, Array.Empty<Guid>()),
+            syntheticHost.MaterializedProjection);
 
-        // Fresh activation: the ephemeral ID cache is gone, so the authoritative read from C0 must apply every event.
-        var freshStore = new ProductionCatchUpEventStore();
+        // Fresh activation: it must reuse the same unchanged durable C0 record and authoritative event sequence. The
+        // ephemeral ID cache is gone, so the authoritative read from C0 must apply every event exactly once.
+        var freshStore = new ProductionCatchUpEventStore(
+            events: syntheticStore.Events,
+            persistentState: unchangedC0Record);
         var freshHost = new ProductionCatchUpProjectionHost
         {
             AllowApply = true,
+            ProjectionStartPosition = c0,
             SafeVersion = 1,
             SafePosition = c0
         };
-        var freshState = c0State.Clone();
         var freshGrain = CreateGrain(
             freshStore,
             freshHost,
-            freshState,
-            processedEvents: Array.Empty<SerializableEvent>());
+            processedEvents: Array.Empty<SerializableEvent>(),
+            persistentState: unchangedC0Record);
         Assert.Empty(GetPrivateField<HashSet<Guid>>(freshGrain, "_processedEventIds"));
+        Assert.Same(syntheticStore.Events, freshStore.Events);
+        Assert.Same(syntheticStore.PersistentState, freshStore.PersistentState);
+        Assert.Same(c0State, freshStore.PersistentState.State);
 
         await freshGrain.RefreshAsync();
 
-        Assert.Equal(syntheticStore.Events.Count, freshHost.AppliedEventCount);
+        Assert.Equal(authoritativeEventIds, freshHost.AppliedEventIds.ToArray());
+        Assert.Equal(authoritativeEventIds.Length, freshHost.AppliedEventCount);
         Assert.Equal(syntheticStore.Events[^1].SortableUniqueIdValue, freshHost.LastAppliedPosition);
+        Assert.Equal(expectedFreshProjection, freshHost.MaterializedProjection);
+        Assert.NotEqual(
+            DeterministicMaterializedProjection.From(c0, Array.Empty<Guid>()),
+            freshHost.MaterializedProjection);
         Assert.Equal(c0, freshStore.ReadSinceValues[0]);
         Assert.Equal(0, freshStore.PersistentState.WriteCalls);
         Assert.Equal(c0, freshStore.PersistentState.State.LastSortableUniqueId);
@@ -499,10 +519,11 @@ public sealed class MultiProjectionGrainCatchUpProductionPathTests
         ProductionCatchUpProjectionHost? host = null,
         MultiProjectionGrainState? state = null,
         GeneralMultiProjectionActorOptions? actorOptions = null,
-        IEnumerable<SerializableEvent>? processedEvents = null)
+        IEnumerable<SerializableEvent>? processedEvents = null,
+        RecordingPersistentState<MultiProjectionGrainState>? persistentState = null)
     {
         host ??= new ProductionCatchUpProjectionHost();
-        var persistentState = new RecordingPersistentState<MultiProjectionGrainState>
+        persistentState ??= new RecordingPersistentState<MultiProjectionGrainState>
         {
             State = state ?? new MultiProjectionGrainState()
         };
@@ -670,17 +691,41 @@ public sealed class MultiProjectionGrainCatchUpProductionPathTests
             Microsoft.Extensions.Logging.ILogger? logger = null) => host;
     }
 
+    private sealed record DeterministicMaterializedProjection(
+        string StartPosition,
+        int EventCount,
+        string OrderedEventIdDigest)
+    {
+        public static DeterministicMaterializedProjection From(string startPosition, IEnumerable<Guid> eventIds)
+        {
+            var ids = eventIds.ToArray();
+            var digestInput = string.Join(
+                "|",
+                new[] { startPosition }.Concat(ids.Select(id => id.ToString("D"))));
+            var digest = Convert.ToHexString(
+                System.Security.Cryptography.SHA256.HashData(
+                    System.Text.Encoding.UTF8.GetBytes(digestInput)));
+            return new DeterministicMaterializedProjection(startPosition, ids.Length, digest);
+        }
+    }
+
     private sealed class ProductionCatchUpProjectionHost : IProjectionActorHost
     {
         public bool FailSnapshotWrite { get; init; }
         public bool AllowApply { get; init; }
+        public string? ProjectionStartPosition { get; init; }
         public int SafeVersion { get; init; }
         public string? SafePosition { get; init; }
         public int StateMetadataCalls { get; private set; }
         public int SafeCheckpointCalls { get; private set; }
         public int SnapshotWriteCalls { get; private set; }
-        public int AppliedEventCount { get; private set; }
+        public IReadOnlyList<Guid> AppliedEventIds => _appliedEventIds;
+        public int AppliedEventCount => _appliedEventIds.Count;
         public string? LastAppliedPosition { get; private set; }
+        public DeterministicMaterializedProjection MaterializedProjection =>
+            DeterministicMaterializedProjection.From(ProjectionStartPosition ?? string.Empty, _appliedEventIds);
+
+        private readonly List<Guid> _appliedEventIds = [];
 
         public Task AddSerializableEventsAsync(IReadOnlyList<SerializableEvent> events, bool finishedCatchUp = true)
         {
@@ -689,7 +734,7 @@ public sealed class MultiProjectionGrainCatchUpProductionPathTests
                 throw new Xunit.Sdk.XunitException("The zero-applied production test unexpectedly applied an event.");
             }
 
-            AppliedEventCount += events.Count;
+            _appliedEventIds.AddRange(events.Select(ev => ev.Id));
             LastAppliedPosition = events[^1].SortableUniqueIdValue;
             return Task.CompletedTask;
         }
@@ -787,13 +832,15 @@ public sealed class MultiProjectionGrainCatchUpProductionPathTests
         public ProductionCatchUpEventStore(
             IReadOnlyList<int>? batchSizes = null,
             TaskCompletionSource? firstReadStarted = null,
-            TaskCompletionSource? releaseFirstRead = null)
+            TaskCompletionSource? releaseFirstRead = null,
+            IReadOnlyList<SerializableEvent>? events = null,
+            RecordingPersistentState<MultiProjectionGrainState>? persistentState = null)
         {
             _batchSizes = batchSizes ?? Enumerable.Repeat(500, 10).ToArray();
             _firstReadStarted = firstReadStarted;
             _releaseFirstRead = releaseFirstRead;
             var totalEventCount = _batchSizes.Sum();
-            Events = Enumerable.Range(0, totalEventCount)
+            Events = events ?? Enumerable.Range(0, totalEventCount)
                 .Select(index => new SerializableEvent(
                     new byte[] { 1 },
                     SortableUniqueId.GetTickString(10_000 + index) + SortableUniqueId.GetIdString(Guid.Empty),
@@ -802,12 +849,13 @@ public sealed class MultiProjectionGrainCatchUpProductionPathTests
                     new List<string>(),
                     "ProductionCatchUpEvent"))
                 .ToArray();
+            PersistentState = persistentState ?? new RecordingPersistentState<MultiProjectionGrainState>();
         }
 
         public IReadOnlyList<SerializableEvent> Events { get; }
         public int ReadCalls => Volatile.Read(ref _readCalls);
         public IReadOnlyList<string?> ReadSinceValues => ReadSinceValuesStorage;
-        public RecordingPersistentState<MultiProjectionGrainState> PersistentState { get; set; } = new();
+        public RecordingPersistentState<MultiProjectionGrainState> PersistentState { get; set; }
 
         protected IReadOnlyList<SerializableEvent> NextBatch()
         {

--- a/dcb/tests/Sekiban.Dcb.Orleans.Tests/MultiProjectionGrainCatchUpProductionPathTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Orleans.Tests/MultiProjectionGrainCatchUpProductionPathTests.cs
@@ -66,6 +66,67 @@ public sealed class MultiProjectionGrainCatchUpProductionPathTests
     }
 
     [Fact]
+    public async Task Synthetic_id_tracking_only_does_not_advance_c0_and_fresh_activation_reapplies_the_range()
+    {
+        var c0 = SortableUniqueId.GetTickString(9_000) + SortableUniqueId.GetIdString(Guid.Empty);
+        var c0State = new MultiProjectionGrainState
+        {
+            ProjectorName = "production-catch-up",
+            ProjectorVersion = "v1",
+            LastSortableUniqueId = c0,
+            EventsProcessed = 123,
+            LastGoodSafeVersion = 1,
+            LastGoodEventsProcessed = 123
+        };
+
+        // Synthetic case: the activation-local ID cache says the range was seen, but the host safe checkpoint stays at
+        // C0 and no durable snapshot contains those effects.
+        var syntheticStore = new ProductionCatchUpEventStore();
+        var syntheticHost = new ProductionCatchUpProjectionHost
+        {
+            SafeVersion = 1,
+            SafePosition = c0
+        };
+        var syntheticGrain = CreateGrain(syntheticStore, syntheticHost, c0State);
+
+        Assert.Equal(syntheticStore.Events.Count, GetPrivateField<HashSet<Guid>>(syntheticGrain, "_processedEventIds").Count);
+        await syntheticGrain.RefreshAsync();
+
+        Assert.Equal(c0, syntheticStore.ReadSinceValues[0]);
+        Assert.Equal(2, syntheticHost.StateMetadataCalls); // one start-position inference plus the fetched checkpoint attempt
+        Assert.Equal(1, syntheticHost.SafeCheckpointCalls); // the persist checkpoint was captured exactly once
+        Assert.Equal(0, syntheticHost.SnapshotWriteCalls);
+        Assert.Equal(0, syntheticStore.PersistentState.WriteCalls);
+        Assert.Equal("no_durable_write", GetPrivateField<string>(syntheticGrain, "_lastPersistOutcome"));
+        Assert.Equal(c0, syntheticStore.PersistentState.State.LastSortableUniqueId);
+        Assert.Equal(c0, c0State.LastSortableUniqueId); // traversal never became the committed restart cursor
+
+        // Fresh activation: the ephemeral ID cache is gone, so the authoritative read from C0 must apply every event.
+        var freshStore = new ProductionCatchUpEventStore();
+        var freshHost = new ProductionCatchUpProjectionHost
+        {
+            AllowApply = true,
+            SafeVersion = 1,
+            SafePosition = c0
+        };
+        var freshState = c0State.Clone();
+        var freshGrain = CreateGrain(
+            freshStore,
+            freshHost,
+            freshState,
+            processedEvents: Array.Empty<SerializableEvent>());
+        Assert.Empty(GetPrivateField<HashSet<Guid>>(freshGrain, "_processedEventIds"));
+
+        await freshGrain.RefreshAsync();
+
+        Assert.Equal(syntheticStore.Events.Count, freshHost.AppliedEventCount);
+        Assert.Equal(syntheticStore.Events[^1].SortableUniqueIdValue, freshHost.LastAppliedPosition);
+        Assert.Equal(c0, freshStore.ReadSinceValues[0]);
+        Assert.Equal(0, freshStore.PersistentState.WriteCalls);
+        Assert.Equal(c0, freshStore.PersistentState.State.LastSortableUniqueId);
+    }
+
+    [Fact]
     public async Task Enumerable_partial_filter_uses_last_fetched_for_the_next_read()
     {
         var store = new ProductionCatchUpEventStore([3]);
@@ -614,7 +675,9 @@ public sealed class MultiProjectionGrainCatchUpProductionPathTests
         public bool FailSnapshotWrite { get; init; }
         public bool AllowApply { get; init; }
         public int SafeVersion { get; init; }
+        public string? SafePosition { get; init; }
         public int StateMetadataCalls { get; private set; }
+        public int SafeCheckpointCalls { get; private set; }
         public int SnapshotWriteCalls { get; private set; }
         public int AppliedEventCount { get; private set; }
         public string? LastAppliedPosition { get; private set; }
@@ -642,7 +705,7 @@ public sealed class MultiProjectionGrainCatchUpProductionPathTests
                     UnsafeLastSortableUniqueId: null,
                     UnsafeLastEventId: null,
                     SafeVersion: SafeVersion,
-                    SafeLastSortableUniqueId: null)));
+                    SafeLastSortableUniqueId: SafePosition)));
         }
 
         public Task<ResultBox<MultiProjectionState>> GetStateAsync(bool canGetUnsafeState = true) =>
@@ -694,7 +757,11 @@ public sealed class MultiProjectionGrainCatchUpProductionPathTests
         public void ForcePromoteBufferedEvents() { }
         public void CompactSafeHistory() { }
         public void ForcePromoteAllBufferedEvents() { }
-        public Task<string> GetSafeLastSortableUniqueIdAsync() => Task.FromResult(string.Empty);
+        public Task<string> GetSafeLastSortableUniqueIdAsync()
+        {
+            SafeCheckpointCalls++;
+            return Task.FromResult(SafePosition ?? string.Empty);
+        }
         public Task<bool> IsSortableUniqueIdReceivedAsync(string sortableUniqueId) => Task.FromResult(false);
         public long EstimateStateSizeBytes(bool includeUnsafeDetails) => 1;
         public string PeekCurrentSafeWindowThreshold() => SortableUniqueId.Generate(DateTime.UtcNow, Guid.Empty);

--- a/dcb/tests/Sekiban.Dcb.Orleans.Tests/MultiProjectionGrainCatchUpProductionPathTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Orleans.Tests/MultiProjectionGrainCatchUpProductionPathTests.cs
@@ -1,0 +1,840 @@
+using System.Reflection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using ResultBoxes;
+using Sekiban.Dcb.Actors;
+using Sekiban.Dcb.ColdEvents;
+using Sekiban.Dcb.Common;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.MultiProjections;
+using Sekiban.Dcb.Orleans.Grains;
+using Sekiban.Dcb.Orleans.Serialization;
+using Sekiban.Dcb.Orleans.Streams;
+using Sekiban.Dcb.Runtime;
+using Sekiban.Dcb.ServiceId;
+using Sekiban.Dcb.Storage;
+using Sekiban.Dcb.Tags;
+using Xunit;
+
+namespace Sekiban.Dcb.Orleans.Tests;
+
+/// <summary>
+///     Production-path killing tests for the catch-up completion/persist seam. These tests drive public RefreshAsync,
+///     which reaches the real enumerable or streaming reader and the real common post-fetch seam. They deliberately do
+///     not call the private persist-decision function in isolation.
+/// </summary>
+public sealed class MultiProjectionGrainCatchUpProductionPathTests
+{
+    [Fact]
+    public async Task Enumerable_zero_applied_batches_stay_active_and_trigger_once_on_fetched_batch_ten()
+    {
+        var store = new ProductionCatchUpEventStore();
+        var host = new ProductionCatchUpProjectionHost();
+        var grain = CreateGrain(store, host);
+
+        await grain.RefreshAsync();
+
+        Assert.Equal(15, store.ReadCalls); // 10 non-empty batches, then the five empty completion reads.
+        Assert.Equal(store.Events[499].SortableUniqueIdValue, store.ReadSinceValues[1]);
+        Assert.Equal(2, host.StateMetadataCalls); // fetched-triggered attempt plus the final catch-up persist check
+        Assert.Equal(1, host.SnapshotWriteCalls); // exactly one fetched-triggered durable snapshot write
+        Assert.Equal(1, store.PersistentState.WriteCalls);
+        Assert.Equal(0L, GetPrivateField<long>(grain, "_eventsFetchedSinceLastCatchUpPersist"));
+        Assert.Equal(
+            store.Events[^1].SortableUniqueIdValue,
+            GetCatchUpCurrentPosition(grain));
+    }
+
+    [Fact]
+    public async Task Streaming_zero_applied_batches_stay_active_and_trigger_once_on_fetched_batch_ten()
+    {
+        var store = new ProductionStreamingCatchUpEventStore();
+        var host = new ProductionCatchUpProjectionHost();
+        var grain = CreateGrain(store, host);
+
+        await grain.RefreshAsync();
+
+        Assert.Equal(15, store.ReadCalls);
+        Assert.Equal(store.Events[499].SortableUniqueIdValue, store.ReadSinceValues[1]);
+        Assert.Equal(2, host.StateMetadataCalls);
+        Assert.Equal(1, host.SnapshotWriteCalls); // exactly one fetched-triggered durable snapshot write
+        Assert.Equal(1, store.PersistentState.WriteCalls);
+        Assert.Equal(0L, GetPrivateField<long>(grain, "_eventsFetchedSinceLastCatchUpPersist"));
+        Assert.Equal(
+            store.Events[^1].SortableUniqueIdValue,
+            GetCatchUpCurrentPosition(grain));
+    }
+
+    [Fact]
+    public async Task Enumerable_partial_filter_uses_last_fetched_for_the_next_read()
+    {
+        var store = new ProductionCatchUpEventStore([3]);
+        var host = new ProductionCatchUpProjectionHost { AllowApply = true };
+        var grain = CreateGrain(store, host, processedEvents: store.Events.Skip(2));
+
+        await grain.RefreshAsync();
+
+        Assert.Equal(2, host.AppliedEventCount);
+        Assert.Equal(store.Events[1].SortableUniqueIdValue, host.LastAppliedPosition);
+        Assert.Equal(store.Events[2].SortableUniqueIdValue, store.ReadSinceValues[1]);
+        Assert.Equal(store.Events[2].SortableUniqueIdValue, GetCatchUpCurrentPosition(grain));
+    }
+
+    [Fact]
+    public async Task Streaming_partial_filter_uses_last_fetched_for_the_next_read()
+    {
+        var store = new ProductionStreamingCatchUpEventStore([3]);
+        var host = new ProductionCatchUpProjectionHost { AllowApply = true };
+        var grain = CreateGrain(store, host, processedEvents: store.Events.Skip(2));
+
+        await grain.RefreshAsync();
+
+        Assert.Equal(2, host.AppliedEventCount);
+        Assert.Equal(store.Events[1].SortableUniqueIdValue, host.LastAppliedPosition);
+        Assert.Equal(store.Events[2].SortableUniqueIdValue, store.ReadSinceValues[1]);
+        Assert.Equal(store.Events[2].SortableUniqueIdValue, GetCatchUpCurrentPosition(grain));
+    }
+
+    [Fact]
+    public async Task Hot_fetched_counter_resets_between_crossings_and_counts_exactly_two_attempts()
+    {
+        var batchSizes = Enumerable.Repeat(500, 10)
+            .Concat([1])
+            .Concat(Enumerable.Repeat(500, 10))
+            .ToArray();
+        var store = new ProductionCatchUpEventStore(batchSizes);
+        var host = new ProductionCatchUpProjectionHost();
+        var grain = CreateGrain(store, host);
+
+        await grain.RefreshAsync();
+
+        Assert.Equal(26, store.ReadCalls); // 21 non-empty batches, then five empty completion reads.
+        Assert.Equal(3, host.StateMetadataCalls);
+        Assert.Equal(2, host.SnapshotWriteCalls);
+        Assert.Equal(2, store.PersistentState.WriteCalls);
+        Assert.Equal(0L, GetPrivateField<long>(grain, "_eventsFetchedSinceLastCatchUpPersist"));
+        Assert.Equal(0L, GetPrivateField<long>(grain, "_eventsProcessedSinceLastCatchUpPersist"));
+    }
+
+    [Fact]
+    public async Task Hot_time_counter_resets_with_a_non_fire_between_exactly_two_attempts()
+    {
+        var store = new ProductionCatchUpEventStore();
+        var host = new ProductionCatchUpProjectionHost();
+        var grain = CreateGrain(store, host);
+        var updateMethod = grain.GetType().GetMethod("UpdateCatchUpProgressAfterBatch", BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(updateMethod);
+
+        SetPrivateField(grain, "_eventsProcessed", 123L);
+        SetPrivateField(grain, "_lastCatchUpPersistUtc", DateTime.UtcNow - TimeSpan.FromMinutes(6));
+        await InvokePrivateTaskAsync(
+            updateMethod!,
+            grain,
+            [
+                1,
+                "beginning",
+                Array.Empty<Guid>(),
+                SortableUniqueId.Generate(DateTime.UtcNow.AddMinutes(-3), Guid.Empty),
+                null,
+                500,
+                1,
+                1,
+                0,
+                0L,
+                0L,
+                0,
+                null,
+                null,
+                "empty"
+            ]);
+
+        Assert.Equal(1, store.PersistentState.WriteCalls);
+        Assert.Equal(1, host.StateMetadataCalls);
+        await InvokePrivateTaskAsync(
+            updateMethod!,
+            grain,
+            [
+                2,
+                "beginning",
+                Array.Empty<Guid>(),
+                SortableUniqueId.Generate(DateTime.UtcNow.AddMinutes(-2), Guid.Empty),
+                null,
+                500,
+                1,
+                1,
+                0,
+                0L,
+                0L,
+                0,
+                null,
+                null,
+                "empty"
+            ]);
+
+        Assert.Equal(1, store.PersistentState.WriteCalls);
+        Assert.Equal(1, host.StateMetadataCalls);
+        SetPrivateField(grain, "_lastCatchUpPersistUtc", DateTime.UtcNow - TimeSpan.FromMinutes(6));
+        await InvokePrivateTaskAsync(
+            updateMethod!,
+            grain,
+            [
+                3,
+                "beginning",
+                Array.Empty<Guid>(),
+                SortableUniqueId.Generate(DateTime.UtcNow.AddMinutes(-1), Guid.Empty),
+                null,
+                500,
+                1,
+                1,
+                0,
+                0L,
+                0L,
+                0,
+                null,
+                null,
+                "empty"
+            ]);
+
+        Assert.Equal(2, store.PersistentState.WriteCalls);
+        Assert.Equal(2, host.StateMetadataCalls);
+        Assert.Equal(0L, GetPrivateField<long>(grain, "_eventsFetchedSinceLastCatchUpPersist"));
+        Assert.Equal(0L, GetPrivateField<long>(grain, "_eventsProcessedSinceLastCatchUpPersist"));
+    }
+
+    [Fact]
+    public async Task Persist_attempt_resets_all_window_fields_and_reports_no_durable_write_for_failed_or_short_circuited_result()
+    {
+        var failedHost = new ProductionCatchUpProjectionHost { FailSnapshotWrite = true };
+        var failedStore = new ProductionCatchUpEventStore();
+        var failedGrain = CreateGrain(failedStore, failedHost);
+        SetPrivateField(failedGrain, "_eventsProcessed", 123L);
+        var failedWindowTime = DateTime.UtcNow - TimeSpan.FromMinutes(1);
+        SetPrivateField(failedGrain, "_lastCatchUpPersistUtc", failedWindowTime);
+        await InvokeProgressUpdateAsync(failedGrain, 1, "failed-checkpoint");
+
+        Assert.Equal(0L, GetPrivateField<long>(failedGrain, "_eventsProcessedSinceLastCatchUpPersist"));
+        Assert.Equal(0L, GetPrivateField<long>(failedGrain, "_eventsFetchedSinceLastCatchUpPersist"));
+        Assert.True(GetPrivateField<DateTime>(failedGrain, "_lastCatchUpPersistUtc") > failedWindowTime);
+        Assert.Equal("no_durable_write", GetPrivateField<string>(failedGrain, "_lastPersistOutcome"));
+
+        var shortCircuitState = new MultiProjectionGrainState
+        {
+            ProjectorVersion = "v1",
+            LastSortableUniqueId = null,
+            LastGoodSafeVersion = 1
+        };
+        var shortCircuitHost = new ProductionCatchUpProjectionHost { SafeVersion = 1 };
+        var shortCircuitStore = new ProductionCatchUpEventStore();
+        var shortCircuitGrain = CreateGrain(shortCircuitStore, shortCircuitHost, shortCircuitState);
+        SetPrivateField(shortCircuitGrain, "_eventsProcessed", 123L);
+        var shortCircuitWindowTime = DateTime.UtcNow - TimeSpan.FromMinutes(1);
+        SetPrivateField(shortCircuitGrain, "_lastCatchUpPersistUtc", shortCircuitWindowTime);
+        await InvokeProgressUpdateAsync(shortCircuitGrain, 1, "short-circuit-checkpoint");
+
+        Assert.Equal(0, shortCircuitStore.PersistentState.WriteCalls);
+        Assert.Equal(0L, GetPrivateField<long>(shortCircuitGrain, "_eventsProcessedSinceLastCatchUpPersist"));
+        Assert.Equal(0L, GetPrivateField<long>(shortCircuitGrain, "_eventsFetchedSinceLastCatchUpPersist"));
+        Assert.True(GetPrivateField<DateTime>(shortCircuitGrain, "_lastCatchUpPersistUtc") > shortCircuitWindowTime);
+        Assert.Equal("no_durable_write", GetPrivateField<string>(shortCircuitGrain, "_lastPersistOutcome"));
+    }
+
+    [Fact]
+    public async Task Unchanged_checkpoint_guard_separates_one_attempt_from_durable_writes_when_enabled_or_disabled()
+    {
+        var unchangedState = new MultiProjectionGrainState
+        {
+            ProjectorVersion = "v1",
+            LastSortableUniqueId = null,
+            LastGoodSafeVersion = 1
+        };
+
+        var guardedHost = new ProductionCatchUpProjectionHost { SafeVersion = 1 };
+        var guardedStore = new ProductionCatchUpEventStore();
+        var guardedGrain = CreateGrain(guardedStore, guardedHost, unchangedState);
+        await InvokeProgressUpdateAsync(guardedGrain, 1, "guarded-checkpoint");
+
+        Assert.Equal(1, guardedHost.StateMetadataCalls); // exactly one persist attempt
+        Assert.Equal(0, guardedHost.SnapshotWriteCalls);
+        Assert.Equal(0, guardedStore.PersistentState.WriteCalls);
+        Assert.Equal("no_durable_write", GetPrivateField<string>(guardedGrain, "_lastPersistOutcome"));
+
+        var unguardedHost = new ProductionCatchUpProjectionHost { SafeVersion = 1 };
+        var unguardedStore = new ProductionCatchUpEventStore();
+        var unguardedGrain = CreateGrain(
+            unguardedStore,
+            unguardedHost,
+            unchangedState,
+            new GeneralMultiProjectionActorOptions
+            {
+                PersistIntervalSeconds = 0,
+                SkipPersistWhenSafeCheckpointUnchanged = false
+            });
+        await InvokeProgressUpdateAsync(unguardedGrain, 1, "unguarded-checkpoint");
+
+        Assert.Equal(1, unguardedHost.StateMetadataCalls); // one attempt, independently counted from writes
+        Assert.Equal(1, unguardedHost.SnapshotWriteCalls);
+        Assert.Equal(1, unguardedStore.PersistentState.WriteCalls);
+        Assert.Equal("durable_write", GetPrivateField<string>(unguardedGrain, "_lastPersistOutcome"));
+    }
+
+    [Fact]
+    public async Task Cold_fetched_counter_resets_between_crossings_and_counts_exactly_two_attempts()
+    {
+        var store = new ProductionCatchUpEventStore();
+        var host = new ProductionCatchUpProjectionHost();
+        var grain = CreateGrain(store, host);
+        var hybrid = CreateHybrid(maxEvents: 100);
+        var coldMetadata = new HybridReadBatchMetadata("cold", UsedCold: true, UsedHot: false, false, 100, 0, 1);
+
+        await InvokeProgressUpdateAsync(
+            grain,
+            1,
+            SortableUniqueId.Generate(DateTime.UtcNow.AddMinutes(-3), Guid.Empty),
+            fetchedCount: 100,
+            hybrid,
+            coldMetadata);
+        await InvokeProgressUpdateAsync(
+            grain,
+            2,
+            SortableUniqueId.Generate(DateTime.UtcNow.AddMinutes(-2), Guid.Empty),
+            fetchedCount: 99,
+            hybrid,
+            coldMetadata);
+        Assert.Equal(1, store.PersistentState.WriteCalls);
+        Assert.Equal(1, host.StateMetadataCalls);
+
+        await InvokeProgressUpdateAsync(
+            grain,
+            3,
+            SortableUniqueId.Generate(DateTime.UtcNow.AddMinutes(-1), Guid.Empty),
+            fetchedCount: 1,
+            hybrid,
+            coldMetadata);
+
+        Assert.Equal(2, store.PersistentState.WriteCalls);
+        Assert.Equal(2, host.StateMetadataCalls);
+        Assert.Equal(0L, GetPrivateField<long>(grain, "_eventsFetchedSinceLastCatchUpPersist"));
+    }
+
+    [Fact]
+    public async Task Window_transitions_reset_preserve_or_leave_unchanged_as_defined()
+    {
+        var firstReadStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseFirstRead = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var newRunStore = new ProductionCatchUpEventStore(
+            firstReadStarted: firstReadStarted,
+            releaseFirstRead: releaseFirstRead);
+        var newRunGrain = CreateGrain(newRunStore);
+        var staleWindowTime = DateTime.UtcNow - TimeSpan.FromMinutes(1);
+        SeedWindow(newRunGrain, staleWindowTime, usedCold: true);
+
+        var newRunTask = InvokePrivateTaskAsync(
+            newRunGrain,
+            "RefreshWithAuthoritativeCursorAsync",
+            [false]);
+        await firstReadStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        AssertWindowReset(newRunGrain, staleWindowTime);
+        releaseFirstRead.TrySetResult();
+        await newRunTask;
+
+        var inheritedReadStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseInheritedRead = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var inheritedStore = new ProductionCatchUpEventStore(
+            firstReadStarted: inheritedReadStarted,
+            releaseFirstRead: releaseInheritedRead);
+        var inheritedGrain = CreateGrain(inheritedStore);
+        var inheritedTime = DateTime.UtcNow - TimeSpan.FromMinutes(2);
+        var inheritedPosition = new SortableUniqueId(SortableUniqueId.Generate(DateTime.UtcNow.AddMinutes(-3), Guid.Empty));
+        SetActiveCatchUp(
+            inheritedGrain,
+            new CatchUpStartPositionLease(inheritedPosition, CatchUpStartPositionSource.RestoredCheckpoint));
+        SeedWindow(inheritedGrain, inheritedTime, usedCold: true);
+
+        var inheritedTask = InvokePrivateTaskAsync(
+            inheritedGrain,
+            "RefreshWithAuthoritativeCursorAsync",
+            [true]);
+        await inheritedReadStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        AssertWindowPreserved(inheritedGrain, inheritedTime, usedCold: true);
+        releaseInheritedRead.TrySetResult();
+        await inheritedTask;
+
+        var earlyReturnGrain = CreateGrain(new ProductionCatchUpEventStore());
+        var earlyReturnTime = DateTime.UtcNow - TimeSpan.FromMinutes(3);
+        SetActiveCatchUp(
+            earlyReturnGrain,
+            new CatchUpStartPositionLease(inheritedPosition, CatchUpStartPositionSource.RestoredCheckpoint));
+        SeedWindow(earlyReturnGrain, earlyReturnTime, usedCold: true);
+
+        await InvokePrivateTaskAsync(
+            earlyReturnGrain,
+            "RefreshWithAuthoritativeCursorAsync",
+            [false]);
+
+        AssertWindowPreserved(earlyReturnGrain, earlyReturnTime, usedCold: true);
+
+        var completedGrain = CreateGrain(new ProductionCatchUpEventStore());
+        var completedTime = DateTime.UtcNow - TimeSpan.FromMinutes(4);
+        SetActiveCatchUp(
+            completedGrain,
+            new CatchUpStartPositionLease(inheritedPosition, CatchUpStartPositionSource.RestoredCheckpoint));
+        SeedWindow(completedGrain, completedTime, usedCold: true);
+
+        await InvokePrivateTaskAsync(completedGrain, "CompleteCatchUp");
+
+        AssertWindowReset(completedGrain, completedTime);
+    }
+
+    private static async Task InvokeProgressUpdateAsync(
+        MultiProjectionGrain grain,
+        int batchNumber,
+        string position,
+        int fetchedCount = 5_000,
+        HybridEventStore? hybridCatchUpStore = null,
+        HybridReadBatchMetadata? hybridReadBatchMetadata = null)
+    {
+        var updateMethod = grain.GetType().GetMethod("UpdateCatchUpProgressAfterBatch", BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(updateMethod);
+        await InvokePrivateTaskAsync(
+            updateMethod!,
+            grain,
+            [
+                batchNumber,
+                "beginning",
+                Array.Empty<Guid>(),
+                position,
+                null,
+                500,
+                fetchedCount,
+                fetchedCount,
+                0,
+                0L,
+                0L,
+                0,
+                hybridCatchUpStore,
+                hybridReadBatchMetadata,
+                "empty"
+            ]);
+    }
+
+    private static HybridEventStore CreateHybrid(int maxEvents) =>
+        new(
+            new ProductionCatchUpEventStore(),
+            new EmptyColdObjectStorage(),
+            new JsonlColdSegmentFormatHandler(),
+            new DefaultServiceIdProvider(),
+            Options.Create(new ColdEventStoreOptions
+            {
+                Enabled = true,
+                CatchUpPersistMaxEventsWithoutSnapshot = maxEvents,
+                CatchUpPersistMaxInterval = TimeSpan.FromHours(1)
+            }),
+            NullLogger<HybridEventStore>.Instance);
+
+    private static MultiProjectionGrain CreateGrain(
+        ProductionCatchUpEventStore store,
+        ProductionCatchUpProjectionHost? host = null,
+        MultiProjectionGrainState? state = null,
+        GeneralMultiProjectionActorOptions? actorOptions = null,
+        IEnumerable<SerializableEvent>? processedEvents = null)
+    {
+        host ??= new ProductionCatchUpProjectionHost();
+        var persistentState = new RecordingPersistentState<MultiProjectionGrainState>
+        {
+            State = state ?? new MultiProjectionGrainState()
+        };
+        store.PersistentState = persistentState;
+        var grain = new MultiProjectionGrain(
+            persistentState,
+            new ProductionCatchUpProjectionHostFactory(host),
+            store,
+            new DefaultOrleansEventSubscriptionResolver(),
+            multiProjectionStateStore: null,
+            eventStats: null,
+            actorOptions: actorOptions ?? new GeneralMultiProjectionActorOptions
+            {
+                PersistIntervalSeconds = 0,
+                SkipPersistWhenSafeCheckpointUnchanged = true
+            },
+            tempFileSnapshotManager: null,
+            logger: NullLogger<MultiProjectionGrain>.Instance,
+            eventStoreFactory: null,
+            serviceIdProvider: new DefaultServiceIdProvider());
+
+        SetPrivateField(grain, "_isInitialized", true);
+        SetPrivateField(grain, "_host", host);
+        SetPrivateField(grain, "_grainKey", "production-catch-up");
+        SetPrivateField(grain, "_projectorName", "production-catch-up");
+        SetPrivateField(grain, "_serviceId", DefaultServiceIdProvider.DefaultServiceId);
+        SetPrivateField(grain, "_eventsProcessed", 123L); // Irregular residue: old modulo must not fire at batch ten.
+
+        var processedIds = GetPrivateField<HashSet<Guid>>(grain, "_processedEventIds");
+        foreach (var ev in processedEvents ?? store.Events)
+        {
+            processedIds.Add(ev.Id);
+        }
+
+        return grain;
+    }
+
+    private static string? GetCatchUpCurrentPosition(MultiProjectionGrain grain)
+    {
+        var progress = GetPrivateField<object>(grain, "_catchUpProgress");
+        var current = progress.GetType().GetProperty("CurrentPosition", BindingFlags.Instance | BindingFlags.Public)!.GetValue(progress);
+        return current?.GetType().GetProperty("Value", BindingFlags.Instance | BindingFlags.Public)!.GetValue(current) as string;
+    }
+
+    private static T GetPrivateField<T>(object target, string name)
+    {
+        var field = target.GetType().GetField(name, BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(field);
+        return Assert.IsAssignableFrom<T>(field!.GetValue(target));
+    }
+
+    private static void SetPrivateField(object target, string name, object? value)
+    {
+        var field = target.GetType().GetField(name, BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(field);
+        field!.SetValue(target, value);
+    }
+
+    private static async Task InvokePrivateTaskAsync(MethodInfo method, object target, object?[] args)
+    {
+        var task = Assert.IsAssignableFrom<Task>(method.Invoke(target, args));
+        await task;
+    }
+
+    private static Task InvokePrivateTaskAsync(
+        MultiProjectionGrain target,
+        string methodName,
+        object?[]? args = null)
+    {
+        var method = target.GetType().GetMethod(methodName, BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(method);
+        return Assert.IsAssignableFrom<Task>(method!.Invoke(target, args));
+    }
+
+    private static void SeedWindow(MultiProjectionGrain grain, DateTime lastPersistUtc, bool usedCold)
+    {
+        SetPrivateField(grain, "_eventsProcessedSinceLastCatchUpPersist", 7L);
+        SetPrivateField(grain, "_eventsFetchedSinceLastCatchUpPersist", 8L);
+        SetPrivateField(grain, "_lastCatchUpPersistUtc", lastPersistUtc);
+        SetPrivateField(grain, "_lastCatchUpUsedCold", usedCold);
+    }
+
+    private static void SetActiveCatchUp(
+        MultiProjectionGrain grain,
+        CatchUpStartPositionLease? startLease)
+    {
+        var progressType = grain.GetType().GetNestedType("CatchUpProgress", BindingFlags.NonPublic);
+        Assert.NotNull(progressType);
+        var progress = Activator.CreateInstance(progressType!);
+        Assert.NotNull(progress);
+        SetPrivateProperty(progress!, "StartLease", startLease);
+        SetPrivateProperty(progress!, "IsActive", startLease is not null);
+        SetPrivateProperty(progress!, "HadNewEvents", false);
+        SetPrivateProperty(progress!, "StartTime", DateTime.UtcNow);
+        SetPrivateProperty(progress!, "LastAttempt", DateTime.UtcNow);
+        SetPrivateField(grain, "_catchUpProgress", progress);
+        if (startLease is not null)
+        {
+            SetPrivateField(grain, "_catchUpTimer", new NoOpDisposable());
+        }
+    }
+
+    private static void SetPrivateProperty(object target, string name, object? value)
+    {
+        var property = target.GetType().GetProperty(name, BindingFlags.Instance | BindingFlags.Public);
+        Assert.NotNull(property);
+        property!.SetValue(target, value);
+    }
+
+    private static void AssertWindowReset(MultiProjectionGrain grain, DateTime before)
+    {
+        Assert.Equal(0L, GetPrivateField<long>(grain, "_eventsProcessedSinceLastCatchUpPersist"));
+        Assert.Equal(0L, GetPrivateField<long>(grain, "_eventsFetchedSinceLastCatchUpPersist"));
+        Assert.True(GetPrivateField<DateTime>(grain, "_lastCatchUpPersistUtc") > before);
+        Assert.Null(GetPrivateFieldValue(grain, "_lastCatchUpUsedCold"));
+    }
+
+    private static void AssertWindowPreserved(MultiProjectionGrain grain, DateTime expectedTime, bool usedCold)
+    {
+        Assert.Equal(7L, GetPrivateField<long>(grain, "_eventsProcessedSinceLastCatchUpPersist"));
+        Assert.Equal(8L, GetPrivateField<long>(grain, "_eventsFetchedSinceLastCatchUpPersist"));
+        Assert.Equal(expectedTime, GetPrivateField<DateTime>(grain, "_lastCatchUpPersistUtc"));
+        Assert.Equal(usedCold, GetPrivateField<bool>(grain, "_lastCatchUpUsedCold"));
+    }
+
+    private static object? GetPrivateFieldValue(object target, string name)
+    {
+        var field = target.GetType().GetField(name, BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(field);
+        return field!.GetValue(target);
+    }
+
+    private sealed class RecordingPersistentState<T> : IPersistentState<T> where T : new()
+    {
+        public T State { get; set; } = new();
+        public string Etag => "test-etag";
+        public bool RecordExists => true;
+        public int WriteCalls { get; private set; }
+
+        public Task ClearStateAsync()
+        {
+            State = new T();
+            return Task.CompletedTask;
+        }
+
+        public Task ReadStateAsync() => Task.CompletedTask;
+
+        public Task WriteStateAsync()
+        {
+            WriteCalls++;
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class NoOpDisposable : IDisposable
+    {
+        public void Dispose() { }
+    }
+
+    private sealed class ProductionCatchUpProjectionHostFactory(ProductionCatchUpProjectionHost host) : IProjectionActorHostFactory
+    {
+        public IProjectionActorHost Create(
+            string projectorName,
+            GeneralMultiProjectionActorOptions? options = null,
+            Microsoft.Extensions.Logging.ILogger? logger = null) => host;
+    }
+
+    private sealed class ProductionCatchUpProjectionHost : IProjectionActorHost
+    {
+        public bool FailSnapshotWrite { get; init; }
+        public bool AllowApply { get; init; }
+        public int SafeVersion { get; init; }
+        public int StateMetadataCalls { get; private set; }
+        public int SnapshotWriteCalls { get; private set; }
+        public int AppliedEventCount { get; private set; }
+        public string? LastAppliedPosition { get; private set; }
+
+        public Task AddSerializableEventsAsync(IReadOnlyList<SerializableEvent> events, bool finishedCatchUp = true)
+        {
+            if (!AllowApply)
+            {
+                throw new Xunit.Sdk.XunitException("The zero-applied production test unexpectedly applied an event.");
+            }
+
+            AppliedEventCount += events.Count;
+            LastAppliedPosition = events[^1].SortableUniqueIdValue;
+            return Task.CompletedTask;
+        }
+
+        public Task<ResultBox<ProjectionStateMetadata>> GetStateMetadataAsync(bool includeUnsafe = true)
+        {
+            StateMetadataCalls++;
+            return Task.FromResult(ResultBox.FromValue(new ProjectionStateMetadata(
+                    "production-catch-up",
+                    "v1",
+                    IsCatchedUp: true,
+                    UnsafeVersion: 0,
+                    UnsafeLastSortableUniqueId: null,
+                    UnsafeLastEventId: null,
+                    SafeVersion: SafeVersion,
+                    SafeLastSortableUniqueId: null)));
+        }
+
+        public Task<ResultBox<MultiProjectionState>> GetStateAsync(bool canGetUnsafeState = true) =>
+            Task.FromResult(ResultBox.Error<MultiProjectionState>(new InvalidOperationException("no state payload")));
+
+        public Task<ProjectionHeadStatus> GetProjectionHeadStatusAsync() =>
+            throw new NotSupportedException();
+
+        public Task<ResultBox<bool>> WriteSnapshotToStreamAsync(
+            Stream target,
+            bool canGetUnsafeState,
+            CancellationToken cancellationToken) => WriteSnapshotAsync(target);
+
+        public Task<ResultBox<bool>> WriteSnapshotForPersistenceToStreamAsync(
+            Stream target,
+            bool canGetUnsafeState,
+            int offloadThresholdBytes,
+            CancellationToken cancellationToken) => WriteSnapshotAsync(target);
+
+        private async Task<ResultBox<bool>> WriteSnapshotAsync(Stream target)
+        {
+            SnapshotWriteCalls++;
+            if (FailSnapshotWrite)
+            {
+                return ResultBox.Error<bool>(new InvalidOperationException("snapshot write failed"));
+            }
+
+            await target.WriteAsync(new byte[] { 1 });
+            return ResultBox.FromValue(true);
+        }
+
+        public Task<ResultBox<bool>> RestoreSnapshotFromStreamAsync(Stream source, CancellationToken cancellationToken) =>
+            Task.FromResult(ResultBox.FromValue(true));
+
+        public Task<ResultBox<SerializableQueryResult>> ExecuteQueryAsync(
+            SerializableQueryParameter query,
+            int? safeVersion,
+            string? safeThreshold,
+            DateTime? safeThresholdTime,
+            int? unsafeVersion) => throw new NotSupportedException();
+
+        public Task<ResultBox<SerializableListQueryResult>> ExecuteListQueryAsync(
+            SerializableQueryParameter query,
+            int? safeVersion,
+            string? safeThreshold,
+            DateTime? safeThresholdTime,
+            int? unsafeVersion) => throw new NotSupportedException();
+
+        public void ForcePromoteBufferedEvents() { }
+        public void CompactSafeHistory() { }
+        public void ForcePromoteAllBufferedEvents() { }
+        public Task<string> GetSafeLastSortableUniqueIdAsync() => Task.FromResult(string.Empty);
+        public Task<bool> IsSortableUniqueIdReceivedAsync(string sortableUniqueId) => Task.FromResult(false);
+        public long EstimateStateSizeBytes(bool includeUnsafeDetails) => 1;
+        public string PeekCurrentSafeWindowThreshold() => SortableUniqueId.Generate(DateTime.UtcNow, Guid.Empty);
+        public string GetProjectorVersion() => "v1";
+
+        public Task<ResultBox<bool>> RewriteSnapshotVersionAsync(
+            Stream source,
+            Stream target,
+            string newVersion,
+            CancellationToken cancellationToken) => throw new NotSupportedException();
+    }
+
+    private class ProductionCatchUpEventStore : IEventStore
+    {
+        private int _readCalls;
+        protected readonly List<string?> ReadSinceValuesStorage = new();
+
+        private readonly IReadOnlyList<int> _batchSizes;
+        private readonly TaskCompletionSource? _firstReadStarted;
+        private readonly TaskCompletionSource? _releaseFirstRead;
+        private int _firstReadBlocked;
+
+        public ProductionCatchUpEventStore(
+            IReadOnlyList<int>? batchSizes = null,
+            TaskCompletionSource? firstReadStarted = null,
+            TaskCompletionSource? releaseFirstRead = null)
+        {
+            _batchSizes = batchSizes ?? Enumerable.Repeat(500, 10).ToArray();
+            _firstReadStarted = firstReadStarted;
+            _releaseFirstRead = releaseFirstRead;
+            var totalEventCount = _batchSizes.Sum();
+            Events = Enumerable.Range(0, totalEventCount)
+                .Select(index => new SerializableEvent(
+                    new byte[] { 1 },
+                    SortableUniqueId.GetTickString(10_000 + index) + SortableUniqueId.GetIdString(Guid.Empty),
+                    Guid.CreateVersion7(),
+                    new EventMetadata("aggregate", "command", "test"),
+                    new List<string>(),
+                    "ProductionCatchUpEvent"))
+                .ToArray();
+        }
+
+        public IReadOnlyList<SerializableEvent> Events { get; }
+        public int ReadCalls => Volatile.Read(ref _readCalls);
+        public IReadOnlyList<string?> ReadSinceValues => ReadSinceValuesStorage;
+        public RecordingPersistentState<MultiProjectionGrainState> PersistentState { get; set; } = new();
+
+        protected IReadOnlyList<SerializableEvent> NextBatch()
+        {
+            var call = Interlocked.Increment(ref _readCalls);
+            var batchIndex = call - 1;
+            if (batchIndex >= _batchSizes.Count)
+            {
+                return Array.Empty<SerializableEvent>();
+            }
+
+            var offset = _batchSizes.Take(batchIndex).Sum();
+            return Events.Skip(offset).Take(_batchSizes[batchIndex]).ToArray();
+        }
+
+        public async Task<ResultBox<IEnumerable<SerializableEvent>>> ReadAllSerializableEventsAsync(SortableUniqueId? since = null) =>
+            ResultBox.FromValue<IEnumerable<SerializableEvent>>(await ReadNextBatchAsync(since));
+
+        public async Task<ResultBox<IEnumerable<SerializableEvent>>> ReadAllSerializableEventsAsync(
+            SortableUniqueId? since,
+            int? maxCount) =>
+            ResultBox.FromValue<IEnumerable<SerializableEvent>>(await ReadNextBatchAsync(since));
+
+        private async Task<IReadOnlyList<SerializableEvent>> ReadNextBatchAsync(SortableUniqueId? since)
+        {
+            ReadSinceValuesStorage.Add(since?.Value);
+            if (_firstReadStarted is not null && Interlocked.Exchange(ref _firstReadBlocked, 1) == 0)
+            {
+                _firstReadStarted.TrySetResult();
+                if (_releaseFirstRead is not null)
+                {
+                    await _releaseFirstRead.Task;
+                }
+            }
+            return NextBatch();
+        }
+
+        public Task<ResultBox<IEnumerable<TagStream>>> ReadTagsAsync(ITag tag) => throw new NotSupportedException();
+        public Task<ResultBox<TagState>> GetLatestTagAsync(ITag tag) => throw new NotSupportedException();
+        public Task<ResultBox<bool>> TagExistsAsync(ITag tag) => throw new NotSupportedException();
+        public Task<ResultBox<long>> GetEventCountAsync(SortableUniqueId? since = null) => throw new NotSupportedException();
+        public Task<ResultBox<IEnumerable<TagInfo>>> GetAllTagsAsync(string? tagGroup = null) => throw new NotSupportedException();
+        public Task<ResultBox<SerializableEvent>> ReadSerializableEventAsync(Guid eventId) => throw new NotSupportedException();
+        public Task<ResultBox<IEnumerable<SerializableEvent>>> ReadSerializableEventsByTagAsync(ITag tag, SortableUniqueId? since = null) => throw new NotSupportedException();
+
+        public Task<ResultBox<(IReadOnlyList<SerializableEvent> Events, IReadOnlyList<TagWriteResult> TagWrites)>> WriteSerializableEventsAsync(
+            IEnumerable<SerializableEvent> events) => throw new NotSupportedException();
+
+        public Task<ResultBox<string>> GetLatestSortableUniqueIdAsync() => throw new NotSupportedException();
+    }
+
+    private sealed class ProductionStreamingCatchUpEventStore : ProductionCatchUpEventStore, IStreamingSerializableEventStore
+    {
+        public ProductionStreamingCatchUpEventStore(IReadOnlyList<int>? batchSizes = null)
+            : base(batchSizes)
+        {
+        }
+
+        public async Task<ResultBox<SerializableEventStreamReadResult>> StreamAllSerializableEventsAsync(
+            SortableUniqueId? since,
+            int? maxCount,
+            Func<SerializableEvent, ValueTask> onEvent,
+            CancellationToken cancellationToken = default)
+        {
+            ReadSinceValuesInternal(since);
+            var batch = NextBatch();
+            foreach (var ev in batch)
+            {
+                await onEvent(ev);
+            }
+
+            return ResultBox.FromValue(new SerializableEventStreamReadResult(
+                batch.Count,
+                batch.Count == 0 ? null : batch[^1].SortableUniqueIdValue));
+        }
+
+        private void ReadSinceValuesInternal(SortableUniqueId? since) => ReadSinceValuesStorage.Add(since?.Value);
+
+    }
+
+    private sealed class EmptyColdObjectStorage : IColdObjectStorage
+    {
+        public Task<ResultBox<ColdStorageObject>> GetAsync(string path, CancellationToken ct) =>
+            Task.FromResult(ResultBox.Error<ColdStorageObject>(new FileNotFoundException(path)));
+
+        public Task<ResultBox<bool>> PutAsync(string path, Stream data, string? expectedETag, CancellationToken ct) =>
+            Task.FromResult(ResultBox.FromValue(true));
+
+        public Task<ResultBox<bool>> PutAsync(string path, byte[] data, string? expectedETag, CancellationToken ct) =>
+            Task.FromResult(ResultBox.FromValue(true));
+
+        public Task<ResultBox<IReadOnlyList<string>>> ListAsync(string prefix, CancellationToken ct) =>
+            Task.FromResult(ResultBox.FromValue<IReadOnlyList<string>>(Array.Empty<string>()));
+
+        public Task<ResultBox<bool>> DeleteAsync(string path, CancellationToken ct) =>
+            Task.FromResult(ResultBox.FromValue(true));
+    }
+}

--- a/dcb/tests/Sekiban.Dcb.Orleans.Tests/MultiProjectionGrainPersistPolicyTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Orleans.Tests/MultiProjectionGrainPersistPolicyTests.cs
@@ -1,6 +1,8 @@
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using ResultBoxes;
 using Sekiban.Dcb.Actors;
+using Sekiban.Dcb.ColdEvents;
 using Sekiban.Dcb.Common;
 using Sekiban.Dcb.Events;
 using Sekiban.Dcb.MultiProjections;
@@ -252,6 +254,188 @@ public class MultiProjectionGrainPersistPolicyTests
         Assert.Empty((await statusStore.ListAsync("projection", "mutable-v2")).GetValue());
     }
 
+    [Fact]
+    public void Hot_thresholds_are_inclusive_and_preserve_legacy_modulo_precedence()
+    {
+        var grain = CreateGrain();
+
+        SetPrivateField(grain, "_eventsProcessed", 4_999L);
+        SetPrivateField(grain, "_eventsProcessedSinceLastCatchUpPersist", 0L);
+        SetPrivateField(grain, "_eventsFetchedSinceLastCatchUpPersist", 4_999L);
+        AssertDecision(grain, null, null, shouldPersist: false, reason: "none");
+
+        SetPrivateField(grain, "_eventsProcessed", 5_000L);
+        SetPrivateField(grain, "_eventsFetchedSinceLastCatchUpPersist", 1L);
+        AssertDecision(grain, null, null, shouldPersist: true, reason: "event_count_checkpoint");
+
+        InvokePrivate(grain, "ResetCatchUpPersistWindow", [false]);
+        SetPrivateField(grain, "_eventsProcessed", 5_001L);
+        SetPrivateField(grain, "_eventsFetchedSinceLastCatchUpPersist", 4_999L);
+        AssertDecision(grain, null, null, shouldPersist: false, reason: "none");
+
+        SetPrivateField(grain, "_eventsFetchedSinceLastCatchUpPersist", 5_000L);
+        AssertDecision(grain, null, null, shouldPersist: true, reason: "fetched_count_checkpoint");
+
+        InvokePrivate(grain, "ResetCatchUpPersistWindow", [false]);
+        SetPrivateField(grain, "_eventsProcessed", 123L);
+        SetPrivateField(grain, "_eventsFetchedSinceLastCatchUpPersist", 5_001L);
+        AssertDecision(grain, null, null, shouldPersist: true, reason: "fetched_count_checkpoint");
+
+        InvokePrivate(grain, "ResetCatchUpPersistWindow", [false]);
+        SetPrivateField(grain, "_eventsProcessed", 123L);
+        SetPrivateField(grain, "_eventsFetchedSinceLastCatchUpPersist", 5_000L);
+        AssertDecision(grain, null, null, shouldPersist: true, reason: "fetched_count_checkpoint");
+    }
+
+    [Fact]
+    public void Routing_uses_UsedCold_and_not_hybrid_store_presence()
+    {
+        var grain = CreateGrain();
+        var hybrid = CreateHybrid(maxEvents: 100);
+
+        SetPrivateField(grain, "_eventsProcessed", 123L);
+        SetPrivateField(grain, "_eventsFetchedSinceLastCatchUpPersist", 5_000L);
+        AssertDecision(
+            grain,
+            hybrid,
+            new HybridReadBatchMetadata("hot-only", UsedCold: false, UsedHot: true, false, 0, 500, 0),
+            shouldPersist: true,
+            reason: "fetched_count_checkpoint");
+
+        InvokePrivate(grain, "ResetCatchUpPersistWindow", [false]);
+        SetPrivateField(grain, "_eventsFetchedSinceLastCatchUpPersist", 100L);
+        AssertDecision(
+            grain,
+            hybrid,
+            new HybridReadBatchMetadata("cold", UsedCold: true, UsedHot: false, false, 100, 0, 1),
+            shouldPersist: true,
+            reason: "fetched_count_checkpoint");
+
+        InvokePrivate(grain, "ResetCatchUpPersistWindow", [false]);
+        SetPrivateField(grain, "_eventsFetchedSinceLastCatchUpPersist", 5_000L);
+        AssertDecision(
+            grain,
+            hybrid,
+            metadata: null,
+            shouldPersist: true,
+            reason: "fetched_count_checkpoint");
+
+        InvokePrivate(grain, "ResetCatchUpPersistWindow", [false]);
+        SetPrivateField(grain, "_eventsFetchedSinceLastCatchUpPersist", 5_000L);
+        AssertDecision(
+            grain,
+            hybridCatchUpStore: null,
+            new HybridReadBatchMetadata("cold-without-store", UsedCold: true, UsedHot: false, false, 100, 0, 1),
+            shouldPersist: false,
+            reason: "none");
+    }
+
+    [Fact]
+    public void Cold_legacy_precedence_and_fetched_only_boundary_are_preserved()
+    {
+        var grain = CreateGrain();
+        var hybrid = CreateHybrid(maxEvents: 100, interval: TimeSpan.FromHours(1));
+        var cold = new HybridReadBatchMetadata("cold", UsedCold: true, UsedHot: false, false, 100, 0, 1);
+
+        SetPrivateField(grain, "_eventsProcessedSinceLastCatchUpPersist", 99L);
+        SetPrivateField(grain, "_eventsFetchedSinceLastCatchUpPersist", 100L);
+        AssertDecision(grain, hybrid, cold, shouldPersist: true, reason: "fetched_count_checkpoint");
+
+        InvokePrivate(grain, "ResetCatchUpPersistWindow", [false]);
+        SetPrivateField(grain, "_eventsProcessedSinceLastCatchUpPersist", 100L);
+        SetPrivateField(grain, "_eventsFetchedSinceLastCatchUpPersist", 1L);
+        AssertDecision(grain, hybrid, cold, shouldPersist: true, reason: "max_events_since_last_persist");
+
+        InvokePrivate(grain, "ResetCatchUpPersistWindow", [false]);
+        AssertDecision(
+            grain,
+            hybrid,
+            cold with { ReachedColdSegmentBoundary = true },
+            shouldPersist: true,
+            reason: "cold_segment_boundary");
+    }
+
+    [Fact]
+    public void Counter_and_time_windows_reset_only_after_a_discriminating_non_fire()
+    {
+        var grain = CreateGrain();
+
+        SetPrivateField(grain, "_eventsProcessed", 123L);
+        SetPrivateField(grain, "_eventsFetchedSinceLastCatchUpPersist", 5_000L);
+        AssertDecision(grain, null, null, shouldPersist: true, reason: "fetched_count_checkpoint");
+        InvokePrivate(grain, "ResetCatchUpPersistWindow", [false]);
+        SetPrivateField(grain, "_eventsFetchedSinceLastCatchUpPersist", 4_999L);
+        AssertDecision(grain, null, null, shouldPersist: false, reason: "none");
+        SetPrivateField(grain, "_eventsFetchedSinceLastCatchUpPersist", 5_000L);
+        AssertDecision(grain, null, null, shouldPersist: true, reason: "fetched_count_checkpoint");
+
+        InvokePrivate(grain, "ResetCatchUpPersistWindow", [false]);
+        SetPrivateField(grain, "_lastCatchUpPersistUtc", DateTime.UtcNow - TimeSpan.FromMinutes(6));
+        AssertDecision(grain, null, null, shouldPersist: true, reason: "time_checkpoint");
+        InvokePrivate(grain, "ResetCatchUpPersistWindow", [false]);
+        SetPrivateField(grain, "_lastCatchUpPersistUtc", DateTime.UtcNow);
+        SetPrivateField(grain, "_eventsFetchedSinceLastCatchUpPersist", 1L);
+        AssertDecision(grain, null, null, shouldPersist: false, reason: "none");
+        SetPrivateField(grain, "_lastCatchUpPersistUtc", DateTime.UtcNow - TimeSpan.FromMinutes(6));
+        AssertDecision(grain, null, null, shouldPersist: true, reason: "time_checkpoint");
+    }
+
+    [Fact]
+    public void Read_path_transition_resets_the_three_window_fields_but_same_path_does_not_mutate_them()
+    {
+        var grain = CreateGrain();
+        var hot = new HybridReadBatchMetadata("hot", UsedCold: false, UsedHot: true, false, 0, 1, 0);
+        var cold = new HybridReadBatchMetadata("cold", UsedCold: true, UsedHot: false, false, 1, 0, 1);
+
+        InvokePrivate(grain, "ObserveCatchUpReadPath", [hot]);
+        SetPrivateField(grain, "_eventsProcessedSinceLastCatchUpPersist", 7L);
+        SetPrivateField(grain, "_eventsFetchedSinceLastCatchUpPersist", 8L);
+        var before = DateTime.UtcNow - TimeSpan.FromMinutes(1);
+        SetPrivateField(grain, "_lastCatchUpPersistUtc", before);
+
+        InvokePrivate(grain, "ObserveCatchUpReadPath", [hot]);
+        Assert.Equal(7L, GetPrivateField<long>(grain, "_eventsProcessedSinceLastCatchUpPersist"));
+        Assert.Equal(8L, GetPrivateField<long>(grain, "_eventsFetchedSinceLastCatchUpPersist"));
+        Assert.Equal(before, GetPrivateField<DateTime>(grain, "_lastCatchUpPersistUtc"));
+
+        InvokePrivate(grain, "ObserveCatchUpReadPath", [cold]);
+        Assert.Equal(0L, GetPrivateField<long>(grain, "_eventsProcessedSinceLastCatchUpPersist"));
+        Assert.Equal(0L, GetPrivateField<long>(grain, "_eventsFetchedSinceLastCatchUpPersist"));
+        Assert.True(GetPrivateField<DateTime>(grain, "_lastCatchUpPersistUtc") > before);
+        Assert.True(GetPrivateField<bool>(grain, "_lastCatchUpUsedCold"));
+    }
+
+    private static void AssertDecision(
+        MultiProjectionGrain grain,
+        HybridEventStore? hybridCatchUpStore,
+        HybridReadBatchMetadata? metadata,
+        bool shouldPersist,
+        string reason)
+    {
+        var decision = InvokePrivate(grain, "GetCatchUpPersistDecision", [hybridCatchUpStore, metadata]);
+        Assert.NotNull(decision);
+        Assert.Equal(shouldPersist, GetProperty<bool>(decision!, "ShouldPersist"));
+        Assert.Equal(reason, GetProperty<string>(decision!, "Reason"));
+    }
+
+    private static HybridEventStore CreateHybrid(
+        int maxEvents,
+        TimeSpan? interval = null,
+        bool persistOnBoundary = true) =>
+        new(
+            new StubEventStore(),
+            new EmptyColdObjectStorage(),
+            new JsonlColdSegmentFormatHandler(),
+            new DefaultServiceIdProvider(),
+            Options.Create(new ColdEventStoreOptions
+            {
+                Enabled = true,
+                CatchUpPersistMaxEventsWithoutSnapshot = maxEvents,
+                CatchUpPersistMaxInterval = interval ?? TimeSpan.FromMinutes(5),
+                PersistSnapshotOnColdSegmentBoundary = persistOnBoundary
+            }),
+            NullLogger<HybridEventStore>.Instance);
+
     private static MultiProjectionGrain CreateGrain(
         GeneralMultiProjectionActorOptions? options = null,
         MultiProjectionGrainState? state = null,
@@ -432,5 +616,23 @@ public class MultiProjectionGrainPersistPolicyTests
             throw new NotSupportedException();
         public Task<ResultBox<IEnumerable<SerializableEvent>>> ReadAllSerializableEventsAsync(SortableUniqueId? since, int? maxCount) =>
             throw new NotSupportedException();
+    }
+
+    private sealed class EmptyColdObjectStorage : IColdObjectStorage
+    {
+        public Task<ResultBox<ColdStorageObject>> GetAsync(string path, CancellationToken ct) =>
+            Task.FromResult(ResultBox.Error<ColdStorageObject>(new FileNotFoundException(path)));
+
+        public Task<ResultBox<bool>> PutAsync(string path, Stream data, string? expectedETag, CancellationToken ct) =>
+            Task.FromResult(ResultBox.FromValue(true));
+
+        public Task<ResultBox<bool>> PutAsync(string path, byte[] data, string? expectedETag, CancellationToken ct) =>
+            Task.FromResult(ResultBox.FromValue(true));
+
+        public Task<ResultBox<IReadOnlyList<string>>> ListAsync(string prefix, CancellationToken ct) =>
+            Task.FromResult(ResultBox.FromValue<IReadOnlyList<string>>(Array.Empty<string>()));
+
+        public Task<ResultBox<bool>> DeleteAsync(string path, CancellationToken ct) =>
+            Task.FromResult(ResultBox.FromValue(true));
     }
 }

--- a/docs/dcb_llm/04_multiple_aggregate_projector.md
+++ b/docs/dcb_llm/04_multiple_aggregate_projector.md
@@ -163,6 +163,23 @@ in global `SortableUniqueId` order) and a **served/unsafe** state (what queries 
   restore takes it as the baseline; a restart that writes zero new events restores exactly the
   same payload/position/threshold/count.
 
+### Catch-up persist cadence and telemetry (SEK-G37 / #1142)
+
+Catch-up completion is defined by `FetchedCount == 0`. A non-empty read whose events are
+all filtered (`AppliedCount == 0`) still advances the traversal cursor and reaches the
+same progress, persist-decision, and telemetry seam as an applied batch. This prevents a
+filtered tail from ending catch-up before its checkpoint fallback can run.
+
+The existing `event_count_checkpoint` trigger remains first on the hot-only path. The
+additive fallbacks report `PersistReason=fetched_count_checkpoint` after 5,000 fetched
+events or `PersistReason=time_checkpoint` after five minutes. Cold reads retain their
+configured segment, applied-count, and interval triggers, plus the fetched-count fallback;
+the cold/hot choice is taken from the read metadata's `UsedCold` value. A hybrid store
+with `UsedCold=false` therefore uses the hot-only constants. The summary reports
+`PersistTriggered` (the decision) separately from `PersistOutcome` (`durable_write`,
+`no_durable_write`, or `not_attempted`); a trigger is not evidence that a durable
+checkpoint was committed.
+
 ### First-query catch-up position contract (SEK-G21 / 10.8.1)
 
 A fresh Orleans activation places a fail-closed barrier in front of its first state, snapshot,

--- a/docs/dcb_llm_ja/04_multiple_aggregate_projector.md
+++ b/docs/dcb_llm_ja/04_multiple_aggregate_projector.md
@@ -155,6 +155,22 @@ Sekiban 内部だけで完結する読み取りならマルチプロジェクシ
 - **`EventsProcessed` は永続的な safe チェックポイント数**で、整合性シグナルとして使用します。復元は
   これをベースラインとし、新規イベントゼロの再起動では同一の payload/position/threshold/count を復元します。
 
+### Catch-up の永続化 cadence と telemetry (SEK-G37 / #1142)
+
+Catch-up の完了判定は `FetchedCount == 0` のみです。読み取ったイベントがすべて
+filter されて `AppliedCount == 0` になった場合も、traversal cursor を進め、適用済み
+batch と同じ progress・persist decision・telemetry の共通 seam を通ります。これにより
+filter 済み tail が checkpoint fallback より前に catch-up を終了させません。
+
+既存の hot-only `event_count_checkpoint` trigger が最初に評価されます。追加 fallback は
+5,000 fetched events 到達時の `PersistReason=fetched_count_checkpoint` と、5 分経過時の
+`PersistReason=time_checkpoint` です。cold read は既存の設定された segment・applied-count・
+interval trigger を維持し、fetched-count fallback も使います。cold/hot の選択は read metadata
+の `UsedCold` だけで決まり、`UsedCold=false` の hybrid store は hot-only の定数を使います。
+summary では `PersistTriggered` (decision) と `PersistOutcome` (`durable_write`,
+`no_durable_write`, `not_attempted`) を分けて報告します。trigger されたこと自体は、
+durable checkpoint が commit された証明ではありません。
+
 ### 初回クエリ catch-up の位置契約 (SEK-G21 / 10.8.1)
 
 Orleans の fresh activation は、最初の state・snapshot・scalar・list クエリの前に fail-closed


### PR DESCRIPTION
## Summary

- Define catch-up completion by `FetchedCount == 0`; non-empty zero-applied batches advance the traversal cursor and use the shared progress/decision/telemetry seam in both enumerable and streaming readers.
- Preserve the legacy hot modulo trigger and add private hot fetched/time fallbacks (5,000 / 5 minutes); add the fetched fallback to the existing cold policy selected by `UsedCold == true`.
- Normalize applied/fetched/time windows, preserve an inherited forced window, and report `PersistTriggered` separately from `PersistOutcome`.
- Add production-path killing tests, fresh-activation durability coverage, EN/JA documentation, and partial-filter cursor assertions without adding public options, interfaces, or serialized state members.

Fixes #1142

## Verification

- `dotnet test dcb/tests/Sekiban.Dcb.Orleans.Tests/Sekiban.Dcb.Orleans.Tests.csproj --framework net9.0 --filter FullyQualifiedName~MultiProjectionGrainCatchUpProductionPathTests --no-restore` — 10 passed.
- Same production-path filter on `net10.0` — 10 passed.
- `MultiProjectionGrainPersistPolicyTests` on `net9.0` and `net10.0` — 12 passed each.
- `MinimalOrleansTests.Hot_fetched_checkpoint_is_committed_and_consumed_by_fresh_activation` on `net9.0` and `net10.0` — 1 passed each; committed C1 was consumed by the fresh activation's first authoritative read.
- `MultiProjectionGrainCatchUpDiagnosticsTests` on `net9.0` — 6 passed.
- `git diff --check` — clean.
