### PR TITLE
feat(dcb): add PostgreSQL tag-head expected-position CAS

### DIFF
--- a/dcb/src/Sekiban.Dcb.Core/Actors/CoreGeneralSekibanExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Actors/CoreGeneralSekibanExecutor.cs
@@ -135,10 +135,22 @@ public class CoreGeneralSekibanExecutor
         return string.IsNullOrEmpty(value) ? DefaultExecutedUser : value;
     }
 
-    public async Task<ResultBox<ExecutionResult>> ExecuteAsync<TCommand>(
+    public Task<ResultBox<ExecutionResult>> ExecuteAsync<TCommand>(
         TCommand command,
         Func<TCommand, ICoreCommandContext, Task<ResultBox<EventOrNone>>> handlerFunc,
-        CancellationToken cancellationToken = default) where TCommand : ICommand
+        CancellationToken cancellationToken = default) where TCommand : ICommand =>
+        ExecuteAsyncCore(command, handlerFunc, null, cancellationToken);
+
+    /// <summary>
+    ///     Shared ordinary-batch pipeline. The legacy public call enters with <paramref name="expectedTagPositions" />
+    ///     null and therefore preserves its unconditional semantics; the additive options call enters with a total
+    ///     expected-head specification.
+    /// </summary>
+    private async Task<ResultBox<ExecutionResult>> ExecuteAsyncCore<TCommand>(
+        TCommand command,
+        Func<TCommand, ICoreCommandContext, Task<ResultBox<EventOrNone>>> handlerFunc,
+        ExpectedTagPositionSpecification? expectedTagPositions,
+        CancellationToken cancellationToken) where TCommand : ICommand
     {
         var stopwatch = Stopwatch.StartNew();
 
@@ -149,6 +161,37 @@ public class CoreGeneralSekibanExecutor
             if (validationErrors.Count > 0)
             {
                 return ResultBox.Error<ExecutionResult>(new SekibanValidationException(validationErrors));
+            }
+
+            // Expected-position is optional, but never best-effort. Validate its discriminated shape and the live
+            // descriptor before the handler can allocate ids, reserve a tag, or reach any provider write method.
+            IExpectedTagPositionEventStore? expectedPositionStore = null;
+            if (expectedTagPositions is not null)
+            {
+                var currentServiceId = ServiceIdValidator.NormalizeAndValidate(_serviceIdProvider.GetCurrentServiceId());
+                expectedTagPositions.ValidateEntryShapes(currentServiceId);
+
+                var capability = Sekiban.Dcb.Capabilities.SekibanDcbCapabilityResolver.DescribeWriteConditions(
+                    _eventStore, "event store");
+                if (!capability.Supports(Sekiban.Dcb.Capabilities.WriteConditionKind.ExpectedTagPosition) ||
+                    _eventStore is not IExpectedTagPositionEventStore resolvedExpectedPositionStore)
+                {
+                    return ResultBox.Error<ExecutionResult>(
+                        new ConditionNotSupportedException(
+                            Sekiban.Dcb.Capabilities.WriteConditionKind.ExpectedTagPosition,
+                            capability.ProviderName));
+                }
+
+                expectedPositionStore = resolvedExpectedPositionStore;
+                if (expectedTagPositions.RequiresEnforcement)
+                {
+                    var enabled = await expectedPositionStore
+                        .EnsureExpectedTagPositionEnforcementEnabledAsync(cancellationToken);
+                    if (!enabled.IsSuccess)
+                    {
+                        return ResultBox.Error<ExecutionResult>(enabled.GetException());
+                    }
+                }
             }
 
             // Step 1: Create command context
@@ -191,6 +234,12 @@ public class CoreGeneralSekibanExecutor
             // If still no events, return early
             if (collectedEvents.Count == 0)
             {
+                if (expectedTagPositions is not null)
+                {
+                    expectedTagPositions.ValidateFor(
+                        ServiceIdValidator.NormalizeAndValidate(_serviceIdProvider.GetCurrentServiceId()),
+                        Array.Empty<string>());
+                }
                 return ResultBox.FromValue(
                     new ExecutionResult(Guid.Empty, 0, new List<TagWriteResult>(), stopwatch.Elapsed, []));
             }
@@ -200,6 +249,13 @@ public class CoreGeneralSekibanExecutor
 
             // Step 3.1: Validate all tags
             TagValidator.ValidateTagsAndThrow(allTags);
+
+            if (expectedTagPositions is not null)
+            {
+                expectedTagPositions.ValidateFor(
+                    ServiceIdValidator.NormalizeAndValidate(_serviceIdProvider.GetCurrentServiceId()),
+                    allTags.Where(tag => tag.IsConsistencyTag()).Select(tag => tag.GetTag()));
+            }
 
             // Establish the persisted floor before any reservation, id allocation, or write.
             await EnsureSortableUniqueIdSeededAsync(cancellationToken);
@@ -289,14 +345,35 @@ public class CoreGeneralSekibanExecutor
                             e.Tags.Select(t => t.GetTag()).ToList()));
                 }
 
-                var writeResult = await _eventStore.WriteEventsAsync(events, _domainTypes.EventTypes);
-                if (!writeResult.IsSuccess)
+                IReadOnlyList<Event> writtenEvents;
+                IReadOnlyList<TagWriteResult> tagWriteResults;
+                if (expectedPositionStore is not null && expectedTagPositions is not null)
                 {
-                    await TagReservationHelper.CancelReservationsAsync(_actorAccessor, reservations);
-                    return ResultBox.Error<ExecutionResult>(writeResult.GetException());
-                }
+                    var serialized = events.Select(e => e.ToSerializableEvent(_domainTypes.EventTypes)).ToList();
+                    var writeResult = await expectedPositionStore.WriteSerializableEventsWithExpectedTagPositionsAsync(
+                        serialized, expectedTagPositions, cancellationToken);
+                    if (!writeResult.IsSuccess)
+                    {
+                        await TagReservationHelper.CancelReservationsAsync(_actorAccessor, reservations);
+                        return ResultBox.Error<ExecutionResult>(writeResult.GetException());
+                    }
 
-                var (writtenEvents, tagWriteResults) = writeResult.GetValue();
+                    // The expected-position store receives a lossless serialization of the exact Event instances above;
+                    // preserving those instances keeps the legacy typed result shape and publication semantics intact.
+                    writtenEvents = events;
+                    tagWriteResults = writeResult.GetValue().TagWrites;
+                }
+                else
+                {
+                    var writeResult = await _eventStore.WriteEventsAsync(events, _domainTypes.EventTypes);
+                    if (!writeResult.IsSuccess)
+                    {
+                        await TagReservationHelper.CancelReservationsAsync(_actorAccessor, reservations);
+                        return ResultBox.Error<ExecutionResult>(writeResult.GetException());
+                    }
+
+                    (writtenEvents, tagWriteResults) = writeResult.GetValue();
+                }
 
                 // Step 6: Confirm reservations with TagConsistentActors
                 await TagReservationHelper.ConfirmReservationsAsync(_actorAccessor, reservations);
@@ -448,14 +525,71 @@ public class CoreGeneralSekibanExecutor
         }
     }
 
-    public async Task<ResultBox<SerializedCommitResult>> CommitSerializableEventsAsync(
+    public Task<ResultBox<SerializedCommitResult>> CommitSerializableEventsAsync(
         SerializedCommitRequest request,
+        CancellationToken cancellationToken) =>
+        CommitSerializableEventsCoreAsync(request, null, cancellationToken);
+
+    /// <summary>
+    ///     V2 serialized entry point. It is additive to the V1/legacy interface and validates the version before it can
+    ///     reach reservation, id allocation, or a provider write.
+    /// </summary>
+    public Task<ResultBox<SerializedCommitResult>> CommitSerializableEventsWithExpectedTagPositionsAsync(
+        VersionedExpectedTagPositionSerializedCommitRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        if (request.Version != VersionedExpectedTagPositionSerializedCommitRequest.CurrentVersion)
+        {
+            return Task.FromResult(ResultBox.Error<SerializedCommitResult>(
+                new UnsupportedSerializedCommitVersionException(
+                    request.Version, VersionedExpectedTagPositionSerializedCommitRequest.CurrentVersion)));
+        }
+
+        return CommitSerializableEventsCoreAsync(
+            new SerializedCommitRequest(
+                request.EventCandidates ?? Array.Empty<SerializableEventCandidate>(),
+                request.ConsistencyTags ?? Array.Empty<ConsistencyTagEntry>()),
+            new ExpectedTagPositionSpecification(request.ExpectedTagPositions ?? Array.Empty<TagHeadExpectationEntry>()),
+            cancellationToken);
+    }
+
+    private async Task<ResultBox<SerializedCommitResult>> CommitSerializableEventsCoreAsync(
+        SerializedCommitRequest request,
+        ExpectedTagPositionSpecification? expectedTagPositions,
         CancellationToken cancellationToken)
     {
         var stopwatch = Stopwatch.StartNew();
 
         try
         {
+            IExpectedTagPositionEventStore? expectedPositionStore = null;
+            if (expectedTagPositions is not null)
+            {
+                var currentServiceId = ServiceIdValidator.NormalizeAndValidate(_serviceIdProvider.GetCurrentServiceId());
+                expectedTagPositions.ValidateEntryShapes(currentServiceId);
+                var capability = Sekiban.Dcb.Capabilities.SekibanDcbCapabilityResolver.DescribeWriteConditions(
+                    _eventStore, "event store");
+                if (!capability.Supports(Sekiban.Dcb.Capabilities.WriteConditionKind.ExpectedTagPosition) ||
+                    _eventStore is not IExpectedTagPositionEventStore resolvedExpectedPositionStore)
+                {
+                    return ResultBox.Error<SerializedCommitResult>(
+                        new ConditionNotSupportedException(
+                            Sekiban.Dcb.Capabilities.WriteConditionKind.ExpectedTagPosition,
+                            capability.ProviderName));
+                }
+
+                expectedPositionStore = resolvedExpectedPositionStore;
+                if (expectedTagPositions.RequiresEnforcement)
+                {
+                    var enabled = await expectedPositionStore
+                        .EnsureExpectedTagPositionEnforcementEnabledAsync(cancellationToken);
+                    if (!enabled.IsSuccess)
+                    {
+                        return ResultBox.Error<SerializedCommitResult>(enabled.GetException());
+                    }
+                }
+            }
+
             if (request.ConsistencyTags.Any(entry => entry.LastSortableUniqueId is null))
             {
                 return ResultBox.Error<SerializedCommitResult>(
@@ -466,6 +600,12 @@ public class CoreGeneralSekibanExecutor
 
             if (request.EventCandidates.Count == 0)
             {
+                if (expectedTagPositions is not null)
+                {
+                    expectedTagPositions.ValidateFor(
+                        ServiceIdValidator.NormalizeAndValidate(_serviceIdProvider.GetCurrentServiceId()),
+                        Array.Empty<string>());
+                }
                 return ResultBox.FromValue(
                     new SerializedCommitResult(
                         Array.Empty<SerializableEvent>(),
@@ -499,6 +639,13 @@ public class CoreGeneralSekibanExecutor
                 return ResultBox.Error<SerializedCommitResult>(
                     new InvalidOperationException(
                         $"Consistency tags must exist in event candidate tags. Unknown tags: {string.Join(", ", unknownConsistencyTags)}"));
+            }
+
+            if (expectedTagPositions is not null)
+            {
+                expectedTagPositions.ValidateFor(
+                    ServiceIdValidator.NormalizeAndValidate(_serviceIdProvider.GetCurrentServiceId()),
+                    request.ConsistencyTags.Select(entry => entry.Tag));
             }
 
             // Step 2: Build FallbackTag objects for non-consistency tags and reservation
@@ -574,15 +721,33 @@ public class CoreGeneralSekibanExecutor
                         candidate.EventPayloadName));
                 }
 
-                // Step 5: Write serializable events
-                var writeResult = await _eventStore.WriteSerializableEventsAsync(serializableEvents);
-                if (!writeResult.IsSuccess)
+                // Step 5: V2 is store-enforced; legacy/V1 keeps the exact old unconditional call and result shape.
+                IReadOnlyList<SerializableEvent> writtenEvents;
+                IReadOnlyList<TagWriteResult> tagWriteResults;
+                if (expectedPositionStore is not null && expectedTagPositions is not null)
                 {
-                    await TagReservationHelper.CancelReservationsAsync(_actorAccessor, reservations);
-                    return ResultBox.Error<SerializedCommitResult>(writeResult.GetException());
-                }
+                    var writeResult = await expectedPositionStore.WriteSerializableEventsWithExpectedTagPositionsAsync(
+                        serializableEvents, expectedTagPositions, cancellationToken);
+                    if (!writeResult.IsSuccess)
+                    {
+                        await TagReservationHelper.CancelReservationsAsync(_actorAccessor, reservations);
+                        return ResultBox.Error<SerializedCommitResult>(writeResult.GetException());
+                    }
 
-                var (writtenEvents, tagWriteResults) = writeResult.GetValue();
+                    writtenEvents = writeResult.GetValue().Events;
+                    tagWriteResults = writeResult.GetValue().TagWrites;
+                }
+                else
+                {
+                    var writeResult = await _eventStore.WriteSerializableEventsAsync(serializableEvents);
+                    if (!writeResult.IsSuccess)
+                    {
+                        await TagReservationHelper.CancelReservationsAsync(_actorAccessor, reservations);
+                        return ResultBox.Error<SerializedCommitResult>(writeResult.GetException());
+                    }
+
+                    (writtenEvents, tagWriteResults) = writeResult.GetValue();
+                }
 
                 // Step 6: Confirm reservations
                 await TagReservationHelper.ConfirmReservationsAsync(_actorAccessor, reservations);
@@ -1017,18 +1182,30 @@ public class CoreGeneralSekibanExecutor
     // Capabilities namespace are fully qualified so no using directive changes above are required. ----
 
     /// <summary>
-    ///     Opt-in overload carrying execution options. With no conditional option it delegates to the unconditional
-    ///     pipeline unchanged; with a conditional-append option it runs the dedicated single-event conditional pipeline,
-    ///     which fails closed BEFORE the handler on a store that cannot enforce the condition.
+    ///     Opt-in overload carrying execution options. With no option it delegates to the legacy unconditional pipeline;
+    ///     expected-tag positions enter the same ordinary batch pipeline with a durable store capability gate; a
+    ///     conditional append continues to use its dedicated single-event path.
     /// </summary>
     public Task<ResultBox<ExecutionResult>> ExecuteAsync<TCommand>(
         TCommand command,
         Func<TCommand, ICoreCommandContext, Task<ResultBox<EventOrNone>>> handlerFunc,
         CommandExecutionOptions? options,
-        CancellationToken cancellationToken = default) where TCommand : ICommand =>
-        options?.ConditionalAppend is { } conditional
+        CancellationToken cancellationToken = default) where TCommand : ICommand
+    {
+        // The two independently additive protocols deliberately do not silently compose: conditional append has a
+        // single-event idempotency receipt contract while expected positions are a complete multi-tag conflict contract.
+        // Reject the ambiguous combination before the handler/provider path rather than dropping the requested fence.
+        if (options?.ConditionalAppend is not null && options.ExpectedTagPositions is not null)
+        {
+            return Task.FromResult(ResultBox.Error<ExecutionResult>(
+                new TagHeadExpectationValidationException(
+                    "ConditionalAppend and ExpectedTagPositions cannot be combined in one command. Use one explicit write-condition protocol.")));
+        }
+
+        return options?.ConditionalAppend is { } conditional
             ? ExecuteConditionalAppendAsync(command, handlerFunc, conditional, cancellationToken)
-            : ExecuteAsync(command, handlerFunc, cancellationToken);
+            : ExecuteAsyncCore(command, handlerFunc, options?.ExpectedTagPositions, cancellationToken);
+    }
 
     private async Task<ResultBox<ExecutionResult>> ExecuteConditionalAppendAsync<TCommand>(
         TCommand command,

--- a/dcb/src/Sekiban.Dcb.Core/Actors/ISerializedExpectedTagPositionSekibanDcbExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Actors/ISerializedExpectedTagPositionSekibanDcbExecutor.cs
@@ -1,0 +1,16 @@
+using ResultBoxes;
+using Sekiban.Dcb.Commands;
+
+namespace Sekiban.Dcb.Actors;
+
+/// <summary>
+///     OPTIONAL additive WASM-boundary capability for the V2, store-enforced expected-tag-position commit envelope.
+///     Kept separate from <see cref="ISerializedSekibanDcbExecutor" /> so existing serialized executors remain source and
+///     binary compatible; acceptance feature-detects it and fails closed before the old executor or provider write path.
+/// </summary>
+public interface ISerializedExpectedTagPositionSekibanDcbExecutor
+{
+    Task<ResultBox<SerializedCommitResult>> CommitSerializableEventsWithExpectedTagPositionsAsync(
+        VersionedExpectedTagPositionSerializedCommitRequest request,
+        CancellationToken cancellationToken = default);
+}

--- a/dcb/src/Sekiban.Dcb.Core/Capabilities/WriteConditionCapabilityDescriptor.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Capabilities/WriteConditionCapabilityDescriptor.cs
@@ -14,10 +14,16 @@ public enum WriteConditionKind
     ///     Single-event conditional append keyed by a caller-supplied idempotency key (the SEK-G15 contract): at most one
     ///     durable claim per key, with same-operation retries recognised and different-operation reuse rejected.
     /// </summary>
-    SingleEventUniqueKey = 1
+    SingleEventUniqueKey = 1,
 
-    // Future kinds (NOT part of this contract): BatchUniqueKey, ExpectedPosition. They are separate capability kinds so
-    // a store can support one without implying the others; add them here and have supporting stores list them.
+    /// <summary>
+    ///     Durable, service-scoped expected-position compare-and-set over every consistency tag in a batch. PostgreSQL
+    ///     is currently the only supporting provider; silence remains fail-closed.
+    /// </summary>
+    ExpectedTagPosition = 2
+
+    // Future kinds (NOT part of this contract): BatchUniqueKey. They are separate capability kinds so a store can
+    // support one without implying the others.
 }
 
 /// <summary>

--- a/dcb/src/Sekiban.Dcb.Core/ColdEvents/HybridEventStore.cs
+++ b/dcb/src/Sekiban.Dcb.Core/ColdEvents/HybridEventStore.cs
@@ -11,7 +11,7 @@ using Sekiban.Dcb.Tags;
 namespace Sekiban.Dcb.ColdEvents;
 
 public sealed class HybridEventStore : IEventStore, IStreamingSerializableEventStore, IStorageDurabilityDescriptorProvider,
-    IWriteConditionCapabilityProvider, IConditionalEventStore
+    IWriteConditionCapabilityProvider, IConditionalEventStore, IExpectedTagPositionEventStore
 {
     private const string ReadAllSerializableEventsCall = nameof(ReadAllSerializableEventsAsync);
 
@@ -35,16 +35,15 @@ public sealed class HybridEventStore : IEventStore, IStreamingSerializableEventS
     {
         var hot = SekibanDcbCapabilityResolver.DescribeWriteConditions(_hotStore, "hot event store");
 
-        // Advertise a write condition only when the hot store BOTH declares it AND can actually be forwarded to (i.e.
-        // implements IConditionalEventStore). A "deceptive" hot store that declares the capability but is not an
-        // IConditionalEventStore is not honoured — otherwise the executor would pass its descriptor-only preflight and
-        // then fail on the forward. This keeps advertise, forward, and the executor preflight consistent.
-        if (_hotStore is not IConditionalEventStore)
+        // Advertise every kind only when the hot store BOTH declares it AND this decorator can forward the corresponding
+        // optional interface. A descriptor-only/deceptive hot store must never make the executor's preflight succeed.
+        var forwardable = hot.SupportedKinds.Where(kind => kind switch
         {
-            return WriteConditionCapabilityDescriptor.None($"HybridEventStore({hot.ProviderName})");
-        }
-
-        return new WriteConditionCapabilityDescriptor(hot.SupportedKinds, $"HybridEventStore({hot.ProviderName})");
+            WriteConditionKind.SingleEventUniqueKey => _hotStore is IConditionalEventStore,
+            WriteConditionKind.ExpectedTagPosition => _hotStore is IExpectedTagPositionEventStore,
+            _ => false
+        }).ToHashSet();
+        return new WriteConditionCapabilityDescriptor(forwardable, $"HybridEventStore({hot.ProviderName})");
     }
 
     /// <summary>
@@ -67,6 +66,38 @@ public sealed class HybridEventStore : IEventStore, IStreamingSerializableEventS
                 new ConditionNotSupportedException(
                     WriteConditionKind.SingleEventUniqueKey,
                     $"HybridEventStore({descriptor.ProviderName})")));
+    }
+
+    /// <inheritdoc />
+    public Task<ResultBox<bool>> EnsureExpectedTagPositionEnforcementEnabledAsync(
+        CancellationToken cancellationToken = default)
+    {
+        if (_hotStore is IExpectedTagPositionEventStore expectedHot)
+        {
+            return expectedHot.EnsureExpectedTagPositionEnforcementEnabledAsync(cancellationToken);
+        }
+
+        var descriptor = SekibanDcbCapabilityResolver.DescribeWriteConditions(_hotStore, "hot event store");
+        return Task.FromResult(ResultBox.Error<bool>(new ConditionNotSupportedException(
+            WriteConditionKind.ExpectedTagPosition,
+            $"HybridEventStore({descriptor.ProviderName})")));
+    }
+
+    /// <inheritdoc />
+    public Task<ResultBox<ExpectedTagPositionWriteResult>> WriteSerializableEventsWithExpectedTagPositionsAsync(
+        IReadOnlyList<SerializableEvent> events,
+        ExpectedTagPositionSpecification specification,
+        CancellationToken cancellationToken = default)
+    {
+        if (_hotStore is IExpectedTagPositionEventStore expectedHot)
+        {
+            return expectedHot.WriteSerializableEventsWithExpectedTagPositionsAsync(events, specification, cancellationToken);
+        }
+
+        var descriptor = SekibanDcbCapabilityResolver.DescribeWriteConditions(_hotStore, "hot event store");
+        return Task.FromResult(ResultBox.Error<ExpectedTagPositionWriteResult>(new ConditionNotSupportedException(
+            WriteConditionKind.ExpectedTagPosition,
+            $"HybridEventStore({descriptor.ProviderName})")));
     }
     private readonly IEventStore _hotStore;
     private readonly IColdObjectStorage _coldStorage;

--- a/dcb/src/Sekiban.Dcb.Core/Commands/CommandExecutionOptions.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Commands/CommandExecutionOptions.cs
@@ -1,3 +1,5 @@
+using Sekiban.Dcb.Storage;
+
 namespace Sekiban.Dcb.Commands;
 
 /// <summary>
@@ -14,6 +16,12 @@ public sealed record CommandExecutionOptions
     ///     <c>ConditionNotSupportedException</c> before the handler runs.
     /// </summary>
     public ConditionalAppendSpecification? ConditionalAppend { get; init; }
+
+    /// <summary>
+    ///     Opts into PostgreSQL's durable expected-tag-position protocol. Every derived consistency tag must have exactly
+    ///     one explicitly discriminated entry. Unsupported stores fail closed before their write path is invoked.
+    /// </summary>
+    public ExpectedTagPositionSpecification? ExpectedTagPositions { get; init; }
 }
 
 /// <summary>

--- a/dcb/src/Sekiban.Dcb.Core/Commands/SerializedCommitAcceptor.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Commands/SerializedCommitAcceptor.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using ResultBoxes;
 using Sekiban.Dcb.Actors;
 using Sekiban.Dcb.Events;
+using Sekiban.Dcb.Storage;
 namespace Sekiban.Dcb.Commands;
 
 /// <summary>
@@ -14,9 +15,11 @@ namespace Sekiban.Dcb.Commands;
 ///     </para>
 ///     <para>
 ///         Phase 2 binds only the resolved shape: a missing version is the legacy official shape (lifted losslessly to V1
-///         via <see cref="LegacyUnversionedSerializedCommitAdapter" />); a known version binds
-///         <see cref="VersionedSerializedCommitRequest" />. Either way the same event candidates + consistency tags are
-///         handed to <see cref="ISerializedSekibanDcbExecutor.CommitSerializableEventsAsync" /> with identical semantics
+///         via <see cref="LegacyUnversionedSerializedCommitAdapter" />); V1 binds
+///         <see cref="VersionedSerializedCommitRequest" />, while V2 binds
+///         <see cref="VersionedExpectedTagPositionSerializedCommitRequest" /> and requires its separate optional executor
+///         capability. Legacy/V1 event candidates + consistency tags are handed to
+///         <see cref="ISerializedSekibanDcbExecutor.CommitSerializableEventsAsync" /> with identical semantics
 ///         (heterogeneous per-event tags preserved). A binding failure becomes a SANITIZED typed shape error — the raw
 ///         System.Text.Json exception is discarded, never attached — so hostile request content cannot leak through the
 ///         error surface, and a null-reference is never surfaced.
@@ -43,13 +46,15 @@ public sealed class SerializedCommitAcceptor : ISerializedCommitAcceptor
                 return Task.FromResult(
                     ResultBox.Error<SerializedCommitResult>(
                         new UnsupportedSerializedCommitEnvelopeVersionException(
-                            discrimination.Version!.Value, VersionedSerializedCommitRequest.CurrentVersion)));
+                            discrimination.Version!.Value, VersionedExpectedTagPositionSerializedCommitRequest.CurrentVersion)));
 
             case SerializedCommitVersionKind.LegacyUnversioned:
                 return BindLegacyThenExecuteAsync(utf8Json, cancellationToken);
 
             case SerializedCommitVersionKind.KnownVersion:
-                return BindVersionedThenExecuteAsync(utf8Json, cancellationToken);
+                return discrimination.Version == VersionedSerializedCommitRequest.CurrentVersion
+                    ? BindVersionedThenExecuteAsync(utf8Json, cancellationToken)
+                    : BindExpectedTagPositionThenExecuteAsync(utf8Json, cancellationToken);
 
             default:
                 return Malformed(SerializedCommitShapeError.UnreadableJson);
@@ -110,6 +115,39 @@ public sealed class SerializedCommitAcceptor : ISerializedCommitAcceptor
         }
 
         return ExecuteAsync(envelope, cancellationToken);
+    }
+
+    private Task<ResultBox<SerializedCommitResult>> BindExpectedTagPositionThenExecuteAsync(
+        ReadOnlyMemory<byte> utf8Json,
+        CancellationToken cancellationToken)
+    {
+        VersionedExpectedTagPositionSerializedCommitRequest? envelope;
+        try
+        {
+            envelope = JsonSerializer.Deserialize<VersionedExpectedTagPositionSerializedCommitRequest>(
+                utf8Json.Span, SerializedCommitWireContract.Options);
+        }
+        catch (JsonException)
+        {
+            return Malformed(SerializedCommitShapeError.VersionedPayloadInvalid);
+        }
+
+        if (envelope is null || envelope.Version != VersionedExpectedTagPositionSerializedCommitRequest.CurrentVersion ||
+            envelope.ConsistencyTags?.Any(entry => entry.LastSortableUniqueId is null) == true ||
+            envelope.ExpectedTagPositions is null)
+        {
+            return Malformed(SerializedCommitShapeError.VersionedPayloadInvalid);
+        }
+
+        // Feature detection occurs before forwarding to the older serialized interface, so an unsupported provider never
+        // gets an opportunity to interpret V2 as an unconditional V1 write.
+        if (_executor is not ISerializedExpectedTagPositionSekibanDcbExecutor expectedPositionExecutor)
+        {
+            return Task.FromResult(ResultBox.Error<SerializedCommitResult>(
+                new ConditionNotSupportedException(Sekiban.Dcb.Capabilities.WriteConditionKind.ExpectedTagPosition, "resolved serialized executor")));
+        }
+
+        return expectedPositionExecutor.CommitSerializableEventsWithExpectedTagPositionsAsync(envelope, cancellationToken);
     }
 
     private Task<ResultBox<SerializedCommitResult>> ExecuteAsync(

--- a/dcb/src/Sekiban.Dcb.Core/Commands/SerializedCommitVersionDiscriminator.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Commands/SerializedCommitVersionDiscriminator.cs
@@ -121,7 +121,8 @@ public static class SerializedCommitVersionDiscriminator
             {
                 return Malformed(SerializedCommitShapeError.VersionNotInteger);
             }
-            return versionValue == VersionedSerializedCommitRequest.CurrentVersion
+            return versionValue is VersionedSerializedCommitRequest.CurrentVersion or
+                VersionedExpectedTagPositionSerializedCommitRequest.CurrentVersion
                 ? new SerializedCommitVersionResult(SerializedCommitVersionKind.KnownVersion, versionValue, null)
                 : new SerializedCommitVersionResult(SerializedCommitVersionKind.UnsupportedVersion, versionValue, null);
         }

--- a/dcb/src/Sekiban.Dcb.Core/Commands/SerializedCommitWireJsonContext.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Commands/SerializedCommitWireJsonContext.cs
@@ -17,6 +17,9 @@ namespace Sekiban.Dcb.Commands;
     DefaultIgnoreCondition = JsonIgnoreCondition.Never)]
 [JsonSerializable(typeof(SerializedCommitRequest))]
 [JsonSerializable(typeof(VersionedSerializedCommitRequest))]
+[JsonSerializable(typeof(VersionedExpectedTagPositionSerializedCommitRequest))]
 [JsonSerializable(typeof(SerializableEventCandidate))]
 [JsonSerializable(typeof(ConsistencyTagEntry))]
+[JsonSerializable(typeof(Sekiban.Dcb.Storage.TagHeadExpectationEntry))]
+[JsonSerializable(typeof(Sekiban.Dcb.Storage.TagHeadExpectation))]
 public partial class SerializedCommitWireJsonContext : JsonSerializerContext;

--- a/dcb/src/Sekiban.Dcb.Core/Commands/VersionedExpectedTagPositionSerializedCommitRequest.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Commands/VersionedExpectedTagPositionSerializedCommitRequest.cs
@@ -1,0 +1,19 @@
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.Storage;
+
+namespace Sekiban.Dcb.Commands;
+
+/// <summary>
+///     Additive V2 serialized commit envelope for PostgreSQL's store-enforced multi-tag expected-position CAS. V1 and
+///     the legacy unversioned payload deliberately remain untouched: their omission semantics continue to mean the
+///     existing reservation-only, no-enforcement flow.
+/// </summary>
+public sealed record VersionedExpectedTagPositionSerializedCommitRequest(
+    int Version,
+    IReadOnlyList<SerializableEventCandidate> EventCandidates,
+    IReadOnlyList<ConsistencyTagEntry> ConsistencyTags,
+    IReadOnlyList<TagHeadExpectationEntry> ExpectedTagPositions)
+{
+    /// <summary>The only supported version for this additive expected-position envelope.</summary>
+    public const int CurrentVersion = 2;
+}

--- a/dcb/src/Sekiban.Dcb.Core/Storage/TagHeadCas/ExpectedTagPositionContracts.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Storage/TagHeadCas/ExpectedTagPositionContracts.cs
@@ -1,0 +1,215 @@
+using ResultBoxes;
+using Sekiban.Dcb.Events;
+
+namespace Sekiban.Dcb.Storage;
+
+/// <summary>
+///     The total, explicitly discriminated expected-position state for one consistency tag.  The discriminator, not a
+///     nullable position, determines the requested behaviour: a missing / null expectation is therefore never silently
+///     interpreted as an unconditional write.
+/// </summary>
+public enum TagHeadExpectationKind
+{
+    /// <summary>Invalid / unspecified. Rejected before a store write.</summary>
+    Unknown = 0,
+
+    /// <summary>Do not compare this tag's head, but still create, lock, reconcile and advance it.</summary>
+    NoEnforcement = 1,
+
+    /// <summary>Require the durably reconciled head to be proven empty.</summary>
+    AssertEmpty = 2,
+
+    /// <summary>Require the durably reconciled head to equal <see cref="TagHeadExpectation.Position" />.</summary>
+    Exact = 3
+}
+
+/// <summary>
+///     One branch of the expected-tag-head protocol.  <see cref="Kind" /> is always required.  <see cref="Position" />
+///     is required only for <see cref="TagHeadExpectationKind.Exact" /> and is forbidden for the other branches.
+/// </summary>
+public sealed record TagHeadExpectation(TagHeadExpectationKind Kind, string? Position = null)
+{
+    public static TagHeadExpectation NoEnforcement() => new(TagHeadExpectationKind.NoEnforcement);
+    public static TagHeadExpectation AssertEmpty() => new(TagHeadExpectationKind.AssertEmpty);
+    public static TagHeadExpectation Exact(string position) => new(TagHeadExpectationKind.Exact, position);
+
+    internal void Validate()
+    {
+        if (Kind == TagHeadExpectationKind.NoEnforcement && Position is null)
+        {
+            return;
+        }
+        if (Kind == TagHeadExpectationKind.AssertEmpty && Position is null)
+        {
+            return;
+        }
+        if (Kind == TagHeadExpectationKind.Exact && !string.IsNullOrWhiteSpace(Position))
+        {
+            return;
+        }
+
+        switch (Kind)
+        {
+            case TagHeadExpectationKind.AssertEmpty:
+                throw new TagHeadExpectationValidationException(
+                    "AssertEmpty must not carry a position. Use the explicit Exact branch for a position.");
+
+            case TagHeadExpectationKind.NoEnforcement:
+                throw new TagHeadExpectationValidationException(
+                    "NoEnforcement must not carry a position. Use the explicit Exact branch for a position.");
+
+            case TagHeadExpectationKind.Exact:
+                throw new TagHeadExpectationValidationException("Exact requires a non-empty position.");
+
+            default:
+                throw new TagHeadExpectationValidationException("An expected tag-head entry has an unknown discriminator.");
+        }
+    }
+}
+
+/// <summary>A service-scoped expected-head entry. Each affected consistency tag must occur exactly once.</summary>
+public sealed record TagHeadExpectationEntry(string ServiceId, string Tag, TagHeadExpectation Expectation);
+
+/// <summary>
+///     A complete request-side specification for the consistency tags derived by an executor.  It is deliberately an
+///     additive object rather than a nullable expected-position parameter on an existing public method.
+/// </summary>
+public sealed record ExpectedTagPositionSpecification(IReadOnlyList<TagHeadExpectationEntry> Entries)
+{
+    /// <summary>True when at least one tag requests a durable comparison rather than NoEnforcement.</summary>
+    public bool RequiresEnforcement => Entries?.Any(e => e.Expectation?.Kind is not TagHeadExpectationKind.NoEnforcement) == true;
+
+    /// <summary>
+    ///     Validates the total request against the exact affected consistency-tag set. This happens before reservation,
+    ///     event allocation, or store mutation.
+    /// </summary>
+    internal IReadOnlyDictionary<string, TagHeadExpectation> ValidateFor(
+        string serviceId,
+        IEnumerable<string> affectedConsistencyTags)
+    {
+        ValidateEntryShapes(serviceId);
+
+        var expectedTags = new HashSet<string>(affectedConsistencyTags, StringComparer.Ordinal);
+        var result = new Dictionary<string, TagHeadExpectation>(StringComparer.Ordinal);
+
+        foreach (var entry in Entries)
+        {
+            if (!result.TryAdd(entry.Tag, entry.Expectation))
+            {
+                throw new TagHeadExpectationValidationException($"Duplicate expected tag-head entry for '{entry.Tag}'.");
+            }
+        }
+
+        if (!result.Keys.ToHashSet(StringComparer.Ordinal).SetEquals(expectedTags))
+        {
+            var missing = expectedTags.Except(result.Keys, StringComparer.Ordinal).Order(StringComparer.Ordinal).ToArray();
+            var unknown = result.Keys.Except(expectedTags, StringComparer.Ordinal).Order(StringComparer.Ordinal).ToArray();
+            throw new TagHeadExpectationValidationException(
+                $"Expected tag-head entries must match the derived consistency tags exactly. Missing: {string.Join(", ", missing)}. " +
+                $"Unknown: {string.Join(", ", unknown)}.");
+        }
+
+        return result;
+    }
+
+    /// <summary>Validates the entry-level total/discriminated shape without deriving a command's tag set.</summary>
+    internal void ValidateEntryShapes(string serviceId)
+    {
+        if (Entries is null)
+        {
+            throw new TagHeadExpectationValidationException("Expected tag-head entries are required; use an empty array for no affected tags.");
+        }
+
+        foreach (var entry in Entries)
+        {
+            if (entry is null || string.IsNullOrWhiteSpace(entry.ServiceId) || string.IsNullOrWhiteSpace(entry.Tag) ||
+                entry.Expectation is null)
+            {
+                throw new TagHeadExpectationValidationException("Every expected tag-head entry needs serviceId, tag, and an explicit expectation.");
+            }
+            if (!string.Equals(entry.ServiceId, serviceId, StringComparison.Ordinal))
+            {
+                throw new TagHeadExpectationValidationException(
+                    $"Expected tag-head entry for '{entry.Tag}' belongs to service '{entry.ServiceId}', not the current service.");
+            }
+            entry.Expectation.Validate();
+        }
+
+        if (Entries.GroupBy(e => e.Tag, StringComparer.Ordinal).Any(g => g.Count() > 1))
+        {
+            var duplicate = Entries.GroupBy(e => e.Tag, StringComparer.Ordinal).First(g => g.Count() > 1).Key;
+            throw new TagHeadExpectationValidationException($"Duplicate expected tag-head entry for '{duplicate}'.");
+        }
+    }
+}
+
+/// <summary>One complete expected/observed pair returned on a durable expected-head conflict.</summary>
+public sealed record TagHeadExpectedObserved(
+    string ServiceId,
+    string Tag,
+    TagHeadExpectation Expected,
+    string? ObservedPosition);
+
+/// <summary>
+///     Typed optimistic-concurrency failure.  The list is complete for the request's affected consistency-tag set, not
+///     merely the first stale entry, so callers can deterministically refresh all heads in one round trip.
+/// </summary>
+public sealed class ExpectedTagPositionConflictException : Exception
+{
+    public ExpectedTagPositionConflictException(IReadOnlyList<TagHeadExpectedObserved> pairs)
+        : base("One or more expected tag positions do not match the durable PostgreSQL heads.") => Pairs = pairs;
+
+    public IReadOnlyList<TagHeadExpectedObserved> Pairs { get; }
+}
+
+/// <summary>Typed malformed-request failure raised before a write or lazy head creation.</summary>
+public sealed class TagHeadExpectationValidationException : ArgumentException
+{
+    public TagHeadExpectationValidationException(string message) : base(message) { }
+}
+
+/// <summary>Typed position invariant failure raised before command rows are materialized.</summary>
+public sealed class TagHeadPositionValidationException : ArgumentException
+{
+    public TagHeadPositionValidationException(string message) : base(message) { }
+}
+
+/// <summary>
+///     The durable expected-position fence is unavailable until an operator has provisioned the schema, drained every
+///     pre-epoch PostgreSQL writer, and set the enablement epoch marker for this service.
+/// </summary>
+public sealed class TagHeadEnforcementNotEnabledException : InvalidOperationException
+{
+    public TagHeadEnforcementNotEnabledException(string serviceId)
+        : base($"Expected tag-position enforcement is not enabled for service '{serviceId}'. Provision, drain pre-10.19 writers, then set the enablement epoch before requesting enforcement.")
+    {
+        ServiceId = serviceId;
+    }
+
+    public string ServiceId { get; }
+}
+
+/// <summary>Result returned by the optional store-enforced expected-position writer.</summary>
+public sealed record ExpectedTagPositionWriteResult(
+    IReadOnlyList<SerializableEvent> Events,
+    IReadOnlyList<Sekiban.Dcb.Tags.TagWriteResult> TagWrites);
+
+/// <summary>
+///     OPTIONAL additive store capability for PostgreSQL's durable multi-tag expected-position protocol. It is kept off
+///     <see cref="IEventStore" /> so existing providers remain binary/source compatible. A supporting store must advertise
+///     <c>WriteConditionKind.ExpectedTagPosition</c>; callers feature-detect it and fail closed before any provider write.
+/// </summary>
+public interface IExpectedTagPositionEventStore
+{
+    /// <summary>Checks the service's provisioning-plane enablement epoch without creating or advancing a head.</summary>
+    Task<ResultBox<bool>> EnsureExpectedTagPositionEnforcementEnabledAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    ///     Writes a serialized batch through the canonical head protocol. NoEnforcement entries still create, lock,
+    ///     reconcile and advance durable heads; they only skip the expected-head comparison.
+    /// </summary>
+    Task<ResultBox<ExpectedTagPositionWriteResult>> WriteSerializableEventsWithExpectedTagPositionsAsync(
+        IReadOnlyList<SerializableEvent> events,
+        ExpectedTagPositionSpecification specification,
+        CancellationToken cancellationToken = default);
+}

--- a/dcb/src/Sekiban.Dcb.Orleans.WithResult/OrleansDcbExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.WithResult/OrleansDcbExecutor.cs
@@ -18,7 +18,8 @@ namespace Sekiban.Dcb.Orleans;
 ///     Orleans-specific implementation of ISekibanExecutor
 ///     Uses Orleans grains for distributed command execution and queries
 /// </summary>
-public class OrleansDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecutor, IExecutorRuntimeDescriptorProvider
+public class OrleansDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecutor,
+    ISerializedExpectedTagPositionSekibanDcbExecutor, IExecutorRuntimeDescriptorProvider
 {
     /// <summary>Commands are executed by Orleans grains across the cluster.</summary>
     public ExecutorRuntimeDescriptor DescribeRuntime() =>
@@ -373,6 +374,12 @@ public class OrleansDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecuto
         SerializedCommitRequest request,
         CancellationToken cancellationToken = default) =>
         _generalExecutor.CommitSerializableEventsAsync(request, cancellationToken);
+
+    /// <summary>Forwards the additive V2 serialized expected-head contract to the common executor/store path.</summary>
+    public Task<ResultBox<SerializedCommitResult>> CommitSerializableEventsWithExpectedTagPositionsAsync(
+        VersionedExpectedTagPositionSerializedCommitRequest request,
+        CancellationToken cancellationToken = default) =>
+        _generalExecutor.CommitSerializableEventsWithExpectedTagPositionsAsync(request, cancellationToken);
 
     private ResultBox<string> ResolveProjectorName(IQueryCommon queryCommon)
     {

--- a/dcb/src/Sekiban.Dcb.Orleans.WithoutResult/OrleansDcbExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.WithoutResult/OrleansDcbExecutor.cs
@@ -19,7 +19,8 @@ namespace Sekiban.Dcb.Orleans;
 ///     Orleans-specific implementation of ISekibanExecutor (exception-based)
 ///     Uses Orleans grains for distributed command execution and queries
 /// </summary>
-public class OrleansDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecutor, IExecutorRuntimeDescriptorProvider
+public class OrleansDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecutor,
+    ISerializedExpectedTagPositionSekibanDcbExecutor, IExecutorRuntimeDescriptorProvider
 {
     /// <summary>Commands are executed by Orleans grains across the cluster.</summary>
     public ExecutorRuntimeDescriptor DescribeRuntime() =>
@@ -337,6 +338,12 @@ public class OrleansDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecuto
         SerializedCommitRequest request,
         CancellationToken cancellationToken = default) =>
         _generalExecutor.CommitSerializableEventsAsync(request, cancellationToken);
+
+    /// <summary>Forwards the additive V2 serialized expected-head contract to the common executor/store path.</summary>
+    public Task<ResultBox<SerializedCommitResult>> CommitSerializableEventsWithExpectedTagPositionsAsync(
+        VersionedExpectedTagPositionSerializedCommitRequest request,
+        CancellationToken cancellationToken = default) =>
+        _generalExecutor.CommitSerializableEventsWithExpectedTagPositionsAsync(request, cancellationToken);
 
     private string ResolveProjectorName(IQueryCommon queryCommon)
     {

--- a/dcb/src/Sekiban.Dcb.Postgres/DbModels/DbTagHead.cs
+++ b/dcb/src/Sekiban.Dcb.Postgres/DbModels/DbTagHead.cs
@@ -1,0 +1,23 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Sekiban.Dcb.Postgres.DbModels;
+
+/// <summary>
+///     Durable, service-scoped head for every PostgreSQL tag that has participated in the canonical tag-head protocol.
+///     A row with <see cref="HeadPosition" /> null is an explicit, transactionally proven-empty head; absence of a row is
+///     never treated as empty until the bootstrap lookup has created that row.
+/// </summary>
+[Table("dcb_tag_heads")]
+public sealed class DbTagHead
+{
+    [Required]
+    [MaxLength(64)]
+    public string ServiceId { get; set; } = string.Empty;
+
+    [Required]
+    public string Tag { get; set; } = string.Empty;
+
+    [MaxLength(100)]
+    public string? HeadPosition { get; set; }
+}

--- a/dcb/src/Sekiban.Dcb.Postgres/DbModels/DbTagHeadEnablementEpoch.cs
+++ b/dcb/src/Sekiban.Dcb.Postgres/DbModels/DbTagHeadEnablementEpoch.cs
@@ -1,0 +1,18 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Sekiban.Dcb.Postgres.DbModels;
+
+/// <summary>
+///     Provisioning-plane marker set only after every pre-protocol PostgreSQL writer has been drained. It is deliberately
+///     per service because the durable head key and the cutover guarantee are per service.
+/// </summary>
+[Table("dcb_tag_head_enablement_epochs")]
+public sealed class DbTagHeadEnablementEpoch
+{
+    [Key]
+    [MaxLength(64)]
+    public string ServiceId { get; set; } = string.Empty;
+
+    public DateTime EnabledAtUtc { get; set; }
+}

--- a/dcb/src/Sekiban.Dcb.Postgres/DbModels/DbTagHeadViolation.cs
+++ b/dcb/src/Sekiban.Dcb.Postgres/DbModels/DbTagHeadViolation.cs
@@ -1,0 +1,38 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Sekiban.Dcb.Postgres.DbModels;
+
+/// <summary>Append-only reconciliation evidence for a head bypass observed from authoritative tag rows.</summary>
+[Table("dcb_tag_head_violations")]
+public sealed class DbTagHeadViolation
+{
+    [Key]
+    [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+    public long Id { get; set; }
+
+    [Required]
+    [MaxLength(64)]
+    public string ServiceId { get; set; } = string.Empty;
+
+    [Required]
+    public string Tag { get; set; } = string.Empty;
+
+    /// <summary>Whether the observed prior head was the explicit proven-empty representation.</summary>
+    public bool PreviousHeadWasEmpty { get; set; }
+
+    /// <summary>Prior non-empty head, or an empty string when <see cref="PreviousHeadWasEmpty" /> is true.</summary>
+    [Required]
+    [MaxLength(100)]
+    public string PreviousHeadPosition { get; set; } = string.Empty;
+
+    [Required]
+    [MaxLength(100)]
+    public string ObservedPosition { get; set; } = string.Empty;
+
+    public DateTime DetectedAtUtc { get; set; }
+
+    [Required]
+    [MaxLength(128)]
+    public string DetectingWriter { get; set; } = string.Empty;
+}

--- a/dcb/src/Sekiban.Dcb.Postgres/Migrations/20260822163309_AddPostgresTagHeadExpectedPositionCas.Designer.cs
+++ b/dcb/src/Sekiban.Dcb.Postgres/Migrations/20260822163309_AddPostgresTagHeadExpectedPositionCas.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Sekiban.Dcb.Postgres;
@@ -11,9 +12,11 @@ using Sekiban.Dcb.Postgres;
 namespace Sekiban.Dcb.Postgres.Migrations
 {
     [DbContext(typeof(SekibanDcbDbContext))]
-    partial class SekibanDcbDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260822163309_AddPostgresTagHeadExpectedPositionCas")]
+    partial class AddPostgresTagHeadExpectedPositionCas
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/dcb/src/Sekiban.Dcb.Postgres/Migrations/20260822163309_AddPostgresTagHeadExpectedPositionCas.cs
+++ b/dcb/src/Sekiban.Dcb.Postgres/Migrations/20260822163309_AddPostgresTagHeadExpectedPositionCas.cs
@@ -1,0 +1,86 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace Sekiban.Dcb.Postgres.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPostgresTagHeadExpectedPositionCas : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "dcb_tag_head_enablement_epochs",
+                columns: table => new
+                {
+                    ServiceId = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    EnabledAtUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_dcb_tag_head_enablement_epochs", x => x.ServiceId);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "dcb_tag_head_violations",
+                columns: table => new
+                {
+                    Id = table.Column<long>(type: "bigint", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    ServiceId = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    Tag = table.Column<string>(type: "text", nullable: false),
+                    PreviousHeadWasEmpty = table.Column<bool>(type: "boolean", nullable: false),
+                    PreviousHeadPosition = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    ObservedPosition = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    DetectedAtUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    DetectingWriter = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_dcb_tag_head_violations", x => x.Id);
+                    table.CheckConstraint("CK_TagHeadViolations_Observed_NotEmpty", "length(\"ObservedPosition\") > 0");
+                });
+
+            migrationBuilder.CreateTable(
+                name: "dcb_tag_heads",
+                columns: table => new
+                {
+                    ServiceId = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    Tag = table.Column<string>(type: "text", nullable: false),
+                    HeadPosition = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_dcb_tag_heads", x => new { x.ServiceId, x.Tag });
+                    table.CheckConstraint("CK_TagHeads_Position_NotEmpty", "\"HeadPosition\" IS NULL OR length(\"HeadPosition\") > 0");
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TagHeadViolations_Service_Tag_Detected",
+                table: "dcb_tag_head_violations",
+                columns: new[] { "ServiceId", "Tag", "DetectedAtUtc" });
+
+            migrationBuilder.CreateIndex(
+                name: "UX_TagHeadViolations_IdempotentRepair",
+                table: "dcb_tag_head_violations",
+                columns: new[] { "ServiceId", "Tag", "PreviousHeadWasEmpty", "PreviousHeadPosition", "ObservedPosition" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "dcb_tag_head_enablement_epochs");
+
+            migrationBuilder.DropTable(
+                name: "dcb_tag_head_violations");
+
+            migrationBuilder.DropTable(
+                name: "dcb_tag_heads");
+        }
+    }
+}

--- a/dcb/src/Sekiban.Dcb.Postgres/PostgresEventStore.cs
+++ b/dcb/src/Sekiban.Dcb.Postgres/PostgresEventStore.cs
@@ -1,5 +1,7 @@
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
 using Npgsql;
+using NpgsqlTypes;
 using ResultBoxes;
 using Sekiban.Dcb.Common;
 using Sekiban.Dcb.Domains;
@@ -17,7 +19,7 @@ using System.Text.Json;
 namespace Sekiban.Dcb.Postgres;
 
 public class PostgresEventStore : IHotEventStore, ISerializableEventStreamReader, IStorageDurabilityDescriptorProvider,
-    IConditionalEventStore, IWriteConditionCapabilityProvider
+    IConditionalEventStore, IExpectedTagPositionEventStore, IWriteConditionCapabilityProvider
 {
     private const string ConditionalProviderName = "Postgres";
 
@@ -41,6 +43,13 @@ public class PostgresEventStore : IHotEventStore, ISerializableEventStreamReader
     internal Func<Task>? AfterConditionalCommitHook { get; set; }
 
     /// <summary>
+    ///     Test-only fault / overlap seam invoked at each fixed real PostgreSQL protocol milestone (before lazy insertion;
+    ///     after locking; after reconciliation; after event DML; after tag DML; after head advancement). It deliberately
+    ///     surrounds the production SQL and transaction rather than replacing it with a test-owned lock or collection.
+    /// </summary>
+    internal Func<Task>? TagHeadProtocolHook { get; set; }
+
+    /// <summary>
     ///     SEK-G16 conditional (unique-key) append. The claim event is inserted under the deterministic id, so the
     ///     existing <c>(ServiceId, Id)</c> primary key is the uniqueness primitive — no schema change. A duplicate raises
     ///     SQLSTATE 23505 (unique_violation), which is classified by fingerprint against the stored winner (the real
@@ -54,43 +63,32 @@ public class PostgresEventStore : IHotEventStore, ISerializableEventStreamReader
         _conditionalAppend.AppendIfUniqueAsync(request, cancellationToken);
 
     /// <inheritdoc />
-    public WriteConditionCapabilityDescriptor DescribeWriteConditions() => _conditionalAppend.Descriptor;
+    public WriteConditionCapabilityDescriptor DescribeWriteConditions() =>
+        WriteConditionCapabilityDescriptor.Supporting(
+            ConditionalProviderName,
+            WriteConditionKind.SingleEventUniqueKey,
+            WriteConditionKind.ExpectedTagPosition);
 
     private async Task<ConditionalWriteOutcome> TryWriteConditionalClaimAsync(
         Guid deterministicId,
         SerializableEvent claimEvent,
         CancellationToken cancellationToken)
     {
-        var serviceId = CurrentServiceId;
-        await using var context = await _contextFactory.CreateDbContextAsync(cancellationToken);
-        await using var transaction = await context.Database.BeginTransactionAsync(cancellationToken);
-
-        var dbEvent = new DbEvent
-        {
-            ServiceId = serviceId,
-            Id = deterministicId,
-            SortableUniqueId = claimEvent.SortableUniqueIdValue,
-            EventType = claimEvent.EventPayloadName,
-            Payload = Encoding.UTF8.GetString(claimEvent.Payload),
-            Tags = JsonSerializer.Serialize(claimEvent.Tags),
-            Timestamp = DateTime.UtcNow,
-            CausationId = claimEvent.EventMetadata.CausationId,
-            CorrelationId = claimEvent.EventMetadata.CorrelationId,
-            ExecutedUser = claimEvent.EventMetadata.ExecutedUser
-        };
-        context.Events.Add(dbEvent);
-        foreach (var tagString in claimEvent.Tags)
-        {
-            var tagGroup = tagString.Contains(':') ? tagString.Split(':')[0] : tagString;
-            context.Tags.Add(
-                DbTag.FromEventTag(tagString, tagGroup, claimEvent.SortableUniqueIdValue, deterministicId,
-                    claimEvent.EventPayloadName, serviceId));
-        }
-
         try
         {
-            await context.SaveChangesAsync(cancellationToken);
-            await transaction.CommitAsync(cancellationToken);
+            // This is intentionally the same private seam used by both ordinary batch writers. A successful conditional
+            // claim can therefore never be a tagged event invisible to the durable head protocol.
+            var result = await WriteSerializableBatchThroughCanonicalHeadSeamAsync(
+                [claimEvent],
+                specification: null,
+                writer: TagHeadWriter.ConditionalClaim,
+                useExecutionStrategy: false,
+                cancellationToken);
+            if (!result.IsSuccess)
+            {
+                throw result.GetException();
+            }
+
             // The claim is now durably committed. A failure past this point is a LOST RESPONSE, not a failed write: signal
             // it as the post-commit ambiguity marker so the shared orchestrator resolves it authoritatively rather than
             // surfacing a raw transport error. (The seam is test-only; production has no hook.)
@@ -113,7 +111,6 @@ public class PostgresEventStore : IHotEventStore, ISerializableEventStreamReader
             ConstraintName: EventsPrimaryKeyConstraint
         })
         {
-            await transaction.RollbackAsync(cancellationToken);
             return ConditionalWriteOutcome.Conflict(ex);
         }
     }
@@ -285,64 +282,25 @@ public class PostgresEventStore : IHotEventStore, ISerializableEventStreamReader
     {
         try
         {
-            await using var context = await _contextFactory.CreateDbContextAsync();
-            var serviceId = CurrentServiceId;
-
-            // Use the execution strategy for retry logic
-            var strategy = context.Database.CreateExecutionStrategy();
-
-            return await strategy.ExecuteAsync(async () =>
+            var typedEvents = events.ToList();
+            var serializableEvents = typedEvents
+                .Select(ev => ev.ToSerializableEvent(_eventTypes))
+                .ToList();
+            var write = await WriteSerializableBatchThroughCanonicalHeadSeamAsync(
+                serializableEvents,
+                specification: null,
+                writer: TagHeadWriter.TypedBatch,
+                useExecutionStrategy: true,
+                CancellationToken.None);
+            if (!write.IsSuccess)
             {
-                // Begin transaction inside the execution strategy
-                await using var transaction = await context.Database.BeginTransactionAsync();
+                return ResultBox.Error<(IReadOnlyList<Event> Events, IReadOnlyList<TagWriteResult> TagWrites)>(
+                    write.GetException());
+            }
 
-                var eventsList = events.ToList();
-                var writtenEvents = new List<Event>();
-                var tagWriteResults = new List<TagWriteResult>();
-
-                // Process each event
-                foreach (var ev in eventsList)
-                {
-                    // Serialize the event payload
-                    var serializedPayload = SerializeEventPayload(ev.Payload);
-
-                    // Create and add the database event
-                    var dbEvent = DbEvent.FromEvent(ev, serializedPayload, serviceId);
-                    context.Events.Add(dbEvent);
-                    writtenEvents.Add(ev);
-
-                    // Process tags associated with this event
-                    foreach (var tagString in ev.Tags)
-                    {
-                        // Extract tag group from tag string (format: "group:content")
-                        var tagGroup = tagString.Contains(':') ? tagString.Split(':')[0] : tagString;
-
-                        // Create a tag entry for this event
-                        var dbTag = DbTag.FromEventTag(
-                            tagString,
-                            tagGroup,
-                            ev.SortableUniqueIdValue,
-                            ev.Id,
-                            ev.EventType,
-                            serviceId);
-                        context.Tags.Add(dbTag);
-
-                        tagWriteResults.Add(
-                            new TagWriteResult(
-                                tagString,
-                                1, // Version placeholder
-                                DateTimeOffset.UtcNow));
-                    }
-                }
-
-                // Save changes
-                await context.SaveChangesAsync();
-                await transaction.CommitAsync();
-
-                return ResultBox.FromValue(
-                    (Events: (IReadOnlyList<Event>)writtenEvents,
-                        TagWrites: (IReadOnlyList<TagWriteResult>)tagWriteResults));
-            });
+            return ResultBox.FromValue(
+                (Events: (IReadOnlyList<Event>)typedEvents,
+                    TagWrites: write.GetValue().TagWrites));
         }
         catch (Exception ex)
         {
@@ -693,76 +651,16 @@ public class PostgresEventStore : IHotEventStore, ISerializableEventStreamReader
     {
         try
         {
-            await using var context = await _contextFactory.CreateDbContextAsync();
-            var serviceId = CurrentServiceId;
-
-            // Use the execution strategy for retry logic
-            var strategy = context.Database.CreateExecutionStrategy();
-
-            return await strategy.ExecuteAsync(async () =>
-            {
-                // Begin transaction inside the execution strategy
-                await using var transaction = await context.Database.BeginTransactionAsync();
-
-                var eventsList = events.ToList();
-                var writtenEvents = new List<SerializableEvent>();
-                var tagWriteResults = new List<TagWriteResult>();
-
-                // Process each event
-                foreach (var se in eventsList)
-                {
-                    // Convert byte[] payload to string
-                    var serializedPayload = Encoding.UTF8.GetString(se.Payload);
-
-                    // Create and add the database event
-                    var dbEvent = new DbEvent
-                    {
-                        ServiceId = serviceId,
-                        Id = se.Id,
-                        SortableUniqueId = se.SortableUniqueIdValue,
-                        EventType = se.EventPayloadName,
-                        Payload = serializedPayload,
-                        Tags = JsonSerializer.Serialize(se.Tags),
-                        Timestamp = DateTime.UtcNow,
-                        CausationId = se.EventMetadata.CausationId,
-                        CorrelationId = se.EventMetadata.CorrelationId,
-                        ExecutedUser = se.EventMetadata.ExecutedUser
-                    };
-                    context.Events.Add(dbEvent);
-                    writtenEvents.Add(se);
-
-                    // Process tags associated with this event
-                    foreach (var tagString in se.Tags)
-                    {
-                        // Extract tag group from tag string (format: "group:content")
-                        var tagGroup = tagString.Contains(':') ? tagString.Split(':')[0] : tagString;
-
-                        // Create a tag entry for this event
-                        var dbTag = DbTag.FromEventTag(
-                            tagString,
-                            tagGroup,
-                            se.SortableUniqueIdValue,
-                            se.Id,
-                            se.EventPayloadName,
-                            serviceId);
-                        context.Tags.Add(dbTag);
-
-                        tagWriteResults.Add(
-                            new TagWriteResult(
-                                tagString,
-                                1, // Version placeholder
-                                DateTimeOffset.UtcNow));
-                    }
-                }
-
-                // Save changes
-                await context.SaveChangesAsync();
-                await transaction.CommitAsync();
-
-                return ResultBox.FromValue(
-                    (Events: (IReadOnlyList<SerializableEvent>)writtenEvents,
-                        TagWrites: (IReadOnlyList<TagWriteResult>)tagWriteResults));
-            });
+            var write = await WriteSerializableBatchThroughCanonicalHeadSeamAsync(
+                events.ToList(),
+                specification: null,
+                writer: TagHeadWriter.SerializedBatch,
+                useExecutionStrategy: true,
+                CancellationToken.None);
+            return !write.IsSuccess
+                ? ResultBox.Error<(IReadOnlyList<SerializableEvent> Events, IReadOnlyList<TagWriteResult> TagWrites)>(
+                    write.GetException())
+                : ResultBox.FromValue((write.GetValue().Events, write.GetValue().TagWrites));
         }
         catch (Exception ex)
         {
@@ -771,12 +669,511 @@ public class PostgresEventStore : IHotEventStore, ISerializableEventStreamReader
         }
     }
 
+    /// <inheritdoc />
+    public async Task<ResultBox<bool>> EnsureExpectedTagPositionEnforcementEnabledAsync(
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var serviceId = CurrentServiceId;
+            await using var context = await _contextFactory.CreateDbContextAsync(cancellationToken);
+            var enabled = await context.TagHeadEnablementEpochs.AsNoTracking()
+                .AnyAsync(epoch => epoch.ServiceId == serviceId, cancellationToken);
+            return enabled
+                ? ResultBox.FromValue(true)
+                : ResultBox.Error<bool>(new TagHeadEnforcementNotEnabledException(serviceId));
+        }
+        catch (Exception ex)
+        {
+            // Deliberately no fallback DDL or schema creation: an unprovisioned runtime must fail closed (normally 42P01).
+            return ResultBox.Error<bool>(ex);
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<ResultBox<ExpectedTagPositionWriteResult>> WriteSerializableEventsWithExpectedTagPositionsAsync(
+        IReadOnlyList<SerializableEvent> events,
+        ExpectedTagPositionSpecification specification,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            ArgumentNullException.ThrowIfNull(specification);
+            specification.ValidateEntryShapes(CurrentServiceId);
+            if (specification.RequiresEnforcement)
+            {
+                var enabled = await EnsureExpectedTagPositionEnforcementEnabledAsync(cancellationToken);
+                if (!enabled.IsSuccess)
+                {
+                    return ResultBox.Error<ExpectedTagPositionWriteResult>(enabled.GetException());
+                }
+            }
+
+            return await WriteSerializableBatchThroughCanonicalHeadSeamAsync(
+                events,
+                specification,
+                TagHeadWriter.ExpectedPositionBatch,
+                useExecutionStrategy: true,
+                cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "WriteSerializableEventsWithExpectedTagPositionsAsync failed");
+            return ResultBox.Error<ExpectedTagPositionWriteResult>(ex);
+        }
+    }
+
+    /// <summary>
+    ///     The one authoritative PostgreSQL tagged-write seam. Typed, serialized, conditional-claim, and expected-position
+    ///     writers all call this method. The transaction deliberately owns lazy creation, canonical locking,
+    ///     reconciliation, command rows, tag-index rows, and per-tag head advancement together.
+    /// </summary>
+    private async Task<ResultBox<ExpectedTagPositionWriteResult>> WriteSerializableBatchThroughCanonicalHeadSeamAsync(
+        IReadOnlyList<SerializableEvent> events,
+        ExpectedTagPositionSpecification? specification,
+        TagHeadWriter writer,
+        bool useExecutionStrategy,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(events);
+        if (specification is not null)
+        {
+            // Batch ordering is fully known before a transaction or a lazy head row exists.
+            ValidateStrictBatchOrder(events);
+        }
+
+        await using var context = await _contextFactory.CreateDbContextAsync(cancellationToken);
+        if (!useExecutionStrategy)
+        {
+            return await PersistThroughCanonicalHeadSeamAsync(context, events, specification, writer, cancellationToken);
+        }
+
+        var strategy = context.Database.CreateExecutionStrategy();
+        return await strategy.ExecuteAsync(
+            () => PersistThroughCanonicalHeadSeamAsync(context, events, specification, writer, cancellationToken));
+    }
+
+    private async Task<ResultBox<ExpectedTagPositionWriteResult>> PersistThroughCanonicalHeadSeamAsync(
+        SekibanDcbDbContext context,
+        IReadOnlyList<SerializableEvent> events,
+        ExpectedTagPositionSpecification? specification,
+        TagHeadWriter writer,
+        CancellationToken cancellationToken)
+    {
+        var serviceId = CurrentServiceId;
+        var keys = events
+            .SelectMany(@event => @event.Tags)
+            .Distinct(StringComparer.Ordinal)
+            .Select(tag => new TagHeadKey(serviceId, tag))
+            .OrderBy(key => key.ServiceId, StringComparer.Ordinal)
+            .ThenBy(key => key.Tag, StringComparer.Ordinal)
+            .ToArray();
+
+        if (specification is not null)
+        {
+            specification.ValidateEntryShapes(serviceId);
+            var presentTags = keys.Select(key => key.Tag).ToHashSet(StringComparer.Ordinal);
+            var unknown = specification.Entries.Select(entry => entry.Tag)
+                .Where(tag => !presentTags.Contains(tag))
+                .Order(StringComparer.Ordinal)
+                .ToArray();
+            if (unknown.Length > 0)
+            {
+                return ResultBox.Error<ExpectedTagPositionWriteResult>(
+                    new TagHeadExpectationValidationException(
+                        $"Expected tag-head entries are not present in this batch: {string.Join(", ", unknown)}."));
+            }
+        }
+
+        await using var transaction = await context.Database.BeginTransactionAsync(cancellationToken);
+        var created = new HashSet<TagHeadKey>();
+        var heads = new Dictionary<TagHeadKey, string?>();
+        var repairs = new List<TagHeadRepair>();
+        try
+        {
+            // Phase 1: lazy rows are inserted in the exact same ordinal ordering as later FOR UPDATE acquisition. Never
+            // let caller/event order reach the unique index first: reversed batches otherwise form a real 40P01 cycle.
+            await InvokeTagHeadProtocolHookAsync();
+            foreach (var key in keys)
+            {
+                var inserted = await ExecuteNonQueryAsync(
+                    context,
+                    transaction,
+                    "INSERT INTO dcb_tag_heads (\"ServiceId\", \"Tag\", \"HeadPosition\") " +
+                    "VALUES (@serviceId, @tag, NULL) ON CONFLICT (\"ServiceId\", \"Tag\") DO NOTHING",
+                    cancellationToken,
+                    Parameter("serviceId", key.ServiceId),
+                    Parameter("tag", key.Tag));
+                if (inserted == 1)
+                {
+                    created.Add(key);
+                }
+            }
+
+            // Phase 2: acquire every row in exactly the same canonical order. A newly inserted row is bootstraped from
+            // dcb_tags while this transaction owns its key; absence is only proven empty after the authoritative MAX.
+            foreach (var key in keys)
+            {
+                var head = await QueryNullableStringAsync(
+                    context,
+                    transaction,
+                    "SELECT \"HeadPosition\" FROM dcb_tag_heads " +
+                    "WHERE \"ServiceId\" = @serviceId AND \"Tag\" = @tag FOR UPDATE",
+                    cancellationToken,
+                    Parameter("serviceId", key.ServiceId),
+                    Parameter("tag", key.Tag));
+
+                if (created.Contains(key))
+                {
+                    var authoritativeMaximum = await QueryNullableStringAsync(
+                        context,
+                        transaction,
+                        "SELECT MAX(\"SortableUniqueId\") FROM dcb_tags " +
+                        "WHERE \"ServiceId\" = @serviceId AND \"Tag\" = @tag",
+                        cancellationToken,
+                        Parameter("serviceId", key.ServiceId),
+                        Parameter("tag", key.Tag));
+                    if (authoritativeMaximum is not null)
+                    {
+                        await UpdateHeadAsync(context, transaction, key, authoritativeMaximum, cancellationToken);
+                        head = authoritativeMaximum;
+                    }
+                    // A persisted null head is the explicit, transactionally proven-empty representation.
+                }
+
+                heads[key] = head;
+            }
+            await InvokeTagHeadProtocolHookAsync();
+
+            // Phase 3: reconciliation is always service-scoped. It observes only rows newer than this durable head and
+            // records / repairs them before expected-head comparison or command DML.
+            foreach (var key in keys)
+            {
+                var priorHead = heads[key];
+                var observedMaximum = await QueryNullableStringAsync(
+                    context,
+                    transaction,
+                    "SELECT MAX(\"SortableUniqueId\") FROM dcb_tags " +
+                    "WHERE \"ServiceId\" = @serviceId AND \"Tag\" = @tag " +
+                    "AND (@headPosition IS NULL OR \"SortableUniqueId\" > @headPosition)",
+                    cancellationToken,
+                    Parameter("serviceId", key.ServiceId),
+                    Parameter("tag", key.Tag),
+                    NullableTextParameter("headPosition", priorHead));
+                if (observedMaximum is null)
+                {
+                    continue;
+                }
+
+                await InsertViolationIdempotentlyAsync(
+                    context, transaction, key, priorHead, observedMaximum, writer, cancellationToken);
+                await UpdateHeadAsync(context, transaction, key, observedMaximum, cancellationToken);
+                heads[key] = observedMaximum;
+                repairs.Add(new TagHeadRepair(key, priorHead, observedMaximum));
+            }
+            await InvokeTagHeadProtocolHookAsync();
+
+            // Phase 4: ALL expectations compare after EVERY key has reconciled. A combined multi-tag conflict contains a
+            // complete pair set, never a first-failure subset.
+            if (specification is not null)
+            {
+                var pairs = specification.Entries
+                    .OrderBy(entry => entry.ServiceId, StringComparer.Ordinal)
+                    .ThenBy(entry => entry.Tag, StringComparer.Ordinal)
+                    .Select(entry => new TagHeadExpectedObserved(
+                        entry.ServiceId,
+                        entry.Tag,
+                        entry.Expectation,
+                        heads[new TagHeadKey(entry.ServiceId, entry.Tag)]))
+                    .ToArray();
+                var mismatched = pairs.Any(pair => !ExpectationMatches(pair.Expected, pair.ObservedPosition));
+                if (mismatched)
+                {
+                    var conflict = new ExpectedTagPositionConflictException(pairs);
+                    if (repairs.Count == 0)
+                    {
+                        // Ordinary stale/mismatch: no repair evidence exists, so all lazy rows and all mutation roll back.
+                        await transaction.RollbackAsync(cancellationToken);
+                        return ResultBox.Error<ExpectedTagPositionWriteResult>(conflict);
+                    }
+
+                    // Repair-only conflict: preserve ONLY repaired heads and their idempotent audit rows. In particular a
+                    // third unrelated lazy tag C cannot leak out of this transaction merely because tags A/B conflicted.
+                    foreach (var key in created.Where(key => repairs.All(repair => repair.Key != key)))
+                    {
+                        await ExecuteNonQueryAsync(
+                            context,
+                            transaction,
+                            "DELETE FROM dcb_tag_heads WHERE \"ServiceId\" = @serviceId AND \"Tag\" = @tag",
+                            cancellationToken,
+                            Parameter("serviceId", key.ServiceId),
+                            Parameter("tag", key.Tag));
+                    }
+                    await transaction.CommitAsync(cancellationToken);
+                    LogCommittedRepairs(repairs, writer);
+                    return ResultBox.Error<ExpectedTagPositionWriteResult>(conflict);
+                }
+
+                // The second half of the position rule depends on the locked/reconciled prior heads. It remains before
+                // event/tag DML and an invalid batch rolls every lazy/repair mutation back.
+                ValidatePositionsAgainstHeads(events, heads, serviceId);
+            }
+
+            // Phase 5: command DML is deliberately split so fault-injection tests can prove transaction atomicity from a
+            // fresh connection after event insertion, tag-index insertion, and head update respectively.
+            foreach (var @event in events)
+            {
+                context.Events.Add(ToDbEvent(@event, serviceId));
+            }
+            await context.SaveChangesAsync(cancellationToken);
+            await InvokeTagHeadProtocolHookAsync();
+
+            var tagWriteResults = new List<TagWriteResult>();
+            foreach (var @event in events)
+            {
+                foreach (var tagString in @event.Tags)
+                {
+                    var tagGroup = tagString.Contains(':') ? tagString.Split(':')[0] : tagString;
+                    context.Tags.Add(DbTag.FromEventTag(
+                        tagString,
+                        tagGroup,
+                        @event.SortableUniqueIdValue,
+                        @event.Id,
+                        @event.EventPayloadName,
+                        serviceId));
+                    tagWriteResults.Add(new TagWriteResult(tagString, 1, DateTimeOffset.UtcNow));
+                }
+            }
+            await context.SaveChangesAsync(cancellationToken);
+            await InvokeTagHeadProtocolHookAsync();
+
+            foreach (var (key, batchMaximum) in GetPerTagBatchMaximums(events, serviceId))
+            {
+                // Legacy writers deliberately perform no expectation comparison, but they still must never regress a
+                // durable head that an earlier canonical writer (or reconciliation) has already advanced. The protocol's
+                // success rule is max(reconciled head, this tag's batch maximum), not "last writer wins".
+                var reconciledHead = heads[key];
+                if (reconciledHead is null ||
+                    StringComparer.Ordinal.Compare(batchMaximum, reconciledHead) > 0)
+                {
+                    await UpdateHeadAsync(context, transaction, key, batchMaximum, cancellationToken);
+                    heads[key] = batchMaximum;
+                }
+            }
+            await InvokeTagHeadProtocolHookAsync();
+
+            await transaction.CommitAsync(cancellationToken);
+            LogCommittedRepairs(repairs, writer);
+            return ResultBox.FromValue(new ExpectedTagPositionWriteResult(events, tagWriteResults));
+        }
+        catch
+        {
+            // A disposed uncommitted Npgsql transaction rolls back too, but make the all-or-nothing boundary explicit for
+            // the injected partial-state tests and for a failure before the using scope unwinds.
+            if (transaction.GetDbTransaction().Connection is not null)
+            {
+                await transaction.RollbackAsync(CancellationToken.None);
+            }
+            throw;
+        }
+    }
+
+    private static DbEvent ToDbEvent(SerializableEvent @event, string serviceId) => new()
+    {
+        ServiceId = serviceId,
+        Id = @event.Id,
+        SortableUniqueId = @event.SortableUniqueIdValue,
+        EventType = @event.EventPayloadName,
+        Payload = Encoding.UTF8.GetString(@event.Payload),
+        Tags = JsonSerializer.Serialize(@event.Tags),
+        Timestamp = DateTime.UtcNow,
+        CausationId = @event.EventMetadata.CausationId,
+        CorrelationId = @event.EventMetadata.CorrelationId,
+        ExecutedUser = @event.EventMetadata.ExecutedUser
+    };
+
+    private static void ValidateStrictBatchOrder(IReadOnlyList<SerializableEvent> events)
+    {
+        for (var index = 1; index < events.Count; index++)
+        {
+            if (StringComparer.Ordinal.Compare(events[index - 1].SortableUniqueIdValue, events[index].SortableUniqueIdValue) >= 0)
+            {
+                throw new TagHeadPositionValidationException(
+                    "Expected-position batches must carry strictly increasing SortableUniqueId values in batch order.");
+            }
+        }
+    }
+
+    private static void ValidatePositionsAgainstHeads(
+        IReadOnlyList<SerializableEvent> events,
+        IReadOnlyDictionary<TagHeadKey, string?> heads,
+        string serviceId)
+    {
+        foreach (var @event in events)
+        {
+            foreach (var tag in @event.Tags)
+            {
+                var priorHead = heads[new TagHeadKey(serviceId, tag)];
+                if (priorHead is not null &&
+                    StringComparer.Ordinal.Compare(@event.SortableUniqueIdValue, priorHead) <= 0)
+                {
+                    throw new TagHeadPositionValidationException(
+                        $"Event position '{@event.SortableUniqueIdValue}' must exceed the reconciled head '{priorHead}' for tag '{tag}'.");
+                }
+            }
+        }
+    }
+
+    private static IEnumerable<KeyValuePair<TagHeadKey, string>> GetPerTagBatchMaximums(
+        IReadOnlyList<SerializableEvent> events,
+        string serviceId)
+    {
+        var maxima = new Dictionary<TagHeadKey, string>();
+        foreach (var @event in events)
+        {
+            foreach (var tag in @event.Tags)
+            {
+                var key = new TagHeadKey(serviceId, tag);
+                if (!maxima.TryGetValue(key, out var existing) ||
+                    StringComparer.Ordinal.Compare(@event.SortableUniqueIdValue, existing) > 0)
+                {
+                    maxima[key] = @event.SortableUniqueIdValue;
+                }
+            }
+        }
+        return maxima.OrderBy(pair => pair.Key.ServiceId, StringComparer.Ordinal)
+            .ThenBy(pair => pair.Key.Tag, StringComparer.Ordinal);
+    }
+
+    private static bool ExpectationMatches(TagHeadExpectation expected, string? observedPosition) => expected.Kind switch
+    {
+        TagHeadExpectationKind.NoEnforcement => true,
+        TagHeadExpectationKind.AssertEmpty => observedPosition is null,
+        TagHeadExpectationKind.Exact => StringComparer.Ordinal.Equals(expected.Position, observedPosition),
+        _ => false
+    };
+
+    private async Task InsertViolationIdempotentlyAsync(
+        SekibanDcbDbContext context,
+        Microsoft.EntityFrameworkCore.Storage.IDbContextTransaction transaction,
+        TagHeadKey key,
+        string? previousHead,
+        string observedPosition,
+        TagHeadWriter writer,
+        CancellationToken cancellationToken) =>
+        await ExecuteNonQueryAsync(
+            context,
+            transaction,
+            "INSERT INTO dcb_tag_head_violations (\"ServiceId\", \"Tag\", \"PreviousHeadWasEmpty\", " +
+            "\"PreviousHeadPosition\", \"ObservedPosition\", \"DetectedAtUtc\", \"DetectingWriter\") " +
+            "VALUES (@serviceId, @tag, @wasEmpty, @previous, @observed, @detectedAtUtc, @writer) " +
+            "ON CONFLICT (\"ServiceId\", \"Tag\", \"PreviousHeadWasEmpty\", \"PreviousHeadPosition\", \"ObservedPosition\") DO NOTHING",
+            cancellationToken,
+            Parameter("serviceId", key.ServiceId),
+            Parameter("tag", key.Tag),
+            Parameter("wasEmpty", previousHead is null),
+            Parameter("previous", previousHead ?? string.Empty),
+            Parameter("observed", observedPosition),
+            Parameter("detectedAtUtc", DateTime.UtcNow),
+            Parameter("writer", writer.ToString()));
+
+    private static Task UpdateHeadAsync(
+        SekibanDcbDbContext context,
+        Microsoft.EntityFrameworkCore.Storage.IDbContextTransaction transaction,
+        TagHeadKey key,
+        string? position,
+        CancellationToken cancellationToken) =>
+        ExecuteNonQueryAsync(
+            context,
+            transaction,
+            "UPDATE dcb_tag_heads SET \"HeadPosition\" = @position " +
+            "WHERE \"ServiceId\" = @serviceId AND \"Tag\" = @tag",
+            cancellationToken,
+            Parameter("position", position),
+            Parameter("serviceId", key.ServiceId),
+            Parameter("tag", key.Tag));
+
+    private static async Task<int> ExecuteNonQueryAsync(
+        SekibanDcbDbContext context,
+        Microsoft.EntityFrameworkCore.Storage.IDbContextTransaction transaction,
+        string commandText,
+        CancellationToken cancellationToken,
+        params NpgsqlParameter[] parameters)
+    {
+        await using var command = CreateCommand(context, transaction, commandText, parameters);
+        return await command.ExecuteNonQueryAsync(cancellationToken);
+    }
+
+    private static async Task<string?> QueryNullableStringAsync(
+        SekibanDcbDbContext context,
+        Microsoft.EntityFrameworkCore.Storage.IDbContextTransaction transaction,
+        string commandText,
+        CancellationToken cancellationToken,
+        params NpgsqlParameter[] parameters)
+    {
+        await using var command = CreateCommand(context, transaction, commandText, parameters);
+        var value = await command.ExecuteScalarAsync(cancellationToken);
+        return value is null or DBNull ? null : (string)value;
+    }
+
+    private static NpgsqlCommand CreateCommand(
+        SekibanDcbDbContext context,
+        Microsoft.EntityFrameworkCore.Storage.IDbContextTransaction transaction,
+        string commandText,
+        IReadOnlyCollection<NpgsqlParameter> parameters)
+    {
+        var connection = context.Database.GetDbConnection() as NpgsqlConnection
+            ?? throw new InvalidOperationException("PostgresEventStore requires an Npgsql connection.");
+        var npgsqlTransaction = transaction.GetDbTransaction() as NpgsqlTransaction
+            ?? throw new InvalidOperationException("PostgresEventStore requires an Npgsql transaction.");
+        var command = new NpgsqlCommand(commandText, connection, npgsqlTransaction);
+        foreach (var parameter in parameters)
+        {
+            command.Parameters.Add(parameter);
+        }
+        return command;
+    }
+
+    private static NpgsqlParameter Parameter(string name, object? value) => new(name, value ?? DBNull.Value);
+
+    // PostgreSQL cannot infer a parameter type when a null is used both in an IS NULL predicate and a comparison. The
+    // head is always text, so make the DML-only runtime query explicit rather than adding any catch-and-create fallback.
+    private static NpgsqlParameter NullableTextParameter(string name, string? value) =>
+        new(name, NpgsqlDbType.Text) { Value = value is null ? DBNull.Value : value };
+
+    private Task InvokeTagHeadProtocolHookAsync() =>
+        TagHeadProtocolHook?.Invoke() ?? Task.CompletedTask;
+
+    private void LogCommittedRepairs(IEnumerable<TagHeadRepair> repairs, TagHeadWriter writer)
+    {
+        foreach (var repair in repairs)
+        {
+            // Intentionally after CommitAsync only: a log entry means the append-only violation record and repair are
+            // durable together, never a false alarm from an aborted transaction.
+            _logger.LogWarning(
+                "Postgres tag-head reconciliation violation committed for {ServiceId}/{Tag}: {PreviousHead} -> {ObservedHead} by {Writer}",
+                repair.Key.ServiceId,
+                repair.Key.Tag,
+                repair.PreviousHead ?? "<proven-empty>",
+                repair.ObservedHead,
+                writer.ToString());
+        }
+    }
+
+    private enum TagHeadWriter
+    {
+        TypedBatch,
+        SerializedBatch,
+        ConditionalClaim,
+        ExpectedPositionBatch
+    }
+
+    private readonly record struct TagHeadKey(string ServiceId, string Tag);
+    private readonly record struct TagHeadRepair(TagHeadKey Key, string? PreviousHead, string ObservedHead);
+
     // Note: Tag state is not stored in the database
     // Tags table only tracks tag-to-event relationships
     // Tag state should be computed by projectors when needed
-
-    private string SerializeEventPayload(IEventPayload payload) =>
-        _eventTypes.SerializeEventPayload(payload);
 
     private ResultBox<IEventPayload> DeserializeEventPayload(string eventType, string json)
     {

--- a/dcb/src/Sekiban.Dcb.Postgres/PostgresEventStoreFactory.cs
+++ b/dcb/src/Sekiban.Dcb.Postgres/PostgresEventStoreFactory.cs
@@ -17,10 +17,12 @@ public sealed class PostgresEventStoreFactory : IEventStoreFactory, IStorageDura
     public StorageDurabilityDescriptor DescribeStorage() =>
         new(StorageDurability.Durable, "Postgres (per-service factory)");
 
-    /// <summary>Every store this factory builds is a conditional (single-event unique-key) store.</summary>
+    /// <summary>Every store this factory builds supports the PostgreSQL conditional and durable expected-head protocols.</summary>
     public WriteConditionCapabilityDescriptor DescribeWriteConditions() =>
         WriteConditionCapabilityDescriptor.Supporting(
-            "Postgres (per-service factory)", WriteConditionKind.SingleEventUniqueKey);
+            "Postgres (per-service factory)",
+            WriteConditionKind.SingleEventUniqueKey,
+            WriteConditionKind.ExpectedTagPosition);
 
     private readonly IDbContextFactory<SekibanDcbDbContext> _contextFactory;
     private readonly IEventTypes _eventTypes;

--- a/dcb/src/Sekiban.Dcb.Postgres/SekibanDcbDbContext.cs
+++ b/dcb/src/Sekiban.Dcb.Postgres/SekibanDcbDbContext.cs
@@ -7,6 +7,9 @@ public class SekibanDcbDbContext : DbContext
     public DbSet<DbEvent> Events { get; set; } = default!;
     public DbSet<DbTag> Tags { get; set; } = default!;
     public DbSet<DbMultiProjectionState> MultiProjectionStates { get; set; } = default!;
+    public DbSet<DbTagHead> TagHeads { get; set; } = default!;
+    public DbSet<DbTagHeadViolation> TagHeadViolations { get; set; } = default!;
+    public DbSet<DbTagHeadEnablementEpoch> TagHeadEnablementEpochs { get; set; } = default!;
 
     public SekibanDcbDbContext(DbContextOptions<SekibanDcbDbContext> options) : base(options)
     {
@@ -87,6 +90,52 @@ public class SekibanDcbDbContext : DbContext
                 "(\"IsOffloaded\" = false AND \"StateData\" IS NOT NULL) OR (\"IsOffloaded\" = true AND \"OffloadKey\" IS NOT NULL)"));
 
             entity.Property(s => s.ServiceId).IsRequired().HasMaxLength(64);
+        });
+
+        // SEK-G40 durable tag-head fence tables. Runtime paths only issue DML against these provisioned tables; migration
+        // is the sole DDL owner.
+        modelBuilder.Entity<DbTagHead>(entity =>
+        {
+            entity.ToTable("dcb_tag_heads", table => table.HasCheckConstraint(
+                "CK_TagHeads_Position_NotEmpty",
+                "\"HeadPosition\" IS NULL OR length(\"HeadPosition\") > 0"));
+            entity.HasKey(head => new { head.ServiceId, head.Tag });
+            entity.Property(head => head.ServiceId).IsRequired().HasMaxLength(64);
+            entity.Property(head => head.Tag).IsRequired();
+            entity.Property(head => head.HeadPosition).HasMaxLength(100);
+        });
+
+        modelBuilder.Entity<DbTagHeadViolation>(entity =>
+        {
+            entity.ToTable("dcb_tag_head_violations", table => table.HasCheckConstraint(
+                "CK_TagHeadViolations_Observed_NotEmpty",
+                "length(\"ObservedPosition\") > 0"));
+            entity.HasKey(violation => violation.Id);
+            entity.Property(violation => violation.ServiceId).IsRequired().HasMaxLength(64);
+            entity.Property(violation => violation.PreviousHeadPosition).IsRequired().HasMaxLength(100);
+            entity.Property(violation => violation.ObservedPosition).IsRequired().HasMaxLength(100);
+            entity.Property(violation => violation.DetectingWriter).IsRequired().HasMaxLength(128);
+            entity.HasIndex(violation => new { violation.ServiceId, violation.Tag, violation.DetectedAtUtc })
+                .HasDatabaseName("IX_TagHeadViolations_Service_Tag_Detected");
+            // The prior-empty boolean gives Postgres a non-null durable identity component, so retries cannot create
+            // duplicate audit records merely because a nullable unique-index component compares distinct.
+            entity.HasIndex(violation => new
+                {
+                    violation.ServiceId,
+                    violation.Tag,
+                    violation.PreviousHeadWasEmpty,
+                    violation.PreviousHeadPosition,
+                    violation.ObservedPosition
+                })
+                .IsUnique()
+                .HasDatabaseName("UX_TagHeadViolations_IdempotentRepair");
+        });
+
+        modelBuilder.Entity<DbTagHeadEnablementEpoch>(entity =>
+        {
+            entity.ToTable("dcb_tag_head_enablement_epochs");
+            entity.HasKey(epoch => epoch.ServiceId);
+            entity.Property(epoch => epoch.ServiceId).IsRequired().HasMaxLength(64);
         });
     }
 }

--- a/dcb/src/Sekiban.Dcb.WithResult/Actors/GeneralSekibanExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.WithResult/Actors/GeneralSekibanExecutor.cs
@@ -16,7 +16,7 @@ namespace Sekiban.Dcb.Actors;
 ///     This implementation uses ResultBox for all error handling
 /// </summary>
 public class GeneralSekibanExecutor : ISekibanExecutor, ISerializedSekibanDcbExecutor, IExecutorRuntimeDescriptorProvider,
-    IConditionalCommandExecutor, ISerializedConditionalSekibanDcbExecutor
+    IConditionalCommandExecutor, ISerializedConditionalSekibanDcbExecutor, ISerializedExpectedTagPositionSekibanDcbExecutor
 {
     private readonly CoreGeneralSekibanExecutor _core;
     private readonly IActorObjectAccessor _actorAccessor;
@@ -188,6 +188,12 @@ public class GeneralSekibanExecutor : ISekibanExecutor, ISerializedSekibanDcbExe
         SerializedCommitRequest request,
         CancellationToken cancellationToken = default) =>
         _core.CommitSerializableEventsAsync(request, cancellationToken);
+
+    /// <summary>Opt-in V2 serialized commit with PostgreSQL's durable expected-tag-position protocol.</summary>
+    public Task<ResultBox<SerializedCommitResult>> CommitSerializableEventsWithExpectedTagPositionsAsync(
+        VersionedExpectedTagPositionSerializedCommitRequest request,
+        CancellationToken cancellationToken = default) =>
+        _core.CommitSerializableEventsWithExpectedTagPositionsAsync(request, cancellationToken);
 
     /// <summary>Opt-in: execute a self-handling command with conditional (unique-key) append options.</summary>
     public Task<ResultBox<ExecutionResult>> ExecuteAsync<TCommand>(

--- a/dcb/src/Sekiban.Dcb.WithResult/Commands/IConditionalCommandExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.WithResult/Commands/IConditionalCommandExecutor.cs
@@ -4,7 +4,8 @@ namespace Sekiban.Dcb.Commands;
 
 /// <summary>
 ///     OPTIONAL, additive executor capability (ResultBox facade) for command execution with
-///     <see cref="CommandExecutionOptions" /> — currently, conditional (unique-key) single-event append. Separate from
+///     <see cref="CommandExecutionOptions" /> — conditional (unique-key) single-event append and/or the additive
+///     PostgreSQL expected-tag-position protocol. Separate from
 ///     <see cref="ICommandExecutor" />/<c>ISekibanExecutor</c> so existing implementors compile untouched; feature-detect
 ///     with <c>is IConditionalCommandExecutor</c>. The existing <c>ExecuteAsync</c> overloads are unchanged and keep
 ///     default (unconditional) behaviour.

--- a/dcb/src/Sekiban.Dcb.WithoutResult/Actors/GeneralSekibanExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.WithoutResult/Actors/GeneralSekibanExecutor.cs
@@ -17,7 +17,7 @@ namespace Sekiban.Dcb.Actors;
 ///     This implementation uses exceptions for all error handling
 /// </summary>
 public class GeneralSekibanExecutor : ISekibanExecutor, ISerializedSekibanDcbExecutor, IExecutorRuntimeDescriptorProvider,
-    IConditionalCommandExecutor, ISerializedConditionalSekibanDcbExecutor
+    IConditionalCommandExecutor, ISerializedConditionalSekibanDcbExecutor, ISerializedExpectedTagPositionSekibanDcbExecutor
 {
     private readonly CoreGeneralSekibanExecutor _core;
     private readonly IActorObjectAccessor _actorAccessor;
@@ -239,6 +239,12 @@ public class GeneralSekibanExecutor : ISekibanExecutor, ISerializedSekibanDcbExe
         SerializedCommitRequest request,
         CancellationToken cancellationToken = default) =>
         _core.CommitSerializableEventsAsync(request, cancellationToken);
+
+    /// <summary>Opt-in V2 serialized commit with PostgreSQL's durable expected-tag-position protocol.</summary>
+    public Task<ResultBox<SerializedCommitResult>> CommitSerializableEventsWithExpectedTagPositionsAsync(
+        VersionedExpectedTagPositionSerializedCommitRequest request,
+        CancellationToken cancellationToken = default) =>
+        _core.CommitSerializableEventsWithExpectedTagPositionsAsync(request, cancellationToken);
 
     /// <summary>Opt-in: execute a self-handling command with conditional (unique-key) append options.</summary>
     public async Task<ExecutionResult> ExecuteAsync<TCommand>(

--- a/dcb/src/Sekiban.Dcb.WithoutResult/Commands/IConditionalCommandExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.WithoutResult/Commands/IConditionalCommandExecutor.cs
@@ -3,7 +3,8 @@ namespace Sekiban.Dcb.Commands;
 
 /// <summary>
 ///     OPTIONAL, additive executor capability (exception-throwing facade) for command execution with
-///     <see cref="CommandExecutionOptions" /> — currently, conditional (unique-key) single-event append. Separate from
+///     <see cref="CommandExecutionOptions" /> — conditional (unique-key) single-event append and/or the additive
+///     PostgreSQL expected-tag-position protocol. Separate from
 ///     <see cref="ICommandExecutor" />/<c>ISekibanExecutor</c> so existing implementors compile untouched; feature-detect
 ///     with <c>is IConditionalCommandExecutor</c>. A typed failure (KeyReuseConflict / ConditionNotSupported) is thrown
 ///     through the guarded boundary, preserving the original exception.

--- a/dcb/tests/Sekiban.Dcb.Postgres.Tests/ConditionalAppend/PostgresSeamArchitectureTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Postgres.Tests/ConditionalAppend/PostgresSeamArchitectureTests.cs
@@ -17,6 +17,7 @@ public class PostgresSeamArchitectureTests
     private static readonly Type StoreType = typeof(PostgresEventStore);
     private static readonly Assembly PostgresAssembly = StoreType.Assembly;
     private const string HookName = "AfterConditionalCommitHook";
+    private const string TagHeadHookName = "TagHeadProtocolHook";
 
     // Authoritative assemblies resolved to the ones this project owns for scanning; only Postgres is owned here.
     private static Assembly? ResolveOwnedAssembly(string name) =>
@@ -43,27 +44,33 @@ public class PostgresSeamArchitectureTests
     }
 
     [Fact]
-    public void SeamInventory_ListsThePostgresHook_ResolvingToARealSettableProperty()
+    public void SeamInventory_ListsThePostgresHooks_ResolvingToRealSettableProperties()
     {
-        var entry = Assert.Single(SeamInventory.Entries.Where(e => e.AssemblyName == SeamInventory.PostgresAssembly));
-        Assert.Equal("Sekiban.Dcb.Postgres.PostgresEventStore", entry.DeclaringTypeFullName);
-        Assert.Equal(HookName, entry.PropertyName);
-
-        var type = PostgresAssembly.GetType(entry.DeclaringTypeFullName);
-        Assert.NotNull(type);
-        var prop = type!.GetProperty(entry.PropertyName,
-            BindingFlags.Instance | BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public);
-        Assert.NotNull(prop);
-        Assert.True(prop!.CanWrite, "The Postgres seam must be settable.");
-        Assert.NotNull(SeamWriteScanner.ResolveBackingField(prop)); // positive: the exact backing field is resolvable
+        var entries = SeamInventory.Entries.Where(e => e.AssemblyName == SeamInventory.PostgresAssembly)
+            .OrderBy(e => e.PropertyName, StringComparer.Ordinal).ToArray();
+        Assert.Equal(new[] { HookName, TagHeadHookName }, entries.Select(e => e.PropertyName).ToArray());
+        foreach (var entry in entries)
+        {
+            Assert.Equal("Sekiban.Dcb.Postgres.PostgresEventStore", entry.DeclaringTypeFullName);
+            var type = PostgresAssembly.GetType(entry.DeclaringTypeFullName);
+            Assert.NotNull(type);
+            var prop = type!.GetProperty(entry.PropertyName,
+                BindingFlags.Instance | BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public);
+            Assert.NotNull(prop);
+            Assert.True(prop!.CanWrite, "The Postgres seam must be settable.");
+            Assert.NotNull(SeamWriteScanner.ResolveBackingField(prop)); // positive: exact backing field is resolvable
+        }
     }
 
     [Fact]
     public void Hook_IsNonPublic_Instance_NotStatic()
     {
         Assert.NotNull(StoreType.GetProperty(HookName, BindingFlags.Instance | BindingFlags.NonPublic));
+        Assert.NotNull(StoreType.GetProperty(TagHeadHookName, BindingFlags.Instance | BindingFlags.NonPublic));
         Assert.Null(StoreType.GetProperty(HookName, BindingFlags.Instance | BindingFlags.Public));
+        Assert.Null(StoreType.GetProperty(TagHeadHookName, BindingFlags.Instance | BindingFlags.Public));
         Assert.Null(StoreType.GetProperty(HookName, BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic));
+        Assert.Null(StoreType.GetProperty(TagHeadHookName, BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic));
     }
 
     [Fact]
@@ -72,6 +79,7 @@ public class PostgresSeamArchitectureTests
         foreach (var contract in new[] { typeof(IEventStore), typeof(IConditionalEventStore), typeof(IHotEventStore) })
         {
             Assert.Null(contract.GetProperty(HookName));
+            Assert.Null(contract.GetProperty(TagHeadHookName));
         }
     }
 

--- a/dcb/tests/Sekiban.Dcb.Postgres.Tests/PostgresTagHeadCasTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Postgres.Tests/PostgresTagHeadCasTests.cs
@@ -1,0 +1,844 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Npgsql;
+using ResultBoxes;
+using Dcb.Domain.Student;
+using Sekiban.Dcb.Actors;
+using Sekiban.Dcb.Commands;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.Postgres.DbModels;
+using Sekiban.Dcb.ServiceId;
+using Sekiban.Dcb.Storage;
+using Sekiban.Dcb.Tags;
+using Sekiban.Dcb.Testing;
+using Xunit;
+
+namespace Sekiban.Dcb.Postgres.Tests;
+
+/// <summary>
+///     Real-PostgreSQL acceptance evidence for SEK-G40's durable expected-tag-position protocol. These tests inspect
+///     provisioned rows through fresh DbContexts; they never replace the production head collection/locking protocol with
+///     a test-owned dictionary or lock.
+/// </summary>
+public sealed class PostgresTagHeadCasTests : PostgresTestBase
+{
+    private const string DefaultService = DefaultServiceIdProvider.DefaultServiceId;
+
+    public PostgresTagHeadCasTests(PostgresTestFixture fixture) : base(fixture) { }
+
+    private PostgresEventStore Store(string serviceId = DefaultService) =>
+        new(Fixture.DbContextFactory, Fixture.DomainTypes.EventTypes, new FixedServiceIdProvider(serviceId));
+
+    private static SerializableEvent EventAt(string position, params string[] tags) => new(
+        "{}"u8.ToArray(),
+        position,
+        Guid.CreateVersion7(),
+        new EventMetadata("cause", "correlation", "g40-test"),
+        tags.ToList(),
+        "G40Marker");
+
+    private static ExpectedTagPositionSpecification Spec(
+        string serviceId,
+        params (string Tag, TagHeadExpectation Expected)[] entries) =>
+        new(entries.Select(entry => new TagHeadExpectationEntry(serviceId, entry.Tag, entry.Expected)).ToArray());
+
+    private async Task EnableEpochAsync(string serviceId = DefaultService)
+    {
+        await using var context = await Fixture.GetDbContextAsync();
+        context.TagHeadEnablementEpochs.Add(new DbTagHeadEnablementEpoch
+        {
+            ServiceId = serviceId,
+            EnabledAtUtc = DateTime.UtcNow
+        });
+        await context.SaveChangesAsync();
+    }
+
+    private async Task<DbTagHead?> HeadAsync(string tag, string serviceId = DefaultService)
+    {
+        await using var context = await Fixture.GetDbContextAsync();
+        return await context.TagHeads.AsNoTracking()
+            .SingleOrDefaultAsync(row => row.ServiceId == serviceId && row.Tag == tag);
+    }
+
+    [Fact]
+    public async Task ThreeStates_EpochGate_NoEnforcementAndExactAdvanceTheRealDurableHead()
+    {
+        const string tag = "Order:three-state";
+        var store = Store();
+
+        // NoEnforcement is still a full head-protocol write even before the operator turns on enforcement.
+        var noEnforcement = await store.WriteSerializableEventsWithExpectedTagPositionsAsync(
+            [EventAt("0001", tag)],
+            Spec(DefaultService, (tag, TagHeadExpectation.NoEnforcement())));
+        Assert.True(noEnforcement.IsSuccess, noEnforcement.IsSuccess ? "" : noEnforcement.GetException().ToString());
+        Assert.Equal("0001", (await HeadAsync(tag))!.HeadPosition);
+
+        // Exact is a durable fence and must fail before its provider write / head advance while the epoch is unset.
+        var beforeEpoch = await store.WriteSerializableEventsWithExpectedTagPositionsAsync(
+            [EventAt("0002", tag)],
+            Spec(DefaultService, (tag, TagHeadExpectation.Exact("0001"))));
+        Assert.False(beforeEpoch.IsSuccess);
+        Assert.IsType<TagHeadEnforcementNotEnabledException>(beforeEpoch.GetException());
+        Assert.Equal("0001", (await HeadAsync(tag))!.HeadPosition);
+        await using (var inspection = await Fixture.GetDbContextAsync())
+        {
+            Assert.Single(await inspection.Events.AsNoTracking().ToListAsync());
+        }
+
+        await EnableEpochAsync();
+        var exact = await store.WriteSerializableEventsWithExpectedTagPositionsAsync(
+            [EventAt("0002", tag)],
+            Spec(DefaultService, (tag, TagHeadExpectation.Exact("0001"))));
+        Assert.True(exact.IsSuccess, exact.IsSuccess ? "" : exact.GetException().ToString());
+        Assert.Equal("0002", (await HeadAsync(tag))!.HeadPosition);
+    }
+
+    [Fact]
+    public async Task VersionedSerializedV2_RealExecutorAndPostgresPath_UsesTheSameExpectedHeadProtocol()
+    {
+        var studentId = Guid.CreateVersion7();
+        var tag = new StudentTag(studentId).GetTag();
+        await EnableEpochAsync();
+        var store = Store();
+        var executor = new GeneralSekibanExecutor(
+            store,
+            new InMemoryObjectAccessor(store, Fixture.DomainTypes),
+            Fixture.DomainTypes);
+        var payload = Fixture.DomainTypes.EventTypes.SerializeEventPayload(new StudentCreated(studentId, "v2"));
+        var request = new VersionedExpectedTagPositionSerializedCommitRequest(
+            VersionedExpectedTagPositionSerializedCommitRequest.CurrentVersion,
+            [new SerializableEventCandidate(System.Text.Encoding.UTF8.GetBytes(payload), nameof(StudentCreated), [tag])],
+            [new ConsistencyTagEntry(tag, string.Empty)],
+            [new TagHeadExpectationEntry(DefaultService, tag, TagHeadExpectation.AssertEmpty())]);
+
+        var result = await executor.CommitSerializableEventsWithExpectedTagPositionsAsync(request);
+
+        Assert.True(result.IsSuccess, result.IsSuccess ? "" : result.GetException().ToString());
+        var written = Assert.Single(result.GetValue().WrittenEvents);
+        Assert.Equal(written.SortableUniqueIdValue, (await HeadAsync(tag))!.HeadPosition);
+    }
+
+    [Fact]
+    public async Task WithResultCommandOptions_ActualPostgresPath_DerivesTheConsistencyTagAndUsesAssertEmptyThenExact()
+    {
+        var studentId = Guid.CreateVersion7();
+        var tag = new StudentTag(studentId).GetTag();
+        await EnableEpochAsync();
+        var store = Store();
+        var executor = new GeneralSekibanExecutor(
+            store,
+            new InMemoryObjectAccessor(store, Fixture.DomainTypes),
+            Fixture.DomainTypes);
+
+        var first = await executor.ExecuteAsync(
+            new TagHeadTestCommand(),
+            (_, context) => context.AppendEvent(new StudentCreated(studentId, "ordinary-v2"), new StudentTag(studentId)),
+            new CommandExecutionOptions
+            {
+                ExpectedTagPositions = Spec(DefaultService, (tag, TagHeadExpectation.AssertEmpty()))
+            });
+        Assert.True(first.IsSuccess, first.IsSuccess ? "" : first.GetException().ToString());
+        var firstPosition = first.GetValue().SortableUniqueId
+            ?? throw new InvalidOperationException("Successful command execution did not return a sortable position.");
+        Assert.Equal(firstPosition, (await HeadAsync(tag))!.HeadPosition);
+
+        var second = await executor.ExecuteAsync(
+            new TagHeadTestCommand(),
+            (_, context) => context.AppendEvent(new StudentCreated(studentId, "ordinary-v2-next"), new StudentTag(studentId)),
+            new CommandExecutionOptions
+            {
+                ExpectedTagPositions = Spec(DefaultService, (tag, TagHeadExpectation.Exact(firstPosition)))
+            });
+        Assert.True(second.IsSuccess, second.IsSuccess ? "" : second.GetException().ToString());
+        Assert.Equal(second.GetValue().SortableUniqueId, (await HeadAsync(tag))!.HeadPosition);
+    }
+
+    [Fact]
+    public async Task DerivedExpectationEntries_MissingDuplicateUnknownMalformedAndServiceMismatch_FailBeforeStoreMutation()
+    {
+        var firstId = Guid.CreateVersion7();
+        var secondId = Guid.CreateVersion7();
+        var firstTag = new StudentTag(firstId).GetTag();
+        var secondTag = new StudentTag(secondId).GetTag();
+        var store = Store();
+        var executor = new GeneralSekibanExecutor(
+            store,
+            new InMemoryObjectAccessor(store, Fixture.DomainTypes),
+            Fixture.DomainTypes);
+
+        async Task<(ResultBox<ExecutionResult> Result, bool HandlerInvoked)> ExecuteInvalidAsync(
+            ExpectedTagPositionSpecification specification)
+        {
+            var handlerInvoked = false;
+            var result = await executor.ExecuteAsync(
+                new TagHeadTestCommand(),
+                (_, context) =>
+                {
+                    handlerInvoked = true;
+                    return context.AppendEvent(
+                        new StudentCreated(firstId, "invalid-spec"),
+                        new StudentTag(firstId),
+                        new StudentTag(secondId));
+                },
+                new CommandExecutionOptions { ExpectedTagPositions = specification });
+            return (result, handlerInvoked);
+        }
+
+        var missing = await ExecuteInvalidAsync(Spec(DefaultService, (firstTag, TagHeadExpectation.NoEnforcement())));
+        Assert.False(missing.Result.IsSuccess);
+        Assert.IsType<TagHeadExpectationValidationException>(missing.Result.GetException());
+        Assert.True(missing.HandlerInvoked); // exact derived-tag validation occurs after the handler, still before a write
+
+        var duplicate = await ExecuteInvalidAsync(Spec(DefaultService,
+            (firstTag, TagHeadExpectation.NoEnforcement()),
+            (firstTag, TagHeadExpectation.NoEnforcement()),
+            (secondTag, TagHeadExpectation.NoEnforcement())));
+        Assert.False(duplicate.Result.IsSuccess);
+        Assert.IsType<TagHeadExpectationValidationException>(duplicate.Result.GetException());
+        Assert.False(duplicate.HandlerInvoked);
+
+        var unknown = await ExecuteInvalidAsync(Spec(DefaultService,
+            (firstTag, TagHeadExpectation.NoEnforcement()),
+            (secondTag, TagHeadExpectation.NoEnforcement()),
+            ("Student:unknown", TagHeadExpectation.NoEnforcement())));
+        Assert.False(unknown.Result.IsSuccess);
+        Assert.IsType<TagHeadExpectationValidationException>(unknown.Result.GetException());
+        Assert.True(unknown.HandlerInvoked);
+
+        var malformed = await ExecuteInvalidAsync(Spec(DefaultService,
+            (firstTag, new TagHeadExpectation(TagHeadExpectationKind.Exact)),
+            (secondTag, TagHeadExpectation.NoEnforcement())));
+        Assert.False(malformed.Result.IsSuccess);
+        Assert.IsType<TagHeadExpectationValidationException>(malformed.Result.GetException());
+        Assert.False(malformed.HandlerInvoked);
+
+        var wrongService = await ExecuteInvalidAsync(new ExpectedTagPositionSpecification(
+            [
+                new TagHeadExpectationEntry("other-service", firstTag, TagHeadExpectation.NoEnforcement()),
+                new TagHeadExpectationEntry(DefaultService, secondTag, TagHeadExpectation.NoEnforcement())
+            ]));
+        Assert.False(wrongService.Result.IsSuccess);
+        Assert.IsType<TagHeadExpectationValidationException>(wrongService.Result.GetException());
+        Assert.False(wrongService.HandlerInvoked);
+
+        await using var inspection = await Fixture.GetDbContextAsync();
+        Assert.Empty(await inspection.Events.AsNoTracking().ToListAsync());
+        Assert.Empty(await inspection.Tags.AsNoTracking().ToListAsync());
+        Assert.Empty(await inspection.TagHeads.AsNoTracking().ToListAsync());
+    }
+
+    [Fact]
+    public async Task Bootstrap_ExistingAuthoritativeTagHistoryIsNotMistakenForAssertEmpty()
+    {
+        const string historicalTag = "Order:historical";
+        const string emptyTag = "Order:proven-empty";
+        var store = Store();
+
+        // Simulate years of pre-epoch dcb_tags history: remove its protocol row after a legacy writer populated dcb_tags.
+        Assert.True((await store.WriteSerializableEventsAsync([EventAt("0010", historicalTag)])).IsSuccess);
+        await using (var prepare = await Fixture.GetDbContextAsync())
+        {
+            await prepare.Database.ExecuteSqlRawAsync(
+                "DELETE FROM dcb_tag_heads WHERE \"ServiceId\" = {0} AND \"Tag\" = {1}", DefaultService, historicalTag);
+        }
+        await EnableEpochAsync();
+
+        var staleEmpty = await store.WriteSerializableEventsWithExpectedTagPositionsAsync(
+            [EventAt("0020", historicalTag)],
+            Spec(DefaultService, (historicalTag, TagHeadExpectation.AssertEmpty())));
+        Assert.False(staleEmpty.IsSuccess);
+        var conflict = Assert.IsType<ExpectedTagPositionConflictException>(staleEmpty.GetException());
+        var pair = Assert.Single(conflict.Pairs);
+        Assert.Equal("0010", pair.ObservedPosition); // authoritative dcb_tags MAX, not absent=head-empty
+        Assert.Null(await HeadAsync(historicalTag)); // ordinary mismatch rolls back its lazy bootstrap row too
+
+        var provenEmpty = await store.WriteSerializableEventsWithExpectedTagPositionsAsync(
+            [EventAt("0030", emptyTag)],
+            Spec(DefaultService, (emptyTag, TagHeadExpectation.AssertEmpty())));
+        Assert.True(provenEmpty.IsSuccess, provenEmpty.IsSuccess ? "" : provenEmpty.GetException().ToString());
+        Assert.Equal("0030", (await HeadAsync(emptyTag))!.HeadPosition);
+    }
+
+    [Fact]
+    public async Task Reconciliation_IsServiceScoped_AndCombinedRepairMismatchLeavesOnlyRepairDurable()
+    {
+        const string a = "Order:A";
+        const string b = "Order:B";
+        const string c = "Order:C-lazy";
+        var store = Store();
+        await EnableEpochAsync();
+
+        await using (var setup = await Fixture.GetDbContextAsync())
+        {
+            setup.TagHeads.AddRange(
+                new DbTagHead { ServiceId = DefaultService, Tag = a, HeadPosition = "0010" },
+                new DbTagHead { ServiceId = DefaultService, Tag = b, HeadPosition = "0020" });
+            // A old/non-participating writer bypassed the head. It is reconciliation evidence, not current command DML.
+            setup.Tags.Add(DbTag.FromEventTag(a, "Order", "0015", Guid.CreateVersion7(), "Bypass", DefaultService));
+            // Cross-service same textual tag has a much larger position and must not repair/default-service-audit anything.
+            setup.Tags.Add(DbTag.FromEventTag(a, "Order", "9999", Guid.CreateVersion7(), "OtherService", "other"));
+            await setup.SaveChangesAsync();
+        }
+
+        var outcome = await store.WriteSerializableEventsWithExpectedTagPositionsAsync(
+            [EventAt("0030", a, b, c)],
+            Spec(DefaultService,
+                (a, TagHeadExpectation.Exact("0010")),
+                (b, TagHeadExpectation.Exact("wrong")),
+                (c, TagHeadExpectation.NoEnforcement())));
+
+        Assert.False(outcome.IsSuccess);
+        var conflict = Assert.IsType<ExpectedTagPositionConflictException>(outcome.GetException());
+        Assert.Equal(new[] { a, b, c }, conflict.Pairs.Select(pair => pair.Tag).ToArray()); // complete combined set
+        Assert.Equal("0015", conflict.Pairs.Single(pair => pair.Tag == a).ObservedPosition);
+        Assert.Equal("0020", conflict.Pairs.Single(pair => pair.Tag == b).ObservedPosition);
+        Assert.Null(conflict.Pairs.Single(pair => pair.Tag == c).ObservedPosition);
+
+        // Fresh-connection inspection: repair/audit A commits; B is unchanged; lazy C and all current command rows vanish.
+        Assert.Equal("0015", (await HeadAsync(a))!.HeadPosition);
+        Assert.Equal("0020", (await HeadAsync(b))!.HeadPosition);
+        Assert.Null(await HeadAsync(c));
+        await using var inspection = await Fixture.GetDbContextAsync();
+        Assert.Equal(2, await inspection.Tags.AsNoTracking().CountAsync()); // setup A + cross-service control, no command tag
+        Assert.Empty(await inspection.Events.AsNoTracking().ToListAsync());
+        var violation = Assert.Single(await inspection.TagHeadViolations.AsNoTracking().ToListAsync());
+        Assert.Equal(DefaultService, violation.ServiceId);
+        Assert.Equal(a, violation.Tag);
+        Assert.Equal("0010", violation.PreviousHeadPosition);
+        Assert.Equal("0015", violation.ObservedPosition);
+    }
+
+    [Fact]
+    public async Task CrossServiceSameTagHigherPosition_IsNeitherViolationNorRepair()
+    {
+        const string service = "alpha";
+        const string tag = "Order:shared";
+        await EnableEpochAsync(service);
+        await using (var setup = await Fixture.GetDbContextAsync())
+        {
+            setup.TagHeads.Add(new DbTagHead { ServiceId = service, Tag = tag, HeadPosition = "0010" });
+            setup.Tags.Add(DbTag.FromEventTag(tag, "Order", "9999", Guid.CreateVersion7(), "Other", "beta"));
+            await setup.SaveChangesAsync();
+        }
+
+        var result = await Store(service).WriteSerializableEventsWithExpectedTagPositionsAsync(
+            [EventAt("0020", tag)],
+            Spec(service, (tag, TagHeadExpectation.Exact("0010"))));
+        Assert.True(result.IsSuccess, result.IsSuccess ? "" : result.GetException().ToString());
+        Assert.Equal("0020", (await HeadAsync(tag, service))!.HeadPosition);
+        await using var inspection = await Fixture.GetDbContextAsync();
+        Assert.Empty(await inspection.TagHeadViolations.AsNoTracking().Where(v => v.ServiceId == service).ToListAsync());
+    }
+
+    [Theory]
+    [InlineData("Order:reconcile-below-batch", "0200")]
+    [InlineData("Order:reconcile-inside-batch", "0350")]
+    [InlineData("Order:reconcile-above-batch", "0500")]
+    public async Task Reconciliation_DetectsAuthoritativeBypassMaximaAcrossTheWholeBatchRange(
+        string tag,
+        string bypassMaximum)
+    {
+        await EnableEpochAsync();
+        await using (var setup = await Fixture.GetDbContextAsync())
+        {
+            setup.TagHeads.Add(new DbTagHead { ServiceId = DefaultService, Tag = tag, HeadPosition = "0100" });
+            setup.Tags.Add(DbTag.FromEventTag(
+                tag, "Order", bypassMaximum, Guid.CreateVersion7(), "OldWriter", DefaultService));
+            await setup.SaveChangesAsync();
+        }
+
+        var result = await Store().WriteSerializableEventsWithExpectedTagPositionsAsync(
+            [EventAt("0300", tag), EventAt("0400", tag)],
+            Spec(DefaultService, (tag, TagHeadExpectation.Exact("0100"))));
+
+        Assert.False(result.IsSuccess);
+        var conflict = Assert.IsType<ExpectedTagPositionConflictException>(result.GetException());
+        var pair = Assert.Single(conflict.Pairs);
+        Assert.Equal("0100", pair.Expected.Position);
+        Assert.Equal(bypassMaximum, pair.ObservedPosition);
+
+        // Reconciliation's repair/audit is intentionally durable even though both candidate command rows are absent.
+        Assert.Equal(bypassMaximum, (await HeadAsync(tag))!.HeadPosition);
+        await using var inspection = await Fixture.GetDbContextAsync();
+        Assert.Empty(await inspection.Events.AsNoTracking().ToListAsync());
+        Assert.Single(await inspection.Tags.AsNoTracking().ToListAsync()); // only the authoritative bypass evidence
+        var violation = Assert.Single(await inspection.TagHeadViolations.AsNoTracking().ToListAsync());
+        Assert.Equal("0100", violation.PreviousHeadPosition);
+        Assert.Equal(bypassMaximum, violation.ObservedPosition);
+    }
+
+    [Fact]
+    public async Task ReconciliationAudit_RollsBackOnFailure_ThenRemainsIdempotentAndAppendOnlyOnRetry()
+    {
+        const string tag = "Order:audit-atomic";
+        await EnableEpochAsync();
+        await using (var setup = await Fixture.GetDbContextAsync())
+        {
+            setup.TagHeads.Add(new DbTagHead { ServiceId = DefaultService, Tag = tag, HeadPosition = "0100" });
+            setup.Tags.Add(DbTag.FromEventTag(tag, "Order", "0200", Guid.CreateVersion7(), "OldWriter", DefaultService));
+            await setup.SaveChangesAsync();
+        }
+
+        var logger = new CountingLogger();
+        var store = new PostgresEventStore(
+            Fixture.DbContextFactory,
+            Fixture.DomainTypes.EventTypes,
+            new FixedServiceIdProvider(DefaultService),
+            logger);
+        var calls = 0;
+        store.TagHeadProtocolHook = () => ++calls == 3
+            ? Task.FromException(new InvalidOperationException("abort after reconciliation"))
+            : Task.CompletedTask;
+        try
+        {
+            var failed = await store.WriteSerializableEventsWithExpectedTagPositionsAsync(
+                [EventAt("0300", tag)], Spec(DefaultService, (tag, TagHeadExpectation.Exact("0100"))));
+            Assert.False(failed.IsSuccess);
+        }
+        finally
+        {
+            store.TagHeadProtocolHook = null;
+        }
+
+        await using (var aborted = await Fixture.GetDbContextAsync())
+        {
+            Assert.Equal("0100", (await aborted.TagHeads.AsNoTracking()
+                .SingleAsync(row => row.ServiceId == DefaultService && row.Tag == tag)).HeadPosition);
+            Assert.Empty(await aborted.TagHeadViolations.AsNoTracking().ToListAsync());
+            Assert.Empty(await aborted.Events.AsNoTracking().ToListAsync());
+        }
+        Assert.Equal(0, logger.WarningCount); // a rolled-back audit must never produce a false committed-violation log
+
+        var repaired = await store.WriteSerializableEventsWithExpectedTagPositionsAsync(
+            [EventAt("0300", tag)], Spec(DefaultService, (tag, TagHeadExpectation.Exact("0100"))));
+        Assert.False(repaired.IsSuccess);
+        Assert.IsType<ExpectedTagPositionConflictException>(repaired.GetException());
+        Assert.Equal("0200", (await HeadAsync(tag))!.HeadPosition);
+        Assert.Equal(1, logger.WarningCount); // emitted only after the repair/audit transaction committed
+
+        // The same stale retry now has no new M to reconcile: it cannot create a second record and must not clean up the
+        // append-only first one.
+        var retry = await store.WriteSerializableEventsWithExpectedTagPositionsAsync(
+            [EventAt("0300", tag)], Spec(DefaultService, (tag, TagHeadExpectation.Exact("0100"))));
+        Assert.False(retry.IsSuccess);
+        await using var committed = await Fixture.GetDbContextAsync();
+        Assert.Single(await committed.TagHeadViolations.AsNoTracking().ToListAsync());
+        Assert.Empty(await committed.Events.AsNoTracking().ToListAsync());
+        Assert.Equal(1, logger.WarningCount); // no duplicate log without a new durable reconciliation record
+    }
+
+    [Fact]
+    public async Task Reconciliation_NoEnforcementAndLegacyWritersStillCommitAndUseMaximumOfRepairAndBatch()
+    {
+        const string noEnforcementTag = "Order:reconcile-no-enforcement";
+        const string legacyTag = "Order:reconcile-legacy";
+        await using (var setup = await Fixture.GetDbContextAsync())
+        {
+            setup.TagHeads.AddRange(
+                new DbTagHead { ServiceId = DefaultService, Tag = noEnforcementTag, HeadPosition = "0100" },
+                new DbTagHead { ServiceId = DefaultService, Tag = legacyTag, HeadPosition = "0100" });
+            setup.Tags.AddRange(
+                DbTag.FromEventTag(noEnforcementTag, "Order", "0150", Guid.CreateVersion7(), "OldWriter", DefaultService),
+                DbTag.FromEventTag(legacyTag, "Order", "0500", Guid.CreateVersion7(), "OldWriter", DefaultService));
+            await setup.SaveChangesAsync();
+        }
+
+        // NoEnforcement skips comparison only: it sees the repair first, commits its event, then advances from 0150 to
+        // the per-tag batch maximum 0200 without needing the enforcement epoch.
+        var noEnforcement = await Store().WriteSerializableEventsWithExpectedTagPositionsAsync(
+            [EventAt("0200", noEnforcementTag)],
+            Spec(DefaultService, (noEnforcementTag, TagHeadExpectation.NoEnforcement())));
+        Assert.True(noEnforcement.IsSuccess, noEnforcement.IsSuccess ? "" : noEnforcement.GetException().ToString());
+
+        // An unconditional legacy write likewise commits. Its older batch position may not regress the repaired 0500
+        // head; its event remains durable, but the head is max(repaired head, batch maximum).
+        var legacy = await Store().WriteSerializableEventsAsync([EventAt("0300", legacyTag)]);
+        Assert.True(legacy.IsSuccess, legacy.IsSuccess ? "" : legacy.GetException().ToString());
+
+        Assert.Equal("0200", (await HeadAsync(noEnforcementTag))!.HeadPosition);
+        Assert.Equal("0500", (await HeadAsync(legacyTag))!.HeadPosition);
+        await using var inspection = await Fixture.GetDbContextAsync();
+        Assert.Equal(2, await inspection.Events.AsNoTracking().CountAsync());
+        Assert.Equal(4, await inspection.Tags.AsNoTracking().CountAsync()); // two bypass rows + two command rows
+        Assert.Equal(2, await inspection.TagHeadViolations.AsNoTracking().CountAsync());
+    }
+
+    [Fact]
+    public async Task PartialStateFailures_AfterEachProductionStage_RollBackFromFreshConnection()
+    {
+        foreach (var (callNumber, stage) in new[]
+                 {
+                     (4, "after event insertion"),
+                     (5, "after tag-index insertion"),
+                     (6, "after head update before commit")
+                 })
+        {
+            await Fixture.ClearDatabaseAsync();
+            var store = Store();
+            var calls = 0;
+            store.TagHeadProtocolHook = () => ++calls == callNumber
+                ? Task.FromException(new InvalidOperationException($"inject-{stage}"))
+                : Task.CompletedTask;
+            try
+            {
+                var failed = await store.WriteSerializableEventsWithExpectedTagPositionsAsync(
+                    [EventAt("0100", "Order:partial")],
+                    Spec(DefaultService, ("Order:partial", TagHeadExpectation.NoEnforcement())));
+                Assert.False(failed.IsSuccess);
+            }
+            finally
+            {
+                store.TagHeadProtocolHook = null;
+            }
+
+            await using var inspection = await Fixture.GetDbContextAsync();
+            Assert.Empty(await inspection.Events.AsNoTracking().ToListAsync());
+            Assert.Empty(await inspection.Tags.AsNoTracking().ToListAsync());
+            Assert.Empty(await inspection.TagHeads.AsNoTracking().ToListAsync());
+            Assert.Empty(await inspection.TagHeadViolations.AsNoTracking().ToListAsync());
+        }
+    }
+
+    [Fact]
+    public async Task RealPostgresRaces_AssertEmptyAndNonemptyHeadCommitExactlyOne()
+    {
+        const string emptyTag = "Order:race-empty";
+        await EnableEpochAsync();
+        var emptyFirst = Store();
+        var emptySecond = Store();
+        var emptyResults = await RunOverlappedAtCanonicalInsertionAsync(
+            emptyFirst,
+            emptySecond,
+            () => emptyFirst.WriteSerializableEventsWithExpectedTagPositionsAsync(
+                [EventAt("0200", emptyTag)], Spec(DefaultService, (emptyTag, TagHeadExpectation.AssertEmpty()))),
+            () => emptySecond.WriteSerializableEventsWithExpectedTagPositionsAsync(
+                [EventAt("0201", emptyTag)], Spec(DefaultService, (emptyTag, TagHeadExpectation.AssertEmpty()))));
+        Assert.Single(emptyResults, result => result.IsSuccess);
+        Assert.Single(emptyResults, result => !result.IsSuccess && result.GetException() is ExpectedTagPositionConflictException);
+        Assert.Equal(1, await CountEventsAsync());
+        await using (var emptyInspection = await Fixture.GetDbContextAsync())
+        {
+            Assert.Single(await emptyInspection.TagHeads.AsNoTracking().ToListAsync()); // no duplicate lazy head row
+        }
+
+        await Fixture.ClearDatabaseAsync();
+        var tag = "Order:race-nonempty";
+        var bootstrap = Store();
+        Assert.True((await bootstrap.WriteSerializableEventsWithExpectedTagPositionsAsync(
+            [EventAt("0300", tag)], Spec(DefaultService, (tag, TagHeadExpectation.NoEnforcement())))).IsSuccess);
+        await EnableEpochAsync();
+        var nonemptyFirst = Store();
+        var nonemptySecond = Store();
+        var nonemptyResults = await RunOverlappedAtCanonicalInsertionAsync(
+            nonemptyFirst,
+            nonemptySecond,
+            () => nonemptyFirst.WriteSerializableEventsWithExpectedTagPositionsAsync(
+                [EventAt("0301", tag)], Spec(DefaultService, (tag, TagHeadExpectation.Exact("0300")))),
+            () => nonemptySecond.WriteSerializableEventsWithExpectedTagPositionsAsync(
+                [EventAt("0302", tag)], Spec(DefaultService, (tag, TagHeadExpectation.Exact("0300")))));
+        Assert.Single(nonemptyResults, result => result.IsSuccess);
+        Assert.Single(nonemptyResults, result => !result.IsSuccess && result.GetException() is ExpectedTagPositionConflictException);
+        Assert.Equal(2, await CountEventsAsync()); // bootstrap + exactly one current command, never merely at-most-one
+    }
+
+    [Fact]
+    public async Task EnforcedAndUnconditionalRace_EveryCommittedTaggedWriteRemainsVisibleInTheDurableHead()
+    {
+        const string tag = "Order:enforced-vs-legacy";
+        var bootstrap = Store();
+        Assert.True((await bootstrap.WriteSerializableEventsAsync([EventAt("1000", tag)])).IsSuccess);
+        await EnableEpochAsync();
+
+        var fenced = Store();
+        var legacy = Store();
+        var arrivals = 0;
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        Func<Task> overlap = async () =>
+        {
+            if (Interlocked.Increment(ref arrivals) > 2)
+            {
+                return;
+            }
+            if (Volatile.Read(ref arrivals) == 2)
+            {
+                release.TrySetResult();
+            }
+            await release.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        };
+        fenced.TagHeadProtocolHook = overlap;
+        legacy.TagHeadProtocolHook = overlap;
+        try
+        {
+            var fencedTask = fenced.WriteSerializableEventsWithExpectedTagPositionsAsync(
+                [EventAt("3000", tag)], Spec(DefaultService, (tag, TagHeadExpectation.Exact("1000"))));
+            var legacyTask = legacy.WriteSerializableEventsAsync([EventAt("2000", tag)]);
+            await Task.WhenAll(fencedTask, legacyTask).WaitAsync(TimeSpan.FromSeconds(15));
+            var fencedResult = await fencedTask;
+            var legacyResult = await legacyTask;
+
+            Assert.True(legacyResult.IsSuccess, legacyResult.IsSuccess ? "" : legacyResult.GetException().ToString());
+            if (fencedResult.IsSuccess)
+            {
+                // Even if the older-position legacy writer commits second, it cannot regress 3000 back to 2000.
+                Assert.Equal("3000", (await HeadAsync(tag))!.HeadPosition);
+                Assert.Equal(3, await CountEventsAsync());
+            }
+            else
+            {
+                Assert.IsType<ExpectedTagPositionConflictException>(fencedResult.GetException());
+                Assert.Equal("2000", (await HeadAsync(tag))!.HeadPosition);
+                Assert.Equal(2, await CountEventsAsync());
+            }
+        }
+        finally
+        {
+            fenced.TagHeadProtocolHook = null;
+            legacy.TagHeadProtocolHook = null;
+            release.TrySetResult();
+        }
+    }
+
+    [Fact]
+    public async Task CanonicalInsertionAndLockOrder_ReversedCallerOrders_NoSqlState40P01()
+    {
+        const string a = "Order:a";
+        const string z = "Order:z";
+        var first = Store();
+        var second = Store();
+        var arrived = 0;
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        Func<Task> overlap = async () =>
+        {
+            // The first hook invocation for each writer occurs immediately before canonical lazy insertion. Later
+            // milestones must not re-enter the barrier.
+            if (Interlocked.Increment(ref arrived) > 2)
+            {
+                return;
+            }
+            if (Volatile.Read(ref arrived) == 2)
+            {
+                release.TrySetResult();
+            }
+            await release.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        };
+        first.TagHeadProtocolHook = overlap;
+        second.TagHeadProtocolHook = overlap;
+        try
+        {
+            var results = await Task.WhenAll(
+                    first.WriteSerializableEventsAsync([EventAt("0400", z, a)]),
+                    second.WriteSerializableEventsAsync([EventAt("0401", a, z)]))
+                .WaitAsync(TimeSpan.FromSeconds(15));
+            Assert.DoesNotContain(results.Where(result => !result.IsSuccess).Select(result => result.GetException()), ContainsDeadlock);
+            Assert.All(results, result => Assert.True(result.IsSuccess, result.IsSuccess ? "" : result.GetException().ToString()));
+        }
+        finally
+        {
+            first.TagHeadProtocolHook = null;
+            second.TagHeadProtocolHook = null;
+        }
+    }
+
+    [Fact]
+    public async Task StrictPositions_UsePerTagMaximum_NotLastGlobalPosition_AndRejectBeforeRows()
+    {
+        const string a = "Order:max-a";
+        const string b = "Order:max-b";
+        var store = Store();
+        var valid = await store.WriteSerializableEventsWithExpectedTagPositionsAsync(
+            [EventAt("0500", a), EventAt("0600", b), EventAt("0700", a)],
+            Spec(DefaultService,
+                (a, TagHeadExpectation.NoEnforcement()),
+                (b, TagHeadExpectation.NoEnforcement())));
+        Assert.True(valid.IsSuccess, valid.IsSuccess ? "" : valid.GetException().ToString());
+        Assert.Equal("0700", (await HeadAsync(a))!.HeadPosition);
+        Assert.Equal("0600", (await HeadAsync(b))!.HeadPosition); // exact per-tag maximum, not global final 0700
+
+        // Continue from both exact heads in a second multi-tag batch. This is not merely a first-write check: every
+        // resulting durable head is pinned after the protocol has already established non-empty state.
+        await EnableEpochAsync();
+        var continuation = await store.WriteSerializableEventsWithExpectedTagPositionsAsync(
+            [EventAt("0800", b), EventAt("0900", a)],
+            Spec(DefaultService,
+                (a, TagHeadExpectation.Exact("0700")),
+                (b, TagHeadExpectation.Exact("0600"))));
+        Assert.True(continuation.IsSuccess, continuation.IsSuccess ? "" : continuation.GetException().ToString());
+        Assert.Equal("0900", (await HeadAsync(a))!.HeadPosition);
+        Assert.Equal("0800", (await HeadAsync(b))!.HeadPosition);
+
+        var invalid = await store.WriteSerializableEventsWithExpectedTagPositionsAsync(
+            [EventAt("0900", a), EventAt("0800", b)],
+            Spec(DefaultService,
+                (a, TagHeadExpectation.NoEnforcement()),
+                (b, TagHeadExpectation.NoEnforcement())));
+        Assert.False(invalid.IsSuccess);
+        Assert.IsType<TagHeadPositionValidationException>(invalid.GetException());
+
+        // Batch order itself is valid here, but 0650 is behind the existing A head. This separately proves the
+        // per-event/per-tag floor rather than merely the global batch-order check above.
+        var behindHead = await store.WriteSerializableEventsWithExpectedTagPositionsAsync(
+            [EventAt("0650", a), EventAt("0800", b)],
+            Spec(DefaultService,
+                (a, TagHeadExpectation.NoEnforcement()),
+                (b, TagHeadExpectation.NoEnforcement())));
+        Assert.False(behindHead.IsSuccess);
+        Assert.IsType<TagHeadPositionValidationException>(behindHead.GetException());
+        Assert.Equal(5, await CountEventsAsync()); // neither invalid command left DML or lazy state behind
+    }
+
+    [Fact]
+    public async Task BestEffortBoundary_AfterReconciliationOldWriterIsNotPretendedToBeAudited()
+    {
+        const string tag = "Order:best-effort";
+        var store = Store();
+        Assert.True((await store.WriteSerializableEventsWithExpectedTagPositionsAsync(
+            [EventAt("1000", tag)], Spec(DefaultService, (tag, TagHeadExpectation.NoEnforcement())))).IsSuccess);
+        await EnableEpochAsync();
+
+        var reconciliationReached = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var allowCommit = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var protocolCalls = 0;
+        store.TagHeadProtocolHook = async () =>
+        {
+            // Invocation 3 is immediately after the production reconciliation MAX query and any repair DML.
+            if (Interlocked.Increment(ref protocolCalls) == 3)
+            {
+                reconciliationReached.TrySetResult();
+                await allowCommit.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            }
+        };
+        try
+        {
+            var newWriter = store.WriteSerializableEventsWithExpectedTagPositionsAsync(
+                [EventAt("3000", tag)], Spec(DefaultService, (tag, TagHeadExpectation.NoEnforcement())));
+            await reconciliationReached.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+            // This stands for an incorrectly undrained pre-epoch writer. It runs AFTER the authoritative MAX query, so
+            // the test documents the honest boundary rather than falsely claiming the current reconciliation saw it.
+            await using (var oldWriter = await Fixture.GetDbContextAsync())
+            {
+                oldWriter.Tags.Add(DbTag.FromEventTag(tag, "Order", "2000", Guid.CreateVersion7(), "OldWriter", DefaultService));
+                await oldWriter.SaveChangesAsync();
+            }
+            allowCommit.TrySetResult();
+            var result = await newWriter;
+            Assert.True(result.IsSuccess, result.IsSuccess ? "" : result.GetException().ToString());
+        }
+        finally
+        {
+            store.TagHeadProtocolHook = null;
+            allowCommit.TrySetResult();
+        }
+
+        Assert.Equal("3000", (await HeadAsync(tag))!.HeadPosition);
+        await using var inspection = await Fixture.GetDbContextAsync();
+        Assert.Empty(await inspection.TagHeadViolations.AsNoTracking().ToListAsync());
+        Assert.Contains(await inspection.Tags.AsNoTracking().Select(row => row.SortableUniqueId).ToListAsync(), p => p == "2000");
+    }
+
+    [Fact]
+    public async Task TypedSerializedAndConditionalWriters_AllAdvanceTheSameHeadTable()
+    {
+        const string typedTag = "Order:typed";
+        const string serializedTag = "Order:serialized";
+        const string claimTag = "Order:conditional";
+        var store = Store();
+
+        // Typed route reaches the common seam via real EventStoreExtensions serialization.
+        var typed = new Event(
+            new StudentCreated(Guid.CreateVersion7(), "writer"),
+            "0800",
+            nameof(StudentCreated),
+            Guid.CreateVersion7(),
+            new EventMetadata("c", "r", "u"),
+            [typedTag]);
+        Assert.True((await store.WriteEventsAsync([typed])).IsSuccess);
+        Assert.True((await store.WriteSerializableEventsAsync([EventAt("0810", serializedTag)])).IsSuccess);
+        var conditionalEvent = new Event(
+                new StudentCreated(Guid.CreateVersion7(), "conditional"),
+                "0820",
+                nameof(StudentCreated),
+                Guid.CreateVersion7(),
+                new EventMetadata("c", "r", "u"),
+                [claimTag])
+            .ToSerializableEvent(Fixture.DomainTypes.EventTypes);
+        var claim = await ((IConditionalEventStore)store).AppendIfUniqueAsync(
+            new ConditionalAppendRequest("g40-common-seam", conditionalEvent));
+        Assert.True(claim.IsSuccess, claim.IsSuccess ? "" : claim.GetException().ToString());
+
+        Assert.Equal("0800", (await HeadAsync(typedTag))!.HeadPosition);
+        Assert.Equal("0810", (await HeadAsync(serializedTag))!.HeadPosition);
+        Assert.Equal("0820", (await HeadAsync(claimTag))!.HeadPosition);
+    }
+
+    private static async Task<T[]> RunOverlappedAtCanonicalInsertionAsync<T>(
+        PostgresEventStore first,
+        PostgresEventStore second,
+        Func<Task<T>> firstWrite,
+        Func<Task<T>> secondWrite)
+    {
+        var arrivals = 0;
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        Func<Task> overlap = async () =>
+        {
+            // Each store's first callback is immediately before production lazy insertion. Synchronizing only those first
+            // two callbacks forces two independent Postgres transactions to contend at the canonical insertion/lock seam.
+            if (Interlocked.Increment(ref arrivals) > 2)
+            {
+                return;
+            }
+            if (Volatile.Read(ref arrivals) == 2)
+            {
+                release.TrySetResult();
+            }
+            await release.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        };
+        first.TagHeadProtocolHook = overlap;
+        second.TagHeadProtocolHook = overlap;
+        try
+        {
+            return await Task.WhenAll(firstWrite(), secondWrite()).WaitAsync(TimeSpan.FromSeconds(15));
+        }
+        finally
+        {
+            first.TagHeadProtocolHook = null;
+            second.TagHeadProtocolHook = null;
+            release.TrySetResult();
+        }
+    }
+
+    private async Task<int> CountEventsAsync()
+    {
+        await using var context = await Fixture.GetDbContextAsync();
+        return await context.Events.AsNoTracking().CountAsync();
+    }
+
+    private static bool ContainsDeadlock(Exception exception) => exception switch
+    {
+        PostgresException { SqlState: "40P01" } => true,
+        _ when exception.InnerException is not null => ContainsDeadlock(exception.InnerException),
+        _ => false
+    };
+
+    private sealed record TagHeadTestCommand : ICommand;
+
+    private sealed class CountingLogger : ILogger<PostgresEventStore>
+    {
+        private int _warningCount;
+        public int WarningCount => Volatile.Read(ref _warningCount);
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+        public bool IsEnabled(LogLevel logLevel) => true;
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            if (logLevel == LogLevel.Warning)
+            {
+                Interlocked.Increment(ref _warningCount);
+            }
+        }
+    }
+}

--- a/dcb/tests/Sekiban.Dcb.Postgres.Tests/PostgresTagHeadSqlPolicyTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Postgres.Tests/PostgresTagHeadSqlPolicyTests.cs
@@ -1,0 +1,184 @@
+using System.Data.Common;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Npgsql;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.Postgres.DbModels;
+using Sekiban.Dcb.ServiceId;
+using Sekiban.Dcb.Storage;
+using Xunit;
+
+namespace Sekiban.Dcb.Postgres.Tests;
+
+/// <summary>
+///     SEK-G40 SQL-policy proofs are deliberately split: a DDL-denied runtime principal, that principal's allowed DML on
+///     a provisioned schema, and an unprovisioned-schema fail-closed call whose captured runtime SQL contains no DDL.
+/// </summary>
+public sealed class PostgresTagHeadSqlPolicyTests : PostgresTestBase
+{
+    public PostgresTagHeadSqlPolicyTests(PostgresTestFixture fixture) : base(fixture) { }
+
+    [Fact]
+    public async Task ProvisioningMigrationAndModel_PinServiceScopedHeadEpochAndViolationTables()
+    {
+        await using var context = await Fixture.GetDbContextAsync();
+        var model = context.GetService<IDesignTimeModel>().Model;
+        var heads = model.FindEntityType(typeof(DbTagHead))
+            ?? throw new InvalidOperationException("Tag-head model is missing.");
+        var violations = model.FindEntityType(typeof(DbTagHeadViolation))
+            ?? throw new InvalidOperationException("Tag-head-violation model is missing.");
+        var epochs = model.FindEntityType(typeof(DbTagHeadEnablementEpoch))
+            ?? throw new InvalidOperationException("Tag-head epoch model is missing.");
+
+        Assert.Equal("dcb_tag_heads", heads.GetTableName());
+        Assert.Equal(new[] { "ServiceId", "Tag" }, heads.FindPrimaryKey()!.Properties.Select(p => p.Name).ToArray());
+        Assert.Contains(heads.GetCheckConstraints(), c => c.Name == "CK_TagHeads_Position_NotEmpty");
+        Assert.Equal("dcb_tag_head_violations", violations.GetTableName());
+        Assert.Contains(violations.GetIndexes(), index =>
+            index.IsUnique && index.GetDatabaseName() == "UX_TagHeadViolations_IdempotentRepair");
+        Assert.Equal("dcb_tag_head_enablement_epochs", epochs.GetTableName());
+        Assert.Equal(new[] { "ServiceId" }, epochs.FindPrimaryKey()!.Properties.Select(p => p.Name).ToArray());
+
+        var migrationNames = (await context.Database.GetAppliedMigrationsAsync()).ToArray();
+        Assert.Contains(migrationNames, name => name.EndsWith("AddPostgresTagHeadExpectedPositionCas", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task DdlDeniedRuntimePrincipal_CanStillRunProvisionedHeadDml()
+    {
+        var role = $"g40_runtime_dml_{Guid.NewGuid():N}";
+        const string password = "g40_runtime_dml_password";
+        var adminConnection = Fixture.ConnectionString;
+        var runtimeConnection = new NpgsqlConnectionStringBuilder(Fixture.ConnectionString)
+        {
+            Username = role,
+            Password = password
+        }.ConnectionString;
+
+        await using var admin = new NpgsqlConnection(adminConnection);
+        await admin.OpenAsync();
+        try
+        {
+            await ExecuteAsync(admin, $"CREATE ROLE {role} LOGIN PASSWORD '{password}'");
+            await ExecuteAsync(admin, $"GRANT USAGE ON SCHEMA public TO {role}");
+            await ExecuteAsync(admin,
+                $"GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE dcb_events, dcb_tags, dcb_tag_heads, dcb_tag_head_violations, dcb_tag_head_enablement_epochs TO {role}");
+            await ExecuteAsync(admin, $"GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO {role}");
+
+            await using (var runtime = new NpgsqlConnection(runtimeConnection))
+            {
+                await runtime.OpenAsync();
+                var ddl = await Assert.ThrowsAsync<PostgresException>(() =>
+                    ExecuteAsync(runtime, "CREATE TABLE g40_runtime_must_not_create (id integer)"));
+                Assert.Equal(PostgresErrorCodes.InsufficientPrivilege, ddl.SqlState); // SQLSTATE 42501
+            }
+
+            var factory = new OneContextFactory(runtimeConnection);
+            var store = new PostgresEventStore(
+                factory,
+                Fixture.DomainTypes.EventTypes,
+                new FixedServiceIdProvider(DefaultServiceIdProvider.DefaultServiceId));
+            var write = await store.WriteSerializableEventsWithExpectedTagPositionsAsync(
+                [new SerializableEvent(
+                    "{}"u8.ToArray(), "7000", Guid.CreateVersion7(), new EventMetadata("c", "r", "u"),
+                    ["Order:dml-only"], "G40Marker")],
+                new ExpectedTagPositionSpecification(
+                    [new TagHeadExpectationEntry(DefaultServiceIdProvider.DefaultServiceId, "Order:dml-only", TagHeadExpectation.NoEnforcement())]));
+            Assert.True(write.IsSuccess, write.IsSuccess ? "" : write.GetException().ToString());
+        }
+        finally
+        {
+            NpgsqlConnection.ClearAllPools();
+            await ExecuteAsync(admin, $"DROP OWNED BY {role}");
+            await ExecuteAsync(admin, $"DROP ROLE IF EXISTS {role}");
+        }
+    }
+
+    [Fact]
+    public async Task UnprovisionedSchema_FailsClosedWith42P01_AndRuntimeEmitsNoDdl()
+    {
+        const string schema = "g40_unprovisioned";
+        await using var admin = new NpgsqlConnection(Fixture.ConnectionString);
+        await admin.OpenAsync();
+        await ExecuteAsync(admin, $"DROP SCHEMA IF EXISTS {schema} CASCADE");
+        await ExecuteAsync(admin, $"CREATE SCHEMA {schema}");
+        try
+        {
+            var recording = new RecordingCommandInterceptor();
+            var missingConnection = new NpgsqlConnectionStringBuilder(Fixture.ConnectionString)
+            {
+                SearchPath = schema
+            }.ConnectionString;
+            var store = new PostgresEventStore(
+                new OneContextFactory(missingConnection, recording),
+                Fixture.DomainTypes.EventTypes,
+                new FixedServiceIdProvider(DefaultServiceIdProvider.DefaultServiceId));
+
+            var result = await store.EnsureExpectedTagPositionEnforcementEnabledAsync();
+
+            Assert.False(result.IsSuccess);
+            var failure = Assert.IsType<PostgresException>(result.GetException());
+            Assert.Equal(PostgresErrorCodes.UndefinedTable, failure.SqlState); // SQLSTATE 42P01
+            Assert.NotEmpty(recording.Commands);
+            Assert.DoesNotContain(recording.Commands, sql =>
+                sql.Contains("CREATE", StringComparison.OrdinalIgnoreCase) ||
+                sql.Contains("ALTER", StringComparison.OrdinalIgnoreCase) ||
+                sql.Contains("MIGRAT", StringComparison.OrdinalIgnoreCase));
+        }
+        finally
+        {
+            await ExecuteAsync(admin, $"DROP SCHEMA IF EXISTS {schema} CASCADE");
+        }
+    }
+
+    private static async Task ExecuteAsync(NpgsqlConnection connection, string sql)
+    {
+        await using var command = new NpgsqlCommand(sql, connection);
+        await command.ExecuteNonQueryAsync();
+    }
+
+    private sealed class OneContextFactory : IDbContextFactory<SekibanDcbDbContext>
+    {
+        private readonly string _connection;
+        private readonly IInterceptor[] _interceptors;
+
+        public OneContextFactory(string connection, params IInterceptor[] interceptors)
+        {
+            _connection = connection;
+            _interceptors = interceptors;
+        }
+
+        public SekibanDcbDbContext CreateDbContext() => new(
+            new DbContextOptionsBuilder<SekibanDcbDbContext>()
+                .UseNpgsql(_connection)
+                .AddInterceptors(_interceptors)
+                .Options);
+    }
+
+    private sealed class RecordingCommandInterceptor : DbCommandInterceptor
+    {
+        public List<string> Commands { get; } = [];
+
+        public override ValueTask<InterceptionResult<DbDataReader>> ReaderExecutingAsync(
+            DbCommand command,
+            CommandEventData eventData,
+            InterceptionResult<DbDataReader> result,
+            CancellationToken cancellationToken = default)
+        {
+            Commands.Add(command.CommandText);
+            return base.ReaderExecutingAsync(command, eventData, result, cancellationToken);
+        }
+
+        public override ValueTask<InterceptionResult<object>> ScalarExecutingAsync(
+            DbCommand command,
+            CommandEventData eventData,
+            InterceptionResult<object> result,
+            CancellationToken cancellationToken = default)
+        {
+            Commands.Add(command.CommandText);
+            return base.ScalarExecutingAsync(command, eventData, result, cancellationToken);
+        }
+    }
+}

--- a/dcb/tests/Sekiban.Dcb.Postgres.Tests/PostgresTagHeadSqlPolicyTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Postgres.Tests/PostgresTagHeadSqlPolicyTests.cs
@@ -46,36 +46,30 @@ public sealed class PostgresTagHeadSqlPolicyTests : PostgresTestBase
     }
 
     [Fact]
-    public async Task DdlDeniedRuntimePrincipal_CanStillRunProvisionedHeadDml()
+    public async Task DmlOnlyRuntimePrincipal_IsDeniedRuntimeDdlWithSqlState42501()
     {
-        var role = $"g40_runtime_dml_{Guid.NewGuid():N}";
-        const string password = "g40_runtime_dml_password";
-        var adminConnection = Fixture.ConnectionString;
-        var runtimeConnection = new NpgsqlConnectionStringBuilder(Fixture.ConnectionString)
-        {
-            Username = role,
-            Password = password
-        }.ConnectionString;
-
-        await using var admin = new NpgsqlConnection(adminConnection);
-        await admin.OpenAsync();
+        var runtime = await CreateDmlOnlyRuntimePrincipalAsync();
         try
         {
-            await ExecuteAsync(admin, $"CREATE ROLE {role} LOGIN PASSWORD '{password}'");
-            await ExecuteAsync(admin, $"GRANT USAGE ON SCHEMA public TO {role}");
-            await ExecuteAsync(admin,
-                $"GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE dcb_events, dcb_tags, dcb_tag_heads, dcb_tag_head_violations, dcb_tag_head_enablement_epochs TO {role}");
-            await ExecuteAsync(admin, $"GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO {role}");
+            await using var connection = new NpgsqlConnection(runtime.ConnectionString);
+            await connection.OpenAsync();
+            var ddl = await Assert.ThrowsAsync<PostgresException>(() =>
+                ExecuteAsync(connection, "CREATE TABLE g40_runtime_must_not_create (id integer)"));
+            Assert.Equal(PostgresErrorCodes.InsufficientPrivilege, ddl.SqlState); // SQLSTATE 42501
+        }
+        finally
+        {
+            await DropRuntimePrincipalAsync(runtime.Role);
+        }
+    }
 
-            await using (var runtime = new NpgsqlConnection(runtimeConnection))
-            {
-                await runtime.OpenAsync();
-                var ddl = await Assert.ThrowsAsync<PostgresException>(() =>
-                    ExecuteAsync(runtime, "CREATE TABLE g40_runtime_must_not_create (id integer)"));
-                Assert.Equal(PostgresErrorCodes.InsufficientPrivilege, ddl.SqlState); // SQLSTATE 42501
-            }
-
-            var factory = new OneContextFactory(runtimeConnection);
+    [Fact]
+    public async Task DmlOnlyRuntimePrincipal_CanRunProvisionedHeadDml()
+    {
+        var runtime = await CreateDmlOnlyRuntimePrincipalAsync();
+        try
+        {
+            var factory = new OneContextFactory(runtime.ConnectionString);
             var store = new PostgresEventStore(
                 factory,
                 Fixture.DomainTypes.EventTypes,
@@ -90,9 +84,7 @@ public sealed class PostgresTagHeadSqlPolicyTests : PostgresTestBase
         }
         finally
         {
-            NpgsqlConnection.ClearAllPools();
-            await ExecuteAsync(admin, $"DROP OWNED BY {role}");
-            await ExecuteAsync(admin, $"DROP ROLE IF EXISTS {role}");
+            await DropRuntimePrincipalAsync(runtime.Role);
         }
     }
 
@@ -138,6 +130,36 @@ public sealed class PostgresTagHeadSqlPolicyTests : PostgresTestBase
         await using var command = new NpgsqlCommand(sql, connection);
         await command.ExecuteNonQueryAsync();
     }
+
+    private async Task<RuntimePrincipal> CreateDmlOnlyRuntimePrincipalAsync()
+    {
+        var role = $"g40_runtime_dml_{Guid.NewGuid():N}";
+        const string password = "g40_runtime_dml_password";
+        await using var admin = new NpgsqlConnection(Fixture.ConnectionString);
+        await admin.OpenAsync();
+        await ExecuteAsync(admin, $"CREATE ROLE {role} LOGIN PASSWORD '{password}'");
+        await ExecuteAsync(admin, $"GRANT USAGE ON SCHEMA public TO {role}");
+        await ExecuteAsync(admin,
+            $"GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE dcb_events, dcb_tags, dcb_tag_heads, dcb_tag_head_violations, dcb_tag_head_enablement_epochs TO {role}");
+        await ExecuteAsync(admin, $"GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO {role}");
+        var connectionString = new NpgsqlConnectionStringBuilder(Fixture.ConnectionString)
+        {
+            Username = role,
+            Password = password
+        }.ConnectionString;
+        return new RuntimePrincipal(role, connectionString);
+    }
+
+    private async Task DropRuntimePrincipalAsync(string role)
+    {
+        NpgsqlConnection.ClearAllPools();
+        await using var admin = new NpgsqlConnection(Fixture.ConnectionString);
+        await admin.OpenAsync();
+        await ExecuteAsync(admin, $"DROP OWNED BY {role}");
+        await ExecuteAsync(admin, $"DROP ROLE IF EXISTS {role}");
+    }
+
+    private sealed record RuntimePrincipal(string Role, string ConnectionString);
 
     private sealed class OneContextFactory : IDbContextFactory<SekibanDcbDbContext>
     {

--- a/dcb/tests/Sekiban.Dcb.Postgres.Tests/PostgresTagHeadSurfaceMatrixTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Postgres.Tests/PostgresTagHeadSurfaceMatrixTests.cs
@@ -1,0 +1,399 @@
+extern alias WithoutResultFacade;
+
+using System.Text.Json;
+using Dcb.Domain.Student;
+using Microsoft.EntityFrameworkCore;
+using ResultBoxes;
+using Sekiban.Dcb.Actors;
+using Sekiban.Dcb.Commands;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.Postgres.DbModels;
+using Sekiban.Dcb.ServiceId;
+using Sekiban.Dcb.Storage;
+using Sekiban.Dcb.Testing;
+using Sekiban.Dcb.Tags;
+using Xunit;
+using WithoutResultExecutor = WithoutResultFacade::Sekiban.Dcb.Actors.GeneralSekibanExecutor;
+using WithoutResultCommandContext = WithoutResultFacade::Sekiban.Dcb.Commands.ICommandContext;
+
+namespace Sekiban.Dcb.Postgres.Tests;
+
+/// <summary>
+///     AC4's real PostgreSQL facade matrix. Every branch uses the production command or serialized facade and then a
+///     fresh DbContext: the request, returned payload, dcb_events/dcb_tags mutation counts, and durable dcb_tag_heads
+///     row must all agree. This intentionally makes dropping an expectation at a facade, bypassing the NoEnforcement
+///     head path, or drifting a DTO/count observable.
+/// </summary>
+public sealed class PostgresTagHeadSurfaceMatrixTests : PostgresTestBase
+{
+    public PostgresTagHeadSurfaceMatrixTests(PostgresTestFixture fixture) : base(fixture) { }
+
+    [Fact]
+    public async Task ThreeStateMatrix_PreservesRequestResultPayloadCountsAndDurableHeadsAcrossProductionSurfaces()
+    {
+        // The public executor constructors resolve the production default service id. Keep the store and every request
+        // on that same service while tags distinguish each matrix cell.
+        const string serviceId = DefaultServiceIdProvider.DefaultServiceId;
+        await AssertWithResultCommandMatrixAsync(serviceId);
+        await AssertWithoutResultCommandMatrixAsync(serviceId);
+        await AssertLegacySerializedOmissionMatrixAsync(serviceId);
+        await AssertVersionedSerializedV2MatrixAsync(serviceId);
+    }
+
+    private async Task AssertWithResultCommandMatrixAsync(string serviceId)
+    {
+        var store = Store(serviceId);
+        var executor = new GeneralSekibanExecutor(store, new InMemoryObjectAccessor(store, Fixture.DomainTypes), Fixture.DomainTypes);
+        var noEnforcement = await ExecuteWithResultAsync(executor, serviceId, "with-no-enforcement", TagHeadExpectation.NoEnforcement());
+
+        Assert.True(noEnforcement.Result.IsSuccess, noEnforcement.Result.IsSuccess ? "" : noEnforcement.Result.GetException().ToString());
+        AssertCommandRequest(noEnforcement.Request, serviceId, noEnforcement.Tag, TagHeadExpectationKind.NoEnforcement, null);
+        AssertExecutionPayload(noEnforcement.Result.GetValue(), noEnforcement.StudentId, noEnforcement.Name, noEnforcement.Tag);
+        await AssertTransitionAsync(serviceId, noEnforcement.Before, noEnforcement.Tag, noEnforcement.Result.GetValue().SortableUniqueId!, 1);
+
+        await EnableEpochAsync(serviceId);
+        var assertEmpty = await ExecuteWithResultAsync(executor, serviceId, "with-assert-empty", TagHeadExpectation.AssertEmpty());
+        Assert.True(assertEmpty.Result.IsSuccess, assertEmpty.Result.IsSuccess ? "" : assertEmpty.Result.GetException().ToString());
+        AssertCommandRequest(assertEmpty.Request, serviceId, assertEmpty.Tag, TagHeadExpectationKind.AssertEmpty, null);
+        AssertExecutionPayload(assertEmpty.Result.GetValue(), assertEmpty.StudentId, assertEmpty.Name, assertEmpty.Tag);
+        await AssertTransitionAsync(serviceId, assertEmpty.Before, assertEmpty.Tag, assertEmpty.Result.GetValue().SortableUniqueId!, 1);
+
+        var exact = await ExecuteWithResultAsync(
+            executor,
+            serviceId,
+            "with-exact",
+            TagHeadExpectation.Exact(assertEmpty.Result.GetValue().SortableUniqueId!),
+            assertEmpty.StudentId,
+            assertEmpty.Tag);
+        Assert.True(exact.Result.IsSuccess, exact.Result.IsSuccess ? "" : exact.Result.GetException().ToString());
+        AssertCommandRequest(exact.Request, serviceId, exact.Tag, TagHeadExpectationKind.Exact,
+            assertEmpty.Result.GetValue().SortableUniqueId);
+        AssertExecutionPayload(exact.Result.GetValue(), exact.StudentId, exact.Name, exact.Tag);
+        await AssertTransitionAsync(serviceId, exact.Before, exact.Tag, exact.Result.GetValue().SortableUniqueId!, 0);
+    }
+
+    private async Task AssertWithoutResultCommandMatrixAsync(string serviceId)
+    {
+        var store = Store(serviceId);
+        var executor = new WithoutResultExecutor(
+            store,
+            new InMemoryObjectAccessor(store, Fixture.DomainTypes),
+            Fixture.DomainTypes);
+        var noEnforcement = await ExecuteWithoutResultAsync(executor, serviceId, "without-no-enforcement", TagHeadExpectation.NoEnforcement());
+
+        AssertCommandRequest(noEnforcement.Request, serviceId, noEnforcement.Tag, TagHeadExpectationKind.NoEnforcement, null);
+        AssertExecutionPayload(noEnforcement.Result, noEnforcement.StudentId, noEnforcement.Name, noEnforcement.Tag);
+        await AssertTransitionAsync(serviceId, noEnforcement.Before, noEnforcement.Tag, noEnforcement.Result.SortableUniqueId!, 1);
+
+        await EnableEpochAsync(serviceId);
+        var assertEmpty = await ExecuteWithoutResultAsync(executor, serviceId, "without-assert-empty", TagHeadExpectation.AssertEmpty());
+        AssertCommandRequest(assertEmpty.Request, serviceId, assertEmpty.Tag, TagHeadExpectationKind.AssertEmpty, null);
+        AssertExecutionPayload(assertEmpty.Result, assertEmpty.StudentId, assertEmpty.Name, assertEmpty.Tag);
+        await AssertTransitionAsync(serviceId, assertEmpty.Before, assertEmpty.Tag, assertEmpty.Result.SortableUniqueId!, 1);
+
+        var exact = await ExecuteWithoutResultAsync(
+            executor,
+            serviceId,
+            "without-exact",
+            TagHeadExpectation.Exact(assertEmpty.Result.SortableUniqueId!),
+            assertEmpty.StudentId,
+            assertEmpty.Tag);
+        AssertCommandRequest(exact.Request, serviceId, exact.Tag, TagHeadExpectationKind.Exact, assertEmpty.Result.SortableUniqueId);
+        AssertExecutionPayload(exact.Result, exact.StudentId, exact.Name, exact.Tag);
+        await AssertTransitionAsync(serviceId, exact.Before, exact.Tag, exact.Result.SortableUniqueId!, 0);
+    }
+
+    private async Task AssertLegacySerializedOmissionMatrixAsync(string serviceId)
+    {
+        var store = Store(serviceId);
+        var executor = new GeneralSekibanExecutor(store, new InMemoryObjectAccessor(store, Fixture.DomainTypes), Fixture.DomainTypes);
+        var studentId = Guid.CreateVersion7();
+        var tag = new StudentTag(studentId).GetTag();
+        const string name = "legacy-omission";
+        var candidate = Candidate(studentId, name, tag);
+        var request = new SerializedCommitRequest([candidate], [new ConsistencyTagEntry(tag, string.Empty)]);
+        var before = await SnapshotAsync(serviceId);
+
+        // There is deliberately no expectedTagPositions member on this legacy DTO: its omission is the frozen V1 route.
+        AssertLegacyRequest(request, candidate, tag);
+        var wire = SerializedCommitWireContract.SerializeToUtf8Bytes(request);
+        AssertLegacyWire(wire);
+        var result = await new SerializedCommitAcceptor(executor).AcceptAsync(wire);
+
+        Assert.True(result.IsSuccess, result.IsSuccess ? "" : result.GetException().ToString());
+        AssertSerializedPayload(result.GetValue(), candidate, tag);
+        await AssertTransitionAsync(serviceId, before, tag, Assert.Single(result.GetValue().WrittenEvents).SortableUniqueIdValue, 1);
+    }
+
+    private async Task AssertVersionedSerializedV2MatrixAsync(string serviceId)
+    {
+        var store = Store(serviceId);
+        var executor = new GeneralSekibanExecutor(store, new InMemoryObjectAccessor(store, Fixture.DomainTypes), Fixture.DomainTypes);
+        var noEnforcement = await ExecuteV2Async(executor, serviceId, "v2-no-enforcement", TagHeadExpectation.NoEnforcement());
+
+        AssertV2Request(noEnforcement.Request, noEnforcement.Candidate, serviceId, noEnforcement.Tag,
+            TagHeadExpectationKind.NoEnforcement, null);
+        AssertV2Wire(noEnforcement.Wire, TagHeadExpectationKind.NoEnforcement, null);
+        Assert.True(noEnforcement.Result.IsSuccess, noEnforcement.Result.IsSuccess ? "" : noEnforcement.Result.GetException().ToString());
+        AssertSerializedPayload(noEnforcement.Result.GetValue(), noEnforcement.Candidate, noEnforcement.Tag);
+        await AssertTransitionAsync(serviceId, noEnforcement.Before, noEnforcement.Tag,
+            Assert.Single(noEnforcement.Result.GetValue().WrittenEvents).SortableUniqueIdValue, 1);
+
+        await EnableEpochAsync(serviceId);
+        var assertEmpty = await ExecuteV2Async(executor, serviceId, "v2-assert-empty", TagHeadExpectation.AssertEmpty());
+        AssertV2Request(assertEmpty.Request, assertEmpty.Candidate, serviceId, assertEmpty.Tag,
+            TagHeadExpectationKind.AssertEmpty, null);
+        AssertV2Wire(assertEmpty.Wire, TagHeadExpectationKind.AssertEmpty, null);
+        Assert.True(assertEmpty.Result.IsSuccess, assertEmpty.Result.IsSuccess ? "" : assertEmpty.Result.GetException().ToString());
+        AssertSerializedPayload(assertEmpty.Result.GetValue(), assertEmpty.Candidate, assertEmpty.Tag);
+        await AssertTransitionAsync(serviceId, assertEmpty.Before, assertEmpty.Tag,
+            Assert.Single(assertEmpty.Result.GetValue().WrittenEvents).SortableUniqueIdValue, 1);
+
+        var exact = await ExecuteV2Async(
+            executor,
+            serviceId,
+            "v2-exact",
+            TagHeadExpectation.Exact(Assert.Single(assertEmpty.Result.GetValue().WrittenEvents).SortableUniqueIdValue),
+            assertEmpty.StudentId,
+            assertEmpty.Tag);
+        AssertV2Request(exact.Request, exact.Candidate, serviceId, exact.Tag, TagHeadExpectationKind.Exact,
+            Assert.Single(assertEmpty.Result.GetValue().WrittenEvents).SortableUniqueIdValue);
+        AssertV2Wire(exact.Wire, TagHeadExpectationKind.Exact,
+            Assert.Single(assertEmpty.Result.GetValue().WrittenEvents).SortableUniqueIdValue);
+        Assert.True(exact.Result.IsSuccess, exact.Result.IsSuccess ? "" : exact.Result.GetException().ToString());
+        AssertSerializedPayload(exact.Result.GetValue(), exact.Candidate, exact.Tag);
+        await AssertTransitionAsync(serviceId, exact.Before, exact.Tag,
+            Assert.Single(exact.Result.GetValue().WrittenEvents).SortableUniqueIdValue, 0);
+    }
+
+    private async Task<WithResultStep> ExecuteWithResultAsync(
+        GeneralSekibanExecutor executor,
+        string serviceId,
+        string name,
+        TagHeadExpectation expected,
+        Guid? studentId = null,
+        string? tag = null)
+    {
+        var id = studentId ?? Guid.CreateVersion7();
+        var resolvedTag = tag ?? new StudentTag(id).GetTag();
+        var request = Options(serviceId, resolvedTag, expected);
+        var before = await SnapshotAsync(serviceId);
+        var result = await executor.ExecuteAsync(
+            new SurfaceMatrixCommand(),
+            (_, context) => context.AppendEvent(new StudentCreated(id, name), new StudentTag(id)),
+            request);
+        return new WithResultStep(result, request, before, id, resolvedTag, name);
+    }
+
+    private async Task<WithoutResultStep> ExecuteWithoutResultAsync(
+        WithoutResultExecutor executor,
+        string serviceId,
+        string name,
+        TagHeadExpectation expected,
+        Guid? studentId = null,
+        string? tag = null)
+    {
+        var id = studentId ?? Guid.CreateVersion7();
+        var resolvedTag = tag ?? new StudentTag(id).GetTag();
+        var request = Options(serviceId, resolvedTag, expected);
+        var before = await SnapshotAsync(serviceId);
+        var result = await executor.ExecuteAsync(
+            new SurfaceMatrixCommand(),
+            (SurfaceMatrixCommand _, WithoutResultCommandContext context) =>
+                context.AppendEvent(new StudentCreated(id, name), new StudentTag(id)),
+            request);
+        return new WithoutResultStep(result, request, before, id, resolvedTag, name);
+    }
+
+    private async Task<V2Step> ExecuteV2Async(
+        GeneralSekibanExecutor executor,
+        string serviceId,
+        string name,
+        TagHeadExpectation expected,
+        Guid? studentId = null,
+        string? tag = null)
+    {
+        var id = studentId ?? Guid.CreateVersion7();
+        var resolvedTag = tag ?? new StudentTag(id).GetTag();
+        var candidate = Candidate(id, name, resolvedTag);
+        var request = new VersionedExpectedTagPositionSerializedCommitRequest(
+            VersionedExpectedTagPositionSerializedCommitRequest.CurrentVersion,
+            [candidate],
+            [new ConsistencyTagEntry(resolvedTag, expected.Position ?? string.Empty)],
+            [new TagHeadExpectationEntry(serviceId, resolvedTag, expected)]);
+        var before = await SnapshotAsync(serviceId);
+        var wire = SerializedCommitWireContract.SerializeToUtf8Bytes(request);
+        var result = await new SerializedCommitAcceptor(executor).AcceptAsync(wire);
+        return new V2Step(result, request, candidate, wire, before, id, resolvedTag);
+    }
+
+    private PostgresEventStore Store(string serviceId) =>
+        new(Fixture.DbContextFactory, Fixture.DomainTypes.EventTypes, new FixedServiceIdProvider(serviceId));
+
+    private async Task EnableEpochAsync(string serviceId)
+    {
+        await using var context = await Fixture.GetDbContextAsync();
+        if (await context.TagHeadEnablementEpochs.AnyAsync(row => row.ServiceId == serviceId))
+        {
+            return;
+        }
+        context.TagHeadEnablementEpochs.Add(new DbTagHeadEnablementEpoch { ServiceId = serviceId, EnabledAtUtc = DateTime.UtcNow });
+        await context.SaveChangesAsync();
+    }
+
+    private async Task<DurableCounts> SnapshotAsync(string serviceId)
+    {
+        await using var context = await Fixture.GetDbContextAsync();
+        return new DurableCounts(
+            await context.Events.AsNoTracking().CountAsync(row => row.ServiceId == serviceId),
+            await context.Tags.AsNoTracking().CountAsync(row => row.ServiceId == serviceId),
+            await context.TagHeads.AsNoTracking().CountAsync(row => row.ServiceId == serviceId));
+    }
+
+    private async Task AssertTransitionAsync(
+        string serviceId,
+        DurableCounts before,
+        string tag,
+        string expectedHead,
+        int expectedHeadDelta)
+    {
+        var after = await SnapshotAsync(serviceId);
+        Assert.Equal(before.Events + 1, after.Events);
+        Assert.Equal(before.Tags + 1, after.Tags);
+        Assert.Equal(before.Heads + expectedHeadDelta, after.Heads);
+        await using var context = await Fixture.GetDbContextAsync();
+        var durable = await context.TagHeads.AsNoTracking()
+            .SingleAsync(row => row.ServiceId == serviceId && row.Tag == tag);
+        Assert.Equal(expectedHead, durable.HeadPosition);
+    }
+
+    private static CommandExecutionOptions Options(string serviceId, string tag, TagHeadExpectation expected) =>
+        new()
+        {
+            ExpectedTagPositions = new ExpectedTagPositionSpecification(
+                [new TagHeadExpectationEntry(serviceId, tag, expected)])
+        };
+
+    private SerializableEventCandidate Candidate(Guid studentId, string name, string tag) =>
+        new(
+            System.Text.Encoding.UTF8.GetBytes(Fixture.DomainTypes.EventTypes.SerializeEventPayload(new StudentCreated(studentId, name))),
+            nameof(StudentCreated),
+            [tag]);
+
+    private static void AssertCommandRequest(
+        CommandExecutionOptions request,
+        string serviceId,
+        string tag,
+        TagHeadExpectationKind kind,
+        string? position)
+    {
+        var specification = Assert.IsType<ExpectedTagPositionSpecification>(request.ExpectedTagPositions);
+        var entry = Assert.Single(specification.Entries);
+        Assert.Equal(serviceId, entry.ServiceId);
+        Assert.Equal(tag, entry.Tag);
+        Assert.Equal(kind, entry.Expectation.Kind);
+        Assert.Equal(position, entry.Expectation.Position);
+    }
+
+    private static void AssertExecutionPayload(ExecutionResult result, Guid studentId, string name, string tag)
+    {
+        Assert.NotEqual(Guid.Empty, result.EventId);
+        Assert.False(string.IsNullOrWhiteSpace(result.SortableUniqueId));
+        var written = Assert.Single(result.Events);
+        Assert.Equal(result.SortableUniqueId, written.SortableUniqueIdValue);
+        Assert.Equal(tag, Assert.Single(written.Tags));
+        Assert.Equal(new StudentCreated(studentId, name), Assert.IsType<StudentCreated>(written.Payload));
+        var tagWrite = Assert.Single(result.TagWrites);
+        Assert.Equal(tag, tagWrite.Tag);
+        Assert.True(tagWrite.Version > 0);
+    }
+
+    private static void AssertLegacyRequest(SerializedCommitRequest request, SerializableEventCandidate candidate, string tag)
+    {
+        Assert.Equal([candidate], request.EventCandidates);
+        Assert.Equal([new ConsistencyTagEntry(tag, string.Empty)], request.ConsistencyTags);
+    }
+
+    private static void AssertLegacyWire(byte[] wire)
+    {
+        using var document = JsonDocument.Parse(wire);
+        var root = document.RootElement;
+        Assert.False(root.TryGetProperty("version", out _));
+        Assert.False(root.TryGetProperty("expectedTagPositions", out _));
+        Assert.Equal(1, root.GetProperty("eventCandidates").GetArrayLength());
+        Assert.Equal(1, root.GetProperty("consistencyTags").GetArrayLength());
+    }
+
+    private static void AssertV2Request(
+        VersionedExpectedTagPositionSerializedCommitRequest request,
+        SerializableEventCandidate candidate,
+        string serviceId,
+        string tag,
+        TagHeadExpectationKind kind,
+        string? position)
+    {
+        Assert.Equal(VersionedExpectedTagPositionSerializedCommitRequest.CurrentVersion, request.Version);
+        Assert.Equal([candidate], request.EventCandidates);
+        Assert.Equal([new ConsistencyTagEntry(tag, position ?? string.Empty)], request.ConsistencyTags);
+        var entry = Assert.Single(request.ExpectedTagPositions);
+        Assert.Equal((serviceId, tag, kind, position),
+            (entry.ServiceId, entry.Tag, entry.Expectation.Kind, entry.Expectation.Position));
+    }
+
+    private static void AssertV2Wire(byte[] wire, TagHeadExpectationKind kind, string? position)
+    {
+        using var document = JsonDocument.Parse(wire);
+        var root = document.RootElement;
+        Assert.Equal(VersionedExpectedTagPositionSerializedCommitRequest.CurrentVersion, root.GetProperty("version").GetInt32());
+        Assert.Equal(1, root.GetProperty("eventCandidates").GetArrayLength());
+        Assert.Equal(1, root.GetProperty("consistencyTags").GetArrayLength());
+        var expectation = root.GetProperty("expectedTagPositions")[0].GetProperty("expectation");
+        Assert.Equal((int)kind, expectation.GetProperty("kind").GetInt32());
+        if (position is null)
+        {
+            Assert.Equal(JsonValueKind.Null, expectation.GetProperty("position").ValueKind);
+        }
+        else
+        {
+            Assert.Equal(position, expectation.GetProperty("position").GetString());
+        }
+    }
+
+    private static void AssertSerializedPayload(SerializedCommitResult result, SerializableEventCandidate candidate, string tag)
+    {
+        var written = Assert.Single(result.WrittenEvents);
+        Assert.Equal(candidate.Payload, written.Payload);
+        Assert.Equal(candidate.EventPayloadName, written.EventPayloadName);
+        Assert.Equal(candidate.Tags, written.Tags);
+        Assert.NotEqual(Guid.Empty, written.Id);
+        Assert.False(string.IsNullOrWhiteSpace(written.SortableUniqueIdValue));
+        var tagWrite = Assert.Single(result.TagWriteResults);
+        Assert.Equal(tag, tagWrite.Tag);
+        Assert.True(tagWrite.Version > 0);
+    }
+
+    private sealed record SurfaceMatrixCommand : ICommand;
+    private sealed record DurableCounts(int Events, int Tags, int Heads);
+    private sealed record WithResultStep(
+        ResultBox<ExecutionResult> Result,
+        CommandExecutionOptions Request,
+        DurableCounts Before,
+        Guid StudentId,
+        string Tag,
+        string Name);
+    private sealed record WithoutResultStep(
+        ExecutionResult Result,
+        CommandExecutionOptions Request,
+        DurableCounts Before,
+        Guid StudentId,
+        string Tag,
+        string Name);
+    private sealed record V2Step(
+        ResultBox<SerializedCommitResult> Result,
+        VersionedExpectedTagPositionSerializedCommitRequest Request,
+        SerializableEventCandidate Candidate,
+        byte[] Wire,
+        DurableCounts Before,
+        Guid StudentId,
+        string Tag);
+}

--- a/dcb/tests/Sekiban.Dcb.Postgres.Tests/PostgresTagHeadWriterSeamArchitectureTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Postgres.Tests/PostgresTagHeadWriterSeamArchitectureTests.cs
@@ -1,0 +1,75 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+namespace Sekiban.Dcb.Postgres.Tests;
+
+/// <summary>
+///     Structural counterpart to the real-table writer test: it follows each compiled async writer state machine and
+///     proves that the ordinary typed, ordinary serialized, and unique conditional-claim paths all call the one private
+///     canonical PostgreSQL head seam. Removing a forwarding call is therefore a test-killing mutation even if another
+///     writer's integration test still happens to advance a head.
+/// </summary>
+public sealed class PostgresTagHeadWriterSeamArchitectureTests
+{
+    private const string CanonicalSeam = "WriteSerializableBatchThroughCanonicalHeadSeamAsync";
+
+    [Fact]
+    public void EveryRequiredPostgresTaggedWriter_CallsTheOneCanonicalHeadSeam()
+    {
+        var store = typeof(PostgresEventStore);
+        var writers = new[]
+        {
+            store.GetMethod(nameof(PostgresEventStore.WriteEventsAsync), BindingFlags.Instance | BindingFlags.Public),
+            store.GetMethod(nameof(PostgresEventStore.WriteSerializableEventsAsync), BindingFlags.Instance | BindingFlags.Public),
+            store.GetMethod(nameof(PostgresEventStore.WriteSerializableEventsWithExpectedTagPositionsAsync), BindingFlags.Instance | BindingFlags.Public),
+            store.GetMethod("TryWriteConditionalClaimAsync", BindingFlags.Instance | BindingFlags.NonPublic)
+        };
+
+        Assert.All(writers, writer =>
+        {
+            Assert.NotNull(writer);
+            Assert.True(AsyncStateMachineCalls(writer!, CanonicalSeam),
+                $"{writer!.Name} no longer reaches {CanonicalSeam}; a tagged PostgreSQL writer would bypass the durable head protocol.");
+        });
+    }
+
+    private static bool AsyncStateMachineCalls(MethodInfo method, string calleeName)
+    {
+        var stateMachine = method.GetCustomAttribute<AsyncStateMachineAttribute>()?.StateMachineType
+            ?? throw new InvalidOperationException($"{method.Name} is expected to be an async writer state machine.");
+        var moveNext = stateMachine.GetMethod("MoveNext", BindingFlags.Instance | BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException($"{stateMachine.FullName} has no MoveNext method.");
+        var il = moveNext.GetMethodBody()?.GetILAsByteArray()
+            ?? throw new InvalidOperationException($"{stateMachine.FullName}.MoveNext has no IL body.");
+
+        for (var index = 0; index + sizeof(int) < il.Length; index++)
+        {
+            if (il[index] is not (0x28 or 0x6f)) // call / callvirt
+            {
+                continue;
+            }
+
+            MethodBase? called;
+            try
+            {
+                called = moveNext.Module.ResolveMethod(BitConverter.ToInt32(il, index + 1));
+            }
+            catch (ArgumentException)
+            {
+                continue;
+            }
+            catch (BadImageFormatException)
+            {
+                continue;
+            }
+
+            if (called?.Name == calleeName && called.DeclaringType == typeof(PostgresEventStore))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/dcb/tests/Sekiban.Dcb.Postgres.Tests/PostgresTestFixture.cs
+++ b/dcb/tests/Sekiban.Dcb.Postgres.Tests/PostgresTestFixture.cs
@@ -11,6 +11,10 @@ public class PostgresTestFixture : IAsyncLifetime
 {
     private PostgreSqlContainer? _postgresContainer;
     private ServiceProvider? _serviceProvider;
+    private string? _connectionString;
+
+    /// <summary>Test-only connection string for independent-principal / unprovisioned-schema integration proofs.</summary>
+    public string ConnectionString => _connectionString ?? throw new InvalidOperationException("Test fixture not initialized");
 
     public IEventStore EventStore => _serviceProvider?.GetRequiredService<IEventStore>() ??
         throw new InvalidOperationException("Test fixture not initialized");
@@ -38,6 +42,7 @@ public class PostgresTestFixture : IAsyncLifetime
         await _postgresContainer.StartAsync();
 
         var connectionString = _postgresContainer.GetConnectionString();
+        _connectionString = connectionString;
 
         // Setup service provider
         var services = new ServiceCollection();
@@ -79,7 +84,8 @@ public class PostgresTestFixture : IAsyncLifetime
         await using var context = await DbContextFactory.CreateDbContextAsync();
 
         // Clear all data but keep schema
-        await context.Database.ExecuteSqlRawAsync("TRUNCATE TABLE dcb_events, dcb_tags RESTART IDENTITY CASCADE");
+        await context.Database.ExecuteSqlRawAsync(
+            "TRUNCATE TABLE dcb_events, dcb_tags, dcb_tag_heads, dcb_tag_head_violations, dcb_tag_head_enablement_epochs RESTART IDENTITY CASCADE");
     }
 
     public async Task<SekibanDcbDbContext> GetDbContextAsync() => await DbContextFactory.CreateDbContextAsync();

--- a/dcb/tests/Sekiban.Dcb.Postgres.Tests/Sekiban.Dcb.Postgres.Tests.csproj
+++ b/dcb/tests/Sekiban.Dcb.Postgres.Tests/Sekiban.Dcb.Postgres.Tests.csproj
@@ -35,6 +35,8 @@
     <ItemGroup>
         <ProjectReference Include="..\..\src\Sekiban.Dcb.Core\Sekiban.Dcb.Core.csproj"/>
         <ProjectReference Include="..\..\src\Sekiban.Dcb.Postgres\Sekiban.Dcb.Postgres.csproj"/>
+        <ProjectReference Include="..\..\src\Sekiban.Dcb.WithoutResult\Sekiban.Dcb.WithoutResult.csproj" Aliases="WithoutResultFacade" />
+        <ProjectReference Include="..\..\src\Sekiban.Dcb.WithoutResult.Model\Sekiban.Dcb.WithoutResult.Model.csproj" Aliases="WithoutResultFacade" />
         <ProjectReference Include="..\..\internalUsages\Dcb.Domain\Dcb.Domain.csproj"/>
         <ProjectReference Include="..\..\src\Sekiban.Dcb.Core.Testing\Sekiban.Dcb.Core.Testing.csproj" />
         <ProjectReference Include="..\Sekiban.Dcb.TestSupport\Sekiban.Dcb.TestSupport.csproj" />

--- a/dcb/tests/Sekiban.Dcb.TestSupport/ProviderWriteCountingEventStore.cs
+++ b/dcb/tests/Sekiban.Dcb.TestSupport/ProviderWriteCountingEventStore.cs
@@ -1,0 +1,63 @@
+using ResultBoxes;
+using Sekiban.Dcb.Capabilities;
+using Sekiban.Dcb.Common;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.Storage;
+using Sekiban.Dcb.Tags;
+
+namespace Sekiban.Dcb.TestSupport;
+
+/// <summary>
+///     Transparent test observer around a real provider. It deliberately does not add any write capability: expected
+///     position requests must be rejected by the normal production capability gate, while a facade that accidentally
+///     drops that request would reach <see cref="WriteSerializableEventsAsync"/> and make the failure visible.
+/// </summary>
+public sealed class ProviderWriteCountingEventStore : IEventStore, IWriteConditionCapabilityProvider
+{
+    private readonly IEventStore _inner;
+    private readonly string _fallbackProviderName;
+    private int _describeCalls;
+    private int _providerWriteCalls;
+
+    public ProviderWriteCountingEventStore(IEventStore inner, string fallbackProviderName)
+    {
+        _inner = inner;
+        _fallbackProviderName = fallbackProviderName;
+    }
+
+    public int DescribeCalls => Volatile.Read(ref _describeCalls);
+    public int ProviderWriteCalls => Volatile.Read(ref _providerWriteCalls);
+
+    public WriteConditionCapabilityDescriptor DescribeWriteConditions()
+    {
+        Interlocked.Increment(ref _describeCalls);
+        return _inner is IWriteConditionCapabilityProvider capabilityProvider
+            ? capabilityProvider.DescribeWriteConditions()
+            : WriteConditionCapabilityDescriptor.None(_fallbackProviderName);
+    }
+
+    public Task<ResultBox<IEnumerable<TagStream>>> ReadTagsAsync(ITag tag) => _inner.ReadTagsAsync(tag);
+    public Task<ResultBox<TagState>> GetLatestTagAsync(ITag tag) => _inner.GetLatestTagAsync(tag);
+    public Task<ResultBox<bool>> TagExistsAsync(ITag tag) => _inner.TagExistsAsync(tag);
+    public Task<ResultBox<long>> GetEventCountAsync(SortableUniqueId? since = null) => _inner.GetEventCountAsync(since);
+    public Task<ResultBox<IEnumerable<TagInfo>>> GetAllTagsAsync(string? tagGroup = null) => _inner.GetAllTagsAsync(tagGroup);
+    public Task<ResultBox<IEnumerable<SerializableEvent>>> ReadAllSerializableEventsAsync(SortableUniqueId? since = null) =>
+        _inner.ReadAllSerializableEventsAsync(since);
+    public Task<ResultBox<IEnumerable<SerializableEvent>>> ReadAllSerializableEventsAsync(
+        SortableUniqueId? since,
+        int? maxCount) => _inner.ReadAllSerializableEventsAsync(since, maxCount);
+    public Task<ResultBox<SerializableEvent>> ReadSerializableEventAsync(Guid eventId) =>
+        _inner.ReadSerializableEventAsync(eventId);
+    public Task<ResultBox<IEnumerable<SerializableEvent>>> ReadSerializableEventsByTagAsync(
+        ITag tag,
+        SortableUniqueId? since = null) => _inner.ReadSerializableEventsByTagAsync(tag, since);
+
+    public Task<ResultBox<(IReadOnlyList<SerializableEvent> Events, IReadOnlyList<TagWriteResult> TagWrites)>>
+        WriteSerializableEventsAsync(IEnumerable<SerializableEvent> events)
+    {
+        Interlocked.Increment(ref _providerWriteCalls);
+        return _inner.WriteSerializableEventsAsync(events);
+    }
+
+    public Task<ResultBox<string>> GetLatestSortableUniqueIdAsync() => _inner.GetLatestSortableUniqueIdAsync();
+}

--- a/dcb/tests/Sekiban.Dcb.TestSupport/SeamInventory.cs
+++ b/dcb/tests/Sekiban.Dcb.TestSupport/SeamInventory.cs
@@ -19,6 +19,7 @@ public static class SeamInventory
     public static readonly IReadOnlyList<SeamEntry> Entries = new[]
     {
         new SeamEntry(PostgresAssembly, "Sekiban.Dcb.Postgres.PostgresEventStore", "AfterConditionalCommitHook"),
+        new SeamEntry(PostgresAssembly, "Sekiban.Dcb.Postgres.PostgresEventStore", "TagHeadProtocolHook"),
         new SeamEntry(SqliteAssembly, "Sekiban.Dcb.Sqlite.SqliteEventStore", "AfterConditionalCommitHook"),
         new SeamEntry(CosmosAssembly, "Sekiban.Dcb.CosmosDb.CosmosDbEventStore", "AfterConditionalCommitHook"),
         new SeamEntry(CoreAssembly, "Sekiban.Dcb.Actors.CoreGeneralSekibanExecutor", "ConditionalEventIdFactory"),

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/ConditionalAppend/ConditionalAppendContractTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/ConditionalAppend/ConditionalAppendContractTests.cs
@@ -5,8 +5,11 @@ using Sekiban.Dcb.Capabilities;
 using Sekiban.Dcb.ColdEvents;
 using Sekiban.Dcb.Commands;
 using Sekiban.Dcb.Common;
+using Sekiban.Dcb.CosmosDb;
+using Sekiban.Dcb.DynamoDB;
 using Sekiban.Dcb.Domains;
 using Sekiban.Dcb.Events;
+using Sekiban.Dcb.Sqlite;
 using Sekiban.Dcb.Storage;
 using Sekiban.Dcb.Tags;
 using Sekiban.Dcb.Testing;
@@ -282,6 +285,24 @@ public class ConditionalAppendContractTests
     }
 
     [Fact]
+    public void ExpectedTagPositionCapability_IsStructurallyPostgresOnly_ForEveryOtherProductionProvider()
+    {
+        // These are the actual provider store types, not a name-based convention. The executor's shared capability gate
+        // therefore rejects before any write method for every listed provider; a future accidental implementation makes
+        // this inventory fail and requires an explicit protocol decision.
+        var providers = new[]
+        {
+            typeof(CoreInMemoryEventStore),
+            typeof(SqliteEventStore),
+            typeof(CosmosDbEventStore),
+            typeof(DynamoDbEventStore)
+        };
+        Assert.All(providers, provider =>
+            Assert.False(typeof(IExpectedTagPositionEventStore).IsAssignableFrom(provider),
+                $"{provider.FullName} must fail closed for PostgreSQL expected-tag-position enforcement."));
+    }
+
+    [Fact]
     public void Capability_Composite_IsIntersectionOfUnderlying()
     {
         var supports = WriteConditionCapabilityDescriptor.Supporting("A", WriteConditionKind.SingleEventUniqueKey);
@@ -335,6 +356,106 @@ public class ConditionalAppendContractTests
         Assert.IsType<ConditionNotSupportedException>(result.GetException());
         Assert.False(handlerInvoked); // fail-closed BEFORE the handler runs
         Assert.Empty((await plain.ReadAllSerializableEventsAsync()).GetValue()); // nothing allocated or written
+    }
+
+    [Fact]
+    public async Task Executor_ExpectedTagPositionOnUnsupportedStore_FailsClosed_BeforeHandlerOrWrite()
+    {
+        var domain = BuildDomainTypes();
+        var plain = new CoreInMemoryEventStore(domain.EventTypes); // deliberately not PostgreSQL expected-position capable
+        var accessor = new InMemoryObjectAccessor(plain, domain);
+        var executor = new GeneralSekibanExecutor(plain, accessor, domain);
+        var handlerInvoked = false;
+        var options = new CommandExecutionOptions
+        {
+            ExpectedTagPositions = new ExpectedTagPositionSpecification(
+                [new TagHeadExpectationEntry("default", "Marker:m", TagHeadExpectation.NoEnforcement())])
+        };
+
+        var result = await executor.ExecuteAsync(
+            new MarkerCommand(),
+            (MarkerCommand _, ICommandContext ctx) =>
+            {
+                handlerInvoked = true;
+                return ctx.AppendEvent(new UniqueMarkerEvent("v"), new MarkerTag("m"));
+            },
+            options);
+
+        Assert.False(result.IsSuccess);
+        Assert.IsType<ConditionNotSupportedException>(result.GetException());
+        Assert.False(handlerInvoked);
+        Assert.Empty((await plain.ReadAllSerializableEventsAsync()).GetValue());
+    }
+
+    [Fact]
+    public async Task Executor_ExpectedTagPositionOnActualSqliteStore_FailsClosed_BeforeHandlerOrWrite()
+    {
+        var domain = BuildDomainTypes();
+        var sqlite = new SqliteEventStore(
+            ":memory:",
+            domain.EventTypes,
+            new SqliteEventStoreOptions { AutoCreateDatabase = false });
+        var executor = new GeneralSekibanExecutor(sqlite, new InMemoryObjectAccessor(sqlite, domain), domain);
+        var handlerInvoked = false;
+
+        var result = await executor.ExecuteAsync(
+            new MarkerCommand(),
+            (MarkerCommand _, ICommandContext ctx) =>
+            {
+                handlerInvoked = true;
+                return ctx.AppendEvent(new UniqueMarkerEvent("v"), new MarkerTag("m"));
+            },
+            new CommandExecutionOptions
+            {
+                ExpectedTagPositions = new ExpectedTagPositionSpecification(
+                    [new TagHeadExpectationEntry("default", "Marker:m", TagHeadExpectation.NoEnforcement())])
+            });
+
+        Assert.False(result.IsSuccess);
+        Assert.IsType<ConditionNotSupportedException>(result.GetException());
+        Assert.False(handlerInvoked);
+    }
+
+    [Fact]
+    public async Task SerializedV2_UnsupportedInMemoryProvider_FailsClosedBeforeAnyProviderWrite()
+    {
+        var domain = BuildDomainTypes();
+        var plain = new CoreInMemoryEventStore(domain.EventTypes);
+        var executor = new GeneralSekibanExecutor(plain, new InMemoryObjectAccessor(plain, domain), domain);
+        var acceptor = new SerializedCommitAcceptor(executor);
+        var json = Encoding.UTF8.GetBytes(
+            """{"version":2,"eventCandidates":[{"payload":"AQID","eventPayloadName":"UniqueMarkerEvent","tags":["Marker:m"]}],"consistencyTags":[{"tag":"Marker:m","lastSortableUniqueId":""}],"expectedTagPositions":[{"serviceId":"default","tag":"Marker:m","expectation":{"kind":2,"position":null}}]}""");
+
+        var result = await acceptor.AcceptAsync(json);
+
+        Assert.False(result.IsSuccess);
+        Assert.IsType<ConditionNotSupportedException>(result.GetException());
+        Assert.Empty((await plain.ReadAllSerializableEventsAsync()).GetValue());
+    }
+
+    [Fact]
+    public async Task Executor_ConditionalAndExpectedPositionCombination_IsRejectedBeforeHandler()
+    {
+        var (executor, store, _) = NewConditional();
+        var handlerInvoked = false;
+        var result = await executor.ExecuteAsync(
+            new MarkerCommand(),
+            (MarkerCommand _, ICommandContext ctx) =>
+            {
+                handlerInvoked = true;
+                return ctx.AppendEvent(new UniqueMarkerEvent("v"), new MarkerTag("m"));
+            },
+            new CommandExecutionOptions
+            {
+                ConditionalAppend = new ConditionalAppendSpecification("op"),
+                ExpectedTagPositions = new ExpectedTagPositionSpecification(
+                    [new TagHeadExpectationEntry("default", "Marker:m", TagHeadExpectation.NoEnforcement())])
+            });
+
+        Assert.False(result.IsSuccess);
+        Assert.IsType<TagHeadExpectationValidationException>(result.GetException());
+        Assert.False(handlerInvoked);
+        Assert.Empty((await store.ReadAllSerializableEventsAsync()).GetValue());
     }
 
     // ---------------- Single-event contract (zero and multi both fail closed, before any store call) ----------------

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/ConditionalAppend/ConditionalAppendSeamArchitectureTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/ConditionalAppend/ConditionalAppendSeamArchitectureTests.cs
@@ -67,6 +67,7 @@ public class ConditionalAppendSeamArchitectureTests
             "Sekiban.Dcb.Core|Sekiban.Dcb.Storage.ConditionalAppendCoordinator|VerificationBudgetOverride",
             "Sekiban.Dcb.CosmosDb|Sekiban.Dcb.CosmosDb.CosmosDbEventStore|AfterConditionalCommitHook",
             "Sekiban.Dcb.Postgres|Sekiban.Dcb.Postgres.PostgresEventStore|AfterConditionalCommitHook",
+            "Sekiban.Dcb.Postgres|Sekiban.Dcb.Postgres.PostgresEventStore|TagHeadProtocolHook",
             "Sekiban.Dcb.Sqlite|Sekiban.Dcb.Sqlite.SqliteEventStore|AfterConditionalCommitHook"
         }.OrderBy(s => s, StringComparer.Ordinal).ToArray();
         Assert.Equal(expected, actual);

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/ConditionalAppend/ExpectedTagPositionUnsupportedProviderInvocationTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/ConditionalAppend/ExpectedTagPositionUnsupportedProviderInvocationTests.cs
@@ -1,0 +1,190 @@
+using System.Reflection;
+using Amazon.DynamoDBv2;
+using Dcb.Domain;
+using Microsoft.Extensions.Options;
+using Orleans;
+using ResultBoxes;
+using Sekiban.Dcb.Actors;
+using Sekiban.Dcb.Capabilities;
+using Sekiban.Dcb.Commands;
+using Sekiban.Dcb.CosmosDb;
+using Sekiban.Dcb.DynamoDB;
+using Sekiban.Dcb.Domains;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.ServiceId;
+using Sekiban.Dcb.Sqlite;
+using Sekiban.Dcb.Storage;
+using Sekiban.Dcb.TestSupport;
+using Sekiban.Dcb.Testing;
+using Sekiban.Dcb.Tests.Cosmos;
+using Sekiban.Dcb.Tags;
+using Xunit;
+using CoreInMemoryEventStore = Sekiban.Dcb.Testing.InMemoryEventStore;
+
+namespace Sekiban.Dcb.Tests.ConditionalAppend;
+
+/// <summary>
+///     AC6 invocation proof, not merely structural assignability. Each row wraps the named real unsupported provider
+///     with a transparent write counter, then drives every newly-added WithResult command/V2/wire route and the Orleans
+///     V2 forwarding route. Dropping the condition at any facade would invoke the handler or provider writer and fail.
+/// </summary>
+public sealed class ExpectedTagPositionUnsupportedProviderInvocationTests
+{
+    private const string ServiceId = DefaultServiceIdProvider.DefaultServiceId;
+    private const string Tag = "ExpectedMarker:m";
+
+    public static IEnumerable<object[]> UnsupportedProviderFactories()
+    {
+        yield return ["InMemory", (Func<DcbDomainTypes, IEventStore>)(domain => new CoreInMemoryEventStore(domain.EventTypes))];
+        yield return ["SQLite", (Func<DcbDomainTypes, IEventStore>)(domain =>
+            new SqliteEventStore(
+                Path.Combine(Path.GetTempPath(), $"g40-ac6-{Guid.NewGuid():N}.db"),
+                domain.EventTypes,
+                new SqliteEventStoreOptions { AutoCreateDatabase = false }))];
+        yield return ["Cosmos", (Func<DcbDomainTypes, IEventStore>)(domain => NewCosmosStore(domain))];
+        yield return ["Dynamo", (Func<DcbDomainTypes, IEventStore>)(domain => NewDynamoStore(domain))];
+    }
+
+    [Theory]
+    [MemberData(nameof(UnsupportedProviderFactories))]
+    public async Task EveryWithResultAndOrleansExpectedPositionEntry_RejectsNamedProviderBeforeHandlerOrWrite(
+        string providerName,
+        Func<DcbDomainTypes, IEventStore> createProvider)
+    {
+        var domain = BuildDomain();
+        var observed = new ProviderWriteCountingEventStore(createProvider(domain), providerName);
+        var descriptor = observed.DescribeWriteConditions();
+        Assert.False(descriptor.Supports(WriteConditionKind.ExpectedTagPosition));
+
+        var executor = new GeneralSekibanExecutor(observed, new InMemoryObjectAccessor(observed, domain), domain);
+        var conditional = Assert.IsAssignableFrom<IConditionalCommandExecutor>(executor);
+        var handlerCalls = 0;
+        var typed = await conditional.ExecuteAsync(
+            new ExpectedMarkerCommand(),
+            (ExpectedMarkerCommand _, ICommandContext context) =>
+            {
+                Interlocked.Increment(ref handlerCalls);
+                return context.AppendEvent(new ExpectedMarkerEvent("typed"), new ExpectedMarkerTag("m"));
+            },
+            ExpectedOptions());
+        AssertUnsupported(typed);
+        Assert.Equal(0, handlerCalls);
+        Assert.Equal(0, observed.ProviderWriteCalls);
+
+        // The direct V2 facade is distinct from the JSON acceptor route.
+        var directV2 = await Assert.IsAssignableFrom<ISerializedExpectedTagPositionSekibanDcbExecutor>(executor)
+            .CommitSerializableEventsWithExpectedTagPositionsAsync(ExpectedV2Request());
+        AssertUnsupported(directV2);
+        Assert.Equal(0, observed.ProviderWriteCalls);
+
+        var wire = await new SerializedCommitAcceptor(executor).AcceptAsync(ExpectedV2Wire());
+        AssertUnsupported(wire);
+        Assert.Equal(0, observed.ProviderWriteCalls);
+
+        // Orleans owns a forwarding body; this verifies its call reaches the same fail-closed gate before it ever asks a
+        // grain or writes the provider. The wire call also exercises the acceptor's optional-executor feature detection.
+        var cluster = DispatchProxy.Create<IClusterClient, UnreachableClusterClient>();
+        var orleans = new Sekiban.Dcb.Orleans.OrleansDcbExecutor(cluster, observed, domain);
+        var orleansDirectV2 = await Assert.IsAssignableFrom<ISerializedExpectedTagPositionSekibanDcbExecutor>(orleans)
+            .CommitSerializableEventsWithExpectedTagPositionsAsync(ExpectedV2Request());
+        AssertUnsupported(orleansDirectV2);
+        Assert.Equal(0, observed.ProviderWriteCalls);
+
+        var orleansWire = await new SerializedCommitAcceptor(orleans).AcceptAsync(ExpectedV2Wire());
+        AssertUnsupported(orleansWire);
+        Assert.Equal(0, observed.ProviderWriteCalls);
+    }
+
+    private static DcbDomainTypes BuildDomain()
+    {
+        var domain = DomainType.GetDomainTypes();
+        ((SimpleEventTypes)domain.EventTypes).RegisterEventType<ExpectedMarkerEvent>();
+        ((SimpleTagTypes)domain.TagTypes).RegisterTagGroupType<ExpectedMarkerTag>();
+        return domain;
+    }
+
+    private static CommandExecutionOptions ExpectedOptions() =>
+        new()
+        {
+            ExpectedTagPositions = new ExpectedTagPositionSpecification(
+                [new TagHeadExpectationEntry(ServiceId, Tag, TagHeadExpectation.NoEnforcement())])
+        };
+
+    private static VersionedExpectedTagPositionSerializedCommitRequest ExpectedV2Request() =>
+        new(
+            VersionedExpectedTagPositionSerializedCommitRequest.CurrentVersion,
+            [new SerializableEventCandidate("{}"u8.ToArray(), nameof(ExpectedMarkerEvent), [Tag])],
+            [new ConsistencyTagEntry(Tag, string.Empty)],
+            [new TagHeadExpectationEntry(ServiceId, Tag, TagHeadExpectation.NoEnforcement())]);
+
+    private static byte[] ExpectedV2Wire() => SerializedCommitWireContract.SerializeToUtf8Bytes(ExpectedV2Request());
+
+    private static CosmosDbEventStore NewCosmosStore(DcbDomainTypes domain)
+    {
+        var options = new CosmosDbEventStoreOptions
+        {
+            EventsContainerName = "events",
+            TagsContainerName = "tags"
+        };
+        return new CosmosDbEventStore(
+            new CosmosDbContext(new InMemoryCosmosClient(), "g40-ac6", null, options),
+            domain.EventTypes,
+            new DefaultServiceIdProvider(),
+            new DefaultCosmosContainerResolver(options));
+    }
+
+    private static DynamoDbEventStore NewDynamoStore(DcbDomainTypes domain)
+    {
+        var client = DispatchProxy.Create<IAmazonDynamoDB, UnreachableDynamoClient>();
+        var options = Options.Create(new DynamoDbEventStoreOptions
+        {
+            AutoCreateTables = false,
+            EventsTableName = "events",
+            TagsTableName = "tags",
+            ProjectionStatesTableName = "states",
+            WriteShardCount = 1
+        });
+        return new DynamoDbEventStore(new DynamoDbContext(client, options), domain.EventTypes, new DefaultServiceIdProvider());
+    }
+
+    private static void AssertUnsupported(ResultBox<ExecutionResult> result)
+    {
+        Assert.False(result.IsSuccess);
+        AssertUnsupported(result.GetException());
+    }
+
+    private static void AssertUnsupported(ResultBox<SerializedCommitResult> result)
+    {
+        Assert.False(result.IsSuccess);
+        AssertUnsupported(result.GetException());
+    }
+
+    private static void AssertUnsupported(Exception exception)
+    {
+        var unsupported = Assert.IsType<ConditionNotSupportedException>(exception);
+        Assert.Equal(WriteConditionKind.ExpectedTagPosition, unsupported.RequestedKind);
+    }
+
+    private sealed record ExpectedMarkerCommand : ICommand;
+    private sealed record ExpectedMarkerEvent(string Value) : IEventPayload;
+
+    private sealed record ExpectedMarkerTag(string Id) : IStringTagGroup<ExpectedMarkerTag>
+    {
+        public static string TagGroupName => "ExpectedMarker";
+        public static ExpectedMarkerTag FromContent(string content) => new(content);
+        public bool IsConsistencyTag() => true;
+        public string GetId() => Id;
+    }
+
+    private class UnreachableDynamoClient : DispatchProxy
+    {
+        protected override object? Invoke(MethodInfo? targetMethod, object?[]? args) =>
+            throw new InvalidOperationException($"Dynamo must not be invoked by a fail-closed expected-position request: {targetMethod?.Name}");
+    }
+
+    private class UnreachableClusterClient : DispatchProxy
+    {
+        protected override object? Invoke(MethodInfo? targetMethod, object?[]? args) =>
+            throw new InvalidOperationException($"Orleans must not resolve a grain before expected-position rejection: {targetMethod?.Name}");
+    }
+}

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/ExpectedTagPositionCompatibilityInventoryTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/ExpectedTagPositionCompatibilityInventoryTests.cs
@@ -1,22 +1,26 @@
+using System.Reflection;
+using ResultBoxes;
 using Sekiban.Dcb.Actors;
 using Sekiban.Dcb.Capabilities;
 using Sekiban.Dcb.Commands;
+using Sekiban.Dcb.Events;
 using Sekiban.Dcb.Storage;
+using Sekiban.Dcb.Tags;
 using Xunit;
 
 namespace Sekiban.Dcb.Tests;
 
 /// <summary>
-///     Pin the additive SEK-G40 public contract separately from the legacy serialized-interface freeze. This inventory
-///     makes accidental discriminator/DTO/interface drift visible while the existing no-migration tests keep every V1
-///     shape and <see cref="ISerializedSekibanDcbExecutor" /> member unchanged.
+///     Frozen additive SEK-G40 public-contract inventory. This inventories every new shape rather than merely asserting
+///     assignability: a renamed DTO member, changed positional/deconstruction shape, altered facade signature, or
+///     broadened capability descriptor must break here. Existing V1 goldens/no-migration tests remain the counter-proof
+///     that the old payload and surface were not changed in place.
 /// </summary>
 public sealed class ExpectedTagPositionCompatibilityInventoryTests
 {
     [Fact]
-    public void NewCapabilityAndThreeStateContract_HaveThePinnedAdditiveShape()
+    public void ThreeStateRequestResultConflictAndExceptionShapes_AreFrozen()
     {
-        Assert.Equal(2, (int)WriteConditionKind.ExpectedTagPosition);
         Assert.Equal(
             new[]
             {
@@ -26,46 +30,235 @@ public sealed class ExpectedTagPositionCompatibilityInventoryTests
                 TagHeadExpectationKind.Exact
             },
             Enum.GetValues<TagHeadExpectationKind>());
+        Assert.Equal(0, (int)TagHeadExpectationKind.Unknown);
+        Assert.Equal(1, (int)TagHeadExpectationKind.NoEnforcement);
+        Assert.Equal(2, (int)TagHeadExpectationKind.AssertEmpty);
+        Assert.Equal(3, (int)TagHeadExpectationKind.Exact);
 
+        AssertRecordShape<TagHeadExpectation>(
+            ["Kind", "Position"],
+            [typeof(TagHeadExpectationKind), typeof(string)],
+            ["Kind", "Position"]);
+        var expectationConstructor = Assert.Single(typeof(TagHeadExpectation).GetConstructors());
+        Assert.True(expectationConstructor.GetParameters()[1].HasDefaultValue);
+        Assert.Null(expectationConstructor.GetParameters()[1].DefaultValue);
         Assert.Equal(TagHeadExpectationKind.NoEnforcement, TagHeadExpectation.NoEnforcement().Kind);
         Assert.Equal(TagHeadExpectationKind.AssertEmpty, TagHeadExpectation.AssertEmpty().Kind);
         Assert.Equal((TagHeadExpectationKind.Exact, "p"),
             (TagHeadExpectation.Exact("p").Kind, TagHeadExpectation.Exact("p").Position));
+        AssertStaticMethod(typeof(TagHeadExpectation), nameof(TagHeadExpectation.NoEnforcement), typeof(TagHeadExpectation));
+        AssertStaticMethod(typeof(TagHeadExpectation), nameof(TagHeadExpectation.AssertEmpty), typeof(TagHeadExpectation));
+        AssertStaticMethod(typeof(TagHeadExpectation), nameof(TagHeadExpectation.Exact), typeof(TagHeadExpectation), typeof(string));
 
-        Assert.Equal(
-            new[] { "ServiceId", "Tag", "Expectation" },
-            typeof(TagHeadExpectationEntry).GetConstructors().Single().GetParameters().Select(parameter => parameter.Name));
-        Assert.Equal(
-            new[] { "Events", "TagWrites" },
-            typeof(ExpectedTagPositionWriteResult).GetConstructors().Single().GetParameters().Select(parameter => parameter.Name));
-        Assert.Equal("Pairs", typeof(ExpectedTagPositionConflictException).GetProperty(nameof(ExpectedTagPositionConflictException.Pairs))!.Name);
+        AssertRecordShape<TagHeadExpectationEntry>(
+            ["ServiceId", "Tag", "Expectation"],
+            [typeof(string), typeof(string), typeof(TagHeadExpectation)],
+            ["ServiceId", "Tag", "Expectation"]);
+        AssertRecordShape<ExpectedTagPositionSpecification>(
+            ["Entries"],
+            [typeof(IReadOnlyList<TagHeadExpectationEntry>)],
+            ["Entries", "RequiresEnforcement"]);
+        var specification = new ExpectedTagPositionSpecification(
+            [new TagHeadExpectationEntry("svc", "Tag:one", TagHeadExpectation.NoEnforcement())]);
+        Assert.False(specification.RequiresEnforcement);
+        Assert.True(new ExpectedTagPositionSpecification(
+            [new TagHeadExpectationEntry("svc", "Tag:one", TagHeadExpectation.AssertEmpty())]).RequiresEnforcement);
+
+        AssertRecordShape<TagHeadExpectedObserved>(
+            ["ServiceId", "Tag", "Expected", "ObservedPosition"],
+            [typeof(string), typeof(string), typeof(TagHeadExpectation), typeof(string)],
+            ["ServiceId", "Tag", "Expected", "ObservedPosition"]);
+        AssertRecordShape<ExpectedTagPositionWriteResult>(
+            ["Events", "TagWrites"],
+            [typeof(IReadOnlyList<SerializableEvent>), typeof(IReadOnlyList<TagWriteResult>)],
+            ["Events", "TagWrites"]);
+
+        AssertConstructor(typeof(ExpectedTagPositionConflictException), [typeof(IReadOnlyList<TagHeadExpectedObserved>)]);
+        AssertProperty(typeof(ExpectedTagPositionConflictException), nameof(ExpectedTagPositionConflictException.Pairs),
+            typeof(IReadOnlyList<TagHeadExpectedObserved>));
+        AssertConstructor(typeof(TagHeadExpectationValidationException), [typeof(string)]);
+        AssertConstructor(typeof(TagHeadPositionValidationException), [typeof(string)]);
+        AssertConstructor(typeof(TagHeadEnforcementNotEnabledException), [typeof(string)]);
+        AssertProperty(typeof(TagHeadEnforcementNotEnabledException), nameof(TagHeadEnforcementNotEnabledException.ServiceId), typeof(string));
     }
 
     [Fact]
-    public void VersionedWireAndOptionalInterfaces_AreAdditiveAndImplementedByTheWithResultFacade()
+    public void CapabilityDescriptorAndOptionalStoreContract_AreFrozen()
     {
-        Assert.Equal(
-            new[] { "Version", "EventCandidates", "ConsistencyTags", "ExpectedTagPositions" },
-            typeof(VersionedExpectedTagPositionSerializedCommitRequest).GetConstructors().Single().GetParameters()
-                .Select(parameter => parameter.Name));
-
-        var serializedMethod = Assert.Single(typeof(ISerializedExpectedTagPositionSekibanDcbExecutor).GetMethods());
-        Assert.Equal(nameof(ISerializedExpectedTagPositionSekibanDcbExecutor.CommitSerializableEventsWithExpectedTagPositionsAsync),
-            serializedMethod.Name);
-        Assert.Equal(
-            new[] { typeof(VersionedExpectedTagPositionSerializedCommitRequest), typeof(CancellationToken) },
-            serializedMethod.GetParameters().Select(parameter => parameter.ParameterType));
-
-        var storeMethods = typeof(IExpectedTagPositionEventStore).GetMethods().Select(method => method.Name)
-            .OrderBy(name => name, StringComparer.Ordinal).ToArray();
         Assert.Equal(
             new[]
             {
-                nameof(IExpectedTagPositionEventStore.EnsureExpectedTagPositionEnforcementEnabledAsync),
-                nameof(IExpectedTagPositionEventStore.WriteSerializableEventsWithExpectedTagPositionsAsync)
+                WriteConditionKind.Unknown,
+                WriteConditionKind.SingleEventUniqueKey,
+                WriteConditionKind.ExpectedTagPosition
             },
-            storeMethods);
+            Enum.GetValues<WriteConditionKind>());
+        Assert.Equal(0, (int)WriteConditionKind.Unknown);
+        Assert.Equal(1, (int)WriteConditionKind.SingleEventUniqueKey);
+        Assert.Equal(2, (int)WriteConditionKind.ExpectedTagPosition);
+
+        AssertRecordShape<WriteConditionCapabilityDescriptor>(
+            ["SupportedKinds", "ProviderName"],
+            [typeof(IReadOnlySet<WriteConditionKind>), typeof(string)],
+            ["SupportedKinds", "ProviderName"]);
+        AssertInstanceMethod(typeof(WriteConditionCapabilityDescriptor), nameof(WriteConditionCapabilityDescriptor.Supports),
+            typeof(bool), typeof(WriteConditionKind));
+        AssertStaticMethod(typeof(WriteConditionCapabilityDescriptor), nameof(WriteConditionCapabilityDescriptor.None),
+            typeof(WriteConditionCapabilityDescriptor), typeof(string));
+        AssertStaticMethod(typeof(WriteConditionCapabilityDescriptor), nameof(WriteConditionCapabilityDescriptor.Supporting),
+            typeof(WriteConditionCapabilityDescriptor), typeof(string), typeof(WriteConditionKind[]));
+        AssertStaticMethod(typeof(WriteConditionCapabilityDescriptor), nameof(WriteConditionCapabilityDescriptor.Intersect),
+            typeof(WriteConditionCapabilityDescriptor), typeof(string), typeof(IReadOnlyCollection<WriteConditionCapabilityDescriptor>));
+        AssertInstanceMethod(typeof(WriteConditionCapabilityDescriptor), nameof(ToString), typeof(string));
+        AssertInstanceMethod(typeof(IWriteConditionCapabilityProvider), nameof(IWriteConditionCapabilityProvider.DescribeWriteConditions),
+            typeof(WriteConditionCapabilityDescriptor));
+
+        AssertMethod(
+            typeof(IExpectedTagPositionEventStore),
+            nameof(IExpectedTagPositionEventStore.EnsureExpectedTagPositionEnforcementEnabledAsync),
+            typeof(Task<ResultBox<bool>>),
+            typeof(CancellationToken));
+        AssertMethod(
+            typeof(IExpectedTagPositionEventStore),
+            nameof(IExpectedTagPositionEventStore.WriteSerializableEventsWithExpectedTagPositionsAsync),
+            typeof(Task<ResultBox<ExpectedTagPositionWriteResult>>),
+            typeof(IReadOnlyList<SerializableEvent>), typeof(ExpectedTagPositionSpecification), typeof(CancellationToken));
+    }
+
+    [Fact]
+    public void VersionedWireAndWithResultFacadeSignatures_AreAdditiveAndExact()
+    {
+        AssertRecordShape<VersionedExpectedTagPositionSerializedCommitRequest>(
+            ["Version", "EventCandidates", "ConsistencyTags", "ExpectedTagPositions"],
+            [typeof(int), typeof(IReadOnlyList<SerializableEventCandidate>), typeof(IReadOnlyList<ConsistencyTagEntry>),
+                typeof(IReadOnlyList<TagHeadExpectationEntry>)],
+            ["Version", "EventCandidates", "ConsistencyTags", "ExpectedTagPositions"]);
+        Assert.Equal(2, VersionedExpectedTagPositionSerializedCommitRequest.CurrentVersion);
+
+        AssertMethod(
+            typeof(ISerializedExpectedTagPositionSekibanDcbExecutor),
+            nameof(ISerializedExpectedTagPositionSekibanDcbExecutor.CommitSerializableEventsWithExpectedTagPositionsAsync),
+            typeof(Task<ResultBox<SerializedCommitResult>>),
+            typeof(VersionedExpectedTagPositionSerializedCommitRequest), typeof(CancellationToken));
+        AssertSerializedExpectedSurface(typeof(GeneralSekibanExecutor));
+        AssertSerializedExpectedSurface(typeof(Sekiban.Dcb.Orleans.OrleansDcbExecutor));
+
         Assert.True(typeof(ISerializedExpectedTagPositionSekibanDcbExecutor).IsAssignableFrom(typeof(GeneralSekibanExecutor)));
         Assert.True(typeof(IConditionalCommandExecutor).IsAssignableFrom(typeof(GeneralSekibanExecutor)));
+        AssertWithResultConditionalExecutorSignatures(typeof(IConditionalCommandExecutor));
+
+        var optionsProperty = typeof(CommandExecutionOptions).GetProperty(nameof(CommandExecutionOptions.ExpectedTagPositions));
+        Assert.NotNull(optionsProperty);
+        Assert.Equal(typeof(ExpectedTagPositionSpecification), optionsProperty.PropertyType);
+        Assert.True(optionsProperty.SetMethod is not null);
+        Assert.Equal(
+            ["ConditionalAppend", "ExpectedTagPositions"],
+            typeof(CommandExecutionOptions).GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+                .Select(property => property.Name));
+        Assert.Equal(typeof(ConditionalAppendSpecification),
+            typeof(CommandExecutionOptions).GetProperty(nameof(CommandExecutionOptions.ConditionalAppend))!.PropertyType);
+        Assert.NotNull(typeof(CommandExecutionOptions).GetConstructor(Type.EmptyTypes));
+    }
+
+    private static void AssertWithResultConditionalExecutorSignatures(Type surface)
+    {
+        var methods = surface.GetMethods().Where(method => method.Name == nameof(IConditionalCommandExecutor.ExecuteAsync)).ToArray();
+        Assert.Equal(2, methods.Length);
+
+        var withHandler = Assert.Single(methods, method => method.GetParameters().Length == 4);
+        Assert.Equal(typeof(Task<ResultBox<ExecutionResult>>), withHandler.ReturnType);
+        Assert.True(withHandler.IsGenericMethodDefinition);
+        var command = withHandler.GetGenericArguments().Single();
+        var parameters = withHandler.GetParameters();
+        Assert.Equal(["command", "handlerFunc", "options", "cancellationToken"], parameters.Select(parameter => parameter.Name));
+        Assert.Equal(command, parameters[0].ParameterType);
+        Assert.Equal(typeof(CommandExecutionOptions), parameters[2].ParameterType);
+        Assert.Equal(typeof(CancellationToken), parameters[3].ParameterType);
+        Assert.True(parameters[3].IsOptional);
+        Assert.Contains(typeof(ICommand), command.GetGenericParameterConstraints());
+        var handlerParameter = parameters[1].ParameterType;
+        Assert.True(handlerParameter.IsGenericType);
+        Assert.Equal(typeof(Func<,,>), handlerParameter.GetGenericTypeDefinition());
+        Assert.Equal(
+            [command, typeof(ICommandContext), typeof(Task<ResultBox<EventOrNone>>)],
+            handlerParameter.GetGenericArguments());
+
+        var selfHandling = Assert.Single(methods, method => method.GetParameters().Length == 3);
+        Assert.Equal(typeof(Task<ResultBox<ExecutionResult>>), selfHandling.ReturnType);
+        Assert.True(selfHandling.IsGenericMethodDefinition);
+        var selfParameters = selfHandling.GetParameters();
+        var selfCommand = selfHandling.GetGenericArguments().Single();
+        Assert.Equal(["command", "options", "cancellationToken"], selfParameters.Select(parameter => parameter.Name));
+        Assert.Equal(selfCommand, selfParameters[0].ParameterType);
+        Assert.Equal(typeof(CommandExecutionOptions), selfParameters[1].ParameterType);
+        Assert.Equal(typeof(CancellationToken), selfParameters[2].ParameterType);
+        Assert.True(selfParameters[2].IsOptional);
+        Assert.Contains(typeof(ICommandWithHandler<>).MakeGenericType(selfCommand), selfCommand.GetGenericParameterConstraints());
+    }
+
+    private static void AssertSerializedExpectedSurface(Type facade) =>
+        AssertMethod(
+            facade,
+            nameof(ISerializedExpectedTagPositionSekibanDcbExecutor.CommitSerializableEventsWithExpectedTagPositionsAsync),
+            typeof(Task<ResultBox<SerializedCommitResult>>),
+            typeof(VersionedExpectedTagPositionSerializedCommitRequest), typeof(CancellationToken));
+
+    private static void AssertRecordShape<T>(
+        IReadOnlyList<string> parameterNames,
+        IReadOnlyList<Type> parameterTypes,
+        IReadOnlyList<string> propertyNames)
+    {
+        var type = typeof(T);
+        AssertConstructor(type, parameterTypes, parameterNames);
+        Assert.Equal(
+            propertyNames,
+            type.GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+                .Select(property => property.Name));
+        var deconstruct = Assert.Single(
+            type.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly),
+            method => method.Name == "Deconstruct");
+        Assert.Equal(parameterTypes.Count, deconstruct.GetParameters().Length);
+        Assert.All(deconstruct.GetParameters(), parameter => Assert.True(parameter.IsOut));
+        Assert.Equal(parameterTypes.Select(type => type.MakeByRefType()),
+            deconstruct.GetParameters().Select(parameter => parameter.ParameterType));
+    }
+
+    private static void AssertConstructor(Type type, IReadOnlyList<Type> parameterTypes, IReadOnlyList<string>? parameterNames = null)
+    {
+        var constructor = Assert.Single(
+            type.GetConstructors(BindingFlags.Public | BindingFlags.Instance),
+            candidate => candidate.GetParameters().Select(parameter => parameter.ParameterType).SequenceEqual(parameterTypes));
+        if (parameterNames is not null)
+        {
+            Assert.Equal(parameterNames, constructor.GetParameters().Select(parameter => parameter.Name));
+        }
+    }
+
+    private static void AssertProperty(Type type, string name, Type propertyType)
+    {
+        var property = type.GetProperty(name, BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly);
+        Assert.NotNull(property);
+        Assert.Equal(propertyType, property.PropertyType);
+    }
+
+    private static void AssertMethod(Type type, string name, Type returnType, params Type[] parameterTypes)
+    {
+        var method = Assert.Single(
+            type.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly),
+            candidate => candidate.Name == name && candidate.ReturnType == returnType &&
+                         candidate.GetParameters().Select(parameter => parameter.ParameterType).SequenceEqual(parameterTypes));
+        Assert.False(method.IsStatic);
+    }
+
+    private static void AssertInstanceMethod(Type type, string name, Type returnType, params Type[] parameterTypes) =>
+        AssertMethod(type, name, returnType, parameterTypes);
+
+    private static void AssertStaticMethod(Type type, string name, Type returnType, params Type[] parameterTypes)
+    {
+        var method = Assert.Single(
+            type.GetMethods(BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly),
+            candidate => candidate.Name == name && candidate.ReturnType == returnType &&
+                         candidate.GetParameters().Select(parameter => parameter.ParameterType).SequenceEqual(parameterTypes));
+        Assert.True(method.IsStatic);
     }
 }

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/ExpectedTagPositionCompatibilityInventoryTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/ExpectedTagPositionCompatibilityInventoryTests.cs
@@ -1,0 +1,71 @@
+using Sekiban.Dcb.Actors;
+using Sekiban.Dcb.Capabilities;
+using Sekiban.Dcb.Commands;
+using Sekiban.Dcb.Storage;
+using Xunit;
+
+namespace Sekiban.Dcb.Tests;
+
+/// <summary>
+///     Pin the additive SEK-G40 public contract separately from the legacy serialized-interface freeze. This inventory
+///     makes accidental discriminator/DTO/interface drift visible while the existing no-migration tests keep every V1
+///     shape and <see cref="ISerializedSekibanDcbExecutor" /> member unchanged.
+/// </summary>
+public sealed class ExpectedTagPositionCompatibilityInventoryTests
+{
+    [Fact]
+    public void NewCapabilityAndThreeStateContract_HaveThePinnedAdditiveShape()
+    {
+        Assert.Equal(2, (int)WriteConditionKind.ExpectedTagPosition);
+        Assert.Equal(
+            new[]
+            {
+                TagHeadExpectationKind.Unknown,
+                TagHeadExpectationKind.NoEnforcement,
+                TagHeadExpectationKind.AssertEmpty,
+                TagHeadExpectationKind.Exact
+            },
+            Enum.GetValues<TagHeadExpectationKind>());
+
+        Assert.Equal(TagHeadExpectationKind.NoEnforcement, TagHeadExpectation.NoEnforcement().Kind);
+        Assert.Equal(TagHeadExpectationKind.AssertEmpty, TagHeadExpectation.AssertEmpty().Kind);
+        Assert.Equal((TagHeadExpectationKind.Exact, "p"),
+            (TagHeadExpectation.Exact("p").Kind, TagHeadExpectation.Exact("p").Position));
+
+        Assert.Equal(
+            new[] { "ServiceId", "Tag", "Expectation" },
+            typeof(TagHeadExpectationEntry).GetConstructors().Single().GetParameters().Select(parameter => parameter.Name));
+        Assert.Equal(
+            new[] { "Events", "TagWrites" },
+            typeof(ExpectedTagPositionWriteResult).GetConstructors().Single().GetParameters().Select(parameter => parameter.Name));
+        Assert.Equal("Pairs", typeof(ExpectedTagPositionConflictException).GetProperty(nameof(ExpectedTagPositionConflictException.Pairs))!.Name);
+    }
+
+    [Fact]
+    public void VersionedWireAndOptionalInterfaces_AreAdditiveAndImplementedByTheWithResultFacade()
+    {
+        Assert.Equal(
+            new[] { "Version", "EventCandidates", "ConsistencyTags", "ExpectedTagPositions" },
+            typeof(VersionedExpectedTagPositionSerializedCommitRequest).GetConstructors().Single().GetParameters()
+                .Select(parameter => parameter.Name));
+
+        var serializedMethod = Assert.Single(typeof(ISerializedExpectedTagPositionSekibanDcbExecutor).GetMethods());
+        Assert.Equal(nameof(ISerializedExpectedTagPositionSekibanDcbExecutor.CommitSerializableEventsWithExpectedTagPositionsAsync),
+            serializedMethod.Name);
+        Assert.Equal(
+            new[] { typeof(VersionedExpectedTagPositionSerializedCommitRequest), typeof(CancellationToken) },
+            serializedMethod.GetParameters().Select(parameter => parameter.ParameterType));
+
+        var storeMethods = typeof(IExpectedTagPositionEventStore).GetMethods().Select(method => method.Name)
+            .OrderBy(name => name, StringComparer.Ordinal).ToArray();
+        Assert.Equal(
+            new[]
+            {
+                nameof(IExpectedTagPositionEventStore.EnsureExpectedTagPositionEnforcementEnabledAsync),
+                nameof(IExpectedTagPositionEventStore.WriteSerializableEventsWithExpectedTagPositionsAsync)
+            },
+            storeMethods);
+        Assert.True(typeof(ISerializedExpectedTagPositionSekibanDcbExecutor).IsAssignableFrom(typeof(GeneralSekibanExecutor)));
+        Assert.True(typeof(IConditionalCommandExecutor).IsAssignableFrom(typeof(GeneralSekibanExecutor)));
+    }
+}

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/Sekiban.Dcb.WithResult.Tests.csproj
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/Sekiban.Dcb.WithResult.Tests.csproj
@@ -15,6 +15,7 @@
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.3" />
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.3" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+        <PackageReference Include="Microsoft.Orleans.Core" Version="10.0.1" />
         <PackageReference Include="xunit" Version="2.9.3" />
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
             <PrivateAssets>all</PrivateAssets>
@@ -30,6 +31,7 @@
 
     <ItemGroup>
         <ProjectReference Include="..\..\src\Sekiban.Dcb.WithResult\Sekiban.Dcb.WithResult.csproj"/>
+        <ProjectReference Include="..\..\src\Sekiban.Dcb.Orleans.WithResult\Sekiban.Dcb.Orleans.WithResult.csproj"/>
         <ProjectReference Include="..\Sekiban.Dcb.TestSupport\Sekiban.Dcb.TestSupport.csproj" />
         <ProjectReference Include="..\..\src\Sekiban.Dcb.CosmosDb\Sekiban.Dcb.CosmosDb.csproj"/>
         <ProjectReference Include="..\..\src\Sekiban.Dcb.DynamoDB\Sekiban.Dcb.DynamoDB.csproj"/>

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/SerializedCommitWire/SerializedCommitAcceptorTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/SerializedCommitWire/SerializedCommitAcceptorTests.cs
@@ -2,6 +2,7 @@ using System.Text;
 using ResultBoxes;
 using Sekiban.Dcb.Actors;
 using Sekiban.Dcb.Commands;
+using Sekiban.Dcb.Storage;
 using Sekiban.Dcb.Tags;
 using Xunit;
 namespace Sekiban.Dcb.Tests.SerializedCommitWire;
@@ -79,7 +80,7 @@ public class SerializedCommitAcceptorTests
         Assert.False(result.IsSuccess);
         var ex = Assert.IsType<UnsupportedSerializedCommitEnvelopeVersionException>(result.GetException());
         Assert.Equal(999, ex.RequestedVersion);
-        Assert.Equal(VersionedSerializedCommitRequest.CurrentVersion, ex.SupportedVersion);
+        Assert.Equal(VersionedExpectedTagPositionSerializedCommitRequest.CurrentVersion, ex.SupportedVersion);
         Assert.Equal(0, exec.CommitCalls); // before executor/store
     }
 
@@ -203,8 +204,9 @@ public class SerializedCommitAcceptorTests
     }
 
     [Theory]
-    [InlineData(SerializedCommitVersionKind.KnownVersion, null, """{"version":1,"eventCandidates":[]}""")]           // exact known
-    [InlineData(SerializedCommitVersionKind.UnsupportedVersion, null, """{"version":2,"eventCandidates":[]}""")]     // exact unknown
+    [InlineData(SerializedCommitVersionKind.KnownVersion, null, """{"version":1,"eventCandidates":[]}""")]           // V1 known
+    [InlineData(SerializedCommitVersionKind.KnownVersion, null, """{"version":2,"eventCandidates":[]}""")]           // V2 known (shape binds later)
+    [InlineData(SerializedCommitVersionKind.UnsupportedVersion, null, """{"version":999,"eventCandidates":[]}""")]   // exact unknown
     [InlineData(SerializedCommitVersionKind.LegacyUnversioned, null, """{"eventCandidates":[],"consistencyTags":[]}""")] // missing → legacy
     [InlineData(SerializedCommitVersionKind.Malformed, SerializedCommitShapeError.VersionNotInteger, """{"version":"1"}""")]   // wrong type (string)
     [InlineData(SerializedCommitVersionKind.Malformed, SerializedCommitShapeError.VersionNotInteger, """{"version":1.5}""")]   // wrong type (float)
@@ -230,5 +232,67 @@ public class SerializedCommitAcceptorTests
         // A PascalCase 'Version' must NOT bind to the camelCase contract property (ambient web-defaults case-insensitivity
         // is deliberately not inherited by the contract-owned options).
         Assert.False(SerializedCommitWireContract.Options.PropertyNameCaseInsensitive);
+    }
+
+    [Fact]
+    public async Task V2ExpectedTagPositions_RoutesOnlyToTheAdditiveExecutorCapability()
+    {
+        var exec = new ExpectedRecordingExecutor();
+        var json = """
+                   {"version":2,"eventCandidates":[{"payload":"AQID","eventPayloadName":"E","tags":["G:1"]}],"consistencyTags":[{"tag":"G:1","lastSortableUniqueId":""}],"expectedTagPositions":[{"serviceId":"default","tag":"G:1","expectation":{"kind":3,"position":"p-1"}}]}
+                   """;
+
+        var result = await new SerializedCommitAcceptor(exec).AcceptAsync(Utf8(json));
+
+        Assert.True(result.IsSuccess, result.IsSuccess ? "" : result.GetException().ToString());
+        Assert.Equal(0, exec.LegacyCalls);
+        var request = Assert.IsType<VersionedExpectedTagPositionSerializedCommitRequest>(exec.Request);
+        Assert.Equal(VersionedExpectedTagPositionSerializedCommitRequest.CurrentVersion, request.Version);
+        var entry = Assert.Single(request.ExpectedTagPositions);
+        Assert.Equal(TagHeadExpectationKind.Exact, entry.Expectation.Kind);
+        Assert.Equal("p-1", entry.Expectation.Position);
+    }
+
+    [Fact]
+    public async Task V2ExpectedTagPositions_UnsupportedExecutorFailsBeforeLegacyExecutorInvocation()
+    {
+        var exec = new RecordingExecutor();
+        var json = """
+                   {"version":2,"eventCandidates":[],"consistencyTags":[],"expectedTagPositions":[]}
+                   """;
+
+        var result = await new SerializedCommitAcceptor(exec).AcceptAsync(Utf8(json));
+
+        Assert.False(result.IsSuccess);
+        Assert.IsType<ConditionNotSupportedException>(result.GetException());
+        Assert.Equal(0, exec.CommitCalls);
+    }
+
+    private sealed class ExpectedRecordingExecutor : ISerializedSekibanDcbExecutor,
+        ISerializedExpectedTagPositionSekibanDcbExecutor
+    {
+        public int LegacyCalls { get; private set; }
+        public VersionedExpectedTagPositionSerializedCommitRequest? Request { get; private set; }
+
+        public Task<ResultBox<SerializableTagState>> GetSerializableTagStateAsync(TagStateId tagStateId) =>
+            throw new NotSupportedException();
+
+        public Task<ResultBox<SerializedCommitResult>> CommitSerializableEventsAsync(
+            SerializedCommitRequest request, CancellationToken cancellationToken = default)
+        {
+            LegacyCalls++;
+            throw new InvalidOperationException("V2 must not fall through to the legacy serialized executor.");
+        }
+
+        public Task<ResultBox<SerializedCommitResult>> CommitSerializableEventsWithExpectedTagPositionsAsync(
+            VersionedExpectedTagPositionSerializedCommitRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            Request = request;
+            return Task.FromResult(ResultBox.FromValue(new SerializedCommitResult(
+                Array.Empty<Sekiban.Dcb.Events.SerializableEvent>(),
+                Array.Empty<TagWriteResult>(),
+                TimeSpan.Zero)));
+        }
     }
 }

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/SerializedCommitWire/SerializedCommitWireGoldenTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/SerializedCommitWire/SerializedCommitWireGoldenTests.cs
@@ -1,5 +1,7 @@
 using System.Text.Json;
 using Sekiban.Dcb.Commands;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.Storage;
 using Xunit;
 using V = Sekiban.Dcb.Tests.SerializedCommitWire.SerializedCommitWireVectors;
 namespace Sekiban.Dcb.Tests.SerializedCommitWire;
@@ -59,6 +61,30 @@ public class SerializedCommitWireGoldenTests
         Assert.NotNull(request);
         var reserialized = SerializedCommitWireContract.SerializeToUtf8Bytes(request!);
         Assert.Equal(V.OfficialCamel, reserialized);
+    }
+
+    [Fact]
+    public void AdditiveV2ExpectedPositionEnvelope_RoundTripsWithoutChangingTheFrozenV1Shapes()
+    {
+        var request = new VersionedExpectedTagPositionSerializedCommitRequest(
+            VersionedExpectedTagPositionSerializedCommitRequest.CurrentVersion,
+            [new SerializableEventCandidate("payload"u8.ToArray(), "Event", ["Marker:m"])],
+            [new ConsistencyTagEntry("Marker:m", "previous")],
+            [new TagHeadExpectationEntry("default", "Marker:m", TagHeadExpectation.Exact("previous"))]);
+
+        var bytes = SerializedCommitWireContract.SerializeToUtf8Bytes(request);
+        var roundTrip = JsonSerializer.Deserialize<VersionedExpectedTagPositionSerializedCommitRequest>(
+            bytes,
+            SerializedCommitWireContract.Options);
+
+        Assert.NotNull(roundTrip);
+        Assert.Equal(VersionedExpectedTagPositionSerializedCommitRequest.CurrentVersion, roundTrip.Version);
+        Assert.Equal("Event", Assert.Single(roundTrip.EventCandidates).EventPayloadName);
+        Assert.Equal("previous", Assert.Single(roundTrip.ConsistencyTags).LastSortableUniqueId);
+        var expectation = Assert.Single(roundTrip.ExpectedTagPositions);
+        Assert.Equal(TagHeadExpectationKind.Exact, expectation.Expectation.Kind);
+        Assert.Equal("previous", expectation.Expectation.Position);
+        Assert.Equal(bytes, SerializedCommitWireContract.SerializeToUtf8Bytes(roundTrip));
     }
 
     [Fact]

--- a/dcb/tests/Sekiban.Dcb.WithoutResult.Tests/ConditionalAppendParityTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithoutResult.Tests/ConditionalAppendParityTests.cs
@@ -29,6 +29,15 @@ public class ConditionalAppendParityTests
         (_, ctx) => ctx.AppendEvent(new UniqueMarkerEvent(value), new MarkerTag("m"));
 
     [Fact]
+    public void ExpectedPositionSerializedV2_IsAnAdditiveCapabilityOnBothWithoutResultFacades()
+    {
+        Assert.True(typeof(ISerializedExpectedTagPositionSekibanDcbExecutor)
+            .IsAssignableFrom(typeof(GeneralSekibanExecutor)));
+        Assert.True(typeof(ISerializedExpectedTagPositionSekibanDcbExecutor)
+            .IsAssignableFrom(typeof(Sekiban.Dcb.Orleans.OrleansDcbExecutor)));
+    }
+
+    [Fact]
     public async Task Conditional_AppendedThenAlreadyCommitted_DoNotThrow()
     {
         var domain = BuildDomain();
@@ -54,6 +63,32 @@ public class ConditionalAppendParityTests
 
         await Assert.ThrowsAsync<ConditionNotSupportedException>(
             () => executor.ExecuteAsync(new MarkerCommand(), AppendMarker("v"), options));
+    }
+
+    [Fact]
+    public async Task ExpectedTagPosition_OnUnsupportedStore_ThrowsBeforeHandlerOrWrite()
+    {
+        var domain = BuildDomain();
+        var plain = new CoreInMemoryEventStore(domain.EventTypes);
+        var executor = new GeneralSekibanExecutor(plain, new InMemoryObjectAccessor(plain, domain), domain);
+        var invoked = false;
+        var options = new CommandExecutionOptions
+        {
+            ExpectedTagPositions = new ExpectedTagPositionSpecification(
+                [new TagHeadExpectationEntry("default", "Marker:m", TagHeadExpectation.NoEnforcement())])
+        };
+
+        await Assert.ThrowsAsync<ConditionNotSupportedException>(
+            () => executor.ExecuteAsync(
+                new MarkerCommand(),
+                (MarkerCommand _, ICommandContext context) =>
+                {
+                    invoked = true;
+                    return context.AppendEvent(new UniqueMarkerEvent("v"), new MarkerTag("m"));
+                },
+                options));
+        Assert.False(invoked);
+        Assert.Empty((await plain.ReadAllSerializableEventsAsync()).GetValue());
     }
 
     [Fact]

--- a/dcb/tests/Sekiban.Dcb.WithoutResult.Tests/ExpectedTagPositionUnsupportedProviderInvocationTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithoutResult.Tests/ExpectedTagPositionUnsupportedProviderInvocationTests.cs
@@ -1,0 +1,183 @@
+using System.Reflection;
+using Amazon.DynamoDBv2;
+using Dcb.Domain.WithoutResult;
+using Microsoft.Azure.Cosmos;
+using Microsoft.Extensions.Options;
+using Orleans;
+using ResultBoxes;
+using Sekiban.Dcb.Actors;
+using Sekiban.Dcb.Capabilities;
+using Sekiban.Dcb.Commands;
+using Sekiban.Dcb.CosmosDb;
+using Sekiban.Dcb.DynamoDB;
+using Sekiban.Dcb.Domains;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.ServiceId;
+using Sekiban.Dcb.Sqlite;
+using Sekiban.Dcb.Storage;
+using Sekiban.Dcb.TestSupport;
+using Sekiban.Dcb.Testing;
+using Sekiban.Dcb.Tags;
+using Xunit;
+using CoreInMemoryEventStore = Sekiban.Dcb.Testing.InMemoryEventStore;
+
+namespace Sekiban.Dcb.WithoutResult.Tests;
+
+/// <summary>
+///     AC6 exception-facade counterpart. Each named real unsupported provider is invoked through the WithoutResult
+///     command facade plus direct/wire V2 and Orleans forwarding. The handler and transparent provider-write counters
+///     prove the throw/ResultBox boundary rejects before a fallback unconditional write can occur.
+/// </summary>
+public sealed class ExpectedTagPositionUnsupportedProviderInvocationTests
+{
+    private const string ServiceId = DefaultServiceIdProvider.DefaultServiceId;
+    private const string Tag = "ExpectedMarker:m";
+
+    public static IEnumerable<object[]> UnsupportedProviderFactories()
+    {
+        yield return ["InMemory", (Func<DcbDomainTypes, IEventStore>)(domain => new CoreInMemoryEventStore(domain.EventTypes))];
+        yield return ["SQLite", (Func<DcbDomainTypes, IEventStore>)(domain =>
+            new SqliteEventStore(
+                Path.Combine(Path.GetTempPath(), $"g40-ac6-without-{Guid.NewGuid():N}.db"),
+                domain.EventTypes,
+                new SqliteEventStoreOptions { AutoCreateDatabase = false }))];
+        yield return ["Cosmos", (Func<DcbDomainTypes, IEventStore>)(domain => NewCosmosStore(domain))];
+        yield return ["Dynamo", (Func<DcbDomainTypes, IEventStore>)(domain => NewDynamoStore(domain))];
+    }
+
+    [Theory]
+    [MemberData(nameof(UnsupportedProviderFactories))]
+    public async Task EveryWithoutResultAndOrleansExpectedPositionEntry_RejectsNamedProviderBeforeHandlerOrWrite(
+        string providerName,
+        Func<DcbDomainTypes, IEventStore> createProvider)
+    {
+        var domain = BuildDomain();
+        var observed = new ProviderWriteCountingEventStore(createProvider(domain), providerName);
+        Assert.False(observed.DescribeWriteConditions().Supports(WriteConditionKind.ExpectedTagPosition));
+
+        var executor = new GeneralSekibanExecutor(observed, new InMemoryObjectAccessor(observed, domain), domain);
+        var conditional = Assert.IsAssignableFrom<IConditionalCommandExecutor>(executor);
+        var handlerCalls = 0;
+        var typed = await Assert.ThrowsAsync<ConditionNotSupportedException>(() =>
+            conditional.ExecuteAsync(
+                new ExpectedMarkerCommand(),
+                (ExpectedMarkerCommand _, ICommandContext context) =>
+                {
+                    Interlocked.Increment(ref handlerCalls);
+                    return context.AppendEvent(new ExpectedMarkerEvent("typed"), new ExpectedMarkerTag("m"));
+                },
+                ExpectedOptions()));
+        AssertUnsupported(typed);
+        Assert.Equal(0, handlerCalls);
+        Assert.Equal(0, observed.ProviderWriteCalls);
+
+        var directV2 = await Assert.IsAssignableFrom<ISerializedExpectedTagPositionSekibanDcbExecutor>(executor)
+            .CommitSerializableEventsWithExpectedTagPositionsAsync(ExpectedV2Request());
+        AssertUnsupported(directV2);
+        Assert.Equal(0, observed.ProviderWriteCalls);
+
+        var wire = await new SerializedCommitAcceptor(executor).AcceptAsync(ExpectedV2Wire());
+        AssertUnsupported(wire);
+        Assert.Equal(0, observed.ProviderWriteCalls);
+
+        var cluster = DispatchProxy.Create<IClusterClient, UnreachableClusterClient>();
+        var orleans = new Sekiban.Dcb.Orleans.OrleansDcbExecutor(cluster, observed, domain);
+        var orleansDirectV2 = await Assert.IsAssignableFrom<ISerializedExpectedTagPositionSekibanDcbExecutor>(orleans)
+            .CommitSerializableEventsWithExpectedTagPositionsAsync(ExpectedV2Request());
+        AssertUnsupported(orleansDirectV2);
+        Assert.Equal(0, observed.ProviderWriteCalls);
+
+        var orleansWire = await new SerializedCommitAcceptor(orleans).AcceptAsync(ExpectedV2Wire());
+        AssertUnsupported(orleansWire);
+        Assert.Equal(0, observed.ProviderWriteCalls);
+    }
+
+    private static DcbDomainTypes BuildDomain()
+    {
+        var domain = DomainType.GetDomainTypes();
+        ((SimpleEventTypes)domain.EventTypes).RegisterEventType<ExpectedMarkerEvent>();
+        ((SimpleTagTypes)domain.TagTypes).RegisterTagGroupType<ExpectedMarkerTag>();
+        return domain;
+    }
+
+    private static CommandExecutionOptions ExpectedOptions() =>
+        new()
+        {
+            ExpectedTagPositions = new ExpectedTagPositionSpecification(
+                [new TagHeadExpectationEntry(ServiceId, Tag, TagHeadExpectation.NoEnforcement())])
+        };
+
+    private static VersionedExpectedTagPositionSerializedCommitRequest ExpectedV2Request() =>
+        new(
+            VersionedExpectedTagPositionSerializedCommitRequest.CurrentVersion,
+            [new SerializableEventCandidate("{}"u8.ToArray(), nameof(ExpectedMarkerEvent), [Tag])],
+            [new ConsistencyTagEntry(Tag, string.Empty)],
+            [new TagHeadExpectationEntry(ServiceId, Tag, TagHeadExpectation.NoEnforcement())]);
+
+    private static byte[] ExpectedV2Wire() => SerializedCommitWireContract.SerializeToUtf8Bytes(ExpectedV2Request());
+
+    private static CosmosDbEventStore NewCosmosStore(DcbDomainTypes domain)
+    {
+        var options = new CosmosDbEventStoreOptions
+        {
+            EventsContainerName = "events",
+            TagsContainerName = "tags"
+        };
+        // No endpoint is touched: the capability gate rejects before CosmosDbEventStore resolves a container or writes.
+        var client = new CosmosClient("https://localhost:8081", Convert.ToBase64String(new byte[64]));
+        return new CosmosDbEventStore(
+            new CosmosDbContext(client, "g40-ac6-without", null, options),
+            domain.EventTypes,
+            new DefaultServiceIdProvider(),
+            new DefaultCosmosContainerResolver(options));
+    }
+
+    private static DynamoDbEventStore NewDynamoStore(DcbDomainTypes domain)
+    {
+        var client = DispatchProxy.Create<IAmazonDynamoDB, UnreachableDynamoClient>();
+        var options = Options.Create(new DynamoDbEventStoreOptions
+        {
+            AutoCreateTables = false,
+            EventsTableName = "events",
+            TagsTableName = "tags",
+            ProjectionStatesTableName = "states",
+            WriteShardCount = 1
+        });
+        return new DynamoDbEventStore(new DynamoDbContext(client, options), domain.EventTypes, new DefaultServiceIdProvider());
+    }
+
+    private static void AssertUnsupported(ResultBox<SerializedCommitResult> result)
+    {
+        Assert.False(result.IsSuccess);
+        AssertUnsupported(result.GetException());
+    }
+
+    private static void AssertUnsupported(Exception exception)
+    {
+        var unsupported = Assert.IsType<ConditionNotSupportedException>(exception);
+        Assert.Equal(WriteConditionKind.ExpectedTagPosition, unsupported.RequestedKind);
+    }
+
+    private sealed record ExpectedMarkerCommand : ICommand;
+    private sealed record ExpectedMarkerEvent(string Value) : IEventPayload;
+
+    private sealed record ExpectedMarkerTag(string Id) : IStringTagGroup<ExpectedMarkerTag>
+    {
+        public static string TagGroupName => "ExpectedMarker";
+        public static ExpectedMarkerTag FromContent(string content) => new(content);
+        public bool IsConsistencyTag() => true;
+        public string GetId() => Id;
+    }
+
+    private class UnreachableDynamoClient : DispatchProxy
+    {
+        protected override object? Invoke(MethodInfo? targetMethod, object?[]? args) =>
+            throw new InvalidOperationException($"Dynamo must not be invoked by a fail-closed expected-position request: {targetMethod?.Name}");
+    }
+
+    private class UnreachableClusterClient : DispatchProxy
+    {
+        protected override object? Invoke(MethodInfo? targetMethod, object?[]? args) =>
+            throw new InvalidOperationException($"Orleans must not resolve a grain before expected-position rejection: {targetMethod?.Name}");
+    }
+}

--- a/dcb/tests/Sekiban.Dcb.WithoutResult.Tests/ExpectedTagPositionWithoutResultCompatibilityInventoryTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithoutResult.Tests/ExpectedTagPositionWithoutResultCompatibilityInventoryTests.cs
@@ -1,0 +1,68 @@
+using System.Reflection;
+using ResultBoxes;
+using Sekiban.Dcb.Actors;
+using Sekiban.Dcb.Commands;
+using Sekiban.Dcb.Events;
+using Xunit;
+
+namespace Sekiban.Dcb.WithoutResult.Tests;
+
+/// <summary>
+///     The exception-based half of the frozen SEK-G40 additive compatibility inventory. It lives in this assembly so
+///     the same namespace names from the WithResult facade cannot mask a signature drift in the WithoutResult package.
+/// </summary>
+public sealed class ExpectedTagPositionWithoutResultCompatibilityInventoryTests
+{
+    [Fact]
+    public void WithoutResultConditionalAndSerializedSurfaces_HaveExactAdditiveSignatures()
+    {
+        var conditionalMethods = typeof(IConditionalCommandExecutor).GetMethods()
+            .Where(method => method.Name == nameof(IConditionalCommandExecutor.ExecuteAsync)).ToArray();
+        Assert.Equal(2, conditionalMethods.Length);
+
+        var withHandler = Assert.Single(conditionalMethods, method => method.GetParameters().Length == 4);
+        Assert.Equal(typeof(Task<ExecutionResult>), withHandler.ReturnType);
+        Assert.True(withHandler.IsGenericMethodDefinition);
+        var command = withHandler.GetGenericArguments().Single();
+        var parameters = withHandler.GetParameters();
+        Assert.Equal(["command", "handlerFunc", "options", "cancellationToken"], parameters.Select(parameter => parameter.Name));
+        Assert.Equal(command, parameters[0].ParameterType);
+        Assert.Equal(typeof(CommandExecutionOptions), parameters[2].ParameterType);
+        Assert.Equal(typeof(CancellationToken), parameters[3].ParameterType);
+        Assert.True(parameters[3].IsOptional);
+        Assert.Contains(typeof(ICommand), command.GetGenericParameterConstraints());
+        Assert.Equal(typeof(Func<,,>), parameters[1].ParameterType.GetGenericTypeDefinition());
+        Assert.Equal(
+            [command, typeof(ICommandContext), typeof(Task<EventOrNone>)],
+            parameters[1].ParameterType.GetGenericArguments());
+
+        var selfHandling = Assert.Single(conditionalMethods, method => method.GetParameters().Length == 3);
+        Assert.Equal(typeof(Task<ExecutionResult>), selfHandling.ReturnType);
+        Assert.True(selfHandling.IsGenericMethodDefinition);
+        var selfParameters = selfHandling.GetParameters();
+        var selfCommand = selfHandling.GetGenericArguments().Single();
+        Assert.Equal(["command", "options", "cancellationToken"], selfParameters.Select(parameter => parameter.Name));
+        Assert.Equal(selfCommand, selfParameters[0].ParameterType);
+        Assert.Equal(typeof(CommandExecutionOptions), selfParameters[1].ParameterType);
+        Assert.Equal(typeof(CancellationToken), selfParameters[2].ParameterType);
+        Assert.True(selfParameters[2].IsOptional);
+        Assert.Contains(typeof(ICommandWithHandler<>).MakeGenericType(selfCommand), selfCommand.GetGenericParameterConstraints());
+
+        Assert.True(typeof(IConditionalCommandExecutor).IsAssignableFrom(typeof(GeneralSekibanExecutor)));
+        Assert.True(typeof(ISerializedExpectedTagPositionSekibanDcbExecutor).IsAssignableFrom(typeof(GeneralSekibanExecutor)));
+        Assert.True(typeof(ISerializedExpectedTagPositionSekibanDcbExecutor)
+            .IsAssignableFrom(typeof(Sekiban.Dcb.Orleans.OrleansDcbExecutor)));
+        AssertSerializedSurface(typeof(GeneralSekibanExecutor));
+        AssertSerializedSurface(typeof(Sekiban.Dcb.Orleans.OrleansDcbExecutor));
+    }
+
+    private static void AssertSerializedSurface(Type facade)
+    {
+        var method = Assert.Single(facade.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly),
+            candidate => candidate.Name == nameof(ISerializedExpectedTagPositionSekibanDcbExecutor.CommitSerializableEventsWithExpectedTagPositionsAsync) &&
+                         candidate.ReturnType == typeof(Task<ResultBox<SerializedCommitResult>>) &&
+                         candidate.GetParameters().Select(parameter => parameter.ParameterType).SequenceEqual(
+                             [typeof(VersionedExpectedTagPositionSerializedCommitRequest), typeof(CancellationToken)]));
+        Assert.False(method.IsStatic);
+    }
+}

--- a/dcb/tests/Sekiban.Dcb.WithoutResult.Tests/Sekiban.Dcb.WithoutResult.Tests.csproj
+++ b/dcb/tests/Sekiban.Dcb.WithoutResult.Tests/Sekiban.Dcb.WithoutResult.Tests.csproj
@@ -33,6 +33,9 @@
         <ProjectReference Include="..\..\src\Sekiban.Dcb.WithoutResult\Sekiban.Dcb.WithoutResult.csproj"/>
         <ProjectReference Include="..\..\src\Sekiban.Dcb.Orleans.WithoutResult\Sekiban.Dcb.Orleans.WithoutResult.csproj"/>
         <ProjectReference Include="..\Sekiban.Dcb.TestSupport\Sekiban.Dcb.TestSupport.csproj" />
+        <ProjectReference Include="..\..\src\Sekiban.Dcb.CosmosDb\Sekiban.Dcb.CosmosDb.csproj"/>
+        <ProjectReference Include="..\..\src\Sekiban.Dcb.DynamoDB\Sekiban.Dcb.DynamoDB.csproj"/>
+        <ProjectReference Include="..\..\src\Sekiban.Dcb.Sqlite\Sekiban.Dcb.Sqlite.csproj"/>
         <ProjectReference Include="..\..\internalUsages\Dcb.Domain.WithoutResult\Dcb.Domain.WithoutResult.csproj"/>
         <ProjectReference Include="..\..\src\Sekiban.Dcb.Core.Testing\Sekiban.Dcb.Core.Testing.csproj" />
         <ProjectReference Include="..\..\src\Sekiban.Dcb.WithoutResult.Testing\Sekiban.Dcb.WithoutResult.Testing.csproj" />

--- a/docs/dcb_llm/11_storage_providers.md
+++ b/docs/dcb_llm/11_storage_providers.md
@@ -581,7 +581,7 @@ The base `IEventStore.WriteSerializableEventsAsync` is unconditional: EventIds a
 
 ### Capability discovery (runtime-resolved, fail-closed)
 
-Support is a **runtime capability descriptor**, reused from the G10 pattern — never a type-name check. `WriteConditionKind` distinguishes kinds (`SingleEventUniqueKey` now; `BatchUniqueKey` / `ExpectedPosition` are reserved future kinds). The descriptor is resolved from the **live** store the container built, and decorators propagate it: a `HybridEventStore` reports exactly what its hot store can enforce (writes land there — it never upgrades on its own authority), and a composite supports a kind only if **every** underlying store does. A store that says nothing supports nothing.
+Support is a **runtime capability descriptor**, reused from the G10 pattern — never a type-name check. `WriteConditionKind` distinguishes kinds (`SingleEventUniqueKey` and PostgreSQL-only `ExpectedTagPosition`; `BatchUniqueKey` remains reserved). The descriptor is resolved from the **live** store the container built, and decorators propagate it: a `HybridEventStore` reports exactly what its hot store can enforce (writes land there — it never upgrades on its own authority), and a composite supports a kind only if **every** underlying store does. A store that says nothing supports nothing.
 
 Requesting a conditional append against a store that does not support the kind **fails closed**: `ConditionNotSupportedException` is raised **before** the command handler runs, before any EventId is allocated, before serialization, and before any store call. There is no silent degradation to an unconditional write.
 
@@ -605,7 +605,7 @@ The store guarantees **at most one durable claim per key**. That is a storage gu
 
 ### Reference implementation and provider status
 
-A deterministic in-memory reference lives in the testing package (`Sekiban.Dcb.Testing.InMemoryConditionalEventStore`, never referenced from a runtime project) and implements the full outcome machine. **All four production providers implement it (SEK-G16)** — PostgreSQL, SQLite, Cosmos DB, and DynamoDB — with identical observable semantics. Expected-position / CAS semantics remain a later slice.
+A deterministic in-memory reference lives in the testing package (`Sekiban.Dcb.Testing.InMemoryConditionalEventStore`, never referenced from a runtime project) and implements the full outcome machine. **All four production providers implement it (SEK-G16)** — PostgreSQL, SQLite, Cosmos DB, and DynamoDB — with identical observable semantics. The distinct multi-tag expected-position CAS is PostgreSQL-only (SEK-G40) and is documented below.
 
 ### Provider mechanics (SEK-G16)
 
@@ -638,6 +638,94 @@ The canonical use: N replicas boot and each tries to perform the same one-time m
 4. If a host builds a *different* operation under the same key (different payload/tags), it gets `KeyReuseConflict` — a programming error surfaced loudly, not silently merged.
 
 **One durable claim is the boundary.** The contract guarantees at most one durable claim per key; it does **not** make the migration's side effects exactly-once. If the migration itself performs external effects (writes to another system, sends notifications), gate those behind the winning claim through an outbox / idempotency layer — the claim tells you *who won*, not that the effect ran exactly once.
+
+## PostgreSQL durable multi-tag expected-position CAS — SEK-G40
+
+**Version: 10.19.0 (minor).** PostgreSQL now offers the optional `WriteConditionKind.ExpectedTagPosition`
+capability. It is a durable DCB fence beneath Orleans reservations: it prevents a command that read stale consistency-tag
+heads from appending after a partitioned/retired writer has bypassed the in-memory reservation layer. It is **not** a
+replacement for reservations, and it does not make arbitrary external effects exactly-once.
+
+### Additive contract and the three explicit states
+
+`IEventStore` and every existing write/result shape remain unchanged. The opt-in `CommandExecutionOptions` has an
+`ExpectedTagPositions` value, and the WASM boundary has a new V2
+`VersionedExpectedTagPositionSerializedCommitRequest` plus optional
+`ISerializedExpectedTagPositionSekibanDcbExecutor`. V1 and unversioned serialized payloads keep their old omission =
+no-enforcement semantics byte-for-byte. WithResult returns typed errors in `ResultBox`; WithoutResult rethrows the same
+typed exception through its guarded boundary.
+
+Every *derived consistency tag* must have exactly one `TagHeadExpectationEntry(ServiceId, Tag, Expectation)`. The
+expectation is an explicit discriminator — never a nullable-position convention:
+
+```csharp
+var noFence = TagHeadExpectation.NoEnforcement(); // still creates, locks, reconciles, and advances the durable head
+var firstWrite = TagHeadExpectation.AssertEmpty(); // requires a transactionally proven-empty head
+var continuation = TagHeadExpectation.Exact("01J...previous-position");
+```
+
+Missing, duplicate, unknown, malformed, or service-mismatched entries fail before reservation/store mutation.
+`NoEnforcement` skips **only** comparison; it is useful when adopting the protocol while retaining unconditional command
+semantics. An unsupported provider (InMemory, SQLite, Cosmos DB, DynamoDB) fails closed with
+`ConditionNotSupportedException` before its handler/write method. `ConditionalAppend` and expected-tag positions are
+separate protocols and cannot be combined in one options object; the ambiguous combination is rejected before a write.
+
+### PostgreSQL all-writer protocol
+
+The ordinary typed batch, serialized batch, and unique conditional-claim writer all reach one internal PostgreSQL
+transaction seam. Thus even legacy/unconditional tagged writes participate in durable head maintenance while doing **no**
+expected-head comparison. For the complete deduplicated `(ServiceId, Tag)` set the seam:
+
+1. sorts ServiceId then Tag with ordinal comparison, lazy-inserts `dcb_tag_heads` in that order, and acquires
+   `FOR UPDATE` in the same order;
+2. bootstraps a newly inserted row from the service-scoped `MAX(dcb_tags.SortableUniqueId)` (a persisted null head is a
+   *proven-empty* row, not an absent-row shortcut);
+3. reconciles authoritative rows newer than the head, writing an append-only `dcb_tag_head_violations` record and
+   repairing the head before any command DML;
+4. compares **all** requested expectations and returns one `ExpectedTagPositionConflictException` containing the complete
+   expected/observed pair set when any is stale; and
+5. on success writes event/tag rows and advances each head to `max(reconciled head, the maximum position for *that tag*
+   in the batch)`, so an unconditional older writer cannot regress a newer durable head.
+
+Positions must strictly increase in an expected-position batch and each event must exceed every carried tag's reconciled
+head. They are rejected rather than regenerated. If reconciliation found bypass evidence and comparison then fails, only
+the repair and idempotent violation record commit; command event/tag rows and unrelated lazily-created head rows do not.
+An ordinary mismatch with no repair rolls everything back, including lazy rows.
+
+Violation records are service-scoped, indexed, append-only, and never auto-cleaned. Operators can read them with the
+provisioning principal, for example:
+
+```sql
+SELECT "ServiceId", "Tag", "PreviousHeadPosition", "ObservedPosition", "DetectedAtUtc", "DetectingWriter"
+FROM dcb_tag_head_violations
+WHERE "ServiceId" = :service_id
+ORDER BY "DetectedAtUtc" DESC;
+```
+
+The runtime does DML only — all three tables (`dcb_tag_heads`, `dcb_tag_head_violations`,
+`dcb_tag_head_enablement_epochs`) are created by the PostgreSQL EF migration/provisioning plane. A runtime schema-missing
+failure (for example SQLSTATE `42P01`) must be fixed by provisioning; it never triggers `CREATE`, `ALTER`, migrations, or
+a catch-and-create fallback.
+
+### Enablement epoch: an operational hard gate
+
+The fence is only meaningful after every old PostgreSQL writer participates. Do this in this exact order:
+
+1. provision the 10.19 schema/migration;
+2. drain or quiesce **all** pre-10.19 PostgreSQL writers;
+3. set one `dcb_tag_head_enablement_epochs` marker for the ServiceId with the provisioning principal;
+4. enable `AssertEmpty` / `Exact` requests and begin monitoring violation records immediately.
+
+Before the marker exists, an enforcement request fails with `TagHeadEnforcementNotEnabledException` before any store write
+or head advance. The guarantee begins at the epoch; pre-epoch history is absorbed only by the authoritative bootstrap
+maximum. Never set the marker merely because a quiet period had no violations: quiet tags have no reconciliation run.
+
+### Honest reconciliation boundary
+
+Reconciliation detects a bypass already visible when its `MAX` query runs. An old writer that inserts **after** that query
+can escape this particular audit if a newer head later overtakes it. This is deliberately best-effort detection, not a
+claim that premature mixed-version enablement is safe. The drain-before-epoch step is the correctness boundary; a zero
+violation count is monitoring evidence, never clean-cutover proof.
 
 ## SEK-G20 generation-aware checkpoint CAS
 

--- a/docs/dcb_llm_ja/11_storage_providers.md
+++ b/docs/dcb_llm_ja/11_storage_providers.md
@@ -588,7 +588,7 @@ var executor = new InMemoryDcbExecutor(domainTypes, new InMemoryEventStore());
 
 ### ケーパビリティの解決（実行時解決・フェイルクローズ）
 
-サポート可否は**実行時ケーパビリティディスクリプタ**で、G10 パターンを再利用します — 型名判定は決して行いません。`WriteConditionKind` は種別を区別します（現在は `SingleEventUniqueKey`。`BatchUniqueKey` / `ExpectedPosition` は将来の予約種別）。ディスクリプタはコンテナが実際に構築した**ライブ**インスタンスから解決され、デコレータは伝播します。`HybridEventStore` はホットストアが強制できる内容をそのまま報告し（書き込みはそこに着地する — 自らの権限で昇格しない）、コンポジットは**すべての**下位ストアが対応する種別のみをサポートします。何も言わないストアは何もサポートしません。
+サポート可否は**実行時ケーパビリティディスクリプタ**で、G10 パターンを再利用します — 型名判定は決して行いません。`WriteConditionKind` は種別を区別します（`SingleEventUniqueKey` と PostgreSQL 専用の `ExpectedTagPosition`、`BatchUniqueKey` は将来の予約種別）。ディスクリプタはコンテナが実際に構築した**ライブ**インスタンスから解決され、デコレータは伝播します。`HybridEventStore` はホットストアが強制できる内容をそのまま報告し（書き込みはそこに着地する — 自らの権限で昇格しない）、コンポジットは**すべての**下位ストアが対応する種別のみをサポートします。何も言わないストアは何もサポートしません。
 
 対応しない種別への条件付き追記要求は**フェイルクローズ**します。`ConditionNotSupportedException` は、コマンドハンドラの実行前・EventId の採番前・シリアライズ前・いかなるストア呼び出しの前に送出されます。無条件書き込みへの暗黙のデグレードはありません。
 
@@ -612,7 +612,7 @@ var executor = new InMemoryDcbExecutor(domainTypes, new InMemoryEventStore());
 
 ### リファレンス実装とプロバイダの状況
 
-決定論的なインメモリのリファレンスがテスト用パッケージにあり（`Sekiban.Dcb.Testing.InMemoryConditionalEventStore`、ランタイムプロジェクトからは参照しない）、アウトカムマシン全体を実装します。**4つの本番プロバイダすべてが SEK-G16 で実装済み**です — PostgreSQL・SQLite・Cosmos DB・DynamoDB — で、観測可能なセマンティクスは同一です。expected-position / CAS セマンティクスはさらに後のスライスのままです。
+決定論的なインメモリのリファレンスがテスト用パッケージにあり（`Sekiban.Dcb.Testing.InMemoryConditionalEventStore`、ランタイムプロジェクトからは参照しない）、アウトカムマシン全体を実装します。**4つの本番プロバイダすべてが SEK-G16 で実装済み**です — PostgreSQL・SQLite・Cosmos DB・DynamoDB — で、観測可能なセマンティクスは同一です。別契約の multi-tag expected-position CAS は PostgreSQL 専用（SEK-G40）であり、以下で説明します。
 
 ### プロバイダの仕組み（SEK-G16）
 
@@ -645,6 +645,96 @@ var executor = new InMemoryDcbExecutor(domainTypes, new InMemoryEventStore());
 4. あるホストが同一キー下で*異なる*操作（異なるペイロード／タグ）を組み立てた場合は `KeyReuseConflict` を得ます — 静かにマージされるのではなく、プログラミングエラーとして大きく表出されます。
 
 **境界は耐久クレーム1つ。** 本コントラクトはキーごとに高々1つの耐久クレームを保証しますが、マイグレーションの副作用をちょうど1回にはしません。マイグレーション自体が外部副作用（他システムへの書き込み、通知送信）を行う場合は、それらを勝者クレームの背後にアウトボックス／冪等層で置いてください — クレームが伝えるのは*誰が勝ったか*であって、副作用がちょうど1回実行されたことではありません。
+
+## PostgreSQL の耐久 multi-tag expected-position CAS — SEK-G40
+
+**バージョン: 10.19.0（minor）。** PostgreSQL は任意の
+`WriteConditionKind.ExpectedTagPosition` capability を提供します。これは Orleans reservation の下にある耐久
+DCB fence であり、パーティション／retire 後の writer が in-memory reservation を迂回しても、古い
+consistency-tag head を読んだ command の追記を防ぎます。reservation の置換ではなく、任意の外部副作用を
+exactly-once にするものでもありません。
+
+### 追加契約と3つの明示状態
+
+`IEventStore` と既存の write/result shape は不変です。opt-in の `CommandExecutionOptions` に
+`ExpectedTagPositions` を追加し、WASM 境界には新しい V2
+`VersionedExpectedTagPositionSerializedCommitRequest` と任意の
+`ISerializedExpectedTagPositionSekibanDcbExecutor` があります。V1 と unversioned serialized payload は従来の
+「省略 = no enforcement」セマンティクスを byte-for-byte で維持します。WithResult は `ResultBox` の型付き失敗、
+WithoutResult は同じ型付き例外を guarded boundary から再送出します。
+
+executor が導出した各 *consistency tag* には、ちょうど1つの
+`TagHeadExpectationEntry(ServiceId, Tag, Expectation)` が必要です。期待値は nullable position の慣習ではなく
+明示 discriminator です:
+
+```csharp
+var noFence = TagHeadExpectation.NoEnforcement(); // durable head の作成・lock・reconcile・advance は行う
+var firstWrite = TagHeadExpectation.AssertEmpty(); // transaction で proven-empty の head を要求
+var continuation = TagHeadExpectation.Exact("01J...previous-position");
+```
+
+欠落・重複・未知・不正形・ServiceId 不一致は reservation/store mutation の前に失敗します。
+`NoEnforcement` が skip するのは比較だけで、unconditional command のまま protocol を導入する用途です。
+InMemory／SQLite／Cosmos／DynamoDB は `ConditionNotSupportedException` で handler/write の前に fail-closed
+します。`ConditionalAppend` と expected-tag position は別 protocol のため、1つの options object での併用は
+write 前に拒否されます。
+
+### PostgreSQL の全 writer protocol
+
+通常 typed batch、serialized batch、unique conditional-claim writer はすべて1つの PostgreSQL transaction seam
+に到達します。そのため legacy/unconditional tagged write も expected-head 比較はせずに durable head maintenance
+には参加します。完全に重複排除した `(ServiceId, Tag)` 集合に対して seam は次を行います:
+
+1. ServiceId → Tag を ordinal で sort し、同じ順序で `dcb_tag_heads` を lazy insert、同じ順序で `FOR UPDATE` lock;
+2. 新規行を service-scoped `MAX(dcb_tags.SortableUniqueId)` から bootstrap（永続 null head は *proven-empty* 行で、
+   absent row を empty と見なす shortcut ではない）;
+3. head より新しい authoritative row を reconcile し、append-only の `dcb_tag_head_violations` と head repair を
+   command DML より前に行う;
+4. すべての expectation を比較し、1つでも stale なら完全な expected/observed pair 集合を持つ
+   `ExpectedTagPositionConflictException` を返す; そして
+5. 成功時に event/tag row を書き、各 head を `max(reconciled head, batch 内の*その tag* の最大 position)`
+   へ進めるため、古い position の unconditional writer が新しい durable head を後退させることはない。
+
+expected-position batch の position は厳密増加し、各 event は carry するすべての tag の reconciled head を超え
+なければなりません。再生成せず拒否します。reconcile で bypass evidence を見つけた後に比較が失敗した場合は、
+repair と idempotent violation record だけを commit し、command event/tag row と無関係な lazy head row は残しません。
+repair のない通常 mismatch は lazy row を含む全変更を rollback します。
+
+violation record は service-scoped・index 済み・append-only で auto-cleanup されません。operator は provisioning
+principal で例えば次のように読めます:
+
+```sql
+SELECT "ServiceId", "Tag", "PreviousHeadPosition", "ObservedPosition", "DetectedAtUtc", "DetectingWriter"
+FROM dcb_tag_head_violations
+WHERE "ServiceId" = :service_id
+ORDER BY "DetectedAtUtc" DESC;
+```
+
+runtime は DML のみです。3 table（`dcb_tag_heads`、`dcb_tag_head_violations`、
+`dcb_tag_head_enablement_epochs`）は PostgreSQL EF migration/provisioning plane が作成します。runtime の
+schema-missing（例: SQLSTATE `42P01`）は provisioning で直し、`CREATE`／`ALTER`／migration／catch-and-create
+fallback は決して実行しません。
+
+### enablement epoch: 運用上の hard gate
+
+fence が意味を持つのは、すべての旧 PostgreSQL writer が protocol に参加した後だけです。必ずこの順で実施します:
+
+1. 10.19 schema/migration を provision;
+2. **すべての** pre-10.19 PostgreSQL writer を drain / quiesce;
+3. provisioning principal で ServiceId ごとに `dcb_tag_head_enablement_epochs` marker を設定;
+4. `AssertEmpty` / `Exact` request を有効化し、直ちに violation record の監視を開始。
+
+marker がない間は enforcement request が `TagHeadEnforcementNotEnabledException` で store write/head advance の前に
+失敗します。保証開始点は epoch であり、epoch 前の履歴は authoritative bootstrap maximum でのみ吸収されます。
+quiet period に violation が無かったからといって marker を設定してはいけません。quiet tag では reconciliation 自体が
+実行されません。
+
+### 正直な reconciliation 境界
+
+reconciliation が検出できるのは `MAX` query 実行時に既に可視な bypass です。その query **後**に旧 writer が insert
+すると、後続の新しい head がそれを追い越す場合、この audit から恒久的に逃げられます。これは意図的に
+best-effort detection であり、premature mixed-version enablement が安全という主張ではありません。正しさの境界は
+drain-before-epoch です。violation 0 件は monitoring evidence であって clean cutover の証明ではありません。
 
 ## SEK-G20 generation-aware checkpoint CAS
 


### PR DESCRIPTION
Implement PostgreSQL store-enforced multi-tag expected-position CAS with canonical all-writer head maintenance, service-scoped reconciliation, audit records, and epoch gating.

Closes #1152
Fixes #1147