### PR TITLE
Fix DCB template README package version

### DIFF
--- a/templates/Sekiban.Dcb.Templates/README.md
+++ b/templates/Sekiban.Dcb.Templates/README.md
@@ -2,7 +2,7 @@
 
 Sekiban DCB (Dynamic Consistency Boundary) 向けの .NET Aspire + Orleans スターターテンプレートです。
 
-生成されるプロジェクトはすべて **.NET 10.0** / **Aspire 13.x** / **Sekiban.Dcb 10.8.2** です。
+生成されるプロジェクトはすべて **.NET 10.0** / **Aspire 13.x** / **Sekiban.Dcb 10.19.0** です。
 
 ## インストール
 


### PR DESCRIPTION
SEK-G44 follow-up.

Updates the package README currency from Sekiban.Dcb 10.8.2 to 10.19.0 before publishing dcbTemplates-v10.19.0. This README is selected by PackageReadmeFile and is rendered on the NuGet package page.

PR #1159 introduced the currency validator, but that validator inspects csproj references only, so the stale README text passed unnoticed.

Scope is intentionally limited to this one documentation line; expanding the validator to README content remains a separate operator decision.

Closes #1162

Refs #1161 — the validator slice (SEK-G45, AC1-AC4) lands as a separate PR, which will carry the closing reference for that issue.



