### PR TITLE
SEK-G42 dcb: stream offloaded snapshot restore

### DIFF
--- a/.github/workflows/dcb_streaming_restore_memory.yml
+++ b/.github/workflows/dcb_streaming_restore_memory.yml
@@ -11,6 +11,7 @@ jobs:
     timeout-minutes: 35
     env:
       SEKIBAN_STREAM_RESTORE_SMOKE: '1'
+      SEKIBAN_STREAM_RESTORE_CONTROLLED_CEILING: '1'
 
     steps:
       - uses: actions/checkout@v4
@@ -30,6 +31,12 @@ jobs:
 
       - name: Build focused memory fixture
         run: dotnet build dcb/tests/Sekiban.Dcb.WithResult.Tests/Sekiban.Dcb.WithResult.Tests.csproj -c Release -f net10.0 --no-restore -p:GeneratePackageOnBuild=false --verbosity minimal
+
+      - name: Run controlled 16-32 MiB small-graph fixture in an isolated process
+        run: |
+          # This separate test host owns the allocation ceiling for the controlled fixture. The normal PR suite still
+          # runs the same fixture's supported-path and intentionally-buffered counter-proof; this is supporting evidence.
+          timeout 10m dotnet test dcb/tests/Sekiban.Dcb.WithResult.Tests/Sekiban.Dcb.WithResult.Tests.csproj -c Release --no-build -f net10.0 --filter "Category=StreamingRestoreControlledMemory" --logger "console;verbosity=normal"
 
       - name: Run 128-200 MiB restore smoke under a process ceiling
         run: |

--- a/.github/workflows/dcb_streaming_restore_memory.yml
+++ b/.github/workflows/dcb_streaming_restore_memory.yml
@@ -1,0 +1,39 @@
+name: DCB Streaming Restore Memory Smoke
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '17 3 * * 0'
+
+jobs:
+  streamingRestoreMemory:
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    env:
+      SEKIBAN_STREAM_RESTORE_SMOKE: '1'
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET 9
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 9.0.x
+
+      - name: Setup .NET 10
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Restore focused dependencies
+        run: dotnet restore dcb/tests/Sekiban.Dcb.WithResult.Tests/Sekiban.Dcb.WithResult.Tests.csproj
+
+      - name: Build focused memory fixture
+        run: dotnet build dcb/tests/Sekiban.Dcb.WithResult.Tests/Sekiban.Dcb.WithResult.Tests.csproj -c Release -f net10.0 --no-restore -p:GeneratePackageOnBuild=false --verbosity minimal
+
+      - name: Run 128-200 MiB restore smoke under a process ceiling
+        run: |
+          # The selected test process is isolated from normal PR CI. 6 GiB virtual-address limit and 30 minute wall
+          # timeout are supporting safety ceilings, while the test records peak RSS and selected-path telemetry.
+          ulimit -Sv 6291456
+          timeout 30m dotnet test dcb/tests/Sekiban.Dcb.WithResult.Tests/Sekiban.Dcb.WithResult.Tests.csproj -c Release --no-build -f net10.0 --filter "Category=StreamingRestoreManualMemory" --logger "console;verbosity=normal"

--- a/dcb/src/Sekiban.Dcb.Core.Model/Domains/AotMultiProjectorTypes.cs
+++ b/dcb/src/Sekiban.Dcb.Core.Model/Domains/AotMultiProjectorTypes.cs
@@ -17,7 +17,6 @@ public sealed class AotMultiProjectorTypes : ICoreMultiProjectorTypes, IStreamin
 {
     private static volatile bool _debugBypassProject;
     private readonly Dictionary<string, ProjectorRegistration> _projectors = new();
-    private readonly StreamingMultiProjectorTypesSupport _streamingRestore = new();
     private static readonly bool DebugBypassProject =
         Environment.GetEnvironmentVariable("SEKIBAN_WASM_DEBUG_BYPASS_MULTI_PROJECT") == "1";
     private static bool _debugBypassProjectSwitch;
@@ -79,7 +78,7 @@ public sealed class AotMultiProjectorTypes : ICoreMultiProjectorTypes, IStreamin
                 var jsonBytes = GzipCompression.Decompress(data);
                 return JsonSerializer.Deserialize(jsonBytes, typeInfo)!;
             });
-        _streamingRestore.RegisterJsonTypeInfo(name, typeInfo);
+        StreamingMultiProjectorTypesSupport.RegisterJsonTypeInfo(this, name, typeInfo);
     }
 
     /// <inheritdoc />
@@ -179,28 +178,9 @@ public sealed class AotMultiProjectorTypes : ICoreMultiProjectorTypes, IStreamin
         return ResultBox.Error<IMultiProjectionPayload>(new Exception($"Projector not found: {projectorName}"));
     }
 
-    public bool SupportsStreamDeserialization(string projectorName) => _streamingRestore.Supports(projectorName);
+    public bool SupportsStreamDeserialization(string projectorName) => StreamingMultiProjectorTypesSupport.Supports(this, projectorName);
 
-    public Task<ResultBox<IMultiProjectionPayload>> DeserializeFromStreamAsync(
-        string projectorName,
-        DcbDomainTypes domainTypes,
-        string safeWindowThreshold,
-        Stream source,
-        CancellationToken cancellationToken = default)
-    {
-        if (!_projectors.ContainsKey(projectorName))
-        {
-            return Task.FromResult(ResultBox.Error<IMultiProjectionPayload>(
-                new Exception($"Projector not found: {projectorName}")));
-        }
-
-        return _streamingRestore.DeserializeAsync(
-            projectorName,
-            domainTypes,
-            safeWindowThreshold,
-            source,
-            cancellationToken);
-    }
+    public Task<ResultBox<IMultiProjectionPayload>> DeserializeFromStreamAsync(string projectorName, DcbDomainTypes domainTypes, string safeWindowThreshold, Stream source, CancellationToken cancellationToken = default) => StreamingMultiProjectorTypesSupport.DeserializeWithProjectorNotFoundAsync(this, projectorName, domainTypes, safeWindowThreshold, source, cancellationToken);
 
     public ResultBox<IMultiProjectionPayload> DeserializeJson(
         string projectorName,

--- a/dcb/src/Sekiban.Dcb.Core.Model/Domains/AotMultiProjectorTypes.cs
+++ b/dcb/src/Sekiban.Dcb.Core.Model/Domains/AotMultiProjectorTypes.cs
@@ -75,7 +75,9 @@ public sealed class AotMultiProjectorTypes : ICoreMultiProjectorTypes, IStreamin
             },
             Deserialize: (domainTypes, safeWindowThreshold, data) =>
             {
-                var jsonBytes = GzipCompression.Decompress(data);
+                // Legacy raw UTF-8 snapshots and gzip snapshots must remain equivalent to the stream helper, which
+                // chooses gzip only from its two-byte marker.
+                var jsonBytes = GzipCompression.DecompressIfGzip(data);
                 return JsonSerializer.Deserialize(jsonBytes, typeInfo)!;
             });
         StreamingMultiProjectorTypesSupport.RegisterJsonTypeInfo(this, name, typeInfo);

--- a/dcb/src/Sekiban.Dcb.Core.Model/Domains/AotMultiProjectorTypes.cs
+++ b/dcb/src/Sekiban.Dcb.Core.Model/Domains/AotMultiProjectorTypes.cs
@@ -17,6 +17,7 @@ public sealed class AotMultiProjectorTypes : ICoreMultiProjectorTypes, IStreamin
 {
     private static volatile bool _debugBypassProject;
     private readonly Dictionary<string, ProjectorRegistration> _projectors = new();
+    private readonly StreamingMultiProjectorTypesSupport _streamingRestore = new();
     private static readonly bool DebugBypassProject =
         Environment.GetEnvironmentVariable("SEKIBAN_WASM_DEBUG_BYPASS_MULTI_PROJECT") == "1";
     private static bool _debugBypassProjectSwitch;
@@ -27,8 +28,7 @@ public sealed class AotMultiProjectorTypes : ICoreMultiProjectorTypes, IStreamin
         string Version,
         Func<DcbDomainTypes, string, IMultiProjectionPayload, SerializationResult> Serialize,
         Func<Stream, DcbDomainTypes, string, IMultiProjectionPayload, SerializationSizeInfo> SerializeToStream,
-        Func<DcbDomainTypes, string, byte[], IMultiProjectionPayload> Deserialize,
-        Func<Stream, DcbDomainTypes, string, CancellationToken, Task<IMultiProjectionPayload>> DeserializeFromStream);
+        Func<DcbDomainTypes, string, byte[], IMultiProjectionPayload> Deserialize);
 
     /// <summary>
     ///     Register a multi-projector with AOT-compatible JsonTypeInfo.
@@ -78,12 +78,8 @@ public sealed class AotMultiProjectorTypes : ICoreMultiProjectorTypes, IStreamin
             {
                 var jsonBytes = GzipCompression.Decompress(data);
                 return JsonSerializer.Deserialize(jsonBytes, typeInfo)!;
-            },
-            DeserializeFromStream: async (source, _, _, cancellationToken) =>
-                await StreamSnapshotPayloadDeserializer.DeserializeJsonAsync(source, typeInfo, cancellationToken)
-                    .ConfigureAwait(false)
-                ?? throw new InvalidOperationException($"Failed to deserialize {typeof(TProjector).Name}")
-        );
+            });
+        _streamingRestore.RegisterJsonTypeInfo(name, typeInfo);
     }
 
     /// <inheritdoc />
@@ -183,41 +179,27 @@ public sealed class AotMultiProjectorTypes : ICoreMultiProjectorTypes, IStreamin
         return ResultBox.Error<IMultiProjectionPayload>(new Exception($"Projector not found: {projectorName}"));
     }
 
-    public bool SupportsStreamDeserialization(string projectorName) => _projectors.ContainsKey(projectorName);
+    public bool SupportsStreamDeserialization(string projectorName) => _streamingRestore.Supports(projectorName);
 
-    public async Task<ResultBox<IMultiProjectionPayload>> DeserializeFromStreamAsync(
+    public Task<ResultBox<IMultiProjectionPayload>> DeserializeFromStreamAsync(
         string projectorName,
         DcbDomainTypes domainTypes,
         string safeWindowThreshold,
         Stream source,
         CancellationToken cancellationToken = default)
     {
-        if (string.IsNullOrWhiteSpace(safeWindowThreshold))
+        if (!_projectors.ContainsKey(projectorName))
         {
-            return ResultBox.Error<IMultiProjectionPayload>(
-                new ArgumentException("safeWindowThreshold must be supplied"));
+            return Task.FromResult(ResultBox.Error<IMultiProjectionPayload>(
+                new Exception($"Projector not found: {projectorName}")));
         }
 
-        if (source is null)
-        {
-            return ResultBox.Error<IMultiProjectionPayload>(new ArgumentNullException(nameof(source)));
-        }
-
-        if (!_projectors.TryGetValue(projectorName, out var registration))
-        {
-            return ResultBox.Error<IMultiProjectionPayload>(new Exception($"Projector not found: {projectorName}"));
-        }
-
-        try
-        {
-            return ResultBox.FromValue(
-                await registration.DeserializeFromStream(source, domainTypes, safeWindowThreshold, cancellationToken)
-                    .ConfigureAwait(false));
-        }
-        catch (Exception ex)
-        {
-            return ResultBox.Error<IMultiProjectionPayload>(ex);
-        }
+        return _streamingRestore.DeserializeAsync(
+            projectorName,
+            domainTypes,
+            safeWindowThreshold,
+            source,
+            cancellationToken);
     }
 
     public ResultBox<IMultiProjectionPayload> DeserializeJson(

--- a/dcb/src/Sekiban.Dcb.Core.Model/Domains/AotMultiProjectorTypes.cs
+++ b/dcb/src/Sekiban.Dcb.Core.Model/Domains/AotMultiProjectorTypes.cs
@@ -13,7 +13,7 @@ namespace Sekiban.Dcb.Domains;
 ///     AOT-compatible implementation of ICoreMultiProjectorTypes.
 ///     Uses JsonTypeInfo for serialization instead of reflection.
 /// </summary>
-public sealed class AotMultiProjectorTypes : ICoreMultiProjectorTypes
+public sealed class AotMultiProjectorTypes : ICoreMultiProjectorTypes, IStreamingMultiProjectorTypes
 {
     private static volatile bool _debugBypassProject;
     private readonly Dictionary<string, ProjectorRegistration> _projectors = new();
@@ -27,7 +27,8 @@ public sealed class AotMultiProjectorTypes : ICoreMultiProjectorTypes
         string Version,
         Func<DcbDomainTypes, string, IMultiProjectionPayload, SerializationResult> Serialize,
         Func<Stream, DcbDomainTypes, string, IMultiProjectionPayload, SerializationSizeInfo> SerializeToStream,
-        Func<DcbDomainTypes, string, byte[], IMultiProjectionPayload> Deserialize);
+        Func<DcbDomainTypes, string, byte[], IMultiProjectionPayload> Deserialize,
+        Func<Stream, DcbDomainTypes, string, CancellationToken, Task<IMultiProjectionPayload>> DeserializeFromStream);
 
     /// <summary>
     ///     Register a multi-projector with AOT-compatible JsonTypeInfo.
@@ -77,7 +78,11 @@ public sealed class AotMultiProjectorTypes : ICoreMultiProjectorTypes
             {
                 var jsonBytes = GzipCompression.Decompress(data);
                 return JsonSerializer.Deserialize(jsonBytes, typeInfo)!;
-            }
+            },
+            DeserializeFromStream: async (source, _, _, cancellationToken) =>
+                await StreamSnapshotPayloadDeserializer.DeserializeJsonAsync(source, typeInfo, cancellationToken)
+                    .ConfigureAwait(false)
+                ?? throw new InvalidOperationException($"Failed to deserialize {typeof(TProjector).Name}")
         );
     }
 
@@ -176,6 +181,43 @@ public sealed class AotMultiProjectorTypes : ICoreMultiProjectorTypes
         if (_projectors.TryGetValue(projectorName, out var reg))
             return ResultBox.FromValue(reg.Deserialize(domainTypes, safeWindowThreshold, data));
         return ResultBox.Error<IMultiProjectionPayload>(new Exception($"Projector not found: {projectorName}"));
+    }
+
+    public bool SupportsStreamDeserialization(string projectorName) => _projectors.ContainsKey(projectorName);
+
+    public async Task<ResultBox<IMultiProjectionPayload>> DeserializeFromStreamAsync(
+        string projectorName,
+        DcbDomainTypes domainTypes,
+        string safeWindowThreshold,
+        Stream source,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(safeWindowThreshold))
+        {
+            return ResultBox.Error<IMultiProjectionPayload>(
+                new ArgumentException("safeWindowThreshold must be supplied"));
+        }
+
+        if (source is null)
+        {
+            return ResultBox.Error<IMultiProjectionPayload>(new ArgumentNullException(nameof(source)));
+        }
+
+        if (!_projectors.TryGetValue(projectorName, out var registration))
+        {
+            return ResultBox.Error<IMultiProjectionPayload>(new Exception($"Projector not found: {projectorName}"));
+        }
+
+        try
+        {
+            return ResultBox.FromValue(
+                await registration.DeserializeFromStream(source, domainTypes, safeWindowThreshold, cancellationToken)
+                    .ConfigureAwait(false));
+        }
+        catch (Exception ex)
+        {
+            return ResultBox.Error<IMultiProjectionPayload>(ex);
+        }
     }
 
     public ResultBox<IMultiProjectionPayload> DeserializeJson(

--- a/dcb/src/Sekiban.Dcb.Core.Model/Domains/IStreamingMultiProjectorTypes.cs
+++ b/dcb/src/Sekiban.Dcb.Core.Model/Domains/IStreamingMultiProjectorTypes.cs
@@ -1,0 +1,48 @@
+using ResultBoxes;
+using Sekiban.Dcb.MultiProjections;
+
+namespace Sekiban.Dcb.Domains;
+
+/// <summary>
+///     Optional capability implemented by multi-projector registries that can restore an individual projector directly
+///     from a payload stream. It deliberately lives beside, rather than on, <see cref="ICoreMultiProjectorTypes" /> so
+///     registries compiled against earlier Sekiban versions remain binary compatible and use the buffered fallback.
+/// </summary>
+/// <remarks>
+///     Support is intentionally queried per projector. A registry can stream its JSON projectors while leaving a custom
+///     binary projector on the compatibility path until that projector opts into
+///     <see cref="ICoreMultiProjectorWithStreamDeserialization" />.
+/// </remarks>
+public interface IStreamingMultiProjectorTypes
+{
+    /// <summary>Returns whether this exact projector can deserialize directly from a payload stream.</summary>
+    bool SupportsStreamDeserialization(string projectorName);
+
+    /// <summary>
+    ///     Deserializes the projector payload from <paramref name="source" />. The caller retains ownership of the
+    ///     stream; implementations must neither dispose it nor seek it, and must honor <paramref name="cancellationToken" />.
+    /// </summary>
+    Task<ResultBox<IMultiProjectionPayload>> DeserializeFromStreamAsync(
+        string projectorName,
+        DcbDomainTypes domainTypes,
+        string safeWindowThreshold,
+        Stream source,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+///     Optional per-projector capability for custom serialization registrations. Implement it on a custom projector to
+///     let a supporting registry avoid the compatibility byte-array restore path for that projector alone.
+/// </summary>
+/// <remarks>
+///     The stream is positioned at the start of the serialized payload (or at its current caller-selected position),
+///     can be non-seekable, and remains owned by the caller. Implementations must not dispose it.
+/// </remarks>
+public interface ICoreMultiProjectorWithStreamDeserialization
+{
+    Task<IMultiProjectionPayload> DeserializeFromStreamAsync(
+        DcbDomainTypes domainTypes,
+        string safeWindowThreshold,
+        Stream source,
+        CancellationToken cancellationToken = default);
+}

--- a/dcb/src/Sekiban.Dcb.Core.Model/MultiProjections/GzipCompression.cs
+++ b/dcb/src/Sekiban.Dcb.Core.Model/MultiProjections/GzipCompression.cs
@@ -194,6 +194,15 @@ public static class GzipCompression
     }
 
     /// <summary>
+    ///     Returns legacy raw UTF-8 JSON unchanged in content, or decompresses a gzip payload. This is internal because
+    ///     it is a registry compatibility detail rather than an additional serialization contract.
+    /// </summary>
+    internal static byte[] DecompressIfGzip(ReadOnlySpan<byte> payload) =>
+        payload.Length >= 2 && payload[0] == 0x1f && payload[1] == 0x8b
+            ? Decompress(payload)
+            : payload.ToArray();
+
+    /// <summary>
     ///     Decompress GZip bytes into a UTF8 string.
     /// </summary>
     public static string DecompressToString(ReadOnlySpan<byte> compressed)

--- a/dcb/src/Sekiban.Dcb.Core.Model/MultiProjections/StreamSnapshotPayloadDeserializer.cs
+++ b/dcb/src/Sekiban.Dcb.Core.Model/MultiProjections/StreamSnapshotPayloadDeserializer.cs
@@ -1,0 +1,160 @@
+using System.IO.Compression;
+using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
+
+namespace Sekiban.Dcb.MultiProjections;
+
+/// <summary>
+///     Shared non-buffering JSON snapshot restore helpers used by optional streaming projector registries.
+///     They inspect only the two-byte gzip marker and then let <see cref="JsonSerializer" /> consume the supplied
+///     stream directly. The source stream is never disposed by this helper.
+/// </summary>
+public static class StreamSnapshotPayloadDeserializer
+{
+    /// <summary>Deserializes raw or gzip-compressed JSON into a reflection-based projector payload.</summary>
+    public static async Task<object?> DeserializeJsonAsync(
+        Stream source,
+        Type payloadType,
+        JsonSerializerOptions options,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(payloadType);
+        ArgumentNullException.ThrowIfNull(options);
+
+        await using var prefixed = await PrefixBufferedStream.CreateAsync(source, cancellationToken)
+            .ConfigureAwait(false);
+        if (prefixed.IsGzip)
+        {
+            await using var gzip = new GZipStream(prefixed, CompressionMode.Decompress, leaveOpen: true);
+            return await JsonSerializer.DeserializeAsync(gzip, payloadType, options, cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        return await JsonSerializer.DeserializeAsync(prefixed, payloadType, options, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    /// <summary>Deserializes raw or gzip-compressed JSON through an AOT <see cref="JsonTypeInfo{T}" />.</summary>
+    public static async Task<T?> DeserializeJsonAsync<T>(
+        Stream source,
+        JsonTypeInfo<T> typeInfo,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(typeInfo);
+
+        await using var prefixed = await PrefixBufferedStream.CreateAsync(source, cancellationToken)
+            .ConfigureAwait(false);
+        if (prefixed.IsGzip)
+        {
+            await using var gzip = new GZipStream(prefixed, CompressionMode.Decompress, leaveOpen: true);
+            return await JsonSerializer.DeserializeAsync(gzip, typeInfo, cancellationToken).ConfigureAwait(false);
+        }
+
+        return await JsonSerializer.DeserializeAsync(prefixed, typeInfo, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    ///     A two-byte replay wrapper that preserves a non-seekable source's current position. Disposal intentionally
+    ///     leaves the underlying source open because stream ownership belongs to the resolver caller.
+    /// </summary>
+    private sealed class PrefixBufferedStream : Stream
+    {
+        private readonly byte[] _prefix;
+        private readonly Stream _inner;
+        private int _prefixPosition;
+
+        private PrefixBufferedStream(byte[] prefix, Stream inner)
+        {
+            _prefix = prefix;
+            _inner = inner;
+        }
+
+        public bool IsGzip => _prefix.Length >= 2 && _prefix[0] == 0x1f && _prefix[1] == 0x8b;
+
+        public static async Task<PrefixBufferedStream> CreateAsync(Stream source, CancellationToken cancellationToken)
+        {
+            var prefix = new byte[2];
+            var count = 0;
+            while (count < prefix.Length)
+            {
+                var read = await source.ReadAsync(prefix.AsMemory(count, prefix.Length - count), cancellationToken)
+                    .ConfigureAwait(false);
+                if (read == 0)
+                {
+                    break;
+                }
+
+                count += read;
+            }
+
+            return new PrefixBufferedStream(count == prefix.Length ? prefix : prefix[..count], source);
+        }
+
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => throw new NotSupportedException("Snapshot restore streams are non-seekable.");
+        public override long Position
+        {
+            get => throw new NotSupportedException("Snapshot restore streams are non-seekable.");
+            set => throw new NotSupportedException("Snapshot restore streams are non-seekable.");
+        }
+
+        public override void Flush() { }
+        public override Task FlushAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+        public override int Read(byte[] buffer, int offset, int count) => Read(buffer.AsSpan(offset, count));
+
+        public override int Read(Span<byte> buffer)
+        {
+            var copied = CopyPrefix(buffer);
+            return copied == buffer.Length
+                ? copied
+                : copied + _inner.Read(buffer[copied..]);
+        }
+
+        public override async ValueTask<int> ReadAsync(
+            Memory<byte> buffer,
+            CancellationToken cancellationToken = default)
+        {
+            var copied = CopyPrefix(buffer.Span);
+            if (copied == buffer.Length)
+            {
+                return copied;
+            }
+
+            return copied + await _inner.ReadAsync(buffer[copied..], cancellationToken).ConfigureAwait(false);
+        }
+
+        public override long Seek(long offset, SeekOrigin origin) =>
+            throw new NotSupportedException("Snapshot restore streams are non-seekable.");
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+        protected override void Dispose(bool disposing)
+        {
+            // Deliberately do not dispose _inner. The resolver caller owns the opened payload stream.
+            base.Dispose(disposing);
+        }
+
+        public override ValueTask DisposeAsync()
+        {
+            // Deliberately do not dispose _inner. The resolver caller owns the opened payload stream.
+            return base.DisposeAsync();
+        }
+
+        private int CopyPrefix(Span<byte> destination)
+        {
+            if (_prefixPosition >= _prefix.Length || destination.Length == 0)
+            {
+                return 0;
+            }
+
+            var count = Math.Min(destination.Length, _prefix.Length - _prefixPosition);
+            _prefix.AsSpan(_prefixPosition, count).CopyTo(destination);
+            _prefixPosition += count;
+            return count;
+        }
+    }
+}

--- a/dcb/src/Sekiban.Dcb.Core.Model/MultiProjections/StreamingMultiProjectorTypesSupport.cs
+++ b/dcb/src/Sekiban.Dcb.Core.Model/MultiProjections/StreamingMultiProjectorTypesSupport.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Runtime.CompilerServices;
 using System.Text.Json.Serialization.Metadata;
 using ResultBoxes;
 using Sekiban.Dcb.Domains;
@@ -10,90 +11,140 @@ namespace Sekiban.Dcb.MultiProjections;
 ///     capability remains limited to <see cref="IStreamingMultiProjectorTypes" /> and registries compiled against
 ///     older packages still use the actor's buffered compatibility route.
 /// </summary>
-internal sealed class StreamingMultiProjectorTypesSupport
+internal static class StreamingMultiProjectorTypesSupport
 {
-    private readonly ConcurrentDictionary<string,
-        Func<DcbDomainTypes, string, Stream, CancellationToken, Task<IMultiProjectionPayload>>> _deserializers = new();
+    // Keep the state private to each registry without making every registry repeat the capability forwarding code.
+    // ConditionalWeakTable does not extend a registry's lifetime.
+    private static readonly ConditionalWeakTable<object, RegistryDeserializers> DeserializersByRegistry = new();
 
-    internal bool Supports(string projectorName) => _deserializers.ContainsKey(projectorName);
+    internal static bool Supports(object registry, string projectorName) =>
+        GetDeserializers(registry).Supports(projectorName);
 
-    internal void RegisterReflection(string projectorName, Type projectorType) =>
-        _deserializers[projectorName] = async (domainTypes, _, source, cancellationToken) =>
-        {
-            var deserialized = await StreamSnapshotPayloadDeserializer.DeserializeJsonAsync(
-                    source,
-                    projectorType,
-                    domainTypes.JsonSerializerOptions,
-                    cancellationToken)
-                .ConfigureAwait(false);
-            return deserialized as IMultiProjectionPayload
-                ?? throw new InvalidOperationException(
-                    $"Failed to deserialize streaming payload to {projectorType.Name}.");
-        };
+    internal static void RegisterReflection(object registry, string projectorName, Type projectorType) =>
+        GetDeserializers(registry).RegisterReflection(projectorName, projectorType);
 
-    internal void RegisterJsonTypeInfo<TProjector>(
+    internal static void RegisterJsonTypeInfo<TProjector>(
+        object registry,
         string projectorName,
-        JsonTypeInfo<TProjector> typeInfo) =>
-        _deserializers[projectorName] = async (_, _, source, cancellationToken) =>
-        {
-            var deserialized = await StreamSnapshotPayloadDeserializer.DeserializeJsonAsync(
-                    source,
-                    typeInfo,
-                    cancellationToken)
-                .ConfigureAwait(false);
-            return deserialized as IMultiProjectionPayload
-                ?? throw new InvalidOperationException(
-                    $"Failed to deserialize streaming payload to {typeof(TProjector).Name}.");
-        };
+        JsonTypeInfo<TProjector> typeInfo) => GetDeserializers(registry).RegisterJsonTypeInfo(projectorName, typeInfo);
 
-    internal void RegisterCustomOrRemove<TProjector>(string projectorName)
-        where TProjector : new()
-    {
-        if (typeof(ICoreMultiProjectorWithStreamDeserialization).IsAssignableFrom(typeof(TProjector)))
-        {
-            _deserializers[projectorName] = (domainTypes, safeWindowThreshold, source, cancellationToken) =>
-                ((ICoreMultiProjectorWithStreamDeserialization)(object)new TProjector())
-                .DeserializeFromStreamAsync(domainTypes, safeWindowThreshold, source, cancellationToken);
-            return;
-        }
+    internal static void RegisterCustomOrRemove<TProjector>(object registry, string projectorName)
+        where TProjector : new() => GetDeserializers(registry).RegisterCustomOrRemove<TProjector>(projectorName);
 
-        // A custom serializer's bytes are not necessarily JSON+gzip, so it must explicitly opt in rather than
-        // inheriting the reflection projector path registered before the custom serializer was installed.
-        _deserializers.TryRemove(projectorName, out _);
-    }
-
-    internal async Task<ResultBox<IMultiProjectionPayload>> DeserializeAsync(
+    internal static Task<ResultBox<IMultiProjectionPayload>> DeserializeAsync(
+        object registry,
         string projectorName,
         DcbDomainTypes domainTypes,
         string safeWindowThreshold,
         Stream source,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken) => GetDeserializers(registry).DeserializeAsync(
+        projectorName,
+        domainTypes,
+        safeWindowThreshold,
+        source,
+        cancellationToken,
+        static name => new NotSupportedException($"Projector '{name}' does not support streaming deserialization."));
+
+    internal static Task<ResultBox<IMultiProjectionPayload>> DeserializeWithProjectorNotFoundAsync(
+        object registry,
+        string projectorName,
+        DcbDomainTypes domainTypes,
+        string safeWindowThreshold,
+        Stream source,
+        CancellationToken cancellationToken) => GetDeserializers(registry).DeserializeAsync(
+        projectorName,
+        domainTypes,
+        safeWindowThreshold,
+        source,
+        cancellationToken,
+        static name => new Exception($"Projector not found: {name}"));
+
+    private static RegistryDeserializers GetDeserializers(object registry) =>
+        DeserializersByRegistry.GetValue(registry, static _ => new RegistryDeserializers());
+
+    private sealed class RegistryDeserializers
     {
-        if (string.IsNullOrWhiteSpace(safeWindowThreshold))
+        private readonly ConcurrentDictionary<string,
+            Func<DcbDomainTypes, string, Stream, CancellationToken, Task<IMultiProjectionPayload>>> _deserializers = new();
+
+        internal bool Supports(string projectorName) => _deserializers.ContainsKey(projectorName);
+
+        internal void RegisterReflection(string projectorName, Type projectorType) =>
+            _deserializers[projectorName] = async (domainTypes, _, source, cancellationToken) =>
+            {
+                var deserialized = await StreamSnapshotPayloadDeserializer.DeserializeJsonAsync(
+                        source,
+                        projectorType,
+                        domainTypes.JsonSerializerOptions,
+                        cancellationToken)
+                    .ConfigureAwait(false);
+                return deserialized as IMultiProjectionPayload
+                    ?? throw new InvalidOperationException(
+                        $"Failed to deserialize streaming payload to {projectorType.Name}.");
+            };
+
+        internal void RegisterJsonTypeInfo<TProjector>(string projectorName, JsonTypeInfo<TProjector> typeInfo) =>
+            _deserializers[projectorName] = async (_, _, source, cancellationToken) =>
+            {
+                var deserialized = await StreamSnapshotPayloadDeserializer.DeserializeJsonAsync(
+                        source,
+                        typeInfo,
+                        cancellationToken)
+                    .ConfigureAwait(false);
+                return deserialized as IMultiProjectionPayload
+                    ?? throw new InvalidOperationException(
+                        $"Failed to deserialize streaming payload to {typeof(TProjector).Name}.");
+            };
+
+        internal void RegisterCustomOrRemove<TProjector>(string projectorName)
+            where TProjector : new()
         {
-            return ResultBox.Error<IMultiProjectionPayload>(
-                new ArgumentException("safeWindowThreshold must be supplied"));
+            if (typeof(ICoreMultiProjectorWithStreamDeserialization).IsAssignableFrom(typeof(TProjector)))
+            {
+                _deserializers[projectorName] = (domainTypes, safeWindowThreshold, source, cancellationToken) =>
+                    ((ICoreMultiProjectorWithStreamDeserialization)(object)new TProjector())
+                    .DeserializeFromStreamAsync(domainTypes, safeWindowThreshold, source, cancellationToken);
+                return;
+            }
+
+            // A custom serializer's bytes are not necessarily JSON+gzip, so it must explicitly opt in rather than
+            // inheriting the reflection projector path registered before the custom serializer was installed.
+            _deserializers.TryRemove(projectorName, out _);
         }
 
-        if (source is null)
+        internal async Task<ResultBox<IMultiProjectionPayload>> DeserializeAsync(
+            string projectorName,
+            DcbDomainTypes domainTypes,
+            string safeWindowThreshold,
+            Stream source,
+            CancellationToken cancellationToken,
+            Func<string, Exception> unsupportedProjectorException)
         {
-            return ResultBox.Error<IMultiProjectionPayload>(new ArgumentNullException(nameof(source)));
-        }
+            if (string.IsNullOrWhiteSpace(safeWindowThreshold))
+            {
+                return ResultBox.Error<IMultiProjectionPayload>(
+                    new ArgumentException("safeWindowThreshold must be supplied"));
+            }
 
-        if (!_deserializers.TryGetValue(projectorName, out var deserialize))
-        {
-            return ResultBox.Error<IMultiProjectionPayload>(
-                new NotSupportedException($"Projector '{projectorName}' does not support streaming deserialization."));
-        }
+            if (source is null)
+            {
+                return ResultBox.Error<IMultiProjectionPayload>(new ArgumentNullException(nameof(source)));
+            }
 
-        try
-        {
-            return ResultBox.FromValue(
-                await deserialize(domainTypes, safeWindowThreshold, source, cancellationToken).ConfigureAwait(false));
-        }
-        catch (Exception ex)
-        {
-            return ResultBox.Error<IMultiProjectionPayload>(ex);
+            if (!_deserializers.TryGetValue(projectorName, out var deserialize))
+            {
+                return ResultBox.Error<IMultiProjectionPayload>(unsupportedProjectorException(projectorName));
+            }
+
+            try
+            {
+                return ResultBox.FromValue(
+                    await deserialize(domainTypes, safeWindowThreshold, source, cancellationToken).ConfigureAwait(false));
+            }
+            catch (Exception ex)
+            {
+                return ResultBox.Error<IMultiProjectionPayload>(ex);
+            }
         }
     }
 }

--- a/dcb/src/Sekiban.Dcb.Core.Model/MultiProjections/StreamingMultiProjectorTypesSupport.cs
+++ b/dcb/src/Sekiban.Dcb.Core.Model/MultiProjections/StreamingMultiProjectorTypesSupport.cs
@@ -1,0 +1,99 @@
+using System.Collections.Concurrent;
+using System.Text.Json.Serialization.Metadata;
+using ResultBoxes;
+using Sekiban.Dcb.Domains;
+
+namespace Sekiban.Dcb.MultiProjections;
+
+/// <summary>
+///     Shared implementation behind the optional stream-restore registry capability. It is internal so the public
+///     capability remains limited to <see cref="IStreamingMultiProjectorTypes" /> and registries compiled against
+///     older packages still use the actor's buffered compatibility route.
+/// </summary>
+internal sealed class StreamingMultiProjectorTypesSupport
+{
+    private readonly ConcurrentDictionary<string,
+        Func<DcbDomainTypes, string, Stream, CancellationToken, Task<IMultiProjectionPayload>>> _deserializers = new();
+
+    internal bool Supports(string projectorName) => _deserializers.ContainsKey(projectorName);
+
+    internal void RegisterReflection(string projectorName, Type projectorType) =>
+        _deserializers[projectorName] = async (domainTypes, _, source, cancellationToken) =>
+        {
+            var deserialized = await StreamSnapshotPayloadDeserializer.DeserializeJsonAsync(
+                    source,
+                    projectorType,
+                    domainTypes.JsonSerializerOptions,
+                    cancellationToken)
+                .ConfigureAwait(false);
+            return deserialized as IMultiProjectionPayload
+                ?? throw new InvalidOperationException(
+                    $"Failed to deserialize streaming payload to {projectorType.Name}.");
+        };
+
+    internal void RegisterJsonTypeInfo<TProjector>(
+        string projectorName,
+        JsonTypeInfo<TProjector> typeInfo) =>
+        _deserializers[projectorName] = async (_, _, source, cancellationToken) =>
+        {
+            var deserialized = await StreamSnapshotPayloadDeserializer.DeserializeJsonAsync(
+                    source,
+                    typeInfo,
+                    cancellationToken)
+                .ConfigureAwait(false);
+            return deserialized as IMultiProjectionPayload
+                ?? throw new InvalidOperationException(
+                    $"Failed to deserialize streaming payload to {typeof(TProjector).Name}.");
+        };
+
+    internal void RegisterCustomOrRemove<TProjector>(string projectorName)
+        where TProjector : new()
+    {
+        if (typeof(ICoreMultiProjectorWithStreamDeserialization).IsAssignableFrom(typeof(TProjector)))
+        {
+            _deserializers[projectorName] = (domainTypes, safeWindowThreshold, source, cancellationToken) =>
+                ((ICoreMultiProjectorWithStreamDeserialization)(object)new TProjector())
+                .DeserializeFromStreamAsync(domainTypes, safeWindowThreshold, source, cancellationToken);
+            return;
+        }
+
+        // A custom serializer's bytes are not necessarily JSON+gzip, so it must explicitly opt in rather than
+        // inheriting the reflection projector path registered before the custom serializer was installed.
+        _deserializers.TryRemove(projectorName, out _);
+    }
+
+    internal async Task<ResultBox<IMultiProjectionPayload>> DeserializeAsync(
+        string projectorName,
+        DcbDomainTypes domainTypes,
+        string safeWindowThreshold,
+        Stream source,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(safeWindowThreshold))
+        {
+            return ResultBox.Error<IMultiProjectionPayload>(
+                new ArgumentException("safeWindowThreshold must be supplied"));
+        }
+
+        if (source is null)
+        {
+            return ResultBox.Error<IMultiProjectionPayload>(new ArgumentNullException(nameof(source)));
+        }
+
+        if (!_deserializers.TryGetValue(projectorName, out var deserialize))
+        {
+            return ResultBox.Error<IMultiProjectionPayload>(
+                new NotSupportedException($"Projector '{projectorName}' does not support streaming deserialization."));
+        }
+
+        try
+        {
+            return ResultBox.FromValue(
+                await deserialize(domainTypes, safeWindowThreshold, source, cancellationToken).ConfigureAwait(false));
+        }
+        catch (Exception ex)
+        {
+            return ResultBox.Error<IMultiProjectionPayload>(ex);
+        }
+    }
+}

--- a/dcb/src/Sekiban.Dcb.Core.Model/Sekiban.Dcb.Core.Model.csproj
+++ b/dcb/src/Sekiban.Dcb.Core.Model/Sekiban.Dcb.Core.Model.csproj
@@ -44,6 +44,15 @@
         <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
             <_Parameter1>Sekiban.Dcb.Core</_Parameter1>
         </AssemblyAttribute>
+        <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+            <_Parameter1>Sekiban.Dcb.WithResult</_Parameter1>
+        </AssemblyAttribute>
+        <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+            <_Parameter1>Sekiban.Dcb.WithoutResult</_Parameter1>
+        </AssemblyAttribute>
+        <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+            <_Parameter1>Sekiban.Dcb.WithoutResult.Model</_Parameter1>
+        </AssemblyAttribute>
     </ItemGroup>
 
 </Project>

--- a/dcb/src/Sekiban.Dcb.Core/Actors/GeneralMultiProjectionActor.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Actors/GeneralMultiProjectionActor.cs
@@ -56,6 +56,11 @@ public class GeneralMultiProjectionActor
     // not a public runtime metric, but a regression guard that proves the supported path did not reach ReadAllBytesAsync.
     private int _lastStreamingRestoreWholePayloadAggregationCount;
 
+    // A restore selects this once and routes the exact value through its primary and clone deserializations. Keeping the
+    // last value private makes that single-selection invariant inspectable without changing the public or serialized
+    // actor contract.
+    private string _lastSnapshotRestoreSafeWindowThreshold = string.Empty;
+
     // Set the instant a per-event fold throws, and never cleared by a later apply. A faulted projection has stopped
     // at a poison event; presenting its pre-crash state as a successful query is the silence issue #1075 was about.
     // While it is set, applies are rejected (so a catch-up retry cannot re-apply the events before the poison and
@@ -382,7 +387,7 @@ public class GeneralMultiProjectionActor
         CancellationToken cancellationToken)
     {
         _lastStreamingRestoreWholePayloadAggregationCount = 0;
-        var safeThreshold = GetSafeWindowThreshold();
+        var safeThreshold = SelectSnapshotRestoreSafeWindowThreshold();
         ResultBox<IMultiProjectionPayload> deserializeResult;
         IMultiProjectionPayload? streamedClonePayload = null;
 
@@ -396,7 +401,7 @@ public class GeneralMultiProjectionActor
                 (deserializeResult, streamedClonePayload) = await DeserializeStreamingPayloadPairAsync(
                         streamingTypes,
                         state.ProjectorName,
-                        safeThreshold.Value,
+                        safeThreshold,
                         payloadStream,
                         cancellationToken)
                     .ConfigureAwait(false);
@@ -422,7 +427,7 @@ public class GeneralMultiProjectionActor
                     "capability-absent");
                 var payloadBytes = await StreamReadHelper.ReadAllBytesAsync(payloadStream, cancellationToken)
                     .ConfigureAwait(false);
-                deserializeResult = _types.Deserialize(state.ProjectorName, _domain, safeThreshold.Value, payloadBytes);
+                deserializeResult = _types.Deserialize(state.ProjectorName, _domain, safeThreshold, payloadBytes);
                 if (!deserializeResult.IsSuccess)
                 {
                     throw deserializeResult.GetException();
@@ -434,7 +439,7 @@ public class GeneralMultiProjectionActor
         else
         {
             var payloadBytes = state.GetPayloadBytes();
-            deserializeResult = _types.Deserialize(state.ProjectorName, _domain, safeThreshold.Value, payloadBytes);
+            deserializeResult = _types.Deserialize(state.ProjectorName, _domain, safeThreshold, payloadBytes);
             if (!deserializeResult.IsSuccess)
             {
                 throw deserializeResult.GetException();
@@ -458,7 +463,7 @@ public class GeneralMultiProjectionActor
                     _projectorName,
                     _types,
                     _domain,
-                    safeThreshold.Value,
+                    safeThreshold,
                     initialVersion: state.Version,
                     initialLastEventId: state.LastEventId,
                     initialLastSortableUniqueId: state.LastSortableUniqueId)
@@ -467,7 +472,7 @@ public class GeneralMultiProjectionActor
                     _projectorName,
                     _types,
                     _domain,
-                    safeThreshold.Value,
+                    safeThreshold,
                     initialVersion: state.Version,
                     initialLastEventId: state.LastEventId,
                     initialLastSortableUniqueId: state.LastSortableUniqueId))
@@ -482,6 +487,12 @@ public class GeneralMultiProjectionActor
         _unsafeLastSortableUniqueId = state.LastSortableUniqueId;
         _unsafeVersion = state.Version;
         _isCatchedUp = state.IsCatchedUp;
+    }
+
+    private string SelectSnapshotRestoreSafeWindowThreshold()
+    {
+        _lastSnapshotRestoreSafeWindowThreshold = GetSafeWindowThreshold().Value;
+        return _lastSnapshotRestoreSafeWindowThreshold;
     }
 
     private async Task<(ResultBox<IMultiProjectionPayload> Primary, IMultiProjectionPayload? Clone)>

--- a/dcb/src/Sekiban.Dcb.Core/Actors/GeneralMultiProjectionActor.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Actors/GeneralMultiProjectionActor.cs
@@ -45,9 +45,11 @@ public class GeneralMultiProjectionActor
     // or expose the previous payload while that boundary is in flight.
     private bool _snapshotRestoreInProgress;
 
-    // A terminal restore failure quarantines the actor's previous state. Atomic publication keeps that state intact for
-    // a later successful restore, but it is not trustworthy enough to serve, apply, promote, compact, or persist until
-    // that recovery succeeds. This is transient actor state: a fresh/rebuilt activation starts without a stale payload.
+    // A terminal restore failure after a payload has been published quarantines that previous state. Atomic publication
+    // keeps it intact for a later successful restore, but it is not trustworthy enough to serve, apply, promote,
+    // compact, or persist until recovery succeeds. A failure before first publication has no stale payload to quarantine
+    // and retains the legacy initial-state/rebuild behavior. This is transient actor state: a fresh/rebuilt activation
+    // starts without a stale payload.
     private Exception? _snapshotRestoreFailure;
 
     // Production seam observation for the most recent capability-present restore. It is intentionally private: this is
@@ -331,6 +333,10 @@ public class GeneralMultiProjectionActor
         bool validateProjectorVersion)
     {
         ThrowIfSnapshotRestoreInProgress();
+        // A fresh actor has no published payload or tracking metadata that could be served stale. Keep its long-standing
+        // version-mismatch behavior: the failed initial restore leaves it available for a normal empty-state rebuild.
+        // Once an accessor exists, however, every failed replacement restore must quarantine the prior checkpoint.
+        var hadPublishedState = _singleStateAccessor is not null;
         _snapshotRestoreInProgress = true;
         try
         {
@@ -356,8 +362,12 @@ public class GeneralMultiProjectionActor
         catch (Exception exception)
         {
             // Keep the original exception instance and stack. Callers receive it unchanged, and later consumption
-            // boundaries fail closed with that same failure until a full replacement restore succeeds.
-            _snapshotRestoreFailure = exception;
+            // boundaries fail closed with that same failure until a full replacement restore succeeds. There is no
+            // such boundary for a failed first restore because no prior payload or metadata exists to expose.
+            if (hadPublishedState)
+            {
+                _snapshotRestoreFailure = exception;
+            }
             throw;
         }
         finally

--- a/dcb/src/Sekiban.Dcb.Core/Actors/GeneralMultiProjectionActor.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Actors/GeneralMultiProjectionActor.cs
@@ -45,6 +45,15 @@ public class GeneralMultiProjectionActor
     // or expose the previous payload while that boundary is in flight.
     private bool _snapshotRestoreInProgress;
 
+    // A terminal restore failure quarantines the actor's previous state. Atomic publication keeps that state intact for
+    // a later successful restore, but it is not trustworthy enough to serve, apply, promote, compact, or persist until
+    // that recovery succeeds. This is transient actor state: a fresh/rebuilt activation starts without a stale payload.
+    private Exception? _snapshotRestoreFailure;
+
+    // Production seam observation for the most recent capability-present restore. It is intentionally private: this is
+    // not a public runtime metric, but a regression guard that proves the supported path did not reach ReadAllBytesAsync.
+    private int _lastStreamingRestoreWholePayloadAggregationCount;
+
     // Set the instant a per-event fold throws, and never cleared by a later apply. A faulted projection has stopped
     // at a poison event; presenting its pre-crash state as a successful query is the silence issue #1075 was about.
     // While it is set, applies are rejected (so a catch-up retry cannot re-apply the events before the poison and
@@ -76,7 +85,7 @@ public class GeneralMultiProjectionActor
     public async Task AddEventsAsync(IReadOnlyList<Event> events, bool finishedCatchUp = true, EventSource source = EventSource.Unknown)
     {
         ThrowIfFaulted();
-        ThrowIfSnapshotRestoreInProgress();
+        ThrowIfSnapshotRestoreUnavailable();
 
         // Initialize projectors if needed
         InitializeProjectorsIfNeeded();
@@ -107,7 +116,7 @@ public class GeneralMultiProjectionActor
     public async Task AddSerializableEventsAsync(IReadOnlyList<SerializableEvent> events, bool finishedCatchUp = true)
     {
         ThrowIfFaulted();
-        ThrowIfSnapshotRestoreInProgress();
+        ThrowIfSnapshotRestoreUnavailable();
         InitializeProjectorsIfNeeded();
         _isCatchedUp = finishedCatchUp;
 
@@ -167,9 +176,10 @@ public class GeneralMultiProjectionActor
 
     public Task<ResultBox<MultiProjectionState>> GetStateAsync(bool canGetUnsafeState = true)
     {
-        if (_snapshotRestoreInProgress)
+        var restoreBlocker = GetSnapshotRestoreBlocker();
+        if (restoreBlocker is not null)
         {
-            return Task.FromResult(ResultBox.Error<MultiProjectionState>(CreateRestoreInProgressException()));
+            return Task.FromResult(ResultBox.Error<MultiProjectionState>(restoreBlocker));
         }
 
         // A faulted projection has no trustworthy state to return. Every read surface — state, and through it the
@@ -215,12 +225,29 @@ public class GeneralMultiProjectionActor
         }
     }
 
+    /// <summary>
+    ///     Rejects all consumption and persistence boundaries while restore is in flight or after its terminal failure.
+    ///     A new restore is deliberately not gated here: it is the documented recovery operation and clears the latch
+    ///     only after it has atomically published a complete replacement payload and tracking metadata.
+    /// </summary>
+    private void ThrowIfSnapshotRestoreUnavailable()
+    {
+        var restoreBlocker = GetSnapshotRestoreBlocker();
+        if (restoreBlocker is not null)
+        {
+            ExceptionDispatchInfo.Capture(restoreBlocker).Throw();
+        }
+    }
+
+    private Exception? GetSnapshotRestoreBlocker() =>
+        _snapshotRestoreInProgress ? CreateRestoreInProgressException() : _snapshotRestoreFailure;
+
     private InvalidOperationException CreateRestoreInProgressException() =>
         new($"Snapshot restore is still in progress for projector '{_projectorName}'.");
 
     public async Task<ProjectionHeadStatus> GetProjectionHeadStatusAsync()
     {
-        ThrowIfSnapshotRestoreInProgress();
+        ThrowIfSnapshotRestoreUnavailable();
         InitializeProjectorsIfNeeded();
 
         var versionResult = _types.GetProjectorVersion(_projectorName);
@@ -303,27 +330,35 @@ public class GeneralMultiProjectionActor
         CancellationToken cancellationToken,
         bool validateProjectorVersion)
     {
-        if (validateProjectorVersion)
-        {
-            var versionResult = _types.GetProjectorVersion(_projectorName);
-            if (!versionResult.IsSuccess)
-            {
-                throw versionResult.GetException();
-            }
-
-            var currentVersion = versionResult.GetValue();
-            if (!string.Equals(currentVersion, state.ProjectorVersion, StringComparison.Ordinal))
-            {
-                throw new InvalidOperationException(
-                    $"Snapshot projector version mismatch. Current='{currentVersion}', Snapshot='{state.ProjectorVersion}' for projector '{_projectorName}'.");
-            }
-        }
-
         ThrowIfSnapshotRestoreInProgress();
         _snapshotRestoreInProgress = true;
         try
         {
+            if (validateProjectorVersion)
+            {
+                var versionResult = _types.GetProjectorVersion(_projectorName);
+                if (!versionResult.IsSuccess)
+                {
+                    throw versionResult.GetException();
+                }
+
+                var currentVersion = versionResult.GetValue();
+                if (!string.Equals(currentVersion, state.ProjectorVersion, StringComparison.Ordinal))
+                {
+                    throw new InvalidOperationException(
+                        $"Snapshot projector version mismatch. Current='{currentVersion}', Snapshot='{state.ProjectorVersion}' for projector '{_projectorName}'.");
+                }
+            }
+
             await RestorePayloadAsync(state, payloadStream, cancellationToken).ConfigureAwait(false);
+            _snapshotRestoreFailure = null;
+        }
+        catch (Exception exception)
+        {
+            // Keep the original exception instance and stack. Callers receive it unchanged, and later consumption
+            // boundaries fail closed with that same failure until a full replacement restore succeeds.
+            _snapshotRestoreFailure = exception;
+            throw;
         }
         finally
         {
@@ -336,6 +371,7 @@ public class GeneralMultiProjectionActor
         Stream? payloadStream,
         CancellationToken cancellationToken)
     {
+        _lastStreamingRestoreWholePayloadAggregationCount = 0;
         var safeThreshold = GetSafeWindowThreshold();
         ResultBox<IMultiProjectionPayload> deserializeResult;
         IMultiProjectionPayload? streamedClonePayload = null;
@@ -451,6 +487,7 @@ public class GeneralMultiProjectionActor
         // deliberately not a MemoryStream or byte[] clone: the offloaded restore guarantee removes the whole-payload
         // overlap while retaining the two object graphs that the dual-state semantics require.
         var temporaryPath = Path.Combine(Path.GetTempPath(), $"sekiban-stream-restore-{Guid.NewGuid():N}.payload");
+        using var aggregationScope = SnapshotRestoreAggregationDiagnostics.BeginStreamingRestoreScope();
         try
         {
             ResultBox<IMultiProjectionPayload> primary;
@@ -512,6 +549,7 @@ public class GeneralMultiProjectionActor
         }
         finally
         {
+            _lastStreamingRestoreWholePayloadAggregationCount = aggregationScope.WholePayloadAggregationCount;
             try
             {
                 File.Delete(temporaryPath);
@@ -525,9 +563,10 @@ public class GeneralMultiProjectionActor
 
     public async Task<ResultBox<SerializedMultiProjectionStatePayload>> BuildSerializedStatePayloadAsync(bool canGetUnsafeState)
     {
-        if (_snapshotRestoreInProgress)
+        var restoreBlocker = GetSnapshotRestoreBlocker();
+        if (restoreBlocker is not null)
         {
-            return ResultBox.Error<SerializedMultiProjectionStatePayload>(CreateRestoreInProgressException());
+            return ResultBox.Error<SerializedMultiProjectionStatePayload>(restoreBlocker);
         }
 
         InitializeProjectorsIfNeeded();
@@ -631,9 +670,10 @@ public class GeneralMultiProjectionActor
         int offloadThresholdBytes = int.MaxValue,
         CancellationToken cancellationToken = default)
     {
-        if (_snapshotRestoreInProgress)
+        var restoreBlocker = GetSnapshotRestoreBlocker();
+        if (restoreBlocker is not null)
         {
-            return ResultBox.Error<SerializableMultiProjectionStateEnvelope>(CreateRestoreInProgressException());
+            return ResultBox.Error<SerializableMultiProjectionStateEnvelope>(restoreBlocker);
         }
 
         // Without a spill buffer we cannot stream-first; fall back to the legacy path.
@@ -849,9 +889,10 @@ public class GeneralMultiProjectionActor
         int offloadThresholdBytes = int.MaxValue,
         CancellationToken cancellationToken = default)
     {
-        if (_snapshotRestoreInProgress)
+        var restoreBlocker = GetSnapshotRestoreBlocker();
+        if (restoreBlocker is not null)
         {
-            return ResultBox.Error<SnapshotPersistenceData>(CreateRestoreInProgressException());
+            return ResultBox.Error<SnapshotPersistenceData>(restoreBlocker);
         }
 
         // Promote buffered events before building a safe snapshot. A deferred-repair failure must fail closed: emitting a
@@ -928,7 +969,7 @@ public class GeneralMultiProjectionActor
     /// </summary>
     public async Task<string> GetSafeLastSortableUniqueIdAsync()
     {
-        ThrowIfSnapshotRestoreInProgress();
+        ThrowIfSnapshotRestoreUnavailable();
         InitializeProjectorsIfNeeded();
 
         // Get safe state to retrieve its last sortable unique ID
@@ -1129,7 +1170,7 @@ public class GeneralMultiProjectionActor
 
     public void ForcePromoteBufferedEvents()
     {
-        ThrowIfSnapshotRestoreInProgress();
+        ThrowIfSnapshotRestoreUnavailable();
         if (_singleStateAccessor is IDualStateAccessor dualAccessor)
         {
             try
@@ -1166,7 +1207,7 @@ public class GeneralMultiProjectionActor
 
     public void CompactSafeHistory()
     {
-        ThrowIfSnapshotRestoreInProgress();
+        ThrowIfSnapshotRestoreUnavailable();
         if (_singleStateAccessor is IDualStateAccessor dualAccessor)
         {
             try
@@ -1199,7 +1240,7 @@ public class GeneralMultiProjectionActor
 
     public void ForcePromoteAllBufferedEvents()
     {
-        ThrowIfSnapshotRestoreInProgress();
+        ThrowIfSnapshotRestoreUnavailable();
         if (_singleStateAccessor is IDualStateAccessor dualAccessor)
         {
             try
@@ -1382,9 +1423,10 @@ public class GeneralMultiProjectionActor
     /// </summary>
     public Task<ResultBox<MultiProjectionState>> GetUnsafeStateAsync()
     {
-        if (_snapshotRestoreInProgress)
+        var restoreBlocker = GetSnapshotRestoreBlocker();
+        if (restoreBlocker is not null)
         {
-            return Task.FromResult(ResultBox.Error<MultiProjectionState>(CreateRestoreInProgressException()));
+            return Task.FromResult(ResultBox.Error<MultiProjectionState>(restoreBlocker));
         }
 
         InitializeProjectorsIfNeeded();
@@ -1395,7 +1437,7 @@ public class GeneralMultiProjectionActor
 
     private void InitializeProjectorsIfNeeded()
     {
-        ThrowIfSnapshotRestoreInProgress();
+        ThrowIfSnapshotRestoreUnavailable();
         if (_singleStateAccessor == null)
         {
             var init = _types.GenerateInitialPayload(_projectorName);
@@ -1458,7 +1500,11 @@ public class GeneralMultiProjectionActor
     ///     Public helper to obtain current safe window threshold without triggering state mutation.
     ///     (Primarily used to supply query context metadata.)
     /// </summary>
-    public SortableUniqueId PeekCurrentSafeWindowThreshold() => GetSafeWindowThreshold();
+    public SortableUniqueId PeekCurrentSafeWindowThreshold()
+    {
+        ThrowIfSnapshotRestoreUnavailable();
+        return GetSafeWindowThreshold();
+    }
 
     private void UpdateObservedLag(IReadOnlyList<Event> events)
     {

--- a/dcb/src/Sekiban.Dcb.Core/Actors/GeneralMultiProjectionActor.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Actors/GeneralMultiProjectionActor.cs
@@ -41,6 +41,10 @@ public class GeneralMultiProjectionActor
     private string _unsafeLastSortableUniqueId = string.Empty;
     private int _unsafeVersion;
 
+    // Snapshot restore has an asynchronous stream boundary. No read, apply, persistence, or promotion path may initialize
+    // or expose the previous payload while that boundary is in flight.
+    private bool _snapshotRestoreInProgress;
+
     // Set the instant a per-event fold throws, and never cleared by a later apply. A faulted projection has stopped
     // at a poison event; presenting its pre-crash state as a successful query is the silence issue #1075 was about.
     // While it is set, applies are rejected (so a catch-up retry cannot re-apply the events before the poison and
@@ -72,6 +76,7 @@ public class GeneralMultiProjectionActor
     public async Task AddEventsAsync(IReadOnlyList<Event> events, bool finishedCatchUp = true, EventSource source = EventSource.Unknown)
     {
         ThrowIfFaulted();
+        ThrowIfSnapshotRestoreInProgress();
 
         // Initialize projectors if needed
         InitializeProjectorsIfNeeded();
@@ -102,6 +107,7 @@ public class GeneralMultiProjectionActor
     public async Task AddSerializableEventsAsync(IReadOnlyList<SerializableEvent> events, bool finishedCatchUp = true)
     {
         ThrowIfFaulted();
+        ThrowIfSnapshotRestoreInProgress();
         InitializeProjectorsIfNeeded();
         _isCatchedUp = finishedCatchUp;
 
@@ -161,6 +167,11 @@ public class GeneralMultiProjectionActor
 
     public Task<ResultBox<MultiProjectionState>> GetStateAsync(bool canGetUnsafeState = true)
     {
+        if (_snapshotRestoreInProgress)
+        {
+            return Task.FromResult(ResultBox.Error<MultiProjectionState>(CreateRestoreInProgressException()));
+        }
+
         // A faulted projection has no trustworthy state to return. Every read surface — state, and through it the
         // scalar and list query surfaces that all fetch state here first — fails with the fault context instead of
         // handing back the last pre-crash payload as a success.
@@ -196,8 +207,20 @@ public class GeneralMultiProjectionActor
         }
     }
 
+    private void ThrowIfSnapshotRestoreInProgress()
+    {
+        if (_snapshotRestoreInProgress)
+        {
+            throw CreateRestoreInProgressException();
+        }
+    }
+
+    private InvalidOperationException CreateRestoreInProgressException() =>
+        new($"Snapshot restore is still in progress for projector '{_projectorName}'.");
+
     public async Task<ProjectionHeadStatus> GetProjectionHeadStatusAsync()
     {
+        ThrowIfSnapshotRestoreInProgress();
         InitializeProjectorsIfNeeded();
 
         var versionResult = _types.GetProjectorVersion(_projectorName);
@@ -250,77 +273,263 @@ public class GeneralMultiProjectionActor
             ToProjectionPosition(consistentStateResult.GetValue()));
     }
 
-    public Task SetCurrentState(SerializableMultiProjectionState state)
+    public Task SetCurrentState(SerializableMultiProjectionState state) =>
+        SetCurrentStateCoreAsync(state, payloadStream: null, CancellationToken.None, validateProjectorVersion: true);
+
+    // Compatibility restore: ignore projector version mismatch and restore snapshot payload as-is.
+    public Task SetCurrentStateIgnoringVersion(SerializableMultiProjectionState state) =>
+        SetCurrentStateCoreAsync(state, payloadStream: null, CancellationToken.None, validateProjectorVersion: false);
+
+    /// <summary>
+    ///     Applies a resolver-produced snapshot restore input. The caller retains ownership of an offloaded payload
+    ///     stream; this actor and the projector registry never dispose it. Restore is awaited before any actor payload
+    ///     or tracking metadata is published.
+    /// </summary>
+    public Task SetResolvedSnapshotAsync(
+        ResolvedSnapshotRestore snapshot,
+        CancellationToken cancellationToken = default)
     {
-        // Validate projector version before restoring state
-        var versionResult = _types.GetProjectorVersion(_projectorName);
-        if (!versionResult.IsSuccess)
-        {
-            throw versionResult.GetException();
-        }
-
-        var currentVersion = versionResult.GetValue();
-        if (!string.Equals(currentVersion, state.ProjectorVersion, StringComparison.Ordinal))
-        {
-            throw new InvalidOperationException(
-                $"Snapshot projector version mismatch. Current='{currentVersion}', Snapshot='{state.ProjectorVersion}' for projector '{_projectorName}'.");
-        }
-
-        RestorePayload(state);
-        return Task.CompletedTask;
+        ArgumentNullException.ThrowIfNull(snapshot);
+        return SetCurrentStateCoreAsync(
+            snapshot.State,
+            snapshot.PayloadStream,
+            cancellationToken,
+            validateProjectorVersion: true);
     }
 
-    // Compatibility restore: ignore projector version mismatch and restore snapshot payload as-is
-    public Task SetCurrentStateIgnoringVersion(SerializableMultiProjectionState state)
+    private async Task SetCurrentStateCoreAsync(
+        SerializableMultiProjectionState state,
+        Stream? payloadStream,
+        CancellationToken cancellationToken,
+        bool validateProjectorVersion)
     {
-        RestorePayload(state);
-        return Task.CompletedTask;
-    }
-
-    private void RestorePayload(SerializableMultiProjectionState state)
-    {
-        var payloadBytes = state.GetPayloadBytes();
-        var projTypeRb = _types.GetProjectorType(state.ProjectorName);
-        if (!projTypeRb.IsSuccess) throw projTypeRb.GetException();
-
-        var safeThreshold = GetSafeWindowThreshold();
-        var deserializeResult = _types.Deserialize(state.ProjectorName, _domain, safeThreshold.Value, payloadBytes);
-        if (!deserializeResult.IsSuccess) throw deserializeResult.GetException();
-
-        var loadedPayload = deserializeResult.GetValue();
-        _logger.LogDebug("[{ProjectorName}] Deserialize: via ICoreMultiProjectorTypes", _projectorName);
-
-        if (loadedPayload is IDualStateAccessor)
+        if (validateProjectorVersion)
         {
-            _singleStateAccessor = loadedPayload;
-        }
-        else
-        {
-            _singleStateAccessor = DualStateProjectionWrapperFactory.CreateFromRestoredSnapshot(
-                loadedPayload,
-                _projectorName,
-                _types,
-                _domain,
-                safeThreshold.Value,
-                initialVersion: state.Version,
-                initialLastEventId: state.LastEventId,
-                initialLastSortableUniqueId: state.LastSortableUniqueId);
-
-            if (_singleStateAccessor == null)
+            var versionResult = _types.GetProjectorVersion(_projectorName);
+            if (!versionResult.IsSuccess)
             {
-                throw new InvalidOperationException($"Failed to create wrapper for projector {_projectorName}");
+                throw versionResult.GetException();
+            }
+
+            var currentVersion = versionResult.GetValue();
+            if (!string.Equals(currentVersion, state.ProjectorVersion, StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException(
+                    $"Snapshot projector version mismatch. Current='{currentVersion}', Snapshot='{state.ProjectorVersion}' for projector '{_projectorName}'.");
             }
         }
 
-        // Update tracking variables
+        ThrowIfSnapshotRestoreInProgress();
+        _snapshotRestoreInProgress = true;
+        try
+        {
+            await RestorePayloadAsync(state, payloadStream, cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            _snapshotRestoreInProgress = false;
+        }
+    }
+
+    private async Task RestorePayloadAsync(
+        SerializableMultiProjectionState state,
+        Stream? payloadStream,
+        CancellationToken cancellationToken)
+    {
+        var safeThreshold = GetSafeWindowThreshold();
+        ResultBox<IMultiProjectionPayload> deserializeResult;
+        IMultiProjectionPayload? streamedClonePayload = null;
+
+        if (payloadStream is not null)
+        {
+            if (_types is IStreamingMultiProjectorTypes streamingTypes &&
+                streamingTypes.SupportsStreamDeserialization(state.ProjectorName))
+            {
+                // A present capability owns the restore attempt. Its failures are never retried through the buffered
+                // compatibility route because doing so both doubles memory and hides stream/data corruption.
+                (deserializeResult, streamedClonePayload) = await DeserializeStreamingPayloadPairAsync(
+                        streamingTypes,
+                        state.ProjectorName,
+                        safeThreshold.Value,
+                        payloadStream,
+                        cancellationToken)
+                    .ConfigureAwait(false);
+                if (!deserializeResult.IsSuccess)
+                {
+                    throw deserializeResult.GetException();
+                }
+
+                _logger.LogDebug(
+                    "[{ProjectorName}] Deserialize: via IStreamingMultiProjectorTypes",
+                    _projectorName);
+            }
+            else
+            {
+                // Old external registries and projector-specific custom serializers that have not opted into the
+                // additive capability remain supported. This is the sole buffered fallback and it occurs exactly once
+                // per restore attempt; the message intentionally carries no payload material.
+                _logger.LogInformation(
+                    "Snapshot restore buffered fallback. Projector={ProjectorName}, Registry={Registry}, Format={Format}, Reason={Reason}",
+                    _projectorName,
+                    _types.GetType().FullName ?? _types.GetType().Name,
+                    "offloaded",
+                    "capability-absent");
+                var payloadBytes = await StreamReadHelper.ReadAllBytesAsync(payloadStream, cancellationToken)
+                    .ConfigureAwait(false);
+                deserializeResult = _types.Deserialize(state.ProjectorName, _domain, safeThreshold.Value, payloadBytes);
+                if (!deserializeResult.IsSuccess)
+                {
+                    throw deserializeResult.GetException();
+                }
+
+                _logger.LogDebug("[{ProjectorName}] Deserialize: buffered compatibility fallback", _projectorName);
+            }
+        }
+        else
+        {
+            var payloadBytes = state.GetPayloadBytes();
+            deserializeResult = _types.Deserialize(state.ProjectorName, _domain, safeThreshold.Value, payloadBytes);
+            if (!deserializeResult.IsSuccess)
+            {
+                throw deserializeResult.GetException();
+            }
+
+            _logger.LogDebug("[{ProjectorName}] Deserialize: via ICoreMultiProjectorTypes", _projectorName);
+        }
+
+        var loadedPayload = deserializeResult.GetValue();
+        IMultiProjectionPayload loadedAccessor;
+        if (loadedPayload is IDualStateAccessor)
+        {
+            loadedAccessor = loadedPayload;
+        }
+        else
+        {
+            loadedAccessor = (streamedClonePayload is not null
+                ? DualStateProjectionWrapperFactory.CreateFromRestoredSnapshot(
+                    loadedPayload,
+                    streamedClonePayload,
+                    _projectorName,
+                    _types,
+                    _domain,
+                    safeThreshold.Value,
+                    initialVersion: state.Version,
+                    initialLastEventId: state.LastEventId,
+                    initialLastSortableUniqueId: state.LastSortableUniqueId)
+                : DualStateProjectionWrapperFactory.CreateFromRestoredSnapshot(
+                    loadedPayload,
+                    _projectorName,
+                    _types,
+                    _domain,
+                    safeThreshold.Value,
+                    initialVersion: state.Version,
+                    initialLastEventId: state.LastEventId,
+                    initialLastSortableUniqueId: state.LastSortableUniqueId))
+                ?? throw new InvalidOperationException($"Failed to create wrapper for projector {_projectorName}");
+        }
+
+        // Publish the payload and all tracking metadata together only after the entire deserialize/wrapper construction
+        // succeeded. A stream failure therefore leaves the previous state intact and the activation cannot serve a
+        // partially restored checkpoint.
+        _singleStateAccessor = loadedAccessor;
         _unsafeLastEventId = state.LastEventId;
         _unsafeLastSortableUniqueId = state.LastSortableUniqueId;
         _unsafeVersion = state.Version;
         _isCatchedUp = state.IsCatchedUp;
     }
 
+    private async Task<(ResultBox<IMultiProjectionPayload> Primary, IMultiProjectionPayload? Clone)>
+        DeserializeStreamingPayloadPairAsync(
+            IStreamingMultiProjectorTypes streamingTypes,
+            string projectorName,
+            string safeWindowThreshold,
+            Stream source,
+            CancellationToken cancellationToken)
+    {
+        // The dual-state wrapper needs independent safe/unsafe graphs. Tee the already-opened payload to an explicit
+        // temporary file while deserializing the first graph, then deserialize that file for the second graph. This is
+        // deliberately not a MemoryStream or byte[] clone: the offloaded restore guarantee removes the whole-payload
+        // overlap while retaining the two object graphs that the dual-state semantics require.
+        var temporaryPath = Path.Combine(Path.GetTempPath(), $"sekiban-stream-restore-{Guid.NewGuid():N}.payload");
+        try
+        {
+            ResultBox<IMultiProjectionPayload> primary;
+            await using (var copy = new FileStream(
+                             temporaryPath,
+                             FileMode.CreateNew,
+                             FileAccess.Write,
+                             FileShare.None,
+                             bufferSize: 81920,
+                             options: FileOptions.Asynchronous | FileOptions.SequentialScan))
+            {
+                await using var tee = new SnapshotRestoreTeeReadStream(source, copy);
+                primary = await streamingTypes.DeserializeFromStreamAsync(
+                        projectorName,
+                        _domain,
+                        safeWindowThreshold,
+                        tee,
+                        cancellationToken)
+                    .ConfigureAwait(false);
+                if (!primary.IsSuccess)
+                {
+                    return (primary, null);
+                }
+
+                // JsonSerializer normally drains the input, but the capability contract permits a custom projector to
+                // finish after it has consumed its own representation. The independent second graph must still see the
+                // complete original payload, so forward any remaining bytes straight to the temporary file instead of
+                // relying on a seek or aggregating them in memory.
+                await tee.CopyToAsync(Stream.Null, bufferSize: 81920, cancellationToken).ConfigureAwait(false);
+                await copy.FlushAsync(cancellationToken).ConfigureAwait(false);
+            }
+
+            if (primary.GetValue() is IDualStateAccessor)
+            {
+                // A projector that already owns dual-state semantics does not need a framework clone.
+                return (primary, null);
+            }
+
+            await using var cloneSource = new FileStream(
+                temporaryPath,
+                FileMode.Open,
+                FileAccess.Read,
+                FileShare.Read,
+                bufferSize: 81920,
+                options: FileOptions.Asynchronous | FileOptions.SequentialScan);
+            var clone = await streamingTypes.DeserializeFromStreamAsync(
+                    projectorName,
+                    _domain,
+                    safeWindowThreshold,
+                    cloneSource,
+                    cancellationToken)
+                .ConfigureAwait(false);
+            if (!clone.IsSuccess)
+            {
+                throw clone.GetException();
+            }
+
+            return (primary, clone.GetValue());
+        }
+        finally
+        {
+            try
+            {
+                File.Delete(temporaryPath);
+            }
+            catch
+            {
+                // A failed cleanup must not mask a deserialize failure; the unique file has no durable role.
+            }
+        }
+    }
+
     public async Task<ResultBox<SerializedMultiProjectionStatePayload>> BuildSerializedStatePayloadAsync(bool canGetUnsafeState)
     {
+        if (_snapshotRestoreInProgress)
+        {
+            return ResultBox.Error<SerializedMultiProjectionStatePayload>(CreateRestoreInProgressException());
+        }
+
         InitializeProjectorsIfNeeded();
         var stateResult = await GetStateAsync(canGetUnsafeState);
         if (!stateResult.IsSuccess) return ResultBox.Error<SerializedMultiProjectionStatePayload>(stateResult.GetException());
@@ -422,6 +631,11 @@ public class GeneralMultiProjectionActor
         int offloadThresholdBytes = int.MaxValue,
         CancellationToken cancellationToken = default)
     {
+        if (_snapshotRestoreInProgress)
+        {
+            return ResultBox.Error<SerializableMultiProjectionStateEnvelope>(CreateRestoreInProgressException());
+        }
+
         // Without a spill buffer we cannot stream-first; fall back to the legacy path.
         if (payloadBufferProvider is null)
         {
@@ -616,7 +830,12 @@ public class GeneralMultiProjectionActor
 
         if (envelope.InlineState == null)
             throw new InvalidOperationException("Inline snapshot missing InlineState");
-        await SetCurrentState(envelope.InlineState);
+        await SetCurrentStateCoreAsync(
+                envelope.InlineState,
+                payloadStream: null,
+                cancellationToken,
+                validateProjectorVersion: true)
+            .ConfigureAwait(false);
     }
 
     /// <summary>
@@ -630,6 +849,11 @@ public class GeneralMultiProjectionActor
         int offloadThresholdBytes = int.MaxValue,
         CancellationToken cancellationToken = default)
     {
+        if (_snapshotRestoreInProgress)
+        {
+            return ResultBox.Error<SnapshotPersistenceData>(CreateRestoreInProgressException());
+        }
+
         // Promote buffered events before building a safe snapshot. A deferred-repair failure must fail closed: emitting a
         // snapshot from the old payload would allow persistence and later compaction to discard the retained repair input.
         try
@@ -704,6 +928,7 @@ public class GeneralMultiProjectionActor
     /// </summary>
     public async Task<string> GetSafeLastSortableUniqueIdAsync()
     {
+        ThrowIfSnapshotRestoreInProgress();
         InitializeProjectorsIfNeeded();
 
         // Get safe state to retrieve its last sortable unique ID
@@ -904,6 +1129,7 @@ public class GeneralMultiProjectionActor
 
     public void ForcePromoteBufferedEvents()
     {
+        ThrowIfSnapshotRestoreInProgress();
         if (_singleStateAccessor is IDualStateAccessor dualAccessor)
         {
             try
@@ -940,6 +1166,7 @@ public class GeneralMultiProjectionActor
 
     public void CompactSafeHistory()
     {
+        ThrowIfSnapshotRestoreInProgress();
         if (_singleStateAccessor is IDualStateAccessor dualAccessor)
         {
             try
@@ -972,6 +1199,7 @@ public class GeneralMultiProjectionActor
 
     public void ForcePromoteAllBufferedEvents()
     {
+        ThrowIfSnapshotRestoreInProgress();
         if (_singleStateAccessor is IDualStateAccessor dualAccessor)
         {
             try
@@ -1154,6 +1382,11 @@ public class GeneralMultiProjectionActor
     /// </summary>
     public Task<ResultBox<MultiProjectionState>> GetUnsafeStateAsync()
     {
+        if (_snapshotRestoreInProgress)
+        {
+            return Task.FromResult(ResultBox.Error<MultiProjectionState>(CreateRestoreInProgressException()));
+        }
+
         InitializeProjectorsIfNeeded();
 
         // Always get unsafe state
@@ -1162,6 +1395,7 @@ public class GeneralMultiProjectionActor
 
     private void InitializeProjectorsIfNeeded()
     {
+        ThrowIfSnapshotRestoreInProgress();
         if (_singleStateAccessor == null)
         {
             var init = _types.GenerateInitialPayload(_projectorName);

--- a/dcb/src/Sekiban.Dcb.Core/Domains/SimpleMultiProjectorTypes.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Domains/SimpleMultiProjectorTypes.cs
@@ -11,7 +11,7 @@ namespace Sekiban.Dcb.Domains;
 /// <summary>
 ///     Simple in-memory registry for multi projectors.
 /// </summary>
-internal class SimpleMultiProjectorTypes : ICoreMultiProjectorTypes
+internal class SimpleMultiProjectorTypes : ICoreMultiProjectorTypes, IStreamingMultiProjectorTypes
 {
     private readonly ConcurrentDictionary<string, Func<IMultiProjectionPayload>> _initialPayloadGenerators = new();
     private readonly ConcurrentDictionary<string,
@@ -22,6 +22,8 @@ internal class SimpleMultiProjectorTypes : ICoreMultiProjectorTypes
     private readonly ConcurrentDictionary<string, (
         Func<DcbDomainTypes, string, object, SerializationResult> serialize,
         Func<DcbDomainTypes, string, ReadOnlySpan<byte>, object> deserialize)> _customSerializers = new();
+    private readonly ConcurrentDictionary<string,
+        Func<DcbDomainTypes, string, Stream, CancellationToken, Task<IMultiProjectionPayload>>> _streamDeserializers = new();
 
     public ResultBox<IMultiProjectionPayload> Project(
         string multiProjectorName,
@@ -170,6 +172,7 @@ internal class SimpleMultiProjectorTypes : ICoreMultiProjectorTypes
 
         // Register the initial payload generator
         _initialPayloadGenerators[projectorName] = () => TProjector.GenerateInitialPayload();
+        RegisterReflectionStreamDeserializer<TProjector>(projectorName);
     }
 
     /// <summary>
@@ -229,6 +232,7 @@ internal class SimpleMultiProjectorTypes : ICoreMultiProjectorTypes
 
         // Register the initial payload generator
         _initialPayloadGenerators[projectorName] = () => TProjector.GenerateInitialPayload();
+        RegisterReflectionStreamDeserializer<TProjector>(projectorName);
     }
 
     /// <summary>
@@ -381,6 +385,7 @@ internal class SimpleMultiProjectorTypes : ICoreMultiProjectorTypes
             // Since ICoreMultiProjectorWithCustomSerialization<T> inherits from ICoreMultiProjector<T>,
             // we can directly call RegisterProjector
             RegisterProjector<T>();
+            RegisterCustomStreamDeserializerIfPresent<T>(projectorName);
 
             return ResultBox.FromValue(true);
         }
@@ -409,12 +414,83 @@ internal class SimpleMultiProjectorTypes : ICoreMultiProjectorTypes
             // Since ICoreMultiProjectorWithCustomSerialization<T> inherits from ICoreMultiProjector<T>,
             // we can directly call RegisterProjector
             RegisterProjectorWithoutResult<T>();
+            RegisterCustomStreamDeserializerIfPresent<T>(projectorName);
 
             return ResultBox.FromValue(true);
         }
         catch (Exception ex)
         {
             return ResultBox.Error<bool>(ex);
+        }
+    }
+
+    public bool SupportsStreamDeserialization(string projectorName) =>
+        _streamDeserializers.ContainsKey(projectorName);
+
+    public async Task<ResultBox<IMultiProjectionPayload>> DeserializeFromStreamAsync(
+        string projectorName,
+        DcbDomainTypes domainTypes,
+        string safeWindowThreshold,
+        Stream source,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(safeWindowThreshold))
+        {
+            return ResultBox.Error<IMultiProjectionPayload>(
+                new ArgumentException("safeWindowThreshold must be supplied"));
+        }
+
+        if (source is null)
+        {
+            return ResultBox.Error<IMultiProjectionPayload>(new ArgumentNullException(nameof(source)));
+        }
+
+        if (!_streamDeserializers.TryGetValue(projectorName, out var deserialize))
+        {
+            return ResultBox.Error<IMultiProjectionPayload>(
+                new NotSupportedException($"Projector '{projectorName}' does not support streaming deserialization."));
+        }
+
+        try
+        {
+            return ResultBox.FromValue(
+                await deserialize(domainTypes, safeWindowThreshold, source, cancellationToken).ConfigureAwait(false));
+        }
+        catch (Exception ex)
+        {
+            return ResultBox.Error<IMultiProjectionPayload>(ex);
+        }
+    }
+
+    private void RegisterReflectionStreamDeserializer<TProjector>(string projectorName)
+        where TProjector : ICoreMultiProjector<TProjector>, new() =>
+        _streamDeserializers[projectorName] = async (domainTypes, _, source, cancellationToken) =>
+        {
+            var deserialized = await StreamSnapshotPayloadDeserializer.DeserializeJsonAsync(
+                    source,
+                    typeof(TProjector),
+                    domainTypes.JsonSerializerOptions,
+                    cancellationToken)
+                .ConfigureAwait(false);
+            return deserialized as IMultiProjectionPayload
+                ?? throw new InvalidOperationException(
+                    $"Failed to deserialize streaming payload to {typeof(TProjector).Name}.");
+        };
+
+    private void RegisterCustomStreamDeserializerIfPresent<TProjector>(string projectorName)
+        where TProjector : ICoreMultiProjectorWithCustomSerialization<TProjector>, new()
+    {
+        if (typeof(ICoreMultiProjectorWithStreamDeserialization).IsAssignableFrom(typeof(TProjector)))
+        {
+            _streamDeserializers[projectorName] = (domainTypes, safeWindowThreshold, source, cancellationToken) =>
+                ((ICoreMultiProjectorWithStreamDeserialization)(object)new TProjector())
+                .DeserializeFromStreamAsync(domainTypes, safeWindowThreshold, source, cancellationToken);
+        }
+        else
+        {
+            // A custom serializer's bytes are not necessarily JSON+gzip, so it must explicitly opt in rather than
+            // inheriting the normal reflection projector path registered above.
+            _streamDeserializers.TryRemove(projectorName, out _);
         }
     }
 }

--- a/dcb/src/Sekiban.Dcb.Core/Domains/SimpleMultiProjectorTypes.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Domains/SimpleMultiProjectorTypes.cs
@@ -22,8 +22,7 @@ internal class SimpleMultiProjectorTypes : ICoreMultiProjectorTypes, IStreamingM
     private readonly ConcurrentDictionary<string, (
         Func<DcbDomainTypes, string, object, SerializationResult> serialize,
         Func<DcbDomainTypes, string, ReadOnlySpan<byte>, object> deserialize)> _customSerializers = new();
-    private readonly ConcurrentDictionary<string,
-        Func<DcbDomainTypes, string, Stream, CancellationToken, Task<IMultiProjectionPayload>>> _streamDeserializers = new();
+    private readonly StreamingMultiProjectorTypesSupport _streamingRestore = new();
 
     public ResultBox<IMultiProjectionPayload> Project(
         string multiProjectorName,
@@ -172,7 +171,7 @@ internal class SimpleMultiProjectorTypes : ICoreMultiProjectorTypes, IStreamingM
 
         // Register the initial payload generator
         _initialPayloadGenerators[projectorName] = () => TProjector.GenerateInitialPayload();
-        RegisterReflectionStreamDeserializer<TProjector>(projectorName);
+        _streamingRestore.RegisterReflection(projectorName, typeof(TProjector));
     }
 
     /// <summary>
@@ -232,7 +231,7 @@ internal class SimpleMultiProjectorTypes : ICoreMultiProjectorTypes, IStreamingM
 
         // Register the initial payload generator
         _initialPayloadGenerators[projectorName] = () => TProjector.GenerateInitialPayload();
-        RegisterReflectionStreamDeserializer<TProjector>(projectorName);
+        _streamingRestore.RegisterReflection(projectorName, typeof(TProjector));
     }
 
     /// <summary>
@@ -385,7 +384,7 @@ internal class SimpleMultiProjectorTypes : ICoreMultiProjectorTypes, IStreamingM
             // Since ICoreMultiProjectorWithCustomSerialization<T> inherits from ICoreMultiProjector<T>,
             // we can directly call RegisterProjector
             RegisterProjector<T>();
-            RegisterCustomStreamDeserializerIfPresent<T>(projectorName);
+            _streamingRestore.RegisterCustomOrRemove<T>(projectorName);
 
             return ResultBox.FromValue(true);
         }
@@ -414,7 +413,7 @@ internal class SimpleMultiProjectorTypes : ICoreMultiProjectorTypes, IStreamingM
             // Since ICoreMultiProjectorWithCustomSerialization<T> inherits from ICoreMultiProjector<T>,
             // we can directly call RegisterProjector
             RegisterProjectorWithoutResult<T>();
-            RegisterCustomStreamDeserializerIfPresent<T>(projectorName);
+            _streamingRestore.RegisterCustomOrRemove<T>(projectorName);
 
             return ResultBox.FromValue(true);
         }
@@ -425,72 +424,18 @@ internal class SimpleMultiProjectorTypes : ICoreMultiProjectorTypes, IStreamingM
     }
 
     public bool SupportsStreamDeserialization(string projectorName) =>
-        _streamDeserializers.ContainsKey(projectorName);
+        _streamingRestore.Supports(projectorName);
 
-    public async Task<ResultBox<IMultiProjectionPayload>> DeserializeFromStreamAsync(
+    public Task<ResultBox<IMultiProjectionPayload>> DeserializeFromStreamAsync(
         string projectorName,
         DcbDomainTypes domainTypes,
         string safeWindowThreshold,
         Stream source,
         CancellationToken cancellationToken = default)
-    {
-        if (string.IsNullOrWhiteSpace(safeWindowThreshold))
-        {
-            return ResultBox.Error<IMultiProjectionPayload>(
-                new ArgumentException("safeWindowThreshold must be supplied"));
-        }
-
-        if (source is null)
-        {
-            return ResultBox.Error<IMultiProjectionPayload>(new ArgumentNullException(nameof(source)));
-        }
-
-        if (!_streamDeserializers.TryGetValue(projectorName, out var deserialize))
-        {
-            return ResultBox.Error<IMultiProjectionPayload>(
-                new NotSupportedException($"Projector '{projectorName}' does not support streaming deserialization."));
-        }
-
-        try
-        {
-            return ResultBox.FromValue(
-                await deserialize(domainTypes, safeWindowThreshold, source, cancellationToken).ConfigureAwait(false));
-        }
-        catch (Exception ex)
-        {
-            return ResultBox.Error<IMultiProjectionPayload>(ex);
-        }
-    }
-
-    private void RegisterReflectionStreamDeserializer<TProjector>(string projectorName)
-        where TProjector : ICoreMultiProjector<TProjector>, new() =>
-        _streamDeserializers[projectorName] = async (domainTypes, _, source, cancellationToken) =>
-        {
-            var deserialized = await StreamSnapshotPayloadDeserializer.DeserializeJsonAsync(
-                    source,
-                    typeof(TProjector),
-                    domainTypes.JsonSerializerOptions,
-                    cancellationToken)
-                .ConfigureAwait(false);
-            return deserialized as IMultiProjectionPayload
-                ?? throw new InvalidOperationException(
-                    $"Failed to deserialize streaming payload to {typeof(TProjector).Name}.");
-        };
-
-    private void RegisterCustomStreamDeserializerIfPresent<TProjector>(string projectorName)
-        where TProjector : ICoreMultiProjectorWithCustomSerialization<TProjector>, new()
-    {
-        if (typeof(ICoreMultiProjectorWithStreamDeserialization).IsAssignableFrom(typeof(TProjector)))
-        {
-            _streamDeserializers[projectorName] = (domainTypes, safeWindowThreshold, source, cancellationToken) =>
-                ((ICoreMultiProjectorWithStreamDeserialization)(object)new TProjector())
-                .DeserializeFromStreamAsync(domainTypes, safeWindowThreshold, source, cancellationToken);
-        }
-        else
-        {
-            // A custom serializer's bytes are not necessarily JSON+gzip, so it must explicitly opt in rather than
-            // inheriting the normal reflection projector path registered above.
-            _streamDeserializers.TryRemove(projectorName, out _);
-        }
-    }
+        => _streamingRestore.DeserializeAsync(
+            projectorName,
+            domainTypes,
+            safeWindowThreshold,
+            source,
+            cancellationToken);
 }

--- a/dcb/src/Sekiban.Dcb.Core/Domains/SimpleMultiProjectorTypes.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Domains/SimpleMultiProjectorTypes.cs
@@ -22,7 +22,6 @@ internal class SimpleMultiProjectorTypes : ICoreMultiProjectorTypes, IStreamingM
     private readonly ConcurrentDictionary<string, (
         Func<DcbDomainTypes, string, object, SerializationResult> serialize,
         Func<DcbDomainTypes, string, ReadOnlySpan<byte>, object> deserialize)> _customSerializers = new();
-    private readonly StreamingMultiProjectorTypesSupport _streamingRestore = new();
 
     public ResultBox<IMultiProjectionPayload> Project(
         string multiProjectorName,
@@ -171,7 +170,7 @@ internal class SimpleMultiProjectorTypes : ICoreMultiProjectorTypes, IStreamingM
 
         // Register the initial payload generator
         _initialPayloadGenerators[projectorName] = () => TProjector.GenerateInitialPayload();
-        _streamingRestore.RegisterReflection(projectorName, typeof(TProjector));
+        StreamingMultiProjectorTypesSupport.RegisterReflection(this, projectorName, typeof(TProjector));
     }
 
     /// <summary>
@@ -231,7 +230,7 @@ internal class SimpleMultiProjectorTypes : ICoreMultiProjectorTypes, IStreamingM
 
         // Register the initial payload generator
         _initialPayloadGenerators[projectorName] = () => TProjector.GenerateInitialPayload();
-        _streamingRestore.RegisterReflection(projectorName, typeof(TProjector));
+        StreamingMultiProjectorTypesSupport.RegisterReflection(this, projectorName, typeof(TProjector));
     }
 
     /// <summary>
@@ -384,7 +383,7 @@ internal class SimpleMultiProjectorTypes : ICoreMultiProjectorTypes, IStreamingM
             // Since ICoreMultiProjectorWithCustomSerialization<T> inherits from ICoreMultiProjector<T>,
             // we can directly call RegisterProjector
             RegisterProjector<T>();
-            _streamingRestore.RegisterCustomOrRemove<T>(projectorName);
+            StreamingMultiProjectorTypesSupport.RegisterCustomOrRemove<T>(this, projectorName);
 
             return ResultBox.FromValue(true);
         }
@@ -413,7 +412,7 @@ internal class SimpleMultiProjectorTypes : ICoreMultiProjectorTypes, IStreamingM
             // Since ICoreMultiProjectorWithCustomSerialization<T> inherits from ICoreMultiProjector<T>,
             // we can directly call RegisterProjector
             RegisterProjectorWithoutResult<T>();
-            _streamingRestore.RegisterCustomOrRemove<T>(projectorName);
+            StreamingMultiProjectorTypesSupport.RegisterCustomOrRemove<T>(this, projectorName);
 
             return ResultBox.FromValue(true);
         }
@@ -423,19 +422,7 @@ internal class SimpleMultiProjectorTypes : ICoreMultiProjectorTypes, IStreamingM
         }
     }
 
-    public bool SupportsStreamDeserialization(string projectorName) =>
-        _streamingRestore.Supports(projectorName);
+    public bool SupportsStreamDeserialization(string projectorName) => StreamingMultiProjectorTypesSupport.Supports(this, projectorName);
 
-    public Task<ResultBox<IMultiProjectionPayload>> DeserializeFromStreamAsync(
-        string projectorName,
-        DcbDomainTypes domainTypes,
-        string safeWindowThreshold,
-        Stream source,
-        CancellationToken cancellationToken = default)
-        => _streamingRestore.DeserializeAsync(
-            projectorName,
-            domainTypes,
-            safeWindowThreshold,
-            source,
-            cancellationToken);
+    public Task<ResultBox<IMultiProjectionPayload>> DeserializeFromStreamAsync(string projectorName, DcbDomainTypes domainTypes, string safeWindowThreshold, Stream source, CancellationToken cancellationToken = default) => StreamingMultiProjectorTypesSupport.DeserializeAsync(this, projectorName, domainTypes, safeWindowThreshold, source, cancellationToken);
 }

--- a/dcb/src/Sekiban.Dcb.Core/MultiProjections/DualStateProjectionWrapperFactory.cs
+++ b/dcb/src/Sekiban.Dcb.Core/MultiProjections/DualStateProjectionWrapperFactory.cs
@@ -64,6 +64,48 @@ public static class DualStateProjectionWrapperFactory
             culture: null) as IMultiProjectionPayload;
     }
 
+    /// <summary>
+    ///     Creates the restored dual-state wrapper from independently deserialized safe and unsafe payload instances.
+    ///     The streaming restore seam uses this overload after teeing the original payload stream to a temporary file and
+    ///     deserializing it a second time, avoiding the legacy serialize-to-byte[] clone in
+    ///     <see cref="CreateFromRestoredSnapshot(IMultiProjectionPayload,string,ICoreMultiProjectorTypes,DcbDomainTypes,string,int,Guid,string?)" />.
+    /// </summary>
+    internal static IMultiProjectionPayload? CreateFromRestoredSnapshot(
+        IMultiProjectionPayload safePayload,
+        IMultiProjectionPayload unsafePayload,
+        string projectorName,
+        ICoreMultiProjectorTypes multiProjectorTypes,
+        DcbDomainTypes domainTypes,
+        string safeWindowThreshold,
+        int initialVersion = 0,
+        Guid initialLastEventId = default,
+        string? initialLastSortableUniqueId = null)
+    {
+        if (safePayload.GetType() != unsafePayload.GetType())
+        {
+            throw new InvalidOperationException(
+                $"Streaming restore clone type mismatch for projector '{projectorName}'.");
+        }
+
+        var wrapperType = typeof(DualStateProjectionWrapper<>).MakeGenericType(safePayload.GetType());
+        return Activator.CreateInstance(
+            wrapperType,
+            BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
+            binder: null,
+            args:
+            [
+                safePayload,
+                unsafePayload,
+                projectorName,
+                multiProjectorTypes,
+                domainTypes.JsonSerializerOptions,
+                initialVersion,
+                initialLastEventId,
+                initialLastSortableUniqueId
+            ],
+            culture: null) as IMultiProjectionPayload;
+    }
+
     private static IMultiProjectionPayload? CreateCore(
         IMultiProjectionPayload payload,
         string projectorName,

--- a/dcb/src/Sekiban.Dcb.Core/MultiProjections/MultiProjectionStateBuilder.cs
+++ b/dcb/src/Sekiban.Dcb.Core/MultiProjections/MultiProjectionStateBuilder.cs
@@ -126,8 +126,8 @@ public class MultiProjectionStateBuilder
             string? startPosition = null;
             if (currentState != null)
             {
-                var envelope = await LoadEnvelopeAsync(currentState, ct);
-                await actor.SetSnapshotAsync(envelope, ct);
+                await using var resolvedSnapshot = await LoadRestoreAsync(currentState, ct);
+                await actor.SetResolvedSnapshotAsync(resolvedSnapshot, ct);
                 startPosition = currentState.LastSortableUniqueId;
                 _logger.LogDebug("  Restored from position: {StartPosition}", startPosition);
             }
@@ -398,7 +398,7 @@ public class MultiProjectionStateBuilder
     ///     Load envelope from saved record.
     ///     Supports both v10 (no outer Gzip) and v9 (with outer Gzip) formats.
     /// </summary>
-    private async Task<SerializableMultiProjectionStateEnvelope> LoadEnvelopeAsync(
+    private async Task<ResolvedSnapshotRestore> LoadRestoreAsync(
         MultiProjectionStateRecord record,
         CancellationToken ct)
     {
@@ -426,7 +426,7 @@ public class MultiProjectionStateBuilder
             throw new InvalidOperationException("Failed to deserialize Envelope JSON");
         }
 
-        return await SnapshotEnvelopeResolver.ResolveInlineAsync(envelope, _blobAccessor, ct);
+        return await SnapshotEnvelopeResolver.ResolveForRestoreAsync(envelope, _blobAccessor, ct);
     }
 
     // SEK-G20: the CLI/offline build persists through the sole checkpoint-mutation coordinator (generation/tombstone CAS

--- a/dcb/src/Sekiban.Dcb.Core/Snapshots/ResolvedSnapshotRestore.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Snapshots/ResolvedSnapshotRestore.cs
@@ -1,0 +1,41 @@
+using Sekiban.Dcb.MultiProjections;
+
+namespace Sekiban.Dcb.Snapshots;
+
+/// <summary>
+///     Runtime-only snapshot restore input. Offloaded payloads retain their opened stream through the resolver-to-actor
+///     seam instead of being re-encoded into an inline envelope.
+/// </summary>
+/// <remarks>
+///     This object owns an offloaded payload stream when present. The code that obtains it from
+///     <see cref="SnapshotEnvelopeResolver.ResolveForRestoreAsync" /> is responsible for disposing this input after the
+///     actor has completed. The actor and projector registry deliberately do not dispose the stream.
+/// </remarks>
+public sealed class ResolvedSnapshotRestore : IAsyncDisposable, IDisposable
+{
+    internal ResolvedSnapshotRestore(
+        SerializableMultiProjectionState state,
+        Stream? payloadStream,
+        bool isOffloaded)
+    {
+        State = state;
+        PayloadStream = payloadStream;
+        IsOffloaded = isOffloaded;
+    }
+
+    /// <summary>Snapshot tracking metadata and, for inline snapshots, the inline payload.</summary>
+    public SerializableMultiProjectionState State { get; }
+
+    /// <summary>
+    ///     Opened offloaded payload stream, or <see langword="null" /> for an inline envelope. It may be non-seekable
+    ///     and is positioned at the payload's current read position.
+    /// </summary>
+    public Stream? PayloadStream { get; }
+
+    /// <summary>Whether this restore came from an offloaded payload.</summary>
+    public bool IsOffloaded { get; }
+
+    public void Dispose() => PayloadStream?.Dispose();
+
+    public ValueTask DisposeAsync() => PayloadStream?.DisposeAsync() ?? ValueTask.CompletedTask;
+}

--- a/dcb/src/Sekiban.Dcb.Core/Snapshots/SnapshotEnvelopeResolver.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Snapshots/SnapshotEnvelopeResolver.cs
@@ -4,19 +4,35 @@ namespace Sekiban.Dcb.Snapshots;
 
 /// <summary>
 ///     Resolves a snapshot envelope into a form that can be applied by the actor.
-///     Inline snapshots are returned as-is; offloaded payload snapshots are materialized
-///     back into an inline envelope using the provided blob accessor.
+///     The restore path retains an opened offloaded payload stream so a stream-capable projector registry can deserialize
+///     it without first materializing a whole payload array.
 /// </summary>
 public static class SnapshotEnvelopeResolver
 {
-    public static async Task<SerializableMultiProjectionStateEnvelope> ResolveInlineAsync(
+    /// <summary>
+    ///     Resolves an envelope for restore. For an offloaded envelope the returned input owns an open payload stream;
+    ///     callers must dispose it after the actor restore completes. This is the production restore seam.
+    /// </summary>
+    public static async Task<ResolvedSnapshotRestore> ResolveForRestoreAsync(
         SerializableMultiProjectionStateEnvelope envelope,
         IBlobStorageSnapshotAccessor? blobAccessor,
         CancellationToken cancellationToken = default)
     {
-        if (!envelope.IsOffloaded || envelope.OffloadedState is null)
+        ArgumentNullException.ThrowIfNull(envelope);
+
+        if (!envelope.IsOffloaded)
         {
-            return envelope;
+            if (envelope.InlineState is null)
+            {
+                throw new InvalidOperationException("Inline snapshot missing InlineState.");
+            }
+
+            return new ResolvedSnapshotRestore(envelope.InlineState, payloadStream: null, isOffloaded: false);
+        }
+
+        if (envelope.OffloadedState is null)
+        {
+            throw new InvalidOperationException("Offloaded snapshot missing OffloadedState.");
         }
 
         if (blobAccessor is null)
@@ -26,10 +42,55 @@ public static class SnapshotEnvelopeResolver
         }
 
         var offloaded = envelope.OffloadedState;
-        await using var stream = await blobAccessor.OpenReadAsync(offloaded.OffloadKey, cancellationToken)
+        var stream = await blobAccessor.OpenReadAsync(offloaded.OffloadKey, cancellationToken).ConfigureAwait(false);
+        try
+        {
+            // The payload intentionally stays absent from this runtime metadata state. SetResolvedSnapshotAsync chooses
+            // the optional streaming capability or the explicit compatibility fallback, never an implicit resolver buffer.
+            var state = new SerializableMultiProjectionState(
+                payloadJson: null,
+                payloadBase64: null,
+                offloaded.MultiProjectionPayloadType,
+                offloaded.ProjectorName,
+                offloaded.ProjectorVersion,
+                offloaded.LastSortableUniqueId,
+                offloaded.LastEventId,
+                offloaded.Version,
+                offloaded.IsCatchedUp,
+                offloaded.IsSafeState,
+                offloaded.OriginalSizeBytes,
+                offloaded.CompressedSizeBytes);
+
+            return new ResolvedSnapshotRestore(state, stream, isOffloaded: true);
+        }
+        catch
+        {
+            await stream.DisposeAsync().ConfigureAwait(false);
+            throw;
+        }
+    }
+
+    /// <summary>
+    ///     Compatibility API for callers that explicitly require an inline envelope. New restore call chains must use
+    ///     <see cref="ResolveForRestoreAsync" /> so a stream-capable registry never receives a materialized payload.
+    /// </summary>
+    public static async Task<SerializableMultiProjectionStateEnvelope> ResolveInlineAsync(
+        SerializableMultiProjectionStateEnvelope envelope,
+        IBlobStorageSnapshotAccessor? blobAccessor,
+        CancellationToken cancellationToken = default)
+    {
+        if (!envelope.IsOffloaded)
+        {
+            return envelope;
+        }
+
+        await using var resolved = await ResolveForRestoreAsync(envelope, blobAccessor, cancellationToken)
             .ConfigureAwait(false);
-        var payloadBytes = await ReadPayloadBytesAsync(stream, offloaded.PayloadLength, cancellationToken)
+        var payloadBytes = await StreamReadHelper.ReadAllBytesAsync(
+                resolved.PayloadStream ?? throw new InvalidOperationException("Offloaded restore stream was not opened."),
+                cancellationToken)
             .ConfigureAwait(false);
+        var offloaded = envelope.OffloadedState!;
 
         var inlineState = SerializableMultiProjectionState.FromRuntimeBytes(
             payloadBytes,
@@ -48,45 +109,5 @@ public static class SnapshotEnvelopeResolver
             IsOffloaded: false,
             InlineState: inlineState,
             OffloadedState: null);
-    }
-
-    private static async Task<byte[]> ReadPayloadBytesAsync(
-        Stream stream,
-        long payloadLength,
-        CancellationToken cancellationToken)
-    {
-        if (payloadLength <= 0 || payloadLength > int.MaxValue)
-        {
-            return await StreamReadHelper.ReadAllBytesAsync(stream, cancellationToken).ConfigureAwait(false);
-        }
-
-        var buffer = new byte[(int)payloadLength];
-        var offset = 0;
-        while (offset < buffer.Length)
-        {
-            var read = await stream.ReadAsync(
-                buffer.AsMemory(offset, buffer.Length - offset),
-                cancellationToken).ConfigureAwait(false);
-            if (read == 0)
-            {
-                break;
-            }
-
-            offset += read;
-        }
-
-        if (offset == buffer.Length)
-        {
-            return buffer;
-        }
-
-        if (offset == 0)
-        {
-            return [];
-        }
-
-        var trimmed = new byte[offset];
-        Buffer.BlockCopy(buffer, 0, trimmed, 0, offset);
-        return trimmed;
     }
 }

--- a/dcb/src/Sekiban.Dcb.Core/Snapshots/SnapshotRestoreAggregationDiagnostics.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Snapshots/SnapshotRestoreAggregationDiagnostics.cs
@@ -1,0 +1,44 @@
+namespace Sekiban.Dcb.Snapshots;
+
+/// <summary>
+///     Internal observability for the supported streaming restore seam. It deliberately records only calls made while
+///     that seam is active, so an explicit compatibility fallback elsewhere does not make a supported restore look
+///     buffered.
+/// </summary>
+internal static class SnapshotRestoreAggregationDiagnostics
+{
+    private static readonly AsyncLocal<Scope?> CurrentScope = new();
+
+    internal static Scope BeginStreamingRestoreScope()
+    {
+        var scope = new Scope(CurrentScope.Value);
+        CurrentScope.Value = scope;
+        return scope;
+    }
+
+    /// <summary>
+    ///     Called by the production whole-payload reader. If it is reached while a stream-capable restore is active,
+    ///     the actor records it as a contract violation for that attempt.
+    /// </summary>
+    internal static void RecordWholePayloadAggregation() => CurrentScope.Value?.RecordWholePayloadAggregation();
+
+    internal sealed class Scope(Scope? previous) : IDisposable
+    {
+        private bool _disposed;
+
+        internal int WholePayloadAggregationCount { get; private set; }
+
+        internal void RecordWholePayloadAggregation() => WholePayloadAggregationCount++;
+
+        public void Dispose()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _disposed = true;
+            CurrentScope.Value = previous;
+        }
+    }
+}

--- a/dcb/src/Sekiban.Dcb.Core/Snapshots/SnapshotRestoreTeeReadStream.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Snapshots/SnapshotRestoreTeeReadStream.cs
@@ -1,0 +1,61 @@
+namespace Sekiban.Dcb.Snapshots;
+
+/// <summary>
+///     Forwards reads from a restore source while copying exactly the consumed bytes to a caller-owned destination.
+///     It is used only inside the streaming restore seam to obtain independent safe and unsafe payload instances without
+///     a full in-memory serialization clone. Disposal never closes either underlying stream.
+/// </summary>
+internal sealed class SnapshotRestoreTeeReadStream(Stream source, Stream copyDestination) : Stream
+{
+    public override bool CanRead => source.CanRead;
+    public override bool CanSeek => false;
+    public override bool CanWrite => false;
+    public override long Length => throw new NotSupportedException("Streaming restore source length is not available.");
+    public override long Position
+    {
+        get => throw new NotSupportedException("Streaming restore source position is not available.");
+        set => throw new NotSupportedException("Streaming restore source position is not available.");
+    }
+
+    public override void Flush() { }
+    public override Task FlushAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    public override int Read(byte[] buffer, int offset, int count) => Read(buffer.AsSpan(offset, count));
+
+    public override int Read(Span<byte> buffer)
+    {
+        var read = source.Read(buffer);
+        if (read > 0)
+        {
+            copyDestination.Write(buffer[..read]);
+        }
+
+        return read;
+    }
+
+    public override async ValueTask<int> ReadAsync(
+        Memory<byte> buffer,
+        CancellationToken cancellationToken = default)
+    {
+        var read = await source.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
+        if (read > 0)
+        {
+            await copyDestination.WriteAsync(buffer[..read], cancellationToken).ConfigureAwait(false);
+        }
+
+        return read;
+    }
+
+    public override long Seek(long offset, SeekOrigin origin) =>
+        throw new NotSupportedException("Streaming restore source is non-seekable.");
+    public override void SetLength(long value) => throw new NotSupportedException();
+    public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+    protected override void Dispose(bool disposing)
+    {
+        // The actor owns the temporary copy and the resolver caller owns the source. Do not dispose either here.
+        base.Dispose(disposing);
+    }
+
+    public override ValueTask DisposeAsync() => base.DisposeAsync();
+}

--- a/dcb/src/Sekiban.Dcb.Core/Snapshots/StreamReadHelper.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Snapshots/StreamReadHelper.cs
@@ -10,6 +10,10 @@ public static class StreamReadHelper
         Stream stream,
         CancellationToken cancellationToken = default)
     {
+        // The actor opens a diagnostic scope only around a capability-present streaming restore. Reaching this
+        // whole-payload helper inside that scope is a real production seam observation, not a test-supplied counter.
+        SnapshotRestoreAggregationDiagnostics.RecordWholePayloadAggregation();
+
         if (TryReadWholeMemoryStream(stream, out var memoryBytes))
         {
             return memoryBytes;

--- a/dcb/src/Sekiban.Dcb.Orleans.Core/Runtimes/NativeProjectionSnapshotHandler.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.Core/Runtimes/NativeProjectionSnapshotHandler.cs
@@ -48,12 +48,15 @@ internal class NativeProjectionSnapshotHandler
                     new InvalidOperationException("Snapshot stream deserialized to null envelope."));
             }
 
-            var resolvedEnvelope = await SnapshotEnvelopeResolver.ResolveInlineAsync(
-                envelope,
-                _blobAccessor,
-                cancellationToken);
+            await using var resolvedSnapshot = await SnapshotEnvelopeResolver.ResolveForRestoreAsync(
+                    envelope,
+                    _blobAccessor,
+                    cancellationToken)
+                .ConfigureAwait(false);
 
-            await _actor.SetSnapshotAsync(resolvedEnvelope);
+            // The resolver-owned stream stays open through the actor and optional per-projector streaming registry.
+            // Do not publish anything from the host until this await succeeds.
+            await _actor.SetResolvedSnapshotAsync(resolvedSnapshot, cancellationToken).ConfigureAwait(false);
             return ResultBox.FromValue(true);
         }
         catch (Exception ex)

--- a/dcb/src/Sekiban.Dcb.WithResult/Domains/SimpleMultiProjectorTypes.cs
+++ b/dcb/src/Sekiban.Dcb.WithResult/Domains/SimpleMultiProjectorTypes.cs
@@ -22,8 +22,7 @@ public class SimpleMultiProjectorTypes : IMultiProjectorTypes, IStreamingMultiPr
     private readonly ConcurrentDictionary<string, (
         Func<DcbDomainTypes, string, object, SerializationResult> serialize,
         Func<DcbDomainTypes, string, ReadOnlySpan<byte>, object> deserialize)> _customSerializers = new();
-    private readonly ConcurrentDictionary<string,
-        Func<DcbDomainTypes, string, Stream, CancellationToken, Task<IMultiProjectionPayload>>> _streamDeserializers = new();
+    private readonly StreamingMultiProjectorTypesSupport _streamingRestore = new();
 
     public ResultBox<IMultiProjectionPayload> Project(
         string multiProjectorName,
@@ -172,7 +171,7 @@ public class SimpleMultiProjectorTypes : IMultiProjectorTypes, IStreamingMultiPr
 
         // Register the initial payload generator
         _initialPayloadGenerators[projectorName] = () => TProjector.GenerateInitialPayload();
-        RegisterReflectionStreamDeserializer<TProjector>(projectorName);
+        _streamingRestore.RegisterReflection(projectorName, typeof(TProjector));
     }
 
     /// <summary>
@@ -232,7 +231,7 @@ public class SimpleMultiProjectorTypes : IMultiProjectorTypes, IStreamingMultiPr
 
         // Register the initial payload generator
         _initialPayloadGenerators[projectorName] = () => TProjector.GenerateInitialPayload();
-        RegisterReflectionStreamDeserializer<TProjector>(projectorName);
+        _streamingRestore.RegisterReflection(projectorName, typeof(TProjector));
     }
 
     /// <summary>
@@ -404,7 +403,7 @@ public class SimpleMultiProjectorTypes : IMultiProjectorTypes, IStreamingMultiPr
             _projectorTypes[projectorName] = typeof(T);
             _projectorVersions[projectorName] = T.MultiProjectorVersion;
             _initialPayloadGenerators[projectorName] = () => T.GenerateInitialPayload();
-            RegisterCustomStreamDeserializerIfPresent<T>(projectorName);
+            _streamingRestore.RegisterCustomOrRemove<T>(projectorName);
 
             return ResultBox.FromValue(true);
         }
@@ -453,7 +452,7 @@ public class SimpleMultiProjectorTypes : IMultiProjectorTypes, IStreamingMultiPr
             _projectorTypes[projectorName] = typeof(T);
             _projectorVersions[projectorName] = T.MultiProjectorVersion;
             _initialPayloadGenerators[projectorName] = () => T.GenerateInitialPayload();
-            RegisterCustomStreamDeserializerIfPresent<T>(projectorName);
+            _streamingRestore.RegisterCustomOrRemove<T>(projectorName);
 
             return ResultBox.FromValue(true);
         }
@@ -464,70 +463,18 @@ public class SimpleMultiProjectorTypes : IMultiProjectorTypes, IStreamingMultiPr
     }
 
     public bool SupportsStreamDeserialization(string projectorName) =>
-        _streamDeserializers.ContainsKey(projectorName);
+        _streamingRestore.Supports(projectorName);
 
-    public async Task<ResultBox<IMultiProjectionPayload>> DeserializeFromStreamAsync(
+    public Task<ResultBox<IMultiProjectionPayload>> DeserializeFromStreamAsync(
         string projectorName,
         DcbDomainTypes domainTypes,
         string safeWindowThreshold,
         Stream source,
         CancellationToken cancellationToken = default)
-    {
-        if (string.IsNullOrWhiteSpace(safeWindowThreshold))
-        {
-            return ResultBox.Error<IMultiProjectionPayload>(
-                new ArgumentException("safeWindowThreshold must be supplied"));
-        }
-
-        if (source is null)
-        {
-            return ResultBox.Error<IMultiProjectionPayload>(new ArgumentNullException(nameof(source)));
-        }
-
-        if (!_streamDeserializers.TryGetValue(projectorName, out var deserialize))
-        {
-            return ResultBox.Error<IMultiProjectionPayload>(
-                new NotSupportedException($"Projector '{projectorName}' does not support streaming deserialization."));
-        }
-
-        try
-        {
-            return ResultBox.FromValue(
-                await deserialize(domainTypes, safeWindowThreshold, source, cancellationToken).ConfigureAwait(false));
-        }
-        catch (Exception ex)
-        {
-            return ResultBox.Error<IMultiProjectionPayload>(ex);
-        }
-    }
-
-    private void RegisterReflectionStreamDeserializer<TProjector>(string projectorName)
-        where TProjector : IMultiProjector<TProjector>, new() =>
-        _streamDeserializers[projectorName] = async (domainTypes, _, source, cancellationToken) =>
-        {
-            var deserialized = await StreamSnapshotPayloadDeserializer.DeserializeJsonAsync(
-                    source,
-                    typeof(TProjector),
-                    domainTypes.JsonSerializerOptions,
-                    cancellationToken)
-                .ConfigureAwait(false);
-            return deserialized as IMultiProjectionPayload
-                ?? throw new InvalidOperationException(
-                    $"Failed to deserialize streaming payload to {typeof(TProjector).Name}.");
-        };
-
-    private void RegisterCustomStreamDeserializerIfPresent<TProjector>(string projectorName)
-        where TProjector : new()
-    {
-        if (typeof(ICoreMultiProjectorWithStreamDeserialization).IsAssignableFrom(typeof(TProjector)))
-        {
-            _streamDeserializers[projectorName] = (domainTypes, safeWindowThreshold, source, cancellationToken) =>
-                ((ICoreMultiProjectorWithStreamDeserialization)(object)new TProjector())
-                .DeserializeFromStreamAsync(domainTypes, safeWindowThreshold, source, cancellationToken);
-        }
-        else
-        {
-            _streamDeserializers.TryRemove(projectorName, out _);
-        }
-    }
+        => _streamingRestore.DeserializeAsync(
+            projectorName,
+            domainTypes,
+            safeWindowThreshold,
+            source,
+            cancellationToken);
 }

--- a/dcb/src/Sekiban.Dcb.WithResult/Domains/SimpleMultiProjectorTypes.cs
+++ b/dcb/src/Sekiban.Dcb.WithResult/Domains/SimpleMultiProjectorTypes.cs
@@ -11,7 +11,7 @@ namespace Sekiban.Dcb.Domains;
 /// <summary>
 ///     Simple in-memory registry for multi projectors.
 /// </summary>
-public class SimpleMultiProjectorTypes : IMultiProjectorTypes
+public class SimpleMultiProjectorTypes : IMultiProjectorTypes, IStreamingMultiProjectorTypes
 {
     private readonly ConcurrentDictionary<string, Func<IMultiProjectionPayload>> _initialPayloadGenerators = new();
     private readonly ConcurrentDictionary<string,
@@ -22,6 +22,8 @@ public class SimpleMultiProjectorTypes : IMultiProjectorTypes
     private readonly ConcurrentDictionary<string, (
         Func<DcbDomainTypes, string, object, SerializationResult> serialize,
         Func<DcbDomainTypes, string, ReadOnlySpan<byte>, object> deserialize)> _customSerializers = new();
+    private readonly ConcurrentDictionary<string,
+        Func<DcbDomainTypes, string, Stream, CancellationToken, Task<IMultiProjectionPayload>>> _streamDeserializers = new();
 
     public ResultBox<IMultiProjectionPayload> Project(
         string multiProjectorName,
@@ -170,6 +172,7 @@ public class SimpleMultiProjectorTypes : IMultiProjectorTypes
 
         // Register the initial payload generator
         _initialPayloadGenerators[projectorName] = () => TProjector.GenerateInitialPayload();
+        RegisterReflectionStreamDeserializer<TProjector>(projectorName);
     }
 
     /// <summary>
@@ -229,6 +232,7 @@ public class SimpleMultiProjectorTypes : IMultiProjectorTypes
 
         // Register the initial payload generator
         _initialPayloadGenerators[projectorName] = () => TProjector.GenerateInitialPayload();
+        RegisterReflectionStreamDeserializer<TProjector>(projectorName);
     }
 
     /// <summary>
@@ -400,6 +404,7 @@ public class SimpleMultiProjectorTypes : IMultiProjectorTypes
             _projectorTypes[projectorName] = typeof(T);
             _projectorVersions[projectorName] = T.MultiProjectorVersion;
             _initialPayloadGenerators[projectorName] = () => T.GenerateInitialPayload();
+            RegisterCustomStreamDeserializerIfPresent<T>(projectorName);
 
             return ResultBox.FromValue(true);
         }
@@ -448,12 +453,81 @@ public class SimpleMultiProjectorTypes : IMultiProjectorTypes
             _projectorTypes[projectorName] = typeof(T);
             _projectorVersions[projectorName] = T.MultiProjectorVersion;
             _initialPayloadGenerators[projectorName] = () => T.GenerateInitialPayload();
+            RegisterCustomStreamDeserializerIfPresent<T>(projectorName);
 
             return ResultBox.FromValue(true);
         }
         catch (Exception ex)
         {
             return ResultBox.Error<bool>(ex);
+        }
+    }
+
+    public bool SupportsStreamDeserialization(string projectorName) =>
+        _streamDeserializers.ContainsKey(projectorName);
+
+    public async Task<ResultBox<IMultiProjectionPayload>> DeserializeFromStreamAsync(
+        string projectorName,
+        DcbDomainTypes domainTypes,
+        string safeWindowThreshold,
+        Stream source,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(safeWindowThreshold))
+        {
+            return ResultBox.Error<IMultiProjectionPayload>(
+                new ArgumentException("safeWindowThreshold must be supplied"));
+        }
+
+        if (source is null)
+        {
+            return ResultBox.Error<IMultiProjectionPayload>(new ArgumentNullException(nameof(source)));
+        }
+
+        if (!_streamDeserializers.TryGetValue(projectorName, out var deserialize))
+        {
+            return ResultBox.Error<IMultiProjectionPayload>(
+                new NotSupportedException($"Projector '{projectorName}' does not support streaming deserialization."));
+        }
+
+        try
+        {
+            return ResultBox.FromValue(
+                await deserialize(domainTypes, safeWindowThreshold, source, cancellationToken).ConfigureAwait(false));
+        }
+        catch (Exception ex)
+        {
+            return ResultBox.Error<IMultiProjectionPayload>(ex);
+        }
+    }
+
+    private void RegisterReflectionStreamDeserializer<TProjector>(string projectorName)
+        where TProjector : IMultiProjector<TProjector>, new() =>
+        _streamDeserializers[projectorName] = async (domainTypes, _, source, cancellationToken) =>
+        {
+            var deserialized = await StreamSnapshotPayloadDeserializer.DeserializeJsonAsync(
+                    source,
+                    typeof(TProjector),
+                    domainTypes.JsonSerializerOptions,
+                    cancellationToken)
+                .ConfigureAwait(false);
+            return deserialized as IMultiProjectionPayload
+                ?? throw new InvalidOperationException(
+                    $"Failed to deserialize streaming payload to {typeof(TProjector).Name}.");
+        };
+
+    private void RegisterCustomStreamDeserializerIfPresent<TProjector>(string projectorName)
+        where TProjector : new()
+    {
+        if (typeof(ICoreMultiProjectorWithStreamDeserialization).IsAssignableFrom(typeof(TProjector)))
+        {
+            _streamDeserializers[projectorName] = (domainTypes, safeWindowThreshold, source, cancellationToken) =>
+                ((ICoreMultiProjectorWithStreamDeserialization)(object)new TProjector())
+                .DeserializeFromStreamAsync(domainTypes, safeWindowThreshold, source, cancellationToken);
+        }
+        else
+        {
+            _streamDeserializers.TryRemove(projectorName, out _);
         }
     }
 }

--- a/dcb/src/Sekiban.Dcb.WithResult/Domains/SimpleMultiProjectorTypes.cs
+++ b/dcb/src/Sekiban.Dcb.WithResult/Domains/SimpleMultiProjectorTypes.cs
@@ -22,7 +22,6 @@ public class SimpleMultiProjectorTypes : IMultiProjectorTypes, IStreamingMultiPr
     private readonly ConcurrentDictionary<string, (
         Func<DcbDomainTypes, string, object, SerializationResult> serialize,
         Func<DcbDomainTypes, string, ReadOnlySpan<byte>, object> deserialize)> _customSerializers = new();
-    private readonly StreamingMultiProjectorTypesSupport _streamingRestore = new();
 
     public ResultBox<IMultiProjectionPayload> Project(
         string multiProjectorName,
@@ -171,7 +170,7 @@ public class SimpleMultiProjectorTypes : IMultiProjectorTypes, IStreamingMultiPr
 
         // Register the initial payload generator
         _initialPayloadGenerators[projectorName] = () => TProjector.GenerateInitialPayload();
-        _streamingRestore.RegisterReflection(projectorName, typeof(TProjector));
+        StreamingMultiProjectorTypesSupport.RegisterReflection(this, projectorName, typeof(TProjector));
     }
 
     /// <summary>
@@ -231,7 +230,7 @@ public class SimpleMultiProjectorTypes : IMultiProjectorTypes, IStreamingMultiPr
 
         // Register the initial payload generator
         _initialPayloadGenerators[projectorName] = () => TProjector.GenerateInitialPayload();
-        _streamingRestore.RegisterReflection(projectorName, typeof(TProjector));
+        StreamingMultiProjectorTypesSupport.RegisterReflection(this, projectorName, typeof(TProjector));
     }
 
     /// <summary>
@@ -403,7 +402,7 @@ public class SimpleMultiProjectorTypes : IMultiProjectorTypes, IStreamingMultiPr
             _projectorTypes[projectorName] = typeof(T);
             _projectorVersions[projectorName] = T.MultiProjectorVersion;
             _initialPayloadGenerators[projectorName] = () => T.GenerateInitialPayload();
-            _streamingRestore.RegisterCustomOrRemove<T>(projectorName);
+            StreamingMultiProjectorTypesSupport.RegisterCustomOrRemove<T>(this, projectorName);
 
             return ResultBox.FromValue(true);
         }
@@ -452,7 +451,7 @@ public class SimpleMultiProjectorTypes : IMultiProjectorTypes, IStreamingMultiPr
             _projectorTypes[projectorName] = typeof(T);
             _projectorVersions[projectorName] = T.MultiProjectorVersion;
             _initialPayloadGenerators[projectorName] = () => T.GenerateInitialPayload();
-            _streamingRestore.RegisterCustomOrRemove<T>(projectorName);
+            StreamingMultiProjectorTypesSupport.RegisterCustomOrRemove<T>(this, projectorName);
 
             return ResultBox.FromValue(true);
         }
@@ -462,19 +461,7 @@ public class SimpleMultiProjectorTypes : IMultiProjectorTypes, IStreamingMultiPr
         }
     }
 
-    public bool SupportsStreamDeserialization(string projectorName) =>
-        _streamingRestore.Supports(projectorName);
+    public bool SupportsStreamDeserialization(string projectorName) => StreamingMultiProjectorTypesSupport.Supports(this, projectorName);
 
-    public Task<ResultBox<IMultiProjectionPayload>> DeserializeFromStreamAsync(
-        string projectorName,
-        DcbDomainTypes domainTypes,
-        string safeWindowThreshold,
-        Stream source,
-        CancellationToken cancellationToken = default)
-        => _streamingRestore.DeserializeAsync(
-            projectorName,
-            domainTypes,
-            safeWindowThreshold,
-            source,
-            cancellationToken);
+    public Task<ResultBox<IMultiProjectionPayload>> DeserializeFromStreamAsync(string projectorName, DcbDomainTypes domainTypes, string safeWindowThreshold, Stream source, CancellationToken cancellationToken = default) => StreamingMultiProjectorTypesSupport.DeserializeAsync(this, projectorName, domainTypes, safeWindowThreshold, source, cancellationToken);
 }

--- a/dcb/src/Sekiban.Dcb.WithoutResult.Model/Domains/AotWithoutResultMultiProjectorTypes.cs
+++ b/dcb/src/Sekiban.Dcb.WithoutResult.Model/Domains/AotWithoutResultMultiProjectorTypes.cs
@@ -19,7 +19,6 @@ public sealed class AotWithoutResultMultiProjectorTypes : ICoreMultiProjectorTyp
         Environment.GetEnvironmentVariable("SEKIBAN_WASM_DEBUG_BYPASS_MULTI_PROJECT") == "1";
     private static bool _debugBypassProjectSwitch;
     private readonly Dictionary<string, ProjectorRegistration> _projectors = new();
-    private readonly StreamingMultiProjectorTypesSupport _streamingRestore = new();
 
     private sealed record ProjectorRegistration(
         Func<IMultiProjectionPayload, Event, List<ITag>, DcbDomainTypes, SortableUniqueId, IMultiProjectionPayload> Project,
@@ -71,7 +70,7 @@ public sealed class AotWithoutResultMultiProjectorTypes : ICoreMultiProjectorTyp
                 return JsonSerializer.Deserialize(jsonBytes, typeInfo)
                     ?? throw new InvalidOperationException($"Failed to deserialize {typeof(TProjector).Name}");
             });
-        _streamingRestore.RegisterJsonTypeInfo(name, typeInfo);
+        StreamingMultiProjectorTypesSupport.RegisterJsonTypeInfo(this, name, typeInfo);
     }
 
     public ResultBox<IMultiProjectionPayload> Project(
@@ -160,28 +159,9 @@ public sealed class AotWithoutResultMultiProjectorTypes : ICoreMultiProjectorTyp
         return ResultBox.Error<IMultiProjectionPayload>(new Exception($"Projector not found: {projectorName}"));
     }
 
-    public bool SupportsStreamDeserialization(string projectorName) => _streamingRestore.Supports(projectorName);
+    public bool SupportsStreamDeserialization(string projectorName) => StreamingMultiProjectorTypesSupport.Supports(this, projectorName);
 
-    public Task<ResultBox<IMultiProjectionPayload>> DeserializeFromStreamAsync(
-        string projectorName,
-        DcbDomainTypes domainTypes,
-        string safeWindowThreshold,
-        Stream source,
-        CancellationToken cancellationToken = default)
-    {
-        if (!_projectors.ContainsKey(projectorName))
-        {
-            return Task.FromResult(ResultBox.Error<IMultiProjectionPayload>(
-                new Exception($"Projector not found: {projectorName}")));
-        }
-
-        return _streamingRestore.DeserializeAsync(
-            projectorName,
-            domainTypes,
-            safeWindowThreshold,
-            source,
-            cancellationToken);
-    }
+    public Task<ResultBox<IMultiProjectionPayload>> DeserializeFromStreamAsync(string projectorName, DcbDomainTypes domainTypes, string safeWindowThreshold, Stream source, CancellationToken cancellationToken = default) => StreamingMultiProjectorTypesSupport.DeserializeWithProjectorNotFoundAsync(this, projectorName, domainTypes, safeWindowThreshold, source, cancellationToken);
 
     public ResultBox<IMultiProjectionPayload> DeserializeJson(
         string projectorName,

--- a/dcb/src/Sekiban.Dcb.WithoutResult.Model/Domains/AotWithoutResultMultiProjectorTypes.cs
+++ b/dcb/src/Sekiban.Dcb.WithoutResult.Model/Domains/AotWithoutResultMultiProjectorTypes.cs
@@ -13,7 +13,7 @@ namespace Sekiban.Dcb.Domains;
 /// <summary>
 ///     AOT-compatible implementation of ICoreMultiProjectorTypes for exception-based projectors.
 /// </summary>
-public sealed class AotWithoutResultMultiProjectorTypes : ICoreMultiProjectorTypes
+public sealed class AotWithoutResultMultiProjectorTypes : ICoreMultiProjectorTypes, IStreamingMultiProjectorTypes
 {
     private static readonly bool DebugBypassProject =
         Environment.GetEnvironmentVariable("SEKIBAN_WASM_DEBUG_BYPASS_MULTI_PROJECT") == "1";
@@ -26,7 +26,8 @@ public sealed class AotWithoutResultMultiProjectorTypes : ICoreMultiProjectorTyp
         string Version,
         Func<DcbDomainTypes, string, IMultiProjectionPayload, SerializationResult> Serialize,
         Func<Stream, DcbDomainTypes, string, IMultiProjectionPayload, SerializationSizeInfo> SerializeToStream,
-        Func<DcbDomainTypes, string, byte[], IMultiProjectionPayload> Deserialize);
+        Func<DcbDomainTypes, string, byte[], IMultiProjectionPayload> Deserialize,
+        Func<Stream, DcbDomainTypes, string, CancellationToken, Task<IMultiProjectionPayload>> DeserializeFromStream);
 
     public void RegisterProjector<TProjector>(JsonTypeInfo<TProjector> typeInfo)
         where TProjector : IMultiProjector<TProjector>, new()
@@ -69,7 +70,11 @@ public sealed class AotWithoutResultMultiProjectorTypes : ICoreMultiProjectorTyp
                 byte[] jsonBytes = GzipCompression.Decompress(data);
                 return JsonSerializer.Deserialize(jsonBytes, typeInfo)
                     ?? throw new InvalidOperationException($"Failed to deserialize {typeof(TProjector).Name}");
-            });
+            },
+            DeserializeFromStream: async (source, _, _, cancellationToken) =>
+                await StreamSnapshotPayloadDeserializer.DeserializeJsonAsync(source, typeInfo, cancellationToken)
+                    .ConfigureAwait(false)
+                ?? throw new InvalidOperationException($"Failed to deserialize {typeof(TProjector).Name}"));
     }
 
     public ResultBox<IMultiProjectionPayload> Project(
@@ -156,6 +161,43 @@ public sealed class AotWithoutResultMultiProjectorTypes : ICoreMultiProjectorTyp
         }
 
         return ResultBox.Error<IMultiProjectionPayload>(new Exception($"Projector not found: {projectorName}"));
+    }
+
+    public bool SupportsStreamDeserialization(string projectorName) => _projectors.ContainsKey(projectorName);
+
+    public async Task<ResultBox<IMultiProjectionPayload>> DeserializeFromStreamAsync(
+        string projectorName,
+        DcbDomainTypes domainTypes,
+        string safeWindowThreshold,
+        Stream source,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(safeWindowThreshold))
+        {
+            return ResultBox.Error<IMultiProjectionPayload>(
+                new ArgumentException("safeWindowThreshold must be supplied"));
+        }
+
+        if (source is null)
+        {
+            return ResultBox.Error<IMultiProjectionPayload>(new ArgumentNullException(nameof(source)));
+        }
+
+        if (!_projectors.TryGetValue(projectorName, out var registration))
+        {
+            return ResultBox.Error<IMultiProjectionPayload>(new Exception($"Projector not found: {projectorName}"));
+        }
+
+        try
+        {
+            return ResultBox.FromValue(
+                await registration.DeserializeFromStream(source, domainTypes, safeWindowThreshold, cancellationToken)
+                    .ConfigureAwait(false));
+        }
+        catch (Exception ex)
+        {
+            return ResultBox.Error<IMultiProjectionPayload>(ex);
+        }
     }
 
     public ResultBox<IMultiProjectionPayload> DeserializeJson(

--- a/dcb/src/Sekiban.Dcb.WithoutResult.Model/Domains/AotWithoutResultMultiProjectorTypes.cs
+++ b/dcb/src/Sekiban.Dcb.WithoutResult.Model/Domains/AotWithoutResultMultiProjectorTypes.cs
@@ -66,7 +66,7 @@ public sealed class AotWithoutResultMultiProjectorTypes : ICoreMultiProjectorTyp
             },
             Deserialize: (_, _, data) =>
             {
-                byte[] jsonBytes = GzipCompression.Decompress(data);
+                byte[] jsonBytes = GzipCompression.DecompressIfGzip(data);
                 return JsonSerializer.Deserialize(jsonBytes, typeInfo)
                     ?? throw new InvalidOperationException($"Failed to deserialize {typeof(TProjector).Name}");
             });

--- a/dcb/src/Sekiban.Dcb.WithoutResult.Model/Domains/AotWithoutResultMultiProjectorTypes.cs
+++ b/dcb/src/Sekiban.Dcb.WithoutResult.Model/Domains/AotWithoutResultMultiProjectorTypes.cs
@@ -19,6 +19,7 @@ public sealed class AotWithoutResultMultiProjectorTypes : ICoreMultiProjectorTyp
         Environment.GetEnvironmentVariable("SEKIBAN_WASM_DEBUG_BYPASS_MULTI_PROJECT") == "1";
     private static bool _debugBypassProjectSwitch;
     private readonly Dictionary<string, ProjectorRegistration> _projectors = new();
+    private readonly StreamingMultiProjectorTypesSupport _streamingRestore = new();
 
     private sealed record ProjectorRegistration(
         Func<IMultiProjectionPayload, Event, List<ITag>, DcbDomainTypes, SortableUniqueId, IMultiProjectionPayload> Project,
@@ -26,8 +27,7 @@ public sealed class AotWithoutResultMultiProjectorTypes : ICoreMultiProjectorTyp
         string Version,
         Func<DcbDomainTypes, string, IMultiProjectionPayload, SerializationResult> Serialize,
         Func<Stream, DcbDomainTypes, string, IMultiProjectionPayload, SerializationSizeInfo> SerializeToStream,
-        Func<DcbDomainTypes, string, byte[], IMultiProjectionPayload> Deserialize,
-        Func<Stream, DcbDomainTypes, string, CancellationToken, Task<IMultiProjectionPayload>> DeserializeFromStream);
+        Func<DcbDomainTypes, string, byte[], IMultiProjectionPayload> Deserialize);
 
     public void RegisterProjector<TProjector>(JsonTypeInfo<TProjector> typeInfo)
         where TProjector : IMultiProjector<TProjector>, new()
@@ -70,11 +70,8 @@ public sealed class AotWithoutResultMultiProjectorTypes : ICoreMultiProjectorTyp
                 byte[] jsonBytes = GzipCompression.Decompress(data);
                 return JsonSerializer.Deserialize(jsonBytes, typeInfo)
                     ?? throw new InvalidOperationException($"Failed to deserialize {typeof(TProjector).Name}");
-            },
-            DeserializeFromStream: async (source, _, _, cancellationToken) =>
-                await StreamSnapshotPayloadDeserializer.DeserializeJsonAsync(source, typeInfo, cancellationToken)
-                    .ConfigureAwait(false)
-                ?? throw new InvalidOperationException($"Failed to deserialize {typeof(TProjector).Name}"));
+            });
+        _streamingRestore.RegisterJsonTypeInfo(name, typeInfo);
     }
 
     public ResultBox<IMultiProjectionPayload> Project(
@@ -163,41 +160,27 @@ public sealed class AotWithoutResultMultiProjectorTypes : ICoreMultiProjectorTyp
         return ResultBox.Error<IMultiProjectionPayload>(new Exception($"Projector not found: {projectorName}"));
     }
 
-    public bool SupportsStreamDeserialization(string projectorName) => _projectors.ContainsKey(projectorName);
+    public bool SupportsStreamDeserialization(string projectorName) => _streamingRestore.Supports(projectorName);
 
-    public async Task<ResultBox<IMultiProjectionPayload>> DeserializeFromStreamAsync(
+    public Task<ResultBox<IMultiProjectionPayload>> DeserializeFromStreamAsync(
         string projectorName,
         DcbDomainTypes domainTypes,
         string safeWindowThreshold,
         Stream source,
         CancellationToken cancellationToken = default)
     {
-        if (string.IsNullOrWhiteSpace(safeWindowThreshold))
+        if (!_projectors.ContainsKey(projectorName))
         {
-            return ResultBox.Error<IMultiProjectionPayload>(
-                new ArgumentException("safeWindowThreshold must be supplied"));
+            return Task.FromResult(ResultBox.Error<IMultiProjectionPayload>(
+                new Exception($"Projector not found: {projectorName}")));
         }
 
-        if (source is null)
-        {
-            return ResultBox.Error<IMultiProjectionPayload>(new ArgumentNullException(nameof(source)));
-        }
-
-        if (!_projectors.TryGetValue(projectorName, out var registration))
-        {
-            return ResultBox.Error<IMultiProjectionPayload>(new Exception($"Projector not found: {projectorName}"));
-        }
-
-        try
-        {
-            return ResultBox.FromValue(
-                await registration.DeserializeFromStream(source, domainTypes, safeWindowThreshold, cancellationToken)
-                    .ConfigureAwait(false));
-        }
-        catch (Exception ex)
-        {
-            return ResultBox.Error<IMultiProjectionPayload>(ex);
-        }
+        return _streamingRestore.DeserializeAsync(
+            projectorName,
+            domainTypes,
+            safeWindowThreshold,
+            source,
+            cancellationToken);
     }
 
     public ResultBox<IMultiProjectionPayload> DeserializeJson(

--- a/dcb/src/Sekiban.Dcb.WithoutResult/Domains/SimpleMultiProjectorTypes.cs
+++ b/dcb/src/Sekiban.Dcb.WithoutResult/Domains/SimpleMultiProjectorTypes.cs
@@ -22,7 +22,6 @@ public class SimpleMultiProjectorTypes : IMultiProjectorTypes, IStreamingMultiPr
     private readonly ConcurrentDictionary<string, (
         Func<DcbDomainTypes, string, object, SerializationResult> serialize,
         Func<DcbDomainTypes, string, ReadOnlySpan<byte>, object> deserialize)> _customSerializers = new();
-    private readonly StreamingMultiProjectorTypesSupport _streamingRestore = new();
 
     public ResultBox<IMultiProjectionPayload> Project(
         string multiProjectorName,
@@ -174,7 +173,7 @@ public class SimpleMultiProjectorTypes : IMultiProjectorTypes, IStreamingMultiPr
 
         // Register the initial payload generator
         _initialPayloadGenerators[projectorName] = () => TProjector.GenerateInitialPayload();
-        _streamingRestore.RegisterReflection(projectorName, typeof(TProjector));
+        StreamingMultiProjectorTypesSupport.RegisterReflection(this, projectorName, typeof(TProjector));
     }
 
     /// <summary>
@@ -341,7 +340,7 @@ public class SimpleMultiProjectorTypes : IMultiProjectorTypes, IStreamingMultiPr
             _projectorTypes[projectorName] = typeof(T);
             _projectorVersions[projectorName] = T.MultiProjectorVersion;
             _initialPayloadGenerators[projectorName] = () => T.GenerateInitialPayload();
-            _streamingRestore.RegisterCustomOrRemove<T>(projectorName);
+            StreamingMultiProjectorTypesSupport.RegisterCustomOrRemove<T>(this, projectorName);
 
             return ResultBox.FromValue(true);
         }
@@ -391,7 +390,7 @@ public class SimpleMultiProjectorTypes : IMultiProjectorTypes, IStreamingMultiPr
             _projectorTypes[projectorName] = typeof(T);
             _projectorVersions[projectorName] = T.MultiProjectorVersion;
             _initialPayloadGenerators[projectorName] = () => T.GenerateInitialPayload();
-            _streamingRestore.RegisterCustomOrRemove<T>(projectorName);
+            StreamingMultiProjectorTypesSupport.RegisterCustomOrRemove<T>(this, projectorName);
 
             return ResultBox.FromValue(true);
         }
@@ -401,19 +400,7 @@ public class SimpleMultiProjectorTypes : IMultiProjectorTypes, IStreamingMultiPr
         }
     }
 
-    public bool SupportsStreamDeserialization(string projectorName) =>
-        _streamingRestore.Supports(projectorName);
+    public bool SupportsStreamDeserialization(string projectorName) => StreamingMultiProjectorTypesSupport.Supports(this, projectorName);
 
-    public Task<ResultBox<IMultiProjectionPayload>> DeserializeFromStreamAsync(
-        string projectorName,
-        DcbDomainTypes domainTypes,
-        string safeWindowThreshold,
-        Stream source,
-        CancellationToken cancellationToken = default)
-        => _streamingRestore.DeserializeAsync(
-            projectorName,
-            domainTypes,
-            safeWindowThreshold,
-            source,
-            cancellationToken);
+    public Task<ResultBox<IMultiProjectionPayload>> DeserializeFromStreamAsync(string projectorName, DcbDomainTypes domainTypes, string safeWindowThreshold, Stream source, CancellationToken cancellationToken = default) => StreamingMultiProjectorTypesSupport.DeserializeAsync(this, projectorName, domainTypes, safeWindowThreshold, source, cancellationToken);
 }

--- a/dcb/src/Sekiban.Dcb.WithoutResult/Domains/SimpleMultiProjectorTypes.cs
+++ b/dcb/src/Sekiban.Dcb.WithoutResult/Domains/SimpleMultiProjectorTypes.cs
@@ -11,7 +11,7 @@ namespace Sekiban.Dcb.Domains;
 /// <summary>
 ///     Simple in-memory registry for multi projectors.
 /// </summary>
-public class SimpleMultiProjectorTypes : IMultiProjectorTypes
+public class SimpleMultiProjectorTypes : IMultiProjectorTypes, IStreamingMultiProjectorTypes
 {
     private readonly ConcurrentDictionary<string, Func<IMultiProjectionPayload>> _initialPayloadGenerators = new();
     private readonly ConcurrentDictionary<string,
@@ -22,6 +22,8 @@ public class SimpleMultiProjectorTypes : IMultiProjectorTypes
     private readonly ConcurrentDictionary<string, (
         Func<DcbDomainTypes, string, object, SerializationResult> serialize,
         Func<DcbDomainTypes, string, ReadOnlySpan<byte>, object> deserialize)> _customSerializers = new();
+    private readonly ConcurrentDictionary<string,
+        Func<DcbDomainTypes, string, Stream, CancellationToken, Task<IMultiProjectionPayload>>> _streamDeserializers = new();
 
     public ResultBox<IMultiProjectionPayload> Project(
         string multiProjectorName,
@@ -173,6 +175,7 @@ public class SimpleMultiProjectorTypes : IMultiProjectorTypes
 
         // Register the initial payload generator
         _initialPayloadGenerators[projectorName] = () => TProjector.GenerateInitialPayload();
+        RegisterReflectionStreamDeserializer<TProjector>(projectorName);
     }
 
     /// <summary>
@@ -339,6 +342,7 @@ public class SimpleMultiProjectorTypes : IMultiProjectorTypes
             _projectorTypes[projectorName] = typeof(T);
             _projectorVersions[projectorName] = T.MultiProjectorVersion;
             _initialPayloadGenerators[projectorName] = () => T.GenerateInitialPayload();
+            RegisterCustomStreamDeserializerIfPresent<T>(projectorName);
 
             return ResultBox.FromValue(true);
         }
@@ -388,12 +392,81 @@ public class SimpleMultiProjectorTypes : IMultiProjectorTypes
             _projectorTypes[projectorName] = typeof(T);
             _projectorVersions[projectorName] = T.MultiProjectorVersion;
             _initialPayloadGenerators[projectorName] = () => T.GenerateInitialPayload();
+            RegisterCustomStreamDeserializerIfPresent<T>(projectorName);
 
             return ResultBox.FromValue(true);
         }
         catch (Exception ex)
         {
             return ResultBox.Error<bool>(ex);
+        }
+    }
+
+    public bool SupportsStreamDeserialization(string projectorName) =>
+        _streamDeserializers.ContainsKey(projectorName);
+
+    public async Task<ResultBox<IMultiProjectionPayload>> DeserializeFromStreamAsync(
+        string projectorName,
+        DcbDomainTypes domainTypes,
+        string safeWindowThreshold,
+        Stream source,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(safeWindowThreshold))
+        {
+            return ResultBox.Error<IMultiProjectionPayload>(
+                new ArgumentException("safeWindowThreshold must be supplied"));
+        }
+
+        if (source is null)
+        {
+            return ResultBox.Error<IMultiProjectionPayload>(new ArgumentNullException(nameof(source)));
+        }
+
+        if (!_streamDeserializers.TryGetValue(projectorName, out var deserialize))
+        {
+            return ResultBox.Error<IMultiProjectionPayload>(
+                new NotSupportedException($"Projector '{projectorName}' does not support streaming deserialization."));
+        }
+
+        try
+        {
+            return ResultBox.FromValue(
+                await deserialize(domainTypes, safeWindowThreshold, source, cancellationToken).ConfigureAwait(false));
+        }
+        catch (Exception ex)
+        {
+            return ResultBox.Error<IMultiProjectionPayload>(ex);
+        }
+    }
+
+    private void RegisterReflectionStreamDeserializer<TProjector>(string projectorName)
+        where TProjector : IMultiProjector<TProjector>, new() =>
+        _streamDeserializers[projectorName] = async (domainTypes, _, source, cancellationToken) =>
+        {
+            var deserialized = await StreamSnapshotPayloadDeserializer.DeserializeJsonAsync(
+                    source,
+                    typeof(TProjector),
+                    domainTypes.JsonSerializerOptions,
+                    cancellationToken)
+                .ConfigureAwait(false);
+            return deserialized as IMultiProjectionPayload
+                ?? throw new InvalidOperationException(
+                    $"Failed to deserialize streaming payload to {typeof(TProjector).Name}.");
+        };
+
+    private void RegisterCustomStreamDeserializerIfPresent<TProjector>(string projectorName)
+        where TProjector : new()
+    {
+        if (typeof(ICoreMultiProjectorWithStreamDeserialization).IsAssignableFrom(typeof(TProjector)))
+        {
+            _streamDeserializers[projectorName] = (domainTypes, safeWindowThreshold, source, cancellationToken) =>
+                ((ICoreMultiProjectorWithStreamDeserialization)(object)new TProjector())
+                .DeserializeFromStreamAsync(domainTypes, safeWindowThreshold, source, cancellationToken);
+        }
+        else
+        {
+            _streamDeserializers.TryRemove(projectorName, out _);
         }
     }
 }

--- a/dcb/src/Sekiban.Dcb.WithoutResult/Domains/SimpleMultiProjectorTypes.cs
+++ b/dcb/src/Sekiban.Dcb.WithoutResult/Domains/SimpleMultiProjectorTypes.cs
@@ -22,8 +22,7 @@ public class SimpleMultiProjectorTypes : IMultiProjectorTypes, IStreamingMultiPr
     private readonly ConcurrentDictionary<string, (
         Func<DcbDomainTypes, string, object, SerializationResult> serialize,
         Func<DcbDomainTypes, string, ReadOnlySpan<byte>, object> deserialize)> _customSerializers = new();
-    private readonly ConcurrentDictionary<string,
-        Func<DcbDomainTypes, string, Stream, CancellationToken, Task<IMultiProjectionPayload>>> _streamDeserializers = new();
+    private readonly StreamingMultiProjectorTypesSupport _streamingRestore = new();
 
     public ResultBox<IMultiProjectionPayload> Project(
         string multiProjectorName,
@@ -175,7 +174,7 @@ public class SimpleMultiProjectorTypes : IMultiProjectorTypes, IStreamingMultiPr
 
         // Register the initial payload generator
         _initialPayloadGenerators[projectorName] = () => TProjector.GenerateInitialPayload();
-        RegisterReflectionStreamDeserializer<TProjector>(projectorName);
+        _streamingRestore.RegisterReflection(projectorName, typeof(TProjector));
     }
 
     /// <summary>
@@ -342,7 +341,7 @@ public class SimpleMultiProjectorTypes : IMultiProjectorTypes, IStreamingMultiPr
             _projectorTypes[projectorName] = typeof(T);
             _projectorVersions[projectorName] = T.MultiProjectorVersion;
             _initialPayloadGenerators[projectorName] = () => T.GenerateInitialPayload();
-            RegisterCustomStreamDeserializerIfPresent<T>(projectorName);
+            _streamingRestore.RegisterCustomOrRemove<T>(projectorName);
 
             return ResultBox.FromValue(true);
         }
@@ -392,7 +391,7 @@ public class SimpleMultiProjectorTypes : IMultiProjectorTypes, IStreamingMultiPr
             _projectorTypes[projectorName] = typeof(T);
             _projectorVersions[projectorName] = T.MultiProjectorVersion;
             _initialPayloadGenerators[projectorName] = () => T.GenerateInitialPayload();
-            RegisterCustomStreamDeserializerIfPresent<T>(projectorName);
+            _streamingRestore.RegisterCustomOrRemove<T>(projectorName);
 
             return ResultBox.FromValue(true);
         }
@@ -403,70 +402,18 @@ public class SimpleMultiProjectorTypes : IMultiProjectorTypes, IStreamingMultiPr
     }
 
     public bool SupportsStreamDeserialization(string projectorName) =>
-        _streamDeserializers.ContainsKey(projectorName);
+        _streamingRestore.Supports(projectorName);
 
-    public async Task<ResultBox<IMultiProjectionPayload>> DeserializeFromStreamAsync(
+    public Task<ResultBox<IMultiProjectionPayload>> DeserializeFromStreamAsync(
         string projectorName,
         DcbDomainTypes domainTypes,
         string safeWindowThreshold,
         Stream source,
         CancellationToken cancellationToken = default)
-    {
-        if (string.IsNullOrWhiteSpace(safeWindowThreshold))
-        {
-            return ResultBox.Error<IMultiProjectionPayload>(
-                new ArgumentException("safeWindowThreshold must be supplied"));
-        }
-
-        if (source is null)
-        {
-            return ResultBox.Error<IMultiProjectionPayload>(new ArgumentNullException(nameof(source)));
-        }
-
-        if (!_streamDeserializers.TryGetValue(projectorName, out var deserialize))
-        {
-            return ResultBox.Error<IMultiProjectionPayload>(
-                new NotSupportedException($"Projector '{projectorName}' does not support streaming deserialization."));
-        }
-
-        try
-        {
-            return ResultBox.FromValue(
-                await deserialize(domainTypes, safeWindowThreshold, source, cancellationToken).ConfigureAwait(false));
-        }
-        catch (Exception ex)
-        {
-            return ResultBox.Error<IMultiProjectionPayload>(ex);
-        }
-    }
-
-    private void RegisterReflectionStreamDeserializer<TProjector>(string projectorName)
-        where TProjector : IMultiProjector<TProjector>, new() =>
-        _streamDeserializers[projectorName] = async (domainTypes, _, source, cancellationToken) =>
-        {
-            var deserialized = await StreamSnapshotPayloadDeserializer.DeserializeJsonAsync(
-                    source,
-                    typeof(TProjector),
-                    domainTypes.JsonSerializerOptions,
-                    cancellationToken)
-                .ConfigureAwait(false);
-            return deserialized as IMultiProjectionPayload
-                ?? throw new InvalidOperationException(
-                    $"Failed to deserialize streaming payload to {typeof(TProjector).Name}.");
-        };
-
-    private void RegisterCustomStreamDeserializerIfPresent<TProjector>(string projectorName)
-        where TProjector : new()
-    {
-        if (typeof(ICoreMultiProjectorWithStreamDeserialization).IsAssignableFrom(typeof(TProjector)))
-        {
-            _streamDeserializers[projectorName] = (domainTypes, safeWindowThreshold, source, cancellationToken) =>
-                ((ICoreMultiProjectorWithStreamDeserialization)(object)new TProjector())
-                .DeserializeFromStreamAsync(domainTypes, safeWindowThreshold, source, cancellationToken);
-        }
-        else
-        {
-            _streamDeserializers.TryRemove(projectorName, out _);
-        }
-    }
+        => _streamingRestore.DeserializeAsync(
+            projectorName,
+            domainTypes,
+            safeWindowThreshold,
+            source,
+            cancellationToken);
 }

--- a/dcb/tests/Sekiban.Dcb.Orleans.Tests/StreamingSnapshotRestoreProductionPathRepairTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Orleans.Tests/StreamingSnapshotRestoreProductionPathRepairTests.cs
@@ -1,0 +1,256 @@
+using System.Reflection;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using ResultBoxes;
+using Sekiban.Dcb.Actors;
+using Sekiban.Dcb.Common;
+using Sekiban.Dcb.Domains;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.MultiProjections;
+using Sekiban.Dcb.Runtime.Native;
+using Sekiban.Dcb.Snapshots;
+using Xunit;
+
+namespace Sekiban.Dcb.Orleans.Tests;
+
+public sealed partial class StreamingSnapshotRestoreProductionPathTests
+{
+    [Fact]
+    public async Task Native_restore_open_failure_preserves_the_original_exception_and_never_selects_buffered_fallback()
+    {
+        var sourceTypes = CreateRegistry();
+        var blob = new BlockingBlobAccessor { BlockOnFirstRead = false };
+        var envelope = await CreateOffloadedEnvelopeAsync(sourceTypes, blob, "open-failure-source");
+        var expected = new IOException("injected-open-read-failure");
+        blob.OpenReadFailure = expected;
+        var targetTypes = new CountingStreamingRegistry(CreateRegistry());
+        var targetDomain = CreateDomain(targetTypes);
+        var logger = new RestoreRecordingLogger();
+        using var services = new ServiceCollection().AddSingleton<IBlobStorageSnapshotAccessor>(blob).BuildServiceProvider();
+        var host = CreateHost(targetDomain, services, logger);
+
+        var result = await RestoreFromEnvelopeAsync(host, envelope, targetDomain);
+
+        Assert.False(result.IsSuccess);
+        Assert.Same(expected, result.GetException());
+        Assert.Equal(1, blob.OpenReadCalls);
+        Assert.Equal(0, targetTypes.StreamDeserializeCalls);
+        Assert.Equal(0, targetTypes.BufferedDeserializeCalls);
+        AssertNoCapabilityAbsentFallbackLog(logger);
+    }
+
+    [Fact]
+    public async Task Native_restore_midstream_read_failure_preserves_the_original_exception_and_never_retries_buffered_fallback()
+    {
+        var sourceTypes = CreateRegistry();
+        var blob = new BlockingBlobAccessor { BlockOnFirstRead = false };
+        var envelope = await CreateOffloadedEnvelopeAsync(sourceTypes, blob, "read-failure-source");
+        var expected = new IOException("injected-mid-stream-read-failure");
+        blob.MidStreamReadFailure = expected;
+        // PrefixBufferedStream consumes the gzip marker first; fail after the stream capability has actually started.
+        blob.FailOnReadNumber = 3;
+        var targetTypes = new CountingStreamingRegistry(CreateRegistry());
+        var targetDomain = CreateDomain(targetTypes);
+        var logger = new RestoreRecordingLogger();
+        using var services = new ServiceCollection().AddSingleton<IBlobStorageSnapshotAccessor>(blob).BuildServiceProvider();
+        var host = CreateHost(targetDomain, services, logger);
+
+        var result = await RestoreFromEnvelopeAsync(host, envelope, targetDomain);
+        var stream = await blob.Opened.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.False(result.IsSuccess);
+        Assert.Same(expected, result.GetException());
+        Assert.Equal(1, blob.OpenReadCalls);
+        Assert.Equal(1, targetTypes.StreamDeserializeCalls);
+        Assert.Equal(0, targetTypes.BufferedDeserializeCalls);
+        Assert.True(stream.ReadCalls >= blob.FailOnReadNumber);
+        AssertNoCapabilityAbsentFallbackLog(logger);
+    }
+
+    [Fact]
+    public async Task Terminal_native_restore_failure_quarantines_query_catchup_apply_promotion_and_persistence_until_a_successful_recovery()
+    {
+        var sourceTypes = CreateRegistry();
+        var blob = new BlockingBlobAccessor { BlockOnFirstRead = false };
+        var envelope = await CreateOffloadedEnvelopeAsync(sourceTypes, blob, "recovered-snapshot");
+        var expected = new IOException("terminal-stream-read-failure");
+        blob.MidStreamReadFailure = expected;
+        blob.FailOnReadNumber = 3;
+        var targetTypes = new CountingStreamingRegistry(CreateRegistry());
+        var targetDomain = CreateDomain(targetTypes);
+        var logger = new RestoreRecordingLogger();
+        using var services = new ServiceCollection().AddSingleton<IBlobStorageSnapshotAccessor>(blob).BuildServiceProvider();
+        var host = CreateHost(targetDomain, services, logger);
+
+        await host.AddSerializableEventsAsync([CreateSerializableEvent("old-state")], finishedCatchUp: true);
+        var before = await host.GetStateAsync(canGetUnsafeState: true);
+        Assert.True(before.IsSuccess);
+        var rollbackBefore = CaptureHostRestoreRollbackSnapshot(host);
+
+        var restoreFailure = await RestoreFromEnvelopeAsync(host, envelope, targetDomain);
+        Assert.False(restoreFailure.IsSuccess);
+        Assert.Same(expected, restoreFailure.GetException());
+        Assert.Equal(1, targetTypes.StreamDeserializeCalls);
+        Assert.Equal(0, targetTypes.BufferedDeserializeCalls);
+        AssertNoCapabilityAbsentFallbackLog(logger);
+
+        // The production host's ordinary query and metadata query cannot expose the state that existed before failure.
+        var query = await host.GetStateAsync(canGetUnsafeState: true);
+        Assert.False(query.IsSuccess);
+        Assert.Same(expected, query.GetException());
+        var metadata = await host.GetStateMetadataAsync(includeUnsafe: true);
+        Assert.False(metadata.IsSuccess);
+        Assert.Same(expected, metadata.GetException());
+        Assert.False(await host.IsSortableUniqueIdReceivedAsync(before.GetValue().LastSortableUniqueId));
+
+        // Catch-up and normal apply are separate public invocations. Neither may mutate the quarantined actor.
+        var catchUpFailure = await Assert.ThrowsAsync<IOException>(
+            () => host.AddSerializableEventsAsync([], finishedCatchUp: true));
+        Assert.Same(expected, catchUpFailure);
+        var applyFailure = await Assert.ThrowsAsync<IOException>(
+            () => host.AddSerializableEventsAsync([CreateSerializableEvent("must-not-apply")], finishedCatchUp: false));
+        Assert.Same(expected, applyFailure);
+        var headFailure = await Assert.ThrowsAsync<IOException>(() => host.GetProjectionHeadStatusAsync());
+        Assert.Same(expected, headFailure);
+        var promotionFailure = Assert.Throws<IOException>(() => host.ForcePromoteBufferedEvents());
+        Assert.Same(expected, promotionFailure);
+        var compactionFailure = Assert.Throws<IOException>(() => host.CompactSafeHistory());
+        Assert.Same(expected, compactionFailure);
+
+        await using (var persistenceTarget = new MemoryStream())
+        {
+            var persistence = await host.WriteSnapshotForPersistenceToStreamAsync(
+                persistenceTarget,
+                canGetUnsafeState: false,
+                offloadThresholdBytes: 1,
+                CancellationToken.None);
+            Assert.False(persistence.IsSuccess);
+            Assert.Same(expected, persistence.GetException());
+            Assert.Equal(0, persistenceTarget.Length);
+        }
+
+        await using (var snapshotTarget = new MemoryStream())
+        {
+            var snapshot = await host.WriteSnapshotToStreamAsync(snapshotTarget, canGetUnsafeState: true, CancellationToken.None);
+            Assert.False(snapshot.IsSuccess);
+            Assert.Same(expected, snapshot.GetException());
+            Assert.Equal(0, snapshotTarget.Length);
+        }
+
+        AssertHostRestoreRollbackSnapshotUnchanged(host, rollbackBefore);
+
+        // Recovery itself remains allowed. A complete later restore atomically replaces state and clears the quarantine.
+        blob.MidStreamReadFailure = null;
+        blob.FailOnReadNumber = int.MaxValue;
+        var recovered = await RestoreFromEnvelopeAsync(host, envelope, targetDomain);
+        Assert.True(recovered.IsSuccess);
+        var recoveredState = await host.GetStateAsync(canGetUnsafeState: true);
+        Assert.True(recoveredState.IsSuccess);
+        Assert.Equal("recovered-snapshot", Assert.IsType<StreamingRestoreProjector>(recoveredState.GetValue().Payload).Value);
+
+        await host.AddSerializableEventsAsync([CreateSerializableEvent("after-recovery")], finishedCatchUp: true);
+        var afterApply = await host.GetStateAsync(canGetUnsafeState: true);
+        Assert.True(afterApply.IsSuccess);
+        Assert.Equal("after-recovery", Assert.IsType<StreamingRestoreProjector>(afterApply.GetValue().Payload).Value);
+
+        await using var recoveredPersistenceTarget = new MemoryStream();
+        var recoveredPersistence = await host.WriteSnapshotForPersistenceToStreamAsync(
+            recoveredPersistenceTarget,
+            canGetUnsafeState: false,
+            offloadThresholdBytes: 1,
+            CancellationToken.None);
+        Assert.True(recoveredPersistence.IsSuccess);
+        Assert.True(recoveredPersistenceTarget.Length > 0);
+    }
+
+    private static NativeProjectionActorHost CreateHost(
+        DcbDomainTypes domain,
+        IServiceProvider services,
+        ILogger logger) => new(
+        domain,
+        services,
+        new NativeMultiProjectionProjectionPrimitive(domain),
+        StreamingRestoreProjector.MultiProjectorName,
+        new GeneralMultiProjectionActorOptions { SafeWindowMs = 1000 },
+        logger);
+
+    private static async Task<ResultBox<bool>> RestoreFromEnvelopeAsync(
+        NativeProjectionActorHost host,
+        SerializableMultiProjectionStateEnvelope envelope,
+        DcbDomainTypes domain)
+    {
+        await using var stream = await SerializeEnvelopeAsync(envelope, domain.JsonSerializerOptions, gzipOuterEnvelope: false);
+        stream.Position = 0;
+        return await host.RestoreSnapshotFromStreamAsync(stream, CancellationToken.None);
+    }
+
+    private static SerializableEvent CreateSerializableEvent(string value) => new(
+        System.Text.Json.JsonSerializer.SerializeToUtf8Bytes(new StreamingRestoreAdded(value)),
+        SortableUniqueId.Generate(DateTime.UtcNow, Guid.NewGuid()),
+        Guid.NewGuid(),
+        new EventMetadata(Guid.NewGuid().ToString("N"), Guid.NewGuid().ToString("N"), "streaming-restore-test"),
+        [],
+        nameof(StreamingRestoreAdded));
+
+    private static void AssertNoCapabilityAbsentFallbackLog(RestoreRecordingLogger logger) =>
+        Assert.DoesNotContain(
+            logger.Messages,
+            message => message.Contains("capability-absent", StringComparison.Ordinal));
+
+    private static HostRestoreRollbackSnapshot CaptureHostRestoreRollbackSnapshot(NativeProjectionActorHost host)
+    {
+        var actor = GetHostActor(host);
+        return new HostRestoreRollbackSnapshot(
+            ReadActorField<object>(actor, "_singleStateAccessor"),
+            ReadActorField<Guid>(actor, "_unsafeLastEventId"),
+            ReadActorField<string>(actor, "_unsafeLastSortableUniqueId"),
+            ReadActorField<int>(actor, "_unsafeVersion"),
+            ReadActorField<bool>(actor, "_isCatchedUp"));
+    }
+
+    private static void AssertHostRestoreRollbackSnapshotUnchanged(
+        NativeProjectionActorHost host,
+        HostRestoreRollbackSnapshot before)
+    {
+        var actor = GetHostActor(host);
+        Assert.Same(before.StateAccessor, ReadActorField<object>(actor, "_singleStateAccessor"));
+        Assert.Equal(before.LastEventId, ReadActorField<Guid>(actor, "_unsafeLastEventId"));
+        Assert.Equal(before.LastSortableUniqueId, ReadActorField<string>(actor, "_unsafeLastSortableUniqueId"));
+        Assert.Equal(before.Version, ReadActorField<int>(actor, "_unsafeVersion"));
+        Assert.Equal(before.IsCatchedUp, ReadActorField<bool>(actor, "_isCatchedUp"));
+    }
+
+    private static GeneralMultiProjectionActor GetHostActor(NativeProjectionActorHost host) =>
+        (GeneralMultiProjectionActor)(typeof(NativeProjectionActorHost)
+            .GetField("_actor", BindingFlags.Instance | BindingFlags.NonPublic)
+            ?.GetValue(host)
+            ?? throw new Xunit.Sdk.XunitException("NativeProjectionActorHost._actor was not found."));
+
+    private static T ReadActorField<T>(GeneralMultiProjectionActor actor, string name) =>
+        (T)(typeof(GeneralMultiProjectionActor)
+            .GetField(name, BindingFlags.Instance | BindingFlags.NonPublic)
+            ?.GetValue(actor)
+            ?? throw new Xunit.Sdk.XunitException($"Actor field '{name}' was not found."));
+
+    private sealed record HostRestoreRollbackSnapshot(
+        object StateAccessor,
+        Guid LastEventId,
+        string LastSortableUniqueId,
+        int Version,
+        bool IsCatchedUp);
+
+    private sealed class RestoreRecordingLogger : ILogger
+    {
+        public List<string> Messages { get; } = [];
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter) => Messages.Add(formatter(state, exception));
+    }
+}

--- a/dcb/tests/Sekiban.Dcb.Orleans.Tests/StreamingSnapshotRestoreProductionPathTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Orleans.Tests/StreamingSnapshotRestoreProductionPathTests.cs
@@ -22,7 +22,7 @@ namespace Sekiban.Dcb.Orleans.Tests;
 ///     NativeProjectionSnapshotHandler.RestoreSnapshotFromStreamAsync — the same state-store activation path in the
 ///     incident trace — rather than calling a registry helper in isolation.
 /// </summary>
-public sealed class StreamingSnapshotRestoreProductionPathTests
+public sealed partial class StreamingSnapshotRestoreProductionPathTests
 {
     [Theory]
     [InlineData(false)] // v10 envelope: raw outer JSON
@@ -234,6 +234,11 @@ public sealed class StreamingSnapshotRestoreProductionPathTests
         private readonly Dictionary<string, byte[]> _payloads = new(StringComparer.Ordinal);
         private int _nextKey;
         public string ProviderName => "blocking-stream-test";
+        public int OpenReadCalls { get; private set; }
+        public bool BlockOnFirstRead { get; set; } = true;
+        public Exception? OpenReadFailure { get; set; }
+        public Exception? MidStreamReadFailure { get; set; }
+        public int FailOnReadNumber { get; set; } = int.MaxValue;
         public TaskCompletionSource<BlockingCappedNonSeekableStream> Opened { get; } =
             new(TaskCreationOptions.RunContinuationsAsynchronously);
 
@@ -248,16 +253,46 @@ public sealed class StreamingSnapshotRestoreProductionPathTests
 
         public Task<Stream> OpenReadAsync(string key, CancellationToken cancellationToken = default)
         {
-            var stream = new BlockingCappedNonSeekableStream(_payloads[key], maxReadBytes: 97);
+            OpenReadCalls++;
+            if (OpenReadFailure is not null)
+            {
+                return Task.FromException<Stream>(OpenReadFailure);
+            }
+
+            var stream = new BlockingCappedNonSeekableStream(
+                _payloads[key],
+                maxReadBytes: 97,
+                blockOnFirstRead: BlockOnFirstRead,
+                midStreamReadFailure: MidStreamReadFailure,
+                failOnReadNumber: FailOnReadNumber);
             Opened.TrySetResult(stream);
             return Task.FromResult<Stream>(stream);
         }
     }
 
-    private sealed class BlockingCappedNonSeekableStream(byte[] payload, int maxReadBytes) : Stream
+    private sealed class BlockingCappedNonSeekableStream : Stream
     {
-        private readonly MemoryStream _inner = new(payload, writable: false);
+        private readonly MemoryStream _inner;
+        private readonly int _maxReadBytes;
+        private readonly bool _blockOnFirstRead;
+        private readonly Exception? _midStreamReadFailure;
+        private readonly int _failOnReadNumber;
         private readonly TaskCompletionSource<bool> _release = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public BlockingCappedNonSeekableStream(
+            byte[] payload,
+            int maxReadBytes,
+            bool blockOnFirstRead = true,
+            Exception? midStreamReadFailure = null,
+            int failOnReadNumber = int.MaxValue)
+        {
+            _inner = new MemoryStream(payload, writable: false);
+            _maxReadBytes = maxReadBytes;
+            _blockOnFirstRead = blockOnFirstRead;
+            _midStreamReadFailure = midStreamReadFailure;
+            _failOnReadNumber = failOnReadNumber;
+        }
+
         public TaskCompletionSource<bool> FirstReadStarted { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
         public int ReadCalls { get; private set; }
         public int LengthAccesses { get; private set; }
@@ -286,15 +321,30 @@ public sealed class StreamingSnapshotRestoreProductionPathTests
             Read(buffer.AsSpan(offset, count));
         public override int Read(Span<byte> buffer)
         {
+            FirstReadStarted.TrySetResult(true);
             ReadCalls++;
-            return _inner.Read(buffer[..Math.Min(maxReadBytes, buffer.Length)]);
+            ThrowIfConfiguredReadFailure();
+            return _inner.Read(buffer[..Math.Min(_maxReadBytes, buffer.Length)]);
         }
         public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
         {
             FirstReadStarted.TrySetResult(true);
-            await _release.Task.WaitAsync(cancellationToken);
+            if (_blockOnFirstRead)
+            {
+                await _release.Task.WaitAsync(cancellationToken);
+            }
+
             ReadCalls++;
-            return await _inner.ReadAsync(buffer[..Math.Min(maxReadBytes, buffer.Length)], cancellationToken);
+            ThrowIfConfiguredReadFailure();
+            return await _inner.ReadAsync(buffer[..Math.Min(_maxReadBytes, buffer.Length)], cancellationToken);
+        }
+
+        private void ThrowIfConfiguredReadFailure()
+        {
+            if (_midStreamReadFailure is not null && ReadCalls >= _failOnReadNumber)
+            {
+                throw _midStreamReadFailure;
+            }
         }
         public override long Seek(long offset, SeekOrigin origin)
         {

--- a/dcb/tests/Sekiban.Dcb.Orleans.Tests/StreamingSnapshotRestoreProductionPathTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Orleans.Tests/StreamingSnapshotRestoreProductionPathTests.cs
@@ -1,0 +1,322 @@
+using System.Text;
+using System.Text.Json;
+using System.IO.Compression;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using ResultBoxes;
+using Sekiban.Dcb.Actors;
+using Sekiban.Dcb.Common;
+using Sekiban.Dcb.Domains;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.MultiProjections;
+using Sekiban.Dcb.Queries;
+using Sekiban.Dcb.Runtime.Native;
+using Sekiban.Dcb.Snapshots;
+using Sekiban.Dcb.Tags;
+using Xunit;
+
+namespace Sekiban.Dcb.Orleans.Tests;
+
+/// <summary>
+///     Production entry-point proof for SEK-G42. This enters through NativeProjectionActorHost, which delegates to
+///     NativeProjectionSnapshotHandler.RestoreSnapshotFromStreamAsync — the same state-store activation path in the
+///     incident trace — rather than calling a registry helper in isolation.
+/// </summary>
+public sealed class StreamingSnapshotRestoreProductionPathTests
+{
+    [Theory]
+    [InlineData(false)] // v10 envelope: raw outer JSON
+    [InlineData(true)]  // v9 envelope: outer gzip JSON
+    public async Task Native_restore_entry_keeps_offloaded_payload_streamed_and_blocks_query_apply_and_persist_until_success(
+        bool gzipOuterEnvelope)
+    {
+        var sourceTypes = CreateRegistry();
+        var blob = new BlockingBlobAccessor();
+        var envelope = await CreateOffloadedEnvelopeAsync(sourceTypes, blob, "restored-through-native-host");
+        var targetTypes = new CountingStreamingRegistry(CreateRegistry());
+        var targetDomain = CreateDomain(targetTypes);
+        using var services = new ServiceCollection()
+            .AddSingleton<IBlobStorageSnapshotAccessor>(blob)
+            .BuildServiceProvider();
+        var host = new NativeProjectionActorHost(
+            targetDomain,
+            services,
+            new NativeMultiProjectionProjectionPrimitive(targetDomain),
+            StreamingRestoreProjector.MultiProjectorName,
+            new GeneralMultiProjectionActorOptions { SafeWindowMs = 1000 },
+            NullLogger.Instance);
+
+        await using var envelopeStream = await SerializeEnvelopeAsync(envelope, targetDomain.JsonSerializerOptions, gzipOuterEnvelope);
+        envelopeStream.Position = 0;
+
+        // This call is the real activation-side OOM entry point. The blob stream forbids Length/Seek and releases only
+        // when the test says so, which exposes any query/apply/persistence attempt that would otherwise race a restore.
+        var restoreTask = host.RestoreSnapshotFromStreamAsync(envelopeStream, CancellationToken.None);
+        var payloadStream = await blob.Opened.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await payloadStream.FirstReadStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.False(restoreTask.IsCompleted);
+        var queryDuringRestore = await host.GetStateAsync(canGetUnsafeState: true);
+        Assert.False(queryDuringRestore.IsSuccess);
+        Assert.Contains("restore is still in progress", queryDuringRestore.GetException().Message, StringComparison.OrdinalIgnoreCase);
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => host.AddSerializableEventsAsync([], finishedCatchUp: true));
+
+        await using var persistenceTarget = new MemoryStream();
+        var persistDuringRestore = await host.WriteSnapshotForPersistenceToStreamAsync(
+            persistenceTarget,
+            canGetUnsafeState: false,
+            offloadThresholdBytes: 1,
+            CancellationToken.None);
+        Assert.False(persistDuringRestore.IsSuccess);
+        await Assert.ThrowsAsync<InvalidOperationException>(() => host.GetProjectionHeadStatusAsync());
+
+        // The production reflection registry owns the actual GZipStream + JsonSerializer.DeserializeAsync path; the
+        // counter wraps it only at the optional capability seam. No legacy Deserialize(byte[]) call is permitted.
+        Assert.Equal(1, targetTypes.StreamDeserializeCalls);
+        Assert.Equal(0, targetTypes.BufferedDeserializeCalls);
+        Assert.Equal(0, payloadStream.LengthAccesses);
+        Assert.Equal(0, payloadStream.SeekCalls);
+        Assert.False(payloadStream.IsDisposed);
+
+        payloadStream.Release();
+        var restoreResult = await restoreTask;
+
+        Assert.True(restoreResult.IsSuccess);
+        Assert.Equal(2, targetTypes.StreamDeserializeCalls);
+        Assert.Equal(0, targetTypes.BufferedDeserializeCalls);
+        Assert.True(payloadStream.ReadCalls > 1);
+        Assert.True(payloadStream.IsDisposed);
+        var state = await host.GetStateAsync(canGetUnsafeState: true);
+        Assert.True(state.IsSuccess);
+        Assert.Equal("restored-through-native-host", Assert.IsType<StreamingRestoreProjector>(state.GetValue().Payload).Value);
+    }
+
+    private static async Task<MemoryStream> SerializeEnvelopeAsync(
+        SerializableMultiProjectionStateEnvelope envelope,
+        JsonSerializerOptions options,
+        bool gzipOuterEnvelope)
+    {
+        var stream = new MemoryStream();
+        if (gzipOuterEnvelope)
+        {
+            await using (var gzip = new GZipStream(stream, CompressionLevel.Fastest, leaveOpen: true))
+            {
+                await JsonSerializer.SerializeAsync(gzip, envelope, options);
+            }
+        }
+        else
+        {
+            await JsonSerializer.SerializeAsync(stream, envelope, options);
+        }
+
+        return stream;
+    }
+
+    private static SimpleMultiProjectorTypes CreateRegistry()
+    {
+        var types = new SimpleMultiProjectorTypes();
+        types.RegisterProjector<StreamingRestoreProjector>();
+        return types;
+    }
+
+    private static DcbDomainTypes CreateDomain(ICoreMultiProjectorTypes types)
+    {
+        var eventTypes = new SimpleEventTypes();
+        eventTypes.RegisterEventType<StreamingRestoreAdded>(nameof(StreamingRestoreAdded));
+        return new DcbDomainTypes(
+            eventTypes,
+            new SimpleTagTypes(),
+            new SimpleTagProjectorTypes(),
+            new SimpleTagStatePayloadTypes(),
+            types,
+            new SimpleQueryTypes());
+    }
+
+    private static async Task<SerializableMultiProjectionStateEnvelope> CreateOffloadedEnvelopeAsync(
+        ICoreMultiProjectorTypes sourceTypes,
+        BlockingBlobAccessor blob,
+        string value)
+    {
+        var actor = new GeneralMultiProjectionActor(CreateDomain(sourceTypes), StreamingRestoreProjector.MultiProjectorName);
+        await actor.AddEventsAsync([CreateEvent(value)]);
+        var snapshot = await actor.BuildSnapshotEnvelopeAsync(
+            canGetUnsafeState: true,
+            blobAccessor: blob,
+            offloadThresholdBytes: 1);
+        Assert.True(snapshot.IsSuccess);
+        Assert.True(snapshot.GetValue().IsOffloaded);
+        return snapshot.GetValue();
+    }
+
+    private static Event CreateEvent(string value) => new(
+        new StreamingRestoreAdded(value),
+        SortableUniqueId.Generate(DateTime.UtcNow, Guid.NewGuid()),
+        nameof(StreamingRestoreAdded),
+        Guid.NewGuid(),
+        new EventMetadata(Guid.NewGuid().ToString("N"), Guid.NewGuid().ToString("N"), "streaming-restore-test"),
+        []);
+
+    public sealed record StreamingRestoreAdded(string Value) : IEventPayload;
+
+    public sealed record StreamingRestoreProjector(string Value) : IMultiProjector<StreamingRestoreProjector>
+    {
+        public StreamingRestoreProjector() : this(string.Empty) { }
+        public static string MultiProjectorName => "streaming-native-restore";
+        public static string MultiProjectorVersion => "1";
+        public static StreamingRestoreProjector GenerateInitialPayload() => new(string.Empty);
+
+        public static ResultBox<StreamingRestoreProjector> Project(
+            StreamingRestoreProjector payload,
+            Event ev,
+            List<ITag> tags,
+            DcbDomainTypes domainTypes,
+            SortableUniqueId safeWindowThreshold) =>
+            ev.Payload is StreamingRestoreAdded added
+                ? ResultBox.FromValue(new StreamingRestoreProjector(added.Value))
+                : ResultBox.FromValue(payload);
+    }
+
+    private sealed class CountingStreamingRegistry(ICoreMultiProjectorTypes inner) : ICoreMultiProjectorTypes, IStreamingMultiProjectorTypes
+    {
+        private readonly IStreamingMultiProjectorTypes _streaming = Assert.IsAssignableFrom<IStreamingMultiProjectorTypes>(inner);
+        public int StreamDeserializeCalls { get; private set; }
+        public int BufferedDeserializeCalls { get; private set; }
+
+        public ResultBox<IMultiProjectionPayload> Project(string multiProjectorName, IMultiProjectionPayload payload,
+            Event ev, List<ITag> tags, DcbDomainTypes domainTypes, SortableUniqueId safeWindowThreshold) =>
+            inner.Project(multiProjectorName, payload, ev, tags, domainTypes, safeWindowThreshold);
+        public ResultBox<string> GetProjectorVersion(string multiProjectorName) => inner.GetProjectorVersion(multiProjectorName);
+        public IReadOnlyList<string> GetAllProjectorNames() => inner.GetAllProjectorNames();
+        public ResultBox<Func<IMultiProjectionPayload>> GetInitialPayloadGenerator(string multiProjectorName) =>
+            inner.GetInitialPayloadGenerator(multiProjectorName);
+        public ResultBox<Type> GetProjectorType(string multiProjectorName) => inner.GetProjectorType(multiProjectorName);
+        public ResultBox<IMultiProjectionPayload> GenerateInitialPayload(string multiProjectorName) =>
+            inner.GenerateInitialPayload(multiProjectorName);
+        public ResultBox<IMultiProjectionPayload> Deserialize(byte[] data, string multiProjectorName, JsonSerializerOptions jsonOptions) =>
+            inner.Deserialize(data, multiProjectorName, jsonOptions);
+        public ResultBox<SerializationResult> Serialize(string projectorName, DcbDomainTypes domainTypes,
+            string safeWindowThreshold, IMultiProjectionPayload payload) =>
+            inner.Serialize(projectorName, domainTypes, safeWindowThreshold, payload);
+        public ResultBox<SerializationSizeInfo> SerializeToStream(string projectorName, DcbDomainTypes domainTypes,
+            string safeWindowThreshold, IMultiProjectionPayload payload, Stream destination) =>
+            inner.SerializeToStream(projectorName, domainTypes, safeWindowThreshold, payload, destination);
+        public ResultBox<IMultiProjectionPayload> Deserialize(string projectorName, DcbDomainTypes domainTypes,
+            string safeWindowThreshold, byte[] data)
+        {
+            BufferedDeserializeCalls++;
+            return inner.Deserialize(projectorName, domainTypes, safeWindowThreshold, data);
+        }
+        public ResultBox<IMultiProjectionPayload> DeserializeJson(string projectorName, string json, DcbDomainTypes domainTypes) =>
+            inner.DeserializeJson(projectorName, json, domainTypes);
+        public ResultBox<bool> RegisterProjectorWithCustomSerialization<T>()
+            where T : ICoreMultiProjectorWithCustomSerialization<T>, new() => inner.RegisterProjectorWithCustomSerialization<T>();
+        public bool SupportsStreamDeserialization(string projectorName) => _streaming.SupportsStreamDeserialization(projectorName);
+        public async Task<ResultBox<IMultiProjectionPayload>> DeserializeFromStreamAsync(
+            string projectorName,
+            DcbDomainTypes domainTypes,
+            string safeWindowThreshold,
+            Stream source,
+            CancellationToken cancellationToken = default)
+        {
+            StreamDeserializeCalls++;
+            return await _streaming.DeserializeFromStreamAsync(
+                projectorName,
+                domainTypes,
+                safeWindowThreshold,
+                source,
+                cancellationToken);
+        }
+    }
+
+    private sealed class BlockingBlobAccessor : IBlobStorageSnapshotAccessor
+    {
+        private readonly Dictionary<string, byte[]> _payloads = new(StringComparer.Ordinal);
+        private int _nextKey;
+        public string ProviderName => "blocking-stream-test";
+        public TaskCompletionSource<BlockingCappedNonSeekableStream> Opened { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public async Task<string> WriteAsync(Stream data, string projectorName, CancellationToken cancellationToken = default)
+        {
+            using var copy = new MemoryStream();
+            await data.CopyToAsync(copy, cancellationToken);
+            var key = $"{projectorName}/{++_nextKey}";
+            _payloads[key] = copy.ToArray();
+            return key;
+        }
+
+        public Task<Stream> OpenReadAsync(string key, CancellationToken cancellationToken = default)
+        {
+            var stream = new BlockingCappedNonSeekableStream(_payloads[key], maxReadBytes: 97);
+            Opened.TrySetResult(stream);
+            return Task.FromResult<Stream>(stream);
+        }
+    }
+
+    private sealed class BlockingCappedNonSeekableStream(byte[] payload, int maxReadBytes) : Stream
+    {
+        private readonly MemoryStream _inner = new(payload, writable: false);
+        private readonly TaskCompletionSource<bool> _release = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public TaskCompletionSource<bool> FirstReadStarted { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public int ReadCalls { get; private set; }
+        public int LengthAccesses { get; private set; }
+        public int SeekCalls { get; private set; }
+        public bool IsDisposed { get; private set; }
+
+        public void Release() => _release.TrySetResult(true);
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length
+        {
+            get
+            {
+                LengthAccesses++;
+                throw new NotSupportedException("The production offloaded restore stream has no Length.");
+            }
+        }
+        public override long Position
+        {
+            get => throw new NotSupportedException("The production offloaded restore stream has no Position.");
+            set => throw new NotSupportedException("The production offloaded restore stream has no Position.");
+        }
+        public override void Flush() { }
+        public override int Read(byte[] buffer, int offset, int count) =>
+            Read(buffer.AsSpan(offset, count));
+        public override int Read(Span<byte> buffer)
+        {
+            ReadCalls++;
+            return _inner.Read(buffer[..Math.Min(maxReadBytes, buffer.Length)]);
+        }
+        public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            FirstReadStarted.TrySetResult(true);
+            await _release.Task.WaitAsync(cancellationToken);
+            ReadCalls++;
+            return await _inner.ReadAsync(buffer[..Math.Min(maxReadBytes, buffer.Length)], cancellationToken);
+        }
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            SeekCalls++;
+            throw new NotSupportedException("The production offloaded restore stream cannot seek.");
+        }
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+        protected override void Dispose(bool disposing)
+        {
+            IsDisposed = true;
+            if (disposing)
+            {
+                _inner.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+        public override async ValueTask DisposeAsync()
+        {
+            IsDisposed = true;
+            await _inner.DisposeAsync();
+            await base.DisposeAsync();
+        }
+    }
+}

--- a/dcb/tests/Sekiban.Dcb.StreamingRestore.Legacy1018Fixture/Legacy1018ExternalRegistry.cs
+++ b/dcb/tests/Sekiban.Dcb.StreamingRestore.Legacy1018Fixture/Legacy1018ExternalRegistry.cs
@@ -1,0 +1,101 @@
+using System.Text;
+using System.Text.Json;
+using ResultBoxes;
+using Sekiban.Dcb.Common;
+using Sekiban.Dcb.Domains;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.MultiProjections;
+using Sekiban.Dcb.Tags;
+
+namespace Sekiban.Dcb.StreamingRestore.Legacy1018Fixture;
+
+/// <summary>
+///     A real separately compiled v10.18 external registry. It knows only the published
+///     <see cref="ICoreMultiProjectorTypes" /> contract and intentionally contains no reference to the newer optional
+///     streaming capability.
+/// </summary>
+public sealed class Legacy1018ExternalRegistry : ICoreMultiProjectorTypes
+{
+    public const string ProjectorName = "legacy-1018-external-registry";
+    public const string ProjectorVersion = "10.18";
+
+    public int DeserializeCalls { get; private set; }
+
+    public ResultBox<IMultiProjectionPayload> Project(
+        string multiProjectorName,
+        IMultiProjectionPayload payload,
+        Event ev,
+        List<ITag> tags,
+        DcbDomainTypes domainTypes,
+        SortableUniqueId safeWindowThreshold) => ResultBox.FromValue(payload);
+
+    public ResultBox<string> GetProjectorVersion(string multiProjectorName) =>
+        multiProjectorName == ProjectorName
+            ? ResultBox.FromValue(ProjectorVersion)
+            : ResultBox.Error<string>(new InvalidOperationException($"Unknown projector '{multiProjectorName}'."));
+
+    public IReadOnlyList<string> GetAllProjectorNames() => [ProjectorName];
+
+    public ResultBox<Func<IMultiProjectionPayload>> GetInitialPayloadGenerator(string multiProjectorName) =>
+        multiProjectorName == ProjectorName
+            ? ResultBox.FromValue<Func<IMultiProjectionPayload>>(() => new Legacy1018Payload(string.Empty))
+            : ResultBox.Error<Func<IMultiProjectionPayload>>(new InvalidOperationException("Unknown projector."));
+
+    public ResultBox<Type> GetProjectorType(string multiProjectorName) =>
+        multiProjectorName == ProjectorName
+            ? ResultBox.FromValue(typeof(Legacy1018Payload))
+            : ResultBox.Error<Type>(new InvalidOperationException("Unknown projector."));
+
+    public ResultBox<IMultiProjectionPayload> GenerateInitialPayload(string multiProjectorName) =>
+        multiProjectorName == ProjectorName
+            ? ResultBox.FromValue<IMultiProjectionPayload>(new Legacy1018Payload(string.Empty))
+            : ResultBox.Error<IMultiProjectionPayload>(new InvalidOperationException("Unknown projector."));
+
+    public ResultBox<IMultiProjectionPayload> Deserialize(
+        byte[] data,
+        string multiProjectorName,
+        JsonSerializerOptions jsonOptions) => DeserializeCore(multiProjectorName, data);
+
+    public ResultBox<IMultiProjectionPayload> Deserialize(
+        string projectorName,
+        DcbDomainTypes domainTypes,
+        string safeWindowThreshold,
+        byte[] data) => DeserializeCore(projectorName, data);
+
+    public ResultBox<IMultiProjectionPayload> DeserializeJson(
+        string projectorName,
+        string json,
+        DcbDomainTypes domainTypes) => DeserializeCore(projectorName, Encoding.UTF8.GetBytes(json));
+
+    public ResultBox<SerializationResult> Serialize(
+        string projectorName,
+        DcbDomainTypes domainTypes,
+        string safeWindowThreshold,
+        IMultiProjectionPayload payload)
+    {
+        if (projectorName != ProjectorName || payload is not Legacy1018Payload typed)
+        {
+            return ResultBox.Error<SerializationResult>(new InvalidOperationException("Unexpected legacy payload."));
+        }
+
+        var bytes = Encoding.UTF8.GetBytes(typed.Value);
+        return ResultBox.FromValue(new SerializationResult(bytes, bytes.Length, bytes.Length));
+    }
+
+    public ResultBox<bool> RegisterProjectorWithCustomSerialization<T>()
+        where T : ICoreMultiProjectorWithCustomSerialization<T>, new() =>
+        ResultBox.Error<bool>(new NotSupportedException("The frozen 10.18 fixture has no custom registrations."));
+
+    private ResultBox<IMultiProjectionPayload> DeserializeCore(string projectorName, byte[] data)
+    {
+        if (projectorName != ProjectorName)
+        {
+            return ResultBox.Error<IMultiProjectionPayload>(new InvalidOperationException("Unknown projector."));
+        }
+
+        DeserializeCalls++;
+        return ResultBox.FromValue<IMultiProjectionPayload>(new Legacy1018Payload(Encoding.UTF8.GetString(data)));
+    }
+}
+
+public sealed record Legacy1018Payload(string Value) : IMultiProjectionPayload;

--- a/dcb/tests/Sekiban.Dcb.StreamingRestore.Legacy1018Fixture/Sekiban.Dcb.StreamingRestore.Legacy1018Fixture.csproj
+++ b/dcb/tests/Sekiban.Dcb.StreamingRestore.Legacy1018Fixture/Sekiban.Dcb.StreamingRestore.Legacy1018Fixture.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <!--
+      This assembly is deliberately compiled against the published 10.18 packages, not this repository's project
+      references. It is the binary-compatibility fixture for the additive streaming-restore capability: an external
+      ICoreMultiProjectorTypes implementor from 10.18 must still load and be invoked by the current runtime.
+    -->
+    <PropertyGroup>
+        <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+        <LangVersion>preview</LangVersion>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+        <GenerateSBOM>false</GenerateSBOM>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Sekiban.Dcb.Core" Version="10.18.0" />
+        <PackageReference Include="Sekiban.Dcb.Core.Model" Version="10.18.0" />
+        <PackageReference Include="ResultBoxes" Version="0.4.0" />
+    </ItemGroup>
+
+</Project>

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/GeneralMultiProjectionActorCatchingUpTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/GeneralMultiProjectionActorCatchingUpTests.cs
@@ -263,20 +263,7 @@ public class GeneralMultiProjectionActorCatchingUpTests
         Assert.True(snapshotResult.IsSuccess);
         var snapshot = snapshotResult.GetValue();
 
-        // Make projector version intentionally mismatch
-        // Modify inline state's ProjectorVersion
-        var inline = snapshot.InlineState!;
-        var mismatchedInline = Sekiban.Dcb.MultiProjections.SerializableMultiProjectionState.FromBytes(
-            inline.GetPayloadBytes(),
-            inline.MultiProjectionPayloadType,
-            inline.ProjectorName,
-            "9.9.9",
-            inline.LastSortableUniqueId,
-            inline.LastEventId,
-            inline.Version,
-            inline.IsCatchedUp,
-            inline.IsSafeState);
-        var mismatchedSnapshot = new Sekiban.Dcb.Snapshots.SerializableMultiProjectionStateEnvelope(false, mismatchedInline, null);
+        var mismatchedSnapshot = WithMismatchedProjectorVersion(snapshot);
 
         var restoredActor = new GeneralMultiProjectionActor(
             _domainTypes,
@@ -287,12 +274,42 @@ public class GeneralMultiProjectionActorCatchingUpTests
         await Assert.ThrowsAsync<InvalidOperationException>(async () =>
             await restoredActor.SetSnapshotAsync(mismatchedSnapshot));
 
-        // And the actor should remain at its initial state (no items)
+        // A first restore failure has no published checkpoint to quarantine, so the actor retains the legacy
+        // initial-state/rebuild contract rather than latching a failure that would prevent catch-up.
         var stateAfterFailedRestore = await restoredActor.GetStateAsync(canGetUnsafeState: false);
         Assert.True(stateAfterFailedRestore.IsSuccess);
         var payload = stateAfterFailedRestore.GetValue().Payload as TestMultiProjector;
         Assert.NotNull(payload);
         Assert.Empty(payload!.Items);
+    }
+
+    [Fact]
+    public async Task SetCurrentState_VersionMismatch_AfterPublishedState_Quarantines_PreviousCheckpoint_UntilRecovery()
+    {
+        var actor = new GeneralMultiProjectionActor(_domainTypes, TestMultiProjector.MultiProjectorName, _options);
+        await actor.AddEventsAsync([CreateEvent(new TestEventCreated("published"), DateTime.UtcNow.AddSeconds(-10))]);
+        var snapshotResult = await actor.GetSnapshotAsync(canGetUnsafeState: false);
+        Assert.True(snapshotResult.IsSuccess);
+        var snapshot = snapshotResult.GetValue();
+
+        var mismatch = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => actor.SetSnapshotAsync(WithMismatchedProjectorVersion(snapshot)));
+
+        // This kills an unconditional legacy-recovery implementation: a replacement failure must never make a
+        // previously published payload usable, and it must retain the original exception instance at all boundaries.
+        var stateAfterMismatch = await actor.GetStateAsync(canGetUnsafeState: false);
+        Assert.False(stateAfterMismatch.IsSuccess);
+        Assert.Same(mismatch, stateAfterMismatch.GetException());
+        var applyFailure = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => actor.AddEventsAsync([CreateEvent(new TestEventCreated("must-not-apply"), DateTime.UtcNow)]));
+        Assert.Same(mismatch, applyFailure);
+
+        // A successful replacement restore is the explicit recovery boundary and clears the quarantine atomically.
+        await actor.SetSnapshotAsync(snapshot);
+        var recovered = await actor.GetStateAsync(canGetUnsafeState: false);
+        Assert.True(recovered.IsSuccess);
+        var payload = Assert.IsType<TestMultiProjector>(recovered.GetValue().Payload);
+        Assert.Equal(["published"], payload.Items);
     }
 
     [Fact]
@@ -446,6 +463,23 @@ public class GeneralMultiProjectionActorCatchingUpTests
 
         var payload = finalState.GetValue().Payload as TestMultiProjector;
         Assert.Equal(4, payload!.Items.Count);
+    }
+
+    private static Sekiban.Dcb.Snapshots.SerializableMultiProjectionStateEnvelope WithMismatchedProjectorVersion(
+        Sekiban.Dcb.Snapshots.SerializableMultiProjectionStateEnvelope snapshot)
+    {
+        var inline = Assert.IsType<SerializableMultiProjectionState>(snapshot.InlineState);
+        var mismatchedInline = SerializableMultiProjectionState.FromBytes(
+            inline.GetPayloadBytes(),
+            inline.MultiProjectionPayloadType,
+            inline.ProjectorName,
+            "9.9.9",
+            inline.LastSortableUniqueId,
+            inline.LastEventId,
+            inline.Version,
+            inline.IsCatchedUp,
+            inline.IsSafeState);
+        return new Sekiban.Dcb.Snapshots.SerializableMultiProjectionStateEnvelope(false, mismatchedInline, null);
     }
 
     private Event CreateEvent(IEventPayload payload, DateTime timestamp)

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/Sekiban.Dcb.WithResult.Tests.csproj
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/Sekiban.Dcb.WithResult.Tests.csproj
@@ -40,7 +40,17 @@
         <ProjectReference Include="..\..\src\Sekiban.Dcb.Core.Testing\Sekiban.Dcb.Core.Testing.csproj" />
         <ProjectReference Include="..\..\src\Sekiban.Dcb.WithResult.Testing\Sekiban.Dcb.WithResult.Testing.csproj" />
         <ProjectReference Include="..\Sekiban.Dcb.LegacyConsumerFixture\Sekiban.Dcb.LegacyConsumerFixture.csproj" />
+        <!-- Build the genuinely separate v10.18 package fixture but do not let its old package references participate
+             in this test project's compile-time dependency resolution. The test loads its produced DLL by reflection. -->
+        <ProjectReference Include="..\Sekiban.Dcb.StreamingRestore.Legacy1018Fixture\Sekiban.Dcb.StreamingRestore.Legacy1018Fixture.csproj"
+                          ReferenceOutputAssembly="false" />
     </ItemGroup>
+
+    <Target Name="CopyStreamingRestoreLegacy1018Fixture" AfterTargets="Build">
+        <Copy SourceFiles="$(MSBuildProjectDirectory)/../Sekiban.Dcb.StreamingRestore.Legacy1018Fixture/bin/$(Configuration)/$(TargetFramework)/Sekiban.Dcb.StreamingRestore.Legacy1018Fixture.dll"
+              DestinationFolder="$(OutputPath)"
+              SkipUnchangedFiles="true" />
+    </Target>
 
     <ItemGroup>
         <!-- SEK-G17: frozen dcb-v10.1.17 wire artifacts. Embedded verbatim so tests read the exact committed bytes as the

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/Sekiban.Dcb.WithResult.Tests.csproj
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/Sekiban.Dcb.WithResult.Tests.csproj
@@ -47,7 +47,8 @@
     </ItemGroup>
 
     <Target Name="BuildStreamingRestoreLegacy1018FixtureForCurrentTarget"
-            BeforeTargets="CopyStreamingRestoreLegacy1018Fixture">
+            BeforeTargets="CopyStreamingRestoreLegacy1018Fixture"
+            Condition="'$(TargetFramework)' != ''">
         <!-- ReferenceOutputAssembly=false intentionally prevents the fixture's old package graph from flowing into
              this test project. Build it explicitly with the parent's inner-build TFM and configuration before copying
              it, because a normal non-reference ProjectReference is otherwise built as Debug by the solution graph. -->
@@ -56,7 +57,9 @@
                  Properties="Configuration=$(Configuration);TargetFramework=$(TargetFramework)" />
     </Target>
 
-    <Target Name="CopyStreamingRestoreLegacy1018Fixture" AfterTargets="Build">
+    <Target Name="CopyStreamingRestoreLegacy1018Fixture"
+            AfterTargets="Build"
+            Condition="'$(TargetFramework)' != ''">
         <Copy SourceFiles="$(MSBuildProjectDirectory)/../Sekiban.Dcb.StreamingRestore.Legacy1018Fixture/bin/$(Configuration)/$(TargetFramework)/Sekiban.Dcb.StreamingRestore.Legacy1018Fixture.dll"
               DestinationFolder="$(OutputPath)"
               SkipUnchangedFiles="true" />

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/Sekiban.Dcb.WithResult.Tests.csproj
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/Sekiban.Dcb.WithResult.Tests.csproj
@@ -46,6 +46,16 @@
                           ReferenceOutputAssembly="false" />
     </ItemGroup>
 
+    <Target Name="BuildStreamingRestoreLegacy1018FixtureForCurrentTarget"
+            BeforeTargets="CopyStreamingRestoreLegacy1018Fixture">
+        <!-- ReferenceOutputAssembly=false intentionally prevents the fixture's old package graph from flowing into
+             this test project. Build it explicitly with the parent's inner-build TFM and configuration before copying
+             it, because a normal non-reference ProjectReference is otherwise built as Debug by the solution graph. -->
+        <MSBuild Projects="$(MSBuildProjectDirectory)/../Sekiban.Dcb.StreamingRestore.Legacy1018Fixture/Sekiban.Dcb.StreamingRestore.Legacy1018Fixture.csproj"
+                 Targets="Build"
+                 Properties="Configuration=$(Configuration);TargetFramework=$(TargetFramework)" />
+    </Target>
+
     <Target Name="CopyStreamingRestoreLegacy1018Fixture" AfterTargets="Build">
         <Copy SourceFiles="$(MSBuildProjectDirectory)/../Sekiban.Dcb.StreamingRestore.Legacy1018Fixture/bin/$(Configuration)/$(TargetFramework)/Sekiban.Dcb.StreamingRestore.Legacy1018Fixture.dll"
               DestinationFolder="$(OutputPath)"

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/StreamingSnapshotRestoreReviewRepairTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/StreamingSnapshotRestoreReviewRepairTests.cs
@@ -1,0 +1,828 @@
+using System.Collections.Concurrent;
+using System.IO.Compression;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
+using ResultBoxes;
+using Sekiban.Dcb.Actors;
+using Sekiban.Dcb.Common;
+using Sekiban.Dcb.Domains;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.MultiProjections;
+using Sekiban.Dcb.Snapshots;
+using Sekiban.Dcb.Tags;
+
+namespace Sekiban.Dcb.Tests;
+
+public sealed partial class StreamingSnapshotRestoreTests
+{
+    // v9 carries JSON text, so gzip bytes cannot be represented in its PayloadJson field. Every representable route is
+    // enumerated here instead of sampling separate one-off examples: 3 registries x (raw v9, raw v10, gzip v10) x
+    // (offloaded stream guarantee, inline byte compatibility fallback).
+    public static IEnumerable<object[]> StreamingRestoreEquivalenceMatrix()
+    {
+        foreach (var registry in Enum.GetValues<MatrixRegistryKind>())
+        {
+            foreach (var delivery in Enum.GetValues<MatrixDelivery>())
+            {
+                yield return [new MatrixCell(registry, MatrixPayloadFormat.RawLegacyJson, MatrixWireVersion.V9, delivery)];
+                yield return [new MatrixCell(registry, MatrixPayloadFormat.RawLegacyJson, MatrixWireVersion.V10, delivery)];
+                yield return [new MatrixCell(registry, MatrixPayloadFormat.GzipJson, MatrixWireVersion.V10, delivery)];
+            }
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(StreamingRestoreEquivalenceMatrix))]
+    public async Task Stream_and_legacy_restore_paths_keep_payload_safe_threshold_and_tracking_metadata_equivalent(
+        MatrixCell cell)
+    {
+        const int expectedVersion = 701;
+        var expectedLastEventId = Guid.Parse("71b3e3a3-29a3-4935-ae64-2ac07b06d582");
+        var expectedLastSortableUniqueId = SortableUniqueId.Generate(
+            new DateTime(2024, 3, 1, 0, 0, 0, DateTimeKind.Utc),
+            Guid.Parse("e266a43d-b220-414b-8da2-6cb9c7d4009a"));
+        var expectedValue = $"matrix-{cell.Registry}-{cell.PayloadFormat}-{cell.WireVersion}-{cell.Delivery}";
+
+        var byteSetup = CreateMatrixRegistry(cell.Registry);
+        var byteDomain = CreateDomain(byteSetup.Registry);
+        var payloadBytes = CreateMatrixPayloadBytes(cell, byteDomain, expectedValue);
+        var legacyState = CreateMatrixState(
+            cell,
+            payloadBytes,
+            byteSetup.ProjectorName,
+            byteSetup.PayloadType,
+            expectedLastSortableUniqueId,
+            expectedLastEventId,
+            expectedVersion);
+        var legacyActor = new GeneralMultiProjectionActor(CreateDomain(byteSetup.Registry), byteSetup.ProjectorName);
+
+        MatrixCustomPayloadProjector.ResetRecordedSafeThresholds();
+        var legacyThresholdWindow = await RestoreInlineAndCaptureThresholdWindowAsync(
+            legacyActor,
+            legacyState);
+        var legacy = await legacyActor.GetStateAsync(canGetUnsafeState: true);
+        Assert.True(legacy.IsSuccess);
+        AssertRecordedThresholdsWithinWindow(
+            byteSetup.BufferedSafeThresholds,
+            legacyThresholdWindow,
+            "legacy byte path");
+        AssertCustomThresholdsWithinWindow(cell.Registry, legacyThresholdWindow, "legacy byte path");
+
+        var restoreSetup = CreateMatrixRegistry(cell.Registry);
+        var restoreActor = new GeneralMultiProjectionActor(CreateDomain(restoreSetup.Registry), restoreSetup.ProjectorName);
+        MatrixCustomPayloadProjector.ResetRecordedSafeThresholds();
+        ThresholdWindow restoreThresholdWindow;
+
+        if (cell.Delivery == MatrixDelivery.Offloaded)
+        {
+            var blob = new CappedBlobAccessor();
+            var key = await blob.WriteAsync(new MemoryStream(payloadBytes, writable: false), restoreSetup.ProjectorName);
+            var envelope = new SerializableMultiProjectionStateEnvelope(
+                IsOffloaded: true,
+                InlineState: null,
+                OffloadedState: new SerializableMultiProjectionStateOffloaded(
+                    key,
+                    blob.ProviderName,
+                    restoreSetup.PayloadType,
+                    restoreSetup.ProjectorName,
+                    MatrixProjectorVersion,
+                    expectedLastSortableUniqueId,
+                    expectedLastEventId,
+                    expectedVersion,
+                    IsCatchedUp: false,
+                    IsSafeState: true,
+                    PayloadLength: payloadBytes.Length,
+                    OriginalSizeBytes: payloadBytes.Length,
+                    CompressedSizeBytes: payloadBytes.Length));
+
+            await using var resolved = await SnapshotEnvelopeResolver.ResolveForRestoreAsync(envelope, blob);
+            restoreThresholdWindow = await RestoreStreamAndCaptureThresholdWindowAsync(restoreActor, resolved);
+            Assert.Equal(2, restoreSetup.StreamDeserializeCalls);
+            Assert.Empty(restoreSetup.BufferedSafeThresholds);
+            AssertRecordedThresholdsWithinWindow(
+                restoreSetup.StreamSafeThresholds,
+                restoreThresholdWindow,
+                "offloaded stream path");
+        }
+        else
+        {
+            restoreThresholdWindow = await RestoreInlineAndCaptureThresholdWindowAsync(restoreActor, legacyState);
+            Assert.Equal(0, restoreSetup.StreamDeserializeCalls);
+            AssertRecordedThresholdsWithinWindow(
+                restoreSetup.BufferedSafeThresholds,
+                restoreThresholdWindow,
+                "inline compatibility path");
+        }
+
+        AssertCustomThresholdsWithinWindow(
+            cell.Registry,
+            restoreThresholdWindow,
+            cell.Delivery == MatrixDelivery.Offloaded ? "offloaded stream path" : "inline compatibility path");
+
+        var restored = await restoreActor.GetStateAsync(canGetUnsafeState: true);
+        Assert.True(restored.IsSuccess);
+        Assert.Equal(expectedValue, GetMatrixPayloadValue(restored.GetValue().Payload));
+        Assert.Equal(GetMatrixPayloadValue(legacy.GetValue().Payload), GetMatrixPayloadValue(restored.GetValue().Payload));
+        Assert.Equal(legacy.GetValue().Version, restored.GetValue().Version);
+        Assert.Equal(expectedVersion, restored.GetValue().Version);
+        Assert.Equal(legacy.GetValue().LastEventId, restored.GetValue().LastEventId);
+        Assert.Equal(expectedLastEventId, restored.GetValue().LastEventId);
+        Assert.Equal(legacy.GetValue().LastSortableUniqueId, restored.GetValue().LastSortableUniqueId);
+        Assert.Equal(expectedLastSortableUniqueId, restored.GetValue().LastSortableUniqueId);
+        Assert.Equal(legacy.GetValue().IsCatchedUp, restored.GetValue().IsCatchedUp);
+        Assert.False(restored.GetValue().IsCatchedUp);
+        Assert.Equal(legacy.GetValue().IsSafeState, restored.GetValue().IsSafeState);
+    }
+
+    [Fact]
+    public void Equivalence_matrix_explicitly_covers_every_representable_registry_format_version_and_delivery_cell()
+    {
+        var cells = StreamingRestoreEquivalenceMatrix().Select(row => Assert.IsType<MatrixCell>(row[0])).ToArray();
+        Assert.Equal(18, cells.Length);
+
+        foreach (var registry in Enum.GetValues<MatrixRegistryKind>())
+        {
+            foreach (var delivery in Enum.GetValues<MatrixDelivery>())
+            {
+                Assert.Contains(cells, cell => cell == new MatrixCell(
+                    registry,
+                    MatrixPayloadFormat.RawLegacyJson,
+                    MatrixWireVersion.V9,
+                    delivery));
+                Assert.Contains(cells, cell => cell == new MatrixCell(
+                    registry,
+                    MatrixPayloadFormat.RawLegacyJson,
+                    MatrixWireVersion.V10,
+                    delivery));
+                Assert.Contains(cells, cell => cell == new MatrixCell(
+                    registry,
+                    MatrixPayloadFormat.GzipJson,
+                    MatrixWireVersion.V10,
+                    delivery));
+            }
+        }
+
+        Assert.DoesNotContain(cells, cell =>
+            cell.PayloadFormat == MatrixPayloadFormat.GzipJson && cell.WireVersion == MatrixWireVersion.V9);
+    }
+
+    [Fact]
+    public void Supported_stream_restore_state_machines_have_no_whole_payload_aggregation_api_reference()
+    {
+        // This is a production structural pin, not read-size telemetry. It kills a mutation that replaces the file tee
+        // with MemoryStream/ToArray or reaches StreamReadHelper from the capability-present seam.
+        AssertNoWholePayloadAggregationReferences(
+            typeof(GeneralMultiProjectionActor).GetMethod(
+                "DeserializeStreamingPayloadPairAsync",
+                BindingFlags.Instance | BindingFlags.NonPublic)!);
+        AssertNoWholePayloadAggregationReferences(
+            typeof(SnapshotEnvelopeResolver).GetMethod(
+                nameof(SnapshotEnvelopeResolver.ResolveForRestoreAsync),
+                BindingFlags.Static | BindingFlags.Public)!);
+        foreach (var method in typeof(StreamSnapshotPayloadDeserializer).GetMethods(
+                     BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly))
+        {
+            AssertNoWholePayloadAggregationReferences(method);
+        }
+    }
+
+    [Fact]
+    public void Stream_restore_public_inventory_pins_all_additive_capability_implementations_and_restore_shape()
+    {
+        AssertStreamingCapabilityInterfaceSurfaces();
+        AssertStreamDeserializerSurface();
+
+        AssertStreamingRegistrySurface(typeof(AotMultiProjectorTypes));
+        AssertStreamingRegistrySurface(typeof(SimpleMultiProjectorTypes));
+        // The core registry is internal, yet it is the implementation used by the actor's direct core path. Keep it in
+        // the inventory too, so every Simple registry is held to the same capability forwarding shape.
+        AssertStreamingRegistrySurface(
+            typeof(GeneralMultiProjectionActor).Assembly.GetType(
+                "Sekiban.Dcb.Domains.SimpleMultiProjectorTypes",
+                throwOnError: true)!);
+
+        var restore = typeof(ResolvedSnapshotRestore);
+        Assert.True(restore.IsPublic);
+        Assert.True(restore.IsSealed);
+        Assert.False(restore.IsAbstract);
+        Assert.Equal(
+            ["IsOffloaded", "PayloadStream", "State"],
+            restore.GetProperties(BindingFlags.Instance | BindingFlags.Public | BindingFlags.DeclaredOnly)
+                .Select(property => property.Name)
+                .OrderBy(name => name));
+        Assert.All(
+            restore.GetProperties(BindingFlags.Instance | BindingFlags.Public | BindingFlags.DeclaredOnly),
+            property =>
+            {
+                Assert.True(property.CanRead);
+                Assert.False(property.CanWrite);
+            });
+        Assert.Equal(typeof(SerializableMultiProjectionState), restore.GetProperty("State")!.PropertyType);
+        Assert.Equal(typeof(Stream), restore.GetProperty("PayloadStream")!.PropertyType);
+        Assert.Equal(typeof(bool), restore.GetProperty("IsOffloaded")!.PropertyType);
+        Assert.Empty(restore.GetConstructors(BindingFlags.Instance | BindingFlags.Public));
+        var constructor = Assert.Single(restore.GetConstructors(BindingFlags.Instance | BindingFlags.NonPublic));
+        Assert.True(constructor.IsAssembly);
+        Assert.Equal(
+            [typeof(SerializableMultiProjectionState), typeof(Stream), typeof(bool)],
+            constructor.GetParameters().Select(parameter => parameter.ParameterType));
+        AssertMethod(
+            restore.GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.DeclaredOnly),
+            nameof(IDisposable.Dispose),
+            typeof(void));
+        AssertMethod(
+            restore.GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.DeclaredOnly),
+            nameof(IAsyncDisposable.DisposeAsync),
+            typeof(ValueTask));
+        Assert.Contains(typeof(IDisposable), restore.GetInterfaces());
+        Assert.Contains(typeof(IAsyncDisposable), restore.GetInterfaces());
+
+        var restoreMethods = restore.GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.DeclaredOnly)
+            .Where(method => !method.IsSpecialName)
+            .Select(method => (method.Name, method.ReturnType))
+            .OrderBy(method => method.Name)
+            .ToArray();
+        Assert.Equal(
+            [(nameof(IDisposable.Dispose), typeof(void)), (nameof(IAsyncDisposable.DisposeAsync), typeof(ValueTask))],
+            restoreMethods);
+
+        var resolverMethod = Assert.Single(
+            typeof(SnapshotEnvelopeResolver).GetMethods(BindingFlags.Static | BindingFlags.Public | BindingFlags.DeclaredOnly),
+            method => method.Name == nameof(SnapshotEnvelopeResolver.ResolveForRestoreAsync));
+        Assert.Equal(typeof(Task<ResolvedSnapshotRestore>), resolverMethod.ReturnType);
+        Assert.Equal(
+            [typeof(SerializableMultiProjectionStateEnvelope), typeof(IBlobStorageSnapshotAccessor), typeof(CancellationToken)],
+            resolverMethod.GetParameters().Select(parameter => parameter.ParameterType));
+        Assert.Equal(
+            ["envelope", "blobAccessor", "cancellationToken"],
+            resolverMethod.GetParameters().Select(parameter => parameter.Name));
+        Assert.True(resolverMethod.GetParameters()[2].IsOptional);
+
+        var actorMethod = Assert.Single(
+            typeof(GeneralMultiProjectionActor).GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.DeclaredOnly),
+            method => method.Name == nameof(GeneralMultiProjectionActor.SetResolvedSnapshotAsync));
+        Assert.Equal(typeof(Task), actorMethod.ReturnType);
+        Assert.Equal(
+            [typeof(ResolvedSnapshotRestore), typeof(CancellationToken)],
+            actorMethod.GetParameters().Select(parameter => parameter.ParameterType));
+        Assert.Equal(
+            ["snapshot", "cancellationToken"],
+            actorMethod.GetParameters().Select(parameter => parameter.Name));
+        Assert.True(actorMethod.GetParameters()[1].IsOptional);
+    }
+
+    private static void AssertStreamingCapabilityInterfaceSurfaces()
+    {
+        var registryCapability = typeof(IStreamingMultiProjectorTypes);
+        Assert.True(registryCapability.IsPublic);
+        var supports = Assert.Single(
+            registryCapability.GetMethods(),
+            method => method.Name == nameof(IStreamingMultiProjectorTypes.SupportsStreamDeserialization));
+        Assert.Equal(typeof(bool), supports.ReturnType);
+        Assert.Equal([typeof(string)], supports.GetParameters().Select(parameter => parameter.ParameterType));
+        Assert.Equal(["projectorName"], supports.GetParameters().Select(parameter => parameter.Name));
+
+        var registryDeserialize = Assert.Single(
+            registryCapability.GetMethods(),
+            method => method.Name == nameof(IStreamingMultiProjectorTypes.DeserializeFromStreamAsync));
+        Assert.Equal(typeof(Task<ResultBox<IMultiProjectionPayload>>), registryDeserialize.ReturnType);
+        Assert.Equal(
+            [typeof(string), typeof(DcbDomainTypes), typeof(string), typeof(Stream), typeof(CancellationToken)],
+            registryDeserialize.GetParameters().Select(parameter => parameter.ParameterType));
+        Assert.Equal(
+            ["projectorName", "domainTypes", "safeWindowThreshold", "source", "cancellationToken"],
+            registryDeserialize.GetParameters().Select(parameter => parameter.Name));
+        Assert.True(registryDeserialize.GetParameters()[4].IsOptional);
+
+        var projectorCapability = typeof(ICoreMultiProjectorWithStreamDeserialization);
+        Assert.True(projectorCapability.IsPublic);
+        var projectorDeserialize = Assert.Single(projectorCapability.GetMethods());
+        Assert.Equal(nameof(ICoreMultiProjectorWithStreamDeserialization.DeserializeFromStreamAsync), projectorDeserialize.Name);
+        Assert.Equal(typeof(Task<IMultiProjectionPayload>), projectorDeserialize.ReturnType);
+        Assert.Equal(
+            [typeof(DcbDomainTypes), typeof(string), typeof(Stream), typeof(CancellationToken)],
+            projectorDeserialize.GetParameters().Select(parameter => parameter.ParameterType));
+        Assert.Equal(
+            ["domainTypes", "safeWindowThreshold", "source", "cancellationToken"],
+            projectorDeserialize.GetParameters().Select(parameter => parameter.Name));
+        Assert.True(projectorDeserialize.GetParameters()[3].IsOptional);
+    }
+
+    private static async Task<ThresholdWindow> RestoreInlineAndCaptureThresholdWindowAsync(
+        GeneralMultiProjectionActor actor,
+        SerializableMultiProjectionState state)
+    {
+        var lower = actor.PeekCurrentSafeWindowThreshold().Value;
+        await actor.SetSnapshotAsync(new SerializableMultiProjectionStateEnvelope(false, state, null));
+        return new ThresholdWindow(lower, actor.PeekCurrentSafeWindowThreshold().Value);
+    }
+
+    private static async Task<ThresholdWindow> RestoreStreamAndCaptureThresholdWindowAsync(
+        GeneralMultiProjectionActor actor,
+        ResolvedSnapshotRestore restore)
+    {
+        var lower = actor.PeekCurrentSafeWindowThreshold().Value;
+        await actor.SetResolvedSnapshotAsync(restore);
+        return new ThresholdWindow(lower, actor.PeekCurrentSafeWindowThreshold().Value);
+    }
+
+    private static async Task<(SerializableMultiProjectionStateEnvelope Envelope, CappedBlobAccessor Blob, int UncompressedWireBytes)>
+        CreateSmallGraphLargeWireFixtureAsync()
+    {
+        // The real JSON graph restored by StreamPayloadProjector is just one short value. The ignored JSON property is
+        // deliberately 25 MiB of deterministic high-entropy ASCII, so the wire is large without retaining a matching
+        // source object graph. It is the controlled AC1 discriminant, not a no-OOM claim.
+        var rawJson = CreateSmallGraphLargeWireJson();
+        var gzip = GzipCompression.Compress(rawJson);
+        Assert.InRange(gzip.Length, 16 * 1024 * 1024, 32 * 1024 * 1024);
+
+        var blob = new CappedBlobAccessor();
+        var key = await blob.WriteAsync(new MemoryStream(gzip, writable: false), StreamPayloadProjector.MultiProjectorName);
+        return (
+            new SerializableMultiProjectionStateEnvelope(
+                IsOffloaded: true,
+                InlineState: null,
+                OffloadedState: new SerializableMultiProjectionStateOffloaded(
+                    key,
+                    blob.ProviderName,
+                    typeof(StreamPayloadProjector).FullName!,
+                    StreamPayloadProjector.MultiProjectorName,
+                    StreamPayloadProjector.MultiProjectorVersion,
+                    SortableUniqueId.MinValue.Value,
+                    Guid.Empty,
+                    Version: 41,
+                    IsCatchedUp: true,
+                    IsSafeState: true,
+                    PayloadLength: gzip.Length,
+                    OriginalSizeBytes: rawJson.Length,
+                    CompressedSizeBytes: gzip.Length)),
+            blob,
+            rawJson.Length);
+    }
+
+    private static byte[] CreateSmallGraphLargeWireJson()
+    {
+        const int totalLength = 25 * 1024 * 1024;
+        var prefix = Encoding.UTF8.GetBytes("{\"Values\":[\"small-graph\"],\"IgnoredLargeWireValue\":\"");
+        var suffix = Encoding.UTF8.GetBytes("\"}");
+        var json = new byte[totalLength];
+        prefix.CopyTo(json, 0);
+        suffix.CopyTo(json, json.Length - suffix.Length);
+
+        const string alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+        uint random = 0x9e37_79b9;
+        for (var index = prefix.Length; index < json.Length - suffix.Length; index++)
+        {
+            random ^= random << 13;
+            random ^= random >> 17;
+            random ^= random << 5;
+            json[index] = (byte)alphabet[(int)(random & 63)];
+        }
+
+        return json;
+    }
+
+    private static void AssertRecordedThresholdsWithinWindow(
+        IReadOnlyList<string> thresholds,
+        ThresholdWindow window,
+        string path)
+    {
+        Assert.NotEmpty(thresholds);
+        Assert.All(thresholds, threshold =>
+        {
+            Assert.False(string.IsNullOrWhiteSpace(threshold));
+            Assert.InRange(
+                string.CompareOrdinal(threshold, window.LowerInclusive),
+                0,
+                int.MaxValue);
+            Assert.InRange(
+                string.CompareOrdinal(threshold, window.UpperInclusive),
+                int.MinValue,
+                0);
+        });
+    }
+
+    private static void AssertCustomThresholdsWithinWindow(
+        MatrixRegistryKind registry,
+        ThresholdWindow window,
+        string path)
+    {
+        if (registry != MatrixRegistryKind.Custom)
+        {
+            return;
+        }
+
+        AssertRecordedThresholdsWithinWindow(
+            MatrixCustomPayloadProjector.DrainRecordedSafeThresholds(),
+            window,
+            path);
+    }
+
+    private static MatrixRegistrySetup CreateMatrixRegistry(MatrixRegistryKind registryKind)
+    {
+        switch (registryKind)
+        {
+            case MatrixRegistryKind.Reflection:
+            {
+                var registry = new SimpleMultiProjectorTypes();
+                registry.RegisterProjector<MatrixPayloadProjector>();
+                return new MatrixRegistrySetup(
+                    new ThresholdRecordingRegistry(registry),
+                    MatrixPayloadProjector.MultiProjectorName,
+                    typeof(MatrixPayloadProjector).FullName!);
+            }
+            case MatrixRegistryKind.Aot:
+            {
+                var registry = new AotMultiProjectorTypes();
+                registry.RegisterProjector<MatrixPayloadProjector>(MatrixJsonContext.Default.MatrixPayloadProjector);
+                return new MatrixRegistrySetup(
+                    new ThresholdRecordingRegistry(registry),
+                    MatrixPayloadProjector.MultiProjectorName,
+                    typeof(MatrixPayloadProjector).FullName!);
+            }
+            case MatrixRegistryKind.Custom:
+            {
+                var registry = new SimpleMultiProjectorTypes();
+                Assert.True(registry.RegisterProjectorWithCustomSerialization<MatrixCustomPayloadProjector>().IsSuccess);
+                return new MatrixRegistrySetup(
+                    new ThresholdRecordingRegistry(registry),
+                    MatrixCustomPayloadProjector.MultiProjectorName,
+                    typeof(MatrixCustomPayloadProjector).FullName!);
+            }
+            default:
+                throw new ArgumentOutOfRangeException(nameof(registryKind), registryKind, null);
+        }
+    }
+
+    private static byte[] CreateMatrixPayloadBytes(
+        MatrixCell cell,
+        DcbDomainTypes domain,
+        string expectedValue)
+    {
+        var payload = cell.Registry == MatrixRegistryKind.Custom
+            ? (IMultiProjectionPayload)new MatrixCustomPayloadProjector(expectedValue)
+            : new MatrixPayloadProjector(expectedValue);
+        // AOT uses its generated metadata (and therefore its generated wire-name policy), not reflection's domain
+        // options. Serializing this cell with the same metadata makes the matrix exercise the real AOT byte and stream
+        // readers instead of treating a casing mismatch as an unrelated restore difference.
+        var raw = cell.Registry == MatrixRegistryKind.Aot
+            ? JsonSerializer.SerializeToUtf8Bytes(
+                Assert.IsType<MatrixPayloadProjector>(payload),
+                MatrixJsonContext.Default.MatrixPayloadProjector)
+            : JsonSerializer.SerializeToUtf8Bytes(payload, payload.GetType(), domain.JsonSerializerOptions);
+        return cell.PayloadFormat == MatrixPayloadFormat.GzipJson ? GzipCompression.Compress(raw) : raw;
+    }
+
+    private static SerializableMultiProjectionState CreateMatrixState(
+        MatrixCell cell,
+        byte[] payloadBytes,
+        string projectorName,
+        string payloadType,
+        string lastSortableUniqueId,
+        Guid lastEventId,
+        int version)
+    {
+        if (cell.WireVersion == MatrixWireVersion.V9)
+        {
+            Assert.Equal(MatrixPayloadFormat.RawLegacyJson, cell.PayloadFormat);
+        }
+
+        return new SerializableMultiProjectionState(
+            payloadJson: cell.WireVersion == MatrixWireVersion.V9 ? Encoding.UTF8.GetString(payloadBytes) : null,
+            payloadBase64: cell.WireVersion == MatrixWireVersion.V10 ? Convert.ToBase64String(payloadBytes) : null,
+            payloadType,
+            projectorName,
+            MatrixProjectorVersion,
+            lastSortableUniqueId,
+            lastEventId,
+            version,
+            isCatchedUp: false,
+            isSafeState: true,
+            originalSizeBytes: payloadBytes.Length,
+            compressedSizeBytes: payloadBytes.Length);
+    }
+
+    private static string GetMatrixPayloadValue(IMultiProjectionPayload payload) => payload switch
+    {
+        MatrixPayloadProjector reflectionOrAot => reflectionOrAot.Value,
+        MatrixCustomPayloadProjector custom => custom.Value,
+        _ => throw new Xunit.Sdk.XunitException($"Unexpected matrix payload type '{payload.GetType().FullName}'.")
+    };
+
+    private static void AssertStreamDeserializerSurface()
+    {
+        var type = typeof(StreamSnapshotPayloadDeserializer);
+        Assert.True(type.IsPublic);
+        Assert.True(type.IsAbstract && type.IsSealed);
+        var methods = type.GetMethods(BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly);
+        Assert.Equal(2, methods.Length);
+        var reflection = Assert.Single(methods, method => !method.IsGenericMethodDefinition);
+        Assert.Equal("DeserializeJsonAsync", reflection.Name);
+        Assert.Equal(typeof(Task<object>), reflection.ReturnType);
+        Assert.Equal(
+            [typeof(Stream), typeof(Type), typeof(JsonSerializerOptions), typeof(CancellationToken)],
+            reflection.GetParameters().Select(parameter => parameter.ParameterType));
+        var aot = Assert.Single(methods, method => method.IsGenericMethodDefinition);
+        Assert.Equal("DeserializeJsonAsync", aot.Name);
+        Assert.Single(aot.GetGenericArguments());
+        Assert.Equal(typeof(Task<>), aot.ReturnType.GetGenericTypeDefinition());
+        Assert.Equal(
+            [typeof(Stream), typeof(JsonTypeInfo<>), typeof(CancellationToken)],
+            aot.GetParameters().Select(parameter =>
+                parameter.ParameterType.IsGenericType
+                    ? parameter.ParameterType.GetGenericTypeDefinition()
+                    : parameter.ParameterType));
+    }
+
+    private static void AssertStreamingRegistrySurface(Type registryType)
+    {
+        Assert.Contains(typeof(IStreamingMultiProjectorTypes), registryType.GetInterfaces());
+        var methods = registryType.GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.DeclaredOnly);
+        AssertMethod(methods, nameof(IStreamingMultiProjectorTypes.SupportsStreamDeserialization), typeof(bool), typeof(string));
+        AssertMethod(
+            methods,
+            nameof(IStreamingMultiProjectorTypes.DeserializeFromStreamAsync),
+            typeof(Task<ResultBox<IMultiProjectionPayload>>),
+            typeof(string), typeof(DcbDomainTypes), typeof(string), typeof(Stream), typeof(CancellationToken));
+    }
+
+    private static void AssertNoWholePayloadAggregationReferences(MethodInfo asyncMethod)
+    {
+        var forbidden = EnumerateReferencedMembers(asyncMethod)
+            .Where(member =>
+                (member.DeclaringType == typeof(StreamReadHelper) && member.Name == "ReadAllBytesAsync") ||
+                (member.DeclaringType == typeof(MemoryStream) && member.Name is ".ctor" or "ToArray") ||
+                (member.DeclaringType == typeof(File) && member.Name is "ReadAllBytes" or "ReadAllBytesAsync") ||
+                (member.DeclaringType == typeof(SerializableMultiProjectionState) && member.Name == "GetPayloadBytes"))
+            .Select(member => $"{member.DeclaringType!.FullName}.{member.Name}")
+            .ToArray();
+        Assert.Empty(forbidden);
+    }
+
+    private static IEnumerable<MemberInfo> EnumerateReferencedMembers(MethodInfo asyncMethod)
+    {
+        var stateMachine = asyncMethod.GetCustomAttribute<AsyncStateMachineAttribute>()?.StateMachineType
+            ?? throw new Xunit.Sdk.XunitException($"{asyncMethod.Name} is expected to be an async state machine.");
+        var moveNext = stateMachine.GetMethod("MoveNext", BindingFlags.Instance | BindingFlags.NonPublic)
+            ?? throw new Xunit.Sdk.XunitException($"{stateMachine.FullName}.MoveNext was not found.");
+        var il = moveNext.GetMethodBody()?.GetILAsByteArray()
+            ?? throw new Xunit.Sdk.XunitException($"{stateMachine.FullName}.MoveNext has no IL body.");
+        var genericTypeArguments = stateMachine.IsGenericType ? stateMachine.GetGenericArguments() : null;
+        var genericMethodArguments = asyncMethod.IsGenericMethod ? asyncMethod.GetGenericArguments() : null;
+
+        for (var offset = 0; offset < il.Length;)
+        {
+            var opCode = ReadOpCode(il, ref offset);
+            if (opCode.OperandType is OperandType.InlineField or OperandType.InlineMethod or OperandType.InlineTok or OperandType.InlineType)
+            {
+                var token = BitConverter.ToInt32(il, offset);
+                offset += sizeof(int);
+                MemberInfo? member = null;
+                try
+                {
+                    member = moveNext.Module.ResolveMember(token, genericTypeArguments, genericMethodArguments);
+                }
+                catch (ArgumentException)
+                {
+                    // A generic method specification can be unresolved while still having no relevant aggregation call.
+                }
+
+                if (member is not null)
+                {
+                    yield return member;
+                }
+
+                continue;
+            }
+
+            offset += OperandSize(opCode.OperandType, il, offset);
+        }
+    }
+
+    private static OpCode ReadOpCode(byte[] il, ref int offset)
+    {
+        short value = il[offset++];
+        if (value == 0xfe)
+        {
+            value = (short)(0xfe00 | il[offset++]);
+        }
+
+        return IlOpCodes[value];
+    }
+
+    private static int OperandSize(OperandType operandType, byte[] il, int offset) => operandType switch
+    {
+        OperandType.InlineNone => 0,
+        OperandType.ShortInlineBrTarget or OperandType.ShortInlineI or OperandType.ShortInlineVar => 1,
+        OperandType.ShortInlineR => 4,
+        OperandType.InlineVar => 2,
+        OperandType.InlineBrTarget or OperandType.InlineField or OperandType.InlineI or OperandType.InlineMethod or
+            OperandType.InlineSig or OperandType.InlineString or OperandType.InlineTok or OperandType.InlineType => 4,
+        OperandType.InlineI8 or OperandType.InlineR => 8,
+        OperandType.InlineSwitch => sizeof(int) + sizeof(int) * BitConverter.ToInt32(il, offset),
+        _ => throw new Xunit.Sdk.XunitException($"Unsupported IL operand type '{operandType}'.")
+    };
+
+    private static readonly IReadOnlyDictionary<short, OpCode> IlOpCodes = typeof(OpCodes)
+        .GetFields(BindingFlags.Public | BindingFlags.Static)
+        .Select(field => (OpCode)field.GetValue(null)!)
+        .ToDictionary(opCode => opCode.Value);
+
+    private const string MatrixProjectorVersion = "matrix-v1";
+
+    public sealed record MatrixPayloadProjector(string Value) : IMultiProjector<MatrixPayloadProjector>
+    {
+        public MatrixPayloadProjector() : this(string.Empty) { }
+        public static string MultiProjectorName => "streaming-restore-matrix";
+        public static string MultiProjectorVersion => MatrixProjectorVersion;
+        public static MatrixPayloadProjector GenerateInitialPayload() => new(string.Empty);
+
+        public static ResultBox<MatrixPayloadProjector> Project(
+            MatrixPayloadProjector payload,
+            Event ev,
+            List<ITag> tags,
+            DcbDomainTypes domainTypes,
+            SortableUniqueId safeWindowThreshold) => ResultBox.FromValue(payload);
+    }
+
+    public sealed record MatrixCustomPayloadProjector(string Value) :
+        ICoreMultiProjectorWithCustomSerialization<MatrixCustomPayloadProjector>,
+        ICoreMultiProjectorWithStreamDeserialization
+    {
+        private static readonly ConcurrentQueue<string> RecordedSafeThresholds = new();
+
+        public MatrixCustomPayloadProjector() : this(string.Empty) { }
+        public static string MultiProjectorName => "streaming-restore-matrix-custom";
+        public static string MultiProjectorVersion => MatrixProjectorVersion;
+        public static MatrixCustomPayloadProjector GenerateInitialPayload() => new(string.Empty);
+
+        public static ResultBox<MatrixCustomPayloadProjector> Project(
+            MatrixCustomPayloadProjector payload,
+            Event ev,
+            List<ITag> tags,
+            DcbDomainTypes domainTypes,
+            SortableUniqueId safeWindowThreshold) => ResultBox.FromValue(payload);
+
+        public static SerializationResult Serialize(
+            DcbDomainTypes domainTypes,
+            string safeWindowThreshold,
+            MatrixCustomPayloadProjector payload)
+        {
+            var raw = JsonSerializer.SerializeToUtf8Bytes(payload, domainTypes.JsonSerializerOptions);
+            var gzip = GzipCompression.Compress(raw);
+            return new SerializationResult(gzip, raw.Length, gzip.Length);
+        }
+
+        public static MatrixCustomPayloadProjector Deserialize(
+            DcbDomainTypes domainTypes,
+            string safeWindowThreshold,
+            ReadOnlySpan<byte> data)
+        {
+            RecordedSafeThresholds.Enqueue(safeWindowThreshold);
+            var raw = data.Length >= 2 && data[0] == 0x1f && data[1] == 0x8b
+                ? GzipCompression.Decompress(data)
+                : data.ToArray();
+            return JsonSerializer.Deserialize<MatrixCustomPayloadProjector>(raw, domainTypes.JsonSerializerOptions)
+                ?? throw new InvalidDataException("matrix custom payload was empty");
+        }
+
+        public async Task<IMultiProjectionPayload> DeserializeFromStreamAsync(
+            DcbDomainTypes domainTypes,
+            string safeWindowThreshold,
+            Stream source,
+            CancellationToken cancellationToken = default)
+        {
+            RecordedSafeThresholds.Enqueue(safeWindowThreshold);
+            return (await StreamSnapshotPayloadDeserializer.DeserializeJsonAsync(
+                    source,
+                    typeof(MatrixCustomPayloadProjector),
+                    domainTypes.JsonSerializerOptions,
+                    cancellationToken)
+                .ConfigureAwait(false)) as MatrixCustomPayloadProjector
+                ?? throw new InvalidDataException("matrix custom payload was empty");
+        }
+
+        internal static void ResetRecordedSafeThresholds()
+        {
+            while (RecordedSafeThresholds.TryDequeue(out _))
+            {
+            }
+        }
+
+        internal static IReadOnlyList<string> DrainRecordedSafeThresholds()
+        {
+            var thresholds = new List<string>();
+            while (RecordedSafeThresholds.TryDequeue(out var threshold))
+            {
+                thresholds.Add(threshold);
+            }
+
+            return thresholds;
+        }
+    }
+
+    [JsonSerializable(typeof(MatrixPayloadProjector))]
+    private sealed partial class MatrixJsonContext : JsonSerializerContext;
+
+    private sealed class ThresholdRecordingRegistry(ICoreMultiProjectorTypes inner) : DelegatingRegistry(inner), IStreamingMultiProjectorTypes
+    {
+        private readonly IStreamingMultiProjectorTypes _streaming = Assert.IsAssignableFrom<IStreamingMultiProjectorTypes>(inner);
+
+        public List<string> StreamSafeThresholds { get; } = [];
+        public List<string> BufferedSafeThresholds { get; } = [];
+        public int StreamDeserializeCalls { get; private set; }
+
+        public override ResultBox<IMultiProjectionPayload> Deserialize(
+            string name,
+            DcbDomainTypes domain,
+            string threshold,
+            byte[] data)
+        {
+            BufferedSafeThresholds.Add(threshold);
+            return base.Deserialize(name, domain, threshold, data);
+        }
+
+        public bool SupportsStreamDeserialization(string projectorName) =>
+            _streaming.SupportsStreamDeserialization(projectorName);
+
+        public async Task<ResultBox<IMultiProjectionPayload>> DeserializeFromStreamAsync(
+            string projectorName,
+            DcbDomainTypes domainTypes,
+            string safeWindowThreshold,
+            Stream source,
+            CancellationToken cancellationToken = default)
+        {
+            StreamDeserializeCalls++;
+            StreamSafeThresholds.Add(safeWindowThreshold);
+            return await _streaming.DeserializeFromStreamAsync(
+                    projectorName,
+                    domainTypes,
+                    safeWindowThreshold,
+                    source,
+                    cancellationToken)
+                .ConfigureAwait(false);
+        }
+    }
+
+    private sealed record MatrixRegistrySetup(
+        ThresholdRecordingRegistry Registry,
+        string ProjectorName,
+        string PayloadType)
+    {
+        public IReadOnlyList<string> StreamSafeThresholds => Registry.StreamSafeThresholds;
+        public IReadOnlyList<string> BufferedSafeThresholds => Registry.BufferedSafeThresholds;
+        public int StreamDeserializeCalls => Registry.StreamDeserializeCalls;
+    }
+
+    public sealed record MatrixCell(
+        MatrixRegistryKind Registry,
+        MatrixPayloadFormat PayloadFormat,
+        MatrixWireVersion WireVersion,
+        MatrixDelivery Delivery);
+
+    public enum MatrixRegistryKind { Reflection, Aot, Custom }
+    public enum MatrixPayloadFormat { RawLegacyJson, GzipJson }
+    public enum MatrixWireVersion { V9, V10 }
+    public enum MatrixDelivery { Offloaded, Inline }
+
+    private sealed record ThresholdWindow(string LowerInclusive, string UpperInclusive);
+
+    private sealed record RestoreRollbackSnapshot(
+        object StateAccessor,
+        Guid LastEventId,
+        string LastSortableUniqueId,
+        int Version,
+        bool IsCatchedUp);
+
+    private static RestoreRollbackSnapshot CaptureRestoreRollbackSnapshot(GeneralMultiProjectionActor actor) => new(
+        ReadActorField<object>(actor, "_singleStateAccessor"),
+        ReadActorField<Guid>(actor, "_unsafeLastEventId"),
+        ReadActorField<string>(actor, "_unsafeLastSortableUniqueId"),
+        ReadActorField<int>(actor, "_unsafeVersion"),
+        ReadActorField<bool>(actor, "_isCatchedUp"));
+
+    private static void AssertRestoreRollbackSnapshotUnchanged(
+        GeneralMultiProjectionActor actor,
+        RestoreRollbackSnapshot before)
+    {
+        Assert.Same(before.StateAccessor, ReadActorField<object>(actor, "_singleStateAccessor"));
+        Assert.Equal(before.LastEventId, ReadActorField<Guid>(actor, "_unsafeLastEventId"));
+        Assert.Equal(before.LastSortableUniqueId, ReadActorField<string>(actor, "_unsafeLastSortableUniqueId"));
+        Assert.Equal(before.Version, ReadActorField<int>(actor, "_unsafeVersion"));
+        Assert.Equal(before.IsCatchedUp, ReadActorField<bool>(actor, "_isCatchedUp"));
+    }
+
+    private static int GetLastStreamingRestoreWholePayloadAggregationCount(GeneralMultiProjectionActor actor) =>
+        ReadActorField<int>(actor, "_lastStreamingRestoreWholePayloadAggregationCount");
+
+    private static T ReadActorField<T>(GeneralMultiProjectionActor actor, string name) =>
+        (T)(typeof(GeneralMultiProjectionActor)
+            .GetField(name, BindingFlags.Instance | BindingFlags.NonPublic)
+            ?.GetValue(actor)
+            ?? throw new Xunit.Sdk.XunitException($"Actor field '{name}' was not found."));
+}

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/StreamingSnapshotRestoreReviewRepairTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/StreamingSnapshotRestoreReviewRepairTests.cs
@@ -62,21 +62,26 @@ public sealed partial class StreamingSnapshotRestoreTests
         var legacyActor = new GeneralMultiProjectionActor(CreateDomain(byteSetup.Registry), byteSetup.ProjectorName);
 
         MatrixCustomPayloadProjector.ResetRecordedSafeThresholds();
-        var legacyThresholdWindow = await RestoreInlineAndCaptureThresholdWindowAsync(
+        var legacySelectedThreshold = await RestoreInlineAndCaptureSelectedThresholdAsync(
             legacyActor,
             legacyState);
         var legacy = await legacyActor.GetStateAsync(canGetUnsafeState: true);
         Assert.True(legacy.IsSuccess);
-        AssertRecordedThresholdsWithinWindow(
+        Assert.Equal(0, byteSetup.StreamDeserializeCalls);
+        // Each path owns an actor and therefore selects its own timestamp-derived threshold. Exact equality is against
+        // that actor's one recorded selection, not a wall-clock range shared by two independently constructed actors.
+        // A recomputation for either byte-path clone or either stream-path clone is consequently observable.
+        AssertRecordedThresholdsExactly(
             byteSetup.BufferedSafeThresholds,
-            legacyThresholdWindow,
+            legacySelectedThreshold,
+            expectedCount: 2,
             "legacy byte path");
-        AssertCustomThresholdsWithinWindow(cell.Registry, legacyThresholdWindow, "legacy byte path");
+        AssertCustomThresholdsExactly(cell.Registry, legacySelectedThreshold, expectedCount: 2, "legacy byte path");
 
         var restoreSetup = CreateMatrixRegistry(cell.Registry);
         var restoreActor = new GeneralMultiProjectionActor(CreateDomain(restoreSetup.Registry), restoreSetup.ProjectorName);
         MatrixCustomPayloadProjector.ResetRecordedSafeThresholds();
-        ThresholdWindow restoreThresholdWindow;
+        string restoreSelectedThreshold;
 
         if (cell.Delivery == MatrixDelivery.Offloaded)
         {
@@ -101,27 +106,30 @@ public sealed partial class StreamingSnapshotRestoreTests
                     CompressedSizeBytes: payloadBytes.Length));
 
             await using var resolved = await SnapshotEnvelopeResolver.ResolveForRestoreAsync(envelope, blob);
-            restoreThresholdWindow = await RestoreStreamAndCaptureThresholdWindowAsync(restoreActor, resolved);
+            restoreSelectedThreshold = await RestoreStreamAndCaptureSelectedThresholdAsync(restoreActor, resolved);
             Assert.Equal(2, restoreSetup.StreamDeserializeCalls);
             Assert.Empty(restoreSetup.BufferedSafeThresholds);
-            AssertRecordedThresholdsWithinWindow(
+            AssertRecordedThresholdsExactly(
                 restoreSetup.StreamSafeThresholds,
-                restoreThresholdWindow,
+                restoreSelectedThreshold,
+                expectedCount: 2,
                 "offloaded stream path");
         }
         else
         {
-            restoreThresholdWindow = await RestoreInlineAndCaptureThresholdWindowAsync(restoreActor, legacyState);
+            restoreSelectedThreshold = await RestoreInlineAndCaptureSelectedThresholdAsync(restoreActor, legacyState);
             Assert.Equal(0, restoreSetup.StreamDeserializeCalls);
-            AssertRecordedThresholdsWithinWindow(
+            AssertRecordedThresholdsExactly(
                 restoreSetup.BufferedSafeThresholds,
-                restoreThresholdWindow,
+                restoreSelectedThreshold,
+                expectedCount: 2,
                 "inline compatibility path");
         }
 
-        AssertCustomThresholdsWithinWindow(
+        AssertCustomThresholdsExactly(
             cell.Registry,
-            restoreThresholdWindow,
+            restoreSelectedThreshold,
+            expectedCount: 2,
             cell.Delivery == MatrixDelivery.Offloaded ? "offloaded stream path" : "inline compatibility path");
 
         var restored = await restoreActor.GetStateAsync(canGetUnsafeState: true);
@@ -172,23 +180,82 @@ public sealed partial class StreamingSnapshotRestoreTests
     }
 
     [Fact]
-    public void Supported_stream_restore_state_machines_have_no_whole_payload_aggregation_api_reference()
+    public void Restore_path_selects_one_safe_threshold_and_cannot_recompute_it_in_a_helper()
     {
-        // This is a production structural pin, not read-size telemetry. It kills a mutation that replaces the file tee
-        // with MemoryStream/ToArray or reaches StreamReadHelper from the capability-present seam.
-        AssertNoWholePayloadAggregationReferences(
-            typeof(GeneralMultiProjectionActor).GetMethod(
-                "DeserializeStreamingPayloadPairAsync",
-                BindingFlags.Instance | BindingFlags.NonPublic)!);
-        AssertNoWholePayloadAggregationReferences(
-            typeof(SnapshotEnvelopeResolver).GetMethod(
-                nameof(SnapshotEnvelopeResolver.ResolveForRestoreAsync),
-                BindingFlags.Static | BindingFlags.Public)!);
-        foreach (var method in typeof(StreamSnapshotPayloadDeserializer).GetMethods(
-                     BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly))
-        {
-            AssertNoWholePayloadAggregationReferences(method);
-        }
+        // The exact matrix assertions prove the values received by primary and clone. This complementary structural
+        // pin prevents a later actor helper from silently asking the wall clock for a second, in-window threshold.
+        var actorType = typeof(GeneralMultiProjectionActor);
+        var restorePayload = actorType.GetMethod(
+            "RestorePayloadAsync",
+            BindingFlags.Instance | BindingFlags.NonPublic)!;
+        var restoreDirectCalls = EnumerateDirectReferencedMembers(GetImplementationMethod(restorePayload))
+            .OfType<MethodInfo>()
+            .Where(method => method.DeclaringType == actorType)
+            .ToArray();
+        Assert.Equal(
+            1,
+            restoreDirectCalls.Count(method => method.Name == "SelectSnapshotRestoreSafeWindowThreshold"));
+
+        var allActorSafeThresholdCalls = EnumerateTransitiveReferencedMembers([restorePayload])
+            .OfType<MethodInfo>()
+            .Where(method =>
+                method.DeclaringType == actorType &&
+                method.Name == "GetSafeWindowThreshold")
+            .ToArray();
+        Assert.Single(allActorSafeThresholdCalls);
+
+        var streamPair = actorType.GetMethod(
+            "DeserializeStreamingPayloadPairAsync",
+            BindingFlags.Instance | BindingFlags.NonPublic)!;
+        Assert.DoesNotContain(
+            EnumerateTransitiveReferencedMembers([streamPair]).OfType<MethodInfo>(),
+            method => method.DeclaringType == actorType && method.Name == "GetSafeWindowThreshold");
+    }
+
+    [Fact]
+    public void Supported_stream_restore_transitive_path_has_no_whole_payload_aggregation_api_reference()
+    {
+        // This is a production structural pin, not read-size telemetry. The capability-present actor branch is a
+        // deliberately closed inventory because RestorePayloadAsync also owns the allowed legacy byte fallback. From
+        // these roots, the scanner follows every method in Core/Core.Model, including async state machines, so a
+        // whole-payload helper moved into a registry forwarder, tee, or prefix wrapper cannot escape the proof.
+        var roots = GetSupportedStreamRestorePathRoots();
+        var teeType = GetSnapshotRestoreTeeReadStreamType();
+        var prefixType = GetPrefixBufferedStreamType();
+        var supportType = GetStreamingMultiProjectorTypesSupportType();
+
+        Assert.Contains(roots, method =>
+            method.DeclaringType == typeof(GeneralMultiProjectionActor) &&
+            method.Name == "DeserializeStreamingPayloadPairAsync");
+        Assert.Contains(roots, method =>
+            method.DeclaringType == typeof(SnapshotEnvelopeResolver) &&
+            method.Name == nameof(SnapshotEnvelopeResolver.ResolveForRestoreAsync));
+        Assert.Contains(roots, method => method.DeclaringType == teeType && method.Name == nameof(Stream.ReadAsync));
+        Assert.Contains(roots, method => method.DeclaringType == prefixType && method.Name == "CreateAsync");
+        Assert.Contains(roots, method => method.DeclaringType == supportType && method.Name == "DeserializeAsync");
+
+        AssertNoWholePayloadAggregationReferences(roots);
+    }
+
+    [Fact]
+    public void Transitive_aggregation_scan_rejects_each_forbidden_call_hidden_in_async_helpers()
+    {
+        // Verify the verifier itself. The async root has no direct aggregation call: each prohibited operation sits in
+        // a private helper (and ReadAllBytesAsync sits behind a second async state machine). A direct-only scan would
+        // miss exactly the mutations this production guard is intended to reject.
+        var root = typeof(StreamingSnapshotRestoreTests).GetMethod(
+            nameof(AggregationVerifierAsyncRoot),
+            BindingFlags.Static | BindingFlags.NonPublic)!;
+        var forbidden = FindWholePayloadAggregationReferences([root]);
+
+        Assert.Contains(forbidden, member => member.DeclaringType == typeof(MemoryStream) && member.Name == ".ctor");
+        Assert.Contains(forbidden, member => member.DeclaringType == typeof(MemoryStream) && member.Name == "ToArray");
+        Assert.Contains(forbidden, member =>
+            member.DeclaringType == typeof(File) &&
+            member.Name.StartsWith("ReadAllBytes", StringComparison.Ordinal));
+        Assert.Contains(forbidden, member =>
+            member.DeclaringType == typeof(SerializableMultiProjectionState) &&
+            member.Name == nameof(SerializableMultiProjectionState.GetPayloadBytes));
     }
 
     [Fact]
@@ -313,22 +380,20 @@ public sealed partial class StreamingSnapshotRestoreTests
         Assert.True(projectorDeserialize.GetParameters()[3].IsOptional);
     }
 
-    private static async Task<ThresholdWindow> RestoreInlineAndCaptureThresholdWindowAsync(
+    private static async Task<string> RestoreInlineAndCaptureSelectedThresholdAsync(
         GeneralMultiProjectionActor actor,
         SerializableMultiProjectionState state)
     {
-        var lower = actor.PeekCurrentSafeWindowThreshold().Value;
         await actor.SetSnapshotAsync(new SerializableMultiProjectionStateEnvelope(false, state, null));
-        return new ThresholdWindow(lower, actor.PeekCurrentSafeWindowThreshold().Value);
+        return GetLastSnapshotRestoreSafeWindowThreshold(actor);
     }
 
-    private static async Task<ThresholdWindow> RestoreStreamAndCaptureThresholdWindowAsync(
+    private static async Task<string> RestoreStreamAndCaptureSelectedThresholdAsync(
         GeneralMultiProjectionActor actor,
         ResolvedSnapshotRestore restore)
     {
-        var lower = actor.PeekCurrentSafeWindowThreshold().Value;
         await actor.SetResolvedSnapshotAsync(restore);
-        return new ThresholdWindow(lower, actor.PeekCurrentSafeWindowThreshold().Value);
+        return GetLastSnapshotRestoreSafeWindowThreshold(actor);
     }
 
     private static async Task<(SerializableMultiProjectionStateEnvelope Envelope, CappedBlobAccessor Blob, int UncompressedWireBytes)>
@@ -368,7 +433,7 @@ public sealed partial class StreamingSnapshotRestoreTests
     private static byte[] CreateSmallGraphLargeWireJson()
     {
         const int totalLength = 25 * 1024 * 1024;
-        var prefix = Encoding.UTF8.GetBytes("{\"Values\":[\"small-graph\"],\"IgnoredLargeWireValue\":\"");
+        var prefix = Encoding.UTF8.GetBytes("{\"values\":[\"small-graph\"],\"ignoredLargeWireValue\":\"");
         var suffix = Encoding.UTF8.GetBytes("\"}");
         var json = new byte[totalLength];
         prefix.CopyTo(json, 0);
@@ -387,29 +452,30 @@ public sealed partial class StreamingSnapshotRestoreTests
         return json;
     }
 
-    private static void AssertRecordedThresholdsWithinWindow(
+    private static void AssertRecordedThresholdsExactly(
         IReadOnlyList<string> thresholds,
-        ThresholdWindow window,
+        string actorSelectedThreshold,
+        int expectedCount,
         string path)
     {
-        Assert.NotEmpty(thresholds);
+        Assert.False(string.IsNullOrWhiteSpace(actorSelectedThreshold));
+        if (thresholds.Count != expectedCount)
+        {
+            throw new Xunit.Sdk.XunitException(
+                $"{path} must deserialize exactly {expectedCount} times; observed {thresholds.Count}.");
+        }
+
         Assert.All(thresholds, threshold =>
         {
             Assert.False(string.IsNullOrWhiteSpace(threshold));
-            Assert.InRange(
-                string.CompareOrdinal(threshold, window.LowerInclusive),
-                0,
-                int.MaxValue);
-            Assert.InRange(
-                string.CompareOrdinal(threshold, window.UpperInclusive),
-                int.MinValue,
-                0);
+            Assert.Equal(actorSelectedThreshold, threshold);
         });
     }
 
-    private static void AssertCustomThresholdsWithinWindow(
+    private static void AssertCustomThresholdsExactly(
         MatrixRegistryKind registry,
-        ThresholdWindow window,
+        string actorSelectedThreshold,
+        int expectedCount,
         string path)
     {
         if (registry != MatrixRegistryKind.Custom)
@@ -417,9 +483,10 @@ public sealed partial class StreamingSnapshotRestoreTests
             return;
         }
 
-        AssertRecordedThresholdsWithinWindow(
+        AssertRecordedThresholdsExactly(
             MatrixCustomPayloadProjector.DrainRecordedSafeThresholds(),
-            window,
+            actorSelectedThreshold,
+            expectedCount,
             path);
     }
 
@@ -551,29 +618,153 @@ public sealed partial class StreamingSnapshotRestoreTests
             typeof(string), typeof(DcbDomainTypes), typeof(string), typeof(Stream), typeof(CancellationToken));
     }
 
-    private static void AssertNoWholePayloadAggregationReferences(MethodInfo asyncMethod)
+    private static IReadOnlyList<MethodBase> GetSupportedStreamRestorePathRoots()
     {
-        var forbidden = EnumerateReferencedMembers(asyncMethod)
-            .Where(member =>
-                (member.DeclaringType == typeof(StreamReadHelper) && member.Name == "ReadAllBytesAsync") ||
-                (member.DeclaringType == typeof(MemoryStream) && member.Name is ".ctor" or "ToArray") ||
-                (member.DeclaringType == typeof(File) && member.Name is "ReadAllBytes" or "ReadAllBytesAsync") ||
-                (member.DeclaringType == typeof(SerializableMultiProjectionState) && member.Name == "GetPayloadBytes"))
-            .Select(member => $"{member.DeclaringType!.FullName}.{member.Name}")
+        var teeType = GetSnapshotRestoreTeeReadStreamType();
+        var streamingSupportType = GetStreamingMultiProjectorTypesSupportType();
+        return
+        [
+            typeof(GeneralMultiProjectionActor).GetMethod(
+                "DeserializeStreamingPayloadPairAsync",
+                BindingFlags.Instance | BindingFlags.NonPublic)!,
+            typeof(SnapshotEnvelopeResolver).GetMethod(
+                nameof(SnapshotEnvelopeResolver.ResolveForRestoreAsync),
+                BindingFlags.Static | BindingFlags.Public)!,
+            GetStreamingRegistryDeserializeMethod(typeof(AotMultiProjectorTypes)),
+            GetStreamingRegistryDeserializeMethod(typeof(SimpleMultiProjectorTypes)),
+            GetStreamingRegistryDeserializeMethod(typeof(GeneralMultiProjectionActor).Assembly.GetType(
+                "Sekiban.Dcb.Domains.SimpleMultiProjectorTypes",
+                throwOnError: true)!),
+            .. GetConcreteMethodsIncludingNestedTypes(teeType),
+            .. GetConcreteMethodsIncludingNestedTypes(typeof(StreamSnapshotPayloadDeserializer)),
+            .. GetConcreteMethodsIncludingNestedTypes(streamingSupportType)
+        ];
+    }
+
+    private static Type GetSnapshotRestoreTeeReadStreamType() =>
+        typeof(SnapshotEnvelopeResolver).Assembly.GetType(
+            "Sekiban.Dcb.Snapshots.SnapshotRestoreTeeReadStream",
+            throwOnError: true)!;
+
+    private static Type GetPrefixBufferedStreamType() =>
+        typeof(StreamSnapshotPayloadDeserializer).GetNestedType(
+            "PrefixBufferedStream",
+            BindingFlags.NonPublic)
+        ?? throw new Xunit.Sdk.XunitException("StreamSnapshotPayloadDeserializer.PrefixBufferedStream was not found.");
+
+    private static Type GetStreamingMultiProjectorTypesSupportType() =>
+        typeof(StreamSnapshotPayloadDeserializer).Assembly.GetType(
+            "Sekiban.Dcb.MultiProjections.StreamingMultiProjectorTypesSupport",
+            throwOnError: true)!;
+
+    private static MethodInfo GetStreamingRegistryDeserializeMethod(Type registryType) =>
+        Assert.Single(
+            registryType.GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.DeclaredOnly),
+            method => method.Name == nameof(IStreamingMultiProjectorTypes.DeserializeFromStreamAsync));
+
+    private static IEnumerable<MethodBase> GetConcreteMethodsIncludingNestedTypes(Type type)
+    {
+        foreach (var constructor in type.GetConstructors(
+                     BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic))
+        {
+            yield return constructor;
+        }
+
+        if (type.TypeInitializer is { } typeInitializer)
+        {
+            yield return typeInitializer;
+        }
+
+        foreach (var method in type.GetMethods(
+                     BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic |
+                     BindingFlags.DeclaredOnly)
+                 .Where(method => !method.IsAbstract))
+        {
+            yield return method;
+        }
+
+        foreach (var nestedType in type.GetNestedTypes(BindingFlags.Public | BindingFlags.NonPublic))
+        {
+            foreach (var nestedMethod in GetConcreteMethodsIncludingNestedTypes(nestedType))
+            {
+                yield return nestedMethod;
+            }
+        }
+    }
+
+    private static void AssertNoWholePayloadAggregationReferences(IEnumerable<MethodBase> roots)
+    {
+        var forbidden = FindWholePayloadAggregationReferences(roots)
+            .Select(DescribeMember)
+            .Distinct(StringComparer.Ordinal)
             .ToArray();
         Assert.Empty(forbidden);
     }
 
-    private static IEnumerable<MemberInfo> EnumerateReferencedMembers(MethodInfo asyncMethod)
+    private static IReadOnlyList<MemberInfo> FindWholePayloadAggregationReferences(IEnumerable<MethodBase> roots) =>
+        EnumerateTransitiveReferencedMembers(roots)
+            .Where(IsWholePayloadAggregationReference)
+            .ToArray();
+
+    private static IEnumerable<MemberInfo> EnumerateTransitiveReferencedMembers(IEnumerable<MethodBase> roots)
     {
-        var stateMachine = asyncMethod.GetCustomAttribute<AsyncStateMachineAttribute>()?.StateMachineType
-            ?? throw new Xunit.Sdk.XunitException($"{asyncMethod.Name} is expected to be an async state machine.");
-        var moveNext = stateMachine.GetMethod("MoveNext", BindingFlags.Instance | BindingFlags.NonPublic)
+        var productAssemblies = new HashSet<Assembly>(roots
+            .Select(root => root.DeclaringType?.Assembly)
+            .OfType<Assembly>())
+        {
+            typeof(SnapshotEnvelopeResolver).Assembly,
+            typeof(StreamSnapshotPayloadDeserializer).Assembly
+        };
+        var pending = new Stack<MethodBase>(roots.Reverse());
+        var visited = new HashSet<MethodBase>();
+
+        while (pending.TryPop(out var candidate))
+        {
+            var implementation = GetImplementationMethod(candidate);
+            if (!visited.Add(implementation))
+            {
+                continue;
+            }
+
+            foreach (var member in EnumerateDirectReferencedMembers(implementation))
+            {
+                yield return member;
+                if (member is MethodBase called &&
+                    called.DeclaringType is not null &&
+                    productAssemblies.Contains(called.DeclaringType.Assembly))
+                {
+                    pending.Push(called);
+                }
+            }
+        }
+    }
+
+    private static MethodBase GetImplementationMethod(MethodBase method)
+    {
+        if (method is not MethodInfo asyncMethod ||
+            asyncMethod.GetCustomAttribute<AsyncStateMachineAttribute>()?.StateMachineType is not { } stateMachine)
+        {
+            return method;
+        }
+
+        return stateMachine.GetMethod("MoveNext", BindingFlags.Instance | BindingFlags.NonPublic)
             ?? throw new Xunit.Sdk.XunitException($"{stateMachine.FullName}.MoveNext was not found.");
-        var il = moveNext.GetMethodBody()?.GetILAsByteArray()
-            ?? throw new Xunit.Sdk.XunitException($"{stateMachine.FullName}.MoveNext has no IL body.");
-        var genericTypeArguments = stateMachine.IsGenericType ? stateMachine.GetGenericArguments() : null;
-        var genericMethodArguments = asyncMethod.IsGenericMethod ? asyncMethod.GetGenericArguments() : null;
+    }
+
+    private static IEnumerable<MemberInfo> EnumerateDirectReferencedMembers(MethodBase method)
+    {
+        var il = method.GetMethodBody()?.GetILAsByteArray();
+        if (il is null)
+        {
+            yield break;
+        }
+
+        var genericTypeArguments = method.DeclaringType?.IsGenericType == true
+            ? method.DeclaringType.GetGenericArguments()
+            : null;
+        var genericMethodArguments = method is MethodInfo methodInfo && methodInfo.IsGenericMethod
+            ? methodInfo.GetGenericArguments()
+            : null;
 
         for (var offset = 0; offset < il.Length;)
         {
@@ -585,9 +776,9 @@ public sealed partial class StreamingSnapshotRestoreTests
                 MemberInfo? member = null;
                 try
                 {
-                    member = moveNext.Module.ResolveMember(token, genericTypeArguments, genericMethodArguments);
+                    member = method.Module.ResolveMember(token, genericTypeArguments, genericMethodArguments);
                 }
-                catch (ArgumentException)
+                catch (Exception exception) when (exception is ArgumentException or BadImageFormatException)
                 {
                     // A generic method specification can be unresolved while still having no relevant aggregation call.
                 }
@@ -603,6 +794,63 @@ public sealed partial class StreamingSnapshotRestoreTests
             offset += OperandSize(opCode.OperandType, il, offset);
         }
     }
+
+    private static bool IsWholePayloadAggregationReference(MemberInfo member)
+    {
+        var declaringType = member.DeclaringType;
+        if (declaringType is null)
+        {
+            return false;
+        }
+
+        return
+            (declaringType == typeof(StreamReadHelper) && member.Name == "ReadAllBytesAsync") ||
+            (declaringType == typeof(SerializableMultiProjectionState) && member.Name == "GetPayloadBytes") ||
+            (declaringType == typeof(MemoryStream) && member.Name is ".ctor" or "ToArray" or "GetBuffer") ||
+            (declaringType == typeof(File) &&
+             (member.Name.StartsWith("ReadAllBytes", StringComparison.Ordinal) ||
+              member.Name.StartsWith("ReadAllText", StringComparison.Ordinal))) ||
+            (declaringType.IsGenericType &&
+             declaringType.GetGenericTypeDefinition() == typeof(System.Buffers.ArrayBufferWriter<>) &&
+             member.Name == ".ctor") ||
+            (declaringType == typeof(StringBuilder) && member.Name == nameof(StringBuilder.ToString)) ||
+            (typeof(TextReader).IsAssignableFrom(declaringType) &&
+             member.Name is "ReadToEnd" or "ReadToEndAsync") ||
+            (typeof(BinaryReader).IsAssignableFrom(declaringType) &&
+             member.Name == nameof(BinaryReader.ReadBytes));
+    }
+
+    private static string DescribeMember(MemberInfo member) =>
+        $"{member.DeclaringType?.FullName ?? "<unknown>"}.{member.Name}";
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static async Task<byte[]> AggregationVerifierAsyncRoot(SerializableMultiProjectionState state)
+    {
+        await Task.Yield();
+        _ = AggregationVerifierHiddenMemoryStreamHelper();
+        _ = AggregationVerifierHiddenReadAllBytesHelperAsync();
+        return AggregationVerifierHiddenPayloadBytesHelper(state);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static byte[] AggregationVerifierHiddenMemoryStreamHelper()
+    {
+        using var aggregate = new MemoryStream();
+        return aggregate.ToArray();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static async Task<byte[]> AggregationVerifierHiddenReadAllBytesHelperAsync()
+    {
+        await Task.Yield();
+        // This helper is scanned, never executed. Its only purpose is to prove that a ReadAllBytes* mutation hidden
+        // behind an async helper cannot evade the recursive production-path guard.
+        return await File.ReadAllBytesAsync(Path.Combine(Path.GetTempPath(), "aggregation-verifier-never-read"));
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static byte[] AggregationVerifierHiddenPayloadBytesHelper(SerializableMultiProjectionState state) =>
+        state.GetPayloadBytes();
 
     private static OpCode ReadOpCode(byte[] il, ref int offset)
     {
@@ -790,8 +1038,6 @@ public sealed partial class StreamingSnapshotRestoreTests
     public enum MatrixWireVersion { V9, V10 }
     public enum MatrixDelivery { Offloaded, Inline }
 
-    private sealed record ThresholdWindow(string LowerInclusive, string UpperInclusive);
-
     private sealed record RestoreRollbackSnapshot(
         object StateAccessor,
         Guid LastEventId,
@@ -819,6 +1065,9 @@ public sealed partial class StreamingSnapshotRestoreTests
 
     private static int GetLastStreamingRestoreWholePayloadAggregationCount(GeneralMultiProjectionActor actor) =>
         ReadActorField<int>(actor, "_lastStreamingRestoreWholePayloadAggregationCount");
+
+    private static string GetLastSnapshotRestoreSafeWindowThreshold(GeneralMultiProjectionActor actor) =>
+        ReadActorField<string>(actor, "_lastSnapshotRestoreSafeWindowThreshold");
 
     private static T ReadActorField<T>(GeneralMultiProjectionActor actor, string name) =>
         (T)(typeof(GeneralMultiProjectionActor)

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/StreamingSnapshotRestoreTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/StreamingSnapshotRestoreTests.cs
@@ -44,10 +44,7 @@ public sealed partial class StreamingSnapshotRestoreTests
 
             Assert.Equal(2, targetTypes.StreamDeserializeCalls);
             Assert.Equal(0, targetTypes.BufferedDeserializeCalls);
-            Assert.True(SatisfiesNoWholePayloadStructuralDiscriminant(
-                targetTypes.StreamDeserializeCalls,
-                targetTypes.BufferedDeserializeCalls,
-                wholePayloadAggregations: 0));
+            Assert.Equal(0, GetLastStreamingRestoreWholePayloadAggregationCount(target));
             Assert.True(stream.ReadCalls > 1);
             Assert.Equal(0, stream.LengthAccesses);
             Assert.Equal(0, stream.SeekCalls);
@@ -106,10 +103,9 @@ public sealed partial class StreamingSnapshotRestoreTests
 
         Assert.Equal(2, targetTypes.StreamDeserializeCalls);
         Assert.Equal(2, targetTypes.WholePayloadAggregations);
-        Assert.False(SatisfiesNoWholePayloadStructuralDiscriminant(
-            targetTypes.StreamDeserializeCalls,
-            targetTypes.BufferedDeserializeCalls,
-            targetTypes.WholePayloadAggregations));
+        // The actor's production-scope counter observes StreamReadHelper itself. This is deliberately independent of
+        // the control registry's own counter, so a MemoryStream/ToArray mutation at the shared seam is also killed.
+        Assert.Equal(2, GetLastStreamingRestoreWholePayloadAggregationCount(target));
     }
 
     [Fact]
@@ -177,18 +173,16 @@ public sealed partial class StreamingSnapshotRestoreTests
         var before = await target.GetStateAsync();
         Assert.True(before.IsSuccess);
         var beforeState = before.GetValue();
+        var beforeRawState = CaptureRestoreRollbackSnapshot(target);
 
         await using var resolved = await SnapshotEnvelopeResolver.ResolveForRestoreAsync(envelope, blob);
-        await Assert.ThrowsAnyAsync<Exception>(() => target.SetResolvedSnapshotAsync(resolved));
+        var exception = await Assert.ThrowsAnyAsync<Exception>(() => target.SetResolvedSnapshotAsync(resolved));
 
         var after = await target.GetStateAsync();
-        Assert.True(after.IsSuccess);
-        Assert.Equal(Payload(beforeState), Payload(after.GetValue()));
-        Assert.Equal(beforeState.Version, after.GetValue().Version);
-        Assert.Equal(beforeState.LastEventId, after.GetValue().LastEventId);
-        Assert.Equal(beforeState.LastSortableUniqueId, after.GetValue().LastSortableUniqueId);
-        Assert.Equal(beforeState.IsCatchedUp, after.GetValue().IsCatchedUp);
-        Assert.Equal(beforeState.IsSafeState, after.GetValue().IsSafeState);
+        Assert.False(after.IsSuccess);
+        Assert.Same(exception, after.GetException());
+        AssertRestoreRollbackSnapshotUnchanged(target, beforeRawState);
+        Assert.Equal(["before"], Payload(beforeState));
     }
 
     [Fact]
@@ -201,18 +195,18 @@ public sealed partial class StreamingSnapshotRestoreTests
         var target = CreateActor(targetTypes);
         await target.AddEventsAsync([CreateEvent("before-corrupt")]);
         var before = (await target.GetStateAsync()).GetValue();
+        var beforeRawState = CaptureRestoreRollbackSnapshot(target);
 
         await using var resolved = await SnapshotEnvelopeResolver.ResolveForRestoreAsync(envelope, blob);
-        await Assert.ThrowsAnyAsync<Exception>(() => target.SetResolvedSnapshotAsync(resolved));
+        var exception = await Assert.ThrowsAnyAsync<Exception>(() => target.SetResolvedSnapshotAsync(resolved));
 
         Assert.Equal(1, targetTypes.StreamDeserializeCalls);
         Assert.Equal(0, targetTypes.BufferedDeserializeCalls);
         var after = await target.GetStateAsync();
-        Assert.True(after.IsSuccess);
-        Assert.Equal(Payload(before), Payload(after.GetValue()));
-        Assert.Equal(before.LastEventId, after.GetValue().LastEventId);
-        Assert.Equal(before.LastSortableUniqueId, after.GetValue().LastSortableUniqueId);
-        Assert.Equal(before.Version, after.GetValue().Version);
+        Assert.False(after.IsSuccess);
+        Assert.Same(exception, after.GetException());
+        AssertRestoreRollbackSnapshotUnchanged(target, beforeRawState);
+        Assert.Equal(["before-corrupt"], Payload(before));
     }
 
     [Theory]
@@ -480,15 +474,12 @@ public sealed partial class StreamingSnapshotRestoreTests
 
     [Fact]
     [Trait("Category", "StreamingRestoreNormalMemory")]
-    public async Task Controlled_18MiB_offloaded_gzip_fixture_uses_the_same_nonbuffering_production_seam()
+    public async Task Controlled_small_graph_large_wire_offloaded_gzip_fixture_uses_the_same_nonbuffering_production_seam()
     {
         // Normal CI fixture: this is intentionally 16-32 MiB before gzip. It proves the selected path and stream
         // structure; it does not claim that the projection graph itself cannot OOM.
-        var largeBytes = new byte[13_500_000];
-        Random.Shared.NextBytes(largeBytes);
-        var largeValue = Convert.ToBase64String(largeBytes);
-        var sourceTypes = CreateReflectionRegistry();
-        var (envelope, blob) = await CreateOffloadedEnvelopeAsync(sourceTypes, [largeValue]);
+        var (envelope, blob, uncompressedWireBytes) = await CreateSmallGraphLargeWireFixtureAsync();
+        Assert.InRange(uncompressedWireBytes, 16 * 1024 * 1024, 32 * 1024 * 1024);
         var targetTypes = new CountingStreamingRegistry(CreateReflectionRegistry());
         var target = CreateActor(targetTypes);
 
@@ -501,10 +492,16 @@ public sealed partial class StreamingSnapshotRestoreTests
         Assert.True(stream.ReadCalls > 1);
         Assert.Equal(0, stream.LengthAccesses);
         Assert.Equal(0, stream.SeekCalls);
-        Assert.True(SatisfiesNoWholePayloadStructuralDiscriminant(
-            targetTypes.StreamDeserializeCalls,
-            targetTypes.BufferedDeserializeCalls,
-            wholePayloadAggregations: 0));
+        Assert.Equal(0, GetLastStreamingRestoreWholePayloadAggregationCount(target));
+
+        // Same envelope, same resolver-to-actor production seam, but a deliberately buffered capability. The shared
+        // actor-side observation — not the registry's test counter — must expose the whole-payload aggregation.
+        var bufferedControlTypes = new IntentionallyBufferedStreamingRegistry(CreateReflectionRegistry());
+        var bufferedControl = CreateActor(bufferedControlTypes);
+        await using var bufferedResolved = await SnapshotEnvelopeResolver.ResolveForRestoreAsync(envelope, blob);
+        await bufferedControl.SetResolvedSnapshotAsync(bufferedResolved);
+        Assert.Equal(2, bufferedControlTypes.WholePayloadAggregations);
+        Assert.Equal(2, GetLastStreamingRestoreWholePayloadAggregationCount(bufferedControl));
     }
 
     [Fact]
@@ -544,10 +541,7 @@ public sealed partial class StreamingSnapshotRestoreTests
             $"streamDeserializeCalls={targetTypes.StreamDeserializeCalls}; bufferedDeserializeCalls={targetTypes.BufferedDeserializeCalls}; " +
             $"readCalls={stream.ReadCalls}; lengthAccesses={stream.LengthAccesses}; seekCalls={stream.SeekCalls}");
 
-        Assert.True(SatisfiesNoWholePayloadStructuralDiscriminant(
-            targetTypes.StreamDeserializeCalls,
-            targetTypes.BufferedDeserializeCalls,
-            wholePayloadAggregations: 0));
+        Assert.Equal(0, GetLastStreamingRestoreWholePayloadAggregationCount(target));
         Assert.True(stream.ReadCalls > 1);
         Assert.Equal(0, stream.LengthAccesses);
         Assert.Equal(0, stream.SeekCalls);
@@ -572,12 +566,6 @@ public sealed partial class StreamingSnapshotRestoreTests
             candidate.GetParameters().Select(parameter => parameter.ParameterType).SequenceEqual(parameterTypes));
         Assert.True(method.IsPublic);
     }
-
-    private static bool SatisfiesNoWholePayloadStructuralDiscriminant(
-        int streamDeserializeCalls,
-        int bufferedDeserializeCalls,
-        int wholePayloadAggregations) =>
-        streamDeserializeCalls == 2 && bufferedDeserializeCalls == 0 && wholePayloadAggregations == 0;
 
     private static GeneralMultiProjectionActor CreateActor(
         ICoreMultiProjectorTypes types,
@@ -756,7 +744,7 @@ public sealed partial class StreamingSnapshotRestoreTests
             Inner.Deserialize(data, name, options);
         public ResultBox<SerializationResult> Serialize(string name, DcbDomainTypes domain, string threshold,
             IMultiProjectionPayload payload) => Inner.Serialize(name, domain, threshold, payload);
-        public ResultBox<IMultiProjectionPayload> Deserialize(string name, DcbDomainTypes domain, string threshold,
+        public virtual ResultBox<IMultiProjectionPayload> Deserialize(string name, DcbDomainTypes domain, string threshold,
             byte[] data)
         {
             BufferedDeserializeCalls++;

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/StreamingSnapshotRestoreTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/StreamingSnapshotRestoreTests.cs
@@ -1,0 +1,951 @@
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Diagnostics;
+using Microsoft.Extensions.Logging;
+using ResultBoxes;
+using Sekiban.Dcb.Actors;
+using Sekiban.Dcb.Common;
+using Sekiban.Dcb.Domains;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.MultiProjections;
+using Sekiban.Dcb.Queries;
+using Sekiban.Dcb.Snapshots;
+using Sekiban.Dcb.Tags;
+
+namespace Sekiban.Dcb.Tests;
+
+/// <summary>
+///     SEK-G42 production restore seam tests. These use an actual offloaded envelope, a non-seekable partial-read stream,
+///     and the actor's resolver-produced input rather than exercising a registry helper in isolation.
+/// </summary>
+public sealed partial class StreamingSnapshotRestoreTests
+{
+    [Fact]
+    public async Task Offloaded_gzip_json_restore_uses_stream_capability_without_a_whole_payload_byte_array()
+    {
+        var sourceTypes = CreateReflectionRegistry();
+        var (envelope, blob) = await CreateOffloadedEnvelopeAsync(sourceTypes, ["one", "two", "three"]);
+        Assert.True(blob.LastWrittenPayload is { Length: >= 2 } &&
+            blob.LastWrittenPayload[0] == 0x1f && blob.LastWrittenPayload[1] == 0x8b);
+        var targetTypes = new CountingStreamingRegistry(CreateReflectionRegistry());
+        var target = CreateActor(targetTypes);
+
+        var resolved = await SnapshotEnvelopeResolver.ResolveForRestoreAsync(envelope, blob);
+        var stream = Assert.IsType<CappedNonSeekableStream>(resolved.PayloadStream);
+        try
+        {
+            // The resolver propagates metadata plus the opened stream; it has not converted the offloaded bytes back
+            // into any v9/v10 inline representation before the actor reaches the streaming capability.
+            Assert.Null(resolved.State.PayloadJson);
+            Assert.Null(resolved.State.PayloadBase64);
+            Assert.Null(resolved.State.RuntimePayloadBytes);
+            await target.SetResolvedSnapshotAsync(resolved);
+
+            Assert.Equal(2, targetTypes.StreamDeserializeCalls);
+            Assert.Equal(0, targetTypes.BufferedDeserializeCalls);
+            Assert.True(SatisfiesNoWholePayloadStructuralDiscriminant(
+                targetTypes.StreamDeserializeCalls,
+                targetTypes.BufferedDeserializeCalls,
+                wholePayloadAggregations: 0));
+            Assert.True(stream.ReadCalls > 1);
+            Assert.Equal(0, stream.LengthAccesses);
+            Assert.Equal(0, stream.SeekCalls);
+            Assert.False(stream.IsDisposed);
+
+            var state = await target.GetStateAsync();
+            Assert.True(state.IsSuccess);
+            Assert.Equal(["one", "two", "three"], Payload(state.GetValue()));
+        }
+        finally
+        {
+            await resolved.DisposeAsync();
+        }
+
+        Assert.True(stream.IsDisposed);
+    }
+
+    [Fact]
+    public async Task Capability_absent_uses_one_observable_buffered_fallback_without_payload_logging()
+    {
+        const string secret = "payload-must-not-appear-in-log";
+        var sourceTypes = CreateReflectionRegistry();
+        var (envelope, blob) = await CreateOffloadedEnvelopeAsync(sourceTypes, [secret]);
+        var targetTypes = new CountingBufferedRegistry(CreateReflectionRegistry());
+        var logger = new RecordingLogger();
+        var target = CreateActor(targetTypes, logger);
+
+        await using var resolved = await SnapshotEnvelopeResolver.ResolveForRestoreAsync(envelope, blob);
+        await target.SetResolvedSnapshotAsync(resolved);
+
+        // The one fallback read is followed by the pre-existing dual-state clone, which has its own byte-array
+        // serializer round-trip. The fallback log proves the offloaded input itself was buffered exactly once.
+        Assert.Equal(2, targetTypes.BufferedDeserializeCalls);
+        var fallback = Assert.Single(
+            logger.Messages,
+            message => message.Contains("capability-absent", StringComparison.Ordinal));
+        Assert.Contains(StreamPayloadProjector.MultiProjectorName, fallback, StringComparison.Ordinal);
+        Assert.Contains(targetTypes.GetType().FullName!, fallback, StringComparison.Ordinal);
+        Assert.Contains("offloaded", fallback, StringComparison.Ordinal);
+        Assert.DoesNotContain(secret, fallback, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Intentionally_buffered_stream_registry_fails_the_same_structural_discriminant()
+    {
+        // A registry that merely performs chunked reads is not sufficient evidence: it can still aggregate them in a
+        // MemoryStream. This negative control does exactly that through the only whole-buffer helper and must fail the
+        // same seam discriminant that the production JSON+gzip registry passes above.
+        var sourceTypes = CreateReflectionRegistry();
+        var (envelope, blob) = await CreateOffloadedEnvelopeAsync(sourceTypes, ["buffered-negative-control"]);
+        var targetTypes = new IntentionallyBufferedStreamingRegistry(CreateReflectionRegistry());
+        var target = CreateActor(targetTypes);
+
+        await using var resolved = await SnapshotEnvelopeResolver.ResolveForRestoreAsync(envelope, blob);
+        await target.SetResolvedSnapshotAsync(resolved);
+
+        Assert.Equal(2, targetTypes.StreamDeserializeCalls);
+        Assert.Equal(2, targetTypes.WholePayloadAggregations);
+        Assert.False(SatisfiesNoWholePayloadStructuralDiscriminant(
+            targetTypes.StreamDeserializeCalls,
+            targetTypes.BufferedDeserializeCalls,
+            targetTypes.WholePayloadAggregations));
+    }
+
+    [Fact]
+    public async Task Present_capability_failure_propagates_and_never_retries_the_buffered_path()
+    {
+        var sourceTypes = CreateReflectionRegistry();
+        var (envelope, blob) = await CreateOffloadedEnvelopeAsync(sourceTypes, ["will-fail"]);
+        var targetTypes = new FailingStreamingRegistry(CreateReflectionRegistry());
+        var target = CreateActor(targetTypes);
+
+        await using var resolved = await SnapshotEnvelopeResolver.ResolveForRestoreAsync(envelope, blob);
+        var exception = await Assert.ThrowsAsync<InvalidDataException>(
+            () => target.SetResolvedSnapshotAsync(resolved));
+
+        Assert.Equal("stream-capability-failure", exception.Message);
+        Assert.Equal(1, targetTypes.StreamDeserializeCalls);
+        Assert.Equal(0, targetTypes.BufferedDeserializeCalls);
+    }
+
+    [Fact]
+    public async Task Nonseekable_partial_stream_honors_cancellation_and_caller_ownership()
+    {
+        var sourceTypes = CreateReflectionRegistry();
+        var (envelope, blob) = await CreateOffloadedEnvelopeAsync(sourceTypes, ["cancel"]);
+        var target = CreateActor(new CountingStreamingRegistry(CreateReflectionRegistry()));
+        await using var resolved = await SnapshotEnvelopeResolver.ResolveForRestoreAsync(envelope, blob);
+        var stream = Assert.IsType<CappedNonSeekableStream>(resolved.PayloadStream);
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => target.SetResolvedSnapshotAsync(resolved, cancellation.Token));
+        Assert.False(stream.IsDisposed);
+    }
+
+    [Fact]
+    public async Task Stream_restore_reads_from_a_nonseekable_streams_current_position_without_disposing_it()
+    {
+        var sourceTypes = CreateReflectionRegistry();
+        var (envelope, blob) = await CreateOffloadedEnvelopeAsync(sourceTypes, ["current-position"]);
+        blob.OpenedPayloadPrefix = [0x99, 0x88, 0x77];
+        var target = CreateActor(new CountingStreamingRegistry(CreateReflectionRegistry()));
+
+        await using var resolved = await SnapshotEnvelopeResolver.ResolveForRestoreAsync(envelope, blob);
+        var stream = Assert.IsType<CappedNonSeekableStream>(resolved.PayloadStream);
+        await target.SetResolvedSnapshotAsync(resolved);
+
+        var state = await target.GetStateAsync();
+        Assert.True(state.IsSuccess);
+        Assert.Equal(["current-position"], Payload(state.GetValue()));
+        Assert.True(stream.ReadCalls > 1);
+        Assert.Equal(0, stream.LengthAccesses);
+        Assert.Equal(0, stream.SeekCalls);
+        Assert.False(stream.IsDisposed);
+    }
+
+    [Fact]
+    public async Task Truncated_gzip_payload_keeps_previous_payload_and_tracking_metadata_unchanged()
+    {
+        var sourceTypes = CreateReflectionRegistry();
+        var (envelope, blob) = await CreateOffloadedEnvelopeAsync(sourceTypes, ["restored"]);
+        blob.TruncateOpenedPayloadTo = 3;
+        var target = CreateActor(new CountingStreamingRegistry(CreateReflectionRegistry()));
+        await target.AddEventsAsync([CreateEvent("before")]);
+        var before = await target.GetStateAsync();
+        Assert.True(before.IsSuccess);
+        var beforeState = before.GetValue();
+
+        await using var resolved = await SnapshotEnvelopeResolver.ResolveForRestoreAsync(envelope, blob);
+        await Assert.ThrowsAnyAsync<Exception>(() => target.SetResolvedSnapshotAsync(resolved));
+
+        var after = await target.GetStateAsync();
+        Assert.True(after.IsSuccess);
+        Assert.Equal(Payload(beforeState), Payload(after.GetValue()));
+        Assert.Equal(beforeState.Version, after.GetValue().Version);
+        Assert.Equal(beforeState.LastEventId, after.GetValue().LastEventId);
+        Assert.Equal(beforeState.LastSortableUniqueId, after.GetValue().LastSortableUniqueId);
+        Assert.Equal(beforeState.IsCatchedUp, after.GetValue().IsCatchedUp);
+        Assert.Equal(beforeState.IsSafeState, after.GetValue().IsSafeState);
+    }
+
+    [Fact]
+    public async Task Corrupt_gzip_payload_propagates_without_a_buffered_retry_or_partial_publication()
+    {
+        var sourceTypes = CreateReflectionRegistry();
+        var (envelope, blob) = await CreateOffloadedEnvelopeAsync(sourceTypes, ["restored"]);
+        blob.OpenedPayloadOverride = [0x1f, 0x8b, 0xff, 0x00, 0x01];
+        var targetTypes = new CountingStreamingRegistry(CreateReflectionRegistry());
+        var target = CreateActor(targetTypes);
+        await target.AddEventsAsync([CreateEvent("before-corrupt")]);
+        var before = (await target.GetStateAsync()).GetValue();
+
+        await using var resolved = await SnapshotEnvelopeResolver.ResolveForRestoreAsync(envelope, blob);
+        await Assert.ThrowsAnyAsync<Exception>(() => target.SetResolvedSnapshotAsync(resolved));
+
+        Assert.Equal(1, targetTypes.StreamDeserializeCalls);
+        Assert.Equal(0, targetTypes.BufferedDeserializeCalls);
+        var after = await target.GetStateAsync();
+        Assert.True(after.IsSuccess);
+        Assert.Equal(Payload(before), Payload(after.GetValue()));
+        Assert.Equal(before.LastEventId, after.GetValue().LastEventId);
+        Assert.Equal(before.LastSortableUniqueId, after.GetValue().LastSortableUniqueId);
+        Assert.Equal(before.Version, after.GetValue().Version);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task Inline_v9_and_v10_legacy_payloads_remain_equivalent(bool useV10Base64)
+    {
+        var registry = CreateReflectionRegistry();
+        var domain = CreateDomain(registry);
+        var payload = new StreamPayloadProjector(["legacy"]);
+        var bytes = JsonSerializer.SerializeToUtf8Bytes(payload, domain.JsonSerializerOptions);
+        var state = new SerializableMultiProjectionState(
+            payloadJson: useV10Base64 ? null : Encoding.UTF8.GetString(bytes),
+            payloadBase64: useV10Base64 ? Convert.ToBase64String(bytes) : null,
+            typeof(StreamPayloadProjector).FullName!,
+            StreamPayloadProjector.MultiProjectorName,
+            StreamPayloadProjector.MultiProjectorVersion,
+            SortableUniqueId.MinValue.Value,
+            Guid.Empty,
+            version: 7);
+        var actor = CreateActor(registry);
+
+        await actor.SetSnapshotAsync(new SerializableMultiProjectionStateEnvelope(false, state, null));
+
+        var restored = await actor.GetStateAsync();
+        Assert.True(restored.IsSuccess);
+        Assert.Equal(["legacy"], Payload(restored.GetValue()));
+        Assert.Equal(7, restored.GetValue().Version);
+    }
+
+    [Fact]
+    public async Task Offloaded_gzip_aot_json_typeinfo_restores_through_the_stream_capability()
+    {
+        var aotTypes = new AotMultiProjectorTypes();
+        aotTypes.RegisterProjector<StreamPayloadProjector>(StreamingRestoreJsonContext.Default.StreamPayloadProjector);
+        var (envelope, blob) = await CreateOffloadedEnvelopeAsync(aotTypes, ["aot"]);
+        Assert.True(blob.LastWrittenPayload is { Length: >= 2 } &&
+            blob.LastWrittenPayload[0] == 0x1f && blob.LastWrittenPayload[1] == 0x8b);
+        var target = CreateActor(aotTypes);
+
+        await using var resolved = await SnapshotEnvelopeResolver.ResolveForRestoreAsync(envelope, blob);
+        await target.SetResolvedSnapshotAsync(resolved);
+        var restored = await target.GetStateAsync();
+
+        Assert.True(restored.IsSuccess);
+        Assert.Equal(["aot"], Payload(restored.GetValue()));
+        Assert.IsAssignableFrom<IStreamingMultiProjectorTypes>(aotTypes);
+    }
+
+    [Fact]
+    public async Task Offloaded_legacy_raw_json_reflection_payload_restores_through_the_same_stream_capability()
+    {
+        // Existing stores can contain uncompressed JSON payloads. The production helper checks only a two-byte prefix,
+        // replays it on the same non-seekable stream, and invokes JsonSerializer.DeserializeAsync without a byte[] copy.
+        var sourceTypes = CreateReflectionRegistry();
+        var domain = CreateDomain(sourceTypes);
+        var bytes = JsonSerializer.SerializeToUtf8Bytes(
+            new StreamPayloadProjector(["legacy-raw"]),
+            domain.JsonSerializerOptions);
+        var blob = new CappedBlobAccessor();
+        var key = await blob.WriteAsync(new MemoryStream(bytes), StreamPayloadProjector.MultiProjectorName);
+        Assert.False(blob.LastWrittenPayload is { Length: >= 2 } &&
+            blob.LastWrittenPayload[0] == 0x1f && blob.LastWrittenPayload[1] == 0x8b);
+        var envelope = new SerializableMultiProjectionStateEnvelope(
+            IsOffloaded: true,
+            InlineState: null,
+            OffloadedState: new SerializableMultiProjectionStateOffloaded(
+                key,
+                blob.ProviderName,
+                typeof(StreamPayloadProjector).FullName!,
+                StreamPayloadProjector.MultiProjectorName,
+                StreamPayloadProjector.MultiProjectorVersion,
+                SortableUniqueId.MinValue.Value,
+                Guid.Empty,
+                Version: 2,
+                IsCatchedUp: true,
+                IsSafeState: true,
+                PayloadLength: bytes.Length,
+                OriginalSizeBytes: bytes.Length,
+                CompressedSizeBytes: bytes.Length));
+        var targetTypes = new CountingStreamingRegistry(CreateReflectionRegistry());
+        var target = CreateActor(targetTypes);
+
+        await using var resolved = await SnapshotEnvelopeResolver.ResolveForRestoreAsync(envelope, blob);
+        await target.SetResolvedSnapshotAsync(resolved);
+
+        var restored = await target.GetStateAsync();
+        Assert.True(restored.IsSuccess);
+        Assert.Equal(["legacy-raw"], Payload(restored.GetValue()));
+        Assert.Equal(2, targetTypes.StreamDeserializeCalls);
+        Assert.Equal(0, targetTypes.BufferedDeserializeCalls);
+    }
+
+    [Fact]
+    public async Task Custom_projector_stream_capability_is_detected_per_projector()
+    {
+        var types = new SimpleMultiProjectorTypes();
+        Assert.True(types.RegisterProjectorWithCustomSerialization<CustomStreamPayloadProjector>().IsSuccess);
+        Assert.True(((IStreamingMultiProjectorTypes)types)
+            .SupportsStreamDeserialization(CustomStreamPayloadProjector.MultiProjectorName));
+        var (envelope, blob) = await CreateOffloadedEnvelopeAsync(
+            types,
+            ["custom"],
+            CustomStreamPayloadProjector.MultiProjectorName);
+        Assert.False(blob.LastWrittenPayload is { Length: >= 2 } &&
+            blob.LastWrittenPayload[0] == 0x1f && blob.LastWrittenPayload[1] == 0x8b);
+        var target = new GeneralMultiProjectionActor(
+            CreateDomain(types),
+            CustomStreamPayloadProjector.MultiProjectorName);
+
+        await using var resolved = await SnapshotEnvelopeResolver.ResolveForRestoreAsync(envelope, blob);
+        await target.SetResolvedSnapshotAsync(resolved);
+        var restored = await target.GetStateAsync();
+
+        Assert.True(restored.IsSuccess);
+        Assert.Equal(["custom"], Assert.IsType<CustomStreamPayloadProjector>(restored.GetValue().Payload).Values);
+    }
+
+    [Fact]
+    public async Task Custom_projector_without_the_optional_capability_uses_exactly_one_logged_fallback()
+    {
+        const string payloadSecret = "custom-buffered-payload-must-not-be-logged";
+        var types = new SimpleMultiProjectorTypes();
+        Assert.True(types.RegisterProjectorWithCustomSerialization<CustomBufferedPayloadProjector>().IsSuccess);
+        var streamingTypes = Assert.IsAssignableFrom<IStreamingMultiProjectorTypes>(types);
+        Assert.False(streamingTypes.SupportsStreamDeserialization(CustomBufferedPayloadProjector.MultiProjectorName));
+        var (envelope, blob) = await CreateOffloadedEnvelopeAsync(
+            types,
+            [payloadSecret],
+            CustomBufferedPayloadProjector.MultiProjectorName);
+        var logger = new RecordingLogger();
+        var target = new GeneralMultiProjectionActor(
+            CreateDomain(types),
+            CustomBufferedPayloadProjector.MultiProjectorName,
+            logger: logger);
+
+        await using var resolved = await SnapshotEnvelopeResolver.ResolveForRestoreAsync(envelope, blob);
+        await target.SetResolvedSnapshotAsync(resolved);
+
+        var restored = await target.GetStateAsync();
+        Assert.True(restored.IsSuccess);
+        Assert.Equal(
+            [payloadSecret],
+            Assert.IsType<CustomBufferedPayloadProjector>(restored.GetValue().Payload).Values);
+        var fallback = Assert.Single(
+            logger.Messages,
+            message => message.Contains("capability-absent", StringComparison.Ordinal));
+        Assert.DoesNotContain(payloadSecret, fallback, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Frozen_10_18_external_registry_binary_loads_and_is_invoked_through_the_buffered_compatibility_path()
+    {
+        // The fixture project references only the published 10.18 packages. At test run its old ICore interface token is
+        // bound to this build, proving the optional capability did not add an abstract member or prevent loading.
+        var fixturePath = Path.Combine(AppContext.BaseDirectory, "Sekiban.Dcb.StreamingRestore.Legacy1018Fixture.dll");
+        var loaded = System.Reflection.Assembly.LoadFrom(fixturePath);
+        var registryType = loaded.GetType(
+            "Sekiban.Dcb.StreamingRestore.Legacy1018Fixture.Legacy1018ExternalRegistry",
+            throwOnError: true)!;
+        var registry = Assert.IsAssignableFrom<ICoreMultiProjectorTypes>(Activator.CreateInstance(registryType));
+        Assert.False(registry is IStreamingMultiProjectorTypes);
+
+        var bytes = Encoding.UTF8.GetBytes("v10.18 external registry payload");
+        var blob = new CappedBlobAccessor();
+        const string projectorName = "legacy-1018-external-registry";
+        const string projectorVersion = "10.18";
+        var key = await blob.WriteAsync(new MemoryStream(bytes), projectorName);
+        var envelope = new SerializableMultiProjectionStateEnvelope(
+            IsOffloaded: true,
+            InlineState: null,
+            OffloadedState: new SerializableMultiProjectionStateOffloaded(
+                key,
+                blob.ProviderName,
+                "Sekiban.Dcb.StreamingRestore.Legacy1018Fixture.Legacy1018Payload",
+                projectorName,
+                projectorVersion,
+                SortableUniqueId.MinValue.Value,
+                Guid.Empty,
+                Version: 3,
+                IsCatchedUp: true,
+                IsSafeState: true,
+                PayloadLength: bytes.Length,
+                OriginalSizeBytes: bytes.Length,
+                CompressedSizeBytes: bytes.Length));
+        var actor = new GeneralMultiProjectionActor(
+            CreateDomain(registry),
+            projectorName);
+
+        await using var resolved = await SnapshotEnvelopeResolver.ResolveForRestoreAsync(envelope, blob);
+        await actor.SetResolvedSnapshotAsync(resolved);
+
+        var state = await actor.GetStateAsync();
+        Assert.True(state.IsSuccess);
+        Assert.Equal(
+            "v10.18 external registry payload",
+            registryType.Assembly
+                .GetType(state.GetValue().Payload.GetType().FullName!, throwOnError: true)!
+                .GetProperty("Value")!
+                .GetValue(state.GetValue().Payload));
+        // Once for the explicitly observable fallback and once for the legacy dual-state clone. Both calls are to the
+        // separately compiled 10.18 implementation, not a test double built against the new capability.
+        Assert.Equal(2, registryType.GetProperty("DeserializeCalls")!.GetValue(registry));
+    }
+
+    [Fact]
+    public void Streaming_restore_public_surface_is_additive_and_the_legacy_registry_contract_is_frozen()
+    {
+        // This list is the published v10.18 ICoreMultiProjectorTypes surface. The stream capability must remain a
+        // separate opt-in interface: adding a member here would break the separately compiled external fixture above.
+        var legacy = typeof(ICoreMultiProjectorTypes).GetMethods();
+        Assert.Equal(12, legacy.Length);
+        AssertMethod(legacy, "Project", typeof(ResultBox<IMultiProjectionPayload>),
+            typeof(string), typeof(IMultiProjectionPayload), typeof(Event), typeof(List<ITag>),
+            typeof(DcbDomainTypes), typeof(SortableUniqueId));
+        AssertMethod(legacy, "GetProjectorVersion", typeof(ResultBox<string>), typeof(string));
+        AssertMethod(legacy, "GetAllProjectorNames", typeof(IReadOnlyList<string>));
+        AssertMethod(legacy, "GetInitialPayloadGenerator", typeof(ResultBox<Func<IMultiProjectionPayload>>), typeof(string));
+        AssertMethod(legacy, "GetProjectorType", typeof(ResultBox<Type>), typeof(string));
+        AssertMethod(legacy, "GenerateInitialPayload", typeof(ResultBox<IMultiProjectionPayload>), typeof(string));
+        AssertMethod(legacy, "Deserialize", typeof(ResultBox<IMultiProjectionPayload>),
+            typeof(byte[]), typeof(string), typeof(JsonSerializerOptions));
+        AssertMethod(legacy, "Deserialize", typeof(ResultBox<IMultiProjectionPayload>),
+            typeof(string), typeof(DcbDomainTypes), typeof(string), typeof(byte[]));
+        AssertMethod(legacy, "Serialize", typeof(ResultBox<SerializationResult>),
+            typeof(string), typeof(DcbDomainTypes), typeof(string), typeof(IMultiProjectionPayload));
+        AssertMethod(legacy, "SerializeToStream", typeof(ResultBox<SerializationSizeInfo>),
+            typeof(string), typeof(DcbDomainTypes), typeof(string), typeof(IMultiProjectionPayload), typeof(Stream));
+        AssertMethod(legacy, "DeserializeJson", typeof(ResultBox<IMultiProjectionPayload>),
+            typeof(string), typeof(string), typeof(DcbDomainTypes));
+        var customRegistration = Assert.Single(
+            legacy,
+            method => method.Name == "RegisterProjectorWithCustomSerialization");
+        Assert.True(customRegistration.IsGenericMethodDefinition);
+        Assert.Equal(typeof(ResultBox<bool>), customRegistration.ReturnType);
+        Assert.Empty(customRegistration.GetParameters());
+        Assert.DoesNotContain(legacy, method => method.Name is "DeserializeFromStreamAsync" or "SupportsStreamDeserialization");
+
+        var streaming = typeof(IStreamingMultiProjectorTypes).GetMethods();
+        Assert.Equal(2, streaming.Length);
+        AssertMethod(streaming, "SupportsStreamDeserialization", typeof(bool), typeof(string));
+        AssertMethod(streaming, "DeserializeFromStreamAsync", typeof(Task<ResultBox<IMultiProjectionPayload>>),
+            typeof(string), typeof(DcbDomainTypes), typeof(string), typeof(Stream), typeof(CancellationToken));
+
+        var custom = typeof(ICoreMultiProjectorWithStreamDeserialization).GetMethods();
+        Assert.Single(custom);
+        AssertMethod(custom, "DeserializeFromStreamAsync", typeof(Task<IMultiProjectionPayload>),
+            typeof(DcbDomainTypes), typeof(string), typeof(Stream), typeof(CancellationToken));
+
+        Assert.Equal(
+            ["IsOffloaded", "PayloadStream", "State"],
+            typeof(ResolvedSnapshotRestore).GetProperties().Select(property => property.Name).OrderBy(name => name));
+        Assert.Contains(typeof(IAsyncDisposable), typeof(ResolvedSnapshotRestore).GetInterfaces());
+        AssertMethod(
+            typeof(SnapshotEnvelopeResolver).GetMethods(),
+            "ResolveForRestoreAsync",
+            typeof(Task<ResolvedSnapshotRestore>),
+            typeof(SerializableMultiProjectionStateEnvelope), typeof(IBlobStorageSnapshotAccessor), typeof(CancellationToken));
+        AssertMethod(
+            typeof(GeneralMultiProjectionActor).GetMethods(),
+            "SetResolvedSnapshotAsync",
+            typeof(Task),
+            typeof(ResolvedSnapshotRestore), typeof(CancellationToken));
+    }
+
+    [Fact]
+    [Trait("Category", "StreamingRestoreNormalMemory")]
+    public async Task Controlled_18MiB_offloaded_gzip_fixture_uses_the_same_nonbuffering_production_seam()
+    {
+        // Normal CI fixture: this is intentionally 16-32 MiB before gzip. It proves the selected path and stream
+        // structure; it does not claim that the projection graph itself cannot OOM.
+        var largeBytes = new byte[13_500_000];
+        Random.Shared.NextBytes(largeBytes);
+        var largeValue = Convert.ToBase64String(largeBytes);
+        var sourceTypes = CreateReflectionRegistry();
+        var (envelope, blob) = await CreateOffloadedEnvelopeAsync(sourceTypes, [largeValue]);
+        var targetTypes = new CountingStreamingRegistry(CreateReflectionRegistry());
+        var target = CreateActor(targetTypes);
+
+        await using var resolved = await SnapshotEnvelopeResolver.ResolveForRestoreAsync(envelope, blob);
+        var stream = Assert.IsType<CappedNonSeekableStream>(resolved.PayloadStream);
+        await target.SetResolvedSnapshotAsync(resolved);
+
+        Assert.Equal(2, targetTypes.StreamDeserializeCalls);
+        Assert.Equal(0, targetTypes.BufferedDeserializeCalls);
+        Assert.True(stream.ReadCalls > 1);
+        Assert.Equal(0, stream.LengthAccesses);
+        Assert.Equal(0, stream.SeekCalls);
+        Assert.True(SatisfiesNoWholePayloadStructuralDiscriminant(
+            targetTypes.StreamDeserializeCalls,
+            targetTypes.BufferedDeserializeCalls,
+            wholePayloadAggregations: 0));
+    }
+
+    [Fact]
+    [Trait("Category", "StreamingRestoreManualMemory")]
+    public async Task Manual_143MiB_offloaded_fixture_reports_peak_and_selected_restore_path_without_claiming_no_oom()
+    {
+        // This intentionally does not run as part of ordinary CI. The dedicated scheduled/manual workflow supplies the
+        // opt-in variable, runs this test in its own process with a timeout and virtual-memory ceiling, and preserves
+        // the console telemetry. The assertion is selected-path structure, never a "no OOM" promise.
+        if (!string.Equals(Environment.GetEnvironmentVariable("SEKIBAN_STREAM_RESTORE_SMOKE"), "1", StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        const int inputBytes = 112_500_000; // Base64 JSON payload ~= 143 MiB; within the 128-200 MiB dedicated band.
+        var stopwatch = Stopwatch.StartNew();
+        var process = Process.GetCurrentProcess();
+        var peakBefore = process.PeakWorkingSet64;
+        var largeBytes = new byte[inputBytes];
+        Random.Shared.NextBytes(largeBytes);
+        var largeValue = Convert.ToBase64String(largeBytes);
+        var sourceTypes = CreateReflectionRegistry();
+        var (envelope, blob) = await CreateOffloadedEnvelopeAsync(sourceTypes, [largeValue]);
+        var targetTypes = new CountingStreamingRegistry(CreateReflectionRegistry());
+        var target = CreateActor(targetTypes);
+
+        await using var resolved = await SnapshotEnvelopeResolver.ResolveForRestoreAsync(envelope, blob);
+        var stream = Assert.IsType<CappedNonSeekableStream>(resolved.PayloadStream);
+        await target.SetResolvedSnapshotAsync(resolved);
+        stopwatch.Stop();
+        process.Refresh();
+
+        Console.WriteLine(
+            $"SEK-G42 streaming-restore telemetry: selected=IStreamingMultiProjectorTypes; " +
+            $"payloadBandMiB=143; elapsedMs={stopwatch.ElapsedMilliseconds}; " +
+            $"peakWorkingSetBytes={process.PeakWorkingSet64}; peakDeltaBytes={process.PeakWorkingSet64 - peakBefore}; " +
+            $"streamDeserializeCalls={targetTypes.StreamDeserializeCalls}; bufferedDeserializeCalls={targetTypes.BufferedDeserializeCalls}; " +
+            $"readCalls={stream.ReadCalls}; lengthAccesses={stream.LengthAccesses}; seekCalls={stream.SeekCalls}");
+
+        Assert.True(SatisfiesNoWholePayloadStructuralDiscriminant(
+            targetTypes.StreamDeserializeCalls,
+            targetTypes.BufferedDeserializeCalls,
+            wholePayloadAggregations: 0));
+        Assert.True(stream.ReadCalls > 1);
+        Assert.Equal(0, stream.LengthAccesses);
+        Assert.Equal(0, stream.SeekCalls);
+    }
+
+    private static SimpleMultiProjectorTypes CreateReflectionRegistry()
+    {
+        var types = new SimpleMultiProjectorTypes();
+        types.RegisterProjector<StreamPayloadProjector>();
+        return types;
+    }
+
+    private static void AssertMethod(
+        IEnumerable<System.Reflection.MethodInfo> methods,
+        string name,
+        Type returnType,
+        params Type[] parameterTypes)
+    {
+        var method = Assert.Single(methods, candidate =>
+            candidate.Name == name &&
+            candidate.ReturnType == returnType &&
+            candidate.GetParameters().Select(parameter => parameter.ParameterType).SequenceEqual(parameterTypes));
+        Assert.True(method.IsPublic);
+    }
+
+    private static bool SatisfiesNoWholePayloadStructuralDiscriminant(
+        int streamDeserializeCalls,
+        int bufferedDeserializeCalls,
+        int wholePayloadAggregations) =>
+        streamDeserializeCalls == 2 && bufferedDeserializeCalls == 0 && wholePayloadAggregations == 0;
+
+    private static GeneralMultiProjectionActor CreateActor(
+        ICoreMultiProjectorTypes types,
+        ILogger? logger = null) =>
+        new(CreateDomain(types), StreamPayloadProjector.MultiProjectorName, logger: logger);
+
+    private static DcbDomainTypes CreateDomain(ICoreMultiProjectorTypes types)
+    {
+        var events = new SimpleEventTypes();
+        events.RegisterEventType<PayloadAdded>(nameof(PayloadAdded));
+        return new DcbDomainTypes(
+            events,
+            new SimpleTagTypes(),
+            new SimpleTagProjectorTypes(),
+            new SimpleTagStatePayloadTypes(),
+            types,
+            new SimpleQueryTypes());
+    }
+
+    private static async Task<(SerializableMultiProjectionStateEnvelope Envelope, CappedBlobAccessor Blob)>
+        CreateOffloadedEnvelopeAsync(
+            ICoreMultiProjectorTypes types,
+            IReadOnlyList<string> values,
+            string? projectorName = null)
+    {
+        var blob = new CappedBlobAccessor();
+        var selectedProjectorName = projectorName ?? StreamPayloadProjector.MultiProjectorName;
+        var actor = new GeneralMultiProjectionActor(CreateDomain(types), selectedProjectorName);
+        foreach (var value in values)
+        {
+            await actor.AddEventsAsync([CreateEvent(value)]);
+        }
+
+        var result = await actor.BuildSnapshotEnvelopeAsync(
+            canGetUnsafeState: true,
+            blobAccessor: blob,
+            offloadThresholdBytes: 1);
+        Assert.True(result.IsSuccess);
+        Assert.True(result.GetValue().IsOffloaded);
+        return (result.GetValue(), blob);
+    }
+
+    private static Event CreateEvent(string value) => new(
+        new PayloadAdded(value),
+        SortableUniqueId.Generate(DateTime.UtcNow, Guid.NewGuid()),
+        nameof(PayloadAdded),
+        Guid.NewGuid(),
+        new EventMetadata(Guid.NewGuid().ToString("N"), Guid.NewGuid().ToString("N"), "test"),
+        []);
+
+    private static IReadOnlyList<string> Payload(MultiProjectionState state) =>
+        Assert.IsType<StreamPayloadProjector>(state.Payload).Values;
+
+    public sealed record PayloadAdded(string Value) : IEventPayload;
+
+    public sealed record StreamPayloadProjector(List<string> Values) : IMultiProjector<StreamPayloadProjector>
+    {
+        public StreamPayloadProjector() : this([]) { }
+        public static string MultiProjectorName => "streaming-restore";
+        public static string MultiProjectorVersion => "1";
+        public static StreamPayloadProjector GenerateInitialPayload() => new([]);
+
+        public static ResultBox<StreamPayloadProjector> Project(
+            StreamPayloadProjector payload,
+            Event ev,
+            List<ITag> tags,
+            DcbDomainTypes domainTypes,
+            SortableUniqueId safeWindowThreshold) =>
+            ev.Payload is PayloadAdded added
+                ? ResultBox.FromValue(payload with { Values = [.. payload.Values, added.Value] })
+                : ResultBox.FromValue(payload);
+    }
+
+    public sealed record CustomStreamPayloadProjector(List<string> Values) :
+        ICoreMultiProjectorWithCustomSerialization<CustomStreamPayloadProjector>,
+        ICoreMultiProjectorWithStreamDeserialization
+    {
+        public CustomStreamPayloadProjector() : this([]) { }
+        public static string MultiProjectorName => "streaming-restore-custom";
+        public static string MultiProjectorVersion => "1";
+        public static CustomStreamPayloadProjector GenerateInitialPayload() => new([]);
+
+        public static ResultBox<CustomStreamPayloadProjector> Project(
+            CustomStreamPayloadProjector payload,
+            Event ev,
+            List<ITag> tags,
+            DcbDomainTypes domainTypes,
+            SortableUniqueId safeWindowThreshold) =>
+            ev.Payload is PayloadAdded added
+                ? ResultBox.FromValue(payload with { Values = [.. payload.Values, added.Value] })
+                : ResultBox.FromValue(payload);
+
+        public static SerializationResult Serialize(
+            DcbDomainTypes domainTypes,
+            string safeWindowThreshold,
+            CustomStreamPayloadProjector payload)
+        {
+            var bytes = JsonSerializer.SerializeToUtf8Bytes(payload, domainTypes.JsonSerializerOptions);
+            return new SerializationResult(bytes, bytes.LongLength, bytes.LongLength);
+        }
+
+        public static CustomStreamPayloadProjector Deserialize(
+            DcbDomainTypes domainTypes,
+            string safeWindowThreshold,
+            ReadOnlySpan<byte> data) =>
+            JsonSerializer.Deserialize<CustomStreamPayloadProjector>(data, domainTypes.JsonSerializerOptions)
+            ?? throw new InvalidDataException("custom stream payload was empty");
+
+        public async Task<IMultiProjectionPayload> DeserializeFromStreamAsync(
+            DcbDomainTypes domainTypes,
+            string safeWindowThreshold,
+            Stream source,
+            CancellationToken cancellationToken = default) =>
+            await JsonSerializer.DeserializeAsync<CustomStreamPayloadProjector>(
+                    source,
+                    domainTypes.JsonSerializerOptions,
+                    cancellationToken)
+                .ConfigureAwait(false)
+            ?? throw new InvalidDataException("custom stream payload was empty");
+    }
+
+    public sealed record CustomBufferedPayloadProjector(List<string> Values) :
+        ICoreMultiProjectorWithCustomSerialization<CustomBufferedPayloadProjector>
+    {
+        public CustomBufferedPayloadProjector() : this([]) { }
+        public static string MultiProjectorName => "streaming-restore-custom-buffered";
+        public static string MultiProjectorVersion => "1";
+        public static CustomBufferedPayloadProjector GenerateInitialPayload() => new([]);
+
+        public static ResultBox<CustomBufferedPayloadProjector> Project(
+            CustomBufferedPayloadProjector payload,
+            Event ev,
+            List<ITag> tags,
+            DcbDomainTypes domainTypes,
+            SortableUniqueId safeWindowThreshold) =>
+            ev.Payload is PayloadAdded added
+                ? ResultBox.FromValue(payload with { Values = [.. payload.Values, added.Value] })
+                : ResultBox.FromValue(payload);
+
+        public static SerializationResult Serialize(
+            DcbDomainTypes domainTypes,
+            string safeWindowThreshold,
+            CustomBufferedPayloadProjector payload)
+        {
+            var bytes = JsonSerializer.SerializeToUtf8Bytes(payload, domainTypes.JsonSerializerOptions);
+            return new SerializationResult(bytes, bytes.LongLength, bytes.LongLength);
+        }
+
+        public static CustomBufferedPayloadProjector Deserialize(
+            DcbDomainTypes domainTypes,
+            string safeWindowThreshold,
+            ReadOnlySpan<byte> data) =>
+            JsonSerializer.Deserialize<CustomBufferedPayloadProjector>(data, domainTypes.JsonSerializerOptions)
+            ?? throw new InvalidDataException("custom buffered payload was empty");
+    }
+
+    [JsonSerializable(typeof(StreamPayloadProjector))]
+    private sealed partial class StreamingRestoreJsonContext : JsonSerializerContext;
+
+    private abstract class DelegatingRegistry : ICoreMultiProjectorTypes
+    {
+        protected DelegatingRegistry(ICoreMultiProjectorTypes inner) => Inner = inner;
+        protected ICoreMultiProjectorTypes Inner { get; }
+        public int BufferedDeserializeCalls { get; protected set; }
+
+        public ResultBox<IMultiProjectionPayload> Project(string name, IMultiProjectionPayload payload, Event ev,
+            List<ITag> tags, DcbDomainTypes domain, SortableUniqueId threshold) =>
+            Inner.Project(name, payload, ev, tags, domain, threshold);
+        public ResultBox<string> GetProjectorVersion(string name) => Inner.GetProjectorVersion(name);
+        public IReadOnlyList<string> GetAllProjectorNames() => Inner.GetAllProjectorNames();
+        public ResultBox<Func<IMultiProjectionPayload>> GetInitialPayloadGenerator(string name) =>
+            Inner.GetInitialPayloadGenerator(name);
+        public ResultBox<Type> GetProjectorType(string name) => Inner.GetProjectorType(name);
+        public ResultBox<IMultiProjectionPayload> GenerateInitialPayload(string name) => Inner.GenerateInitialPayload(name);
+        public ResultBox<IMultiProjectionPayload> Deserialize(byte[] data, string name, JsonSerializerOptions options) =>
+            Inner.Deserialize(data, name, options);
+        public ResultBox<SerializationResult> Serialize(string name, DcbDomainTypes domain, string threshold,
+            IMultiProjectionPayload payload) => Inner.Serialize(name, domain, threshold, payload);
+        public ResultBox<IMultiProjectionPayload> Deserialize(string name, DcbDomainTypes domain, string threshold,
+            byte[] data)
+        {
+            BufferedDeserializeCalls++;
+            return Inner.Deserialize(name, domain, threshold, data);
+        }
+        public ResultBox<bool> RegisterProjectorWithCustomSerialization<T>()
+            where T : ICoreMultiProjectorWithCustomSerialization<T>, new() =>
+            Inner.RegisterProjectorWithCustomSerialization<T>();
+    }
+
+    private sealed class CountingBufferedRegistry(ICoreMultiProjectorTypes inner) : DelegatingRegistry(inner);
+
+    private class CountingStreamingRegistry(ICoreMultiProjectorTypes inner) : DelegatingRegistry(inner), IStreamingMultiProjectorTypes
+    {
+        private readonly IStreamingMultiProjectorTypes _streaming = Assert.IsAssignableFrom<IStreamingMultiProjectorTypes>(inner);
+        public int StreamDeserializeCalls { get; protected set; }
+        public bool SupportsStreamDeserialization(string projectorName) => _streaming.SupportsStreamDeserialization(projectorName);
+
+        public virtual async Task<ResultBox<IMultiProjectionPayload>> DeserializeFromStreamAsync(
+            string projectorName,
+            DcbDomainTypes domainTypes,
+            string safeWindowThreshold,
+            Stream source,
+            CancellationToken cancellationToken = default)
+        {
+            StreamDeserializeCalls++;
+            return await _streaming.DeserializeFromStreamAsync(
+                projectorName,
+                domainTypes,
+                safeWindowThreshold,
+                source,
+                cancellationToken);
+        }
+    }
+
+    private sealed class FailingStreamingRegistry(ICoreMultiProjectorTypes inner) : CountingStreamingRegistry(inner)
+    {
+        public override async Task<ResultBox<IMultiProjectionPayload>> DeserializeFromStreamAsync(
+            string projectorName,
+            DcbDomainTypes domainTypes,
+            string safeWindowThreshold,
+            Stream source,
+            CancellationToken cancellationToken = default)
+        {
+            StreamDeserializeCalls++;
+            await Task.CompletedTask;
+            return ResultBox.Error<IMultiProjectionPayload>(new InvalidDataException("stream-capability-failure"));
+        }
+    }
+
+    private sealed class IntentionallyBufferedStreamingRegistry(ICoreMultiProjectorTypes inner) : DelegatingRegistry(inner), IStreamingMultiProjectorTypes
+    {
+        private readonly IStreamingMultiProjectorTypes _streaming = Assert.IsAssignableFrom<IStreamingMultiProjectorTypes>(inner);
+        public int StreamDeserializeCalls { get; private set; }
+        public int WholePayloadAggregations { get; private set; }
+
+        public bool SupportsStreamDeserialization(string projectorName) => _streaming.SupportsStreamDeserialization(projectorName);
+
+        public async Task<ResultBox<IMultiProjectionPayload>> DeserializeFromStreamAsync(
+            string projectorName,
+            DcbDomainTypes domainTypes,
+            string safeWindowThreshold,
+            Stream source,
+            CancellationToken cancellationToken = default)
+        {
+            StreamDeserializeCalls++;
+            WholePayloadAggregations++;
+            var bytes = await StreamReadHelper.ReadAllBytesAsync(source, cancellationToken);
+            return Inner.Deserialize(projectorName, domainTypes, safeWindowThreshold, bytes);
+        }
+    }
+
+    private sealed class CappedBlobAccessor : IBlobStorageSnapshotAccessor
+    {
+        private readonly Dictionary<string, byte[]> _payloads = new(StringComparer.Ordinal);
+        private int _nextKey;
+        public string ProviderName => "capped-test";
+        public byte[]? LastWrittenPayload { get; private set; }
+        public int? TruncateOpenedPayloadTo { get; set; }
+        public byte[]? OpenedPayloadPrefix { get; set; }
+        public byte[]? OpenedPayloadOverride { get; set; }
+
+        public async Task<string> WriteAsync(Stream data, string projectorName, CancellationToken cancellationToken = default)
+        {
+            using var copy = new MemoryStream();
+            await data.CopyToAsync(copy, cancellationToken);
+            var key = $"{projectorName}/{++_nextKey}";
+            LastWrittenPayload = copy.ToArray();
+            _payloads[key] = LastWrittenPayload;
+            return key;
+        }
+
+        public Task<Stream> OpenReadAsync(string key, CancellationToken cancellationToken = default)
+        {
+            var payload = OpenedPayloadOverride ?? _payloads[key];
+            if (TruncateOpenedPayloadTo is { } truncated)
+            {
+                payload = payload[..Math.Min(payload.Length, truncated)];
+            }
+
+            var initialOffset = 0;
+            if (OpenedPayloadPrefix is { Length: > 0 } prefix)
+            {
+                var prefixed = new byte[prefix.Length + payload.Length];
+                prefix.CopyTo(prefixed, 0);
+                payload.CopyTo(prefixed, prefix.Length);
+                payload = prefixed;
+                initialOffset = prefix.Length;
+            }
+
+            return Task.FromResult<Stream>(new CappedNonSeekableStream(payload, maxReadBytes: 127, initialOffset));
+        }
+    }
+
+    private sealed class CappedNonSeekableStream : Stream
+    {
+        private readonly MemoryStream _inner;
+        private readonly int _maxReadBytes;
+        public CappedNonSeekableStream(byte[] payload, int maxReadBytes, int initialOffset = 0)
+        {
+            _inner = new MemoryStream(payload, writable: false);
+            _maxReadBytes = maxReadBytes;
+            _inner.Position = initialOffset;
+        }
+
+        public int ReadCalls { get; private set; }
+        public int LengthAccesses { get; private set; }
+        public int SeekCalls { get; private set; }
+        public bool IsDisposed { get; private set; }
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length
+        {
+            get
+            {
+                LengthAccesses++;
+                throw new NotSupportedException("Length is forbidden for this production-stream test.");
+            }
+        }
+        public override long Position
+        {
+            get => throw new NotSupportedException("Position is forbidden for this production-stream test.");
+            set => throw new NotSupportedException("Position is forbidden for this production-stream test.");
+        }
+        public override void Flush() { }
+        public override int Read(byte[] buffer, int offset, int count) =>
+            Read(buffer.AsSpan(offset, count));
+        public override int Read(Span<byte> buffer)
+        {
+            ReadCalls++;
+            return _inner.Read(buffer[..Math.Min(buffer.Length, _maxReadBytes)]);
+        }
+        public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            ReadCalls++;
+            return await _inner.ReadAsync(buffer[..Math.Min(buffer.Length, _maxReadBytes)], cancellationToken);
+        }
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            SeekCalls++;
+            throw new NotSupportedException("Seek is forbidden for this production-stream test.");
+        }
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+        protected override void Dispose(bool disposing)
+        {
+            IsDisposed = true;
+            if (disposing)
+            {
+                _inner.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+        public override async ValueTask DisposeAsync()
+        {
+            IsDisposed = true;
+            await _inner.DisposeAsync();
+            await base.DisposeAsync();
+        }
+    }
+
+    private sealed class RecordingLogger : ILogger
+    {
+        public List<string> Messages { get; } = [];
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+        public bool IsEnabled(LogLevel logLevel) => true;
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+            Func<TState, Exception?, string> formatter) => Messages.Add(formatter(state, exception));
+    }
+}

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/StreamingSnapshotRestoreTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/StreamingSnapshotRestoreTests.cs
@@ -505,6 +505,75 @@ public sealed partial class StreamingSnapshotRestoreTests
     }
 
     [Fact]
+    [Trait("Category", "StreamingRestoreControlledMemory")]
+    public async Task Isolated_small_graph_large_wire_fixture_has_a_bounded_supported_restore_allocation()
+    {
+        // The memory workflow starts a dedicated test process for this trait. Normal CI still runs the preceding
+        // same-fixture production/counter-proof test; this opt-in assertion is the process-isolated supporting ceiling,
+        // not a no-OOM promise and not a substitute for the path-complete aggregation guard.
+        if (!string.Equals(
+                Environment.GetEnvironmentVariable("SEKIBAN_STREAM_RESTORE_CONTROLLED_CEILING"),
+                "1",
+                StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        // JSON's internal buffers differ materially between the supported runtimes, so retain room for their normal
+        // streaming allocations while keeping a substantial gap to the same-fixture buffered control below.
+        const long restoreAllocationCeilingBytes = 256L * 1024 * 1024;
+        var (envelope, blob, uncompressedWireBytes) = await CreateSmallGraphLargeWireFixtureAsync();
+        Assert.InRange(uncompressedWireBytes, 16 * 1024 * 1024, 32 * 1024 * 1024);
+        var targetTypes = new CountingStreamingRegistry(CreateReflectionRegistry());
+        var target = CreateActor(targetTypes);
+
+        CollectForIsolatedMemoryMeasurement();
+        var allocatedBefore = GC.GetTotalAllocatedBytes(precise: true);
+        var process = Process.GetCurrentProcess();
+        process.Refresh();
+        var peakBefore = process.PeakWorkingSet64;
+
+        await using var resolved = await SnapshotEnvelopeResolver.ResolveForRestoreAsync(envelope, blob);
+        await target.SetResolvedSnapshotAsync(resolved);
+
+        process.Refresh();
+        var restoreAllocationBytes = GC.GetTotalAllocatedBytes(precise: true) - allocatedBefore;
+        var peakDeltaBytes = Math.Max(0, process.PeakWorkingSet64 - peakBefore);
+        Console.WriteLine(
+            $"SEK-G42 controlled streaming-restore telemetry: processId={Environment.ProcessId}; " +
+            $"wireBytes={uncompressedWireBytes}; restoreAllocationBytes={restoreAllocationBytes}; " +
+            $"peakDeltaBytes={peakDeltaBytes}; wholePayloadAggregations={GetLastStreamingRestoreWholePayloadAggregationCount(target)}");
+
+        Assert.InRange(restoreAllocationBytes, 0, restoreAllocationCeilingBytes);
+        Assert.Equal(2, targetTypes.StreamDeserializeCalls);
+        Assert.Equal(0, targetTypes.BufferedDeserializeCalls);
+        Assert.Equal(0, GetLastStreamingRestoreWholePayloadAggregationCount(target));
+        var restored = await target.GetStateAsync(canGetUnsafeState: true);
+        Assert.True(restored.IsSuccess);
+        Assert.Equal(["small-graph"], Payload(restored.GetValue()));
+
+        // The same wire through the deliberate capability-present buffering control must exceed the selected-path
+        // ceiling. This makes the fixture a real counter-proof while the transitive IL guard catches uninstrumented
+        // helper mutations that would otherwise bypass a runtime counter.
+        var bufferedControlTypes = new IntentionallyBufferedStreamingRegistry(CreateReflectionRegistry());
+        var bufferedControl = CreateActor(bufferedControlTypes);
+        CollectForIsolatedMemoryMeasurement();
+        var bufferedAllocationBefore = GC.GetTotalAllocatedBytes(precise: true);
+        await using var bufferedResolved = await SnapshotEnvelopeResolver.ResolveForRestoreAsync(envelope, blob);
+        await bufferedControl.SetResolvedSnapshotAsync(bufferedResolved);
+        var bufferedRestoreAllocationBytes = GC.GetTotalAllocatedBytes(precise: true) - bufferedAllocationBefore;
+        Console.WriteLine(
+            $"SEK-G42 controlled buffered-control telemetry: restoreAllocationBytes={bufferedRestoreAllocationBytes}; " +
+            $"wholePayloadAggregations={GetLastStreamingRestoreWholePayloadAggregationCount(bufferedControl)}");
+
+        Assert.True(
+            bufferedRestoreAllocationBytes > restoreAllocationCeilingBytes,
+            $"The intentionally buffered control must exceed {restoreAllocationCeilingBytes} allocated bytes; actual={bufferedRestoreAllocationBytes}.");
+        Assert.Equal(2, bufferedControlTypes.WholePayloadAggregations);
+        Assert.Equal(2, GetLastStreamingRestoreWholePayloadAggregationCount(bufferedControl));
+    }
+
+    [Fact]
     [Trait("Category", "StreamingRestoreManualMemory")]
     public async Task Manual_143MiB_offloaded_fixture_reports_peak_and_selected_restore_path_without_claiming_no_oom()
     {
@@ -545,6 +614,13 @@ public sealed partial class StreamingSnapshotRestoreTests
         Assert.True(stream.ReadCalls > 1);
         Assert.Equal(0, stream.LengthAccesses);
         Assert.Equal(0, stream.SeekCalls);
+    }
+
+    private static void CollectForIsolatedMemoryMeasurement()
+    {
+        GC.Collect(GC.MaxGeneration, GCCollectionMode.Forced, blocking: true, compacting: true);
+        GC.WaitForPendingFinalizers();
+        GC.Collect(GC.MaxGeneration, GCCollectionMode.Forced, blocking: true, compacting: true);
     }
 
     private static SimpleMultiProjectorTypes CreateReflectionRegistry()

--- a/dcb/tests/Sekiban.Dcb.WithoutResult.Tests/StreamingSnapshotRestorePublicInventoryTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithoutResult.Tests/StreamingSnapshotRestorePublicInventoryTests.cs
@@ -1,0 +1,45 @@
+using System.Reflection;
+using ResultBoxes;
+using Sekiban.Dcb.Domains;
+using Sekiban.Dcb.MultiProjections;
+
+namespace Sekiban.Dcb.WithoutResult.Tests;
+
+/// <summary>
+///     Pins the exception-based public registry implementations separately from the WithResult facade. This prevents
+///     an additive streaming-capability change from being accidentally present only on one command-result surface.
+/// </summary>
+public sealed class StreamingSnapshotRestorePublicInventoryTests
+{
+    [Fact]
+    public void WithoutResult_streaming_registry_implementations_keep_the_complete_public_capability_shape()
+    {
+        AssertStreamingRegistrySurface(typeof(SimpleMultiProjectorTypes));
+        AssertStreamingRegistrySurface(typeof(AotWithoutResultMultiProjectorTypes));
+    }
+
+    private static void AssertStreamingRegistrySurface(Type implementation)
+    {
+        Assert.True(implementation.IsPublic);
+        Assert.Contains(typeof(IStreamingMultiProjectorTypes), implementation.GetInterfaces());
+
+        var supports = Assert.Single(
+            implementation.GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.DeclaredOnly),
+            method => method.Name == nameof(IStreamingMultiProjectorTypes.SupportsStreamDeserialization));
+        Assert.Equal(typeof(bool), supports.ReturnType);
+        Assert.Equal([typeof(string)], supports.GetParameters().Select(parameter => parameter.ParameterType));
+        Assert.Equal(["projectorName"], supports.GetParameters().Select(parameter => parameter.Name));
+
+        var deserialize = Assert.Single(
+            implementation.GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.DeclaredOnly),
+            method => method.Name == nameof(IStreamingMultiProjectorTypes.DeserializeFromStreamAsync));
+        Assert.Equal(typeof(Task<ResultBox<IMultiProjectionPayload>>), deserialize.ReturnType);
+        Assert.Equal(
+            [typeof(string), typeof(DcbDomainTypes), typeof(string), typeof(Stream), typeof(CancellationToken)],
+            deserialize.GetParameters().Select(parameter => parameter.ParameterType));
+        Assert.Equal(
+            ["projectorName", "domainTypes", "safeWindowThreshold", "source", "cancellationToken"],
+            deserialize.GetParameters().Select(parameter => parameter.Name));
+        Assert.True(deserialize.GetParameters()[4].IsOptional);
+    }
+}

--- a/docs/dcb_llm/04_multiple_aggregate_projector.md
+++ b/docs/dcb_llm/04_multiple_aggregate_projector.md
@@ -127,8 +127,10 @@ buffer. Save-side streaming and compression-format changes are outside this rest
 Stream implementations must use asynchronous reads, honor `CancellationToken`, support non-seekable partial-read streams
 at their current position, and never dispose the stream. The resolver caller owns disposal. While a stream restore is in
 progress, state queries, event application, promotion, compaction, and snapshot persistence fail rather than publishing
-old or partial payload/tracking metadata. A failed restore returns an activation error before it can be served; the host
-then follows its normal recovery/catch-up policy.
+old or partial payload/tracking metadata. A terminal restore failure keeps that same fail-closed barrier latched: the
+previous payload and tracking metadata are not usable by query, apply, catch-up, promotion, or persistence. A later
+restore/rebuild attempt is still permitted, and only a successful atomic restore clears the barrier; otherwise the host
+follows its normal recovery/catch-up policy without serving the stale state.
 
 #### Restore caller inventory
 
@@ -140,7 +142,9 @@ then follows its normal recovery/catch-up policy.
 | `GeneralMultiProjectionActor.SetCurrentState` / `SetCurrentStateIgnoringVersion` | Direct legacy inline state | Buffered compatibility path only |
 | `SnapshotEnvelopeResolver.ResolveInlineAsync` | Explicit compatibility adapter | Materializes only because its caller explicitly asks for an inline envelope; production offloaded restore must use `ResolveForRestoreAsync` |
 
-The normal DCB test suite includes a controlled 18 MiB offloaded gzip fixture. The separate **DCB Streaming Restore
+The normal DCB test suite includes a controlled small-graph, 16–32 MiB offloaded gzip wire fixture. It combines a
+production aggregation counter with structural guards that reject whole-payload aggregation APIs from the supported
+stream seam. The separate **DCB Streaming Restore
 Memory Smoke** workflow runs a 143 MiB fixture on a weekly/manual schedule in an isolated process with a timeout and
 virtual-memory ceiling. It records elapsed time, peak RSS, selected capability path, read counts, and buffer counters;
 it evaluates absence of the full-payload materialization path, not a claim that an OOM is impossible.

--- a/docs/dcb_llm/04_multiple_aggregate_projector.md
+++ b/docs/dcb_llm/04_multiple_aggregate_projector.md
@@ -127,10 +127,11 @@ buffer. Save-side streaming and compression-format changes are outside this rest
 Stream implementations must use asynchronous reads, honor `CancellationToken`, support non-seekable partial-read streams
 at their current position, and never dispose the stream. The resolver caller owns disposal. While a stream restore is in
 progress, state queries, event application, promotion, compaction, and snapshot persistence fail rather than publishing
-old or partial payload/tracking metadata. A terminal restore failure keeps that same fail-closed barrier latched: the
-previous payload and tracking metadata are not usable by query, apply, catch-up, promotion, or persistence. A later
-restore/rebuild attempt is still permitted, and only a successful atomic restore clears the barrier; otherwise the host
-follows its normal recovery/catch-up policy without serving the stale state.
+old or partial payload/tracking metadata. When a terminal restore failure leaves an already-published payload or
+tracking metadata, that same fail-closed barrier remains latched: the previous checkpoint is not usable by query,
+apply, catch-up, promotion, or persistence. A failed first restore has no prior payload to serve and retains the legacy
+empty-state/rebuild path. A later restore/rebuild attempt is still permitted, and only a successful atomic restore
+clears a latched barrier; otherwise the host follows its normal recovery/catch-up policy without serving stale state.
 
 #### Restore caller inventory
 

--- a/docs/dcb_llm/04_multiple_aggregate_projector.md
+++ b/docs/dcb_llm/04_multiple_aggregate_projector.md
@@ -102,6 +102,49 @@ services.AddSingleton<IBlobStorageSnapshotAccessor>(sp =>
 The Orleans grain detects the accessor and periodically checkpoints state, reducing silo memory usage
 (`src/Sekiban.Dcb.Orleans/Grains/MultiProjectionGrainState.cs`).
 
+### Streaming restore for offloaded snapshots
+
+When an offloaded snapshot is restored, Sekiban opens the blob payload once and carries that non-seekable stream through
+the resolver and actor to the projector registry. The built-in reflection and AOT JSON registries use this path. A custom
+projector can opt in per projector by implementing the additive `ICoreMultiProjectorWithStreamDeserialization`; registries
+expose the separate `IStreamingMultiProjectorTypes` capability. `ICoreMultiProjectorTypes` itself is unchanged, so
+existing external registries remain supported.
+
+The guarantee is deliberately limited: for an **offloaded** snapshot whose projector supports the capability, restore
+does not materialize an additional contiguous `byte[]` or `string` proportional to the complete uncompressed payload.
+The projection graph still has to exist (and can dominate memory), so this is **not a no-OOM guarantee**. Sekiban uses a
+temporary file only to create the independent safe/unsafe restore graphs; it does not create a whole managed payload
+buffer. Save-side streaming and compression-format changes are outside this restore guarantee.
+
+| Snapshot and registry condition | Restore behavior | Guaranteed non-buffering path? |
+| --- | --- | --- |
+| Offloaded payload + capability present | The opened stream is passed to the projector, using async reads and the current stream position. Reflection/AOT JSON accepts gzip or raw legacy JSON. | Yes |
+| Offloaded payload + custom projector implements the stream capability | The custom projector receives the caller-owned stream. | Yes, subject to the custom implementation honoring the contract |
+| Offloaded payload + capability absent | One observable compatibility fallback buffers the payload and logs projector, registry, `Format=offloaded`, and `Reason=capability-absent`; payload content is never logged. | No |
+| Offloaded payload + capability present but open/read/decompress/deserialize fails | The original failure is returned. Sekiban makes **zero** buffered retries. | No successful restore; fail closed |
+| Inline JSON/Base64 (including legacy v9/V10 inline envelopes) | The existing inline restore remains buffered for compatibility. | No — inline Base64 is explicitly outside this guarantee |
+
+Stream implementations must use asynchronous reads, honor `CancellationToken`, support non-seekable partial-read streams
+at their current position, and never dispose the stream. The resolver caller owns disposal. While a stream restore is in
+progress, state queries, event application, promotion, compaction, and snapshot persistence fail rather than publishing
+old or partial payload/tracking metadata. A failed restore returns an activation error before it can be served; the host
+then follows its normal recovery/catch-up policy.
+
+#### Restore caller inventory
+
+| Caller | Snapshot shape | Path |
+| --- | --- | --- |
+| `MultiProjectionGrain` → `NativeProjectionActorHost` → `NativeProjectionSnapshotHandler` | Orleans state-store activation; this is the production incident/OOM entry point | Opens the outer state stream, calls `SnapshotEnvelopeResolver.ResolveForRestoreAsync`, then awaits `GeneralMultiProjectionActor.SetResolvedSnapshotAsync` |
+| `MultiProjectionStateBuilder.LoadRestoreAsync` | Offline/builder checkpoint restore | Deserializes the outer envelope, resolves the offloaded payload stream, and awaits the same actor seam |
+| `NativeMultiProjectionProjectionPrimitive.ApplySnapshot` | Inline primitive snapshot | Calls `SetSnapshotAsync`; inline compatibility path only |
+| `GeneralMultiProjectionActor.SetCurrentState` / `SetCurrentStateIgnoringVersion` | Direct legacy inline state | Buffered compatibility path only |
+| `SnapshotEnvelopeResolver.ResolveInlineAsync` | Explicit compatibility adapter | Materializes only because its caller explicitly asks for an inline envelope; production offloaded restore must use `ResolveForRestoreAsync` |
+
+The normal DCB test suite includes a controlled 18 MiB offloaded gzip fixture. The separate **DCB Streaming Restore
+Memory Smoke** workflow runs a 143 MiB fixture on a weekly/manual schedule in an isolated process with a timeout and
+virtual-memory ceiling. It records elapsed time, peak RSS, selected capability path, read counts, and buffer counters;
+it evaluates absence of the full-payload materialization path, not a claim that an OOM is impossible.
+
 ## Consistency Considerations
 
 - MultiProjection receives events in global order; use `WaitForSortableUniqueId` on queries to avoid stale reads.

--- a/docs/dcb_llm/04_multiple_aggregate_projector.md
+++ b/docs/dcb_llm/04_multiple_aggregate_projector.md
@@ -146,9 +146,11 @@ clears a latched barrier; otherwise the host follows its normal recovery/catch-u
 The normal DCB test suite includes a controlled small-graph, 16–32 MiB offloaded gzip wire fixture. It combines a
 production aggregation counter with structural guards that reject whole-payload aggregation APIs from the supported
 stream seam. The separate **DCB Streaming Restore
-Memory Smoke** workflow runs a 143 MiB fixture on a weekly/manual schedule in an isolated process with a timeout and
-virtual-memory ceiling. It records elapsed time, peak RSS, selected capability path, read counts, and buffer counters;
-it evaluates absence of the full-payload materialization path, not a claim that an OOM is impossible.
+Memory Smoke** workflow also runs that controlled fixture in its own process with an allocation ceiling and an
+intentionally buffered control which must exceed it. Its 143 MiB fixture runs only on a weekly/manual schedule with a
+timeout and virtual-memory ceiling. The workflow records elapsed time, peak RSS, selected capability path, read counts,
+and buffer counters; it evaluates absence of the full-payload materialization path, not a claim that an OOM is
+impossible.
 
 ## Consistency Considerations
 

--- a/docs/dcb_llm_ja/04_multiple_aggregate_projector.md
+++ b/docs/dcb_llm_ja/04_multiple_aggregate_projector.md
@@ -101,6 +101,49 @@ services.AddSingleton<IBlobStorageSnapshotAccessor>(sp =>
 
 `MultiProjectionGrain` がアクセサを検出すると、定期的にスナップショットを保存しメモリ使用量を抑えます。
 
+### 退避済みスナップショットのストリーミング復元
+
+退避済みスナップショットを復元する際、Sekiban は Blob ペイロードを 1 回だけ開き、その非 seekable stream を
+resolver と actor を通して projector registry まで渡します。組み込みの reflection JSON / AOT JSON registry はこの
+経路を使います。custom projector は加法的な `ICoreMultiProjectorWithStreamDeserialization` を実装することで
+projector 単位で opt-in できます。registry 側は別インターフェース `IStreamingMultiProjectorTypes` で capability を
+公開します。`ICoreMultiProjectorTypes` 自体は変更されないため、既存の外部 registry も引き続き利用できます。
+
+保証は意図的に限定されています。capability をサポートする projector の **退避済み** スナップショットでは、復元時に
+完全な非圧縮ペイロードの長さに比例する追加の連続 `byte[]` / `string` を materialize しません。projection graph
+そのものは必要で、こちらがメモリ使用量の大半になる場合があるため、これは **no-OOM の保証ではありません**。
+Sekiban は independent な safe/unsafe restore graph を作るためだけに一時ファイルを使いますが、payload 全体の managed
+buffer は作りません。save 側の streaming 化と圧縮形式の変更は、この restore の保証の範囲外です。
+
+| スナップショットと registry の条件 | 復元時の動作 | 非 buffering 経路の保証 |
+| --- | --- | --- |
+| 退避済み payload + capability あり | 開いた stream を projector に渡し、非同期読み取りと現在位置を使う。reflection/AOT JSON は gzip と raw の legacy JSON を受け入れる。 | あり |
+| 退避済み payload + custom projector が stream capability を実装 | custom projector が caller 所有の stream を受け取る。 | custom 実装が契約を守る範囲であり |
+| 退避済み payload + capability なし | 1 回だけ observable な compatibility fallback が payload を buffer し、projector / registry / `Format=offloaded` / `Reason=capability-absent` を log する。payload 内容は log しない。 | なし |
+| 退避済み payload + capability はあるが open/read/decompress/deserialize が失敗 | 元の failure を返す。buffering retry は **0 回**。 | restore は成功せず fail-closed |
+| inline JSON/Base64（legacy v9/V10 inline envelope を含む） | 互換性のため既存の inline restore は buffer を使う。 | なし — inline Base64 はこの保証の明示的な対象外 |
+
+stream 実装は非同期 read を使い、`CancellationToken` を尊重し、現在位置からの非 seekable partial-read stream を
+サポートし、stream を dispose してはいけません。dispose の責任は resolver caller にあります。stream restore の最中は、
+state query・event apply・promotion・compaction・snapshot persistence は old / partial payload や tracking metadata を
+publish する代わりに失敗します。restore の失敗は activation を serve 前に error とし、その後 host は通常の
+recovery/catch-up policy に従います。
+
+#### Restore caller inventory
+
+| Caller | Snapshot 形状 | 経路 |
+| --- | --- | --- |
+| `MultiProjectionGrain` → `NativeProjectionActorHost` → `NativeProjectionSnapshotHandler` | Orleans の state-store activation。incident/OOM の本番 entry point | outer state stream を開き、`SnapshotEnvelopeResolver.ResolveForRestoreAsync` を呼び、その後 `GeneralMultiProjectionActor.SetResolvedSnapshotAsync` を await する |
+| `MultiProjectionStateBuilder.LoadRestoreAsync` | offline/builder checkpoint restore | outer envelope を deserialize し、退避済み payload stream を resolve して同じ actor seam を await する |
+| `NativeMultiProjectionProjectionPrimitive.ApplySnapshot` | inline primitive snapshot | `SetSnapshotAsync` を呼ぶ。inline compatibility path のみ |
+| `GeneralMultiProjectionActor.SetCurrentState` / `SetCurrentStateIgnoringVersion` | direct legacy inline state | buffered compatibility path のみ |
+| `SnapshotEnvelopeResolver.ResolveInlineAsync` | explicit compatibility adapter | caller が inline envelope を明示的に要求したためだけに materialize する。本番の offloaded restore では `ResolveForRestoreAsync` を使う必要がある |
+
+通常の DCB test suite には制御された 18 MiB の offloaded gzip fixture があります。別の **DCB Streaming Restore
+Memory Smoke** workflow は、週次/manual schedule で 143 MiB fixture を timeout と virtual-memory ceiling 付きの
+isolated process で実行します。elapsed time、peak RSS、選択された capability path、read count、buffer counter を記録し、
+full-payload materialization path がないことを評価します。OOM が不可能だという主張ではありません。
+
 ## 整合性のポイント
 
 - イベントはグローバル順序で届くため、`IWaitForSortableUniqueId` を活用すると最新データを保証できます。

--- a/docs/dcb_llm_ja/04_multiple_aggregate_projector.md
+++ b/docs/dcb_llm_ja/04_multiple_aggregate_projector.md
@@ -126,8 +126,10 @@ buffer は作りません。save 側の streaming 化と圧縮形式の変更は
 stream 実装は非同期 read を使い、`CancellationToken` を尊重し、現在位置からの非 seekable partial-read stream を
 サポートし、stream を dispose してはいけません。dispose の責任は resolver caller にあります。stream restore の最中は、
 state query・event apply・promotion・compaction・snapshot persistence は old / partial payload や tracking metadata を
-publish する代わりに失敗します。restore の失敗は activation を serve 前に error とし、その後 host は通常の
-recovery/catch-up policy に従います。
+publish する代わりに失敗します。terminal な restore failure の後も、この fail-closed barrier は latch されたままです。
+以前の payload と tracking metadata は query、apply、catch-up、promotion、persistence に利用できません。後続の
+restore/rebuild attempt 自体は許可され、atomic な restore が成功した場合だけ barrier が解除されます。それ以外では
+host は stale state を serve せず通常の recovery/catch-up policy に従います。
 
 #### Restore caller inventory
 
@@ -139,7 +141,9 @@ recovery/catch-up policy に従います。
 | `GeneralMultiProjectionActor.SetCurrentState` / `SetCurrentStateIgnoringVersion` | direct legacy inline state | buffered compatibility path のみ |
 | `SnapshotEnvelopeResolver.ResolveInlineAsync` | explicit compatibility adapter | caller が inline envelope を明示的に要求したためだけに materialize する。本番の offloaded restore では `ResolveForRestoreAsync` を使う必要がある |
 
-通常の DCB test suite には制御された 18 MiB の offloaded gzip fixture があります。別の **DCB Streaming Restore
+通常の DCB test suite には、小さな graph と 16–32 MiB の offloaded gzip wire を組み合わせた制御 fixture があります。
+これは production aggregation counter と、supported stream seam に whole-payload aggregation API が入ることを拒否する
+structural guard を併用します。別の **DCB Streaming Restore
 Memory Smoke** workflow は、週次/manual schedule で 143 MiB fixture を timeout と virtual-memory ceiling 付きの
 isolated process で実行します。elapsed time、peak RSS、選択された capability path、read count、buffer counter を記録し、
 full-payload materialization path がないことを評価します。OOM が不可能だという主張ではありません。

--- a/docs/dcb_llm_ja/04_multiple_aggregate_projector.md
+++ b/docs/dcb_llm_ja/04_multiple_aggregate_projector.md
@@ -126,10 +126,12 @@ buffer は作りません。save 側の streaming 化と圧縮形式の変更は
 stream 実装は非同期 read を使い、`CancellationToken` を尊重し、現在位置からの非 seekable partial-read stream を
 サポートし、stream を dispose してはいけません。dispose の責任は resolver caller にあります。stream restore の最中は、
 state query・event apply・promotion・compaction・snapshot persistence は old / partial payload や tracking metadata を
-publish する代わりに失敗します。terminal な restore failure の後も、この fail-closed barrier は latch されたままです。
-以前の payload と tracking metadata は query、apply、catch-up、promotion、persistence に利用できません。後続の
-restore/rebuild attempt 自体は許可され、atomic な restore が成功した場合だけ barrier が解除されます。それ以外では
-host は stale state を serve せず通常の recovery/catch-up policy に従います。
+publish する代わりに失敗します。terminal な restore failure により既に publish 済みの payload または tracking
+metadata が残る場合、この fail-closed barrier は latch されたままです。以前の checkpoint は query、apply、catch-up、
+promotion、persistence に利用できません。初回 restore が失敗しただけであれば serve すべき以前の payload はないため、
+legacy の empty-state/rebuild path を維持します。後続の restore/rebuild attempt 自体は許可され、atomic な restore が
+成功した場合だけ latch 済み barrier が解除されます。それ以外では host は stale state を serve せず通常の
+recovery/catch-up policy に従います。
 
 #### Restore caller inventory
 

--- a/docs/dcb_llm_ja/04_multiple_aggregate_projector.md
+++ b/docs/dcb_llm_ja/04_multiple_aggregate_projector.md
@@ -146,9 +146,10 @@ recovery/catch-up policy に従います。
 通常の DCB test suite には、小さな graph と 16–32 MiB の offloaded gzip wire を組み合わせた制御 fixture があります。
 これは production aggregation counter と、supported stream seam に whole-payload aggregation API が入ることを拒否する
 structural guard を併用します。別の **DCB Streaming Restore
-Memory Smoke** workflow は、週次/manual schedule で 143 MiB fixture を timeout と virtual-memory ceiling 付きの
-isolated process で実行します。elapsed time、peak RSS、選択された capability path、read count、buffer counter を記録し、
-full-payload materialization path がないことを評価します。OOM が不可能だという主張ではありません。
+Memory Smoke** workflow は、その制御 fixture も allocation ceiling 付きの独立 process で実行し、意図的に buffering
+する control がその ceiling を超えることを確認します。143 MiB fixture は週次/manual schedule でのみ timeout と
+virtual-memory ceiling 付きで実行します。elapsed time、peak RSS、選択された capability path、read count、buffer counter
+を記録し、full-payload materialization path がないことを評価します。OOM が不可能だという主張ではありません。
 
 ## 整合性のポイント
 


### PR DESCRIPTION
Closes #1156
Fixes #1145

## Summary
- carry offloaded snapshot streams from resolver through actor to optional per-projector deserializers
- retain a one-time observable fallback for capability-absent external registries and propagate real stream failures
- add production-path, compatibility, structural-memory, and net9/net10 coverage plus EN/JA guidance

## Validation
- focused WithResult streaming restore tests: 18 passed on net9.0 and net10.0
- focused production NativeProjectionActorHost tests: 2 passed on net9.0 and net10.0
- release build includes the separately compiled 10.18 registry fixture
