### PR TITLE
perf(dcb): defer out-of-order repair to consumption

### DIFF
--- a/dcb/src/Sekiban.Dcb.Core/Actors/GeneralMultiProjectionActor.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Actors/GeneralMultiProjectionActor.cs
@@ -210,14 +210,9 @@ public class GeneralMultiProjectionActor
 
         if (_singleStateAccessor is IDualStateAccessor dualAccessor)
         {
-            try
-            {
-                dualAccessor.PromoteBufferedEvents(safeWindowThreshold, _domain);
-            }
-            catch (Exception)
-            {
-                // Head-status reads are observational; ignore best-effort safe-window promotion failures here.
-            }
+            // A deferred safe-history repair is a consumption boundary. Returning an old head after its repair failed
+            // would falsely advertise a stale payload/position as current, so propagate the failure to the caller.
+            dualAccessor.PromoteBufferedEvents(safeWindowThreshold, _domain);
 
             var current = new ProjectionPosition(
                 dualAccessor.UnsafeVersion,
@@ -627,14 +622,15 @@ public class GeneralMultiProjectionActor
         int offloadThresholdBytes = int.MaxValue,
         CancellationToken cancellationToken = default)
     {
-        // Promote buffered events before building a safe snapshot
+        // Promote buffered events before building a safe snapshot. A deferred-repair failure must fail closed: emitting a
+        // snapshot from the old payload would allow persistence and later compaction to discard the retained repair input.
         try
         {
             ForcePromoteBufferedEvents();
         }
-        catch
+        catch (Exception exception)
         {
-            // Ignore promotion errors to avoid blocking persistence
+            return ResultBox.Error<SnapshotPersistenceData>(exception);
         }
         var envelopeRb = await BuildSnapshotEnvelopeAsync(
             canGetUnsafeState,
@@ -992,7 +988,14 @@ public class GeneralMultiProjectionActor
             if (canGetUnsafeState)
             {
                 // Promote buffered events before reading unsafe state
-                try { dualAccessor.PromoteBufferedEvents(safeWindowThreshold, _domain); } catch { }
+                try
+                {
+                    dualAccessor.PromoteBufferedEvents(safeWindowThreshold, _domain);
+                }
+                catch (Exception exception)
+                {
+                    return Task.FromResult(ResultBox.Error<MultiProjectionState>(exception));
+                }
 
                 statePayload = (IMultiProjectionPayload)dualAccessor.GetUnsafeProjectorPayload();
                 lastSortableId = dualAccessor.UnsafeLastSortableUniqueId;

--- a/dcb/src/Sekiban.Dcb.Core/Actors/GeneralMultiProjectionActor.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Actors/GeneralMultiProjectionActor.cs
@@ -211,8 +211,16 @@ public class GeneralMultiProjectionActor
         if (_singleStateAccessor is IDualStateAccessor dualAccessor)
         {
             // A deferred safe-history repair is a consumption boundary. Returning an old head after its repair failed
-            // would falsely advertise a stale payload/position as current, so propagate the failure to the caller.
-            dualAccessor.PromoteBufferedEvents(safeWindowThreshold, _domain);
+            // would falsely advertise a stale payload/position as current, so capture the actual replay-failing event
+            // before propagating the original failure to the caller.
+            try
+            {
+                dualAccessor.PromoteBufferedEvents(safeWindowThreshold, _domain);
+            }
+            catch (Exception exception)
+            {
+                CaptureDeferredRepairFaultAndRethrow(exception);
+            }
 
             var current = new ProjectionPosition(
                 dualAccessor.UnsafeVersion,
@@ -630,6 +638,9 @@ public class GeneralMultiProjectionActor
         }
         catch (Exception exception)
         {
+            // ForcePromoteBufferedEvents has already recorded deferred replay provenance through the actor's normal
+            // first-observed-fault path. Preserve this same exception instance for the snapshot ResultBox rather than
+            // wrapping or capturing it a second time.
             return ResultBox.Error<SnapshotPersistenceData>(exception);
         }
         var envelopeRb = await BuildSnapshotEnvelopeAsync(
@@ -794,15 +805,47 @@ public class GeneralMultiProjectionActor
     /// </summary>
     private void CaptureFaultAndRethrow(Event ev, Exception ex)
     {
+        var original = CaptureFault(ev.Id, ev.EventType, ev.SortableUniqueIdValue, ex);
+        ExceptionDispatchInfo.Capture(original).Throw();
+    }
+
+    /// <summary>
+    ///     Captures a deferred safe-history replay failure at a consumption boundary. The wrapper records the exact
+    ///     event whose fold failed on the original exception before it leaves <c>RebuildSafeState</c>; it is deliberately
+    ///     not the earlier arrival that happened to mark history dirty. This feeds the same descriptor/log discipline as
+    ///     the normal per-event path without adding a public or serialized contract.
+    /// </summary>
+    private void CaptureDeferredRepairFaultAndRethrow(Exception exception)
+    {
+        var original = CaptureDeferredRepairFault(exception);
+        ExceptionDispatchInfo.Capture(original).Throw();
+    }
+
+    private Exception CaptureDeferredRepairFault(Exception exception)
+    {
+        if (!DeferredSafeRepairFaultAttribution.TryGetReplayEvent(
+                exception,
+                out var eventId,
+                out var eventType,
+                out var position))
+        {
+            return exception;
+        }
+
+        return CaptureFault(eventId, eventType, position, exception);
+    }
+
+    private Exception CaptureFault(Guid eventId, string eventType, string position, Exception ex)
+    {
         var original = ex.InnerException ?? ex;
 
         if (_fault is null)
         {
             _fault = new ProjectionFaultDescriptor(
-                ev.Id,
-                ev.EventType,
+                eventId,
+                eventType,
                 _projectorName,
-                ev.SortableUniqueIdValue,
+                position,
                 original.Message,
                 DateTime.UtcNow.Ticks);
             // The original exception is available only at this boundary. Emit it exactly once, with its real stack;
@@ -817,33 +860,13 @@ public class GeneralMultiProjectionActor
         }
 
         _fault.Annotate(original);
-        ExceptionDispatchInfo.Capture(original).Throw();
+        return original;
     }
 
     /// <summary>The deserialize-boundary counterpart of <see cref="CaptureFaultAndRethrow" />, before an Event exists.</summary>
     private void CaptureSerializableFaultAndRethrow(SerializableEvent se, Exception ex)
     {
-        var original = ex.InnerException ?? ex;
-
-        if (_fault is null)
-        {
-            _fault = new ProjectionFaultDescriptor(
-                se.Id,
-                se.EventPayloadName,
-                _projectorName,
-                se.SortableUniqueIdValue,
-                original.Message,
-                DateTime.UtcNow.Ticks);
-            _logger.LogError(
-                ProjectionFaultFirstObserved,
-                original,
-                "Projection fault first observed: {ProjectorName}, EventId: {EventId}, Position: {Position}",
-                _fault.ProjectorName,
-                _fault.EventId,
-                _fault.Position);
-        }
-
-        _fault.Annotate(original);
+        var original = CaptureFault(se.Id, se.EventPayloadName, se.SortableUniqueIdValue, ex);
         ExceptionDispatchInfo.Capture(original).Throw();
     }
 
@@ -883,8 +906,17 @@ public class GeneralMultiProjectionActor
     {
         if (_singleStateAccessor is IDualStateAccessor dualAccessor)
         {
-            var threshold = GetSafeWindowThreshold();
-            dualAccessor.PromoteBufferedEvents(threshold, _domain);
+            try
+            {
+                var threshold = GetSafeWindowThreshold();
+                dualAccessor.PromoteBufferedEvents(threshold, _domain);
+            }
+            catch (Exception exception)
+            {
+                // Snapshot and grain persistence call this entry point before capturing a checkpoint. A deferred replay
+                // fault therefore has to establish the actor descriptor here, before those callers fail closed.
+                CaptureDeferredRepairFaultAndRethrow(exception);
+            }
             return;
         }
 
@@ -910,7 +942,14 @@ public class GeneralMultiProjectionActor
     {
         if (_singleStateAccessor is IDualStateAccessor dualAccessor)
         {
-            dualAccessor.CompactSafeHistory();
+            try
+            {
+                dualAccessor.CompactSafeHistory();
+            }
+            catch (Exception exception)
+            {
+                CaptureDeferredRepairFaultAndRethrow(exception);
+            }
         }
     }
 
@@ -935,12 +974,19 @@ public class GeneralMultiProjectionActor
     {
         if (_singleStateAccessor is IDualStateAccessor dualAccessor)
         {
-            var maxThreshold = SortableUniqueId.MaxValue;
-            dualAccessor.PromoteBufferedEvents(maxThreshold, _domain);
-            _logger.LogDebug(
-                "[SafePromotion] projector={ProjectorName} force-promote-all invoked threshold={Threshold}",
-                _projectorName,
-                maxThreshold.Value);
+            try
+            {
+                var maxThreshold = SortableUniqueId.MaxValue;
+                dualAccessor.PromoteBufferedEvents(maxThreshold, _domain);
+                _logger.LogDebug(
+                    "[SafePromotion] projector={ProjectorName} force-promote-all invoked threshold={Threshold}",
+                    _projectorName,
+                    maxThreshold.Value);
+            }
+            catch (Exception exception)
+            {
+                CaptureDeferredRepairFaultAndRethrow(exception);
+            }
             return;
         }
 
@@ -994,7 +1040,8 @@ public class GeneralMultiProjectionActor
                 }
                 catch (Exception exception)
                 {
-                    return Task.FromResult(ResultBox.Error<MultiProjectionState>(exception));
+                    return Task.FromResult(ResultBox.Error<MultiProjectionState>(
+                        CaptureDeferredRepairFault(exception)));
                 }
 
                 statePayload = (IMultiProjectionPayload)dualAccessor.GetUnsafeProjectorPayload();
@@ -1022,7 +1069,15 @@ public class GeneralMultiProjectionActor
             else
             {
                 // Promote buffered events and get safe state
-                dualAccessor.PromoteBufferedEvents(safeWindowThreshold, _domain);
+                try
+                {
+                    dualAccessor.PromoteBufferedEvents(safeWindowThreshold, _domain);
+                }
+                catch (Exception exception)
+                {
+                    return Task.FromResult(ResultBox.Error<MultiProjectionState>(
+                        CaptureDeferredRepairFault(exception)));
+                }
 
                 statePayload = (IMultiProjectionPayload)dualAccessor.GetSafeProjectorPayload();
                 var safeSortableId = dualAccessor.SafeLastSortableUniqueId;

--- a/dcb/src/Sekiban.Dcb.Core/MultiProjections/DualStateProjectionWrapper.cs
+++ b/dcb/src/Sekiban.Dcb.Core/MultiProjections/DualStateProjectionWrapper.cs
@@ -160,14 +160,20 @@ public class DualStateProjectionWrapper<T>
         if (isInSafeWindow)
         {
             // Still inside the safe window: hold it in the buffer. The served state is (safe baseline + ordered buffer).
-            // While either state is deferred, even an apparently in-order tail must stay retained until consumption; folding
-            // it now would make the result depend on arrival order again.
+            // Only a deferred SAFE-history repair suppresses the normal unsafe-window reconcile. An ordinary unsafe
+            // out-of-order arrival must still reconcile immediately so a fold failure is captured at this ProcessEvent
+            // boundary with the offending event's fault attribution.
             var inOrder = !_safeHistoryDirty && !_servedStateDirty && IsStrictlyAfterServedHead(evt);
             _bufferedEvents[evt.Id] = evt;
 
             if (inOrder)
             {
                 ProjectUnsafeInOrder(evt, safeWindowThreshold, domainTypes);
+            }
+            else if (!_safeHistoryDirty)
+            {
+                ReconcileServedState(safeWindowThreshold, domainTypes);
+                _servedStateDirty = false;
             }
             else
             {
@@ -187,7 +193,8 @@ public class DualStateProjectionWrapper<T>
             {
                 ProjectSafeInOrder(evt, domainTypes);
                 _safeVersion++;
-                _servedStateDirty = true;
+                ReconcileServedState(safeWindowThreshold, domainTypes);
+                _servedStateDirty = false;
             }
             else
             {
@@ -210,11 +217,12 @@ public class DualStateProjectionWrapper<T>
 
         if (IsStrictlyAfterSafeHead(evt))
         {
-            // In-order fresh arrivals still fold incrementally, but the served state is deliberately deferred to the next
-            // consumption boundary so a following disorder cannot trigger an arrival-time re-fold.
+            // The clean fresh path keeps the established immediate served-state reconciliation. Once an out-of-order safe
+            // arrival marks the history dirty, the branch above suppresses this path until a real consumption boundary.
             ProjectSafeInOrder(evt, domainTypes);
             _safeVersion++;
-            _servedStateDirty = true;
+            ReconcileServedState(safeWindowThreshold, domainTypes);
+            _servedStateDirty = false;
             return this;
         }
 

--- a/dcb/src/Sekiban.Dcb.Core/MultiProjections/DualStateProjectionWrapper.cs
+++ b/dcb/src/Sekiban.Dcb.Core/MultiProjections/DualStateProjectionWrapper.cs
@@ -387,7 +387,8 @@ public class DualStateProjectionWrapper<T>
     ///     The sole fresh-history consumption seam. A dirty arrival does no re-fold and no reconciliation; a real consumer
     ///     reaches this method to repair the sorted history, publish safe payload + metadata as one state transition, then
     ///     reconcile the served state before the caller consumes it. If either repair or reconciliation fails, the prior
-    ///     published state remains intact and the original dirty-causing event stays attributable for retry/fault handling.
+    ///     published state remains intact. The replay event whose projector fold failed is attached to the original
+    ///     exception for actor fault capture, while the earlier dirty-producing arrival remains separate diagnostics.
     /// </summary>
     private void ConsumeServedState(SortableUniqueId safeWindowThreshold, DcbDomainTypes domainTypes)
     {
@@ -446,7 +447,7 @@ public class DualStateProjectionWrapper<T>
             _unsafeLastEventId = published.UnsafeLastEventId;
             _unsafeLastSortableUniqueId = published.UnsafeLastSortableUniqueId;
             _servedStateDirty = true;
-            AttachDeferredRepairAttribution(exception);
+            AttachDeferredRepairDirtyAttribution(exception);
             throw;
         }
     }
@@ -463,16 +464,22 @@ public class DualStateProjectionWrapper<T>
         _servedStateDirty = true;
     }
 
-    private void AttachDeferredRepairAttribution(Exception exception)
+    private void AttachDeferredRepairDirtyAttribution(Exception exception)
     {
         if (_dirtyCausingEventId is { } eventId)
         {
-            exception.Data["DeferredSafeRepairEventId"] = eventId.ToString();
+            DeferredSafeRepairFaultAttribution.TryAnnotate(
+                exception,
+                DeferredSafeRepairFaultAttribution.DirtyEventIdDataKey,
+                eventId.ToString());
         }
 
         if (!string.IsNullOrEmpty(_dirtyCausingPosition))
         {
-            exception.Data["DeferredSafeRepairPosition"] = _dirtyCausingPosition;
+            DeferredSafeRepairFaultAttribution.TryAnnotate(
+                exception,
+                DeferredSafeRepairFaultAttribution.DirtyPositionDataKey,
+                _dirtyCausingPosition);
         }
     }
 
@@ -552,7 +559,9 @@ public class DualStateProjectionWrapper<T>
                     safeWindowThreshold);
                 if (!projected.IsSuccess)
                 {
-                    throw projected.GetException();
+                    var exception = projected.GetException();
+                    DeferredSafeRepairFaultAttribution.AnnotateReplayEvent(exception, ev);
+                    throw exception;
                 }
                 served = (T)projected.GetValue();
                 lastEventId = ev.Id;
@@ -655,7 +664,9 @@ public class DualStateProjectionWrapper<T>
 
             if (!projected.IsSuccess)
             {
-                throw projected.GetException();
+                var exception = projected.GetException();
+                DeferredSafeRepairFaultAttribution.AnnotateReplayEvent(exception, ev);
+                throw exception;
             }
 
             newSafeProjector = (T)projected.GetValue();
@@ -694,5 +705,102 @@ public class DualStateProjectionWrapper<T>
         var json = JsonSerializer.Serialize(source, source.GetType(), options);
         var cloned = JsonSerializer.Deserialize(json, source.GetType(), options);
         return (T)cloned!;
+    }
+}
+
+/// <summary>
+///     Internal provenance exchanged by the deferred-repair wrapper and its actor host. It deliberately lives outside
+///     serialized projection state and public accessor contracts: the original projector exception remains the thing
+///     callers receive, with only diagnostic <see cref="Exception.Data" /> attached to it.
+/// </summary>
+internal static class DeferredSafeRepairFaultAttribution
+{
+    internal const string ReplayEventIdDataKey = "DeferredSafeRepairEventId";
+    internal const string ReplayEventTypeDataKey = "DeferredSafeRepairEventType";
+    internal const string ReplayPositionDataKey = "DeferredSafeRepairPosition";
+    internal const string DirtyEventIdDataKey = "DeferredSafeRepairDirtyEventId";
+    internal const string DirtyPositionDataKey = "DeferredSafeRepairDirtyPosition";
+
+    internal static void AnnotateReplayEvent(Exception exception, Event replayEvent)
+    {
+        Annotate(exception, ReplayEventIdDataKey, replayEvent.Id.ToString());
+        Annotate(exception, ReplayEventTypeDataKey, replayEvent.EventType);
+        Annotate(exception, ReplayPositionDataKey, replayEvent.SortableUniqueIdValue);
+    }
+
+    internal static bool TryGetReplayEvent(
+        Exception exception,
+        out Guid eventId,
+        out string eventType,
+        out string position)
+    {
+        if (TryGetReplayEventCore(exception, out eventId, out eventType, out position))
+        {
+            return true;
+        }
+
+        return exception.InnerException is not null &&
+               TryGetReplayEventCore(exception.InnerException, out eventId, out eventType, out position);
+    }
+
+    internal static void TryAnnotate(Exception exception, string key, string value)
+    {
+        Annotate(exception, key, value);
+    }
+
+    private static bool TryGetReplayEventCore(
+        Exception exception,
+        out Guid eventId,
+        out string eventType,
+        out string position)
+    {
+        eventId = Guid.Empty;
+        eventType = string.Empty;
+        position = string.Empty;
+
+        try
+        {
+            var eventIdText = exception.Data[ReplayEventIdDataKey] as string;
+            eventType = exception.Data[ReplayEventTypeDataKey] as string ?? string.Empty;
+            position = exception.Data[ReplayPositionDataKey] as string ?? string.Empty;
+            return Guid.TryParse(eventIdText, out eventId) &&
+                   !string.IsNullOrEmpty(eventType) &&
+                   !string.IsNullOrEmpty(position);
+        }
+        catch (Exception)
+        {
+            eventId = Guid.Empty;
+            eventType = string.Empty;
+            position = string.Empty;
+            return false;
+        }
+    }
+
+    private static void Annotate(Exception exception, string key, string value)
+    {
+        TryAnnotateOne(exception, key, value);
+
+        // Actor fault capture intentionally unwraps legacy boundary exceptions before it records the descriptor. Keep
+        // the provenance with both layers when a projector implementation supplied one, without changing either type
+        // or stack semantics.
+        if (exception.InnerException is not null)
+        {
+            TryAnnotateOne(exception.InnerException, key, value);
+        }
+    }
+
+    private static void TryAnnotateOne(Exception exception, string key, string value)
+    {
+        try
+        {
+            if (!exception.Data.IsReadOnly && !exception.Data.Contains(key))
+            {
+                exception.Data[key] = value;
+            }
+        }
+        catch (Exception)
+        {
+            // Provenance is diagnostic and must never replace the projector failure itself.
+        }
     }
 }

--- a/dcb/src/Sekiban.Dcb.Core/MultiProjections/DualStateProjectionWrapper.cs
+++ b/dcb/src/Sekiban.Dcb.Core/MultiProjections/DualStateProjectionWrapper.cs
@@ -15,8 +15,9 @@ public class DualStateProjectionWrapper<T>
     : ISafeAndUnsafeStateAccessor<T>, IMultiProjectionPayload, IDualStateAccessor, IDualStateRebuildSignals
     where T : IMultiProjectionPayload
 {
-    // Keep track of safe events until the next persisted safe snapshot boundary.
-    private readonly Dictionary<Guid, Event> _allSafeEvents = new();
+    // Keep track of safe events until the next persisted safe snapshot boundary. The key is the complete stable
+    // projection order, not arrival order: SortableUniqueId can tie, so EventId is the required deterministic tiebreaker.
+    private readonly SortedDictionary<SafeEventOrderKey, Event> _allSafeEvents = new();
 
     // Keep duplicate detection across the current in-memory history until the next compaction boundary.
     private readonly HashSet<Guid> _processedEventIds = new();
@@ -28,6 +29,16 @@ public class DualStateProjectionWrapper<T>
     private readonly ICoreMultiProjectorTypes _types;
     private readonly JsonSerializerOptions _jsonOptions;
     private bool _useIncrementalSafePromotion;
+
+    // In the fresh (pre-compaction) path an out-of-order safe arrival is retained but not folded. Subsequent arrivals
+    // must also remain unfurled until a real consumption boundary repairs the ordered history. This deliberately keeps
+    // an apparent in-order tail from accidentally reintroducing the old per-arrival re-fold behaviour.
+    private bool _safeHistoryDirty;
+    private bool _servedStateDirty;
+    private Guid? _dirtyCausingEventId;
+    private string? _dirtyCausingPosition;
+    private SortableUniqueId? _lastSafeWindowThreshold;
+    private DcbDomainTypes? _lastDomainTypes;
 
     // SEK-G18 integrity-guard signal: an out-of-global-order safe promotion / arrival was observed that the incremental
     // path cannot reorder. The grain/host must respond with a full ordered rebuild from the authoritative event store.
@@ -49,6 +60,7 @@ public class DualStateProjectionWrapper<T>
     // Safe state - events older than SafeWindow
     private T _safeProjector;
     private int _safeVersion;
+    private readonly int _safeHistoryBaseVersion;
     private Guid _safeLastEventId;
     private string _safeLastSortableUniqueId = string.Empty;
 
@@ -78,6 +90,7 @@ public class DualStateProjectionWrapper<T>
 
         // Initialize version tracking
         _safeVersion = initialVersion;
+        _safeHistoryBaseVersion = initialVersion;
         _unsafeVersion = initialVersion;
         _safeLastEventId = initialLastEventId;
         _unsafeLastEventId = initialLastEventId;
@@ -103,6 +116,7 @@ public class DualStateProjectionWrapper<T>
         _useIncrementalSafePromotion = true;
 
         _safeVersion = initialVersion;
+        _safeHistoryBaseVersion = initialVersion;
         _unsafeVersion = initialVersion;
         _safeLastEventId = initialLastEventId;
         _unsafeLastEventId = initialLastEventId;
@@ -112,18 +126,25 @@ public class DualStateProjectionWrapper<T>
 
     public SafeProjection<T> GetSafeProjection(SortableUniqueId safeWindowThreshold, DcbDomainTypes domainTypes)
     {
+        RememberConsumptionContext(safeWindowThreshold, domainTypes);
         ProcessBufferedEvents(safeWindowThreshold, domainTypes);
         return new SafeProjection<T>(_safeProjector, _safeLastSortableUniqueId, _safeVersion);
     }
 
     public UnsafeProjection<T> GetUnsafeProjection(DcbDomainTypes domainTypes)
-        => new UnsafeProjection<T>(_unsafeProjector, _unsafeLastSortableUniqueId, _unsafeLastEventId, _unsafeVersion);
+    {
+        _lastDomainTypes = domainTypes;
+        ConsumeServedState(_lastSafeWindowThreshold ?? ZeroThreshold, domainTypes);
+        return new UnsafeProjection<T>(_unsafeProjector, _unsafeLastSortableUniqueId, _unsafeLastEventId, _unsafeVersion);
+    }
 
     public ISafeAndUnsafeStateAccessor<T> ProcessEvent(
         Event evt,
         SortableUniqueId safeWindowThreshold,
         DcbDomainTypes domainTypes)
     {
+        RememberConsumptionContext(safeWindowThreshold, domainTypes);
+
         // Check if this event has already been processed (duplicate prevention)
         var eventTime = new SortableUniqueId(evt.SortableUniqueIdValue);
         var isInSafeWindow = !eventTime.IsEarlierThanOrEqual(safeWindowThreshold);
@@ -136,31 +157,21 @@ public class DualStateProjectionWrapper<T>
 
         _processedEventIds.Add(evt.Id);
 
-        var tags = evt.Tags.Select(tagString => domainTypes.TagTypes.GetTag(tagString)).ToList();
-
         if (isInSafeWindow)
         {
-            // Still inside the safe window: hold it in the buffer. The served state is (safe baseline + ordered buffer),
-            // so an in-order arrival can be folded onto the served accumulator directly; an out-of-order arrival forces a
-            // re-derivation so the served state never depends on arrival order.
-            var inOrder = IsStrictlyAfterServedHead(evt.SortableUniqueIdValue);
+            // Still inside the safe window: hold it in the buffer. The served state is (safe baseline + ordered buffer).
+            // While either state is deferred, even an apparently in-order tail must stay retained until consumption; folding
+            // it now would make the result depend on arrival order again.
+            var inOrder = !_safeHistoryDirty && !_servedStateDirty && IsStrictlyAfterServedHead(evt);
             _bufferedEvents[evt.Id] = evt;
 
             if (inOrder)
             {
-                var served = _types.Project(_projectorName, _unsafeProjector, evt, tags, domainTypes, safeWindowThreshold);
-                if (!served.IsSuccess)
-                {
-                    throw served.GetException();
-                }
-                _unsafeProjector = (T)served.GetValue();
-                _unsafeLastEventId = evt.Id;
-                _unsafeLastSortableUniqueId = evt.SortableUniqueIdValue;
-                _unsafeVersion = _safeVersion + _bufferedEvents.Count;
+                ProjectUnsafeInOrder(evt, safeWindowThreshold, domainTypes);
             }
             else
             {
-                ReconcileServedState(safeWindowThreshold, domainTypes);
+                _servedStateDirty = true;
             }
 
             return this;
@@ -168,39 +179,48 @@ public class DualStateProjectionWrapper<T>
 
         // Already at/under the safe threshold. It must fold onto the safe state IN GLOBAL ORDER — never out of order into
         // the accumulator.
-        _allSafeEvents[evt.Id] = evt;
+        _allSafeEvents[SafeEventOrderKey.From(evt)] = evt;
 
-        if (IsStrictlyAfterSafeHead(evt.SortableUniqueIdValue))
+        if (_useIncrementalSafePromotion)
         {
-            // In order: fold directly onto the safe baseline.
-            var safeProjected = _types.Project(_projectorName, _safeProjector, evt, tags, domainTypes, ZeroThreshold);
-            if (!safeProjected.IsSuccess)
+            if (IsStrictlyAfterSafeHead(evt))
             {
-                throw safeProjected.GetException();
+                ProjectSafeInOrder(evt, domainTypes);
+                _safeVersion++;
+                _servedStateDirty = true;
             }
-            _safeProjector = (T)safeProjected.GetValue();
-            _safeLastEventId = evt.Id;
-            _safeLastSortableUniqueId = evt.SortableUniqueIdValue;
-            _safeVersion++;
-        }
-        else if (!_useIncrementalSafePromotion)
-        {
-            // Fresh path still retains the FULL safe history in _allSafeEvents, so a global re-sort places the
-            // out-of-order arrival correctly (no compacted baseline, no data loss).
-            RebuildSafeState(domainTypes);
-            _safeVersion++;
-        }
-        else
-        {
-            // Compacted/incremental baseline: the full history is gone, so the wrapper cannot reorder locally. Signal a
-            // full ordered rebuild from the authoritative event store (SEK-G18 integrity guard) rather than fold out of
-            // order or rebuild a compacted baseline from the initial payload.
-            SignalRebuild(evt);
+            else
+            {
+                // Compacted/incremental baseline: the full history is gone, so the wrapper cannot reorder locally. Signal
+                // a full ordered rebuild from the authoritative event store (SEK-G18 integrity guard) rather than fold
+                // out of order or rebuild a compacted baseline from the initial payload.
+                SignalRebuild(evt);
+                _servedStateDirty = true;
+            }
             return this;
         }
 
-        // The safe baseline advanced; re-derive the served state from it plus the still-buffered events.
-        ReconcileServedState(safeWindowThreshold, domainTypes);
+        if (_safeHistoryDirty)
+        {
+            // A dirty fresh history is repaired only at a consumption boundary. Do not fold a later in-order arrival onto
+            // the stale safe payload and do not reconcile at the end of this ProcessEvent.
+            _servedStateDirty = true;
+            return this;
+        }
+
+        if (IsStrictlyAfterSafeHead(evt))
+        {
+            // In-order fresh arrivals still fold incrementally, but the served state is deliberately deferred to the next
+            // consumption boundary so a following disorder cannot trigger an arrival-time re-fold.
+            ProjectSafeInOrder(evt, domainTypes);
+            _safeVersion++;
+            _servedStateDirty = true;
+            return this;
+        }
+
+        // Fresh path retains the complete ordered history. Marking dirty is O(log N) insertion plus constant metadata;
+        // crucially, do not rebuild or reconcile here. The next real consume performs the single repair.
+        MarkSafeHistoryDirty(evt);
         return this;
     }
 
@@ -210,11 +230,21 @@ public class DualStateProjectionWrapper<T>
     string IDualStateAccessor.UnsafeLastSortableUniqueId => _unsafeLastSortableUniqueId;
     string? IDualStateAccessor.SafeLastSortableUniqueId =>
         string.IsNullOrEmpty(_safeLastSortableUniqueId) ? null : _safeLastSortableUniqueId;
-    object IDualStateAccessor.GetSafeProjectorPayload() => _safeProjector!;
-    object IDualStateAccessor.GetUnsafeProjectorPayload() => _unsafeProjector!;
+    object IDualStateAccessor.GetSafeProjectorPayload()
+    {
+        ConsumeUsingRememberedContext();
+        return _safeProjector!;
+    }
+
+    object IDualStateAccessor.GetUnsafeProjectorPayload()
+    {
+        ConsumeUsingRememberedContext();
+        return _unsafeProjector!;
+    }
 
     // SEK-G18 internal seam (not on the public IDualStateAccessor surface).
-    bool IDualStateRebuildSignals.IsServedIdenticalToSafe => !_rebuildRequired && _bufferedEvents.Count == 0;
+    bool IDualStateRebuildSignals.IsServedIdenticalToSafe =>
+        !_rebuildRequired && !_safeHistoryDirty && !_servedStateDirty && _bufferedEvents.Count == 0;
     bool IDualStateRebuildSignals.RebuildRequired => _rebuildRequired;
     string? IDualStateRebuildSignals.RebuildOffendingEventId => _rebuildOffendingEventId;
     string? IDualStateRebuildSignals.RebuildOffendingPosition => _rebuildOffendingPosition;
@@ -228,23 +258,28 @@ public class DualStateProjectionWrapper<T>
     void IDualStateAccessor.PromoteBufferedEvents(
         SortableUniqueId safeWindowThreshold, DcbDomainTypes domainTypes)
     {
+        RememberConsumptionContext(safeWindowThreshold, domainTypes);
         ProcessBufferedEvents(safeWindowThreshold, domainTypes);
     }
 
     void IDualStateAccessor.CompactSafeHistory()
     {
-        var hadSafeEvents = _allSafeEvents.Count > 0;
-        _allSafeEvents.Clear();
-        if (hadSafeEvents)
+        // Compaction is a consumption boundary too. A dirty fresh history must be repaired and its payload/metadata
+        // published before the history is cleared and the wrapper switches to the compacted incremental mode.
+        ConsumeUsingRememberedContext();
+        if (_rebuildRequired)
         {
-            _allSafeEvents.TrimExcess();
+            return;
         }
+
+        _allSafeEvents.Clear();
         RebuildProcessedEventIdsFromBufferedEvents();
         _useIncrementalSafePromotion = true;
     }
 
     private void ProcessBufferedEvents(SortableUniqueId safeWindowThreshold, DcbDomainTypes domainTypes)
     {
+        RememberConsumptionContext(safeWindowThreshold, domainTypes);
         var eventsToProcess = new List<Event>();
         var keysToRemove = new List<Guid>();
 
@@ -267,34 +302,213 @@ public class DualStateProjectionWrapper<T>
             _bufferedEvents.Remove(key);
         }
 
-        // Add newly safe events to our collection and rebuild
+        // Add newly safe events to the retained total-order collection. Fresh history is repaired only when it is consumed;
+        // the sorted collection makes arrival insertion O(log N) rather than re-sorting and re-folding N events per arrival.
         if (eventsToProcess.Count > 0)
         {
             foreach (var ev in eventsToProcess)
             {
-                _allSafeEvents[ev.Id] = ev;
+                _allSafeEvents[SafeEventOrderKey.From(ev)] = ev;
             }
 
             if (_useIncrementalSafePromotion)
             {
                 ApplyEventsIncrementally(eventsToProcess, domainTypes);
+
+                // Do not advance the safe version if the incremental guard tripped — a full rebuild will re-establish it.
+                if (!_rebuildRequired)
+                {
+                    _safeVersion += eventsToProcess.Count;
+                }
+
+                _servedStateDirty = true;
+            }
+            else if (_safeHistoryDirty)
+            {
+                // A later promotion must not fold onto a stale safe payload after a prior out-of-order arrival. It remains
+                // in the sorted history for the one deferred repair at the consumption boundary below.
+                _servedStateDirty = true;
             }
             else
             {
-                RebuildSafeState(domainTypes);
-            }
+                var orderedPromotions = eventsToProcess
+                    .OrderBy(SafeEventOrderKey.From)
+                    .ToList();
 
-            // Do not advance the safe version if the incremental guard tripped — a full rebuild will re-establish it.
-            if (!_rebuildRequired)
-            {
-                _safeVersion += eventsToProcess.Count;
+                if (!IsStrictlyAfterSafeHead(orderedPromotions[0]))
+                {
+                    MarkSafeHistoryDirty(orderedPromotions[0]);
+                }
+                else
+                {
+                    foreach (var ev in orderedPromotions)
+                    {
+                        ProjectSafeInOrder(ev, domainTypes);
+                        _safeVersion++;
+                    }
+
+                    _servedStateDirty = true;
+                }
             }
         }
 
-        // Re-derive the served (unsafe) state = safe baseline + still-buffered events in global SortableUniqueId order.
-        // Reads promote before reading, so this keeps the served payload converged and IsSafeState truthful.
-        ReconcileServedState(safeWindowThreshold, domainTypes);
+        // This is deliberately unconditional, including a zero-event promotion: a dirty safe history may have been
+        // created by ProcessEvent before the caller reached this consumption boundary.
+        ConsumeServedState(safeWindowThreshold, domainTypes);
     }
+
+    private void RememberConsumptionContext(SortableUniqueId safeWindowThreshold, DcbDomainTypes domainTypes)
+    {
+        _lastSafeWindowThreshold = safeWindowThreshold;
+        _lastDomainTypes = domainTypes;
+    }
+
+    private void ConsumeUsingRememberedContext()
+    {
+        if (!_safeHistoryDirty && !_servedStateDirty)
+        {
+            return;
+        }
+
+        var domainTypes = _lastDomainTypes ?? throw new InvalidOperationException(
+            "Deferred dual-state consumption has no domain context.");
+        ConsumeServedState(_lastSafeWindowThreshold ?? ZeroThreshold, domainTypes);
+    }
+
+    /// <summary>
+    ///     The sole fresh-history consumption seam. A dirty arrival does no re-fold and no reconciliation; a real consumer
+    ///     reaches this method to repair the sorted history, publish safe payload + metadata as one state transition, then
+    ///     reconcile the served state before the caller consumes it. If either repair or reconciliation fails, the prior
+    ///     published state remains intact and the original dirty-causing event stays attributable for retry/fault handling.
+    /// </summary>
+    private void ConsumeServedState(SortableUniqueId safeWindowThreshold, DcbDomainTypes domainTypes)
+    {
+        if (_rebuildRequired)
+        {
+            return;
+        }
+
+        if (!_safeHistoryDirty)
+        {
+            if (_servedStateDirty)
+            {
+                ReconcileServedState(safeWindowThreshold, domainTypes);
+                _servedStateDirty = false;
+            }
+
+            return;
+        }
+
+        var published = new PublishedState(
+            _safeProjector,
+            _safeVersion,
+            _safeLastEventId,
+            _safeLastSortableUniqueId,
+            _unsafeProjector,
+            _unsafeVersion,
+            _unsafeLastEventId,
+            _unsafeLastSortableUniqueId);
+
+        try
+        {
+            var repaired = RebuildSafeState(domainTypes);
+
+            // Publish the repaired safe payload and every accompanying metadata value together. Reconcile then publishes
+            // the served projection only after the repair is complete; a reconciliation failure rolls this transition back.
+            _safeProjector = repaired.Projector;
+            _safeVersion = repaired.Version;
+            _safeLastEventId = repaired.LastEventId;
+            _safeLastSortableUniqueId = repaired.LastSortableUniqueId;
+
+            ReconcileServedState(safeWindowThreshold, domainTypes);
+
+            _safeHistoryDirty = false;
+            _servedStateDirty = false;
+            _dirtyCausingEventId = null;
+            _dirtyCausingPosition = null;
+        }
+        catch (Exception exception)
+        {
+            _safeProjector = published.SafeProjector;
+            _safeVersion = published.SafeVersion;
+            _safeLastEventId = published.SafeLastEventId;
+            _safeLastSortableUniqueId = published.SafeLastSortableUniqueId;
+            _unsafeProjector = published.UnsafeProjector;
+            _unsafeVersion = published.UnsafeVersion;
+            _unsafeLastEventId = published.UnsafeLastEventId;
+            _unsafeLastSortableUniqueId = published.UnsafeLastSortableUniqueId;
+            _servedStateDirty = true;
+            AttachDeferredRepairAttribution(exception);
+            throw;
+        }
+    }
+
+    private void MarkSafeHistoryDirty(Event causingEvent)
+    {
+        if (!_safeHistoryDirty)
+        {
+            _dirtyCausingEventId = causingEvent.Id;
+            _dirtyCausingPosition = causingEvent.SortableUniqueIdValue;
+        }
+
+        _safeHistoryDirty = true;
+        _servedStateDirty = true;
+    }
+
+    private void AttachDeferredRepairAttribution(Exception exception)
+    {
+        if (_dirtyCausingEventId is { } eventId)
+        {
+            exception.Data["DeferredSafeRepairEventId"] = eventId.ToString();
+        }
+
+        if (!string.IsNullOrEmpty(_dirtyCausingPosition))
+        {
+            exception.Data["DeferredSafeRepairPosition"] = _dirtyCausingPosition;
+        }
+    }
+
+    private void ProjectSafeInOrder(Event evt, DcbDomainTypes domainTypes)
+    {
+        var safeProjected = _types.Project(
+            _projectorName,
+            _safeProjector,
+            evt,
+            ResolveTags(evt, domainTypes),
+            domainTypes,
+            ZeroThreshold);
+        if (!safeProjected.IsSuccess)
+        {
+            throw safeProjected.GetException();
+        }
+
+        _safeProjector = (T)safeProjected.GetValue();
+        _safeLastEventId = evt.Id;
+        _safeLastSortableUniqueId = evt.SortableUniqueIdValue;
+    }
+
+    private void ProjectUnsafeInOrder(Event evt, SortableUniqueId safeWindowThreshold, DcbDomainTypes domainTypes)
+    {
+        var served = _types.Project(
+            _projectorName,
+            _unsafeProjector,
+            evt,
+            ResolveTags(evt, domainTypes),
+            domainTypes,
+            safeWindowThreshold);
+        if (!served.IsSuccess)
+        {
+            throw served.GetException();
+        }
+
+        _unsafeProjector = (T)served.GetValue();
+        _unsafeLastEventId = evt.Id;
+        _unsafeLastSortableUniqueId = evt.SortableUniqueIdValue;
+        _unsafeVersion = _safeVersion + _bufferedEvents.Count;
+    }
+
+    private static List<ITag> ResolveTags(Event evt, DcbDomainTypes domainTypes) =>
+        evt.Tags.Select(tagString => domainTypes.TagTypes.GetTag(tagString)).ToList();
 
     /// <summary>
     ///     SEK-G18 graduation reconcile: re-derive the served (unsafe) state as the safe baseline plus the still-buffered
@@ -317,12 +531,17 @@ public class DualStateProjectionWrapper<T>
         if (_bufferedEvents.Count > 0)
         {
             var ordered = _bufferedEvents.Values
-                .OrderBy(ev => ev.SortableUniqueIdValue, StringComparer.Ordinal)
+                .OrderBy(SafeEventOrderKey.From)
                 .ToList();
             foreach (var ev in ordered)
             {
-                var tags = ev.Tags.Select(tagString => domainTypes.TagTypes.GetTag(tagString)).ToList();
-                var projected = _types.Project(_projectorName, served, ev, tags, domainTypes, safeWindowThreshold);
+                var projected = _types.Project(
+                    _projectorName,
+                    served,
+                    ev,
+                    ResolveTags(ev, domainTypes),
+                    domainTypes,
+                    safeWindowThreshold);
                 if (!projected.IsSuccess)
                 {
                     throw projected.GetException();
@@ -339,16 +558,46 @@ public class DualStateProjectionWrapper<T>
         _unsafeVersion = _safeVersion + _bufferedEvents.Count;
     }
 
-    private bool IsStrictlyAfterSafeHead(string sortableUniqueId) =>
+    private bool IsStrictlyAfterSafeHead(Event evt) =>
         string.IsNullOrEmpty(_safeLastSortableUniqueId)
-        || string.Compare(sortableUniqueId, _safeLastSortableUniqueId, StringComparison.Ordinal) > 0;
+        || SafeEventOrderKey.From(evt).CompareTo(
+            new SafeEventOrderKey(_safeLastSortableUniqueId, _safeLastEventId)) > 0;
 
-    private bool IsStrictlyAfterServedHead(string sortableUniqueId) =>
+    private bool IsStrictlyAfterServedHead(Event evt) =>
         string.IsNullOrEmpty(_unsafeLastSortableUniqueId)
-        || string.Compare(sortableUniqueId, _unsafeLastSortableUniqueId, StringComparison.Ordinal) > 0;
+        || SafeEventOrderKey.From(evt).CompareTo(
+            new SafeEventOrderKey(_unsafeLastSortableUniqueId, _unsafeLastEventId)) > 0;
 
     private static readonly SortableUniqueId ZeroThreshold =
         new("000000000000000000000000000000000000000000000000");
+
+    private readonly record struct SafeEventOrderKey(string SortableUniqueId, Guid EventId)
+        : IComparable<SafeEventOrderKey>
+    {
+        public static SafeEventOrderKey From(Event evt) => new(evt.SortableUniqueIdValue, evt.Id);
+
+        public int CompareTo(SafeEventOrderKey other)
+        {
+            var position = string.Compare(SortableUniqueId, other.SortableUniqueId, StringComparison.Ordinal);
+            return position != 0 ? position : EventId.CompareTo(other.EventId);
+        }
+    }
+
+    private readonly record struct RepairedSafeState(
+        T Projector,
+        int Version,
+        Guid LastEventId,
+        string LastSortableUniqueId);
+
+    private readonly record struct PublishedState(
+        T SafeProjector,
+        int SafeVersion,
+        Guid SafeLastEventId,
+        string SafeLastSortableUniqueId,
+        T UnsafeProjector,
+        int UnsafeVersion,
+        Guid UnsafeLastEventId,
+        string UnsafeLastSortableUniqueId);
 
     private void RebuildProcessedEventIdsFromBufferedEvents()
     {
@@ -365,18 +614,16 @@ public class DualStateProjectionWrapper<T>
         }
     }
 
-    private void RebuildSafeState(DcbDomainTypes domainTypes)
+    private RepairedSafeState RebuildSafeState(DcbDomainTypes domainTypes)
     {
         if (_allSafeEvents.Count == 0)
         {
-            return;
+            return new RepairedSafeState(
+                _safeProjector,
+                _safeVersion,
+                _safeLastEventId,
+                _safeLastSortableUniqueId);
         }
-
-        var allEvents = _allSafeEvents.Values.ToList();
-        allEvents.Sort((a, b) => string.Compare(
-            a.SortableUniqueIdValue,
-            b.SortableUniqueIdValue,
-            StringComparison.Ordinal));
 
         var rebuiltProjector = _types.GenerateInitialPayload(_projectorName);
         if (!rebuiltProjector.IsSuccess)
@@ -388,16 +635,15 @@ public class DualStateProjectionWrapper<T>
         var newSafeLastEventId = Guid.Empty;
         var newSafeLastSortableId = string.Empty;
 
-        foreach (var ev in allEvents)
+        foreach (var ev in _allSafeEvents.Values)
         {
-            var tags = ev.Tags.Select(tagString => domainTypes.TagTypes.GetTag(tagString)).ToList();
             var projected = _types.Project(
                 _projectorName,
                 newSafeProjector,
                 ev,
-                tags,
+                ResolveTags(ev, domainTypes),
                 domainTypes,
-                new SortableUniqueId("000000000000000000000000000000000000000000000000"));
+                ZeroThreshold);
 
             if (!projected.IsSuccess)
             {
@@ -409,46 +655,29 @@ public class DualStateProjectionWrapper<T>
             newSafeLastSortableId = ev.SortableUniqueIdValue;
         }
 
-        _safeProjector = newSafeProjector;
-        _safeLastEventId = newSafeLastEventId;
-        _safeLastSortableUniqueId = newSafeLastSortableId;
+        return new RepairedSafeState(
+            newSafeProjector,
+            _safeHistoryBaseVersion + _allSafeEvents.Count,
+            newSafeLastEventId,
+            newSafeLastSortableId);
     }
 
     private void ApplyEventsIncrementally(List<Event> events, DcbDomainTypes domainTypes)
     {
-        events.Sort((a, b) => string.Compare(
-            a.SortableUniqueIdValue,
-            b.SortableUniqueIdValue,
-            StringComparison.Ordinal));
+        events.Sort((a, b) => SafeEventOrderKey.From(a).CompareTo(SafeEventOrderKey.From(b)));
 
         foreach (var ev in events)
         {
             // SEK-G18 integrity guard: an incrementally-promoted event MUST sort strictly after the held safe head.
             // If it does not, the incremental (fold-onto-baseline) path cannot reorder it into the safe payload, so signal
             // a full ordered rebuild rather than folding it out of global order.
-            if (!IsStrictlyAfterSafeHead(ev.SortableUniqueIdValue))
+            if (!IsStrictlyAfterSafeHead(ev))
             {
                 SignalRebuild(ev);
                 return;
             }
 
-            var tags = ev.Tags.Select(tagString => domainTypes.TagTypes.GetTag(tagString)).ToList();
-            var projected = _types.Project(
-                _projectorName,
-                _safeProjector,
-                ev,
-                tags,
-                domainTypes,
-                ZeroThreshold);
-
-            if (!projected.IsSuccess)
-            {
-                throw projected.GetException();
-            }
-
-            _safeProjector = (T)projected.GetValue();
-            _safeLastEventId = ev.Id;
-            _safeLastSortableUniqueId = ev.SortableUniqueIdValue;
+            ProjectSafeInOrder(ev, domainTypes);
         }
     }
 

--- a/dcb/src/Sekiban.Dcb.Orleans.Core/Grains/MultiProjectionGrain.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.Core/Grains/MultiProjectionGrain.cs
@@ -1446,12 +1446,20 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
                 projectorName,
                 startUtc);
 
-            // Phase1: force promotion of buffered events before snapshot
+            // Phase1: force promotion of buffered events before snapshot. Deferred safe-history repair is fail-closed:
+            // publishing an old snapshot after a repair failure would permit compaction/switch to lose the retained
+            // ordering input, so do not continue to checkpoint capture or any durable write.
             try
             {
                 _host.ForcePromoteBufferedEvents();
             }
-            catch { }
+            catch (Exception exception)
+            {
+                _lastError = $"Deferred safe-history repair failed: {exception.Message}";
+                _logger.LogWarning(exception, "[{ProjectorName}] {LastError}", projectorName, _lastError);
+                _lastPersistOutcome = PersistOutcomeNoDurableWrite;
+                return ResultBox.Error<bool>(exception);
+            }
 
             var checkpoint = await CapturePersistCheckpointAsync(projectorName);
             var shortCircuit = TryShortCircuitPersist(projectorName, checkpoint);

--- a/dcb/tests/Sekiban.Dcb.Orleans.Tests/MultiProjectionGrainPersistPolicyTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Orleans.Tests/MultiProjectionGrainPersistPolicyTests.cs
@@ -177,6 +177,30 @@ public class MultiProjectionGrainPersistPolicyTests
     }
 
     [Fact]
+    public async Task PersistStateAsync_WhenDeferredRepairFails_DoesNotWriteOrCompactAndReturnsTheOriginalFailure()
+    {
+        // The real wrapper-level tests establish the deferred-repair failure and its retained cause. This is the
+        // production persistence boundary: a host reporting that repair failure must stop before snapshot capture,
+        // the grain-state provider write, or the irreversible compaction call.
+        var persistentState = new TestPersistentState<MultiProjectionGrainState>(new MultiProjectionGrainState());
+        var repairFailure = new InvalidOperationException("deferred repair failed");
+        var host = new DeferredRepairFailingHost(repairFailure);
+        var grain = CreateGrain(persistentState: persistentState);
+        SetPrivateField(grain, "_grainKey", "projection");
+        SetPrivateField(grain, "_projectorName", "projection");
+        SetPrivateField(grain, "_host", host);
+
+        var result = await grain.PersistStateAsync();
+
+        Assert.False(result.IsSuccess);
+        Assert.Same(repairFailure, result.GetException());
+        Assert.Equal(1, host.ForcePromoteCalls);
+        Assert.Equal(0, host.SnapshotWriteCalls);
+        Assert.Equal(0, host.CompactCalls);
+        Assert.Equal(0, persistentState.WriteCalls);
+    }
+
+    [Fact]
     public async Task ProjectionStatusHeartbeat_PinsHostVersionAndRebasesMissingRowsWithoutUnconditionalCreate()
     {
         // This deliberately invokes the production grain writer against the real in-memory status store. A fake result
@@ -441,9 +465,10 @@ public class MultiProjectionGrainPersistPolicyTests
         MultiProjectionGrainState? state = null,
         IProjectionActorHostFactory? actorHostFactory = null,
         IProjectionStatusStore? projectionStatusStore = null,
-        ProjectionStatusOptions? projectionStatusOptions = null) =>
+        ProjectionStatusOptions? projectionStatusOptions = null,
+        TestPersistentState<MultiProjectionGrainState>? persistentState = null) =>
         new(
-            new TestPersistentState<MultiProjectionGrainState>(state ?? new MultiProjectionGrainState()),
+            persistentState ?? new TestPersistentState<MultiProjectionGrainState>(state ?? new MultiProjectionGrainState()),
             actorHostFactory ?? new StubProjectionActorHostFactory(),
             new StubEventStore(),
             new DefaultOrleansEventSubscriptionResolver(),
@@ -501,6 +526,7 @@ public class MultiProjectionGrainPersistPolicyTests
         public TestPersistentState(T state) => State = state;
 
         public T State { get; set; }
+        public int WriteCalls { get; private set; }
         public string Etag => "test-etag";
         public bool RecordExists => true;
 
@@ -511,7 +537,11 @@ public class MultiProjectionGrainPersistPolicyTests
         }
 
         public Task ReadStateAsync() => Task.CompletedTask;
-        public Task WriteStateAsync() => Task.CompletedTask;
+        public Task WriteStateAsync()
+        {
+            WriteCalls++;
+            return Task.CompletedTask;
+        }
     }
 
     private sealed class StubProjectionActorHostFactory : IProjectionActorHostFactory
@@ -547,7 +577,7 @@ public class MultiProjectionGrainPersistPolicyTests
         public Task<ResultBox<bool>> WriteSnapshotToStreamAsync(Stream target, bool canGetUnsafeState, CancellationToken cancellationToken) =>
             throw new NotSupportedException();
 
-        public Task<ResultBox<bool>> WriteSnapshotForPersistenceToStreamAsync(
+        public virtual Task<ResultBox<bool>> WriteSnapshotForPersistenceToStreamAsync(
             Stream target,
             bool canGetUnsafeState,
             int offloadThresholdBytes,
@@ -571,8 +601,8 @@ public class MultiProjectionGrainPersistPolicyTests
             DateTime? safeThresholdTime,
             int? unsafeVersion) => throw new NotSupportedException();
 
-        public void ForcePromoteBufferedEvents() => throw new NotSupportedException();
-        public void CompactSafeHistory() => throw new NotSupportedException();
+        public virtual void ForcePromoteBufferedEvents() => throw new NotSupportedException();
+        public virtual void CompactSafeHistory() => throw new NotSupportedException();
         public void ForcePromoteAllBufferedEvents() => throw new NotSupportedException();
         public Task<string> GetSafeLastSortableUniqueIdAsync() => throw new NotSupportedException();
         public Task<bool> IsSortableUniqueIdReceivedAsync(string sortableUniqueId) => throw new NotSupportedException();
@@ -592,6 +622,31 @@ public class MultiProjectionGrainPersistPolicyTests
         public string ProjectorVersion { get; set; } = projectorVersion;
 
         public override string GetProjectorVersion() => ProjectorVersion;
+    }
+
+    private sealed class DeferredRepairFailingHost(Exception repairFailure) : StubProjectionActorHost
+    {
+        public int ForcePromoteCalls { get; private set; }
+        public int SnapshotWriteCalls { get; private set; }
+        public int CompactCalls { get; private set; }
+
+        public override void ForcePromoteBufferedEvents()
+        {
+            ForcePromoteCalls++;
+            throw repairFailure;
+        }
+
+        public override void CompactSafeHistory() => CompactCalls++;
+
+        public override Task<ResultBox<bool>> WriteSnapshotForPersistenceToStreamAsync(
+            Stream target,
+            bool canGetUnsafeState,
+            int offloadThresholdBytes,
+            CancellationToken cancellationToken)
+        {
+            SnapshotWriteCalls++;
+            return Task.FromResult(ResultBox.FromValue(true));
+        }
     }
 
     private sealed class FixedServiceIdProvider(string serviceId) : IServiceIdProvider

--- a/dcb/tests/Sekiban.Dcb.Orleans.Tests/MultiProjectionGrainWatermarkRetirementTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Orleans.Tests/MultiProjectionGrainWatermarkRetirementTests.cs
@@ -134,7 +134,7 @@ public sealed class MultiProjectionGrainWatermarkRetirementTests : IAsyncLifetim
                 .SelectMany(host => host.CompactionObservations),
             observation => observation.RealAllSafeEventsCountBeforeCompaction > 0);
         Assert.Equal(
-            typeof(Dictionary<,>),
+            typeof(SortedDictionary<,>),
             observation.RealAllSafeEventsCollection.GetType().GetGenericTypeDefinition());
         Assert.True(observation.DurableIntermediateCheckpointWasCommittedBeforeCompaction);
         Assert.True(observation.RealAllSafeEventsCountBeforeCompaction > 0);

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/DualStateProjectionWrapperCompactionTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/DualStateProjectionWrapperCompactionTests.cs
@@ -108,7 +108,7 @@ public class DualStateProjectionWrapperCompactionTests
     }
 
     [Fact]
-    public void CompactSafeHistory_ShouldTrimSafeHistoryCapacity_WhenSafeHistoryHadEntries()
+    public void CompactSafeHistory_ShouldClearSortedSafeHistory_WhenSafeHistoryHadEntries()
     {
         var wrapper = CreateWrapper();
         var futureThreshold = SortableUniqueId.Generate(DateTime.UtcNow.AddMinutes(5), Guid.Empty);
@@ -119,13 +119,11 @@ public class DualStateProjectionWrapperCompactionTests
             wrapper.ProcessEvent(CreateEvent(new CountedEvent(1), now.AddSeconds(i)), futureThreshold, _domainTypes);
         }
 
-        var capacityBefore = GetPrivateCapacity(wrapper, "_allSafeEvents");
-        Assert.True(capacityBefore > 0);
+        Assert.Equal(32, GetPrivateCount(wrapper, "_allSafeEvents"));
 
         ((IDualStateAccessor)wrapper).CompactSafeHistory();
 
         Assert.Equal(0, GetPrivateCount(wrapper, "_allSafeEvents"));
-        Assert.True(GetPrivateCapacity(wrapper, "_allSafeEvents") < capacityBefore);
     }
 
     private DualStateProjectionWrapper<CountingProjector> CreateWrapper() =>
@@ -159,20 +157,6 @@ public class DualStateProjectionWrapperCompactionTests
         Assert.NotNull(countProperty);
 
         return (int)countProperty!.GetValue(value)!;
-    }
-
-    private static int GetPrivateCapacity(object target, string fieldName)
-    {
-        var field = target.GetType().GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic);
-        Assert.NotNull(field);
-
-        var value = field!.GetValue(target);
-        Assert.NotNull(value);
-
-        var entriesField = value!.GetType().GetField("_entries", BindingFlags.Instance | BindingFlags.NonPublic);
-        Assert.NotNull(entriesField);
-
-        return (entriesField!.GetValue(value) as Array)?.Length ?? 0;
     }
 
     public record CountedEvent(int Amount) : IEventPayload;

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/DualStateProjectionWrapperDeferredRepairTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/DualStateProjectionWrapperDeferredRepairTests.cs
@@ -1,0 +1,629 @@
+using ResultBoxes;
+using Sekiban.Dcb;
+using Sekiban.Dcb.Actors;
+using Sekiban.Dcb.Common;
+using Sekiban.Dcb.Domains;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.MultiProjections;
+using Sekiban.Dcb.Queries;
+using Sekiban.Dcb.Tags;
+using System.Reflection;
+
+namespace Sekiban.Dcb.Tests;
+
+/// <summary>
+///     Production-surface evidence for SEK-G41. These tests intentionally drive the public wrapper/actor entry points,
+///     rather than invoking the private consume helper, so removal of a forwarding path or reintroduction of an
+///     arrival-time reconcile is observable.
+/// </summary>
+public class DualStateProjectionWrapperDeferredRepairTests
+{
+    [Theory]
+    [InlineData("GetSafeProjection")]
+    [InlineData("GetUnsafeProjection")]
+    [InlineData("PromoteBufferedEventsZero")]
+    [InlineData("GetSafeProjectorPayload")]
+    [InlineData("GetUnsafeProjectorPayload")]
+    [InlineData("CompactSafeHistory")]
+    public void DirtyHistory_IsConsumedExactlyOnceThroughEachWrapperProductionEntryPoint(string entryPoint)
+    {
+        var fixture = new Fixture();
+        var wrapper = fixture.CreateWrapper();
+        var seed = SeedDirtyHistory(wrapper, fixture.DomainTypes);
+        var accessor = (IDualStateAccessor)wrapper;
+
+        // The high event was folded once before the disorder. The two retained arrivals caused neither fold nor tag
+        // resolution, and served metadata remains untouched until a genuine consumption boundary is reached.
+        Assert.Equal(1, fixture.TagTypes.FoldCount);
+        Assert.Equal(1, fixture.TagTypes.TagResolutionCount);
+        Assert.True(GetPrivateBool(wrapper, "_safeHistoryDirty"));
+        Assert.Equal(1, accessor.SafeVersion);
+        Assert.Equal(0, accessor.UnsafeVersion);
+
+        InvokeWrapperEntryPoint(entryPoint, wrapper, accessor, fixture.DomainTypes);
+
+        // Inspect the published fields directly. Calling either payload getter here would itself enter the consumption
+        // seam and could hide a missing forwarding call in the entry point under test.
+        AssertConsumedState(wrapper, accessor, fixture, seed, expectedFoldCount: 4);
+        Assert.False(GetPrivateBool(wrapper, "_safeHistoryDirty"));
+        Assert.False(GetPrivateBool(wrapper, "_servedStateDirty"));
+
+        if (entryPoint == "CompactSafeHistory")
+        {
+            Assert.Equal(0, GetPrivateCount(wrapper, "_allSafeEvents"));
+            Assert.True(GetPrivateBool(wrapper, "_useIncrementalSafePromotion"));
+        }
+        else
+        {
+            Assert.Equal(3, GetPrivateCount(wrapper, "_allSafeEvents"));
+        }
+    }
+
+    [Theory]
+    [InlineData("GetSafeProjection")]
+    [InlineData("GetUnsafeProjection")]
+    [InlineData("PromoteBufferedEventsZero")]
+    [InlineData("GetSafeProjectorPayload")]
+    [InlineData("GetUnsafeProjectorPayload")]
+    [InlineData("CompactSafeHistory")]
+    public void DirtyHistory_EachWrapperConsumptionEntryPoint_FailsWithoutPublishingAndCanRetry(string entryPoint)
+    {
+        var fixture = new Fixture();
+        var wrapper = fixture.CreateWrapper();
+        var seed = SeedDirtyHistory(wrapper, fixture.DomainTypes);
+        var accessor = (IDualStateAccessor)wrapper;
+        var published = CapturePublishedState(wrapper, accessor);
+        fixture.TagTypes.FailDuringFold.Add(seed.Low.Id);
+
+        var failure = Assert.Throws<InvalidOperationException>(
+            () => InvokeWrapperEntryPoint(entryPoint, wrapper, accessor, fixture.DomainTypes));
+
+        Assert.Equal(seed.Low.Id.ToString(), failure.Data["DeferredSafeRepairEventId"]);
+        Assert.Equal(seed.Low.SortableUniqueIdValue, failure.Data["DeferredSafeRepairPosition"]);
+        AssertPublishedState(published, wrapper, accessor);
+        Assert.True(GetPrivateBool(wrapper, "_safeHistoryDirty"));
+        Assert.True(GetPrivateBool(wrapper, "_servedStateDirty"));
+        Assert.Equal(3, GetPrivateCount(wrapper, "_allSafeEvents"));
+        Assert.False(GetPrivateBool(wrapper, "_useIncrementalSafePromotion"));
+
+        fixture.TagTypes.FailDuringFold.Remove(seed.Low.Id);
+        InvokeWrapperEntryPoint(entryPoint, wrapper, accessor, fixture.DomainTypes);
+
+        AssertConsumedState(wrapper, accessor, fixture, seed, expectedFoldCount: 5);
+        Assert.Equal(entryPoint == "CompactSafeHistory" ? 0 : 3, GetPrivateCount(wrapper, "_allSafeEvents"));
+        Assert.Equal(entryPoint == "CompactSafeHistory", GetPrivateBool(wrapper, "_useIncrementalSafePromotion"));
+    }
+
+    [Fact]
+    public async Task DirtyHistory_IsConsumedThroughTheSeventhProductionActorHeadStatusEntryPoint()
+    {
+        var fixture = new Fixture();
+        var actor = new GeneralMultiProjectionActor(
+            fixture.DomainTypes,
+            CountingProjector.MultiProjectorName,
+            new GeneralMultiProjectionActorOptions { SafeWindowMs = 1 });
+        var seed = CreateSeedEvents();
+
+        // Separate real actor deliveries preserve the disorder; AddEventsAsync's per-batch ordering cannot hide it.
+        await actor.AddEventsAsync([seed.High]);
+        await actor.AddEventsAsync([seed.Low]);
+        await actor.AddEventsAsync([seed.Middle]);
+        Assert.Equal(1, fixture.TagTypes.FoldCount);
+
+        var head = await actor.GetProjectionHeadStatusAsync();
+
+        Assert.Equal(3, head.Current.EventVersion);
+        Assert.Equal(3, head.Consistent.EventVersion);
+        Assert.Equal(seed.High.SortableUniqueIdValue, head.Current.LastSortableUniqueId);
+        Assert.Equal(seed.High.SortableUniqueIdValue, head.Consistent.LastSortableUniqueId);
+        Assert.Equal(4, fixture.TagTypes.FoldCount);
+        Assert.Equal(4, fixture.TagTypes.TagResolutionCount);
+    }
+
+    [Fact]
+    public async Task DirtyHistory_ActorHeadStatusEntryPoint_FailsWithoutPublishingAndCanRetry()
+    {
+        var fixture = new Fixture();
+        var actor = new GeneralMultiProjectionActor(
+            fixture.DomainTypes,
+            CountingProjector.MultiProjectorName,
+            new GeneralMultiProjectionActorOptions { SafeWindowMs = 1 });
+        var seed = CreateSeedEvents();
+
+        await actor.AddEventsAsync([seed.High]);
+        await actor.AddEventsAsync([seed.Low]);
+        await actor.AddEventsAsync([seed.Middle]);
+        var wrapper = Assert.IsType<DualStateProjectionWrapper<CountingProjector>>(
+            GetPrivateValue<object>(actor, "_singleStateAccessor"));
+        var accessor = (IDualStateAccessor)wrapper;
+        var published = CapturePublishedState(wrapper, accessor);
+        fixture.TagTypes.FailDuringFold.Add(seed.Low.Id);
+
+        var failure = await Assert.ThrowsAsync<InvalidOperationException>(actor.GetProjectionHeadStatusAsync);
+
+        Assert.Equal(seed.Low.Id.ToString(), failure.Data["DeferredSafeRepairEventId"]);
+        Assert.Equal(seed.Low.SortableUniqueIdValue, failure.Data["DeferredSafeRepairPosition"]);
+        AssertPublishedState(published, wrapper, accessor);
+        Assert.True(GetPrivateBool(wrapper, "_safeHistoryDirty"));
+        Assert.Equal(3, GetPrivateCount(wrapper, "_allSafeEvents"));
+
+        fixture.TagTypes.FailDuringFold.Remove(seed.Low.Id);
+        var retried = await actor.GetProjectionHeadStatusAsync();
+        Assert.Equal(3, retried.Current.EventVersion);
+        Assert.Equal(3, retried.Consistent.EventVersion);
+        AssertConsumedState(wrapper, accessor, fixture, seed, expectedFoldCount: 5);
+    }
+
+    [Fact]
+    public void DirtyProcessEvent_SuppressesReconcileUntilTheFirstRealConsumeThenReconcilesOnce()
+    {
+        var fixture = new Fixture();
+        var wrapper = fixture.CreateWrapper();
+        var accessor = (IDualStateAccessor)wrapper;
+        var baseline = DateTime.UtcNow.AddMinutes(-10);
+        var threshold = new SortableUniqueId(SortableUniqueId.Generate(baseline.AddSeconds(5), Guid.Empty));
+        var low = CreateEvent(new FoldEvent(1, "A"), SortableUniqueId.Generate(baseline, Guid.Empty), GuidFromInt(201));
+        var middle = CreateEvent(new FoldEvent(2, "B"), SortableUniqueId.Generate(baseline.AddSeconds(1), Guid.Empty), GuidFromInt(202));
+        var high = CreateEvent(new FoldEvent(3, "C"), SortableUniqueId.Generate(baseline.AddSeconds(2), Guid.Empty), GuidFromInt(203));
+        var buffered = CreateEvent(new FoldEvent(4, "U"), SortableUniqueId.Generate(baseline.AddSeconds(10), Guid.Empty), GuidFromInt(204));
+
+        wrapper.ProcessEvent(buffered, threshold, fixture.DomainTypes); // one direct unsafe fold
+        wrapper.ProcessEvent(high, threshold, fixture.DomainTypes);     // one direct safe fold, served now deferred
+        wrapper.ProcessEvent(low, threshold, fixture.DomainTypes);      // dirty-producing arrival: must not reconcile U
+        wrapper.ProcessEvent(middle, threshold, fixture.DomainTypes);   // apparent in-order tail: must remain unfurled
+
+        Assert.True(GetPrivateBool(wrapper, "_safeHistoryDirty"));
+        Assert.Equal(2, fixture.TagTypes.FoldCount);
+        Assert.Equal(2, fixture.TagTypes.TagResolutionCount);
+        Assert.Equal("C", GetPrivateProjector(wrapper, "_safeProjector").Order);
+        Assert.Equal("U", GetPrivateProjector(wrapper, "_unsafeProjector").Order);
+        Assert.Equal(1, accessor.SafeVersion);
+        Assert.Equal(1, accessor.UnsafeVersion);
+
+        var consumed = wrapper.GetUnsafeProjection(fixture.DomainTypes);
+
+        Assert.Equal("ABCU", consumed.State.Order);
+        Assert.Equal(10, consumed.State.Total);
+        Assert.Equal(4, consumed.Version);
+        Assert.Equal(6, fixture.TagTypes.FoldCount); // rebuild A/B/C once, then reconcile buffered U once
+        Assert.Equal(6, fixture.TagTypes.TagResolutionCount);
+
+        _ = wrapper.GetUnsafeProjection(fixture.DomainTypes);
+        Assert.Equal(6, fixture.TagTypes.FoldCount);
+        Assert.Equal(6, fixture.TagTypes.TagResolutionCount);
+    }
+
+    [Fact]
+    public void DeferredRepair_IsLosslessForSortableUniqueIdTies()
+    {
+        var fixture = new Fixture();
+        var baseline = DateTime.UtcNow.AddMinutes(-10);
+        var tiedPosition = SortableUniqueId.Generate(baseline, Guid.Empty);
+        var laterPosition = SortableUniqueId.Generate(baseline.AddTicks(1), Guid.Empty);
+        var firstTie = CreateEvent(new FoldEvent(1, "A"), tiedPosition, Guid.Parse("00000000-0000-0000-0000-000000000001"));
+        var secondTie = CreateEvent(new FoldEvent(2, "B"), tiedPosition, Guid.Parse("00000000-0000-0000-0000-000000000002"));
+        var later = CreateEvent(new FoldEvent(4, "C"), laterPosition, Guid.Parse("00000000-0000-0000-0000-000000000003"));
+
+        var immediate = fixture.CreateWrapper();
+        immediate.ProcessEvent(firstTie, SortableUniqueId.MaxValue, fixture.DomainTypes);
+        _ = immediate.GetUnsafeProjection(fixture.DomainTypes);
+        immediate.ProcessEvent(secondTie, SortableUniqueId.MaxValue, fixture.DomainTypes);
+        _ = immediate.GetUnsafeProjection(fixture.DomainTypes);
+        immediate.ProcessEvent(later, SortableUniqueId.MaxValue, fixture.DomainTypes);
+        var immediateProjection = immediate.GetUnsafeProjection(fixture.DomainTypes);
+
+        var deferredFixture = new Fixture();
+        var deferred = deferredFixture.CreateWrapper();
+        deferred.ProcessEvent(later, SortableUniqueId.MaxValue, deferredFixture.DomainTypes);
+        deferred.ProcessEvent(secondTie, SortableUniqueId.MaxValue, deferredFixture.DomainTypes);
+        deferred.ProcessEvent(firstTie, SortableUniqueId.MaxValue, deferredFixture.DomainTypes);
+        var deferredProjection = deferred.GetUnsafeProjection(deferredFixture.DomainTypes);
+
+        Assert.Equal("ABC", immediateProjection.State.Order);
+        Assert.Equal(immediateProjection.State, deferredProjection.State);
+        Assert.Equal(immediateProjection.LastEventId, deferredProjection.LastEventId);
+        Assert.Equal(immediateProjection.LastSortableUniqueId, deferredProjection.LastSortableUniqueId);
+        Assert.Equal(3, deferredProjection.Version);
+    }
+
+    [Fact]
+    public void DeferredRepair_FoldAndTagResolutionCountsAreLinearAndEachDirtyEpochRepairsOnce()
+    {
+        const int smallCount = 64;
+        var small = RunDeferredComplexityScenario(smallCount);
+        var large = RunDeferredComplexityScenario(smallCount * 2);
+
+        // Deterministic fold counts are the primary complexity proof. The only insertion-time fold is the first high
+        // arrival; the first consume then folds N retained events once. Doubling N with one consume remains linear.
+        Assert.Equal(smallCount + 1, small.FoldsAfterFirstConsume);
+        Assert.Equal((smallCount * 2) + 1, large.FoldsAfterFirstConsume);
+        Assert.Equal(small.FoldsAfterFirstConsume, small.TagResolutionsAfterFirstConsume);
+        Assert.Equal(large.FoldsAfterFirstConsume, large.TagResolutionsAfterFirstConsume);
+        Assert.Equal(2, small.FoldStartCountAfterFirstConsume); // initial in-order fold + one deferred rebuild
+        Assert.Equal(2, large.FoldStartCountAfterFirstConsume);
+
+        // A repeated consume is free, while a later out-of-order epoch adds exactly one further complete rebuild.
+        Assert.Equal(small.FoldsAfterFirstConsume, small.FoldsAfterRepeatConsume);
+        Assert.Equal(3, small.FoldStartCountAfterSecondEpoch);
+        Assert.Equal((smallCount * 2) + 4, small.FoldsAfterSecondEpoch);
+    }
+
+    [Fact]
+    public void RepairFailure_PublishesNothingRetainsCauseAndBlocksCompactionUntilRetry()
+    {
+        var fixture = new Fixture();
+        var wrapper = fixture.CreateWrapper();
+        var seed = CreateSeedEvents();
+        var accessor = (IDualStateAccessor)wrapper;
+
+        wrapper.ProcessEvent(seed.High, SortableUniqueId.MaxValue, fixture.DomainTypes);
+        wrapper.ProcessEvent(seed.Low, SortableUniqueId.MaxValue, fixture.DomainTypes);
+        fixture.TagTypes.FailDuringFold.Add(seed.Low.Id);
+
+        var safeBefore = GetPrivateProjector(wrapper, "_safeProjector");
+        var unsafeBefore = GetPrivateProjector(wrapper, "_unsafeProjector");
+        var safeVersionBefore = accessor.SafeVersion;
+        var unsafeVersionBefore = accessor.UnsafeVersion;
+        var safeLastBefore = GetPrivateValue<string>(wrapper, "_safeLastSortableUniqueId");
+        var unsafeLastBefore = GetPrivateValue<string>(wrapper, "_unsafeLastSortableUniqueId");
+
+        var failure = Assert.Throws<InvalidOperationException>(() => wrapper.GetUnsafeProjection(fixture.DomainTypes));
+        Assert.Equal(seed.Low.Id.ToString(), failure.Data["DeferredSafeRepairEventId"]);
+        Assert.Equal(seed.Low.SortableUniqueIdValue, failure.Data["DeferredSafeRepairPosition"]);
+        Assert.Equal(safeBefore, GetPrivateProjector(wrapper, "_safeProjector"));
+        Assert.Equal(unsafeBefore, GetPrivateProjector(wrapper, "_unsafeProjector"));
+        Assert.Equal(safeVersionBefore, accessor.SafeVersion);
+        Assert.Equal(unsafeVersionBefore, accessor.UnsafeVersion);
+        Assert.Equal(safeLastBefore, GetPrivateValue<string>(wrapper, "_safeLastSortableUniqueId"));
+        Assert.Equal(unsafeLastBefore, GetPrivateValue<string>(wrapper, "_unsafeLastSortableUniqueId"));
+        Assert.True(GetPrivateBool(wrapper, "_safeHistoryDirty"));
+        Assert.Equal(2, GetPrivateCount(wrapper, "_allSafeEvents"));
+
+        Assert.Throws<InvalidOperationException>(() => accessor.CompactSafeHistory());
+        Assert.False(GetPrivateBool(wrapper, "_useIncrementalSafePromotion"));
+        Assert.Equal(2, GetPrivateCount(wrapper, "_allSafeEvents"));
+
+        fixture.TagTypes.FailDuringFold.Remove(seed.Low.Id);
+        accessor.CompactSafeHistory();
+
+        var repaired = Assert.IsType<CountingProjector>(accessor.GetSafeProjectorPayload());
+        Assert.Equal(4, repaired.Total);
+        Assert.Equal("AC", repaired.Order);
+        Assert.Equal(0, GetPrivateCount(wrapper, "_allSafeEvents"));
+        Assert.True(GetPrivateBool(wrapper, "_useIncrementalSafePromotion"));
+    }
+
+    [Fact]
+    public async Task RepairFailure_FailsClosedAtTheProductionSnapshotPersistenceBoundary()
+    {
+        var fixture = new Fixture();
+        var actor = new GeneralMultiProjectionActor(
+            fixture.DomainTypes,
+            CountingProjector.MultiProjectorName,
+            new GeneralMultiProjectionActorOptions { SafeWindowMs = 1 });
+        var seed = CreateSeedEvents();
+
+        await actor.AddEventsAsync([seed.High]);
+        await actor.AddEventsAsync([seed.Low]);
+        fixture.TagTypes.FailDuringFold.Add(seed.Low.Id);
+
+        var result = await actor.BuildSnapshotForPersistenceAsync();
+
+        Assert.False(result.IsSuccess);
+        var failure = result.GetException();
+        Assert.Equal(seed.Low.Id.ToString(), failure.Data["DeferredSafeRepairEventId"]);
+        Assert.Equal(seed.Low.SortableUniqueIdValue, failure.Data["DeferredSafeRepairPosition"]);
+        Assert.Equal(2, fixture.TagTypes.FoldCount); // the staged repair attempted its first fold, but no state was published
+    }
+
+    [Fact]
+    public void PublicDualStateSurface_IsFrozenWithoutDeferredRepairMembers()
+    {
+        var wrapperPublicMethods = typeof(DualStateProjectionWrapper<CountingProjector>)
+            .GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.DeclaredOnly)
+            .Where(method => !method.IsSpecialName)
+            .Select(method => method.Name)
+            .OrderBy(name => name, StringComparer.Ordinal)
+            .ToArray();
+        Assert.Equal(["GetSafeProjection", "GetUnsafeProjection", "ProcessEvent"], wrapperPublicMethods);
+
+        var accessorMethods = typeof(IDualStateAccessor)
+            .GetMethods()
+            .Where(method => !method.IsSpecialName)
+            .Select(method => method.Name)
+            .OrderBy(name => name, StringComparer.Ordinal)
+            .ToArray();
+        Assert.Equal(
+            [
+                "CompactSafeHistory",
+                "GetSafeProjectorPayload",
+                "GetUnsafeProjectorPayload",
+                "ProcessEventAs",
+                "PromoteBufferedEvents"
+            ],
+            accessorMethods);
+        Assert.DoesNotContain(accessorMethods, name => name.Contains("Consume", StringComparison.Ordinal));
+    }
+
+    private static ComplexityObservation RunDeferredComplexityScenario(int eventCount)
+    {
+        var fixture = new Fixture();
+        var wrapper = fixture.CreateWrapper();
+        var baseline = DateTime.UtcNow.AddDays(-1);
+        var events = Enumerable.Range(0, eventCount)
+            .Select(index => CreateEvent(
+                new FoldEvent(1, index.ToString("D4")),
+                SortableUniqueId.Generate(baseline.AddTicks(index), Guid.Empty),
+                GuidFromInt(index + 1)))
+            .ToArray();
+
+        foreach (var ev in events.Reverse())
+        {
+            wrapper.ProcessEvent(ev, SortableUniqueId.MaxValue, fixture.DomainTypes);
+        }
+
+        Assert.Equal(1, fixture.TagTypes.FoldCount);
+        Assert.Equal(1, fixture.TagTypes.TagResolutionCount);
+
+        _ = wrapper.GetUnsafeProjection(fixture.DomainTypes);
+        var foldsAfterFirstConsume = fixture.TagTypes.FoldCount;
+        var tagsAfterFirstConsume = fixture.TagTypes.TagResolutionCount;
+        var startsAfterFirstConsume = fixture.TagTypes.FoldStartCount;
+
+        _ = wrapper.GetUnsafeProjection(fixture.DomainTypes);
+        var foldsAfterRepeatConsume = fixture.TagTypes.FoldCount;
+
+        var later = CreateEvent(
+            new FoldEvent(1, "later"),
+            SortableUniqueId.Generate(baseline.AddTicks(eventCount + 2), Guid.Empty),
+            GuidFromInt(eventCount + 100));
+        var beforeLater = CreateEvent(
+            new FoldEvent(1, "before-later"),
+            SortableUniqueId.Generate(baseline.AddTicks(eventCount + 1), Guid.Empty),
+            GuidFromInt(eventCount + 101));
+        wrapper.ProcessEvent(later, SortableUniqueId.MaxValue, fixture.DomainTypes);
+        wrapper.ProcessEvent(beforeLater, SortableUniqueId.MaxValue, fixture.DomainTypes);
+        _ = wrapper.GetUnsafeProjection(fixture.DomainTypes);
+
+        return new ComplexityObservation(
+            foldsAfterFirstConsume,
+            tagsAfterFirstConsume,
+            startsAfterFirstConsume,
+            foldsAfterRepeatConsume,
+            fixture.TagTypes.FoldCount,
+            fixture.TagTypes.FoldStartCount);
+    }
+
+    private static void AssertConsumedState(
+        DualStateProjectionWrapper<CountingProjector> wrapper,
+        IDualStateAccessor accessor,
+        Fixture fixture,
+        DirtySeed seed,
+        int expectedFoldCount)
+    {
+        var safe = GetPrivateProjector(wrapper, "_safeProjector");
+        var unsafeState = GetPrivateProjector(wrapper, "_unsafeProjector");
+        Assert.Equal(6, safe.Total);
+        Assert.Equal("ABC", safe.Order);
+        Assert.Equal(safe, unsafeState);
+        Assert.Equal(3, accessor.SafeVersion);
+        Assert.Equal(3, accessor.UnsafeVersion);
+        Assert.Equal(seed.High.Id, GetPrivateValue<Guid>(wrapper, "_safeLastEventId"));
+        Assert.Equal(seed.High.SortableUniqueIdValue, GetPrivateValue<string>(wrapper, "_safeLastSortableUniqueId"));
+        Assert.Equal(seed.High.Id, accessor.UnsafeLastEventId);
+        Assert.Equal(seed.High.SortableUniqueIdValue, accessor.UnsafeLastSortableUniqueId);
+        Assert.Equal(expectedFoldCount, fixture.TagTypes.FoldCount);
+        Assert.Equal(expectedFoldCount, fixture.TagTypes.TagResolutionCount);
+    }
+
+    private static DirtySeed SeedDirtyHistory(DualStateProjectionWrapper<CountingProjector> wrapper, DcbDomainTypes domainTypes)
+    {
+        var seed = CreateSeedEvents();
+        wrapper.ProcessEvent(seed.High, SortableUniqueId.MaxValue, domainTypes);
+        wrapper.ProcessEvent(seed.Low, SortableUniqueId.MaxValue, domainTypes);
+        wrapper.ProcessEvent(seed.Middle, SortableUniqueId.MaxValue, domainTypes);
+        return seed;
+    }
+
+    private static void InvokeWrapperEntryPoint(
+        string entryPoint,
+        DualStateProjectionWrapper<CountingProjector> wrapper,
+        IDualStateAccessor accessor,
+        DcbDomainTypes domainTypes)
+    {
+        switch (entryPoint)
+        {
+            case "GetSafeProjection":
+                _ = wrapper.GetSafeProjection(SortableUniqueId.MaxValue, domainTypes);
+                return;
+            case "GetUnsafeProjection":
+                _ = wrapper.GetUnsafeProjection(domainTypes);
+                return;
+            case "PromoteBufferedEventsZero":
+                // No event crosses the threshold here. This must nevertheless consume the existing dirty safe history.
+                accessor.PromoteBufferedEvents(SortableUniqueId.MaxValue, domainTypes);
+                return;
+            case "GetSafeProjectorPayload":
+                _ = accessor.GetSafeProjectorPayload();
+                return;
+            case "GetUnsafeProjectorPayload":
+                _ = accessor.GetUnsafeProjectorPayload();
+                return;
+            case "CompactSafeHistory":
+                accessor.CompactSafeHistory();
+                return;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(entryPoint), entryPoint, null);
+        }
+    }
+
+    private static PublishedState CapturePublishedState(
+        DualStateProjectionWrapper<CountingProjector> wrapper,
+        IDualStateAccessor accessor) =>
+        new(
+            GetPrivateProjector(wrapper, "_safeProjector"),
+            accessor.SafeVersion,
+            GetPrivateValue<Guid>(wrapper, "_safeLastEventId"),
+            GetPrivateValue<string>(wrapper, "_safeLastSortableUniqueId"),
+            GetPrivateProjector(wrapper, "_unsafeProjector"),
+            accessor.UnsafeVersion,
+            accessor.UnsafeLastEventId,
+            accessor.UnsafeLastSortableUniqueId);
+
+    private static void AssertPublishedState(
+        PublishedState expected,
+        DualStateProjectionWrapper<CountingProjector> wrapper,
+        IDualStateAccessor accessor)
+    {
+        Assert.Equal(expected.SafeProjector, GetPrivateProjector(wrapper, "_safeProjector"));
+        Assert.Equal(expected.SafeVersion, accessor.SafeVersion);
+        Assert.Equal(expected.SafeLastEventId, GetPrivateValue<Guid>(wrapper, "_safeLastEventId"));
+        Assert.Equal(expected.SafeLastSortableUniqueId, GetPrivateValue<string>(wrapper, "_safeLastSortableUniqueId"));
+        Assert.Equal(expected.UnsafeProjector, GetPrivateProjector(wrapper, "_unsafeProjector"));
+        Assert.Equal(expected.UnsafeVersion, accessor.UnsafeVersion);
+        Assert.Equal(expected.UnsafeLastEventId, accessor.UnsafeLastEventId);
+        Assert.Equal(expected.UnsafeLastSortableUniqueId, accessor.UnsafeLastSortableUniqueId);
+    }
+
+    private static DirtySeed CreateSeedEvents()
+    {
+        var baseline = DateTime.UtcNow.AddMinutes(-10);
+        return new DirtySeed(
+            CreateEvent(new FoldEvent(1, "A"), SortableUniqueId.Generate(baseline, Guid.Empty), Guid.Parse("00000000-0000-0000-0000-000000000011")),
+            CreateEvent(new FoldEvent(2, "B"), SortableUniqueId.Generate(baseline.AddTicks(1), Guid.Empty), Guid.Parse("00000000-0000-0000-0000-000000000012")),
+            CreateEvent(new FoldEvent(3, "C"), SortableUniqueId.Generate(baseline.AddTicks(2), Guid.Empty), Guid.Parse("00000000-0000-0000-0000-000000000013")));
+    }
+
+    private static Event CreateEvent(FoldEvent payload, string sortableUniqueId, Guid eventId) =>
+        new(
+            payload,
+            sortableUniqueId,
+            nameof(FoldEvent),
+            eventId,
+            new EventMetadata(eventId.ToString(), eventId.ToString(), "test"),
+            ["count:all"]);
+
+    private static Guid GuidFromInt(int value) => new($"00000000-0000-0000-0000-{value:D12}");
+
+    private static int GetPrivateCount(object target, string fieldName)
+    {
+        var value = GetPrivateValue<object>(target, fieldName);
+        var count = value.GetType().GetProperty("Count")?.GetValue(value);
+        return Assert.IsType<int>(count);
+    }
+
+    private static bool GetPrivateBool(object target, string fieldName) => GetPrivateValue<bool>(target, fieldName);
+
+    private static CountingProjector GetPrivateProjector(object target, string fieldName) =>
+        Assert.IsType<CountingProjector>(GetPrivateValue<object>(target, fieldName));
+
+    private static T GetPrivateValue<T>(object target, string fieldName)
+    {
+        var field = target.GetType().GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(field);
+        return Assert.IsAssignableFrom<T>(field!.GetValue(target));
+    }
+
+    private sealed class Fixture
+    {
+        public Fixture()
+        {
+            var eventTypes = new SimpleEventTypes();
+            eventTypes.RegisterEventType<FoldEvent>(nameof(FoldEvent));
+            TagTypes = new CountingTagTypes();
+            var multiProjectorTypes = new SimpleMultiProjectorTypes();
+            multiProjectorTypes.RegisterProjector<CountingProjector>();
+            DomainTypes = new DcbDomainTypes(
+                eventTypes,
+                TagTypes,
+                new SimpleTagProjectorTypes(),
+                new SimpleTagStatePayloadTypes(),
+                multiProjectorTypes,
+                new SimpleQueryTypes(),
+                new System.Text.Json.JsonSerializerOptions());
+            Types = multiProjectorTypes;
+        }
+
+        public CountingTagTypes TagTypes { get; }
+        public DcbDomainTypes DomainTypes { get; }
+        public SimpleMultiProjectorTypes Types { get; }
+
+        public DualStateProjectionWrapper<CountingProjector> CreateWrapper() => new(
+            CountingProjector.GenerateInitialPayload(),
+            CountingProjector.MultiProjectorName,
+            Types,
+            DomainTypes.JsonSerializerOptions);
+    }
+
+    private sealed class CountingTagTypes : ITagTypes
+    {
+        public int TagResolutionCount { get; set; }
+        public int FoldCount { get; set; }
+        public int FoldStartCount { get; set; }
+        public HashSet<Guid> FailDuringFold { get; } = [];
+
+        public ITag GetTag(string tag)
+        {
+            TagResolutionCount++;
+            return new FallbackTag("count", tag);
+        }
+
+        public IReadOnlyList<string> GetAllTagGroupNames() => Array.Empty<string>();
+    }
+
+    private sealed record DirtySeed(Event Low, Event Middle, Event High);
+
+    private sealed record PublishedState(
+        CountingProjector SafeProjector,
+        int SafeVersion,
+        Guid SafeLastEventId,
+        string SafeLastSortableUniqueId,
+        CountingProjector UnsafeProjector,
+        int UnsafeVersion,
+        Guid UnsafeLastEventId,
+        string UnsafeLastSortableUniqueId);
+
+    private sealed record ComplexityObservation(
+        int FoldsAfterFirstConsume,
+        int TagResolutionsAfterFirstConsume,
+        int FoldStartCountAfterFirstConsume,
+        int FoldsAfterRepeatConsume,
+        int FoldsAfterSecondEpoch,
+        int FoldStartCountAfterSecondEpoch);
+
+    public sealed record FoldEvent(int Amount, string Label) : IEventPayload;
+
+    public sealed record CountingProjector(int Total = 0, string Order = "") : IMultiProjector<CountingProjector>
+    {
+        public CountingProjector() : this(0, string.Empty) { }
+
+        public static string MultiProjectorName => nameof(CountingProjector);
+        public static string MultiProjectorVersion => "1.0.0";
+        public static CountingProjector GenerateInitialPayload() => new();
+
+        public static ResultBox<CountingProjector> Project(
+            CountingProjector payload,
+            Event ev,
+            List<ITag> tags,
+            DcbDomainTypes domainTypes,
+            SortableUniqueId safeWindowThreshold)
+        {
+            var counters = Assert.IsType<CountingTagTypes>(domainTypes.TagTypes);
+            counters.FoldCount++;
+            if (payload.Order.Length == 0)
+            {
+                counters.FoldStartCount++;
+            }
+
+            if (counters.FailDuringFold.Contains(ev.Id))
+            {
+                return ResultBox.Error<CountingProjector>(
+                    new InvalidOperationException($"Configured fold failure for {ev.Id}"));
+            }
+
+            return ev.Payload is FoldEvent fold
+                ? ResultBox.FromValue(payload with { Total = payload.Total + fold.Amount, Order = payload.Order + fold.Label })
+                : ResultBox.FromValue(payload);
+        }
+    }
+}

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/DualStateProjectionWrapperDeferredRepairTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/DualStateProjectionWrapperDeferredRepairTests.cs
@@ -32,13 +32,13 @@ public class DualStateProjectionWrapperDeferredRepairTests
         var seed = SeedDirtyHistory(wrapper, fixture.DomainTypes);
         var accessor = (IDualStateAccessor)wrapper;
 
-        // The high event was folded once before the disorder. The two retained arrivals caused neither fold nor tag
-        // resolution, and served metadata remains untouched until a genuine consumption boundary is reached.
+        // The high event was folded once and cleanly reconciled before the disorder. The two retained out-of-order safe
+        // arrivals caused neither an additional fold nor tag resolution; their repair waits for a real consumption.
         Assert.Equal(1, fixture.TagTypes.FoldCount);
         Assert.Equal(1, fixture.TagTypes.TagResolutionCount);
         Assert.True(GetPrivateBool(wrapper, "_safeHistoryDirty"));
         Assert.Equal(1, accessor.SafeVersion);
-        Assert.Equal(0, accessor.UnsafeVersion);
+        Assert.Equal(1, accessor.UnsafeVersion);
 
         InvokeWrapperEntryPoint(entryPoint, wrapper, accessor, fixture.DomainTypes);
 
@@ -167,8 +167,8 @@ public class DualStateProjectionWrapperDeferredRepairTests
         var high = CreateEvent(new FoldEvent(3, "C"), SortableUniqueId.Generate(baseline.AddSeconds(2), Guid.Empty), GuidFromInt(203));
         var buffered = CreateEvent(new FoldEvent(4, "U"), SortableUniqueId.Generate(baseline.AddSeconds(10), Guid.Empty), GuidFromInt(204));
 
+        wrapper.ProcessEvent(high, threshold, fixture.DomainTypes);     // one direct safe fold and clean reconcile
         wrapper.ProcessEvent(buffered, threshold, fixture.DomainTypes); // one direct unsafe fold
-        wrapper.ProcessEvent(high, threshold, fixture.DomainTypes);     // one direct safe fold, served now deferred
         wrapper.ProcessEvent(low, threshold, fixture.DomainTypes);      // dirty-producing arrival: must not reconcile U
         wrapper.ProcessEvent(middle, threshold, fixture.DomainTypes);   // apparent in-order tail: must remain unfurled
 
@@ -176,9 +176,9 @@ public class DualStateProjectionWrapperDeferredRepairTests
         Assert.Equal(2, fixture.TagTypes.FoldCount);
         Assert.Equal(2, fixture.TagTypes.TagResolutionCount);
         Assert.Equal("C", GetPrivateProjector(wrapper, "_safeProjector").Order);
-        Assert.Equal("U", GetPrivateProjector(wrapper, "_unsafeProjector").Order);
+        Assert.Equal("CU", GetPrivateProjector(wrapper, "_unsafeProjector").Order);
         Assert.Equal(1, accessor.SafeVersion);
-        Assert.Equal(1, accessor.UnsafeVersion);
+        Assert.Equal(2, accessor.UnsafeVersion);
 
         var consumed = wrapper.GetUnsafeProjection(fixture.DomainTypes);
 

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/DualStateProjectionWrapperDeferredRepairTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/DualStateProjectionWrapperDeferredRepairTests.cs
@@ -1,4 +1,5 @@
 using ResultBoxes;
+using Microsoft.Extensions.Logging;
 using Sekiban.Dcb;
 using Sekiban.Dcb.Actors;
 using Sekiban.Dcb.Common;
@@ -73,23 +74,27 @@ public class DualStateProjectionWrapperDeferredRepairTests
         var seed = SeedDirtyHistory(wrapper, fixture.DomainTypes);
         var accessor = (IDualStateAccessor)wrapper;
         var published = CapturePublishedState(wrapper, accessor);
-        fixture.TagTypes.FailDuringFold.Add(seed.Low.Id);
+        // Low made the retained history dirty, but high is the event that fails when the sorted history is replayed.
+        // This must never be attributed to the dirty trigger merely because it arrived later.
+        fixture.TagTypes.FailDuringFold.Add(seed.High.Id);
 
         var failure = Assert.Throws<InvalidOperationException>(
             () => InvokeWrapperEntryPoint(entryPoint, wrapper, accessor, fixture.DomainTypes));
 
-        Assert.Equal(seed.Low.Id.ToString(), failure.Data["DeferredSafeRepairEventId"]);
-        Assert.Equal(seed.Low.SortableUniqueIdValue, failure.Data["DeferredSafeRepairPosition"]);
+        Assert.Equal(seed.High.Id.ToString(), failure.Data["DeferredSafeRepairEventId"]);
+        Assert.Equal(seed.High.SortableUniqueIdValue, failure.Data["DeferredSafeRepairPosition"]);
+        Assert.Equal(seed.Low.Id.ToString(), failure.Data["DeferredSafeRepairDirtyEventId"]);
+        Assert.Equal(seed.Low.SortableUniqueIdValue, failure.Data["DeferredSafeRepairDirtyPosition"]);
         AssertPublishedState(published, wrapper, accessor);
         Assert.True(GetPrivateBool(wrapper, "_safeHistoryDirty"));
         Assert.True(GetPrivateBool(wrapper, "_servedStateDirty"));
         Assert.Equal(3, GetPrivateCount(wrapper, "_allSafeEvents"));
         Assert.False(GetPrivateBool(wrapper, "_useIncrementalSafePromotion"));
 
-        fixture.TagTypes.FailDuringFold.Remove(seed.Low.Id);
+        fixture.TagTypes.FailDuringFold.Remove(seed.High.Id);
         InvokeWrapperEntryPoint(entryPoint, wrapper, accessor, fixture.DomainTypes);
 
-        AssertConsumedState(wrapper, accessor, fixture, seed, expectedFoldCount: 5);
+        AssertConsumedState(wrapper, accessor, fixture, seed, expectedFoldCount: 7);
         Assert.Equal(entryPoint == "CompactSafeHistory" ? 0 : 3, GetPrivateCount(wrapper, "_allSafeEvents"));
         Assert.Equal(entryPoint == "CompactSafeHistory", GetPrivateBool(wrapper, "_useIncrementalSafePromotion"));
     }
@@ -124,10 +129,12 @@ public class DualStateProjectionWrapperDeferredRepairTests
     public async Task DirtyHistory_ActorHeadStatusEntryPoint_FailsWithoutPublishingAndCanRetry()
     {
         var fixture = new Fixture();
+        var logger = new RecordingLogger();
         var actor = new GeneralMultiProjectionActor(
             fixture.DomainTypes,
             CountingProjector.MultiProjectorName,
-            new GeneralMultiProjectionActorOptions { SafeWindowMs = 1 });
+            new GeneralMultiProjectionActorOptions { SafeWindowMs = 1 },
+            logger);
         var seed = CreateSeedEvents();
 
         await actor.AddEventsAsync([seed.High]);
@@ -137,21 +144,92 @@ public class DualStateProjectionWrapperDeferredRepairTests
             GetPrivateValue<object>(actor, "_singleStateAccessor"));
         var accessor = (IDualStateAccessor)wrapper;
         var published = CapturePublishedState(wrapper, accessor);
-        fixture.TagTypes.FailDuringFold.Add(seed.Low.Id);
+        var original = new InvalidOperationException($"Configured replay fold failure for {seed.High.Id}");
+        fixture.TagTypes.ReplayFailures[seed.High.Id] = original;
 
         var failure = await Assert.ThrowsAsync<InvalidOperationException>(actor.GetProjectionHeadStatusAsync);
 
-        Assert.Equal(seed.Low.Id.ToString(), failure.Data["DeferredSafeRepairEventId"]);
-        Assert.Equal(seed.Low.SortableUniqueIdValue, failure.Data["DeferredSafeRepairPosition"]);
+        Assert.Same(original, failure);
+        Assert.Equal(original.Message, failure.Message);
+        Assert.Contains("RebuildSafeState", failure.StackTrace, StringComparison.Ordinal);
+        Assert.Equal(seed.High.Id.ToString(), failure.Data["DeferredSafeRepairEventId"]);
+        Assert.Equal(seed.High.SortableUniqueIdValue, failure.Data["DeferredSafeRepairPosition"]);
+        Assert.Equal(seed.Low.Id.ToString(), failure.Data["DeferredSafeRepairDirtyEventId"]);
+        Assert.Equal(seed.Low.SortableUniqueIdValue, failure.Data["DeferredSafeRepairDirtyPosition"]);
+        var fault = Assert.IsType<ProjectionFaultDescriptor>(actor.CurrentFault);
+        Assert.Equal(seed.High.Id, fault.EventId);
+        Assert.Equal(nameof(FoldEvent), fault.EventType);
+        Assert.Equal(seed.High.SortableUniqueIdValue, fault.Position);
+        Assert.Equal(seed.High.Id.ToString(), failure.Data[ProjectionFaultDescriptor.EventIdDataKey]);
+        Assert.Equal(seed.High.SortableUniqueIdValue, failure.Data[ProjectionFaultDescriptor.PositionDataKey]);
+        var firstObserved = Assert.Single(
+            logger.Entries,
+            entry => entry.EventId.Name == "ProjectionFaultFirstObserved");
+        Assert.Same(original, firstObserved.Exception);
         AssertPublishedState(published, wrapper, accessor);
         Assert.True(GetPrivateBool(wrapper, "_safeHistoryDirty"));
         Assert.Equal(3, GetPrivateCount(wrapper, "_allSafeEvents"));
 
-        fixture.TagTypes.FailDuringFold.Remove(seed.Low.Id);
+        // A fault re-raise does not create another first-observed entry. Deliberate recovery leaves the retained dirty
+        // history in place, then lets the same actor consume it without dropping high/low/middle.
+        _ = await actor.GetStateAsync();
+        Assert.Single(logger.Entries, entry => entry.EventId.Name == "ProjectionFaultFirstObserved");
+        fixture.TagTypes.ReplayFailures.Remove(seed.High.Id);
+        actor.ClearFaultForRebuild();
         var retried = await actor.GetProjectionHeadStatusAsync();
         Assert.Equal(3, retried.Current.EventVersion);
         Assert.Equal(3, retried.Consistent.EventVersion);
-        AssertConsumedState(wrapper, accessor, fixture, seed, expectedFoldCount: 5);
+        AssertConsumedState(wrapper, accessor, fixture, seed, expectedFoldCount: 7);
+    }
+
+    [Fact]
+    public async Task DirtyHistory_ActorStateRead_CapturesTheReplayFailingEventWithoutReturningStaleState()
+    {
+        var fixture = new Fixture();
+        var logger = new RecordingLogger();
+        var actor = new GeneralMultiProjectionActor(
+            fixture.DomainTypes,
+            CountingProjector.MultiProjectorName,
+            new GeneralMultiProjectionActorOptions { SafeWindowMs = 1 },
+            logger);
+        var seed = CreateSeedEvents();
+
+        await actor.AddEventsAsync([seed.High]);
+        await actor.AddEventsAsync([seed.Low]);
+        await actor.AddEventsAsync([seed.Middle]);
+        var wrapper = Assert.IsType<DualStateProjectionWrapper<CountingProjector>>(
+            GetPrivateValue<object>(actor, "_singleStateAccessor"));
+        var accessor = (IDualStateAccessor)wrapper;
+        var published = CapturePublishedState(wrapper, accessor);
+        var original = new InvalidOperationException($"Configured state-read replay failure for {seed.High.Id}");
+        fixture.TagTypes.ReplayFailures[seed.High.Id] = original;
+
+        var state = await actor.GetStateAsync(canGetUnsafeState: true);
+
+        Assert.False(state.IsSuccess);
+        var failure = Assert.IsType<InvalidOperationException>(state.GetException());
+        Assert.Same(original, failure);
+        Assert.Equal(original.Message, failure.Message);
+        Assert.Contains("RebuildSafeState", failure.StackTrace, StringComparison.Ordinal);
+        Assert.Equal(seed.High.Id.ToString(), failure.Data["DeferredSafeRepairEventId"]);
+        Assert.Equal(seed.High.SortableUniqueIdValue, failure.Data["DeferredSafeRepairPosition"]);
+        Assert.Equal(seed.Low.Id.ToString(), failure.Data["DeferredSafeRepairDirtyEventId"]);
+        Assert.Equal(seed.Low.SortableUniqueIdValue, failure.Data["DeferredSafeRepairDirtyPosition"]);
+        Assert.Equal(seed.High.Id, Assert.IsType<ProjectionFaultDescriptor>(actor.CurrentFault).EventId);
+        var firstObserved = Assert.Single(
+            logger.Entries,
+            entry => entry.EventId.Name == "ProjectionFaultFirstObserved");
+        Assert.Same(original, firstObserved.Exception);
+        AssertPublishedState(published, wrapper, accessor);
+        Assert.True(GetPrivateBool(wrapper, "_safeHistoryDirty"));
+        Assert.True(GetPrivateBool(wrapper, "_servedStateDirty"));
+        Assert.Equal(3, GetPrivateCount(wrapper, "_allSafeEvents"));
+
+        fixture.TagTypes.ReplayFailures.Remove(seed.High.Id);
+        actor.ClearFaultForRebuild();
+        var retried = await actor.GetStateAsync(canGetUnsafeState: true);
+        Assert.True(retried.IsSuccess);
+        Assert.Equal("ABC", Assert.IsType<CountingProjector>(retried.GetValue().Payload).Order);
     }
 
     [Fact]
@@ -258,32 +336,27 @@ public class DualStateProjectionWrapperDeferredRepairTests
 
         wrapper.ProcessEvent(seed.High, SortableUniqueId.MaxValue, fixture.DomainTypes);
         wrapper.ProcessEvent(seed.Low, SortableUniqueId.MaxValue, fixture.DomainTypes);
-        fixture.TagTypes.FailDuringFold.Add(seed.Low.Id);
+        fixture.TagTypes.FailDuringFold.Add(seed.High.Id);
 
-        var safeBefore = GetPrivateProjector(wrapper, "_safeProjector");
-        var unsafeBefore = GetPrivateProjector(wrapper, "_unsafeProjector");
-        var safeVersionBefore = accessor.SafeVersion;
-        var unsafeVersionBefore = accessor.UnsafeVersion;
-        var safeLastBefore = GetPrivateValue<string>(wrapper, "_safeLastSortableUniqueId");
-        var unsafeLastBefore = GetPrivateValue<string>(wrapper, "_unsafeLastSortableUniqueId");
+        // This snapshot includes both payloads and every published safe/unsafe metadata field, so repair cannot leak a
+        // partial checkpoint before its failing high replay event is reported.
+        var published = CapturePublishedState(wrapper, accessor);
 
         var failure = Assert.Throws<InvalidOperationException>(() => wrapper.GetUnsafeProjection(fixture.DomainTypes));
-        Assert.Equal(seed.Low.Id.ToString(), failure.Data["DeferredSafeRepairEventId"]);
-        Assert.Equal(seed.Low.SortableUniqueIdValue, failure.Data["DeferredSafeRepairPosition"]);
-        Assert.Equal(safeBefore, GetPrivateProjector(wrapper, "_safeProjector"));
-        Assert.Equal(unsafeBefore, GetPrivateProjector(wrapper, "_unsafeProjector"));
-        Assert.Equal(safeVersionBefore, accessor.SafeVersion);
-        Assert.Equal(unsafeVersionBefore, accessor.UnsafeVersion);
-        Assert.Equal(safeLastBefore, GetPrivateValue<string>(wrapper, "_safeLastSortableUniqueId"));
-        Assert.Equal(unsafeLastBefore, GetPrivateValue<string>(wrapper, "_unsafeLastSortableUniqueId"));
+        Assert.Equal(seed.High.Id.ToString(), failure.Data["DeferredSafeRepairEventId"]);
+        Assert.Equal(seed.High.SortableUniqueIdValue, failure.Data["DeferredSafeRepairPosition"]);
+        Assert.Equal(seed.Low.Id.ToString(), failure.Data["DeferredSafeRepairDirtyEventId"]);
+        Assert.Equal(seed.Low.SortableUniqueIdValue, failure.Data["DeferredSafeRepairDirtyPosition"]);
+        AssertPublishedState(published, wrapper, accessor);
         Assert.True(GetPrivateBool(wrapper, "_safeHistoryDirty"));
+        Assert.True(GetPrivateBool(wrapper, "_servedStateDirty"));
         Assert.Equal(2, GetPrivateCount(wrapper, "_allSafeEvents"));
 
         Assert.Throws<InvalidOperationException>(() => accessor.CompactSafeHistory());
         Assert.False(GetPrivateBool(wrapper, "_useIncrementalSafePromotion"));
         Assert.Equal(2, GetPrivateCount(wrapper, "_allSafeEvents"));
 
-        fixture.TagTypes.FailDuringFold.Remove(seed.Low.Id);
+        fixture.TagTypes.FailDuringFold.Remove(seed.High.Id);
         accessor.CompactSafeHistory();
 
         var repaired = Assert.IsType<CountingProjector>(accessor.GetSafeProjectorPayload());
@@ -297,23 +370,52 @@ public class DualStateProjectionWrapperDeferredRepairTests
     public async Task RepairFailure_FailsClosedAtTheProductionSnapshotPersistenceBoundary()
     {
         var fixture = new Fixture();
+        var logger = new RecordingLogger();
         var actor = new GeneralMultiProjectionActor(
             fixture.DomainTypes,
             CountingProjector.MultiProjectorName,
-            new GeneralMultiProjectionActorOptions { SafeWindowMs = 1 });
+            new GeneralMultiProjectionActorOptions { SafeWindowMs = 1 },
+            logger);
         var seed = CreateSeedEvents();
 
         await actor.AddEventsAsync([seed.High]);
         await actor.AddEventsAsync([seed.Low]);
-        fixture.TagTypes.FailDuringFold.Add(seed.Low.Id);
+        var wrapper = Assert.IsType<DualStateProjectionWrapper<CountingProjector>>(
+            GetPrivateValue<object>(actor, "_singleStateAccessor"));
+        var accessor = (IDualStateAccessor)wrapper;
+        var published = CapturePublishedState(wrapper, accessor);
+        var original = new InvalidOperationException($"Configured snapshot replay failure for {seed.High.Id}");
+        fixture.TagTypes.ReplayFailures[seed.High.Id] = original;
 
         var result = await actor.BuildSnapshotForPersistenceAsync();
 
         Assert.False(result.IsSuccess);
-        var failure = result.GetException();
-        Assert.Equal(seed.Low.Id.ToString(), failure.Data["DeferredSafeRepairEventId"]);
-        Assert.Equal(seed.Low.SortableUniqueIdValue, failure.Data["DeferredSafeRepairPosition"]);
-        Assert.Equal(2, fixture.TagTypes.FoldCount); // the staged repair attempted its first fold, but no state was published
+        var failure = Assert.IsType<InvalidOperationException>(result.GetException());
+        Assert.Same(original, failure);
+        Assert.Equal(original.Message, failure.Message);
+        Assert.Contains("RebuildSafeState", failure.StackTrace, StringComparison.Ordinal);
+        Assert.Equal(seed.High.Id.ToString(), failure.Data["DeferredSafeRepairEventId"]);
+        Assert.Equal(seed.High.SortableUniqueIdValue, failure.Data["DeferredSafeRepairPosition"]);
+        Assert.Equal(seed.Low.Id.ToString(), failure.Data["DeferredSafeRepairDirtyEventId"]);
+        Assert.Equal(seed.Low.SortableUniqueIdValue, failure.Data["DeferredSafeRepairDirtyPosition"]);
+        var fault = Assert.IsType<ProjectionFaultDescriptor>(actor.CurrentFault);
+        Assert.Equal(seed.High.Id, fault.EventId);
+        Assert.Equal(seed.High.SortableUniqueIdValue, fault.Position);
+        var firstObserved = Assert.Single(
+            logger.Entries,
+            entry => entry.EventId.Name == "ProjectionFaultFirstObserved");
+        Assert.Same(original, firstObserved.Exception);
+        AssertPublishedState(published, wrapper, accessor);
+        Assert.True(GetPrivateBool(wrapper, "_safeHistoryDirty"));
+        Assert.True(GetPrivateBool(wrapper, "_servedStateDirty"));
+        Assert.Equal(2, GetPrivateCount(wrapper, "_allSafeEvents"));
+        Assert.Equal(3, fixture.TagTypes.FoldCount); // low folded into an unpublished local replay, then high failed
+
+        fixture.TagTypes.ReplayFailures.Remove(seed.High.Id);
+        actor.ClearFaultForRebuild();
+        var retried = await actor.BuildSnapshotForPersistenceAsync();
+        Assert.True(retried.IsSuccess);
+        Assert.Equal(seed.High.SortableUniqueIdValue, retried.GetValue().SafeLastSortableUniqueId);
     }
 
     [Fact]
@@ -561,6 +663,7 @@ public class DualStateProjectionWrapperDeferredRepairTests
         public int FoldCount { get; set; }
         public int FoldStartCount { get; set; }
         public HashSet<Guid> FailDuringFold { get; } = [];
+        public Dictionary<Guid, Exception> ReplayFailures { get; } = [];
 
         public ITag GetTag(string tag)
         {
@@ -615,6 +718,11 @@ public class DualStateProjectionWrapperDeferredRepairTests
                 counters.FoldStartCount++;
             }
 
+            if (counters.ReplayFailures.TryGetValue(ev.Id, out var replayFailure))
+            {
+                return ResultBox.Error<CountingProjector>(replayFailure);
+            }
+
             if (counters.FailDuringFold.Contains(ev.Id))
             {
                 return ResultBox.Error<CountingProjector>(
@@ -625,5 +733,31 @@ public class DualStateProjectionWrapperDeferredRepairTests
                 ? ResultBox.FromValue(payload with { Total = payload.Total + fold.Amount, Order = payload.Order + fold.Label })
                 : ResultBox.FromValue(payload);
         }
+    }
+
+    private sealed class RecordingLogger : ILogger
+    {
+        public List<LogEntry> Entries { get; } = [];
+
+        public IDisposable BeginScope<TState>(TState state) where TState : notnull => NoopDisposable.Instance;
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            Entries.Add(new LogEntry(eventId, exception, formatter(state, exception)));
+        }
+    }
+
+    private sealed record LogEntry(EventId EventId, Exception? Exception, string Message);
+
+    private sealed class NoopDisposable : IDisposable
+    {
+        public static readonly NoopDisposable Instance = new();
+        public void Dispose() { }
     }
 }


### PR DESCRIPTION
Replace arrival-time re-folding with sorted retained history and one private consumption seam.

Closes #1154
Fixes #1146