### PR TITLE
feat(dcb): native tagged streams for Cosmos DB and DynamoDB

### DIFF
--- a/dcb/src/Sekiban.Dcb.CosmosDb/CosmosDbEventStore.TaggedStream.cs
+++ b/dcb/src/Sekiban.Dcb.CosmosDb/CosmosDbEventStore.TaggedStream.cs
@@ -13,6 +13,18 @@ namespace Sekiban.Dcb.CosmosDb;
 
 public partial class CosmosDbEventStore
 {
+    private const string TaggedStreamIndexQueryWithoutBounds =
+        "SELECT c.eventId FROM c WHERE c.pk = @pk ORDER BY c.sortableUniqueId";
+
+    private const string TaggedStreamIndexQuerySinceOnly =
+        "SELECT c.eventId FROM c WHERE c.pk = @pk AND c.sortableUniqueId > @since ORDER BY c.sortableUniqueId";
+
+    private const string TaggedStreamIndexQueryUntilOnly =
+        "SELECT c.eventId FROM c WHERE c.pk = @pk AND c.sortableUniqueId <= @until ORDER BY c.sortableUniqueId";
+
+    private const string TaggedStreamIndexQuerySinceAndUntil =
+        "SELECT c.eventId FROM c WHERE c.pk = @pk AND c.sortableUniqueId > @since AND c.sortableUniqueId <= @until ORDER BY c.sortableUniqueId";
+
     /// <summary>
     ///     Declares that this store has a callback-native tagged stream. The legacy list member remains intentionally
     ///     unchanged; callers that need bounded cold rebuilds resolve this capability instead of wrapping that list.
@@ -214,37 +226,39 @@ public partial class CosmosDbEventStore
         int pageSize)
     {
         var tagPartitionKey = GetTagPartitionKey(tagString, serviceId);
-        var where = "c.pk = @pk";
-        if (since is not null)
-        {
-            where += " AND c.sortableUniqueId > @since";
-        }
-
-        if (until is not null)
-        {
-            where += " AND c.sortableUniqueId <= @until";
-        }
-
-        var query = new QueryDefinition($"SELECT c.eventId FROM c WHERE {where} ORDER BY c.sortableUniqueId")
-            .WithParameter("@pk", tagPartitionKey);
-        if (since is not null)
-        {
-            query = query.WithParameter("@since", since.Value);
-        }
-
-        if (until is not null)
-        {
-            query = query.WithParameter("@until", until.Value);
-        }
-
         return (
-            query,
+            CreateTaggedStreamIndexQuery(tagPartitionKey, since, until),
             new QueryRequestOptions
             {
                 PartitionKey = new PartitionKey(tagPartitionKey),
                 MaxItemCount = pageSize
             });
     }
+
+    /// <summary>
+    ///     Selects one fully static query shape before binding values. Keeping query text constant and binding all
+    ///     runtime values through Cosmos parameters is intentional: it preserves the four exact bound semantics while
+    ///     making the native path verifiably free of dynamically assembled SQL text.
+    /// </summary>
+    private static QueryDefinition CreateTaggedStreamIndexQuery(
+        string tagPartitionKey,
+        SortableUniqueId? since,
+        SortableUniqueId? until) =>
+        (since, until) switch
+        {
+            ({ } lower, { } upper) => new QueryDefinition(TaggedStreamIndexQuerySinceAndUntil)
+                .WithParameter("@pk", tagPartitionKey)
+                .WithParameter("@since", lower.Value)
+                .WithParameter("@until", upper.Value),
+            ({ } lower, null) => new QueryDefinition(TaggedStreamIndexQuerySinceOnly)
+                .WithParameter("@pk", tagPartitionKey)
+                .WithParameter("@since", lower.Value),
+            (null, { } upper) => new QueryDefinition(TaggedStreamIndexQueryUntilOnly)
+                .WithParameter("@pk", tagPartitionKey)
+                .WithParameter("@until", upper.Value),
+            _ => new QueryDefinition(TaggedStreamIndexQueryWithoutBounds)
+                .WithParameter("@pk", tagPartitionKey)
+        };
 
     private static async Task<SerializableEvent?> ReadEventPointAsync(
         Container eventsContainer,

--- a/dcb/src/Sekiban.Dcb.CosmosDb/CosmosDbEventStore.TaggedStream.cs
+++ b/dcb/src/Sekiban.Dcb.CosmosDb/CosmosDbEventStore.TaggedStream.cs
@@ -1,0 +1,301 @@
+using Microsoft.Azure.Cosmos;
+using ResultBoxes;
+using Sekiban.Dcb.Capabilities;
+using Sekiban.Dcb.Common;
+using Sekiban.Dcb.CosmosDb.Models;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.Storage;
+using Sekiban.Dcb.Tags;
+using System.Net;
+using System.Text;
+
+namespace Sekiban.Dcb.CosmosDb;
+
+public partial class CosmosDbEventStore
+{
+    /// <summary>
+    ///     Declares that this store has a callback-native tagged stream. The legacy list member remains intentionally
+    ///     unchanged; callers that need bounded cold rebuilds resolve this capability instead of wrapping that list.
+    /// </summary>
+    public TaggedStreamCapabilityDescriptor DescribeTaggedStream() =>
+        TaggedStreamCapabilityDescriptor.Native("CosmosDb");
+
+    /// <summary>
+    ///     Streams one tag-index query page at a time and keeps a bounded, ordinal queue of event point reads. Reads may
+    ///     complete out of order, but only the queue head is published, so a slow or failed head cannot let a later event
+    ///     escape. This deliberately does not share the legacy list implementation, which materializes the complete
+    ///     identifier history before issuing its reads.
+    /// </summary>
+    public async Task<ResultBox<SerializableEventStreamReadResult>> StreamSerializableEventsByTagAsync(
+        ITag tag,
+        SortableUniqueId? since,
+        SortableUniqueId? until,
+        Func<SerializableEvent, ValueTask> onEvent,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(tag);
+        ArgumentNullException.ThrowIfNull(onEvent);
+
+        var options = _context.Options;
+        var telemetryGate = new object();
+        var indexPages = 0;
+        var pointReads = 0;
+        var peakInFlightReads = 0;
+        var throttledRequests = 0;
+        var requestCharge = 0d;
+        var emitted = 0;
+        string? lastSortableUniqueId = null;
+        var pendingReads = new Queue<TaggedStreamPointRead>();
+        using var issuedReadCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+
+        void RecordResponse(double charge)
+        {
+            lock (telemetryGate)
+            {
+                requestCharge += charge;
+            }
+        }
+
+        void RecordThrottle(double charge)
+        {
+            lock (telemetryGate)
+            {
+                requestCharge += charge;
+                throttledRequests++;
+            }
+        }
+
+        async Task ObserveOutstandingReadsAsync()
+        {
+            await issuedReadCancellation.CancelAsync().ConfigureAwait(false);
+            while (pendingReads.TryDequeue(out var pendingRead))
+            {
+                try
+                {
+                    await pendingRead.Completion.ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                    // The linked token intentionally cancels speculative reads after the ordinal head failed/cancelled.
+                }
+                catch
+                {
+                    // The head failure is the result surfaced to the caller. Observe tail failures before returning.
+                }
+            }
+        }
+
+        async Task EmitHeadAsync()
+        {
+            var pendingRead = pendingReads.Dequeue();
+            var serializableEvent = await pendingRead.Completion.ConfigureAwait(false);
+            if (serializableEvent is null)
+            {
+                return; // A tag row whose event was deleted is treated the same as the compatible list reader.
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+            await onEvent(serializableEvent).ConfigureAwait(false);
+            emitted++;
+            lastSortableUniqueId = serializableEvent.SortableUniqueIdValue;
+        }
+
+        try
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var pageSize = options.GetTaggedStreamIndexPageSize();
+            var window = options.ValidateTaggedStreamPointReadWindow();
+            var serviceId = CurrentServiceId;
+            var tagsSettings = _containerResolver.ResolveTagsContainer(serviceId);
+            var eventsSettings = _containerResolver.ResolveEventsContainer(serviceId);
+            var tagsContainer = await _context.GetTagsContainerAsync(tagsSettings).ConfigureAwait(false);
+            var eventsContainer = await _context.GetEventsContainerAsync(eventsSettings).ConfigureAwait(false);
+            var (queryDefinition, requestOptions) = BuildTaggedStreamIndexQuery(
+                tag.GetTag(), serviceId, since, until, pageSize);
+
+            using var iterator = tagsContainer.GetItemQueryIterator<dynamic>(queryDefinition, requestOptions: requestOptions);
+            while (iterator.HasMoreResults)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                FeedResponse<dynamic> page;
+                try
+                {
+                    page = await iterator.ReadNextAsync(cancellationToken).ConfigureAwait(false);
+                }
+                catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.TooManyRequests)
+                {
+                    RecordThrottle(ex.RequestCharge);
+                    throw;
+                }
+                lock (telemetryGate)
+                {
+                    indexPages++;
+                    requestCharge += page.RequestCharge;
+                }
+
+                foreach (var row in page)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    while (pendingReads.Count >= window)
+                    {
+                        await EmitHeadAsync().ConfigureAwait(false);
+                    }
+
+                    var eventId = (string)row.eventId;
+                    Interlocked.Increment(ref pointReads);
+                    pendingReads.Enqueue(new TaggedStreamPointRead(ReadEventPointAsync(
+                        eventsContainer,
+                        serviceId,
+                        eventId,
+                        RecordResponse,
+                        RecordThrottle,
+                        issuedReadCancellation.Token)));
+                    peakInFlightReads = Math.Max(peakInFlightReads, pendingReads.Count);
+                }
+            }
+
+            while (pendingReads.Count > 0)
+            {
+                var pendingRead = pendingReads.Dequeue();
+                var serializableEvent = await pendingRead.Completion.ConfigureAwait(false);
+                if (serializableEvent is null)
+                {
+                    continue;
+                }
+
+                cancellationToken.ThrowIfCancellationRequested();
+                await onEvent(serializableEvent).ConfigureAwait(false);
+                emitted++;
+                lastSortableUniqueId = serializableEvent.SortableUniqueIdValue;
+            }
+
+            return ResultBox.FromValue(new SerializableEventStreamReadResult(emitted, lastSortableUniqueId));
+        }
+        catch (OperationCanceledException)
+        {
+            await ObserveOutstandingReadsAsync().ConfigureAwait(false);
+            throw;
+        }
+        catch (Exception ex)
+        {
+            await ObserveOutstandingReadsAsync().ConfigureAwait(false);
+            return ResultBox.Error<SerializableEventStreamReadResult>(ex);
+        }
+        finally
+        {
+            CosmosTaggedStreamTelemetry telemetry;
+            lock (telemetryGate)
+            {
+                telemetry = new CosmosTaggedStreamTelemetry(
+                    indexPages,
+                    pointReads,
+                    peakInFlightReads,
+                    requestCharge,
+                    throttledRequests);
+            }
+
+            CosmosDbTelemetry.RecordTaggedStream(telemetry);
+            try
+            {
+                options.TaggedStreamTelemetryCallback?.Invoke(telemetry);
+            }
+            catch
+            {
+                // Instrumentation must not change stream correctness or turn a completed callback into a failed rebuild.
+            }
+        }
+    }
+
+    private static (QueryDefinition QueryDefinition, QueryRequestOptions RequestOptions) BuildTaggedStreamIndexQuery(
+        string tagString,
+        string serviceId,
+        SortableUniqueId? since,
+        SortableUniqueId? until,
+        int pageSize)
+    {
+        var tagPartitionKey = GetTagPartitionKey(tagString, serviceId);
+        var where = "c.pk = @pk";
+        if (since is not null)
+        {
+            where += " AND c.sortableUniqueId > @since";
+        }
+
+        if (until is not null)
+        {
+            where += " AND c.sortableUniqueId <= @until";
+        }
+
+        var query = new QueryDefinition($"SELECT c.eventId FROM c WHERE {where} ORDER BY c.sortableUniqueId")
+            .WithParameter("@pk", tagPartitionKey);
+        if (since is not null)
+        {
+            query = query.WithParameter("@since", since.Value);
+        }
+
+        if (until is not null)
+        {
+            query = query.WithParameter("@until", until.Value);
+        }
+
+        return (
+            query,
+            new QueryRequestOptions
+            {
+                PartitionKey = new PartitionKey(tagPartitionKey),
+                MaxItemCount = pageSize
+            });
+    }
+
+    private static async Task<SerializableEvent?> ReadEventPointAsync(
+        Container eventsContainer,
+        string serviceId,
+        string eventId,
+        Action<double> recordResponse,
+        Action<double> recordThrottle,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var response = await eventsContainer.ReadItemAsync<CosmosEvent>(
+                eventId,
+                new PartitionKey(GetEventPartitionKey(eventId, serviceId)),
+                requestOptions: null,
+                cancellationToken: cancellationToken).ConfigureAwait(false);
+            recordResponse(response.RequestCharge);
+
+            var cosmosEvent = response.Resource;
+            if (!ServiceIdMatches(cosmosEvent.ServiceId, serviceId))
+            {
+                throw new UnauthorizedAccessException($"Event {eventId} does not belong to service {serviceId}.");
+            }
+
+            return new SerializableEvent(
+                Encoding.UTF8.GetBytes(cosmosEvent.Payload),
+                cosmosEvent.SortableUniqueId,
+                Guid.Parse(cosmosEvent.Id),
+                new EventMetadata(
+                    cosmosEvent.CausationId ?? string.Empty,
+                    cosmosEvent.CorrelationId ?? string.Empty,
+                    cosmosEvent.ExecutedUser ?? string.Empty),
+                cosmosEvent.Tags?.ToList() ?? [],
+                cosmosEvent.EventType);
+        }
+        catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
+        {
+            recordResponse(ex.RequestCharge);
+            return null;
+        }
+        catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.TooManyRequests)
+        {
+            recordThrottle(ex.RequestCharge);
+            throw;
+        }
+        catch (CosmosException ex)
+        {
+            recordResponse(ex.RequestCharge);
+            throw;
+        }
+    }
+
+    private sealed record TaggedStreamPointRead(Task<SerializableEvent?> Completion);
+}

--- a/dcb/src/Sekiban.Dcb.CosmosDb/CosmosDbEventStore.cs
+++ b/dcb/src/Sekiban.Dcb.CosmosDb/CosmosDbEventStore.cs
@@ -20,7 +20,8 @@ namespace Sekiban.Dcb.CosmosDb;
 ///     CosmosDB-backed event store implementation.
 /// </summary>
 public partial class CosmosDbEventStore : IHotEventStore, IStorageDurabilityDescriptorProvider,
-    IConditionalEventStore, IWriteConditionCapabilityProvider
+    IConditionalEventStore, IWriteConditionCapabilityProvider, IStreamingTaggedSerializableEventStore,
+    ITaggedStreamCapabilityProvider
 {
     private const string ConditionalProviderName = "CosmosDb";
 

--- a/dcb/src/Sekiban.Dcb.CosmosDb/CosmosDbEventStoreOptions.cs
+++ b/dcb/src/Sekiban.Dcb.CosmosDb/CosmosDbEventStoreOptions.cs
@@ -148,10 +148,86 @@ public class CosmosDbEventStoreOptions
     public int MaxConcurrentDeserializations { get; set; } = Environment.ProcessorCount * 2;
 
     /// <summary>
+    ///     Default maximum number of in-flight event point reads used only by the native tagged-stream path.
+    ///     It is intentionally separate from <see cref="MaxConcurrentDeserializations" />: a tagged stream is an
+    ///     ordered, bounded producer rather than a bulk list deserialization operation.
+    /// </summary>
+    public const int DefaultMaxConcurrentTaggedStreamPointReads = 8;
+
+    /// <summary>Hard upper bound for <see cref="MaxConcurrentTaggedStreamPointReads" />.</summary>
+    public const int MaximumMaxConcurrentTaggedStreamPointReads = 64;
+
+    // The compatibility preset deliberately retains MaxItemCountPerPage = -1 for its legacy readers. Native tagged
+    // streams instead make that SDK-default sentinel explicit at their own boundary so W remains coupled to a known
+    // page size without changing any existing list-reader request shape.
+    internal const int DefaultTaggedStreamIndexPageSize = 100;
+
+    /// <summary>
+    ///     Maximum event point reads the native tagged stream may issue before it has emitted the queue head.
+    ///     The value is validated for every tagged stream: 1 through 64 and no larger than its tag-index page size.
+    /// </summary>
+    public int MaxConcurrentTaggedStreamPointReads { get; set; } = DefaultMaxConcurrentTaggedStreamPointReads;
+
+    /// <summary>
+    ///     Optional bounded telemetry seam for one native tagged-stream invocation. The callback receives aggregate
+    ///     page/read/RU/throttle values only; it never receives event identifiers or tag strings.
+    /// </summary>
+    public Action<CosmosTaggedStreamTelemetry>? TaggedStreamTelemetryCallback { get; set; }
+
+    /// <summary>
     ///     Callback for progress reporting during bulk read operations.
     ///     Called with (eventsRead, totalRuConsumed) after each page.
     /// </summary>
     public Action<int, double>? ReadProgressCallback { get; set; }
+
+    /// <summary>
+    ///     Validates and returns the native tagged-stream point-read window. A tagged stream needs a concrete page cap
+    ///     to make the one-page-plus-window memory bound meaningful, so the SDK-default sentinel is rejected here.
+    /// </summary>
+    public int ValidateTaggedStreamPointReadWindow()
+    {
+        var pageSize = GetTaggedStreamIndexPageSize();
+
+        if (MaxConcurrentTaggedStreamPointReads is < 1 or > MaximumMaxConcurrentTaggedStreamPointReads)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(MaxConcurrentTaggedStreamPointReads),
+                MaxConcurrentTaggedStreamPointReads,
+                $"Native tagged-stream point reads must be between 1 and {MaximumMaxConcurrentTaggedStreamPointReads}.");
+        }
+
+        if (MaxConcurrentTaggedStreamPointReads > pageSize)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(MaxConcurrentTaggedStreamPointReads),
+                MaxConcurrentTaggedStreamPointReads,
+                "Native tagged-stream point reads may not exceed MaxItemCountPerPage.");
+        }
+
+        return MaxConcurrentTaggedStreamPointReads;
+    }
+
+    /// <summary>
+    ///     Returns the page cap used only by a native tagged stream. The old SDK-default sentinel remains untouched for
+    ///     compatible list readers, while this path uses an explicit cap to retain the <c>W &lt;= page size</c> invariant.
+    /// </summary>
+    internal int GetTaggedStreamIndexPageSize()
+    {
+        if (MaxItemCountPerPage == -1)
+        {
+            return DefaultTaggedStreamIndexPageSize;
+        }
+
+        if (MaxItemCountPerPage < 1)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(MaxItemCountPerPage),
+                MaxItemCountPerPage,
+                "Native tagged streaming requires MaxItemCountPerPage to be at least one or the SDK-default sentinel (-1).");
+        }
+
+        return MaxItemCountPerPage;
+    }
 
     /// <summary>
     ///     Creates QueryRequestOptions configured based on current settings.
@@ -209,3 +285,13 @@ public class CosmosDbEventStoreOptions
             MaxConcurrentDeserializations = 1 // Sequential processing
         };
 }
+
+/// <summary>
+///     Aggregate telemetry for one Cosmos native tagged stream. It deliberately contains no high-cardinality identifiers.
+/// </summary>
+public sealed record CosmosTaggedStreamTelemetry(
+    int IndexPages,
+    int PointReads,
+    int PeakInFlightPointReads,
+    double RequestCharge,
+    int ThrottledRequests);

--- a/dcb/src/Sekiban.Dcb.CosmosDb/CosmosDbTelemetry.cs
+++ b/dcb/src/Sekiban.Dcb.CosmosDb/CosmosDbTelemetry.cs
@@ -34,6 +34,23 @@ public static class CosmosDbTelemetry
         "sekiban.dcb.cosmos.event_write.partial_failures",
         description: "Multi-event writes that failed partway through the parallel event-create phase.");
 
+    private static readonly Counter<long> TaggedStreamIndexPages = Meter.CreateCounter<long>(
+        "sekiban.dcb.cosmos.tag_stream.index_pages",
+        description: "Tag-index pages read by the native tagged-stream path.");
+
+    private static readonly Counter<long> TaggedStreamPointReads = Meter.CreateCounter<long>(
+        "sekiban.dcb.cosmos.tag_stream.point_reads",
+        description: "Event point reads issued by the native tagged-stream path.");
+
+    private static readonly Counter<double> TaggedStreamRequestCharge = Meter.CreateCounter<double>(
+        "sekiban.dcb.cosmos.tag_stream.request_charge",
+        unit: "Request Units",
+        description: "Cosmos request charge consumed by native tagged streams.");
+
+    private static readonly Counter<long> TaggedStreamThrottles = Meter.CreateCounter<long>(
+        "sekiban.dcb.cosmos.tag_stream.throttles",
+        description: "429 responses observed by native tagged streams.");
+
     /// <summary>Records a failed tag-write attempt. <paramref name="reason" /> must be a bounded label.</summary>
     internal static void RecordTagWriteFailure(TagWriteFailureReason reason) =>
         TagWriteFailures.Add(1, new KeyValuePair<string, object?>("reason", ToLabel(reason)));
@@ -63,6 +80,30 @@ public static class CosmosDbTelemetry
 
     /// <summary>Records a partially-failed multi-event write.</summary>
     internal static void RecordPartialEventWrite() => PartialEventWrites.Add(1);
+
+    /// <summary>Records the bounded aggregate for a native tagged stream without creating tag/event-id dimensions.</summary>
+    internal static void RecordTaggedStream(CosmosTaggedStreamTelemetry telemetry)
+    {
+        if (telemetry.IndexPages > 0)
+        {
+            TaggedStreamIndexPages.Add(telemetry.IndexPages);
+        }
+
+        if (telemetry.PointReads > 0)
+        {
+            TaggedStreamPointReads.Add(telemetry.PointReads);
+        }
+
+        if (telemetry.RequestCharge > 0)
+        {
+            TaggedStreamRequestCharge.Add(telemetry.RequestCharge);
+        }
+
+        if (telemetry.ThrottledRequests > 0)
+        {
+            TaggedStreamThrottles.Add(telemetry.ThrottledRequests);
+        }
+    }
 
     /// <summary>Records how a sweep run ended. <paramref name="outcome" /> must be a bounded label.</summary>
     internal static void RecordSweepRun(SweepRunOutcome outcome) =>

--- a/dcb/src/Sekiban.Dcb.DynamoDB/DynamoDbEventStore.TaggedStream.cs
+++ b/dcb/src/Sekiban.Dcb.DynamoDB/DynamoDbEventStore.TaggedStream.cs
@@ -1,0 +1,309 @@
+using Amazon.DynamoDBv2;
+using Amazon.DynamoDBv2.Model;
+using ResultBoxes;
+using Sekiban.Dcb.Capabilities;
+using Sekiban.Dcb.Common;
+using Sekiban.Dcb.DynamoDB.Models;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.Storage;
+using Sekiban.Dcb.Tags;
+using System.Text;
+
+namespace Sekiban.Dcb.DynamoDB;
+
+public partial class DynamoDbEventStore
+{
+    private const string TaggedStreamHighSortKeySuffix = "\uffff";
+
+    /// <summary>Declares the callback-native tag stream used by cold rebuilds.</summary>
+    public TaggedStreamCapabilityDescriptor DescribeTaggedStream() =>
+        TaggedStreamCapabilityDescriptor.Native("DynamoDB");
+
+    /// <summary>
+    ///     Streams tag references in Dynamo's sort-key order, retaining only one query page and one BatchGet chunk at a
+    ///     time. BatchGetItem has no response order contract, so every chunk is explicitly rejoined to the already
+    ///     ordered query references before callbacks run.
+    /// </summary>
+    public async Task<ResultBox<SerializableEventStreamReadResult>> StreamSerializableEventsByTagAsync(
+        ITag tag,
+        SortableUniqueId? since,
+        SortableUniqueId? until,
+        Func<SerializableEvent, ValueTask> onEvent,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(tag);
+        ArgumentNullException.ThrowIfNull(onEvent);
+
+        var queryPages = 0;
+        var batchGetChunks = 0;
+        var peakPageReferences = 0;
+        var peakChunkBodies = 0;
+        var consumedCapacity = 0d;
+        var emitted = 0;
+        string? lastSortableUniqueId = null;
+
+        try
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var pageSize = ValidateTaggedStreamPageSize();
+            var batchSize = ValidateTaggedStreamBatchSize();
+            await _context.EnsureTablesAsync(cancellationToken).ConfigureAwait(false);
+
+            var serviceId = CurrentServiceId;
+            var tagPartitionKey = BuildTagPk(serviceId, tag.GetTag());
+            Dictionary<string, AttributeValue>? lastEvaluatedKey = null;
+
+            do
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var query = BuildTaggedStreamQuery(tagPartitionKey, since, until, pageSize, lastEvaluatedKey);
+                var page = await _client.QueryAsync(query, cancellationToken).ConfigureAwait(false);
+                queryPages++;
+                consumedCapacity += page.ConsumedCapacity?.CapacityUnits ?? 0d;
+
+                // This is the one bounded reference page. Nothing from a prior page survives its loop iteration.
+                var pageReferences = page.Items
+                    .Where(item => item.ContainsKey("eventId") && item.ContainsKey("sortableUniqueId"))
+                    .Select(item => new TaggedStreamReference(
+                        item["eventId"].S,
+                        item["sortableUniqueId"].S))
+                    .ToList();
+                peakPageReferences = Math.Max(peakPageReferences, pageReferences.Count);
+
+                for (var start = 0; start < pageReferences.Count; start += batchSize)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    // This is the one bounded event body chunk. The backing page remains references only.
+                    var chunk = pageReferences.GetRange(start, Math.Min(batchSize, pageReferences.Count - start));
+                    var read = BuildTaggedStreamBatchGetRequest(serviceId, chunk);
+                    var eventsById = await ExecuteTaggedStreamBatchGetWithRetryAsync(
+                        read,
+                        capacity => consumedCapacity += capacity,
+                        cancellationToken).ConfigureAwait(false);
+                    batchGetChunks++;
+                    peakChunkBodies = Math.Max(peakChunkBodies, eventsById.Count);
+
+                    // The query order, not BatchGet's arbitrary response order, is the public callback order.
+                    foreach (var reference in chunk)
+                    {
+                        cancellationToken.ThrowIfCancellationRequested();
+                        if (!eventsById.TryGetValue(reference.EventId, out var dynamoEvent))
+                        {
+                            throw new InvalidOperationException(
+                                $"Event not found for tag entry: {reference.EventId}");
+                        }
+
+                        if (!string.Equals(dynamoEvent.ServiceId, serviceId, StringComparison.Ordinal))
+                        {
+                            throw new UnauthorizedAccessException(
+                                $"Event {reference.EventId} does not belong to service {serviceId}.");
+                        }
+
+                        if (!string.Equals(
+                                dynamoEvent.SortableUniqueId,
+                                reference.SortableUniqueId,
+                                StringComparison.Ordinal))
+                        {
+                            throw new InvalidOperationException(
+                                $"Event {reference.EventId} does not match its ordered tag reference.");
+                        }
+
+                        var serializableEvent = ToSerializableEvent(dynamoEvent);
+                        await onEvent(serializableEvent).ConfigureAwait(false);
+                        emitted++;
+                        lastSortableUniqueId = serializableEvent.SortableUniqueIdValue;
+                    }
+                }
+
+                _options.ReadProgressCallback?.Invoke(emitted, consumedCapacity);
+                lastEvaluatedKey = page.LastEvaluatedKey;
+            } while (lastEvaluatedKey is { Count: > 0 });
+
+            return ResultBox.FromValue(new SerializableEventStreamReadResult(emitted, lastSortableUniqueId));
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            if (_logger is not null)
+            {
+                LogReadFailed(_logger, ex.Message, ex);
+            }
+
+            return ResultBox.Error<SerializableEventStreamReadResult>(ex);
+        }
+        finally
+        {
+            var telemetry = new DynamoDbTaggedStreamTelemetry(
+                queryPages,
+                batchGetChunks,
+                peakPageReferences,
+                peakChunkBodies,
+                consumedCapacity);
+            try
+            {
+                _options.TaggedStreamTelemetryCallback?.Invoke(telemetry);
+            }
+            catch
+            {
+                // Observability is deliberately unable to alter a data-path result.
+            }
+        }
+    }
+
+    private QueryRequest BuildTaggedStreamQuery(
+        string tagPartitionKey,
+        SortableUniqueId? since,
+        SortableUniqueId? until,
+        int pageSize,
+        Dictionary<string, AttributeValue>? lastEvaluatedKey)
+    {
+        var values = new Dictionary<string, AttributeValue>
+        {
+            [":pk"] = new() { S = tagPartitionKey }
+        };
+        string keyCondition;
+        if (since is not null && until is not null)
+        {
+            // A real tag row's suffix begins with '#', which sorts before the high sentinel. Thus this inclusive
+            // BETWEEN lower bound is exactly exclusive-after <paramref name="since" /> while remaining valid Dynamo
+            // key-condition syntax; the upper sentinel makes <paramref name="until" /> inclusive for every event id.
+            keyCondition = "pk = :pk AND sk BETWEEN :since AND :until";
+            values[":since"] = new AttributeValue { S = ToExclusiveAfterSortKey(since.Value) };
+            values[":until"] = new AttributeValue { S = ToInclusiveUntilSortKey(until.Value) };
+        }
+        else if (since is not null)
+        {
+            keyCondition = "pk = :pk AND sk > :since";
+            values[":since"] = new AttributeValue { S = ToExclusiveAfterSortKey(since.Value) };
+        }
+        else if (until is not null)
+        {
+            keyCondition = "pk = :pk AND sk <= :until";
+            values[":until"] = new AttributeValue { S = ToInclusiveUntilSortKey(until.Value) };
+        }
+        else
+        {
+            keyCondition = "pk = :pk";
+        }
+
+        return new QueryRequest
+        {
+            TableName = _context.TagsTableName,
+            KeyConditionExpression = keyCondition,
+            ExpressionAttributeValues = values,
+            ScanIndexForward = true,
+            Limit = pageSize,
+            ExclusiveStartKey = lastEvaluatedKey,
+            ConsistentRead = _options.UseConsistentReads,
+            ReturnConsumedCapacity = ReturnConsumedCapacity.TOTAL
+        };
+    }
+
+    private BatchGetItemRequest BuildTaggedStreamBatchGetRequest(
+        string serviceId,
+        IReadOnlyList<TaggedStreamReference> references)
+    {
+        return new BatchGetItemRequest
+        {
+            RequestItems = new Dictionary<string, KeysAndAttributes>
+            {
+                [_context.EventsTableName] = new KeysAndAttributes
+                {
+                    Keys = references.Select(reference => BuildEventKey(serviceId, reference.EventId)).ToList(),
+                    ConsistentRead = _options.UseConsistentReads
+                }
+            },
+            ReturnConsumedCapacity = ReturnConsumedCapacity.TOTAL
+        };
+    }
+
+    private async Task<Dictionary<string, DynamoEvent>> ExecuteTaggedStreamBatchGetWithRetryAsync(
+        BatchGetItemRequest request,
+        Action<double> recordCapacity,
+        CancellationToken cancellationToken)
+    {
+        var eventsById = new Dictionary<string, DynamoEvent>(StringComparer.Ordinal);
+        var pending = request.RequestItems;
+
+        for (var attempt = 0; attempt <= _options.MaxRetryAttempts; attempt++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var response = await _client.BatchGetItemAsync(
+                new BatchGetItemRequest
+                {
+                    RequestItems = pending,
+                    ReturnConsumedCapacity = ReturnConsumedCapacity.TOTAL
+                },
+                cancellationToken).ConfigureAwait(false);
+            recordCapacity(response.ConsumedCapacity?.Sum(capacity => capacity.CapacityUnits ?? 0d) ?? 0d);
+
+            if (response.Responses.TryGetValue(_context.EventsTableName, out var items))
+            {
+                foreach (var item in items)
+                {
+                    var dynamoEvent = DynamoEvent.FromAttributeValues(item);
+                    eventsById[dynamoEvent.EventId] = dynamoEvent;
+                }
+            }
+
+            if (response.UnprocessedKeys is not { Count: > 0 })
+            {
+                return eventsById;
+            }
+
+            pending = response.UnprocessedKeys;
+            await Task.Delay(ComputeBackoff(attempt), cancellationToken).ConfigureAwait(false);
+        }
+
+        throw new InvalidOperationException("BatchGetItem exceeded retry limit.");
+    }
+
+    private int ValidateTaggedStreamPageSize()
+    {
+        if (_options.QueryPageSize < 1)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(_options.QueryPageSize),
+                _options.QueryPageSize,
+                "Native tagged streaming requires QueryPageSize to be at least one.");
+        }
+
+        return _options.QueryPageSize;
+    }
+
+    private int ValidateTaggedStreamBatchSize()
+    {
+        if (_options.MaxBatchGetItems is < 1 or > 100)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(_options.MaxBatchGetItems),
+                _options.MaxBatchGetItems,
+                "Native tagged streaming requires MaxBatchGetItems to be between 1 and 100.");
+        }
+
+        return _options.MaxBatchGetItems;
+    }
+
+    private static string ToExclusiveAfterSortKey(string sortableUniqueId) =>
+        $"{sortableUniqueId}{TaggedStreamHighSortKeySuffix}";
+
+    private static string ToInclusiveUntilSortKey(string sortableUniqueId) =>
+        $"{sortableUniqueId}{TaggedStreamHighSortKeySuffix}";
+
+    private static SerializableEvent ToSerializableEvent(DynamoEvent dynamoEvent) =>
+        new(
+            Encoding.UTF8.GetBytes(dynamoEvent.Payload),
+            dynamoEvent.SortableUniqueId,
+            Guid.Parse(dynamoEvent.EventId),
+            new EventMetadata(
+                dynamoEvent.CausationId ?? string.Empty,
+                dynamoEvent.CorrelationId ?? string.Empty,
+                dynamoEvent.ExecutedUser ?? string.Empty),
+            dynamoEvent.Tags.ToList(),
+            dynamoEvent.EventType);
+
+    private sealed record TaggedStreamReference(string EventId, string SortableUniqueId);
+}

--- a/dcb/src/Sekiban.Dcb.DynamoDB/DynamoDbEventStore.cs
+++ b/dcb/src/Sekiban.Dcb.DynamoDB/DynamoDbEventStore.cs
@@ -20,8 +20,9 @@ namespace Sekiban.Dcb.DynamoDB;
 /// <summary>
 ///     DynamoDB-backed event store implementation.
 /// </summary>
-public class DynamoDbEventStore : IHotEventStore, IStorageDurabilityDescriptorProvider,
-    IConditionalEventStore, IWriteConditionCapabilityProvider
+public partial class DynamoDbEventStore : IHotEventStore, IStorageDurabilityDescriptorProvider,
+    IConditionalEventStore, IWriteConditionCapabilityProvider, IStreamingTaggedSerializableEventStore,
+    ITaggedStreamCapabilityProvider
 {
     private const string ConditionalProviderName = "DynamoDB";
 

--- a/dcb/src/Sekiban.Dcb.DynamoDB/DynamoDbEventStoreOptions.cs
+++ b/dcb/src/Sekiban.Dcb.DynamoDB/DynamoDbEventStoreOptions.cs
@@ -97,4 +97,18 @@ public class DynamoDbEventStoreOptions
     ///     Callback for reporting read progress (events read, consumed capacity).
     /// </summary>
     public Action<long, double>? ReadProgressCallback { get; set; }
+
+    /// <summary>
+    ///     Optional aggregate telemetry for one native tagged-stream invocation. This supplements the existing
+    ///     <see cref="ReadProgressCallback" /> seam with its bounded page/chunk high-water marks.
+    /// </summary>
+    public Action<DynamoDbTaggedStreamTelemetry>? TaggedStreamTelemetryCallback { get; set; }
 }
+
+/// <summary>Bounded aggregate telemetry for one DynamoDB native tagged stream.</summary>
+public sealed record DynamoDbTaggedStreamTelemetry(
+    int QueryPages,
+    int BatchGetChunks,
+    int PeakPageReferences,
+    int PeakChunkBodies,
+    double ConsumedCapacity);

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/Cosmos/InMemoryCosmosContainer.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/Cosmos/InMemoryCosmosContainer.cs
@@ -77,12 +77,14 @@ public sealed class InMemoryCosmosContainer : NotSupportedCosmosContainer
     public int MaximumInFlightPointReads => Volatile.Read(ref _maximumInFlightPointReads);
     public IReadOnlyList<CancellationToken> PointReadTokens => _pointReadTokens;
     public IReadOnlyList<CancellationToken> QueryReadTokens => _queryReadTokens;
+    public IReadOnlyList<string> QueryTexts => _queryTexts;
 
     private int _pointReads;
     private int _inFlightPointReads;
     private int _maximumInFlightPointReads;
     private readonly List<CancellationToken> _pointReadTokens = new();
     private readonly List<CancellationToken> _queryReadTokens = new();
+    private readonly List<string> _queryTexts = new();
 
     public override string Id => _name;
 
@@ -445,6 +447,10 @@ public sealed class InMemoryCosmosContainer : NotSupportedCosmosContainer
         Queries++;
 
         var text = queryDefinition.QueryText;
+        lock (_gate)
+        {
+            _queryTexts.Add(text);
+        }
         var parameters = queryDefinition
             .GetQueryParameters()
             .ToDictionary(parameter => parameter.Name, parameter => parameter.Value, StringComparer.Ordinal);

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/Cosmos/InMemoryCosmosContainer.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/Cosmos/InMemoryCosmosContainer.cs
@@ -36,6 +36,9 @@ public sealed class InMemoryCosmosContainer : NotSupportedCosmosContainer
     /// </summary>
     public Queue<Exception> PostWriteFaults { get; } = new();
 
+    /// <summary>Fails the next N point reads, before their resource is materialized.</summary>
+    public Queue<Exception> ReadFaults { get; } = new();
+
     private void ThrowIfPostFaulted()
     {
         if (PostWriteFaults.Count > 0)
@@ -57,12 +60,29 @@ public sealed class InMemoryCosmosContainer : NotSupportedCosmosContainer
     /// </summary>
     public Func<CancellationToken, Task>? ReadItemGate { get; set; }
 
+    /// <summary>
+    ///     Optional per-id point-read gate. It supplements <see cref="ReadItemGate" /> for ordered-stream tests that
+    ///     need the second request to finish before the first without changing the production ordering contract.
+    /// </summary>
+    public Func<string, CancellationToken, Task>? ReadItemGateById { get; set; }
+
     /// <summary>Every document currently stored, newest last.</summary>
     public IReadOnlyList<JObject> Items => _items.Values.ToList();
 
     public int Creates { get; private set; }
     public int Deletes { get; private set; }
     public int Queries { get; private set; }
+    public int PointReads => Volatile.Read(ref _pointReads);
+    public int InFlightPointReads => Volatile.Read(ref _inFlightPointReads);
+    public int MaximumInFlightPointReads => Volatile.Read(ref _maximumInFlightPointReads);
+    public IReadOnlyList<CancellationToken> PointReadTokens => _pointReadTokens;
+    public IReadOnlyList<CancellationToken> QueryReadTokens => _queryReadTokens;
+
+    private int _pointReads;
+    private int _inFlightPointReads;
+    private int _maximumInFlightPointReads;
+    private readonly List<CancellationToken> _pointReadTokens = new();
+    private readonly List<CancellationToken> _queryReadTokens = new();
 
     public override string Id => _name;
 
@@ -169,27 +189,59 @@ public sealed class InMemoryCosmosContainer : NotSupportedCosmosContainer
         ItemRequestOptions? requestOptions = null,
         CancellationToken cancellationToken = default)
     {
-        // Optional blocking gate (observing the read's token) — lets a test prove the bounded verification budget cancels
-        // a stuck production read. Awaited OUTSIDE the lock.
-        if (ReadItemGate is not null)
+        Interlocked.Increment(ref _pointReads);
+        var inFlight = Interlocked.Increment(ref _inFlightPointReads);
+        while (true)
         {
-            await ReadItemGate(cancellationToken).ConfigureAwait(false);
-        }
-
-        lock (_gate)
-        {
-            // Partition-scoped point read, exactly as Cosmos behaves: an id is unique WITHIN a partition, but the same id
-            // can exist in different partitions (e.g. tag rows share the event id across per-tag partitions). Matching by
-            // id alone would return another partition's row.
-            var pk = UnwrapPartitionKey(partitionKey);
-            var match = _items.TryGetValue((pk, id), out var found) ? found : null;
-
-            if (match == null)
+            var observedMaximum = Volatile.Read(ref _maximumInFlightPointReads);
+            if (inFlight <= observedMaximum ||
+                Interlocked.CompareExchange(ref _maximumInFlightPointReads, inFlight, observedMaximum) == observedMaximum)
             {
-                throw CosmosFailures.NotFound();
+                break;
+            }
+        }
+        try
+        {
+            lock (_gate)
+            {
+                _pointReadTokens.Add(cancellationToken);
+                if (ReadFaults.Count > 0)
+                {
+                    throw ReadFaults.Dequeue();
+                }
             }
 
-            return new FakeItemResponse<T>(match.ToObject<T>()!, HttpStatusCode.OK);
+            // Optional blocking gate (observing the read's token) — lets a test prove the bounded verification budget cancels
+            // a stuck production read. Awaited OUTSIDE the lock.
+            if (ReadItemGateById is not null)
+            {
+                await ReadItemGateById(id, cancellationToken).ConfigureAwait(false);
+            }
+
+            if (ReadItemGate is not null)
+            {
+                await ReadItemGate(cancellationToken).ConfigureAwait(false);
+            }
+
+            lock (_gate)
+            {
+                // Partition-scoped point read, exactly as Cosmos behaves: an id is unique WITHIN a partition, but the same id
+                // can exist in different partitions (e.g. tag rows share the event id across per-tag partitions). Matching by
+                // id alone would return another partition's row.
+                var pk = UnwrapPartitionKey(partitionKey);
+                var match = _items.TryGetValue((pk, id), out var found) ? found : null;
+
+                if (match == null)
+                {
+                    throw CosmosFailures.NotFound();
+                }
+
+                return new FakeItemResponse<T>(match.ToObject<T>()!, HttpStatusCode.OK);
+            }
+        }
+        finally
+        {
+            Interlocked.Decrement(ref _inFlightPointReads);
         }
     }
 
@@ -402,12 +454,16 @@ public sealed class InMemoryCosmosContainer : NotSupportedCosmosContainer
         // A query with an item cap pages; the store and the repair both follow continuation tokens.
         var pageSize = requestOptions?.MaxItemCount is > 0 ? requestOptions.MaxItemCount!.Value : rows.Count;
         var offset = continuationToken == null ? 0 : int.Parse(continuationToken, null);
-        var page = rows.Skip(offset).Take(Math.Max(1, pageSize)).ToList();
-        var consumed = offset + page.Count;
-        var next = consumed < rows.Count ? consumed.ToString(null as IFormatProvider) : null;
+        var typed = rows.Select(Materialize<T>).ToList();
+        return new FakeFeedIterator<T>(typed, Math.Max(1, pageSize), offset, RecordQueryReadToken);
+    }
 
-        var typed = page.Select(Materialize<T>).ToList();
-        return new FakeFeedIterator<T>(typed, next);
+    private void RecordQueryReadToken(CancellationToken cancellationToken)
+    {
+        lock (_gate)
+        {
+            _queryReadTokens.Add(cancellationToken);
+        }
     }
 
     private static T Materialize<T>(JObject row) =>
@@ -467,7 +523,16 @@ public sealed class InMemoryCosmosContainer : NotSupportedCosmosContainer
 
             if (parameters.TryGetValue("@since", out var since))
             {
-                rows = rows.Where(row => SinceMatches(text, row["sortableUniqueId"]!.Value<string>(), (string)since));
+                rows = rows.Where(row => SinceMatches(
+                    text,
+                    row["sortableUniqueId"]!.Value<string>() ?? string.Empty,
+                    (string)since));
+            }
+
+            if (parameters.TryGetValue("@until", out var until))
+            {
+                rows = rows.Where(row =>
+                    string.CompareOrdinal(row["sortableUniqueId"]!.Value<string>(), (string)until) <= 0);
             }
 
             if (text.Contains("COUNT(1)", StringComparison.Ordinal))
@@ -506,7 +571,10 @@ public sealed class InMemoryCosmosContainer : NotSupportedCosmosContainer
 
             if (parameters.TryGetValue("@since", out var since))
             {
-                rows = rows.Where(row => SinceMatches(text, row["sortableUniqueId"]!.Value<string>(), (string)since));
+                rows = rows.Where(row => SinceMatches(
+                    text,
+                    row["sortableUniqueId"]!.Value<string>() ?? string.Empty,
+                    (string)since));
             }
 
             if (parameters.TryGetValue("@from", out var from))
@@ -728,23 +796,33 @@ internal sealed class FakeItemResponse<T> : ItemResponse<T>
 
 internal sealed class FakeFeedIterator<T> : FeedIterator<T>
 {
-    private readonly string? _continuationToken;
     private readonly IReadOnlyList<T> _rows;
-    private bool _served;
+    private readonly int _pageSize;
+    private readonly Action<CancellationToken>? _recordToken;
+    private int _offset;
 
-    public FakeFeedIterator(IReadOnlyList<T> rows, string? continuationToken)
+    public FakeFeedIterator(
+        IReadOnlyList<T> rows,
+        int pageSize,
+        int offset,
+        Action<CancellationToken>? recordToken = null)
     {
         _rows = rows;
-        _continuationToken = continuationToken;
+        _pageSize = pageSize;
+        _offset = offset;
+        _recordToken = recordToken;
     }
 
-    public override bool HasMoreResults => !_served;
+    public override bool HasMoreResults => _offset < _rows.Count;
 
     public override Task<FeedResponse<T>> ReadNextAsync(CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
-        _served = true;
-        return Task.FromResult<FeedResponse<T>>(new FakeFeedResponse<T>(_rows, _continuationToken));
+        _recordToken?.Invoke(cancellationToken);
+        var page = _rows.Skip(_offset).Take(_pageSize).ToList();
+        _offset += page.Count;
+        var continuation = _offset < _rows.Count ? _offset.ToString(null as IFormatProvider) : null;
+        return Task.FromResult<FeedResponse<T>>(new FakeFeedResponse<T>(page, continuation));
     }
 }
 

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/RemoteTaggedStreamTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/RemoteTaggedStreamTests.cs
@@ -129,6 +129,66 @@ public sealed class RemoteTaggedStreamTests
     }
 
     [Fact]
+    public async Task CosmosNativeTaggedStream_SelectsAStaticParameterizedQueryForEachBoundShape()
+    {
+        var options = new CosmosDbEventStoreOptions
+        {
+            EventsContainerName = "g54-events",
+            TagsContainerName = "g54-tags",
+            MaxItemCountPerPage = 8,
+            MaxConcurrentTaggedStreamPointReads = 2
+        };
+        var (store, client) = NewCosmosStore(options);
+        var tag = new NativeTag("cosmos-static-bound-shapes");
+        Assert.True((await store.WriteSerializableEventsAsync(FivePointFixture(tag))).IsSuccess);
+        var tags = client.Container(options.TagsContainerName);
+
+        await AssertBoundShapeAsync(
+            null,
+            null,
+            new[] { P0, P1, P2, P3, P4 },
+            "SELECT c.eventId FROM c WHERE c.pk = @pk ORDER BY c.sortableUniqueId");
+        await AssertBoundShapeAsync(
+            new SortableUniqueId(P1),
+            null,
+            new[] { P2, P3, P4 },
+            "SELECT c.eventId FROM c WHERE c.pk = @pk AND c.sortableUniqueId > @since ORDER BY c.sortableUniqueId");
+        await AssertBoundShapeAsync(
+            null,
+            new SortableUniqueId(P3),
+            new[] { P0, P1, P2, P3 },
+            "SELECT c.eventId FROM c WHERE c.pk = @pk AND c.sortableUniqueId <= @until ORDER BY c.sortableUniqueId");
+        await AssertBoundShapeAsync(
+            new SortableUniqueId(P1),
+            new SortableUniqueId(P3),
+            new[] { P2, P3 },
+            "SELECT c.eventId FROM c WHERE c.pk = @pk AND c.sortableUniqueId > @since AND c.sortableUniqueId <= @until ORDER BY c.sortableUniqueId");
+
+        async Task AssertBoundShapeAsync(
+            SortableUniqueId? since,
+            SortableUniqueId? until,
+            IReadOnlyList<string> expectedIds,
+            string expectedQueryText)
+        {
+            var queryStart = tags.QueryTexts.Count;
+            var emitted = new List<string>();
+            var result = await store.StreamSerializableEventsByTagAsync(
+                tag,
+                since,
+                until,
+                @event =>
+                {
+                    emitted.Add(@event.SortableUniqueIdValue);
+                    return ValueTask.CompletedTask;
+                });
+
+            Assert.True(result.IsSuccess, result.IsSuccess ? string.Empty : result.GetException().ToString());
+            Assert.Equal(expectedIds, emitted);
+            Assert.Equal(expectedQueryText, tags.QueryTexts.Skip(queryStart).Single());
+        }
+    }
+
+    [Fact]
     public async Task CosmosNativeTaggedStream_DefaultWindowReportsTheEmulatorRuModelAndKeepsAllFiveReadsBounded()
     {
         var telemetry = new List<CosmosTaggedStreamTelemetry>();
@@ -688,6 +748,11 @@ public sealed class RemoteTaggedStreamTests
         Assert.DoesNotContain("FetchSerializableEventsByIdsAsync", cosmos, StringComparison.Ordinal);
         Assert.DoesNotContain("Task.WhenAll", cosmos, StringComparison.Ordinal);
         Assert.DoesNotContain("ReadSerializableEventsByTagAsync", cosmos, StringComparison.Ordinal);
+        Assert.DoesNotContain("where +=", cosmos, StringComparison.Ordinal);
+        Assert.Contains("TaggedStreamIndexQueryWithoutBounds", cosmos, StringComparison.Ordinal);
+        Assert.Contains("TaggedStreamIndexQuerySinceOnly", cosmos, StringComparison.Ordinal);
+        Assert.Contains("TaggedStreamIndexQueryUntilOnly", cosmos, StringComparison.Ordinal);
+        Assert.Contains("TaggedStreamIndexQuerySinceAndUntil", cosmos, StringComparison.Ordinal);
         Assert.DoesNotContain("QueryTagsAsync", dynamo, StringComparison.Ordinal);
         Assert.DoesNotContain("BatchGetEventsAsync", dynamo, StringComparison.Ordinal);
         Assert.DoesNotContain("Task.WhenAll", dynamo, StringComparison.Ordinal);

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/RemoteTaggedStreamTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/RemoteTaggedStreamTests.cs
@@ -129,6 +129,46 @@ public sealed class RemoteTaggedStreamTests
     }
 
     [Fact]
+    public async Task CosmosNativeTaggedStream_DefaultWindowReportsTheEmulatorRuModelAndKeepsAllFiveReadsBounded()
+    {
+        var telemetry = new List<CosmosTaggedStreamTelemetry>();
+        var options = new CosmosDbEventStoreOptions
+        {
+            EventsContainerName = "g54-events",
+            TagsContainerName = "g54-tags",
+            TaggedStreamTelemetryCallback = telemetry.Add
+        };
+        var (store, client) = NewCosmosStore(options);
+        var tag = new NativeTag("cosmos-default-window-telemetry");
+        Assert.True((await store.WriteSerializableEventsAsync(FivePointFixture(tag))).IsSuccess);
+
+        var emitted = new List<string>();
+        var result = await store.StreamSerializableEventsByTagAsync(
+            tag,
+            null,
+            null,
+            @event =>
+            {
+                emitted.Add(@event.SortableUniqueIdValue);
+                return ValueTask.CompletedTask;
+            });
+
+        Assert.True(result.IsSuccess, result.IsSuccess ? string.Empty : result.GetException().ToString());
+        Assert.Equal(new[] { P0, P1, P2, P3, P4 }, emitted);
+        Assert.Equal(CosmosDbEventStoreOptions.DefaultMaxConcurrentTaggedStreamPointReads,
+            options.MaxConcurrentTaggedStreamPointReads);
+        var observed = Assert.Single(telemetry);
+        Assert.Equal(1, observed.IndexPages);
+        Assert.Equal(5, observed.PointReads);
+        Assert.InRange(observed.PeakInFlightPointReads, 1, options.MaxConcurrentTaggedStreamPointReads);
+        // InMemoryCosmosContainer deterministically charges one unit per index row and point read: 2 units/reference.
+        Assert.Equal(10d, observed.RequestCharge);
+        Assert.Equal(0, observed.ThrottledRequests);
+        Assert.InRange(client.Container(options.EventsContainerName).MaximumInFlightPointReads, 1,
+            options.MaxConcurrentTaggedStreamPointReads);
+    }
+
+    [Fact]
     public async Task CosmosNativeTaggedStream_CompletionOrderMutant_IsKilledByHeadOrderedPublication()
     {
         var options = new CosmosDbEventStoreOptions

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/RemoteTaggedStreamTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/RemoteTaggedStreamTests.cs
@@ -1,0 +1,1154 @@
+using Amazon.DynamoDBv2;
+using Amazon.DynamoDBv2.Model;
+using Amazon.Runtime;
+using Dcb.Domain;
+using Microsoft.Extensions.Options;
+using ResultBoxes;
+using Sekiban.Dcb.Actors;
+using Sekiban.Dcb.Capabilities;
+using Sekiban.Dcb.Common;
+using Sekiban.Dcb.CosmosDb;
+using Sekiban.Dcb.DynamoDB;
+using Sekiban.Dcb.DynamoDB.Models;
+using Sekiban.Dcb.Domains;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.InMemory;
+using Sekiban.Dcb.Queries;
+using Sekiban.Dcb.ServiceId;
+using Sekiban.Dcb.Storage;
+using Sekiban.Dcb.Tags;
+using Sekiban.Dcb.Tests.Cosmos;
+using System.Text;
+using System.Text.Json;
+
+namespace Sekiban.Dcb.Tests;
+
+/// <summary>
+///     SEK-G54 provider-real native tagged-stream matrix. Cosmos uses the existing container-shaped in-process emulator;
+///     DynamoDB uses a request-shaped harness that evaluates the real request's key condition and returns BatchGet rows
+///     in deliberately hostile order. These tests live in WithResult.Tests so both net9/net10 DCB PR jobs execute them.
+/// </summary>
+public sealed class RemoteTaggedStreamTests
+{
+    private const string ServiceId = "g54-service";
+    private const string EventsTable = "g54-events";
+    private const string TagsTable = "g54-tags";
+    private static readonly DateTime BaseTime = new(2026, 9, 1, 0, 0, 0, DateTimeKind.Utc);
+    private static readonly string P0 = SortableUniqueId.Generate(BaseTime.AddSeconds(-1), Guid.Parse("00000000-0000-0000-0000-000000000001"));
+    private static readonly string P1 = SortableUniqueId.Generate(BaseTime, Guid.Parse("00000000-0000-0000-0000-000000000002"));
+    private static readonly string P2 = SortableUniqueId.Generate(BaseTime.AddSeconds(1), Guid.Parse("00000000-0000-0000-0000-000000000003"));
+    private static readonly string P3 = SortableUniqueId.Generate(BaseTime.AddSeconds(2), Guid.Parse("00000000-0000-0000-0000-000000000004"));
+    private static readonly string P4 = SortableUniqueId.Generate(BaseTime.AddSeconds(3), Guid.Parse("00000000-0000-0000-0000-000000000005"));
+    private static readonly JsonSerializerOptions PayloadJsonOptions = new() { PropertyNameCaseInsensitive = true };
+
+    [Fact]
+    public async Task CosmosAndDynamoNativeStreams_KeepStreamingColdListColdAndCachedIncrementalParity()
+    {
+        var domain = BuildParityDomain();
+
+        var cosmosOptions = new CosmosDbEventStoreOptions
+        {
+            EventsContainerName = "g54-parity-events",
+            TagsContainerName = "g54-parity-tags",
+            MaxItemCountPerPage = 1,
+            MaxConcurrentTaggedStreamPointReads = 1
+        };
+        var (cosmos, _) = NewCosmosStore(cosmosOptions);
+        var cosmosTag = new RemoteParityTag("cosmos");
+        Assert.True((await cosmos.WriteSerializableEventsAsync(ParityEvents(domain, cosmosTag))).IsSuccess);
+        var cosmosResult = await RunParityRoutesAsync(cosmos, "CosmosDb", domain, cosmosTag);
+
+        // Keep the provider's arbitrary BatchGet order hostile on the actor route too. If the production rejoin is
+        // removed, the G53 consumer guard sees P2 before P1 and the rebuild fails before it can publish state.
+        var dynamoClient = new NativeTaggedStreamDynamoClient { ReverseBatchResponses = true };
+        var dynamoOptions = new DynamoDbEventStoreOptions
+        {
+            AutoCreateTables = false,
+            EventsTableName = EventsTable,
+            TagsTableName = TagsTable,
+            QueryPageSize = 1,
+            MaxBatchGetItems = 1
+        };
+        var dynamo = NewDynamoStore(dynamoClient, dynamoOptions, domain);
+        var dynamoTag = new RemoteParityTag("dynamo");
+        SeedDynamo(dynamoClient, dynamoTag, ParityEvents(domain, dynamoTag));
+        var dynamoResult = await RunParityRoutesAsync(dynamo, "DynamoDB", domain, dynamoTag);
+
+        AssertEquivalent(cosmosResult.StreamingCold, dynamoResult.StreamingCold, "Cosmos / Dynamo streaming cold");
+    }
+
+    [Fact]
+    public async Task CosmosNativeTaggedStream_FivePointBounds_PreservesPayloadVersionLastSuid_AndReportsBoundedTelemetry()
+    {
+        var telemetry = new List<CosmosTaggedStreamTelemetry>();
+        var options = new CosmosDbEventStoreOptions
+        {
+            EventsContainerName = "g54-events",
+            TagsContainerName = "g54-tags",
+            MaxItemCountPerPage = 1,
+            MaxConcurrentTaggedStreamPointReads = 1,
+            TaggedStreamTelemetryCallback = telemetry.Add
+        };
+        var (store, client) = NewCosmosStore(options);
+        var tag = new NativeTag("cosmos-bounds");
+        var fixture = FivePointFixture(tag);
+        Assert.True((await store.WriteSerializableEventsAsync(fixture)).IsSuccess);
+
+        var emitted = new List<SerializableEvent>();
+        var stream = await store.StreamSerializableEventsByTagAsync(
+            tag,
+            new SortableUniqueId(P1),
+            new SortableUniqueId(P3),
+            @event =>
+            {
+                emitted.Add(@event);
+                return ValueTask.CompletedTask;
+            },
+            new CancellationTokenSource().Token);
+
+        Assert.True(stream.IsSuccess, stream.IsSuccess ? string.Empty : stream.GetException().ToString());
+        Assert.Equal(new[] { P2, P3 }, emitted.Select(@event => @event.SortableUniqueIdValue));
+        Assert.All(emitted, @event => Assert.Equal("RemoteTaggedV2", @event.EventPayloadName));
+        Assert.All(emitted, @event => Assert.Equal(Encoding.UTF8.GetBytes("{\"v\":2}"), @event.Payload));
+        Assert.Equal(2, stream.GetValue().EventsRead);
+        Assert.Equal(P3, stream.GetValue().LastSortableUniqueId);
+        Assert.Equal(2, client.Container(options.EventsContainerName).PointReads);
+        Assert.Equal(1, client.Container(options.EventsContainerName).MaximumInFlightPointReads);
+        Assert.All(client.Container(options.TagsContainerName).QueryReadTokens, token => Assert.True(token.CanBeCanceled));
+        var observed = Assert.Single(telemetry);
+        Assert.Equal(2, observed.IndexPages);
+        Assert.Equal(2, observed.PointReads);
+        Assert.Equal(1, observed.PeakInFlightPointReads);
+        Assert.True(observed.RequestCharge > 0);
+        Assert.Equal(0, observed.ThrottledRequests);
+
+        var resolution = SekibanDcbCapabilityResolver.ResolveTaggedStream(store, "Cosmos");
+        Assert.True(resolution.IsSupported);
+        Assert.True(resolution.Descriptor.NativeStreaming);
+        Assert.Equal("CosmosDb", resolution.Descriptor.ProviderName);
+    }
+
+    [Fact]
+    public async Task CosmosNativeTaggedStream_CompletionOrderMutant_IsKilledByHeadOrderedPublication()
+    {
+        var options = new CosmosDbEventStoreOptions
+        {
+            EventsContainerName = "g54-events",
+            TagsContainerName = "g54-tags",
+            MaxItemCountPerPage = 2,
+            MaxConcurrentTaggedStreamPointReads = 2
+        };
+        var (store, client) = NewCosmosStore(options);
+        var tag = new NativeTag("cosmos-completion-order");
+        var fixture = FivePointFixture(tag);
+        Assert.True((await store.WriteSerializableEventsAsync(fixture)).IsSuccess);
+
+        var firstEventId = fixture.Single(@event => @event.SortableUniqueIdValue == P2).Id.ToString();
+        var secondEventId = fixture.Single(@event => @event.SortableUniqueIdValue == P3).Id.ToString();
+        var firstStarted = NewSignal();
+        var secondFinished = NewSignal();
+        var releaseFirst = NewSignal();
+        var events = client.Container(options.EventsContainerName);
+        events.ReadItemGateById = async (id, cancellationToken) =>
+        {
+            if (id == firstEventId)
+            {
+                firstStarted.TrySetResult();
+                await releaseFirst.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
+            }
+            else if (id == secondEventId)
+            {
+                secondFinished.TrySetResult();
+            }
+        };
+
+        var emitted = new List<string>();
+        var streaming = store.StreamSerializableEventsByTagAsync(
+            tag,
+            new SortableUniqueId(P1),
+            new SortableUniqueId(P3),
+            @event =>
+            {
+                emitted.Add(@event.SortableUniqueIdValue);
+                return ValueTask.CompletedTask;
+            });
+
+        try
+        {
+            await firstStarted.Task.WaitAsync(TimeSpan.FromSeconds(10));
+            await secondFinished.Task.WaitAsync(TimeSpan.FromSeconds(10));
+            Assert.Empty(emitted); // P3 completed first, but the P2 head is not released yet.
+        }
+        finally
+        {
+            releaseFirst.TrySetResult();
+        }
+
+        var result = await streaming;
+        Assert.True(result.IsSuccess, result.IsSuccess ? string.Empty : result.GetException().ToString());
+        Assert.Equal(new[] { P2, P3 }, emitted);
+        Assert.Equal(options.MaxConcurrentTaggedStreamPointReads, events.MaximumInFlightPointReads);
+    }
+
+    [Fact]
+    public async Task CosmosNativeTaggedStream_FailedHeadCancelsQueuedReadsAndPublishesNothingAfterTheHead()
+    {
+        var options = new CosmosDbEventStoreOptions
+        {
+            EventsContainerName = "g54-events",
+            TagsContainerName = "g54-tags",
+            MaxItemCountPerPage = 2,
+            MaxConcurrentTaggedStreamPointReads = 2
+        };
+        var (store, client) = NewCosmosStore(options);
+        var tag = new NativeTag("cosmos-failed-head");
+        var fixture = FivePointFixture(tag);
+        Assert.True((await store.WriteSerializableEventsAsync(fixture)).IsSuccess);
+        var events = client.Container(options.EventsContainerName);
+        var tailStarted = NewSignal();
+        var p3EventId = fixture.Single(@event => @event.SortableUniqueIdValue == P3).Id.ToString();
+        events.ReadItemGateById = async (id, cancellationToken) =>
+        {
+            if (id == p3EventId)
+            {
+                tailStarted.TrySetResult();
+                await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken).ConfigureAwait(false);
+            }
+        };
+        events.ReadFaults.Enqueue(new InvalidOperationException("failed P2 head"));
+
+        var emitted = new List<string>();
+        var result = await store.StreamSerializableEventsByTagAsync(
+            tag,
+            new SortableUniqueId(P1),
+            new SortableUniqueId(P3),
+            @event =>
+            {
+                emitted.Add(@event.SortableUniqueIdValue);
+                return ValueTask.CompletedTask;
+            });
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal("failed P2 head", result.GetException().Message);
+        Assert.Empty(emitted);
+        await tailStarted.Task.WaitAsync(TimeSpan.FromSeconds(10));
+        Assert.Equal(2, events.PointReads);
+        Assert.All(events.PointReadTokens, token => Assert.True(token.IsCancellationRequested));
+    }
+
+    [Fact]
+    public async Task CosmosNativeTaggedStream_CancellationStopsNewPointReads_AndForwardsProviderTokens()
+    {
+        var options = new CosmosDbEventStoreOptions
+        {
+            EventsContainerName = "g54-events",
+            TagsContainerName = "g54-tags",
+            MaxItemCountPerPage = 2,
+            MaxConcurrentTaggedStreamPointReads = 2
+        };
+        var (store, client) = NewCosmosStore(options);
+        var tag = new NativeTag("cosmos-cancel");
+        Assert.True((await store.WriteSerializableEventsAsync(FivePointFixture(tag))).IsSuccess);
+        var events = client.Container(options.EventsContainerName);
+        var readStarted = NewSignal();
+        events.ReadItemGate = async cancellationToken =>
+        {
+            readStarted.TrySetResult();
+            await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken).ConfigureAwait(false);
+        };
+
+        using var cancellation = new CancellationTokenSource();
+        var streaming = store.StreamSerializableEventsByTagAsync(
+            tag,
+            new SortableUniqueId(P1),
+            new SortableUniqueId(P3),
+            _ => ValueTask.CompletedTask,
+            cancellation.Token);
+        await readStarted.Task.WaitAsync(TimeSpan.FromSeconds(10));
+        var issuedBeforeCancellation = events.PointReads;
+        cancellation.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => streaming);
+        Assert.Equal(issuedBeforeCancellation, events.PointReads);
+        Assert.InRange(events.PointReads, 1, options.MaxConcurrentTaggedStreamPointReads);
+        Assert.InRange(events.MaximumInFlightPointReads, 1, options.MaxConcurrentTaggedStreamPointReads);
+        Assert.All(events.PointReadTokens, token => Assert.True(token.CanBeCanceled && token.IsCancellationRequested));
+        Assert.All(
+            client.Container(options.TagsContainerName).QueryReadTokens,
+            token => Assert.True(token.CanBeCanceled && token.IsCancellationRequested));
+    }
+
+    [Fact]
+    public async Task CosmosNativeTaggedStream_CapturedHeadExcludesAnAppendAboveTheHeadDuringAReleasedCallback()
+    {
+        var options = new CosmosDbEventStoreOptions
+        {
+            EventsContainerName = "g54-events",
+            TagsContainerName = "g54-tags",
+            MaxItemCountPerPage = 1,
+            MaxConcurrentTaggedStreamPointReads = 1
+        };
+        var (store, _) = NewCosmosStore(options);
+        var tag = new NativeTag("cosmos-captured-head");
+        var initial = FivePointFixture(tag).Where(@event => @event.SortableUniqueIdValue != P4).ToList();
+        Assert.True((await store.WriteSerializableEventsAsync(initial)).IsSuccess);
+        var capturedHead = await store.GetLatestSortableUniqueIdAsync();
+        Assert.True(capturedHead.IsSuccess, capturedHead.IsSuccess ? string.Empty : capturedHead.GetException().ToString());
+        Assert.Equal(P3, capturedHead.GetValue());
+
+        var firstCallback = NewSignal();
+        var releaseCallback = NewSignal();
+        var emitted = new List<string>();
+        var stream = store.StreamSerializableEventsByTagAsync(
+            tag,
+            new SortableUniqueId(P1),
+            new SortableUniqueId(capturedHead.GetValue()),
+            async @event =>
+            {
+                emitted.Add(@event.SortableUniqueIdValue);
+                if (emitted.Count == 1)
+                {
+                    firstCallback.TrySetResult();
+                    await releaseCallback.Task;
+                }
+            });
+
+        try
+        {
+            await firstCallback.Task.WaitAsync(TimeSpan.FromSeconds(10));
+            var appendAboveHead = FivePointFixture(tag).Single(@event => @event.SortableUniqueIdValue == P4);
+            Assert.True((await store.WriteSerializableEventsAsync([appendAboveHead])).IsSuccess);
+        }
+        finally
+        {
+            releaseCallback.TrySetResult();
+        }
+
+        var result = await stream;
+        Assert.True(result.IsSuccess, result.IsSuccess ? string.Empty : result.GetException().ToString());
+        Assert.Equal(new[] { P2, P3 }, emitted);
+        Assert.DoesNotContain(P4, emitted);
+    }
+
+    [Fact]
+    public async Task CosmosNativeTaggedStream_ThrottledPointReadReports429AndRequestChargeTelemetry()
+    {
+        var telemetry = new List<CosmosTaggedStreamTelemetry>();
+        var options = new CosmosDbEventStoreOptions
+        {
+            EventsContainerName = "g54-events",
+            TagsContainerName = "g54-tags",
+            MaxItemCountPerPage = 1,
+            MaxConcurrentTaggedStreamPointReads = 1,
+            TaggedStreamTelemetryCallback = telemetry.Add
+        };
+        var (store, client) = NewCosmosStore(options);
+        var tag = new NativeTag("cosmos-telemetry");
+        Assert.True((await store.WriteSerializableEventsAsync([FixtureEvent(P2, tag, 2)])).IsSuccess);
+        client.Container(options.EventsContainerName).ReadFaults.Enqueue(CosmosFailures.Throttled(TimeSpan.FromMilliseconds(1)));
+
+        var result = await store.StreamSerializableEventsByTagAsync(tag, null, null, _ => ValueTask.CompletedTask);
+
+        Assert.False(result.IsSuccess);
+        var observed = Assert.Single(telemetry);
+        Assert.Equal(1, observed.ThrottledRequests);
+        Assert.True(observed.RequestCharge > 0);
+    }
+
+    [Theory]
+    [InlineData(0, 1000)]
+    [InlineData(65, 1000)]
+    [InlineData(9, 8)]
+    public async Task CosmosNativeTaggedStream_InvalidWindowFailsBeforeItReadsTheTagIndex(
+        int configuredWindow,
+        int pageSize)
+    {
+        var options = new CosmosDbEventStoreOptions
+        {
+            EventsContainerName = "g54-events",
+            TagsContainerName = "g54-tags",
+            MaxItemCountPerPage = pageSize,
+            MaxConcurrentTaggedStreamPointReads = configuredWindow
+        };
+        var (store, client) = NewCosmosStore(options);
+
+        var result = await store.StreamSerializableEventsByTagAsync(
+            new NativeTag("cosmos-invalid-window"),
+            null,
+            null,
+            _ => ValueTask.CompletedTask);
+
+        Assert.False(result.IsSuccess);
+        Assert.IsType<ArgumentOutOfRangeException>(result.GetException());
+        Assert.Equal(0, client.Container(options.TagsContainerName).Queries);
+        Assert.Equal(configuredWindow, options.MaxConcurrentTaggedStreamPointReads);
+        Assert.Equal(CosmosDbEventStoreOptions.DefaultMaxConcurrentTaggedStreamPointReads,
+            new CosmosDbEventStoreOptions().MaxConcurrentTaggedStreamPointReads);
+    }
+
+    [Fact]
+    public async Task CosmosNativeTaggedStream_CompatibilityPresetKeepsItsLegacyListSentinelButUsesABoundedNativePage()
+    {
+        var options = CosmosDbEventStoreOptions.CreateForCompatibility();
+        options.EventsContainerName = "g54-events";
+        options.TagsContainerName = "g54-tags";
+        var (store, _) = NewCosmosStore(options);
+
+        var result = await store.StreamSerializableEventsByTagAsync(
+            new NativeTag("cosmos-compatibility-page"),
+            null,
+            null,
+            _ => ValueTask.CompletedTask);
+
+        Assert.True(result.IsSuccess, result.IsSuccess ? string.Empty : result.GetException().ToString());
+        Assert.Equal(-1, options.MaxItemCountPerPage); // Existing list-reader compatibility behavior remains unchanged.
+        Assert.Equal(CosmosDbEventStoreOptions.DefaultTaggedStreamIndexPageSize, options.GetTaggedStreamIndexPageSize());
+    }
+
+    [Fact]
+    public async Task DynamoNativeTaggedStream_BoundsArePushedDown_AndBatchGetOrderMutantIsKilled()
+    {
+        var telemetry = new List<DynamoDbTaggedStreamTelemetry>();
+        var progress = new List<(long EventsRead, double ConsumedCapacity)>();
+        var client = new NativeTaggedStreamDynamoClient { ReverseBatchResponses = true };
+        var options = new DynamoDbEventStoreOptions
+        {
+            AutoCreateTables = false,
+            EventsTableName = EventsTable,
+            TagsTableName = TagsTable,
+            QueryPageSize = 2,
+            MaxBatchGetItems = 2,
+            TaggedStreamTelemetryCallback = telemetry.Add,
+            ReadProgressCallback = (eventsRead, consumedCapacity) => progress.Add((eventsRead, consumedCapacity))
+        };
+        var store = NewDynamoStore(client, options);
+        var tag = new NativeTag("dynamo-bounds");
+        SeedDynamo(client, tag, FivePointFixture(tag));
+
+        var emitted = new List<SerializableEvent>();
+        using var tokenSource = new CancellationTokenSource();
+        var result = await store.StreamSerializableEventsByTagAsync(
+            tag,
+            new SortableUniqueId(P1),
+            new SortableUniqueId(P3),
+            @event =>
+            {
+                emitted.Add(@event);
+                return ValueTask.CompletedTask;
+            },
+            tokenSource.Token);
+
+        Assert.True(result.IsSuccess, result.IsSuccess ? string.Empty : result.GetException().ToString());
+        Assert.Equal(new[] { P2, P3 }, emitted.Select(@event => @event.SortableUniqueIdValue));
+        Assert.All(emitted, @event => Assert.Equal(Encoding.UTF8.GetBytes("{\"v\":2}"), @event.Payload));
+        Assert.Equal(P3, result.GetValue().LastSortableUniqueId);
+        var query = Assert.Single(client.Queries);
+        Assert.Equal("pk = :pk AND sk BETWEEN :since AND :until", query.KeyConditionExpression);
+        Assert.Equal(P1 + "\uffff", query.ExpressionAttributeValues[":since"].S);
+        Assert.Equal(P3 + "\uffff", query.ExpressionAttributeValues[":until"].S);
+        Assert.All(client.QueryTokens, token => Assert.True(token.CanBeCanceled));
+        Assert.All(client.BatchGetTokens, token => Assert.True(token.CanBeCanceled));
+        var observed = Assert.Single(telemetry);
+        Assert.Equal(1, observed.QueryPages);
+        Assert.Equal(1, observed.BatchGetChunks);
+        Assert.Equal(2, observed.PeakPageReferences);
+        Assert.Equal(2, observed.PeakChunkBodies);
+        Assert.True(observed.ConsumedCapacity > 0);
+        var existingProgress = Assert.Single(progress);
+        Assert.Equal(2, existingProgress.EventsRead);
+        Assert.True(existingProgress.ConsumedCapacity > 0);
+
+        var resolution = SekibanDcbCapabilityResolver.ResolveTaggedStream(store, "DynamoDB");
+        Assert.True(resolution.IsSupported);
+        Assert.True(resolution.Descriptor.NativeStreaming);
+        Assert.Equal("DynamoDB", resolution.Descriptor.ProviderName);
+    }
+
+    [Fact]
+    public async Task DynamoNativeTaggedStream_RetainsOnlyOnePageAndOneChunk()
+    {
+        var telemetry = new List<DynamoDbTaggedStreamTelemetry>();
+        var client = new NativeTaggedStreamDynamoClient();
+        var options = new DynamoDbEventStoreOptions
+        {
+            AutoCreateTables = false,
+            EventsTableName = EventsTable,
+            TagsTableName = TagsTable,
+            QueryPageSize = 3,
+            MaxBatchGetItems = 2,
+            TaggedStreamTelemetryCallback = telemetry.Add
+        };
+        var store = NewDynamoStore(client, options);
+        var tag = new NativeTag("dynamo-bounds-memory");
+        SeedDynamo(client, tag, FivePointFixture(tag));
+        var emitted = new List<string>();
+
+        var result = await store.StreamSerializableEventsByTagAsync(
+            tag,
+            null,
+            null,
+            @event =>
+            {
+                emitted.Add(@event.SortableUniqueIdValue);
+                return ValueTask.CompletedTask;
+            });
+
+        Assert.True(result.IsSuccess, result.IsSuccess ? string.Empty : result.GetException().ToString());
+        Assert.Equal(new[] { P0, P1, P2, P3, P4 }, emitted);
+        var observed = Assert.Single(telemetry);
+        Assert.Equal(2, observed.QueryPages);
+        Assert.Equal(3, observed.BatchGetChunks);
+        Assert.InRange(observed.PeakPageReferences, 1, options.QueryPageSize);
+        Assert.InRange(observed.PeakChunkBodies, 1, options.MaxBatchGetItems);
+        Assert.InRange(client.MaximumQueryRows, 1, options.QueryPageSize);
+        Assert.InRange(client.MaximumBatchKeys, 1, options.MaxBatchGetItems);
+    }
+
+    [Fact]
+    public async Task DynamoNativeTaggedStream_CancellationAfterTheFirstPagePreventsAnyBatchOrLaterPage()
+    {
+        var client = new NativeTaggedStreamDynamoClient();
+        var options = new DynamoDbEventStoreOptions
+        {
+            AutoCreateTables = false,
+            EventsTableName = EventsTable,
+            TagsTableName = TagsTable,
+            QueryPageSize = 1,
+            MaxBatchGetItems = 1
+        };
+        var store = NewDynamoStore(client, options);
+        var tag = new NativeTag("dynamo-cancel");
+        SeedDynamo(client, tag, FivePointFixture(tag));
+        using var cancellation = new CancellationTokenSource();
+        client.AfterQuery = cancellation.Cancel;
+
+        var streaming = store.StreamSerializableEventsByTagAsync(
+            tag,
+            null,
+            null,
+            _ => ValueTask.CompletedTask,
+            cancellation.Token);
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => streaming);
+        Assert.Single(client.Queries);
+        Assert.All(client.QueryTokens, token => Assert.True(token.CanBeCanceled && token.IsCancellationRequested));
+        Assert.Empty(client.BatchGetTokens);
+    }
+
+    [Fact]
+    public async Task DynamoNativeTaggedStream_CapturedHeadExcludesAnAppendAboveTheHeadDuringAReleasedCallback()
+    {
+        var client = new NativeTaggedStreamDynamoClient();
+        var options = new DynamoDbEventStoreOptions
+        {
+            AutoCreateTables = false,
+            EventsTableName = EventsTable,
+            TagsTableName = TagsTable,
+            QueryPageSize = 1,
+            MaxBatchGetItems = 1
+        };
+        var store = NewDynamoStore(client, options);
+        var tag = new NativeTag("dynamo-captured-head");
+        var initial = FivePointFixture(tag).Where(@event => @event.SortableUniqueIdValue != P4).ToList();
+        SeedDynamo(client, tag, initial);
+        var capturedHead = new SortableUniqueId(P3); // The caller captures this settled head before starting the stream.
+
+        var firstCallback = NewSignal();
+        var releaseCallback = NewSignal();
+        var emitted = new List<string>();
+        var stream = store.StreamSerializableEventsByTagAsync(
+            tag,
+            new SortableUniqueId(P1),
+            capturedHead,
+            async @event =>
+            {
+                emitted.Add(@event.SortableUniqueIdValue);
+                if (emitted.Count == 1)
+                {
+                    firstCallback.TrySetResult();
+                    await releaseCallback.Task;
+                }
+            });
+
+        try
+        {
+            await firstCallback.Task.WaitAsync(TimeSpan.FromSeconds(10));
+            SeedDynamo(client, tag, FivePointFixture(tag).Where(@event => @event.SortableUniqueIdValue == P4));
+        }
+        finally
+        {
+            releaseCallback.TrySetResult();
+        }
+
+        var result = await stream;
+        Assert.True(result.IsSuccess, result.IsSuccess ? string.Empty : result.GetException().ToString());
+        Assert.Equal(new[] { P2, P3 }, emitted);
+        Assert.DoesNotContain(P4, emitted);
+    }
+
+    [Fact]
+    public async Task DynamoNativeTaggedStream_PreCancelledTokenDoesNotIssueAProviderRequest()
+    {
+        var client = new NativeTaggedStreamDynamoClient();
+        var options = new DynamoDbEventStoreOptions
+        {
+            AutoCreateTables = false,
+            EventsTableName = EventsTable,
+            TagsTableName = TagsTable
+        };
+        var store = NewDynamoStore(client, options);
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => store.StreamSerializableEventsByTagAsync(
+            new NativeTag("dynamo-precancel"),
+            null,
+            null,
+            _ => ValueTask.CompletedTask,
+            cancellation.Token));
+        Assert.Empty(client.Queries);
+        Assert.Empty(client.BatchGetTokens);
+    }
+
+    [Fact]
+    public void TaggedStreamInterfaceSignature_RemainsTheG53FrozenCapabilityContract()
+    {
+        var method = typeof(IStreamingTaggedSerializableEventStore).GetMethod(
+            nameof(IStreamingTaggedSerializableEventStore.StreamSerializableEventsByTagAsync));
+        Assert.NotNull(method);
+        Assert.Equal(
+            new[]
+            {
+                typeof(ITag),
+                typeof(SortableUniqueId),
+                typeof(SortableUniqueId),
+                typeof(Func<SerializableEvent, ValueTask>),
+                typeof(CancellationToken)
+            },
+            method!.GetParameters().Select(parameter => parameter.ParameterType));
+        Assert.Equal(
+            typeof(Task<ResultBoxes.ResultBox<SerializableEventStreamReadResult>>),
+            method.ReturnType);
+    }
+
+    [Fact]
+    public void NativeRemoteTaggedStreamPaths_TripwireLegacyListDrainAndAllReferenceFanOut()
+    {
+        var root = FindRepositoryRoot();
+        var cosmos = File.ReadAllText(Path.Combine(
+            root,
+            "dcb/src/Sekiban.Dcb.CosmosDb/CosmosDbEventStore.TaggedStream.cs"));
+        var dynamo = File.ReadAllText(Path.Combine(
+            root,
+            "dcb/src/Sekiban.Dcb.DynamoDB/DynamoDbEventStore.TaggedStream.cs"));
+
+        // These are direct regression tripwires: restoring the old whole-history helpers or a fan-out over every
+        // reference must make the dedicated native paths fail before a cold-rebuild consumer can silently regress.
+        Assert.DoesNotContain("FetchEventIdsAsync", cosmos, StringComparison.Ordinal);
+        Assert.DoesNotContain("FetchSerializableEventsByIdsAsync", cosmos, StringComparison.Ordinal);
+        Assert.DoesNotContain("Task.WhenAll", cosmos, StringComparison.Ordinal);
+        Assert.DoesNotContain("ReadSerializableEventsByTagAsync", cosmos, StringComparison.Ordinal);
+        Assert.DoesNotContain("QueryTagsAsync", dynamo, StringComparison.Ordinal);
+        Assert.DoesNotContain("BatchGetEventsAsync", dynamo, StringComparison.Ordinal);
+        Assert.DoesNotContain("Task.WhenAll", dynamo, StringComparison.Ordinal);
+        Assert.DoesNotContain("ReadSerializableEventsByTagAsync", dynamo, StringComparison.Ordinal);
+    }
+
+    private static (CosmosDbEventStore Store, InMemoryCosmosClient Client) NewCosmosStore(CosmosDbEventStoreOptions options)
+    {
+        var client = new InMemoryCosmosClient();
+        var context = new CosmosDbContext(client, "g54-db", options: options);
+        return (
+            new CosmosDbEventStore(
+                context,
+                DomainType.GetDomainTypes().EventTypes,
+                new FixedServiceIdProvider(ServiceId),
+                new DefaultCosmosContainerResolver(options)),
+            client);
+    }
+
+    private static DynamoDbEventStore NewDynamoStore(
+        NativeTaggedStreamDynamoClient client,
+        DynamoDbEventStoreOptions options) =>
+        NewDynamoStore(client, options, DomainType.GetDomainTypes());
+
+    private static DynamoDbEventStore NewDynamoStore(
+        NativeTaggedStreamDynamoClient client,
+        DynamoDbEventStoreOptions options,
+        DcbDomainTypes domain) =>
+        new(new DynamoDbContext(client, Options.Create(options)), domain.EventTypes,
+            new FixedServiceIdProvider(ServiceId));
+
+    private static async Task<RemoteParityResult> RunParityRoutesAsync(
+        IEventStore provider,
+        string providerName,
+        DcbDomainTypes domain,
+        RemoteParityTag tag)
+    {
+        var streamingColdStore = new RemoteStreamingCountingStore(provider, providerName);
+        var streamingCold = await ReadRemoteColdAsync(streamingColdStore, domain, tag, P2);
+        Assert.Equal(1, streamingColdStore.StreamCalls);
+        Assert.Equal(0, streamingColdStore.ListCalls);
+        AssertRemoteParityExpected(streamingCold);
+
+        var listColdStore = new RemoteListCountingStore(provider);
+        var listCold = await ReadRemoteColdAsync(listColdStore, domain, tag, P2);
+        Assert.Equal(0, listColdStore.StreamCalls);
+        Assert.Equal(1, listColdStore.ListCalls);
+        AssertRemoteParityExpected(listCold);
+
+        var cachedIncrementalStore = new RemoteStreamingCountingStore(provider, providerName);
+        var cachedIncremental = await ReadRemoteCachedIncrementalAsync(cachedIncrementalStore, domain, tag);
+        Assert.Equal(2, cachedIncrementalStore.StreamCalls);
+        Assert.Equal(0, cachedIncrementalStore.ListCalls);
+        AssertRemoteParityExpected(cachedIncremental);
+
+        // A skipped callback, version/last-id mutation, or a stream-to-list fallback changes one of these values.
+        AssertEquivalent(streamingCold, listCold, $"{providerName} streaming / list cold");
+        AssertEquivalent(streamingCold, cachedIncremental, $"{providerName} streaming / cached incremental");
+        return new RemoteParityResult(streamingCold, listCold, cachedIncremental);
+    }
+
+    private static async Task<SerializableTagState> ReadRemoteColdAsync(
+        IEventStore store,
+        DcbDomainTypes domain,
+        RemoteParityTag tag,
+        string head)
+    {
+        var actor = CreateRemoteParityActor(
+            store,
+            domain,
+            tag,
+            new RemoteHeadActorAccessor(head),
+            new InMemoryTagStatePersistent());
+        return await actor.GetStateAsync();
+    }
+
+    private static async Task<SerializableTagState> ReadRemoteCachedIncrementalAsync(
+        IEventStore store,
+        DcbDomainTypes domain,
+        RemoteParityTag tag)
+    {
+        var accessor = new RemoteHeadActorAccessor(P1);
+        var actor = CreateRemoteParityActor(store, domain, tag, accessor, new InMemoryTagStatePersistent());
+        var initial = await actor.GetStateAsync();
+        Assert.Equal(1, initial.Version);
+        Assert.Equal(P1, initial.LastSortedUniqueId);
+
+        accessor.Head = P2;
+        var incremental = await actor.GetStateAsync();
+        var cacheHit = await actor.GetStateAsync();
+        Assert.Equal(incremental.Payload, cacheHit.Payload);
+        Assert.Equal(incremental.Version, cacheHit.Version);
+        Assert.Equal(incremental.LastSortedUniqueId, cacheHit.LastSortedUniqueId);
+        return incremental;
+    }
+
+    private static GeneralTagStateActor CreateRemoteParityActor(
+        IEventStore store,
+        DcbDomainTypes domain,
+        RemoteParityTag tag,
+        IActorObjectAccessor accessor,
+        ITagStatePersistent persistent) =>
+        new(
+            $"{tag.GetTag()}:{RemoteParityProjector.ProjectorName}",
+            store,
+            domain.EventTypes,
+            domain.TagProjectorTypes,
+            domain.TagTypes,
+            domain.TagStatePayloadTypes,
+            new TagStateOptions(),
+            accessor,
+            persistent);
+
+    private static IReadOnlyList<SerializableEvent> ParityEvents(DcbDomainTypes domain, RemoteParityTag tag) =>
+    [
+        new Event(
+                new RemoteParityAdded(3),
+                P1,
+                nameof(RemoteParityAdded),
+                Guid.Parse("00000000-0000-0000-0000-000000000201"),
+                new EventMetadata("cause", "correlation", "parity"),
+                [tag.GetTag()])
+            .ToSerializableEvent(domain.EventTypes),
+        new Event(
+                new RemoteParityAdded(4),
+                P2,
+                nameof(RemoteParityAdded),
+                Guid.Parse("00000000-0000-0000-0000-000000000202"),
+                new EventMetadata("cause", "correlation", "parity"),
+                [tag.GetTag()])
+            .ToSerializableEvent(domain.EventTypes)
+    ];
+
+    private static DcbDomainTypes BuildParityDomain()
+    {
+        var events = new SimpleEventTypes();
+        events.RegisterEventType<RemoteParityAdded>();
+        var tagProjectors = new SimpleTagProjectorTypes();
+        tagProjectors.RegisterProjector<RemoteParityProjector>();
+        var payloads = new SimpleTagStatePayloadTypes();
+        payloads.RegisterPayloadType<RemoteParityState>();
+        return new DcbDomainTypes(
+            events,
+            new SimpleTagTypes(),
+            tagProjectors,
+            payloads,
+            new SimpleMultiProjectorTypes(),
+            new SimpleQueryTypes(),
+            new JsonSerializerOptions());
+    }
+
+    private static void AssertRemoteParityExpected(SerializableTagState state)
+    {
+        Assert.Equal(2, state.Version);
+        Assert.Equal(P2, state.LastSortedUniqueId);
+        var payload = JsonSerializer.Deserialize<RemoteParityState>(state.Payload, PayloadJsonOptions);
+        Assert.NotNull(payload);
+        Assert.Equal(7, payload.Total);
+    }
+
+    private static void AssertEquivalent(SerializableTagState expected, SerializableTagState actual, string route)
+    {
+        Assert.True(expected.Payload.SequenceEqual(actual.Payload), $"Payload differed for {route}.");
+        Assert.Equal(expected.Version, actual.Version);
+        Assert.Equal(expected.LastSortedUniqueId, actual.LastSortedUniqueId);
+    }
+
+    private static IReadOnlyList<SerializableEvent> FivePointFixture(ITag tag) =>
+    [
+        FixtureEvent(P4, tag, 4),
+        FixtureEvent(P2, tag, 2),
+        FixtureEvent(P0, tag, 0),
+        FixtureEvent(P3, tag, 3),
+        FixtureEvent(P1, tag, 1)
+    ];
+
+    private static SerializableEvent FixtureEvent(string sortableUniqueId, ITag tag, int value) =>
+        new(
+            Encoding.UTF8.GetBytes("{\"v\":2}"),
+            sortableUniqueId,
+            Guid.Parse($"00000000-0000-0000-0000-{value + 101:D12}"),
+            new EventMetadata("cause", "correlation", "user"),
+            [tag.GetTag()],
+            "RemoteTaggedV2");
+
+    private static void SeedDynamo(
+        NativeTaggedStreamDynamoClient client,
+        ITag tag,
+        IEnumerable<SerializableEvent> serializableEvents)
+    {
+        foreach (var serializableEvent in serializableEvents)
+        {
+            var source = new Event(
+                new NativePayload(serializableEvent.SortableUniqueIdValue),
+                serializableEvent.SortableUniqueIdValue,
+                serializableEvent.EventPayloadName,
+                serializableEvent.Id,
+                serializableEvent.EventMetadata,
+                serializableEvent.Tags);
+            var dynamoEvent = DynamoEvent.FromEvent(
+                source,
+                Encoding.UTF8.GetString(serializableEvent.Payload),
+                "unused-gsi",
+                ServiceId);
+            var dynamoTag = DynamoTag.FromEventTag(
+                ServiceId,
+                tag.GetTag(),
+                $"{ServiceId}|{tag.GetTagGroup()}",
+                serializableEvent.SortableUniqueIdValue,
+                serializableEvent.Id,
+                serializableEvent.EventPayloadName);
+            client.Seed(EventsTable, dynamoEvent.ToAttributeValues());
+            client.Seed(TagsTable, dynamoTag.ToAttributeValues());
+        }
+    }
+
+    private static TaskCompletionSource NewSignal() =>
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    private static string FindRepositoryRoot()
+    {
+        for (var directory = new DirectoryInfo(AppContext.BaseDirectory);
+             directory is not null;
+             directory = directory.Parent)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "global.json")) &&
+                Directory.Exists(Path.Combine(directory.FullName, "dcb")))
+            {
+                return directory.FullName;
+            }
+        }
+
+        throw new DirectoryNotFoundException("Could not locate the Sekiban repository root for native stream tripwires.");
+    }
+
+    private sealed record RemoteParityResult(
+        SerializableTagState StreamingCold,
+        SerializableTagState ListCold,
+        SerializableTagState CachedIncremental);
+
+    private sealed record RemoteParityAdded(int Delta) : IEventPayload;
+
+    private sealed record RemoteParityState(int Total) : ITagStatePayload;
+
+    private sealed class RemoteParityProjector : ITagProjector<RemoteParityProjector>
+    {
+        public static string ProjectorVersion => "1";
+        public static string ProjectorName => nameof(RemoteParityProjector);
+
+        public static ITagStatePayload Project(ITagStatePayload current, Event @event)
+        {
+            var state = current as RemoteParityState ?? new RemoteParityState(0);
+            return @event.Payload is RemoteParityAdded added
+                ? state with { Total = state.Total + added.Delta }
+                : state;
+        }
+    }
+
+    private sealed class RemoteParityTag(string providerName) : ITag
+    {
+        public bool IsConsistencyTag() => false;
+        public string GetTagGroup() => "G54Parity";
+        public string GetTagContent() => providerName;
+        public string GetTag() => $"G54Parity:{providerName}";
+    }
+
+    private sealed class RemoteHeadActorAccessor(string head) : IActorObjectAccessor
+    {
+        private readonly RemoteHeadActor _actor = new();
+        public string Head { get; set; } = head;
+
+        public Task<ResultBox<T>> GetActorAsync<T>(string actorId) where T : class
+        {
+            if (typeof(T) != typeof(ITagConsistentActorCommon))
+            {
+                return Task.FromResult(ResultBox.Error<T>(new NotSupportedException()));
+            }
+
+            _actor.Head = Head;
+            return Task.FromResult(ResultBox.FromValue((T)(object)_actor));
+        }
+
+        public Task<bool> ActorExistsAsync(string actorId) => Task.FromResult(true);
+    }
+
+    private sealed class RemoteHeadActor : ITagConsistentActorCommon
+    {
+        public string Head { get; set; } = string.Empty;
+        public Task<string> GetTagActorIdAsync() => Task.FromResult("G54Parity:head");
+        public Task<ResultBox<string>> GetLatestSortableUniqueIdAsync() => Task.FromResult(ResultBox.FromValue(Head));
+        public Task<ResultBox<TagWriteReservation>> MakeReservationAsync(string? lastSortableUniqueId) =>
+            Task.FromResult(ResultBox.FromValue(new TagWriteReservation("reservation", DateTime.UtcNow.ToString("O"), "G54Parity:head")));
+        public Task<bool> ConfirmReservationAsync(TagWriteReservation reservation) => Task.FromResult(true);
+        public Task<bool> CancelReservationAsync(TagWriteReservation reservation) => Task.FromResult(true);
+        public Task NotifyEventWrittenAsync() => Task.CompletedTask;
+    }
+
+    private abstract class RemoteCountingStore(IEventStore inner) : IEventStore
+    {
+        protected IEventStore Inner { get; } = inner;
+        public int StreamCalls { get; protected set; }
+        public int ListCalls { get; private set; }
+
+        public Task<ResultBox<IEnumerable<TagStream>>> ReadTagsAsync(ITag tag) => Inner.ReadTagsAsync(tag);
+        public Task<ResultBox<TagState>> GetLatestTagAsync(ITag tag) => Inner.GetLatestTagAsync(tag);
+        public Task<ResultBox<bool>> TagExistsAsync(ITag tag) => Inner.TagExistsAsync(tag);
+        public Task<ResultBox<long>> GetEventCountAsync(SortableUniqueId? since = null) => Inner.GetEventCountAsync(since);
+        public Task<ResultBox<IEnumerable<TagInfo>>> GetAllTagsAsync(string? tagGroup = null) => Inner.GetAllTagsAsync(tagGroup);
+        public Task<ResultBox<IEnumerable<SerializableEvent>>> ReadAllSerializableEventsAsync(SortableUniqueId? since = null) =>
+            Inner.ReadAllSerializableEventsAsync(since);
+        public Task<ResultBox<IEnumerable<SerializableEvent>>> ReadAllSerializableEventsAsync(SortableUniqueId? since, int? maxCount) =>
+            Inner.ReadAllSerializableEventsAsync(since, maxCount);
+        public Task<ResultBox<SerializableEvent>> ReadSerializableEventAsync(Guid eventId) => Inner.ReadSerializableEventAsync(eventId);
+        public Task<ResultBox<(IReadOnlyList<SerializableEvent> Events, IReadOnlyList<TagWriteResult> TagWrites)>>
+            WriteSerializableEventsAsync(IEnumerable<SerializableEvent> events) => Inner.WriteSerializableEventsAsync(events);
+        public Task<ResultBox<string>> GetLatestSortableUniqueIdAsync() => Inner.GetLatestSortableUniqueIdAsync();
+
+        public Task<ResultBox<IEnumerable<SerializableEvent>>> ReadSerializableEventsByTagAsync(
+            ITag tag,
+            SortableUniqueId? since = null)
+        {
+            ListCalls++;
+            return Inner.ReadSerializableEventsByTagAsync(tag, since);
+        }
+    }
+
+    private sealed class RemoteListCountingStore(IEventStore inner) : RemoteCountingStore(inner);
+
+    private sealed class RemoteStreamingCountingStore(IEventStore inner, string providerName) : RemoteCountingStore(inner),
+        IStreamingTaggedSerializableEventStore, ITaggedStreamCapabilityProvider
+    {
+        public TaggedStreamCapabilityDescriptor DescribeTaggedStream() =>
+            TaggedStreamCapabilityDescriptor.Native($"{providerName} parity wrapper");
+
+        public Task<ResultBox<SerializableEventStreamReadResult>> StreamSerializableEventsByTagAsync(
+            ITag tag,
+            SortableUniqueId? since,
+            SortableUniqueId? until,
+            Func<SerializableEvent, ValueTask> onEvent,
+            CancellationToken cancellationToken = default)
+        {
+            StreamCalls++;
+            return ((IStreamingTaggedSerializableEventStore)Inner).StreamSerializableEventsByTagAsync(
+                tag,
+                since,
+                until,
+                onEvent,
+                cancellationToken);
+        }
+    }
+
+    private sealed record NativePayload(string Value) : IEventPayload;
+
+    private sealed class NativeTag(string content) : ITag
+    {
+        public bool IsConsistencyTag() => false;
+        public string GetTagGroup() => "Remote";
+        public string GetTagContent() => content;
+    }
+
+    /// <summary>
+    ///     In-process Dynamo request harness. It intentionally bases filtering on the exact production
+    ///     <see cref="QueryRequest.KeyConditionExpression" /> and makes BatchGet responses reverse ordered on demand;
+    ///     replacing the explicit reorder in production with response enumeration therefore fails deterministically.
+    /// </summary>
+    private sealed class NativeTaggedStreamDynamoClient : AmazonDynamoDBClient
+    {
+        private readonly Dictionary<(string Table, string Pk, string Sk), Dictionary<string, AttributeValue>> _items = new();
+        private readonly object _gate = new();
+
+        public NativeTaggedStreamDynamoClient()
+            : base(
+                new BasicAWSCredentials("g54", "g54"),
+                new AmazonDynamoDBConfig { ServiceURL = "http://localhost:8000", AuthenticationRegion = "us-east-1" })
+        {
+        }
+
+        public bool ReverseBatchResponses { get; set; }
+        public Action? AfterQuery { get; set; }
+        public List<QueryRequest> Queries { get; } = new();
+        public List<CancellationToken> QueryTokens { get; } = new();
+        public List<CancellationToken> BatchGetTokens { get; } = new();
+        public int MaximumQueryRows { get; private set; }
+        public int MaximumBatchKeys { get; private set; }
+
+        public void Seed(string table, Dictionary<string, AttributeValue> item)
+        {
+            lock (_gate)
+            {
+                _items[(table, item["pk"].S, item["sk"].S)] = Clone(item);
+            }
+        }
+
+        public override Task<QueryResponse> QueryAsync(
+            QueryRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            lock (_gate)
+            {
+                Queries.Add(request);
+                QueryTokens.Add(cancellationToken);
+                var response = Query(request);
+                AfterQuery?.Invoke();
+                return Task.FromResult(response);
+            }
+        }
+
+        public override Task<BatchGetItemResponse> BatchGetItemAsync(
+            BatchGetItemRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            lock (_gate)
+            {
+                BatchGetTokens.Add(cancellationToken);
+                var keys = request.RequestItems[EventsTable].Keys;
+                MaximumBatchKeys = Math.Max(MaximumBatchKeys, keys.Count);
+                var rows = keys
+                    .Select(key => _items.TryGetValue((EventsTable, key["pk"].S, key["sk"].S), out var item)
+                        ? Clone(item)
+                        : null)
+                    .Where(item => item is not null)
+                    .Select(item => item!)
+                    .ToList();
+                if (ReverseBatchResponses)
+                {
+                    rows.Reverse();
+                }
+
+                return Task.FromResult(new BatchGetItemResponse
+                {
+                    Responses = new Dictionary<string, List<Dictionary<string, AttributeValue>>>
+                    {
+                        [EventsTable] = rows
+                    },
+                    UnprocessedKeys = new Dictionary<string, KeysAndAttributes>(),
+                    ConsumedCapacity = [new ConsumedCapacity { CapacityUnits = 1d }]
+                });
+            }
+        }
+
+        private QueryResponse Query(QueryRequest request)
+        {
+            var values = request.ExpressionAttributeValues;
+            var tagPartitionKey = values[":pk"].S;
+            var rows = _items
+                .Where(entry => entry.Key.Table == request.TableName && entry.Key.Pk == tagPartitionKey)
+                .Select(entry => entry.Value)
+                .Where(item => MatchesKeyCondition(item["sk"].S, request.KeyConditionExpression, values))
+                .OrderBy(item => item["sk"].S, StringComparer.Ordinal)
+                .ToList();
+            var offset = request.ExclusiveStartKey is { Count: > 0 } &&
+                         request.ExclusiveStartKey.TryGetValue("cursor", out var cursor)
+                ? int.Parse(cursor.N, System.Globalization.CultureInfo.InvariantCulture)
+                : 0;
+            var page = rows.Skip(offset).Take(request.Limit ?? rows.Count).Select(Clone).ToList();
+            MaximumQueryRows = Math.Max(MaximumQueryRows, page.Count);
+            var nextOffset = offset + page.Count;
+            return new QueryResponse
+            {
+                Items = page,
+                Count = page.Count,
+                LastEvaluatedKey = nextOffset < rows.Count
+                    ? new Dictionary<string, AttributeValue>
+                    {
+                        ["cursor"] = new AttributeValue
+                        {
+                            N = nextOffset.ToString(System.Globalization.CultureInfo.InvariantCulture)
+                        }
+                    }
+                    : new Dictionary<string, AttributeValue>(),
+                ConsumedCapacity = new ConsumedCapacity { CapacityUnits = 1d }
+            };
+        }
+
+        private static bool MatchesKeyCondition(
+            string sortKey,
+            string keyCondition,
+            IReadOnlyDictionary<string, AttributeValue> values)
+        {
+            if (keyCondition.Contains("BETWEEN :since AND :until", StringComparison.Ordinal))
+            {
+                return string.CompareOrdinal(sortKey, values[":since"].S) >= 0 &&
+                       string.CompareOrdinal(sortKey, values[":until"].S) <= 0;
+            }
+
+            if (keyCondition.Contains("sk > :since", StringComparison.Ordinal))
+            {
+                return string.CompareOrdinal(sortKey, values[":since"].S) > 0;
+            }
+
+            if (keyCondition.Contains("sk <= :until", StringComparison.Ordinal))
+            {
+                return string.CompareOrdinal(sortKey, values[":until"].S) <= 0;
+            }
+
+            return true;
+        }
+
+        private static Dictionary<string, AttributeValue> Clone(Dictionary<string, AttributeValue> item) =>
+            item.ToDictionary(pair => pair.Key, pair => pair.Value, StringComparer.Ordinal);
+    }
+}

--- a/docs/dcb_llm/11_storage_providers.md
+++ b/docs/dcb_llm/11_storage_providers.md
@@ -153,8 +153,24 @@ continue to use the list fallback without recompilation.
 - The callback contract emits strictly increasing ordinal `SortableUniqueId` values. Tag-state consumers reject a
   decreasing value before publishing a rebuilt state; an equal value follows the established duplicate-skip policy.
 - `InMemory` and the in-process executor stores implement the callback shape for parity tests. They are not a
-  bounded-memory production provider. Cosmos DB and DynamoDB remain on the list fallback until their dedicated
-  streaming work lands.
+  bounded-memory production provider. Cosmos DB and DynamoDB implement the same native capability without changing
+  their compatible list readers:
+  - Cosmos DB pages the ordered tag index and runs an ordinal sliding window of event point reads. The separate
+    `MaxConcurrentTaggedStreamPointReads` option defaults to **8**, is validated from **1 through 64**, and may not
+    exceed the effective tag-index page cap (`MaxItemCountPerPage` when explicitly configured, or 100 for the legacy
+    SDK-default sentinel); completed reads wait behind the queue head, so a slow or failed head never publishes a later
+    event. A failed head cancels and observes already-issued reads. Its aggregate callback
+    (`TaggedStreamTelemetryCallback`) and `Sekiban.Dcb.CosmosDb` meter report only bounded page/read/RU/429 values
+    (`sekiban.dcb.cosmos.tag_stream.index_pages`, `.point_reads`, `.request_charge`, and `.throttles`) — never raw
+    tag strings or event ids. This is deliberately **not** an RU-sublinear read: budget for one ordered tag-index scan
+    plus approximately one event point read per referenced event; the window limits in-flight work and memory, not
+    total RU.
+  - DynamoDB pushes `since` (exclusive) and `until` (inclusive) into the tag row sort-key condition, reads one query
+    page at a time, reads one bounded `BatchGetItem` chunk at a time, and reorders the unordered BatchGet response by
+    the query references before invoking the callback. `ReadProgressCallback` and the optional
+    `TaggedStreamTelemetryCallback` expose page/chunk and consumed-capacity aggregates. The implementation keeps at
+    most one reference page plus one event-body chunk and forwards the caller cancellation token to Query, BatchGet,
+    and retry delay operations.
 - Capability selection is fail-closed: a store must implement the optional interface **and** declare native tagged
   streaming through the live-instance descriptor. `HybridEventStore` forwards only a verified hot-store stream and
   returns an unsupported `ResultBox` without reading its hot list API otherwise.

--- a/docs/dcb_llm_ja/11_storage_providers.md
+++ b/docs/dcb_llm_ja/11_storage_providers.md
@@ -158,7 +158,23 @@ downstream の store は再コンパイルなしで従来の list fallback を�
 - callback は ordinal な `SortableUniqueId` を厳密昇順で返します。tag-state consumer は小さい値を受け取った場合、
   再構築済み state を publish する前に拒否します。同じ値は既存の duplicate-skip policy に従います。
 - `InMemory` と in-process executor の store は parity test 用に callback shape を実装しますが、bounded-memory の
-  production provider ではありません。Cosmos DB と DynamoDB は専用の streaming 作業が入るまで list fallback のままです。
+  production provider ではありません。Cosmos DB と DynamoDB は互換性のある既存 list reader を変更せず、同じ native
+  capability を実装します:
+  - Cosmos DB は順序付き tag index を page 単位で読み、event point read を ordinal sliding window で実行します。専用の
+    `MaxConcurrentTaggedStreamPointReads` は既定 **8**、**1〜64** で検証され、effective tag-index page cap を超えられません
+    （明示設定時は `MaxItemCountPerPage`、legacy SDK-default sentinel 時は 100）。完了済み read も queue head の後ろで待つため、
+    遅い／失敗した head が後続 event を publish することはありません。head
+    failure 時は、既に発行済みの read を cancel して観測します。aggregate callback
+    (`TaggedStreamTelemetryCallback`) と `Sekiban.Dcb.CosmosDb` meter は、raw tag string/event id を含めず、bounded な
+    page/read/RU/429 値だけを報告します（`sekiban.dcb.cosmos.tag_stream.index_pages`、`.point_reads`、
+    `.request_charge`、`.throttles`）。これは意図的に RU-sublinear な read ではありません。順序付き tag-index scan
+    1 回と、参照 event 1 件につきおおむね 1 回の event point read を予算化してください。window は total RU ではなく、
+    in-flight work と memory を制限します。
+  - DynamoDB は `since`（exclusive）と `until`（inclusive）を tag row の sort-key condition に push down し、query は
+    1 page ずつ、`BatchGetItem` は 1 つの bounded chunk ずつ読みます。順序保証のない BatchGet response は、callback の前に
+    query reference 順へ並べ直されます。`ReadProgressCallback` と optional な `TaggedStreamTelemetryCallback` は
+    page/chunk と consumed capacity の aggregate を公開します。実装は最大で 1 reference page と 1 event-body chunk のみを
+    保持し、caller の cancellation token を Query、BatchGet、retry delay に渡します。
 - capability 選択は fail-closed です。store は optional interface の実装に加え、live-instance descriptor で native
   tagged streaming を宣言する必要があります。`HybridEventStore` は検証済み hot-store stream だけを forward し、それ
   以外では hot の list API を読まずに unsupported `ResultBox` を返します。


### PR DESCRIPTION
## Summary
- Adds native callback tagged streams for Cosmos DB (ordered sliding point-read window) and DynamoDB (ordered query page plus BatchGet chunk).
- Repairs Sonar S2077 in the Cosmos native path by selecting one of four fully static query texts and binding `@pk`, `@since`, and `@until` only through `WithParameter`.
- Keeps the G53 public stream contract, resolver, accumulator, and compatible list readers unchanged.
- Documents provider telemetry and the non-sub-linear Cosmos RU characteristic.

## Acceptance evidence
- AC1: actor-level streaming cold, list cold, and cached incremental parity asserts payload bytes, version, last SUID, stream=1/list=0 for Cosmos and DynamoDB.
- AC2/AC4: five-point since/until fixtures, captured-head append-above-head tests, head-order Cosmos window, default-W aggregate telemetry, and hostile BatchGet ordering.
- AC3: cancellation prevents later provider work and verifies propagated Cosmos ReadNext/ReadItem and Dynamo Query/BatchGet tokens.
- AC5: one-page/window and one-page/one-chunk counters plus legacy-list/all-reference-fanout source tripwires.
- AC6: Cosmos RU/429 and Dynamo page/chunk/consumed-capacity telemetry assertions; EN/JA docs updated.
- AC7: frozen G53 interface/capability tests pass and both providers report native support.
- Repair: four bound shapes (neither/since/until/both) are exercised against their exact static Cosmos query text.

## Tests
- dotnet test dcb/tests/Sekiban.Dcb.WithResult.Tests/Sekiban.Dcb.WithResult.Tests.csproj --framework net9.0 --no-restore --filter FullyQualifiedName~RemoteTaggedStreamTests (20 passed)
- same net10.0 (20 passed)
- TaggedStreamContractTests and HybridTaggedStreamCapabilityTests: net9.0 (14 passed), net10.0 (14 passed)

Closes #1180