### PR TITLE
fix(dcb): retire integrity watermark after unreadable snapshot

### DIFF
--- a/dcb/src/Sekiban.Dcb.Orleans.Core/Grains/MultiProjectionGrain.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.Core/Grains/MultiProjectionGrain.cs
@@ -109,6 +109,7 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
     private StateRestoreSource _stateRestoreSource = StateRestoreSource.None;
     private bool _activationHealthy = true;  // Default to healthy for backward compatibility
     private string? _activationFailureReason;
+    private bool _restoreRetirementFailed;
 
     // Orleans infrastructure
     private IAsyncStream<SerializableEvent>? _orleansStream;
@@ -600,6 +601,11 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
     {
         await EnsureInitializedAsync();
 
+        if (_restoreRetirementFailed)
+        {
+            return ResultBox.Error<MultiProjectionState>(CreateRestoreRetirementFailure());
+        }
+
         if (_host == null)
         {
             return ResultBox.Error<MultiProjectionState>(
@@ -898,6 +904,61 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
         return true;
     }
 
+    private async Task<bool> RetireIntegrityWatermarkAsync(string projectorName, string failureReason)
+    {
+        try
+        {
+            var outcome = await _stateStore.ExecuteWriteAsync(
+                GrainStateWriteKind.MetadataMaintenance,
+                s =>
+                {
+                    s.LastGoodSafeVersion = 0;
+                    s.LastGoodPayloadBytes = 0;
+                    s.LastGoodOriginalSizeBytes = 0;
+                    s.LastGoodEventsProcessed = 0;
+                });
+
+            if (outcome == GrainStateWriteOutcome.Committed)
+            {
+                // The external record was positively obtained but could not become a host snapshot. Invalidate that
+                // derived record before the ordered rebuild so the existing external-store ordering check remains
+                // unchanged and no recovery bypass is needed. The authoritative event stream remains untouched.
+                await InvalidateExternalDerivedSnapshotAsync();
+                _logger.LogWarning(
+                    "[{ProjectorName}] Integrity watermark retired after known-present snapshot restore failure. "
+                    + "Failure={FailureReason}",
+                    projectorName,
+                    failureReason);
+                return true;
+            }
+
+            _lastPersistOutcome = PersistOutcomeNoDurableWrite;
+            _lastError = $"Integrity watermark retirement was not committed: {outcome}";
+            _logger.LogError(
+                "[{ProjectorName}] Integrity watermark retirement failed; no durable checkpoint was committed. "
+                + "Outcome={Outcome}, Failure={FailureReason}",
+                projectorName,
+                outcome,
+                failureReason);
+            return false;
+        }
+        catch (Exception ex)
+        {
+            _lastPersistOutcome = PersistOutcomeNoDurableWrite;
+            _lastError = $"Integrity watermark retirement failed: {ex.Message}";
+            _logger.LogError(
+                ex,
+                "[{ProjectorName}] Integrity watermark retirement failed; no durable checkpoint was committed. "
+                + "Failure={FailureReason}",
+                projectorName,
+                failureReason);
+            return false;
+        }
+    }
+
+    private InvalidOperationException CreateRestoreRetirementFailure() =>
+        new($"Projection activation halted because integrity watermark retirement did not commit: {_activationFailureReason}");
+
     private async Task<StreamingExternalStorePersistResult> SaveStreamingSnapshotToExternalStoreAsync(
         string projectorName,
         PersistCheckpoint checkpoint,
@@ -1072,6 +1133,11 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
     {
         await EnsureInitializedAsync();
 
+        if (_restoreRetirementFailed)
+        {
+            return ResultBox.Error<string>(CreateRestoreRetirementFailure());
+        }
+
         if (_host == null)
         {
             return ResultBox.Error<string>(
@@ -1110,6 +1176,11 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
     public async Task AddEventsAsync(IReadOnlyList<SerializableEvent> events, bool finishedCatchUp = true)
     {
         await EnsureInitializedAsync();
+
+        if (_restoreRetirementFailed)
+        {
+            throw CreateRestoreRetirementFailure();
+        }
 
         if (_host == null)
         {
@@ -1337,6 +1408,12 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
     public async Task<ResultBox<bool>> PersistStateAsync()
     {
         _lastPersistOutcome = PersistOutcomeNotAttempted;
+        if (_restoreRetirementFailed)
+        {
+            _lastPersistOutcome = PersistOutcomeNoDurableWrite;
+            return ResultBox.Error<bool>(CreateRestoreRetirementFailure());
+        }
+
         try
         {
             var startUtc = DateTime.UtcNow;
@@ -1757,6 +1834,11 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
     {
         await EnsureInitializedAsync();
 
+        if (_restoreRetirementFailed)
+        {
+            return;
+        }
+
         // Defensive: ensure stream is prepared even if lifecycle hook hasn't run yet
         if (_orleansStream == null)
         {
@@ -1862,6 +1944,11 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
     private async Task<SerializableQueryResult> ExecuteQueryInternalAsync(
         SerializableQueryParameter queryParameter, bool waitForCatchUp)
     {
+        if (_restoreRetirementFailed)
+        {
+            throw CreateRestoreRetirementFailure();
+        }
+
         // Check health if FailOnUnhealthyActivation is enabled
         if (_injectedActorOptions?.FailOnUnhealthyActivation == true && !_activationHealthy)
         {
@@ -1922,6 +2009,11 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
     private async Task<SerializableListQueryResult> ExecuteListQueryInternalAsync(
         SerializableQueryParameter queryParameter, bool waitForCatchUp)
     {
+        if (_restoreRetirementFailed)
+        {
+            throw CreateRestoreRetirementFailure();
+        }
+
         // Check health if FailOnUnhealthyActivation is enabled
         if (_injectedActorOptions?.FailOnUnhealthyActivation == true && !_activationHealthy)
         {
@@ -2057,6 +2149,13 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
         _logger.LogDebug("[{ProjectorName}] Refreshing: Re-reading events from event store", projectorName);
 
         await EnsureInitializedAsync();
+        if (_restoreRetirementFailed)
+        {
+            return new CatchUpInvocationResult(
+                new CatchUpStartPositionLease(null, CatchUpStartPositionSource.InferredCheckpoint),
+                null);
+        }
+
         if (_host == null)
         {
             return new CatchUpInvocationResult(
@@ -2197,6 +2296,8 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
 
         // Create projection host via factory
         bool forceFullCatchUp = false;
+        var knownRecordObtained = false;
+        var knownRecordFailureHandled = false;
         if (_host == null)
         {
             _logger.LogDebug("Creating new projection host: {ProjectorName}", projectorName);
@@ -2328,6 +2429,7 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
                     else if (stateStoreResult.GetValue().HasValue)
                     {
                         var record = stateStoreResult.GetValue().GetValue();
+                        knownRecordObtained = true;
                         var stateStreamResult = await _multiProjectionStateStore.OpenStateDataReadStreamAsync(
                             record,
                             cancellationToken);
@@ -2346,7 +2448,15 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
                                 record.OffloadKey);
                             _stateRestoreSource = StateRestoreSource.Failed;
                             _activationFailureReason = errorMsg;
-                            forceFullCatchUp = true;
+                            knownRecordFailureHandled = true;
+                            if (await RetireIntegrityWatermarkAsync(projectorName, errorMsg))
+                            {
+                                forceFullCatchUp = true;
+                            }
+                            else
+                            {
+                                _restoreRetirementFailed = true;
+                            }
                         }
                         else
                         {
@@ -2366,9 +2476,18 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
                                     restoreResult.GetException(),
                                     "Snapshot restore failed: {ProjectorName}",
                                     projectorName);
+                                var errorMsg = restoreResult.GetException().Message;
                                 _stateRestoreSource = StateRestoreSource.Failed;
-                                _activationFailureReason = restoreResult.GetException().Message;
-                                forceFullCatchUp = true;
+                                _activationFailureReason = errorMsg;
+                                knownRecordFailureHandled = true;
+                                if (await RetireIntegrityWatermarkAsync(projectorName, errorMsg))
+                                {
+                                    forceFullCatchUp = true;
+                                }
+                                else
+                                {
+                                    _restoreRetirementFailed = true;
+                                }
                             }
                             else
                             {
@@ -2466,9 +2585,26 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
                         ex,
                         "State restoration exception: {ProjectorName}",
                         projectorName);
-                    _stateRestoreSource = StateRestoreSource.Failed;
-                    _activationFailureReason = ex.Message;
-                    forceFullCatchUp = true;
+                    if (knownRecordObtained && !knownRecordFailureHandled)
+                    {
+                        knownRecordFailureHandled = true;
+                        _stateRestoreSource = StateRestoreSource.Failed;
+                        _activationFailureReason = ex.Message;
+                        if (await RetireIntegrityWatermarkAsync(projectorName, ex.Message))
+                        {
+                            forceFullCatchUp = true;
+                        }
+                        else
+                        {
+                            _restoreRetirementFailed = true;
+                        }
+                    }
+                    else if (!knownRecordObtained)
+                    {
+                        _stateRestoreSource = StateRestoreSource.Failed;
+                        _activationFailureReason = ex.Message;
+                        forceFullCatchUp = true;
+                    }
                 }
             }
             else if (_multiProjectionStateStore == null)
@@ -2479,7 +2615,20 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
                     projectorName);
             }
 
-            if (!restoredFromExternalStore)
+            // A known record that failed at any point after record acquisition is not a valid restore baseline. This is
+            // especially important when the host restore returned success but stream disposal then threw: discard any
+            // partially-restored host only after the watermark retirement has committed, then begin the ordered replay
+            // against a fresh host. The retirement-write failure path is deliberately excluded by the flag above.
+            if (knownRecordObtained &&
+                _stateRestoreSource == StateRestoreSource.Failed &&
+                !_restoreRetirementFailed)
+            {
+                RecreateHostForFullRebuild();
+                restoredFromExternalStore = false;
+                forceFullCatchUp = true;
+            }
+
+            if (!restoredFromExternalStore && !_restoreRetirementFailed)
             {
                 _logger.LogInformation("No persisted state, will perform full catch-up: {ProjectorName}", projectorName);
                 forceFullCatchUp = true;
@@ -2504,28 +2653,43 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
         // If nothing was restored, we cannot be sure a fault is not waiting in the un-caught-up tail (its descriptor
         // may have been lost to a process crash while persistence was failing). The first query must therefore
         // synchronously catch up before it can answer — no fresh-activation empty-success window.
-        if (_projectionFault is null)
+        if (_projectionFault is null && !_restoreRetirementFailed)
         {
             _firstQueryGate.Arm();
         }
 
-        _ = CatchUpFromEventStoreAsync(forceFullCatchUp);
+        if (!_restoreRetirementFailed)
+        {
+            _ = CatchUpFromEventStoreAsync(forceFullCatchUp);
+        }
 
         // Auto-start subscription so stream-only projections resume after crashes/restarts.
-        try
+        if (!_restoreRetirementFailed)
         {
-            await StartSubscriptionAsync();
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(
-                ex,
-                "Failed to auto-start stream subscription on activation: {ProjectorName}",
-                projectorName);
+            try
+            {
+                await StartSubscriptionAsync();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(
+                    ex,
+                    "Failed to auto-start stream subscription on activation: {ProjectorName}",
+                    projectorName);
+            }
         }
 
         // Mark state restore source based on whether we need full catch-up
-        if (_stateRestoreSource == StateRestoreSource.Failed && _eventsProcessed == 0)
+        if (_restoreRetirementFailed)
+        {
+            _activationHealthy = false;
+            _logger.LogError(
+                MultiProjectionLogEvents.UnhealthyActivation,
+                "Grain activation halted: integrity watermark retirement failed; no durable checkpoint was committed: {ProjectorName}, Reason: {Reason}",
+                projectorName,
+                _activationFailureReason);
+        }
+        else if (_stateRestoreSource == StateRestoreSource.Failed && _eventsProcessed == 0)
         {
             // External store restore failed, catch-up will rebuild state
             _activationHealthy = false;
@@ -3670,6 +3834,11 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
 
     private async Task CatchUpFromEventStoreAsync(bool forceFull = false)
     {
+        if (_restoreRetirementFailed)
+        {
+            return;
+        }
+
         // Legacy method for compatibility - now triggers timer-based catch-up
         if (_host == null || _eventStore == null) return;
 

--- a/dcb/src/Sekiban.Dcb.Orleans.Core/Grains/MultiProjectionGrain.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.Core/Grains/MultiProjectionGrain.cs
@@ -111,6 +111,11 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
     private string? _activationFailureReason;
     private bool _restoreRetirementFailed;
 
+    // A known-record restore failure durably clears the four-field integrity watermark before replay begins. A
+    // zero-progress deactivation in that same activation must not repopulate only the payload-size portions of that
+    // watermark; keep the retired all-zero bundle until a fresh safe checkpoint is durably established.
+    private bool _retiredWatermarkAwaitingFreshSafeCheckpoint;
+
     // Orleans infrastructure
     private IAsyncStream<SerializableEvent>? _orleansStream;
     private StreamSubscriptionHandle<SerializableEvent>? _orleansStreamHandle;
@@ -924,6 +929,7 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
                 // derived record before the ordered rebuild so the existing external-store ordering check remains
                 // unchanged and no recovery bypass is needed. The authoritative event stream remains untouched.
                 await InvalidateExternalDerivedSnapshotAsync();
+                _retiredWatermarkAwaitingFreshSafeCheckpoint = true;
                 _logger.LogWarning(
                     "[{ProjectorName}] Integrity watermark retired after known-present snapshot restore failure. "
                     + "Failure={FailureReason}",
@@ -1577,25 +1583,29 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
                 // Update LastGood fields only when the external store save succeeded.
                 if (externalStoreSaved)
                 {
-                    if (safeVersion.HasValue && safeVersion.Value > 0)
+                    if (safeVersion is > 0)
                     {
                         s.LastGoodSafeVersion = safeVersion.Value;
                     }
-                    if (envelopeSize > 0)
-                    {
-                        s.LastGoodPayloadBytes = envelopeSize;
-                    }
-                    if (originalSizeBytes > 0)
-                    {
-                        s.LastGoodOriginalSizeBytes = originalSizeBytes;
-                    }
-                    s.LastGoodEventsProcessed = _eventsProcessed;
 
-                    // SEK-G18 #6: the rebuilt checkpoint is now durably committed to the external store, so the durable
-                    // rebuild marker can be cleared — a subsequent activation may safely restore this fresh checkpoint.
-                    s.RebuildRequired = false;
-                    s.RebuildOffendingEventId = null;
-                    s.RebuildOffendingPosition = null;
+                    if (!_retiredWatermarkAwaitingFreshSafeCheckpoint || safeVersion is > 0)
+                    {
+                        if (envelopeSize > 0)
+                        {
+                            s.LastGoodPayloadBytes = envelopeSize;
+                        }
+                        if (originalSizeBytes > 0)
+                        {
+                            s.LastGoodOriginalSizeBytes = originalSizeBytes;
+                        }
+                        s.LastGoodEventsProcessed = _eventsProcessed;
+
+                        // SEK-G18 #6: the rebuilt checkpoint is now durably committed to the external store, so the durable
+                        // rebuild marker can be cleared — a subsequent activation may safely restore this fresh checkpoint.
+                        s.RebuildRequired = false;
+                        s.RebuildOffendingEventId = null;
+                        s.RebuildOffendingPosition = null;
+                    }
                 }
 
                 // Clear legacy fields
@@ -1606,6 +1616,10 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
             }
 
             await WriteOrleansStateWithRetryAsync(projectorName, ApplyPersistFields);
+            if (externalStoreSaved && safeVersion is > 0)
+            {
+                _retiredWatermarkAwaitingFreshSafeCheckpoint = false;
+            }
             _host.CompactSafeHistory();
             CompactRetainedCollections();
             _lastError = null;
@@ -1698,13 +1712,18 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
 
                     if (externalStoreSaved)
                     {
-                        if (safeVersion.HasValue && safeVersion.Value > 0)
-                            s.LastGoodSafeVersion = safeVersion.Value;
+                    if (safeVersion is > 0)
+                    {
+                        s.LastGoodSafeVersion = safeVersion.Value;
+                    }
+                    if (!_retiredWatermarkAwaitingFreshSafeCheckpoint || safeVersion is > 0)
+                    {
                         if (tempFileSize > 0)
                             s.LastGoodPayloadBytes = tempFileSize;
                         if (tempFileSize > 0)
                             s.LastGoodOriginalSizeBytes = tempFileSize;
                         s.LastGoodEventsProcessed = _eventsProcessed;
+                    }
                     }
 
                     s.SerializedState = null;
@@ -1714,6 +1733,10 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
                 }
 
                 await WriteOrleansStateWithRetryAsync(projectorName, ApplyPersistFields);
+                if (externalStoreSaved && safeVersion is > 0)
+                {
+                    _retiredWatermarkAwaitingFreshSafeCheckpoint = false;
+                }
                 _host.CompactSafeHistory();
                 CompactRetainedCollections();
 

--- a/dcb/tests/Sekiban.Dcb.Orleans.Tests/MultiProjectionGrainWatermarkRetirementTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Orleans.Tests/MultiProjectionGrainWatermarkRetirementTests.cs
@@ -1,0 +1,1203 @@
+using System.Collections.Concurrent;
+using System.Reflection;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Orleans.Runtime;
+using Orleans.Runtime.Hosting;
+using Orleans.Storage;
+using Orleans.TestingHost;
+using ResultBoxes;
+using Sekiban.Dcb.Actors;
+using Sekiban.Dcb.Common;
+using Sekiban.Dcb.Domains;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.MultiProjections;
+using Sekiban.Dcb.Orleans;
+using Sekiban.Dcb.Orleans.Grains;
+using Sekiban.Dcb.Orleans.Serialization;
+using Sekiban.Dcb.Orleans.Streams;
+using Sekiban.Dcb.Queries;
+using Sekiban.Dcb.Runtime;
+using Sekiban.Dcb.ServiceId;
+using Sekiban.Dcb.Snapshots;
+using Sekiban.Dcb.Storage;
+using Sekiban.Dcb.Tags;
+using Sekiban.Dcb.Testing;
+using Xunit;
+
+namespace Sekiban.Dcb.Orleans.Tests;
+
+/// <summary>
+///     Production activation-path tests for the integrity-watermark retirement contract. The tests use the real
+///     Orleans grain, activation restore path, enumerable catch-up path, coordinated provider writes, and external
+///     checkpoint store. They deliberately do not invoke the private persist guard or decision function in isolation.
+/// </summary>
+[Collection("watermark-retirement")]
+public sealed class MultiProjectionGrainWatermarkRetirementTests : IAsyncLifetime
+{
+    private static WatermarkHarness? ActiveHarness;
+    private readonly WatermarkHarness _harness = new();
+    private TestCluster _cluster = null!;
+
+    public async Task InitializeAsync()
+    {
+        _harness.Reset();
+        ActiveHarness = _harness;
+        var builder = new TestClusterBuilder();
+        builder.Options.InitialSilosCount = 1;
+        var id = Guid.NewGuid().ToString("N")[..8];
+        builder.Options.ClusterId = $"G38-wm-{id}";
+        builder.Options.ServiceId = $"G38-wm-{id}";
+        var portBase = 30_000 + (Environment.ProcessId % 4_000) * 4;
+        builder.PortAllocator = new FixedPortAllocator(portBase, portBase + 1);
+        builder.Options.BaseSiloPort = portBase;
+        builder.Options.BaseGatewayPort = portBase + 1;
+        builder.AddSiloBuilderConfigurator<SiloConfigurator>();
+        _cluster = builder.Build();
+        await _cluster.DeployAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _cluster.StopAllSilosAsync();
+        _cluster.Dispose();
+    }
+
+    [Fact]
+    public async Task Known_present_restore_failure_retires_watermark_and_durably_converges_below_old_w()
+    {
+        const string projectorName = "g38-convergence";
+        var events = BuildEvents(5_000);
+        var seed = await _harness.SeedKnownPresentCheckpointAsync(projectorName, oldSafeVersion: 10_000, events);
+        _harness.RestoreBehavior = RestoreBehavior.ResultBoxFailure;
+
+        var grain = _cluster.Client.GetGrain<IMultiProjectionGrain>(projectorName);
+        await grain.GetStatusAsync();
+        await WaitUntilAsync(
+            () => _harness.StateStore.Records.Any(record => record.EventsProcessed > 0),
+            TimeSpan.FromSeconds(15),
+            () => $"hosts={_harness.Hosts.Count}, writes={_harness.ProviderStorage.WriteCalls}, attempts={_harness.ProviderStorage.WriteAttempts}, upserts={_harness.StateStore.UpsertCalls}, records={_harness.StateStore.Records.Count}, reads={_harness.EventStore.ReadSinceValues.Count}");
+
+        var intermediate = Assert.Single(
+            _harness.StateStore.Records,
+            record => record.EventsProcessed > 0);
+        Assert.True(intermediate.EventsProcessed > 0);
+        Assert.True(intermediate.EventsProcessed < seed.OldSafeVersion);
+        Assert.Equal(intermediate.LastSortableUniqueId, _harness.StateStore.LatestRecord!.LastSortableUniqueId);
+
+        var firstCheckpointHost = _harness.Hosts.First(host => host.AppliedEventIds.Count > 0);
+        Assert.True(firstCheckpointHost.CompactionCalls > 0);
+        Assert.Empty(firstCheckpointHost.NonIncrementalRetention);
+        Assert.True(firstCheckpointHost.AppliedEventIds.Count > 0);
+
+        // Force a genuine activation replacement. The replacement must restore the durable intermediate record and
+        // start its authoritative read strictly after that record, rather than merely returning a persist success.
+        _harness.RestoreBehavior = RestoreBehavior.None;
+        await grain.RequestDeactivationAsync();
+
+        var fresh = _cluster.Client.GetGrain<IMultiProjectionGrain>(projectorName);
+        await fresh.GetStatusAsync();
+        await WaitUntilAsync(() => _harness.Hosts.Count >= 2, TimeSpan.FromSeconds(10));
+        await WaitUntilAsync(
+            () => _harness.Hosts.Skip(1).Any(host => host.RestoreCalls > 0),
+            TimeSpan.FromSeconds(10));
+
+        var replacementHost = _harness.Hosts.Skip(1).First(host => host.RestoreCalls > 0);
+        Assert.True(replacementHost.RestoreCalls > 0);
+        Assert.Contains(
+            _harness.EventStore.ReadSinceValues,
+            since => string.Equals(since, intermediate.LastSortableUniqueId, StringComparison.Ordinal));
+        Assert.NotEqual(seed.OldSafeVersion, intermediate.EventsProcessed);
+        Assert.True(_harness.ProviderStorage.WriteCalls > 0);
+        Assert.True((await fresh.GetHealthStatusAsync()).IsHealthy);
+    }
+
+    [Fact]
+    public async Task Stream_open_and_host_restore_resultbox_failures_each_retire_all_four_fields()
+    {
+        await AssertResultBoxRetiresAllFourFieldsAsync(
+            "g38-open-resultbox",
+            StateStreamBehavior.ResultBoxFailure,
+            RestoreBehavior.None);
+        await AssertResultBoxRetiresAllFourFieldsAsync(
+            "g38-restore-resultbox",
+            StateStreamBehavior.Success,
+            RestoreBehavior.ResultBoxFailure);
+    }
+
+    [Theory]
+    [InlineData(StateStreamBehavior.Throw)]
+    [InlineData(StateStreamBehavior.CanSeekThrows)]
+    [InlineData(StateStreamBehavior.LengthThrows)]
+    [InlineData(StateStreamBehavior.PositionThrows)]
+    [InlineData(StateStreamBehavior.ReadThrows)]
+    [InlineData(StateStreamBehavior.DisposeThrows)]
+    public async Task Known_present_stream_and_restore_throws_retire_durably(StateStreamBehavior streamBehavior)
+    {
+        var projectorName = $"g38-throw-{streamBehavior}";
+        await _harness.SeedKnownPresentCheckpointAsync(projectorName, oldSafeVersion: 700, BuildEvents(20));
+        _harness.StreamBehavior = streamBehavior;
+        _harness.RestoreBehavior = RestoreBehavior.None;
+
+        var grain = _cluster.Client.GetGrain<IMultiProjectionGrain>(projectorName);
+        await grain.GetStatusAsync();
+        await WaitUntilAsync(
+            () => _harness.ProviderStorage.CommittedStates.Any(IsRetiredState),
+            TimeSpan.FromSeconds(10));
+        await WaitUntilAsync(
+            () => _harness.StateStore.Records.Any(record => record.EventsProcessed > 0),
+            TimeSpan.FromSeconds(10));
+
+        AssertRetiredCommittedState(projectorName);
+        var intermediate = Assert.Single(
+            _harness.StateStore.Records,
+            record => record.EventsProcessed > 0);
+        Assert.True(intermediate.EventsProcessed < 700);
+        Assert.Contains(
+            _harness.Hosts,
+            host => host.ProjectorName == projectorName && host.AppliedEventIds.Count > 0);
+        Assert.True((await grain.GetHealthStatusAsync()).IsHealthy == false);
+    }
+
+    [Fact]
+    public async Task Known_present_host_restore_throw_retires_durably()
+    {
+        const string projectorName = "g38-restore-throw";
+        await _harness.SeedKnownPresentCheckpointAsync(projectorName, oldSafeVersion: 700, BuildEvents(20));
+        _harness.StreamBehavior = StateStreamBehavior.Success;
+        _harness.RestoreBehavior = RestoreBehavior.Throw;
+
+        var grain = _cluster.Client.GetGrain<IMultiProjectionGrain>(projectorName);
+        await grain.GetStatusAsync();
+        await WaitUntilAsync(
+            () => _harness.ProviderStorage.CommittedStates.Any(IsRetiredState),
+            TimeSpan.FromSeconds(10));
+        await WaitUntilAsync(
+            () => _harness.StateStore.Records.Any(record => record.EventsProcessed > 0),
+            TimeSpan.FromSeconds(10));
+
+        AssertRetiredCommittedState(projectorName);
+        var intermediate = Assert.Single(
+            _harness.StateStore.Records,
+            record => record.EventsProcessed > 0);
+        Assert.True(intermediate.EventsProcessed < 700);
+        Assert.Contains(
+            _harness.Hosts,
+            host => host.ProjectorName == projectorName && host.AppliedEventIds.Count > 0);
+        Assert.False((await grain.GetHealthStatusAsync()).IsHealthy);
+    }
+
+    [Fact]
+    public async Task Pre_record_query_failure_does_not_retire_the_existing_watermark()
+    {
+        const string projectorName = "g38-pre-record-failure";
+        await _harness.SeedKnownPresentCheckpointAsync(projectorName, oldSafeVersion: 700, BuildEvents(0));
+        _harness.GetLatestBehavior = GetLatestBehavior.Throw;
+
+        var grain = _cluster.Client.GetGrain<IMultiProjectionGrain>(projectorName);
+        await grain.GetStatusAsync();
+        await Task.Delay(300);
+
+        var provider = _harness.ProviderStorage.Get(projectorName);
+        Assert.NotNull(provider);
+        Assert.Equal(700, provider!.LastGoodSafeVersion);
+        Assert.Equal(701, provider.LastGoodPayloadBytes);
+        Assert.Equal(702, provider.LastGoodOriginalSizeBytes);
+        Assert.Equal(703, provider.LastGoodEventsProcessed);
+        Assert.Empty(_harness.Hosts.Single(host => host.ProjectorName == projectorName).AppliedEventIds);
+        Assert.False((await grain.GetHealthStatusAsync()).IsHealthy);
+    }
+
+    [Fact]
+    public async Task Retirement_write_failure_rolls_back_and_does_not_start_rebuild_or_claim_checkpoint()
+    {
+        const string projectorName = "g38-retirement-write-failure";
+        await _harness.SeedKnownPresentCheckpointAsync(projectorName, oldSafeVersion: 700, BuildEvents(20));
+        _harness.RestoreBehavior = RestoreBehavior.ResultBoxFailure;
+        _harness.ProviderStorage.FailWrites = true;
+
+        var grain = _cluster.Client.GetGrain<IMultiProjectionGrain>(projectorName);
+        await grain.GetStatusAsync();
+        await WaitUntilAsync(
+            () => _harness.ProviderStorage.WriteAttempts > 0,
+            TimeSpan.FromSeconds(10));
+        await Task.Delay(300);
+
+        var host = Assert.Single(_harness.Hosts, candidate => candidate.ProjectorName == projectorName);
+        Assert.Empty(host.AppliedEventIds);
+        Assert.Equal(0, _harness.StateStore.UpsertCalls);
+        Assert.Equal(700, _harness.ProviderStorage.Get(projectorName)!.LastGoodSafeVersion);
+        Assert.Equal(701, _harness.ProviderStorage.Get(projectorName)!.LastGoodPayloadBytes);
+        Assert.Equal(702, _harness.ProviderStorage.Get(projectorName)!.LastGoodOriginalSizeBytes);
+        Assert.Equal(703, _harness.ProviderStorage.Get(projectorName)!.LastGoodEventsProcessed);
+
+        var health = await grain.GetHealthStatusAsync();
+        Assert.False(health.IsHealthy);
+        Assert.Contains("retirement", health.LastError ?? string.Empty, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(
+            _harness.LoggerProvider.Messages,
+            message => message.Contains("Integrity watermark retirement failed", StringComparison.Ordinal) &&
+                       message.Contains("no durable checkpoint", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task Retirement_write_then_deactivation_persists_zero_and_fresh_activation_consumes_it()
+    {
+        const string projectorName = "g38-crash-window";
+        await _harness.SeedKnownPresentCheckpointAsync(projectorName, oldSafeVersion: 700, BuildEvents(20));
+        _harness.RestoreBehavior = RestoreBehavior.ResultBoxFailure;
+        _harness.EventStore.BlockReads = true;
+        _harness.EventStore.ReturnEmptyAfterBlockedRead = true;
+
+        var grain = _cluster.Client.GetGrain<IMultiProjectionGrain>(projectorName);
+        await grain.GetStatusAsync();
+        await WaitUntilAsync(
+            () =>
+            {
+                var provider = _harness.ProviderStorage.Get(projectorName);
+                return provider is not null &&
+                       provider.LastGoodSafeVersion == 0 &&
+                       provider.LastGoodPayloadBytes == 0 &&
+                       provider.LastGoodOriginalSizeBytes == 0 &&
+                       provider.LastGoodEventsProcessed == 0;
+            },
+            TimeSpan.FromSeconds(10));
+        await _harness.EventStore.WaitForBlockedReadStartedAsync();
+
+        // Stop at the retirement/rebuild boundary: the blocked authoritative read has not delivered an event yet.
+        var deactivation = grain.RequestDeactivationAsync();
+        _harness.EventStore.ReleaseBlockedRead();
+        await deactivation;
+        await WaitUntilAsync(
+            () => _harness.StateStore.Records.Any(record => record.EventsProcessed == 0),
+            TimeSpan.FromSeconds(10));
+
+        var zeroCheckpoint = _harness.StateStore.Records.Last(record => record.EventsProcessed == 0);
+        Assert.Equal(0, zeroCheckpoint.EventsProcessed);
+        Assert.NotEqual(700, zeroCheckpoint.EventsProcessed);
+        Assert.Empty(_harness.Hosts.First(host => host.ProjectorName == projectorName).AppliedEventIds);
+
+        var hostsBeforeFreshActivation = _harness.Hosts.ToHashSet();
+        _harness.RestoreBehavior = RestoreBehavior.None;
+        _harness.EventStore.BlockReads = false;
+        var fresh = _cluster.Client.GetGrain<IMultiProjectionGrain>(projectorName);
+        await fresh.GetStatusAsync();
+        await WaitUntilAsync(
+            () => _harness.Hosts.Any(host => !hostsBeforeFreshActivation.Contains(host) && host.RestoreCalls > 0),
+            TimeSpan.FromSeconds(10));
+
+        var freshRestore = _harness.StateStore.OpenedRecords.Last(record => record.EventsProcessed == 0);
+        Assert.Equal(zeroCheckpoint.EventsProcessed, freshRestore.EventsProcessed);
+        Assert.Equal(zeroCheckpoint.LastSortableUniqueId, freshRestore.LastSortableUniqueId);
+        Assert.Contains(
+            _harness.EventStore.ReadSinceValues,
+            since => since is null || string.IsNullOrEmpty(since));
+    }
+
+    [Fact]
+    public async Task Absent_external_snapshot_keeps_zero_reset_and_existing_log_reason()
+    {
+        const string projectorName = "g38-absent-compatibility";
+        await _harness.SeedKnownPresentCheckpointAsync(projectorName, oldSafeVersion: 700, BuildEvents(0));
+        _harness.GetLatestBehavior = GetLatestBehavior.Absent;
+
+        var grain = _cluster.Client.GetGrain<IMultiProjectionGrain>(projectorName);
+        await grain.GetStatusAsync();
+        await WaitUntilAsync(() => _harness.ProviderStorage.WriteCalls > 0, TimeSpan.FromSeconds(10));
+
+        var provider = _harness.ProviderStorage.Get(projectorName);
+        Assert.NotNull(provider);
+        Assert.Equal(0, provider!.LastGoodSafeVersion);
+        Assert.Equal(0, provider.LastGoodPayloadBytes);
+        Assert.Equal(0, provider.LastGoodOriginalSizeBytes);
+        Assert.Equal(0, provider.LastGoodEventsProcessed);
+        Assert.Contains(
+            _harness.LoggerProvider.Messages,
+            message => message.Contains("Resetting integrity guard", StringComparison.Ordinal) &&
+                       message.Contains("external snapshot is missing", StringComparison.Ordinal));
+        Assert.DoesNotContain(
+            _harness.LoggerProvider.Messages,
+            message => message.Contains("Integrity watermark retired", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task Normal_regression_still_uses_the_unchanged_guard_without_a_provider_write()
+    {
+        const string projectorName = "g38-normal-regression";
+        await _harness.SeedKnownPresentCheckpointAsync(projectorName, oldSafeVersion: 700, BuildEvents(0));
+        _harness.RestoreBehavior = RestoreBehavior.None;
+
+        var grain = _cluster.Client.GetGrain<IMultiProjectionGrain>(projectorName);
+        await grain.GetStatusAsync();
+        var host = Assert.Single(_harness.Hosts, candidate => candidate.ProjectorName == projectorName);
+        host.ForceSafeVersion(699);
+        var writesBefore = _harness.ProviderStorage.WriteCalls;
+
+        var result = await grain.PersistStateAsync();
+
+        Assert.True(result.IsSuccess);
+        Assert.False(result.GetValue());
+        Assert.Equal(writesBefore, _harness.ProviderStorage.WriteCalls);
+        var provider = _harness.ProviderStorage.Get(projectorName)!;
+        Assert.Equal(700, provider.LastGoodSafeVersion);
+        Assert.Equal(701, provider.LastGoodPayloadBytes);
+        Assert.Equal(702, provider.LastGoodOriginalSizeBytes);
+        Assert.Equal(703, provider.LastGoodEventsProcessed);
+    }
+
+    [Fact]
+    public async Task Fresh_recovery_establishes_w2_and_the_guard_is_rearmed_for_a_later_regression()
+    {
+        const string projectorName = "g38-do-it-twice";
+        await _harness.SeedKnownPresentCheckpointAsync(projectorName, oldSafeVersion: 700, BuildEvents(10));
+        _harness.RestoreBehavior = RestoreBehavior.ResultBoxFailure;
+
+        var grain = _cluster.Client.GetGrain<IMultiProjectionGrain>(projectorName);
+        await grain.GetStatusAsync();
+        await WaitUntilAsync(
+            () => _harness.StateStore.Records.Any(record => record.EventsProcessed > 0),
+            TimeSpan.FromSeconds(10));
+        var w2 = _harness.StateStore.LatestRecord!.EventsProcessed;
+        Assert.True(w2 > 0);
+
+        var host = _harness.Hosts
+            .Where(candidate => candidate.ProjectorName == projectorName)
+            .OrderByDescending(candidate => candidate.AppliedEventIds.Count)
+            .First();
+        Assert.Equal(w2, _harness.ProviderStorage.Get(projectorName)!.LastGoodSafeVersion);
+        host.ForceSafeVersion(Math.Max(0, (int)w2 - 1));
+        var writesBefore = _harness.ProviderStorage.WriteCalls;
+        var blocked = await grain.PersistStateAsync();
+        Assert.True(blocked.IsSuccess);
+        Assert.False(blocked.GetValue());
+        Assert.Equal(writesBefore, _harness.ProviderStorage.WriteCalls);
+
+        host.ForceSafeVersion((int)w2);
+        var atWatermark = await grain.PersistStateAsync();
+        Assert.True(atWatermark.IsSuccess);
+        Assert.True(atWatermark.GetValue());
+    }
+
+    [Fact]
+    public async Task No_public_or_serialized_surface_was_added_for_retirement()
+    {
+        var grainType = typeof(MultiProjectionGrain);
+        Assert.Null(grainType.GetMethod("RetireIntegrityWatermarkAsync", BindingFlags.Public | BindingFlags.Instance));
+        Assert.Null(grainType.GetProperty("RestoreRetirementFailed", BindingFlags.Public | BindingFlags.Instance));
+        Assert.Null(typeof(MultiProjectionGrainState).GetProperty("RestoreRetirementFailed"));
+        Assert.Null(typeof(GeneralMultiProjectionActorOptions).GetProperty("IntegrityWatermark"));
+    }
+
+    private async Task AssertResultBoxRetiresAllFourFieldsAsync(
+        string projectorName,
+        StateStreamBehavior streamBehavior,
+        RestoreBehavior restoreBehavior)
+    {
+        await _harness.SeedKnownPresentCheckpointAsync(projectorName, oldSafeVersion: 700, BuildEvents(0));
+        _harness.StreamBehavior = streamBehavior;
+        _harness.RestoreBehavior = restoreBehavior;
+
+        var grain = _cluster.Client.GetGrain<IMultiProjectionGrain>(projectorName);
+        await grain.GetStatusAsync();
+        await WaitUntilAsync(() => _harness.ProviderStorage.WriteCalls > 0, TimeSpan.FromSeconds(10));
+
+        var provider = _harness.ProviderStorage.Get(projectorName);
+        Assert.NotNull(provider);
+        Assert.Equal(0, provider!.LastGoodSafeVersion);
+        Assert.Equal(0, provider.LastGoodPayloadBytes);
+        Assert.Equal(0, provider.LastGoodOriginalSizeBytes);
+        Assert.Equal(0, provider.LastGoodEventsProcessed);
+        AssertRetiredWatermark(projectorName);
+        Assert.False((await grain.GetHealthStatusAsync()).IsHealthy);
+    }
+
+    private void AssertRetiredWatermark(string projectorName)
+    {
+        var provider = _harness.ProviderStorage.Get(projectorName);
+        Assert.NotNull(provider);
+        Assert.Equal(0, provider.LastGoodSafeVersion);
+        Assert.Equal(0, provider.LastGoodPayloadBytes);
+        Assert.Equal(0, provider.LastGoodOriginalSizeBytes);
+        Assert.Equal(0, provider.LastGoodEventsProcessed);
+
+        AssertRetiredCommittedState(projectorName);
+    }
+
+    private void AssertRetiredCommittedState(string projectorName)
+    {
+        var committed = Assert.Single(
+            _harness.ProviderStorage.CommittedStates,
+            state => string.Equals(state.ProjectorName, projectorName, StringComparison.Ordinal) &&
+                    IsRetiredState(state));
+        Assert.Equal(0, committed.LastGoodSafeVersion);
+        Assert.Equal(0, committed.LastGoodPayloadBytes);
+        Assert.Equal(0, committed.LastGoodOriginalSizeBytes);
+        Assert.Equal(0, committed.LastGoodEventsProcessed);
+    }
+
+    private static bool IsRetiredState(MultiProjectionGrainState state) =>
+        state.LastGoodSafeVersion == 0 &&
+        state.LastGoodPayloadBytes == 0 &&
+        state.LastGoodOriginalSizeBytes == 0 &&
+        state.LastGoodEventsProcessed == 0;
+
+    private static IReadOnlyList<SerializableEvent> BuildEvents(int count)
+    {
+        return Enumerable.Range(0, count)
+            .Select(index => new SerializableEvent(
+                [1],
+                SortableUniqueId.GetTickString(1_000 + index) + SortableUniqueId.GetIdString(Guid.NewGuid()),
+                Guid.NewGuid(),
+                new EventMetadata("g38", "test", "watermark"),
+                [],
+                "G38Event"))
+            .ToArray();
+    }
+
+    private static async Task WaitUntilAsync(
+        Func<bool> condition,
+        TimeSpan timeout,
+        Func<string>? diagnostic = null)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            if (condition())
+            {
+                return;
+            }
+
+            await Task.Delay(50);
+        }
+
+        Assert.True(condition(), "Timed out waiting for the production-path condition. " + diagnostic?.Invoke());
+    }
+
+    private sealed class SiloConfigurator : ISiloConfigurator
+    {
+        public void Configure(ISiloBuilder siloBuilder)
+        {
+            siloBuilder
+                .ConfigureServices(services =>
+                {
+                    services.AddSingleton(_ => TestDomainTypes.Create());
+                    services.AddSingleton<IEventStore>(ActiveHarness!.EventStore);
+                    services.AddSingleton<IMultiProjectionStateStore>(ActiveHarness.StateStore);
+                    services.AddSingleton<IEventSubscriptionResolver>(
+                        new DefaultOrleansEventSubscriptionResolver("EventStreamProvider", "AllEvents", Guid.Empty));
+                    services.AddSingleton<IBlobStorageSnapshotAccessor, MockBlobStorageSnapshotAccessor>();
+                    services.AddTransient<IMultiProjectionEventStatistics, NoOpMultiProjectionEventStatistics>();
+                    services.AddLogging(builder => builder.AddProvider(ActiveHarness!.LoggerProvider));
+                    services.AddTransient(_ => new GeneralMultiProjectionActorOptions
+                    {
+                        SafeWindowMs = 20_000,
+                        PersistIntervalSeconds = 0,
+                        SkipPersistWhenSafeCheckpointUnchanged = true
+                    });
+                    services.AddSekibanDcbNativeRuntime();
+                    // The test factory must be registered after the native runtime's default factory so the real grain
+                    // activation path uses the deterministic host below.
+                    services.AddSingleton<IProjectionActorHostFactory>(ActiveHarness.HostFactory);
+                    services.AddGrainStorage("OrleansStorage", (_, _) => ActiveHarness!.ProviderStorage);
+                })
+                .AddMemoryGrainStorageAsDefault()
+                .AddMemoryGrainStorage("PubSubStore")
+                .AddMemoryStreams("EventStreamProvider")
+                .AddMemoryGrainStorage("EventStreamProvider");
+        }
+    }
+
+    private sealed class FixedPortAllocator(int baseSiloPort, int baseGatewayPort) : ITestClusterPortAllocator
+    {
+        public (int, int) AllocateConsecutivePortPairs(int numPorts) => (baseSiloPort, baseGatewayPort);
+
+        public void Dispose() { }
+    }
+
+    private enum RestoreBehavior
+    {
+        None,
+        ResultBoxFailure,
+        Throw
+    }
+
+    public enum StateStreamBehavior
+    {
+        Success,
+        ResultBoxFailure,
+        Throw,
+        CanSeekThrows,
+        LengthThrows,
+        PositionThrows,
+        ReadThrows,
+        DisposeThrows
+    }
+
+    private enum GetLatestBehavior
+    {
+        Success,
+        Absent,
+        Throw
+    }
+
+    private sealed record SeededCheckpoint(int OldSafeVersion, string OldPosition);
+
+    private sealed class WatermarkHarness
+    {
+        public WatermarkEventStore EventStore { get; } = new();
+        public WatermarkStateStore StateStore { get; } = new();
+        public WatermarkGrainStorage ProviderStorage { get; } = new();
+        public WatermarkHostFactory HostFactory { get; }
+        public ConcurrentBag<WatermarkProjectionHost> Hosts { get; } = new();
+        public RecordingLoggerProvider LoggerProvider { get; } = new();
+        public RestoreBehavior RestoreBehavior { get; set; }
+        public StateStreamBehavior StreamBehavior
+        {
+            get => StateStore.StreamBehavior;
+            set => StateStore.StreamBehavior = value;
+        }
+
+        public GetLatestBehavior GetLatestBehavior
+        {
+            get => StateStore.GetLatestBehavior;
+            set => StateStore.GetLatestBehavior = value;
+        }
+
+        public WatermarkHarness()
+        {
+            HostFactory = new WatermarkHostFactory(this);
+        }
+
+        public void Reset()
+        {
+            EventStore.Reset();
+            StateStore.Reset();
+            ProviderStorage.Reset();
+            while (Hosts.TryTake(out _)) { }
+            LoggerProvider.Clear();
+            RestoreBehavior = RestoreBehavior.None;
+            StreamBehavior = StateStreamBehavior.Success;
+            GetLatestBehavior = GetLatestBehavior.Success;
+        }
+
+        public async Task<SeededCheckpoint> SeedKnownPresentCheckpointAsync(
+            string projectorName,
+            int oldSafeVersion,
+            IReadOnlyList<SerializableEvent> events)
+        {
+            EventStore.SetEvents(events);
+            var oldPosition = SortableUniqueId.GetTickString(10_000) + SortableUniqueId.GetIdString(Guid.Empty);
+            var request = new MultiProjectionStateWriteRequest(
+                projectorName,
+                "v1",
+                typeof(SerializableMultiProjectionStateEnvelope).FullName!,
+                oldPosition,
+                oldSafeVersion,
+                false,
+                null,
+                null,
+                100,
+                100,
+                SortableUniqueId.GetTickString(9_000) + SortableUniqueId.GetIdString(Guid.Empty),
+                DateTime.UtcNow,
+                DateTime.UtcNow,
+                "G38_TEST_SEED",
+                "test");
+            await StateStore.SeedAsync(request, [1]);
+            ProviderStorage.Seed(
+                projectorName,
+                new MultiProjectionGrainState
+                {
+                    ProjectorName = projectorName,
+                    ProjectorVersion = "v1",
+                    LastSortableUniqueId = oldPosition,
+                    EventsProcessed = oldSafeVersion,
+                    LastGoodSafeVersion = oldSafeVersion,
+                    LastGoodPayloadBytes = 701,
+                    LastGoodOriginalSizeBytes = 702,
+                    LastGoodEventsProcessed = 703
+                });
+            return new SeededCheckpoint(oldSafeVersion, oldPosition);
+        }
+    }
+
+    private sealed class WatermarkHostFactory(WatermarkHarness harness) : IProjectionActorHostFactory
+    {
+        public IProjectionActorHost Create(
+            string projectorName,
+            GeneralMultiProjectionActorOptions? options = null,
+            ILogger? logger = null)
+        {
+            var host = new WatermarkProjectionHost(harness, projectorName);
+            harness.Hosts.Add(host);
+            return host;
+        }
+    }
+
+    private sealed class WatermarkProjectionHost(WatermarkHarness harness, string projectorName) : IProjectionActorHost
+    {
+        private readonly List<Guid> _appliedEventIds = [];
+        private string? _safePosition;
+        private int _forcedSafeVersion = -1;
+
+        public string ProjectorName { get; } = projectorName;
+        public int RestoreCalls { get; private set; }
+        public int CompactionCalls { get; private set; }
+        public List<Guid> AppliedEventIds => _appliedEventIds;
+        public HashSet<Guid> NonIncrementalRetention { get; } = [];
+
+        public void ForceSafeVersion(int version) => _forcedSafeVersion = version;
+
+        public Task AddSerializableEventsAsync(IReadOnlyList<SerializableEvent> events, bool finishedCatchUp = true)
+        {
+            _appliedEventIds.AddRange(events.Select(item => item.Id));
+            foreach (var item in events)
+            {
+                NonIncrementalRetention.Add(item.Id);
+            }
+
+            if (events.Count > 0)
+            {
+                _safePosition = events[^1].SortableUniqueIdValue;
+            }
+
+            return Task.CompletedTask;
+        }
+
+        public Task<ResultBox<ProjectionStateMetadata>> GetStateMetadataAsync(bool includeUnsafe = true)
+        {
+            var safeVersion = _forcedSafeVersion >= 0 ? _forcedSafeVersion : _appliedEventIds.Count;
+            return Task.FromResult(ResultBox.FromValue(new ProjectionStateMetadata(
+                ProjectorName,
+                "v1",
+                true,
+                0,
+                null,
+                null,
+                safeVersion,
+                _safePosition)));
+        }
+
+        public Task<ResultBox<MultiProjectionState>> GetStateAsync(bool canGetUnsafeState = true) =>
+            Task.FromResult(ResultBox.Error<MultiProjectionState>(new InvalidOperationException("test host state unavailable")));
+
+        public Task<ProjectionHeadStatus> GetProjectionHeadStatusAsync() => throw new NotSupportedException();
+
+        public Task<ResultBox<bool>> WriteSnapshotToStreamAsync(
+            Stream target,
+            bool canGetUnsafeState,
+            CancellationToken cancellationToken) => WriteSnapshotAsync(target, cancellationToken);
+
+        public Task<ResultBox<bool>> WriteSnapshotForPersistenceToStreamAsync(
+            Stream target,
+            bool canGetUnsafeState,
+            int offloadThresholdBytes,
+            CancellationToken cancellationToken) => WriteSnapshotAsync(target, cancellationToken);
+
+        private async Task<ResultBox<bool>> WriteSnapshotAsync(Stream target, CancellationToken cancellationToken)
+        {
+            await target.WriteAsync(new byte[] { 1 }, cancellationToken);
+            return ResultBox.FromValue(true);
+        }
+
+        public async Task<ResultBox<bool>> RestoreSnapshotFromStreamAsync(Stream source, CancellationToken cancellationToken)
+        {
+            RestoreCalls++;
+            if (harness.RestoreBehavior == RestoreBehavior.ResultBoxFailure)
+            {
+                return ResultBox.Error<bool>(new InvalidOperationException("injected host restore ResultBox failure"));
+            }
+
+            if (harness.RestoreBehavior == RestoreBehavior.Throw)
+            {
+                throw new InvalidOperationException("injected host restore throw");
+            }
+
+            var buffer = new byte[16];
+            while (await source.ReadAsync(buffer, cancellationToken) > 0) { }
+            return ResultBox.FromValue(true);
+        }
+
+        public Task<ResultBox<SerializableQueryResult>> ExecuteQueryAsync(
+            SerializableQueryParameter query,
+            int? safeVersion,
+            string? safeThreshold,
+            DateTime? safeThresholdTime,
+            int? unsafeVersion) => throw new NotSupportedException();
+
+        public Task<ResultBox<SerializableListQueryResult>> ExecuteListQueryAsync(
+            SerializableQueryParameter query,
+            int? safeVersion,
+            string? safeThreshold,
+            DateTime? safeThresholdTime,
+            int? unsafeVersion) => throw new NotSupportedException();
+
+        public void ForcePromoteBufferedEvents() { }
+
+        public void CompactSafeHistory()
+        {
+            CompactionCalls++;
+            NonIncrementalRetention.Clear();
+        }
+
+        public void ForcePromoteAllBufferedEvents() { }
+
+        public Task<string> GetSafeLastSortableUniqueIdAsync() => Task.FromResult(_safePosition ?? string.Empty);
+
+        public Task<bool> IsSortableUniqueIdReceivedAsync(string sortableUniqueId) => Task.FromResult(false);
+
+        public long EstimateStateSizeBytes(bool includeUnsafeDetails) => 1;
+
+        public string PeekCurrentSafeWindowThreshold() =>
+            SortableUniqueId.GetTickString(20_000) + SortableUniqueId.GetIdString(Guid.Empty);
+
+        public string GetProjectorVersion() => "v1";
+
+        public Task<ResultBox<bool>> RewriteSnapshotVersionAsync(
+            Stream source,
+            Stream target,
+            string newVersion,
+            CancellationToken cancellationToken) => throw new NotSupportedException();
+    }
+
+    private sealed class WatermarkEventStore : IEventStore
+    {
+        private readonly object _gate = new();
+        private IReadOnlyList<SerializableEvent> _events = [];
+        private TaskCompletionSource<bool> _blockedReadStarted = CreateSignal();
+        private TaskCompletionSource<bool> _releaseBlockedRead = CreateSignal();
+        public List<string?> ReadSinceValues { get; } = [];
+        public bool BlockReads { get; set; }
+        public bool ReturnEmptyAfterBlockedRead { get; set; }
+
+        private static TaskCompletionSource<bool> CreateSignal() =>
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public void Reset()
+        {
+            lock (_gate)
+            {
+                _events = [];
+                ReadSinceValues.Clear();
+                _blockedReadStarted = CreateSignal();
+                _releaseBlockedRead = CreateSignal();
+            }
+
+            BlockReads = false;
+            ReturnEmptyAfterBlockedRead = false;
+        }
+
+        public void SetEvents(IReadOnlyList<SerializableEvent> events)
+        {
+            lock (_gate)
+            {
+                _events = events;
+                ReadSinceValues.Clear();
+            }
+        }
+
+        public Task WaitForBlockedReadStartedAsync() => _blockedReadStarted.Task.WaitAsync(TimeSpan.FromSeconds(10));
+
+        public void ReleaseBlockedRead() => _releaseBlockedRead.TrySetResult(true);
+
+        public Task<ResultBox<string>> GetLatestSortableUniqueIdAsync()
+        {
+            lock (_gate)
+            {
+                return Task.FromResult(ResultBox.FromValue(_events.LastOrDefault()?.SortableUniqueIdValue ?? string.Empty));
+            }
+        }
+
+        public Task<ResultBox<IEnumerable<SerializableEvent>>> ReadAllSerializableEventsAsync(SortableUniqueId? since = null) =>
+            ReadAllSerializableEventsAsync(since, null);
+
+        public async Task<ResultBox<IEnumerable<SerializableEvent>>> ReadAllSerializableEventsAsync(
+            SortableUniqueId? since,
+            int? maxCount)
+        {
+            IReadOnlyList<SerializableEvent> events;
+            Task? releaseTask = null;
+            bool returnEmpty = false;
+            lock (_gate)
+            {
+                ReadSinceValues.Add(since?.Value);
+                events = _events.ToArray();
+                if (BlockReads)
+                {
+                    _blockedReadStarted.TrySetResult(true);
+                    releaseTask = _releaseBlockedRead.Task;
+                    returnEmpty = ReturnEmptyAfterBlockedRead;
+                }
+            }
+
+            if (releaseTask is not null)
+            {
+                await releaseTask;
+                if (returnEmpty)
+                {
+                    return ResultBox.FromValue<IEnumerable<SerializableEvent>>([]);
+                }
+            }
+
+            var result = events.Where(item => since is null ||
+                string.Compare(item.SortableUniqueIdValue, since.Value, StringComparison.Ordinal) > 0);
+            if (maxCount.HasValue)
+            {
+                result = result.Take(maxCount.Value);
+            }
+
+            return ResultBox.FromValue<IEnumerable<SerializableEvent>>(result.ToArray());
+        }
+
+        public Task<ResultBox<IEnumerable<TagStream>>> ReadTagsAsync(ITag tag) => throw new NotSupportedException();
+        public Task<ResultBox<TagState>> GetLatestTagAsync(ITag tag) => throw new NotSupportedException();
+        public Task<ResultBox<bool>> TagExistsAsync(ITag tag) => throw new NotSupportedException();
+        public Task<ResultBox<long>> GetEventCountAsync(SortableUniqueId? since = null) => throw new NotSupportedException();
+        public Task<ResultBox<IEnumerable<TagInfo>>> GetAllTagsAsync(string? tagGroup = null) => throw new NotSupportedException();
+        public Task<ResultBox<SerializableEvent>> ReadSerializableEventAsync(Guid eventId) => throw new NotSupportedException();
+        public Task<ResultBox<IEnumerable<SerializableEvent>>> ReadSerializableEventsByTagAsync(ITag tag, SortableUniqueId? since = null) => throw new NotSupportedException();
+        public Task<ResultBox<(IReadOnlyList<SerializableEvent> Events, IReadOnlyList<TagWriteResult> TagWrites)>> WriteSerializableEventsAsync(IEnumerable<SerializableEvent> events) => throw new NotSupportedException();
+    }
+
+    private sealed class WatermarkStateStore : IMultiProjectionStateStore
+    {
+        private readonly InMemoryMultiProjectionStateStore _inner = new();
+        private readonly object _gate = new();
+        private int _upsertCalls;
+        public int UpsertCalls => Volatile.Read(ref _upsertCalls);
+        public List<MultiProjectionStateRecord> Records { get; } = [];
+        public List<MultiProjectionStateRecord> OpenedRecords { get; } = [];
+        public MultiProjectionStateRecord? LatestRecord { get; private set; }
+        public GetLatestBehavior GetLatestBehavior { get; set; }
+        public StateStreamBehavior StreamBehavior { get; set; }
+
+        public void Reset()
+        {
+            _inner.Clear();
+            lock (_gate)
+            {
+                Volatile.Write(ref _upsertCalls, 0);
+                Records.Clear();
+                OpenedRecords.Clear();
+                LatestRecord = null;
+            }
+            GetLatestBehavior = GetLatestBehavior.Success;
+            StreamBehavior = StateStreamBehavior.Success;
+        }
+
+        public async Task SeedAsync(MultiProjectionStateWriteRequest request, byte[] payload)
+        {
+            var result = await _inner.UpsertFromStreamAsync(request, new MemoryStream(payload), payload.Length);
+            Assert.True(result.IsSuccess, result.IsSuccess ? "" : result.GetException().ToString());
+        }
+
+        public Task<ResultBox<OptionalValue<MultiProjectionStateRecord>>> GetLatestForVersionAsync(
+            string projectorName,
+            string projectorVersion,
+            CancellationToken cancellationToken = default)
+        {
+            if (GetLatestBehavior == GetLatestBehavior.Throw)
+            {
+                throw new InvalidOperationException("injected GetLatestForVersionAsync throw");
+            }
+
+            if (GetLatestBehavior == GetLatestBehavior.Absent)
+            {
+                return Task.FromResult(
+                    ResultBox.FromValue(OptionalValue<MultiProjectionStateRecord>.Empty));
+            }
+
+            return _inner.GetLatestForVersionAsync(projectorName, projectorVersion, cancellationToken);
+        }
+
+        public Task<ResultBox<OptionalValue<MultiProjectionStateRecord>>> GetLatestAnyVersionAsync(
+            string projectorName,
+            CancellationToken cancellationToken = default) => _inner.GetLatestAnyVersionAsync(projectorName, cancellationToken);
+
+        public Task<ResultBox<bool>> UpsertAsync(
+            MultiProjectionStateRecord record,
+            int offloadThresholdBytes = 1_000_000,
+            CancellationToken cancellationToken = default)
+        {
+            Interlocked.Increment(ref _upsertCalls);
+            lock (_gate)
+            {
+                Records.Add(record);
+                LatestRecord = record;
+            }
+            return _inner.UpsertAsync(record, offloadThresholdBytes, cancellationToken);
+        }
+
+        public Task<ResultBox<IReadOnlyList<ProjectorStateInfo>>> ListAllAsync(CancellationToken cancellationToken = default) =>
+            _inner.ListAllAsync(cancellationToken);
+
+        public Task<ResultBox<bool>> DeleteAsync(
+            string projectorName,
+            string projectorVersion,
+            CancellationToken cancellationToken = default) => _inner.DeleteAsync(projectorName, projectorVersion, cancellationToken);
+
+        public Task<ResultBox<int>> DeleteAllAsync(string? projectorName = null, CancellationToken cancellationToken = default) =>
+            _inner.DeleteAllAsync(projectorName, cancellationToken);
+
+        public Task<ResultBox<Stream>> OpenStateDataReadStreamAsync(
+            MultiProjectionStateRecord record,
+            CancellationToken cancellationToken = default)
+        {
+            lock (_gate)
+            {
+                OpenedRecords.Add(record);
+            }
+
+            switch (StreamBehavior)
+            {
+                case StateStreamBehavior.ResultBoxFailure:
+                    return Task.FromResult(ResultBox.Error<Stream>(new InvalidOperationException("injected stream-open ResultBox failure")));
+                case StateStreamBehavior.Throw:
+                    throw new InvalidOperationException("injected stream-open throw");
+                case StateStreamBehavior.CanSeekThrows:
+                case StateStreamBehavior.LengthThrows:
+                case StateStreamBehavior.PositionThrows:
+                case StateStreamBehavior.ReadThrows:
+                case StateStreamBehavior.DisposeThrows:
+                    return Task.FromResult(ResultBox.FromValue<Stream>(new ThrowingReadStream(StreamBehavior)));
+                default:
+                    return _inner.OpenStateDataReadStreamAsync(record, cancellationToken);
+            }
+        }
+
+        public Task<ResultBox<bool>> UpsertFromStreamAsync(
+            MultiProjectionStateWriteRequest request,
+            Stream stream,
+            int offloadThresholdBytes,
+            CancellationToken cancellationToken = default)
+        {
+            Interlocked.Increment(ref _upsertCalls);
+            var record = request.ToRecord();
+            lock (_gate)
+            {
+                Records.Add(record);
+                LatestRecord = record;
+            }
+            return _inner.UpsertFromStreamAsync(request, stream, offloadThresholdBytes, cancellationToken);
+        }
+    }
+
+    private sealed class RecordingLoggerProvider : ILoggerProvider
+    {
+        public ConcurrentQueue<string> Messages { get; } = new();
+
+        public ILogger CreateLogger(string categoryName) => new RecordingLogger(Messages);
+
+        public void Clear()
+        {
+            while (Messages.TryDequeue(out _)) { }
+        }
+
+        public void Dispose() { }
+    }
+
+    private sealed class RecordingLogger(ConcurrentQueue<string> messages) : ILogger
+    {
+        public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            messages.Enqueue(formatter(state, exception));
+        }
+
+        private sealed class NullScope : IDisposable
+        {
+            public static NullScope Instance { get; } = new();
+
+            public void Dispose() { }
+        }
+    }
+
+    private sealed class ThrowingReadStream(StateStreamBehavior behavior) : MemoryStream([1])
+    {
+        public override bool CanSeek => behavior == StateStreamBehavior.CanSeekThrows
+            ? throw new InvalidOperationException("injected stream CanSeek throw")
+            : base.CanSeek;
+
+        public override long Length => behavior == StateStreamBehavior.LengthThrows
+            ? throw new InvalidOperationException("injected stream Length throw")
+            : base.Length;
+
+        public override long Position
+        {
+            get => base.Position;
+            set
+            {
+                if (behavior == StateStreamBehavior.PositionThrows)
+                {
+                    throw new InvalidOperationException("injected stream Position throw");
+                }
+
+                base.Position = value;
+            }
+        }
+
+        public override int Read(byte[] buffer, int offset, int count) =>
+            behavior == StateStreamBehavior.ReadThrows
+                ? throw new InvalidOperationException("injected stream Read throw")
+                : base.Read(buffer, offset, count);
+
+        public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default) =>
+            behavior == StateStreamBehavior.ReadThrows
+                ? ValueTask.FromException<int>(new InvalidOperationException("injected stream ReadAsync throw"))
+                : base.ReadAsync(buffer, cancellationToken);
+
+        public override ValueTask DisposeAsync() =>
+            behavior == StateStreamBehavior.DisposeThrows
+                ? ValueTask.FromException(new InvalidOperationException("injected stream DisposeAsync throw"))
+                : base.DisposeAsync();
+    }
+
+    private sealed class WatermarkGrainStorage : IGrainStorage
+    {
+        private readonly object _gate = new();
+        private readonly Dictionary<string, MultiProjectionGrainState> _states = new(StringComparer.Ordinal);
+        private int _writeCalls;
+        private int _writeAttempts;
+        public bool FailWrites { get; set; }
+        public int WriteCalls => Volatile.Read(ref _writeCalls);
+        public int WriteAttempts => Volatile.Read(ref _writeAttempts);
+        public List<MultiProjectionGrainState> CommittedStates { get; } = [];
+
+        public void Reset()
+        {
+            lock (_gate)
+            {
+                _states.Clear();
+                CommittedStates.Clear();
+                Volatile.Write(ref _writeCalls, 0);
+                Volatile.Write(ref _writeAttempts, 0);
+            }
+            FailWrites = false;
+        }
+
+        public void Seed(string grainKey, MultiProjectionGrainState state)
+        {
+            lock (_gate)
+            {
+                _states[grainKey] = state.Clone();
+            }
+        }
+
+        public MultiProjectionGrainState? Get(string grainKey)
+        {
+            lock (_gate)
+            {
+                var pair = _states
+                    .Where(item =>
+                    string.Equals(item.Key, grainKey, StringComparison.Ordinal) ||
+                    item.Key.EndsWith("/" + grainKey, StringComparison.Ordinal) ||
+                    item.Key.EndsWith("@" + grainKey, StringComparison.Ordinal))
+                    .OrderByDescending(item => item.Key.Length)
+                    .FirstOrDefault();
+                return pair.Value?.Clone();
+            }
+        }
+
+        public Task ReadStateAsync<T>(string grainType, GrainId grainId, IGrainState<T> grainState)
+        {
+            lock (_gate)
+            {
+                var key = grainId.ToString();
+                var pair = _states.FirstOrDefault(item =>
+                    string.Equals(item.Key, key, StringComparison.Ordinal) ||
+                    key.EndsWith("/" + item.Key, StringComparison.Ordinal) ||
+                    key.EndsWith("@" + item.Key, StringComparison.Ordinal));
+                if (pair.Value is { } state && grainState.State is MultiProjectionGrainState)
+                {
+                    grainState.State = (T)(object)state.Clone();
+                    grainState.RecordExists = true;
+                }
+                else
+                {
+                    grainState.RecordExists = false;
+                }
+            }
+
+            return Task.CompletedTask;
+        }
+
+        public Task WriteStateAsync<T>(string grainType, GrainId grainId, IGrainState<T> grainState)
+        {
+            Interlocked.Increment(ref _writeAttempts);
+            if (FailWrites)
+            {
+                throw new InvalidOperationException("injected Orleans retirement write failure");
+            }
+
+            if (grainState.State is MultiProjectionGrainState state)
+            {
+                lock (_gate)
+                {
+                    _states[grainId.ToString()] = state.Clone();
+                    CommittedStates.Add(state.Clone());
+                    Interlocked.Increment(ref _writeCalls);
+                }
+            }
+
+            return Task.CompletedTask;
+        }
+
+        public Task ClearStateAsync<T>(string grainType, GrainId grainId, IGrainState<T> grainState)
+        {
+            lock (_gate)
+            {
+                _states.Remove(grainId.ToString());
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class TestDomainTypes
+    {
+        public static DcbDomainTypes Create()
+        {
+            var eventTypes = new SimpleEventTypes();
+            eventTypes.RegisterEventType<G38Event>("G38Event");
+            var multiProjectors = new SimpleMultiProjectorTypes();
+            multiProjectors.RegisterProjector<G38Projector>();
+            return new DcbDomainTypes(
+                eventTypes,
+                new SimpleTagTypes(),
+                new SimpleTagProjectorTypes(),
+                new SimpleTagStatePayloadTypes(),
+                multiProjectors,
+                new SimpleQueryTypes(),
+                new System.Text.Json.JsonSerializerOptions());
+        }
+    }
+
+    public record G38Event(string Value) : IEventPayload;
+
+    [GenerateSerializer]
+    public record G38Projector : IMultiProjector<G38Projector>
+    {
+        [Id(0)]
+        public int Count { get; init; }
+        public static string MultiProjectorName => "g38-unused-projector";
+        public static string MultiProjectorVersion => "v1";
+        public static G38Projector GenerateInitialPayload() => new();
+        public static ResultBox<G38Projector> Project(
+            G38Projector payload,
+            Event ev,
+            List<ITag> tags,
+            DcbDomainTypes domainTypes,
+            SortableUniqueId safeWindowThreshold) => ResultBox.FromValue(payload with { Count = payload.Count + 1 });
+    }
+}
+
+[CollectionDefinition("watermark-retirement", DisableParallelization = true)]
+public sealed class WatermarkRetirementCollection : ICollectionFixture<object> { }

--- a/dcb/tests/Sekiban.Dcb.Orleans.Tests/MultiProjectionGrainWatermarkRetirementTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Orleans.Tests/MultiProjectionGrainWatermarkRetirementTests.cs
@@ -18,6 +18,7 @@ using Sekiban.Dcb.Orleans.Serialization;
 using Sekiban.Dcb.Orleans.Streams;
 using Sekiban.Dcb.Queries;
 using Sekiban.Dcb.Runtime;
+using Sekiban.Dcb.Runtime.Native;
 using Sekiban.Dcb.ServiceId;
 using Sekiban.Dcb.Snapshots;
 using Sekiban.Dcb.Storage;
@@ -86,8 +87,6 @@ public sealed class MultiProjectionGrainWatermarkRetirementTests : IAsyncLifetim
         Assert.Equal(intermediate.LastSortableUniqueId, _harness.StateStore.LatestRecord!.LastSortableUniqueId);
 
         var firstCheckpointHost = _harness.Hosts.First(host => host.AppliedEventIds.Count > 0);
-        Assert.True(firstCheckpointHost.CompactionCalls > 0);
-        Assert.Empty(firstCheckpointHost.NonIncrementalRetention);
         Assert.True(firstCheckpointHost.AppliedEventIds.Count > 0);
 
         // Force a genuine activation replacement. The replacement must restore the durable intermediate record and
@@ -110,6 +109,42 @@ public sealed class MultiProjectionGrainWatermarkRetirementTests : IAsyncLifetim
         Assert.NotEqual(seed.OldSafeVersion, intermediate.EventsProcessed);
         Assert.True(_harness.ProviderStorage.WriteCalls > 0);
         Assert.True((await fresh.GetHealthStatusAsync()).IsHealthy);
+    }
+
+    [Fact]
+    public async Task Known_present_restore_failure_convergence_compacts_the_real_dual_state_safe_event_history_after_durable_checkpoint()
+    {
+        var projectorName = G38Projector.MultiProjectorName;
+        var events = BuildEvents(5_000);
+        var seed = await _harness.SeedKnownPresentCheckpointAsync(projectorName, oldSafeVersion: 10_000, events);
+        _harness.UseNativeHost = true;
+        _harness.RestoreBehavior = RestoreBehavior.ResultBoxFailure;
+
+        var grain = _cluster.Client.GetGrain<IMultiProjectionGrain>(projectorName);
+        await grain.GetStatusAsync();
+        await WaitUntilAsync(
+            () => _harness.NativeHosts
+                .SelectMany(host => host.CompactionObservations)
+                .Any(observation => observation.RealAllSafeEventsCountBeforeCompaction > 0),
+            TimeSpan.FromSeconds(15),
+            () => $"nativeHosts={_harness.NativeHosts.Count}, writes={_harness.ProviderStorage.WriteCalls}, records={_harness.StateStore.Records.Count}, logs={string.Join(" | ", _harness.LoggerProvider.Messages.TakeLast(12))}");
+
+        var observation = Assert.Single(
+            _harness.NativeHosts
+                .SelectMany(host => host.CompactionObservations),
+            observation => observation.RealAllSafeEventsCountBeforeCompaction > 0);
+        Assert.Equal(
+            typeof(Dictionary<,>),
+            observation.RealAllSafeEventsCollection.GetType().GetGenericTypeDefinition());
+        Assert.True(observation.DurableIntermediateCheckpointWasCommittedBeforeCompaction);
+        Assert.True(observation.RealAllSafeEventsCountBeforeCompaction > 0);
+        Assert.Equal(0, observation.RealAllSafeEventsCountAfterCompaction);
+
+        var intermediate = Assert.Single(
+            _harness.StateStore.Records,
+            record => record.EventsProcessed > 0);
+        Assert.InRange(intermediate.EventsProcessed, 1, seed.OldSafeVersion - 1);
+        Assert.Equal(intermediate.LastSortableUniqueId, _harness.StateStore.LatestRecord!.LastSortableUniqueId);
     }
 
     [Fact]
@@ -209,6 +244,40 @@ public sealed class MultiProjectionGrainWatermarkRetirementTests : IAsyncLifetim
     }
 
     [Fact]
+    public async Task Pre_record_query_resultbox_error_does_not_retire_the_existing_watermark()
+    {
+        const string projectorName = "g38-pre-record-resultbox-error";
+        await _harness.SeedKnownPresentCheckpointAsync(projectorName, oldSafeVersion: 700, BuildEvents(0));
+        _harness.GetLatestBehavior = GetLatestBehavior.ResultBoxFailure;
+
+        var grain = _cluster.Client.GetGrain<IMultiProjectionGrain>(projectorName);
+        await grain.GetStatusAsync();
+        await Task.Delay(300);
+
+        var committed = Assert.Single(
+            _harness.ProviderStorage.CommittedStates,
+            state => string.Equals(state.ProjectorName, projectorName, StringComparison.Ordinal));
+        Assert.Equal(700, committed.LastGoodSafeVersion);
+        Assert.Equal(701, committed.LastGoodPayloadBytes);
+        Assert.Equal(702, committed.LastGoodOriginalSizeBytes);
+        Assert.Equal(703, committed.LastGoodEventsProcessed);
+
+        var provider = _harness.ProviderStorage.Get(projectorName);
+        Assert.NotNull(provider);
+        Assert.Equal(700, provider!.LastGoodSafeVersion);
+        Assert.Equal(701, provider.LastGoodPayloadBytes);
+        Assert.Equal(702, provider.LastGoodOriginalSizeBytes);
+        Assert.Equal(703, provider.LastGoodEventsProcessed);
+        Assert.Equal(0, _harness.ProviderStorage.RetirementMetadataMaintenanceCommitCount);
+        Assert.Equal(0, _harness.ProviderStorage.WriteAttempts);
+        Assert.Equal(0, _harness.ProviderStorage.WriteCalls);
+        Assert.DoesNotContain(
+            _harness.LoggerProvider.Messages,
+            message => message.Contains("Integrity watermark retired", StringComparison.Ordinal));
+        Assert.False((await grain.GetHealthStatusAsync()).IsHealthy);
+    }
+
+    [Fact]
     public async Task Retirement_write_failure_rolls_back_and_does_not_start_rebuild_or_claim_checkpoint()
     {
         const string projectorName = "g38-retirement-write-failure";
@@ -241,7 +310,7 @@ public sealed class MultiProjectionGrainWatermarkRetirementTests : IAsyncLifetim
     }
 
     [Fact]
-    public async Task Retirement_write_then_deactivation_persists_zero_and_fresh_activation_consumes_it()
+    public async Task Retirement_write_then_replacement_reads_zero_and_durably_checkpoints_fresh_events_below_old_w()
     {
         const string projectorName = "g38-crash-window";
         await _harness.SeedKnownPresentCheckpointAsync(projectorName, oldSafeVersion: 700, BuildEvents(20));
@@ -278,20 +347,71 @@ public sealed class MultiProjectionGrainWatermarkRetirementTests : IAsyncLifetim
         Assert.Empty(_harness.Hosts.First(host => host.ProjectorName == projectorName).AppliedEventIds);
 
         var hostsBeforeFreshActivation = _harness.Hosts.ToHashSet();
+        var externalRecordsBeforeReplacement = _harness.StateStore.Records.Count;
+        var committedStatesBeforeReplacement = _harness.ProviderStorage.CommittedStates.Count;
+        var providerWritesBeforeReplacement = _harness.ProviderStorage.WriteCalls;
+        var providerReadsBeforeReplacement = _harness.ProviderStorage.ReadStates.Count;
         _harness.RestoreBehavior = RestoreBehavior.None;
         _harness.EventStore.BlockReads = false;
+        _harness.EventStore.SetEvents([]);
         var fresh = _cluster.Client.GetGrain<IMultiProjectionGrain>(projectorName);
         await fresh.GetStatusAsync();
         await WaitUntilAsync(
             () => _harness.Hosts.Any(host => !hostsBeforeFreshActivation.Contains(host) && host.RestoreCalls > 0),
             TimeSpan.FromSeconds(10));
 
-        var freshRestore = _harness.StateStore.OpenedRecords.Last(record => record.EventsProcessed == 0);
-        Assert.Equal(zeroCheckpoint.EventsProcessed, freshRestore.EventsProcessed);
-        Assert.Equal(zeroCheckpoint.LastSortableUniqueId, freshRestore.LastSortableUniqueId);
+        await WaitUntilAsync(
+            () => _harness.ProviderStorage.ReadStates
+                .Skip(providerReadsBeforeReplacement)
+                .Any(IsRetiredState),
+            TimeSpan.FromSeconds(10),
+            () => string.Join(
+                "; ",
+                _harness.ProviderStorage.ReadStates
+                    .Skip(providerReadsBeforeReplacement)
+                    .Select(state => $"{state.LastGoodSafeVersion}/{state.LastGoodPayloadBytes}/{state.LastGoodOriginalSizeBytes}/{state.LastGoodEventsProcessed}")));
+        var replacementRead = _harness.ProviderStorage.ReadStates
+            .Skip(providerReadsBeforeReplacement)
+            .Last(IsRetiredState);
+        Assert.Equal(0, replacementRead.LastGoodSafeVersion);
+        Assert.Equal(0, replacementRead.LastGoodPayloadBytes);
+        Assert.Equal(0, replacementRead.LastGoodOriginalSizeBytes);
+        Assert.Equal(0, replacementRead.LastGoodEventsProcessed);
+
+        var replacementHost = _harness.Hosts.Single(
+            host => !hostsBeforeFreshActivation.Contains(host) && host.RestoreCalls > 0);
+        var freshEvents = BuildEvents(3);
+        await fresh.AddEventsAsync(freshEvents);
+        var persistResult = await fresh.PersistStateAsync();
+        Assert.True(persistResult.IsSuccess);
+        Assert.True(persistResult.GetValue());
+
+        await WaitUntilAsync(
+            () => _harness.StateStore.Records
+                .Skip(externalRecordsBeforeReplacement)
+                .Any(record => record.EventsProcessed > 0),
+            TimeSpan.FromSeconds(10));
+        var replacementCheckpoint = _harness.StateStore.Records
+            .Skip(externalRecordsBeforeReplacement)
+            .Last(record => record.EventsProcessed > 0);
+        Assert.InRange(replacementCheckpoint.EventsProcessed, 1, 699);
+        Assert.Equal(freshEvents[^1].SortableUniqueIdValue, replacementCheckpoint.LastSortableUniqueId);
+        Assert.Equal(
+            freshEvents.Select(item => item.Id),
+            replacementHost.AppliedEventIds);
+
+        var provider = _harness.ProviderStorage.Get(projectorName);
+        Assert.NotNull(provider);
+        Assert.InRange(provider!.LastGoodSafeVersion, 1, 699);
+        Assert.InRange(provider.LastGoodEventsProcessed, 1, 699);
+        Assert.True(provider.LastGoodPayloadBytes > 0);
+        Assert.True(provider.LastGoodOriginalSizeBytes > 0);
+        Assert.True(_harness.ProviderStorage.WriteCalls > providerWritesBeforeReplacement);
         Assert.Contains(
-            _harness.EventStore.ReadSinceValues,
-            since => since is null || string.IsNullOrEmpty(since));
+            _harness.ProviderStorage.CommittedStates.Skip(committedStatesBeforeReplacement),
+            state => state.EventsProcessed == replacementCheckpoint.EventsProcessed &&
+                     state.LastGoodSafeVersion == provider.LastGoodSafeVersion &&
+                     state.LastGoodEventsProcessed == provider.LastGoodEventsProcessed);
     }
 
     [Fact]
@@ -445,7 +565,7 @@ public sealed class MultiProjectionGrainWatermarkRetirementTests : IAsyncLifetim
     {
         return Enumerable.Range(0, count)
             .Select(index => new SerializableEvent(
-                [1],
+                System.Text.Json.JsonSerializer.SerializeToUtf8Bytes(new G38Event(index.ToString())),
                 SortableUniqueId.GetTickString(1_000 + index) + SortableUniqueId.GetIdString(Guid.NewGuid()),
                 Guid.NewGuid(),
                 new EventMetadata("g38", "test", "watermark"),
@@ -495,9 +615,9 @@ public sealed class MultiProjectionGrainWatermarkRetirementTests : IAsyncLifetim
                         SkipPersistWhenSafeCheckpointUnchanged = true
                     });
                     services.AddSekibanDcbNativeRuntime();
-                    // The test factory must be registered after the native runtime's default factory so the real grain
-                    // activation path uses the deterministic host below.
-                    services.AddSingleton<IProjectionActorHostFactory>(ActiveHarness.HostFactory);
+                    // The test factory must be registered after the native runtime's default factory so each test can
+                    // select either the deterministic host or an observing wrapper around the real native host.
+                    services.AddSingleton<IProjectionActorHostFactory>(sp => ActiveHarness!.CreateHostFactory(sp));
                     services.AddGrainStorage("OrleansStorage", (_, _) => ActiveHarness!.ProviderStorage);
                 })
                 .AddMemoryGrainStorageAsDefault()
@@ -537,6 +657,7 @@ public sealed class MultiProjectionGrainWatermarkRetirementTests : IAsyncLifetim
     {
         Success,
         Absent,
+        ResultBoxFailure,
         Throw
     }
 
@@ -547,10 +668,11 @@ public sealed class MultiProjectionGrainWatermarkRetirementTests : IAsyncLifetim
         public WatermarkEventStore EventStore { get; } = new();
         public WatermarkStateStore StateStore { get; } = new();
         public WatermarkGrainStorage ProviderStorage { get; } = new();
-        public WatermarkHostFactory HostFactory { get; }
         public ConcurrentBag<WatermarkProjectionHost> Hosts { get; } = new();
+        public ConcurrentBag<ObservingNativeProjectionHost> NativeHosts { get; } = new();
         public RecordingLoggerProvider LoggerProvider { get; } = new();
         public RestoreBehavior RestoreBehavior { get; set; }
+        public bool UseNativeHost { get; set; }
         public StateStreamBehavior StreamBehavior
         {
             get => StateStore.StreamBehavior;
@@ -563,22 +685,26 @@ public sealed class MultiProjectionGrainWatermarkRetirementTests : IAsyncLifetim
             set => StateStore.GetLatestBehavior = value;
         }
 
-        public WatermarkHarness()
-        {
-            HostFactory = new WatermarkHostFactory(this);
-        }
-
         public void Reset()
         {
             EventStore.Reset();
             StateStore.Reset();
             ProviderStorage.Reset();
             while (Hosts.TryTake(out _)) { }
+            while (NativeHosts.TryTake(out _)) { }
             LoggerProvider.Clear();
             RestoreBehavior = RestoreBehavior.None;
+            UseNativeHost = false;
             StreamBehavior = StateStreamBehavior.Success;
             GetLatestBehavior = GetLatestBehavior.Success;
         }
+
+        public IProjectionActorHostFactory CreateHostFactory(IServiceProvider serviceProvider) =>
+            new WatermarkHostFactory(
+                this,
+                serviceProvider.GetRequiredService<DcbDomainTypes>(),
+                serviceProvider,
+                serviceProvider.GetRequiredService<NativeMultiProjectionProjectionPrimitive>());
 
         public async Task<SeededCheckpoint> SeedKnownPresentCheckpointAsync(
             string projectorName,
@@ -621,18 +747,193 @@ public sealed class MultiProjectionGrainWatermarkRetirementTests : IAsyncLifetim
         }
     }
 
-    private sealed class WatermarkHostFactory(WatermarkHarness harness) : IProjectionActorHostFactory
+    private sealed class WatermarkHostFactory(
+        WatermarkHarness harness,
+        DcbDomainTypes domainTypes,
+        IServiceProvider serviceProvider,
+        NativeMultiProjectionProjectionPrimitive primitive) : IProjectionActorHostFactory
     {
         public IProjectionActorHost Create(
             string projectorName,
             GeneralMultiProjectionActorOptions? options = null,
             ILogger? logger = null)
         {
+            if (harness.UseNativeHost)
+            {
+                var nativeHost = new ObservingNativeProjectionHost(
+                    harness,
+                    projectorName,
+                    new NativeProjectionActorHost(
+                        domainTypes,
+                        serviceProvider,
+                        primitive,
+                        projectorName,
+                        options,
+                        logger));
+                harness.NativeHosts.Add(nativeHost);
+                return nativeHost;
+            }
+
             var host = new WatermarkProjectionHost(harness, projectorName);
             harness.Hosts.Add(host);
             return host;
         }
     }
+
+    private sealed class ObservingNativeProjectionHost(
+        WatermarkHarness harness,
+        string projectorName,
+        NativeProjectionActorHost inner) : IProjectionActorHost
+    {
+        public ConcurrentQueue<NativeCompactionObservation> CompactionObservations { get; } = new();
+
+        public Sekiban.Dcb.Actors.ProjectionFaultDescriptor? CurrentFault => inner.CurrentFault;
+
+        public Task AddSerializableEventsAsync(IReadOnlyList<SerializableEvent> events, bool finishedCatchUp = true) =>
+            inner.AddSerializableEventsAsync(events, finishedCatchUp);
+
+        public Task<ResultBox<ProjectionStateMetadata>> GetStateMetadataAsync(bool includeUnsafe = true) =>
+            inner.GetStateMetadataAsync(includeUnsafe);
+
+        public Task<ResultBox<MultiProjectionState>> GetStateAsync(bool canGetUnsafeState = true) =>
+            inner.GetStateAsync(canGetUnsafeState);
+
+        public Task<ProjectionHeadStatus> GetProjectionHeadStatusAsync() => inner.GetProjectionHeadStatusAsync();
+
+        public Task<ResultBox<bool>> WriteSnapshotToStreamAsync(
+            Stream target,
+            bool canGetUnsafeState,
+            CancellationToken cancellationToken) =>
+            inner.WriteSnapshotToStreamAsync(target, canGetUnsafeState, cancellationToken);
+
+        public Task<ResultBox<bool>> WriteSnapshotForPersistenceToStreamAsync(
+            Stream target,
+            bool canGetUnsafeState,
+            int offloadThresholdBytes,
+            CancellationToken cancellationToken) =>
+            inner.WriteSnapshotForPersistenceToStreamAsync(
+                target,
+                canGetUnsafeState,
+                offloadThresholdBytes,
+                cancellationToken);
+
+        public Task<ResultBox<bool>> RestoreSnapshotFromStreamAsync(Stream source, CancellationToken cancellationToken)
+        {
+            if (harness.RestoreBehavior == RestoreBehavior.ResultBoxFailure)
+            {
+                return Task.FromResult(ResultBox.Error<bool>(
+                    new InvalidOperationException("injected native host restore ResultBox failure")));
+            }
+
+            if (harness.RestoreBehavior == RestoreBehavior.Throw)
+            {
+                throw new InvalidOperationException("injected native host restore throw");
+            }
+
+            return inner.RestoreSnapshotFromStreamAsync(source, cancellationToken);
+        }
+
+        public Task<ResultBox<SerializableQueryResult>> ExecuteQueryAsync(
+            SerializableQueryParameter query,
+            int? safeVersion,
+            string? safeThreshold,
+            DateTime? safeThresholdTime,
+            int? unsafeVersion) =>
+            inner.ExecuteQueryAsync(query, safeVersion, safeThreshold, safeThresholdTime, unsafeVersion);
+
+        public Task<ResultBox<SerializableListQueryResult>> ExecuteListQueryAsync(
+            SerializableQueryParameter query,
+            int? safeVersion,
+            string? safeThreshold,
+            DateTime? safeThresholdTime,
+            int? unsafeVersion) =>
+            inner.ExecuteListQueryAsync(query, safeVersion, safeThreshold, safeThresholdTime, unsafeVersion);
+
+        public void ForcePromoteBufferedEvents() => inner.ForcePromoteBufferedEvents();
+
+        public void CompactSafeHistory()
+        {
+            var realAllSafeEvents = GetRealAllSafeEventsCollection();
+            var before = GetCollectionCount(realAllSafeEvents);
+            var durableIntermediateCheckpointWasCommitted =
+                harness.StateStore.Records.Any(record =>
+                    string.Equals(record.ProjectorName, projectorName, StringComparison.Ordinal) &&
+                    record.EventsProcessed > 0) &&
+                harness.ProviderStorage.Get(projectorName) is { } provider &&
+                provider.LastGoodSafeVersion > 0 &&
+                provider.LastGoodEventsProcessed > 0;
+
+            inner.CompactSafeHistory();
+
+            CompactionObservations.Enqueue(new NativeCompactionObservation(
+                realAllSafeEvents,
+                before,
+                GetCollectionCount(realAllSafeEvents),
+                durableIntermediateCheckpointWasCommitted));
+        }
+
+        public void ForcePromoteAllBufferedEvents() => inner.ForcePromoteAllBufferedEvents();
+
+        public Task<string> GetSafeLastSortableUniqueIdAsync() => inner.GetSafeLastSortableUniqueIdAsync();
+
+        public Task<bool> IsSortableUniqueIdReceivedAsync(string sortableUniqueId) =>
+            inner.IsSortableUniqueIdReceivedAsync(sortableUniqueId);
+
+        public long EstimateStateSizeBytes(bool includeUnsafeDetails) => inner.EstimateStateSizeBytes(includeUnsafeDetails);
+
+        public string PeekCurrentSafeWindowThreshold() => inner.PeekCurrentSafeWindowThreshold();
+
+        public string GetProjectorVersion() => inner.GetProjectorVersion();
+
+        public Task<ResultBox<bool>> RewriteSnapshotVersionAsync(
+            Stream source,
+            Stream target,
+            string newVersion,
+            CancellationToken cancellationToken) =>
+            inner.RewriteSnapshotVersionAsync(source, target, newVersion, cancellationToken);
+
+        public void RestoreFault(Sekiban.Dcb.Actors.ProjectionFaultDescriptor fault) => inner.RestoreFault(fault);
+
+        public void ClearFaultForRebuild() => inner.ClearFaultForRebuild();
+
+        private object GetRealAllSafeEventsCollection()
+        {
+            var actorField = typeof(NativeProjectionActorHost).GetField(
+                "_actor",
+                BindingFlags.Instance | BindingFlags.NonPublic);
+            var actor = actorField?.GetValue(inner) ?? throw new InvalidOperationException("Native actor was not found.");
+            var accessorField = actor.GetType().GetField(
+                "_singleStateAccessor",
+                BindingFlags.Instance | BindingFlags.NonPublic);
+            var wrapper = accessorField?.GetValue(actor) ??
+                throw new InvalidOperationException("Native dual-state wrapper was not found.");
+            if (!wrapper.GetType().IsGenericType ||
+                wrapper.GetType().GetGenericTypeDefinition() != typeof(DualStateProjectionWrapper<>))
+            {
+                throw new InvalidOperationException("Native host did not create a DualStateProjectionWrapper.");
+            }
+
+            var allSafeEventsField = wrapper.GetType().GetField(
+                "_allSafeEvents",
+                BindingFlags.Instance | BindingFlags.NonPublic);
+            return allSafeEventsField?.GetValue(wrapper) ??
+                throw new InvalidOperationException("Native wrapper _allSafeEvents collection was not found.");
+        }
+
+        private static int GetCollectionCount(object collection)
+        {
+            var countProperty = collection.GetType().GetProperty("Count");
+            return countProperty?.GetValue(collection) is int count
+                ? count
+                : throw new InvalidOperationException("Native wrapper _allSafeEvents collection has no count.");
+        }
+    }
+
+    private sealed record NativeCompactionObservation(
+        object RealAllSafeEventsCollection,
+        int RealAllSafeEventsCountBeforeCompaction,
+        int RealAllSafeEventsCountAfterCompaction,
+        bool DurableIntermediateCheckpointWasCommittedBeforeCompaction);
 
     private sealed class WatermarkProjectionHost(WatermarkHarness harness, string projectorName) : IProjectionActorHost
     {
@@ -642,20 +943,13 @@ public sealed class MultiProjectionGrainWatermarkRetirementTests : IAsyncLifetim
 
         public string ProjectorName { get; } = projectorName;
         public int RestoreCalls { get; private set; }
-        public int CompactionCalls { get; private set; }
         public List<Guid> AppliedEventIds => _appliedEventIds;
-        public HashSet<Guid> NonIncrementalRetention { get; } = [];
 
         public void ForceSafeVersion(int version) => _forcedSafeVersion = version;
 
         public Task AddSerializableEventsAsync(IReadOnlyList<SerializableEvent> events, bool finishedCatchUp = true)
         {
             _appliedEventIds.AddRange(events.Select(item => item.Id));
-            foreach (var item in events)
-            {
-                NonIncrementalRetention.Add(item.Id);
-            }
-
             if (events.Count > 0)
             {
                 _safePosition = events[^1].SortableUniqueIdValue;
@@ -734,11 +1028,7 @@ public sealed class MultiProjectionGrainWatermarkRetirementTests : IAsyncLifetim
 
         public void ForcePromoteBufferedEvents() { }
 
-        public void CompactSafeHistory()
-        {
-            CompactionCalls++;
-            NonIncrementalRetention.Clear();
-        }
+        public void CompactSafeHistory() { }
 
         public void ForcePromoteAllBufferedEvents() { }
 
@@ -896,6 +1186,12 @@ public sealed class MultiProjectionGrainWatermarkRetirementTests : IAsyncLifetim
             string projectorVersion,
             CancellationToken cancellationToken = default)
         {
+            if (GetLatestBehavior == GetLatestBehavior.ResultBoxFailure)
+            {
+                return Task.FromResult(ResultBox.Error<OptionalValue<MultiProjectionStateRecord>>(
+                    new InvalidOperationException("injected GetLatestForVersionAsync ResultBox failure")));
+            }
+
             if (GetLatestBehavior == GetLatestBehavior.Throw)
             {
                 throw new InvalidOperationException("injected GetLatestForVersionAsync throw");
@@ -1066,10 +1362,13 @@ public sealed class MultiProjectionGrainWatermarkRetirementTests : IAsyncLifetim
         private readonly Dictionary<string, MultiProjectionGrainState> _states = new(StringComparer.Ordinal);
         private int _writeCalls;
         private int _writeAttempts;
+        private int _retirementMetadataMaintenanceCommitCount;
         public bool FailWrites { get; set; }
         public int WriteCalls => Volatile.Read(ref _writeCalls);
         public int WriteAttempts => Volatile.Read(ref _writeAttempts);
+        public int RetirementMetadataMaintenanceCommitCount => Volatile.Read(ref _retirementMetadataMaintenanceCommitCount);
         public List<MultiProjectionGrainState> CommittedStates { get; } = [];
+        public List<MultiProjectionGrainState> ReadStates { get; } = [];
 
         public void Reset()
         {
@@ -1077,8 +1376,10 @@ public sealed class MultiProjectionGrainWatermarkRetirementTests : IAsyncLifetim
             {
                 _states.Clear();
                 CommittedStates.Clear();
+                ReadStates.Clear();
                 Volatile.Write(ref _writeCalls, 0);
                 Volatile.Write(ref _writeAttempts, 0);
+                Volatile.Write(ref _retirementMetadataMaintenanceCommitCount, 0);
             }
             FailWrites = false;
         }
@@ -1088,6 +1389,7 @@ public sealed class MultiProjectionGrainWatermarkRetirementTests : IAsyncLifetim
             lock (_gate)
             {
                 _states[grainKey] = state.Clone();
+                CommittedStates.Add(state.Clone());
             }
         }
 
@@ -1111,14 +1413,18 @@ public sealed class MultiProjectionGrainWatermarkRetirementTests : IAsyncLifetim
             lock (_gate)
             {
                 var key = grainId.ToString();
-                var pair = _states.FirstOrDefault(item =>
-                    string.Equals(item.Key, key, StringComparison.Ordinal) ||
-                    key.EndsWith("/" + item.Key, StringComparison.Ordinal) ||
-                    key.EndsWith("@" + item.Key, StringComparison.Ordinal));
+                var pair = _states
+                    .Where(item =>
+                        string.Equals(item.Key, key, StringComparison.Ordinal) ||
+                        key.EndsWith("/" + item.Key, StringComparison.Ordinal) ||
+                        key.EndsWith("@" + item.Key, StringComparison.Ordinal))
+                    .OrderByDescending(item => item.Key.Length)
+                    .FirstOrDefault();
                 if (pair.Value is { } state && grainState.State is MultiProjectionGrainState)
                 {
                     grainState.State = (T)(object)state.Clone();
                     grainState.RecordExists = true;
+                    ReadStates.Add(state.Clone());
                 }
                 else
                 {
@@ -1143,6 +1449,10 @@ public sealed class MultiProjectionGrainWatermarkRetirementTests : IAsyncLifetim
                 {
                     _states[grainId.ToString()] = state.Clone();
                     CommittedStates.Add(state.Clone());
+                    if (IsRetiredState(state))
+                    {
+                        Interlocked.Increment(ref _retirementMetadataMaintenanceCommitCount);
+                    }
                     Interlocked.Increment(ref _writeCalls);
                 }
             }


### PR DESCRIPTION
Fixes #1148
Fixes #1139

## Summary

- Retire the integrity watermark only after a known-present external snapshot cannot become a host snapshot.
- Keep the existing `TryShortCircuitPersist` regression guard unchanged.
- Invalidate the unreadable derived checkpoint through the existing external-store coordinator after the durable retirement, then begin the ordered rebuild.
- Fail closed before rebuild when the retirement transition does not commit, retaining the old committed/provider state and emitting a distinct retirement-failure log.
- Add production-path Orleans tests covering all eleven issue acceptance criteria.

## Acceptance evidence

1. **Convergence:** the production activation test seeds `W=10000`, injects a known-present restore `ResultBox` failure, observes the committed retirement, and proves a durable `0 < S < W` checkpoint. A fresh activation opens that durable record and starts its authoritative event read strictly after the checkpoint position.
2. **Guard preservation:** the normal successful-restore path forces `SafeVersion=699` below `LastGoodSafeVersion=700` and asserts a successful `false` result, zero provider writes, and unchanged four-field values.
3. **Returned failures:** stream-open and host-restore `ResultBox` failures are exercised independently.
4. **Thrown known-record failures:** open, `CanSeek`, `Length`, `Position`, read, disposal, and host-restore throws each prove durable retirement and a rebuild checkpoint with `0 < S < 700`.
5. **Four-field exactness:** the test observes the committed provider write and provider payload; all four distinct seeded `LastGood*` values are asserted as zero, so partial clearing fails.
6. **Crash/deactivation window:** the authoritative read is blocked before delivery, deactivation follows the retirement, a zero checkpoint is durably written, and a fresh activation consumes that same zero record before reading from the beginning.
7. **Retirement-write failure:** injected provider failure leaves all old values committed, applies no events, performs no external upsert, reports no durable checkpoint, and emits the distinct retirement-failure message.
8. **Absent compatibility:** the existing four-field reset and the unchanged `Resetting integrity guard ... external snapshot is missing` reason are pinned; no retirement log is emitted.
9. **Do-it-twice:** after recovery establishes `W2`, below-`W2` is blocked with no provider write and `W2` is accepted by the existing contract.
10. **Public surface/guard:** targeted reflection pins find no public retirement member, option, or serialized-state member. The `TryShortCircuitPersist` function body compares byte-for-byte with `origin/main`.
11. **Compaction resume:** the convergence test directly observes a durable intermediate checkpoint followed by `CompactSafeHistory()` and an empty non-incremental retention set.

## Verification

- `dotnet test ... --framework net9.0 --filter FullyQualifiedName~MultiProjectionGrainWatermarkRetirementTests`: 16 passed.
- `dotnet test ... --framework net10.0 --filter FullyQualifiedName~MultiProjectionGrainWatermarkRetirementTests`: 16 passed.
- Existing `MultiProjectionGrainCatchUpProductionPathTests`: 11 passed on net9.0 and 11 passed on net10.0.
- Existing persist-policy and retention-compaction suites: 14 passed on net9.0 and 14 passed on net10.0.
- `git diff --cached --check` and post-commit `git diff --check`: clean.
- No public API, option, interface, or serialized-state member was added.
