### PR TITLE
feat(dcb): add cancellable tag-state reads

### DIFF
--- a/.github/workflows/run_test_dcb.yml
+++ b/.github/workflows/run_test_dcb.yml
@@ -34,6 +34,7 @@ on:
       - 'dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/**'
       - 'dcb/tests/Sekiban.Dcb.WithResult.Tests/**'
       - 'dcb/tests/Sekiban.Dcb.WithoutResult.Tests/**'
+      - 'dcb/tests/Sekiban.Dcb.TagStateCancellation.Legacy1018Fixture/**'
       - 'dcb/tests/Sekiban.Dcb.ColdEvents.Tests/**'
       - 'dcb/tests/Sekiban.Dcb.BlobStorage.AzureStorage.Unit/**'
 

--- a/dcb/src/Sekiban.Dcb.Core/Actors/CoreGeneralSekibanExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Actors/CoreGeneralSekibanExecutor.cs
@@ -421,10 +421,16 @@ public class CoreGeneralSekibanExecutor
         }
     }
 
-    public async Task<ResultBox<TagState>> GetTagStateAsync(TagStateId tagStateId)
+    public Task<ResultBox<TagState>> GetTagStateAsync(TagStateId tagStateId) =>
+        GetTagStateAsync(tagStateId, CancellationToken.None);
+
+    public async Task<ResultBox<TagState>> GetTagStateAsync(
+        TagStateId tagStateId,
+        CancellationToken cancellationToken)
     {
         try
         {
+            cancellationToken.ThrowIfCancellationRequested();
             // Step 0: Validate tagStateId using DataAnnotations attributes
             var validationErrors = SekibanValidator.Validate(tagStateId);
             if (validationErrors.Count > 0)
@@ -435,6 +441,7 @@ public class CoreGeneralSekibanExecutor
             // Get the tag state actor for this tag state ID
             var tagStateActorId = tagStateId.GetTagStateId();
             var actorResult = await _actorAccessor.GetActorAsync<ITagStateActorCommon>(tagStateActorId);
+            cancellationToken.ThrowIfCancellationRequested();
 
             if (!actorResult.IsSuccess)
             {
@@ -444,12 +451,14 @@ public class CoreGeneralSekibanExecutor
             var actor = actorResult.GetValue();
 
             // Get the state from the actor
-            var state = await actor.GetStateAsync();
+            var state = await actor.GetStateAsync(cancellationToken);
+            cancellationToken.ThrowIfCancellationRequested();
 
             // Convert SerializableTagState to TagState
             // We need to deserialize the payload from the serializable state
             if (state.ResolvedPayloadName == nameof(EmptyTagStatePayload))
             {
+                cancellationToken.ThrowIfCancellationRequested();
                 return ResultBox.FromValue(
                     new TagState(
                         new EmptyTagStatePayload(),
@@ -472,6 +481,7 @@ public class CoreGeneralSekibanExecutor
             var deserializeResult = _domainTypes.TagStatePayloadTypes.DeserializePayload(
                 state.ResolvedPayloadName,
                 state.Payload);
+            cancellationToken.ThrowIfCancellationRequested();
 
             if (!deserializeResult.IsSuccess)
             {
@@ -479,6 +489,7 @@ public class CoreGeneralSekibanExecutor
             }
 
             var payload = deserializeResult.GetValue();
+            cancellationToken.ThrowIfCancellationRequested();
 
             return ResultBox.FromValue(
                 new TagState(

--- a/dcb/src/Sekiban.Dcb.Core/Actors/GeneralTagStateActor.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Actors/GeneralTagStateActor.cs
@@ -193,25 +193,37 @@ public class GeneralTagStateActor : ITagStateActorCommon
 
     public Task<string> GetTagStateActorIdAsync() => Task.FromResult(_tagStateId.GetTagStateId());
 
-    public async Task<SerializableTagState> GetStateAsync()
+    public Task<SerializableTagState> GetStateAsync() => GetStateAsync(CancellationToken.None);
+
+    public async Task<SerializableTagState> GetStateAsync(CancellationToken cancellationToken)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         if (_statePersistent is not ISerializableTagStatePersistent)
         {
-            var typedState = await GetTypedTagStateAsync();
+            var typedState = await GetTypedTagStateAsync(cancellationToken);
+            cancellationToken.ThrowIfCancellationRequested();
             return SerializeTagState(typedState);
         }
 
-        return await GetSerializableStateAsync();
+        var serializableState = await GetSerializableStateAsync(cancellationToken);
+        cancellationToken.ThrowIfCancellationRequested();
+        return serializableState;
     }
 
-    public async Task<TagState> GetTagStateAsync()
+    public Task<TagState> GetTagStateAsync() => GetTagStateAsync(CancellationToken.None);
+
+    public async Task<TagState> GetTagStateAsync(CancellationToken cancellationToken)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         if (_statePersistent is not ISerializableTagStatePersistent)
         {
-            return await GetTypedTagStateAsync();
+            var typedState = await GetTypedTagStateAsync(cancellationToken);
+            cancellationToken.ThrowIfCancellationRequested();
+            return typedState;
         }
 
-        var serializableState = await GetSerializableStateAsync();
+        var serializableState = await GetSerializableStateAsync(cancellationToken);
+        cancellationToken.ThrowIfCancellationRequested();
         return DeserializeTagState(serializableState);
     }
 
@@ -236,8 +248,9 @@ public class GeneralTagStateActor : ITagStateActorCommon
         await _statePersistent.SaveStateAsync(newState);
     }
 
-    private async Task<SerializableTagState> GetSerializableStateAsync()
+    private async Task<SerializableTagState> GetSerializableStateAsync(CancellationToken cancellationToken)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         var projectorVersion = GetCurrentProjectorVersion();
 
         // Always get the latest sortable unique ID from TagConsistentActor
@@ -245,10 +258,12 @@ public class GeneralTagStateActor : ITagStateActorCommon
         var tagConsistentActorId = $"{_tagStateId.TagGroup}:{_tagStateId.TagContent}";
         var tagConsistentActorResult
             = await _actorAccessor.GetActorAsync<ITagConsistentActorCommon>(tagConsistentActorId);
+        cancellationToken.ThrowIfCancellationRequested();
         if (tagConsistentActorResult.IsSuccess)
         {
             var tagConsistentActor = tagConsistentActorResult.GetValue();
             var latestSortableUniqueIdResult = await tagConsistentActor.GetLatestSortableUniqueIdAsync();
+            cancellationToken.ThrowIfCancellationRequested();
             if (latestSortableUniqueIdResult.IsSuccess)
             {
                 currentLatestSortableUniqueId = latestSortableUniqueIdResult.GetValue();
@@ -259,6 +274,7 @@ public class GeneralTagStateActor : ITagStateActorCommon
         if (_statePersistent is ISerializableTagStatePersistent serializablePersistent)
         {
             var cachedSerializableState = await serializablePersistent.LoadSerializableStateAsync();
+            cancellationToken.ThrowIfCancellationRequested();
             if (cachedSerializableState != null &&
                 cachedSerializableState.ProjectorVersion == projectorVersion &&
                 cachedSerializableState.LastSortedUniqueId == currentLatestSortableUniqueId)
@@ -274,6 +290,7 @@ public class GeneralTagStateActor : ITagStateActorCommon
         else
         {
             cachedState = await _statePersistent.LoadStateAsync();
+            cancellationToken.ThrowIfCancellationRequested();
             if (
                 cachedState != null &&
                 cachedState.ProjectorVersion == projectorVersion &&
@@ -285,23 +302,28 @@ public class GeneralTagStateActor : ITagStateActorCommon
 
         // Cache is stale or doesn't exist, compute new state.
         // Pass the latest sortable unique ID and cached state to avoid duplicate calls.
-        var computedState = await ComputeStateFromEventsAsync(currentLatestSortableUniqueId, cachedState);
+        var computedState = await ComputeStateFromEventsAsync(currentLatestSortableUniqueId, cachedState, cancellationToken);
+        cancellationToken.ThrowIfCancellationRequested();
         var computedSerializableState = SerializeTagState(computedState);
 
         if (_statePersistent is ISerializableTagStatePersistent serializableStatePersistent)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             await serializableStatePersistent.SaveSerializableStateAsync(computedSerializableState);
         }
         else
         {
+            cancellationToken.ThrowIfCancellationRequested();
             await _statePersistent.SaveStateAsync(computedState);
         }
 
+        cancellationToken.ThrowIfCancellationRequested();
         return computedSerializableState;
     }
 
-    private async Task<TagState> GetTypedTagStateAsync()
+    private async Task<TagState> GetTypedTagStateAsync(CancellationToken cancellationToken)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         var projectorVersion = GetCurrentProjectorVersion();
 
         // Always get the latest sortable unique ID from TagConsistentActor
@@ -309,10 +331,12 @@ public class GeneralTagStateActor : ITagStateActorCommon
         var tagConsistentActorId = $"{_tagStateId.TagGroup}:{_tagStateId.TagContent}";
         var tagConsistentActorResult
             = await _actorAccessor.GetActorAsync<ITagConsistentActorCommon>(tagConsistentActorId);
+        cancellationToken.ThrowIfCancellationRequested();
         if (tagConsistentActorResult.IsSuccess)
         {
             var tagConsistentActor = tagConsistentActorResult.GetValue();
             var latestSortableUniqueIdResult = await tagConsistentActor.GetLatestSortableUniqueIdAsync();
+            cancellationToken.ThrowIfCancellationRequested();
             if (latestSortableUniqueIdResult.IsSuccess)
             {
                 currentLatestSortableUniqueId = latestSortableUniqueIdResult.GetValue();
@@ -321,6 +345,7 @@ public class GeneralTagStateActor : ITagStateActorCommon
 
         // Check if we have cached state
         var cachedState = await _statePersistent.LoadStateAsync();
+        cancellationToken.ThrowIfCancellationRequested();
 
         // If cached state exists and is up-to-date, return it
         if (
@@ -333,11 +358,14 @@ public class GeneralTagStateActor : ITagStateActorCommon
 
         // Cache is stale or doesn't exist, compute new state
         // Pass the latest sortable unique ID and cached state to avoid duplicate calls
-        var computedState = await ComputeStateFromEventsAsync(currentLatestSortableUniqueId, cachedState);
+        var computedState = await ComputeStateFromEventsAsync(currentLatestSortableUniqueId, cachedState, cancellationToken);
+        cancellationToken.ThrowIfCancellationRequested();
 
         // Save the newly computed state to cache
+        cancellationToken.ThrowIfCancellationRequested();
         await _statePersistent.SaveStateAsync(computedState);
 
+        cancellationToken.ThrowIfCancellationRequested();
         return computedState;
     }
 
@@ -414,8 +442,12 @@ public class GeneralTagStateActor : ITagStateActorCommon
         return projectorVersionResult.IsSuccess ? projectorVersionResult.GetValue() : string.Empty;
     }
 
-    private async Task<TagState> ComputeStateFromEventsAsync(string? latestSortableUniqueId, TagState? cachedState)
+    private async Task<TagState> ComputeStateFromEventsAsync(
+        string? latestSortableUniqueId,
+        TagState? cachedState,
+        CancellationToken cancellationToken)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         // Get the projector function
         var projectorFuncResult = _tagProjectorTypes.GetProjectorFunction(_tagStateId.TagProjectorName);
         if (!projectorFuncResult.IsSuccess)
@@ -475,10 +507,16 @@ public class GeneralTagStateActor : ITagStateActorCommon
                     incrementalCachedState.Payload,
                     lastSortedUniqueId,
                     lastSortedUniqueId,
-                    CancellationToken.None);
+                    cancellationToken);
+                cancellationToken.ThrowIfCancellationRequested();
                 if (!streamResult.IsSuccess)
                 {
                     var error = streamResult.GetException();
+                    if (error is OperationCanceledException cancellationException)
+                    {
+                        throw cancellationException;
+                    }
+
                     _logger.LogError(error, "[GeneralTagStateActor] Error streaming events for tag {Tag}", tag.GetTag());
                     throw new InvalidOperationException($"Failed to stream events for tag {tag.GetTag()}: {error.Message}", error);
                 }
@@ -491,6 +529,7 @@ public class GeneralTagStateActor : ITagStateActorCommon
             else
             {
                 var eventsResult = await _eventStore.ReadEventsByTagAsync(tag, _eventTypes, since);
+                cancellationToken.ThrowIfCancellationRequested();
                 if (!eventsResult.IsSuccess)
                 {
                     // Log the error and throw exception instead of silently returning cached state
@@ -519,7 +558,9 @@ public class GeneralTagStateActor : ITagStateActorCommon
                 // Project only the new events on top of cached state
                 foreach (var evt in newEvents)
                 {
+                    cancellationToken.ThrowIfCancellationRequested();
                     currentState = projectFunc(currentState, evt);
+                    cancellationToken.ThrowIfCancellationRequested();
                     version++;
                     lastSortedUniqueId = evt.SortableUniqueIdValue;
                 }
@@ -540,10 +581,16 @@ public class GeneralTagStateActor : ITagStateActorCommon
                     new EmptyTagStatePayload(),
                     null,
                     string.Empty,
-                    CancellationToken.None);
+                    cancellationToken);
+                cancellationToken.ThrowIfCancellationRequested();
                 if (!streamResult.IsSuccess)
                 {
                     var error = streamResult.GetException();
+                    if (error is OperationCanceledException cancellationException)
+                    {
+                        throw cancellationException;
+                    }
+
                     _logger.LogError(
                         error,
                         "[GeneralTagStateActor] Error streaming events for full rebuild of tag {Tag}",
@@ -561,6 +608,7 @@ public class GeneralTagStateActor : ITagStateActorCommon
             else
             {
                 var eventsResult = await _eventStore.ReadEventsByTagAsync(tag, _eventTypes);
+                cancellationToken.ThrowIfCancellationRequested();
                 if (!eventsResult.IsSuccess)
                 {
                     // Log the error for debugging
@@ -590,11 +638,13 @@ public class GeneralTagStateActor : ITagStateActorCommon
 
                 foreach (var evt in events)
                 {
+                    cancellationToken.ThrowIfCancellationRequested();
                     // Initialize state with EmptyTagStatePayload if needed
                     currentState ??= new EmptyTagStatePayload();
 
                     // Project the event
                     currentState = projectFunc(currentState, evt);
+                    cancellationToken.ThrowIfCancellationRequested();
                     version++;
 
                     // Keep track of the last sortable unique id
@@ -607,6 +657,7 @@ public class GeneralTagStateActor : ITagStateActorCommon
         }
 
         // If no events were processed, ensure we have at least EmptyTagStatePayload
+        cancellationToken.ThrowIfCancellationRequested();
         currentState ??= new EmptyTagStatePayload();
 
         return new TagState(

--- a/dcb/src/Sekiban.Dcb.Core/Actors/ITagStateActorCommon.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Actors/ITagStateActorCommon.cs
@@ -4,5 +4,12 @@ namespace Sekiban.Dcb.Actors;
 public interface ITagStateActorCommon
 {
     Task<SerializableTagState> GetStateAsync();
+
+    /// <summary>
+    ///     Additive cancellation entry point. Existing actor implementations retain the token-less behavior until they
+    ///     opt in by overriding this member.
+    /// </summary>
+    Task<SerializableTagState> GetStateAsync(CancellationToken cancellationToken) => GetStateAsync();
+
     Task<string> GetTagStateActorIdAsync();
 }

--- a/dcb/src/Sekiban.Dcb.Core/Capabilities/TaggedStreamProjectionHelper.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Capabilities/TaggedStreamProjectionHelper.cs
@@ -34,6 +34,7 @@ internal static class TaggedStreamProjectionHelper
         string initialLastSortableUniqueId,
         CancellationToken cancellationToken)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         var state = initialState;
         var eventCount = 0;
         var lastSortableUniqueId = initialLastSortableUniqueId;
@@ -44,6 +45,9 @@ internal static class TaggedStreamProjectionHelper
             until,
             serializableEvent =>
             {
+                // The provider can only stop between callback invocations. Observe before every consumer-side step so
+                // a cancellation never deserializes or projects another event after it has reached this boundary.
+                cancellationToken.ThrowIfCancellationRequested();
                 if (!SekibanDcbCapabilityResolver.IsTaggedStreamOrderValid(
                         previousId,
                         serializableEvent.SortableUniqueIdValue,
@@ -70,6 +74,7 @@ internal static class TaggedStreamProjectionHelper
                 }
 
                 var eventResult = serializableEvent.ToEvent(eventTypes);
+                cancellationToken.ThrowIfCancellationRequested();
                 if (!eventResult.IsSuccess)
                 {
                     throw new InvalidOperationException(
@@ -78,6 +83,7 @@ internal static class TaggedStreamProjectionHelper
                 }
 
                 state = projector(state, eventResult.GetValue());
+                cancellationToken.ThrowIfCancellationRequested();
                 eventCount++;
                 lastSortableUniqueId = serializableEvent.SortableUniqueIdValue;
                 previousId = serializableEvent.SortableUniqueIdValue;
@@ -85,6 +91,7 @@ internal static class TaggedStreamProjectionHelper
             },
             cancellationToken);
 
+        cancellationToken.ThrowIfCancellationRequested();
         if (!streamResult.IsSuccess)
         {
             return ResultBox.Error<TaggedStreamProjectionState>(streamResult.GetException());

--- a/dcb/src/Sekiban.Dcb.Core/Services/TagStateService.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Services/TagStateService.cs
@@ -69,10 +69,21 @@ public class TagStateService
     /// <param name="tagString">Tag string in format 'group:content'</param>
     /// <param name="projectorName">Name of the tag projector to use</param>
     /// <returns>Projected tag state result</returns>
-    public async Task<ResultBox<TagStateProjectionResult>> ProjectTagStateAsync(string tagString, string projectorName)
+    public Task<ResultBox<TagStateProjectionResult>> ProjectTagStateAsync(string tagString, string projectorName) =>
+        ProjectTagStateAsync(tagString, projectorName, CancellationToken.None);
+
+    /// <summary>
+    ///     Project events for a tag using a specified projector with optional cooperative cancellation.
+    /// </summary>
+    public async Task<ResultBox<TagStateProjectionResult>> ProjectTagStateAsync(
+        string tagString,
+        string projectorName,
+        CancellationToken cancellationToken)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         var tag = ParseTag(tagString);
-        return await ProjectTagStateAsync(tag, projectorName);
+        cancellationToken.ThrowIfCancellationRequested();
+        return await ProjectTagStateAsync(tag, projectorName, cancellationToken);
     }
 
     /// <summary>
@@ -81,10 +92,20 @@ public class TagStateService
     /// </summary>
     /// <param name="tagString">Tag string in format 'group:content'</param>
     /// <returns>Projected tag state result</returns>
-    public async Task<ResultBox<TagStateProjectionResult>> ProjectTagStateAsync(string tagString)
+    public Task<ResultBox<TagStateProjectionResult>> ProjectTagStateAsync(string tagString) =>
+        ProjectTagStateAsync(tagString, CancellationToken.None);
+
+    /// <summary>
+    ///     Project events for a tag inferred from its tag group with optional cooperative cancellation.
+    /// </summary>
+    public async Task<ResultBox<TagStateProjectionResult>> ProjectTagStateAsync(
+        string tagString,
+        CancellationToken cancellationToken)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         var tag = ParseTag(tagString);
-        return await ProjectTagStateAsync(tag);
+        cancellationToken.ThrowIfCancellationRequested();
+        return await ProjectTagStateAsync(tag, cancellationToken);
     }
 
     /// <summary>
@@ -93,8 +114,17 @@ public class TagStateService
     /// </summary>
     /// <param name="tag">The tag to project</param>
     /// <returns>Projected tag state result</returns>
-    public async Task<ResultBox<TagStateProjectionResult>> ProjectTagStateAsync(ITag tag)
+    public Task<ResultBox<TagStateProjectionResult>> ProjectTagStateAsync(ITag tag) =>
+        ProjectTagStateAsync(tag, CancellationToken.None);
+
+    /// <summary>
+    ///     Project events for a tag inferred from its tag group with optional cooperative cancellation.
+    /// </summary>
+    public async Task<ResultBox<TagStateProjectionResult>> ProjectTagStateAsync(
+        ITag tag,
+        CancellationToken cancellationToken)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         var tagGroup = tag.GetTagGroup();
         var projectorName = _tagProjectorTypes.TryGetProjectorForTagGroup(tagGroup);
 
@@ -107,7 +137,8 @@ public class TagStateService
                     $"Available projectors: {string.Join(", ", GetAllTagProjectorNames())}"));
         }
 
-        return await ProjectTagStateAsync(tag, projectorName);
+        cancellationToken.ThrowIfCancellationRequested();
+        return await ProjectTagStateAsync(tag, projectorName, cancellationToken);
     }
 
     /// <summary>
@@ -116,8 +147,18 @@ public class TagStateService
     /// <param name="tag">The tag to project</param>
     /// <param name="projectorName">Name of the tag projector to use</param>
     /// <returns>Projected tag state result</returns>
-    public async Task<ResultBox<TagStateProjectionResult>> ProjectTagStateAsync(ITag tag, string projectorName)
+    public Task<ResultBox<TagStateProjectionResult>> ProjectTagStateAsync(ITag tag, string projectorName) =>
+        ProjectTagStateAsync(tag, projectorName, CancellationToken.None);
+
+    /// <summary>
+    ///     Project events for a tag using a specified projector with optional cooperative cancellation.
+    /// </summary>
+    public async Task<ResultBox<TagStateProjectionResult>> ProjectTagStateAsync(
+        ITag tag,
+        string projectorName,
+        CancellationToken cancellationToken)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         // Get the projector function
         var projectorFuncResult = _tagProjectorTypes.GetProjectorFunction(projectorName);
         if (!projectorFuncResult.IsSuccess)
@@ -131,8 +172,7 @@ public class TagStateService
 
         var projectorFunc = projectorFuncResult.GetValue();
 
-        // Project all events. Existing public operations have no cancellation token, so the optional stream receives
-        // CancellationToken.None just like the actor/grain paths.
+        // Project all events. The legacy overload enters here with CancellationToken.None.
         ITagStatePayload state = new EmptyTagStatePayload();
         string? lastSortableUniqueId = null;
         var eventCount = 0;
@@ -150,9 +190,15 @@ public class TagStateService
                 state,
                 null,
                 string.Empty,
-                CancellationToken.None);
+                cancellationToken);
+            cancellationToken.ThrowIfCancellationRequested();
             if (!streamResult.IsSuccess)
             {
+                if (streamResult.GetException() is OperationCanceledException cancellationException)
+                {
+                    throw cancellationException;
+                }
+
                 return ResultBox.Error<TagStateProjectionResult>(streamResult.GetException());
             }
 
@@ -164,6 +210,7 @@ public class TagStateService
         else
         {
             var eventsResult = await _eventStore.ReadEventsByTagAsync(tag, _eventTypes);
+            cancellationToken.ThrowIfCancellationRequested();
             if (!eventsResult.IsSuccess)
             {
                 return ResultBox.Error<TagStateProjectionResult>(eventsResult.GetException());
@@ -171,12 +218,14 @@ public class TagStateService
 
             foreach (var evt in eventsResult.GetValue())
             {
+                cancellationToken.ThrowIfCancellationRequested();
                 state = projectorFunc(state, evt);
                 eventCount++;
                 lastSortableUniqueId = evt.SortableUniqueIdValue;
             }
         }
 
+        cancellationToken.ThrowIfCancellationRequested();
         var result = new TagStateProjectionResult(
             tag,
             projectorName,

--- a/dcb/src/Sekiban.Dcb.Orleans.Core/Grains/ITagStateGrain.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.Core/Grains/ITagStateGrain.cs
@@ -18,9 +18,19 @@ public interface ITagStateGrain : IGrainWithStringKey
     Task<SerializableTagState> GetStateAsync();
 
     /// <summary>
+    ///     Get the current state while propagating cancellation to the grain implementation.
+    /// </summary>
+    Task<SerializableTagState> GetStateAsync(CancellationToken cancellationToken);
+
+    /// <summary>
     ///     Get the tag state
     /// </summary>
     Task<TagState> GetTagStateAsync();
+
+    /// <summary>
+    ///     Get the tag state while propagating cancellation to the grain implementation.
+    /// </summary>
+    Task<TagState> GetTagStateAsync(CancellationToken cancellationToken);
 
     /// <summary>
     ///     Update the state

--- a/dcb/src/Sekiban.Dcb.Orleans.Core/Grains/TagStateGrain.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.Core/Grains/TagStateGrain.cs
@@ -56,8 +56,12 @@ public class TagStateGrain : Grain, ITagStateGrain
         return Task.FromResult(_tagStateId.GetTagStateId());
     }
 
-    public async Task<SerializableTagState> GetStateAsync()
+    public Task<SerializableTagState> GetStateAsync() => GetStateAsync(CancellationToken.None);
+
+    public async Task<SerializableTagState> GetStateAsync(CancellationToken cancellationToken)
     {
+        cancellationToken.ThrowIfCancellationRequested();
+
         if (_tagStateId == null)
         {
             // Return empty serializable state
@@ -73,7 +77,8 @@ public class TagStateGrain : Grain, ITagStateGrain
                 nameof(EmptyTagStatePayload));
         }
 
-        var latestSortableUniqueId = await GetLatestSortableUniqueIdAsync(_tagStateId);
+        var latestSortableUniqueId = await GetLatestSortableUniqueIdAsync(_tagStateId, cancellationToken);
+        cancellationToken.ThrowIfCancellationRequested();
         var cachedState = _cache.State?.CachedState;
 
         var projectorVersionResult = _tagProjectorTypes.GetProjectorVersion(_tagStateId.TagProjectorName);
@@ -93,7 +98,8 @@ public class TagStateGrain : Grain, ITagStateGrain
         var tag = _tagTypes.GetTag($"{_tagStateId.TagGroup}:{_tagStateId.TagContent}");
         var taggedStream = SekibanDcbCapabilityResolver.ResolveTaggedStream(_eventStore, "event store");
 
-        using var accumulator = await _tagStateProjectionPrimitive.CreateAccumulatorAsync(_tagStateId);
+        using var accumulator = await _tagStateProjectionPrimitive.CreateAccumulatorAsync(_tagStateId, cancellationToken);
+        cancellationToken.ThrowIfCancellationRequested();
         if (!accumulator.ApplyState(usableCachedState))
         {
             throw new InvalidOperationException(
@@ -112,6 +118,8 @@ public class TagStateGrain : Grain, ITagStateGrain
                 until,
                 serializableEvent =>
                 {
+                    cancellationToken.ThrowIfCancellationRequested();
+
                     if (!SekibanDcbCapabilityResolver.IsTaggedStreamOrderValid(
                             previousId,
                             serializableEvent.SortableUniqueIdValue,
@@ -137,7 +145,7 @@ public class TagStateGrain : Grain, ITagStateGrain
                             $"Tagged stream for {tag.GetTag()} exceeded captured head {latestSortableUniqueId}.");
                     }
 
-                    if (!accumulator.ApplyEvent(serializableEvent, latestSortableUniqueId, CancellationToken.None))
+                    if (!accumulator.ApplyEvent(serializableEvent, latestSortableUniqueId, cancellationToken))
                     {
                         throw new InvalidOperationException(
                             $"Failed to apply streamed event for tag state {_tagStateId.GetTagStateId()}");
@@ -146,9 +154,15 @@ public class TagStateGrain : Grain, ITagStateGrain
                     previousId = serializableEvent.SortableUniqueIdValue;
                     return ValueTask.CompletedTask;
                 },
-                CancellationToken.None);
+                cancellationToken);
+            cancellationToken.ThrowIfCancellationRequested();
             if (!streamResult.IsSuccess)
             {
+                if (streamResult.GetException() is OperationCanceledException cancellationException)
+                {
+                    throw cancellationException;
+                }
+
                 throw new InvalidOperationException(
                     $"Failed to stream serialized events: {streamResult.GetException().Message}",
                     streamResult.GetException());
@@ -156,7 +170,8 @@ public class TagStateGrain : Grain, ITagStateGrain
         }
         else
         {
-            var eventsResult = await ReadSerializableEventsByTagAsync(tag, since);
+            var eventsResult = await ReadSerializableEventsByTagAsync(tag, since, cancellationToken);
+            cancellationToken.ThrowIfCancellationRequested();
             if (!eventsResult.IsSuccess)
             {
                 throw new InvalidOperationException(
@@ -164,21 +179,27 @@ public class TagStateGrain : Grain, ITagStateGrain
                     eventsResult.GetException());
             }
 
-            if (!accumulator.ApplyEvents(eventsResult.GetValue(), latestSortableUniqueId))
+            if (!accumulator.ApplyEvents(eventsResult.GetValue(), latestSortableUniqueId, cancellationToken))
             {
                 throw new InvalidOperationException(
                     $"Failed to apply events for tag state {_tagStateId.GetTagStateId()}");
             }
         }
 
+        cancellationToken.ThrowIfCancellationRequested();
         var projectedState = accumulator.GetSerializedState();
         _cache.State = new TagStateCacheState { CachedState = projectedState };
         await _cache.WriteStateAsync();
+        cancellationToken.ThrowIfCancellationRequested();
         return projectedState;
     }
 
-    public async Task<TagState> GetTagStateAsync()
+    public Task<TagState> GetTagStateAsync() => GetTagStateAsync(CancellationToken.None);
+
+    public async Task<TagState> GetTagStateAsync(CancellationToken cancellationToken)
     {
+        cancellationToken.ThrowIfCancellationRequested();
+
         if (_tagStateId == null)
         {
             // Return empty tag state
@@ -192,7 +213,8 @@ public class TagStateGrain : Grain, ITagStateGrain
                 string.Empty);
         }
 
-        var serialized = await GetStateAsync();
+        var serialized = await GetStateAsync(cancellationToken);
+        cancellationToken.ThrowIfCancellationRequested();
         if (serialized.ResolvedPayloadName == nameof(EmptyTagStatePayload))
         {
             return new TagState(
@@ -299,16 +321,21 @@ public class TagStateGrain : Grain, ITagStateGrain
         return base.OnActivateAsync(cancellationToken);
     }
 
-    private async Task<string?> GetLatestSortableUniqueIdAsync(TagStateId tagStateId)
+    private async Task<string?> GetLatestSortableUniqueIdAsync(
+        TagStateId tagStateId,
+        CancellationToken cancellationToken)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         var tagConsistentActorId = $"{tagStateId.TagGroup}:{tagStateId.TagContent}";
         var tagConsistentActorResult = await _actorAccessor.GetActorAsync<ITagConsistentActorCommon>(tagConsistentActorId);
+        cancellationToken.ThrowIfCancellationRequested();
         if (!tagConsistentActorResult.IsSuccess)
         {
             return null;
         }
 
         var latestSortableUniqueIdResult = await tagConsistentActorResult.GetValue().GetLatestSortableUniqueIdAsync();
+        cancellationToken.ThrowIfCancellationRequested();
         return latestSortableUniqueIdResult.IsSuccess
             ? latestSortableUniqueIdResult.GetValue()
             : null;
@@ -347,9 +374,12 @@ public class TagStateGrain : Grain, ITagStateGrain
 
     private async Task<ResultBox<IReadOnlyList<SerializableEvent>>> ReadSerializableEventsByTagAsync(
         ITag tag,
-        SortableUniqueId? since)
+        SortableUniqueId? since,
+        CancellationToken cancellationToken)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         var serializableResult = await _eventStore.ReadSerializableEventsByTagAsync(tag, since);
+        cancellationToken.ThrowIfCancellationRequested();
         if (serializableResult.IsSuccess)
         {
             return ResultBox.FromValue<IReadOnlyList<SerializableEvent>>(serializableResult.GetValue().ToList());

--- a/dcb/src/Sekiban.Dcb.Orleans.Core/Grains/TagStateGrain.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.Core/Grains/TagStateGrain.cs
@@ -179,16 +179,28 @@ public class TagStateGrain : Grain, ITagStateGrain
                     eventsResult.GetException());
             }
 
-            if (!accumulator.ApplyEvents(eventsResult.GetValue(), latestSortableUniqueId, cancellationToken))
+            // IEventStore's frozen list read cannot be interrupted. Once it returns, feed one ordered event at a time
+            // so every legacy/default accumulator receives a cancellation observation between events.
+            foreach (var serializableEvent in eventsResult.GetValue().OrderBy(
+                         @event => @event.SortableUniqueIdValue,
+                         StringComparer.Ordinal))
             {
-                throw new InvalidOperationException(
-                    $"Failed to apply events for tag state {_tagStateId.GetTagStateId()}");
+                cancellationToken.ThrowIfCancellationRequested();
+                if (!accumulator.ApplyEvent(serializableEvent, latestSortableUniqueId, cancellationToken))
+                {
+                    throw new InvalidOperationException(
+                        $"Failed to apply events for tag state {_tagStateId.GetTagStateId()}");
+                }
             }
         }
 
         cancellationToken.ThrowIfCancellationRequested();
         var projectedState = accumulator.GetSerializedState();
+        // Cache persistence itself is token-unaware. The two checks define the public boundary: a cancellation
+        // observed before the write starts cannot publish the locally-folded state.
+        cancellationToken.ThrowIfCancellationRequested();
         _cache.State = new TagStateCacheState { CachedState = projectedState };
+        cancellationToken.ThrowIfCancellationRequested();
         await _cache.WriteStateAsync();
         cancellationToken.ThrowIfCancellationRequested();
         return projectedState;
@@ -230,6 +242,7 @@ public class TagStateGrain : Grain, ITagStateGrain
         var deserializeResult = _tagStatePayloadTypes.DeserializePayload(
             serialized.ResolvedPayloadName,
             serialized.Payload);
+        cancellationToken.ThrowIfCancellationRequested();
         if (!deserializeResult.IsSuccess)
         {
             throw new InvalidOperationException(
@@ -237,6 +250,7 @@ public class TagStateGrain : Grain, ITagStateGrain
                 deserializeResult.GetException());
         }
 
+        cancellationToken.ThrowIfCancellationRequested();
         return new TagState(
             deserializeResult.GetValue(),
             serialized.Version,

--- a/dcb/src/Sekiban.Dcb.Orleans.Core/OrleansActorObjectAccessor.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.Core/OrleansActorObjectAccessor.cs
@@ -139,6 +139,9 @@ public class OrleansActorObjectAccessor : IActorObjectAccessor, IExecutorRuntime
 
         public Task<SerializableTagState> GetStateAsync() => _grain.GetStateAsync();
 
+        public Task<SerializableTagState> GetStateAsync(CancellationToken cancellationToken) =>
+            _grain.GetStateAsync(cancellationToken);
+
         public Task<string> GetTagStateActorIdAsync() => _grain.GetTagStateActorIdAsync();
     }
 }

--- a/dcb/src/Sekiban.Dcb.Orleans.Core/Runtimes/NativeTagStateProjectionPrimitive.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.Core/Runtimes/NativeTagStateProjectionPrimitive.cs
@@ -119,6 +119,7 @@ public sealed class NativeTagStateProjectionPrimitive : ITagStateProjectionPrimi
             string? latestSortableUniqueId,
             CancellationToken cancellationToken = default)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             if (!_hasProjector)
             {
                 _version = 0;
@@ -129,6 +130,7 @@ public sealed class NativeTagStateProjectionPrimitive : ITagStateProjectionPrimi
 
             foreach (var serializableEvent in events.OrderBy(e => e.SortableUniqueIdValue, StringComparer.Ordinal))
             {
+                cancellationToken.ThrowIfCancellationRequested();
                 if (!ApplyEvent(serializableEvent, latestSortableUniqueId, cancellationToken))
                 {
                     return false;
@@ -147,6 +149,7 @@ public sealed class NativeTagStateProjectionPrimitive : ITagStateProjectionPrimi
             string? latestSortableUniqueId,
             CancellationToken cancellationToken = default)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             if (!_hasProjector)
             {
                 _version = 0;
@@ -169,11 +172,13 @@ public sealed class NativeTagStateProjectionPrimitive : ITagStateProjectionPrimi
             }
 
             var eventResult = serializableEvent.ToEvent(_eventTypes);
+            cancellationToken.ThrowIfCancellationRequested();
             if (!eventResult.IsSuccess)
             {
                 return false;
             }
 
+            cancellationToken.ThrowIfCancellationRequested();
             _currentPayload = _projector!(_currentPayload, eventResult.GetValue());
             _version++;
             _lastSortableUniqueId = serializableEvent.SortableUniqueIdValue;

--- a/dcb/src/Sekiban.Dcb.Orleans.WithResult/OrleansDcbExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.WithResult/OrleansDcbExecutor.cs
@@ -150,6 +150,9 @@ public class OrleansDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecuto
     public Task<ResultBox<TagState>> GetTagStateAsync(TagStateId tagStateId) =>
         _generalExecutor.GetTagStateAsync(tagStateId);
 
+    public Task<ResultBox<TagState>> GetTagStateAsync(TagStateId tagStateId, CancellationToken cancellationToken) =>
+        _generalExecutor.GetTagStateAsync(tagStateId, cancellationToken);
+
     /// <summary>
     ///     Execute a single-result query using Orleans grains
     /// </summary>

--- a/dcb/src/Sekiban.Dcb.Orleans.WithoutResult/OrleansDcbExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.WithoutResult/OrleansDcbExecutor.cs
@@ -151,6 +151,9 @@ public class OrleansDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecuto
     public Task<TagState> GetTagStateAsync(TagStateId tagStateId) =>
         _generalExecutor.GetTagStateAsync(tagStateId);
 
+    public Task<TagState> GetTagStateAsync(TagStateId tagStateId, CancellationToken cancellationToken) =>
+        _generalExecutor.GetTagStateAsync(tagStateId, cancellationToken);
+
     /// <summary>
     ///     Execute a single-result query using Orleans grains
     /// </summary>

--- a/dcb/src/Sekiban.Dcb.Sqlite/Services/TagStateService.cs
+++ b/dcb/src/Sekiban.Dcb.Sqlite/Services/TagStateService.cs
@@ -56,14 +56,34 @@ public class TagStateService
     public Task<ResultBox<TagStateProjectionResult>> ProjectTagStateAsync(string tagString, string projectorName) =>
         ConvertProjectionAsync(_inner.ProjectTagStateAsync(tagString, projectorName));
 
+    public Task<ResultBox<TagStateProjectionResult>> ProjectTagStateAsync(
+        string tagString,
+        string projectorName,
+        CancellationToken cancellationToken) =>
+        ConvertProjectionAsync(_inner.ProjectTagStateAsync(tagString, projectorName, cancellationToken));
+
     public Task<ResultBox<TagStateProjectionResult>> ProjectTagStateAsync(string tagString) =>
         ConvertProjectionAsync(_inner.ProjectTagStateAsync(tagString));
+
+    public Task<ResultBox<TagStateProjectionResult>> ProjectTagStateAsync(
+        string tagString,
+        CancellationToken cancellationToken) =>
+        ConvertProjectionAsync(_inner.ProjectTagStateAsync(tagString, cancellationToken));
 
     public Task<ResultBox<TagStateProjectionResult>> ProjectTagStateAsync(ITag tag) =>
         ConvertProjectionAsync(_inner.ProjectTagStateAsync(tag));
 
+    public Task<ResultBox<TagStateProjectionResult>> ProjectTagStateAsync(ITag tag, CancellationToken cancellationToken) =>
+        ConvertProjectionAsync(_inner.ProjectTagStateAsync(tag, cancellationToken));
+
     public Task<ResultBox<TagStateProjectionResult>> ProjectTagStateAsync(ITag tag, string projectorName) =>
         ConvertProjectionAsync(_inner.ProjectTagStateAsync(tag, projectorName));
+
+    public Task<ResultBox<TagStateProjectionResult>> ProjectTagStateAsync(
+        ITag tag,
+        string projectorName,
+        CancellationToken cancellationToken) =>
+        ConvertProjectionAsync(_inner.ProjectTagStateAsync(tag, projectorName, cancellationToken));
 
     /// <inheritdoc cref="CoreTagStateService.GetAllTagProjectorNames" />
     public IReadOnlyList<string> GetAllTagProjectorNames() => _inner.GetAllTagProjectorNames();

--- a/dcb/src/Sekiban.Dcb.WithResult/Actors/GeneralSekibanExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.WithResult/Actors/GeneralSekibanExecutor.cs
@@ -157,6 +157,9 @@ public class GeneralSekibanExecutor : ISekibanExecutor, ISerializedSekibanDcbExe
     public Task<ResultBox<TagState>> GetTagStateAsync(TagStateId tagStateId) =>
         _core.GetTagStateAsync(tagStateId);
 
+    public Task<ResultBox<TagState>> GetTagStateAsync(TagStateId tagStateId, CancellationToken cancellationToken) =>
+        _core.GetTagStateAsync(tagStateId, cancellationToken);
+
     /// <summary>
     ///     Execute a single-result query
     /// </summary>

--- a/dcb/src/Sekiban.Dcb.WithResult/ISekibanExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.WithResult/ISekibanExecutor.cs
@@ -17,7 +17,19 @@ public interface ISekibanExecutor : ICommandExecutor
     /// <param name="tagStateId">The tag state identifier</param>
     /// <returns>ResultBox containing the tag state or error</returns>
     Task<ResultBox<TagState>> GetTagStateAsync(TagStateId tagStateId);
+
+    /// <summary>
+    ///     Additive cancellation entry point. Existing executor implementations retain token-less behavior until they
+    ///     override this default compatibility fallback.
+    /// </summary>
+    Task<ResultBox<TagState>> GetTagStateAsync(TagStateId tagStateId, CancellationToken cancellationToken) =>
+        GetTagStateAsync(tagStateId);
+
     Task<ResultBox<TagState>> GetTagStateAsync<TProjector>(ITag tag) where TProjector : ITagProjector<TProjector> => GetTagStateAsync(TagStateId.FromProjector<TProjector>(tag));
+
+    Task<ResultBox<TagState>> GetTagStateAsync<TProjector>(ITag tag, CancellationToken cancellationToken)
+        where TProjector : ITagProjector<TProjector> =>
+        GetTagStateAsync(TagStateId.FromProjector<TProjector>(tag), cancellationToken);
 
     /// <summary>
     ///     Execute a single-result query

--- a/dcb/src/Sekiban.Dcb.WithResult/InMemory/InMemoryDcbExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.WithResult/InMemory/InMemoryDcbExecutor.cs
@@ -113,6 +113,11 @@ public class InMemoryDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecut
     Task<ResultBox<TagState>> ISekibanExecutor.GetTagStateAsync(TagStateId tagStateId) =>
         _inner.GetTagStateAsync(tagStateId);
 
+    Task<ResultBox<TagState>> ISekibanExecutor.GetTagStateAsync(
+        TagStateId tagStateId,
+        CancellationToken cancellationToken) =>
+        _inner.GetTagStateAsync(tagStateId, cancellationToken);
+
     Task<ResultBox<TResult>> ISekibanExecutor.QueryAsync<TResult>(IQueryCommon<TResult> queryCommon) =>
         _inner.QueryAsync(queryCommon);
 

--- a/dcb/src/Sekiban.Dcb.WithoutResult/Actors/GeneralSekibanExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.WithoutResult/Actors/GeneralSekibanExecutor.cs
@@ -192,6 +192,13 @@ public class GeneralSekibanExecutor : ISekibanExecutor, ISerializedSekibanDcbExe
             new BoundaryContext("ISekibanExecutor.GetTagStateAsync", tagStateId.GetTagStateId()));
     }
 
+    public async Task<TagState> GetTagStateAsync(TagStateId tagStateId, CancellationToken cancellationToken)
+    {
+        return await GuardedUnwrap.UnwrapAsync(
+            _core.GetTagStateAsync(tagStateId, cancellationToken),
+            new BoundaryContext("ISekibanExecutor.GetTagStateAsync", tagStateId.GetTagStateId()));
+    }
+
     /// <summary>
     ///     Execute a single-result query
     /// </summary>

--- a/dcb/src/Sekiban.Dcb.WithoutResult/ISekibanExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.WithoutResult/ISekibanExecutor.cs
@@ -20,9 +20,20 @@ public interface ISekibanExecutor : ICommandExecutor
     /// <exception cref="Exception">Thrown when tag state cannot be retrieved</exception>
     Task<TagState> GetTagStateAsync(TagStateId tagStateId);
 
+    /// <summary>
+    ///     Additive cancellation entry point. Existing executor implementations retain token-less behavior until they
+    ///     override this default compatibility fallback.
+    /// </summary>
+    Task<TagState> GetTagStateAsync(TagStateId tagStateId, CancellationToken cancellationToken) =>
+        GetTagStateAsync(tagStateId);
+
     Task<TagState> GetTagStateAsync<TProjector>(ITag tag)
         where TProjector : ITagProjector<TProjector> =>
         GetTagStateAsync(TagStateId.FromProjector<TProjector>(tag));
+
+    Task<TagState> GetTagStateAsync<TProjector>(ITag tag, CancellationToken cancellationToken)
+        where TProjector : ITagProjector<TProjector> =>
+        GetTagStateAsync(TagStateId.FromProjector<TProjector>(tag), cancellationToken);
 
     /// <summary>
     ///     Execute a single-result query

--- a/dcb/src/Sekiban.Dcb.WithoutResult/InMemory/InMemoryDcbExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.WithoutResult/InMemory/InMemoryDcbExecutor.cs
@@ -115,6 +115,9 @@ public class InMemoryDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecut
     Task<TagState> ISekibanExecutor.GetTagStateAsync(TagStateId tagStateId) =>
         _inner.GetTagStateAsync(tagStateId);
 
+    Task<TagState> ISekibanExecutor.GetTagStateAsync(TagStateId tagStateId, CancellationToken cancellationToken) =>
+        _inner.GetTagStateAsync(tagStateId, cancellationToken);
+
     Task<TResult> ISekibanExecutor.QueryAsync<TResult>(IQueryCommon<TResult> queryCommon) =>
         _inner.QueryAsync(queryCommon);
 

--- a/dcb/tests/Sekiban.Dcb.Orleans.Tests/OrleansTagStateGrainPersistenceTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Orleans.Tests/OrleansTagStateGrainPersistenceTests.cs
@@ -15,7 +15,11 @@ using Orleans.TestingHost;
 using Orleans;
 using Orleans.Configuration;
 using Orleans.Hosting;
+using Orleans.Runtime;
+using Orleans.Runtime.Hosting;
+using Orleans.Storage;
 using Microsoft.Extensions.DependencyInjection;
+using System.Reflection;
 using System.Text.Json;
 using Xunit;
 namespace Sekiban.Dcb.Orleans.Tests;
@@ -25,6 +29,7 @@ public class OrleansTagStateGrainPersistenceTests : IAsyncLifetime
     // Shared in-memory store per test run to keep state deterministic and inspectable
     private static readonly CountingEventStore SharedEventStore = new();
     private static readonly TagStateGrainRequestCounter SharedGrainRequestCounter = new();
+    private static readonly CountingTagStateCacheStorage SharedTagStateCacheStorage = new();
 
     private TestCluster _cluster = null!;
     private IClusterClient _client => _cluster.Client;
@@ -69,6 +74,7 @@ public class OrleansTagStateGrainPersistenceTests : IAsyncLifetime
         SharedEventStore.Clear();
         SharedEventStore.ClearCounts();
         SharedGrainRequestCounter.Clear();
+        SharedTagStateCacheStorage.Reset();
     }
 
     [Fact]
@@ -205,6 +211,28 @@ public class OrleansTagStateGrainPersistenceTests : IAsyncLifetime
         AssertPostDispatchCancellationAsync(_client);
 
     [Fact]
+    public async Task CancellationTokenProbe_Frozen1018ClientUsesTokenlessGrainMethodAgainstNewSilo()
+    {
+        ResetSharedState();
+        var grain = GetTagStateGrain(BuildTagStateId(Guid.NewGuid()));
+        var fixturePath = Path.Combine(
+            AppContext.BaseDirectory,
+            "Sekiban.Dcb.TagStateCancellation.Legacy1018Fixture.dll");
+        var assembly = Assembly.LoadFrom(fixturePath);
+        var type = assembly.GetType(
+            "Sekiban.Dcb.TagStateCancellation.Legacy1018Fixture.Legacy1018TagStateGrainClient",
+            throwOnError: true)!;
+        var method = type.GetMethod("GetStateAsync", BindingFlags.Public | BindingFlags.Static)!;
+
+        var call = Assert.IsAssignableFrom<Task<SerializableTagState>>(method.Invoke(null, [grain]));
+        var state = await call;
+
+        Assert.Equal(0, state.Version);
+        Assert.Equal("Counter", state.TagGroup);
+        Assert.Equal(1, SharedGrainRequestCounter.GetStateRequestCount);
+    }
+
+    [Fact]
     public async Task CancellationTokenProbe_AckFalse_CoversPreCancelledAndPostDispatchCancellation()
     {
         var cluster = await CreateClusterAsync(waitForCancellationAcknowledgement: false, portOffset: 2_000);
@@ -236,6 +264,7 @@ public class OrleansTagStateGrainPersistenceTests : IAsyncLifetime
         Assert.Equal(0, SharedEventStore.StreamSerializableEventsByTagCallCount);
         Assert.Equal(0, SharedEventStore.StreamRowsRead);
         Assert.Equal(0, SharedEventStore.StreamCallbackCount);
+        Assert.Equal(0, SharedTagStateCacheStorage.TagStateWriteCount);
     }
 
     private static async Task AssertPostDispatchCancellationAsync(IClusterClient client)
@@ -258,6 +287,7 @@ public class OrleansTagStateGrainPersistenceTests : IAsyncLifetime
         await grain.ClearCacheAsync();
         SharedEventStore.ClearCounts();
         SharedGrainRequestCounter.Clear();
+        SharedTagStateCacheStorage.ClearWriteCount();
         var firstRowGate = SharedEventStore.GateFirstStreamRow();
 
         using var cancellation = new CancellationTokenSource();
@@ -277,6 +307,16 @@ public class OrleansTagStateGrainPersistenceTests : IAsyncLifetime
         Assert.Equal(1, SharedEventStore.StreamRowsRead);
         Assert.Equal(0, SharedEventStore.StreamCallbackCount);
         Assert.True(firstRowGate.ReceivedCancelableGrainToken);
+        Assert.Equal(0, SharedTagStateCacheStorage.TagStateWriteCount);
+
+        // A cancelled fold must not retain a cache value. A subsequent ordinary (legacy token-less) call therefore
+        // rebuilds both rows instead of observing a partially published state.
+        SharedEventStore.ClearCounts();
+        var recovered = await grain.GetStateAsync();
+        Assert.Equal(2, recovered.Version);
+        Assert.Equal(1, SharedEventStore.StreamSerializableEventsByTagCallCount);
+        Assert.Equal(2, SharedEventStore.StreamRowsRead);
+        Assert.Equal(1, SharedTagStateCacheStorage.TagStateWriteCount);
     }
 
     private ITagStateGrain GetTagStateGrain(TagStateId id) =>
@@ -367,9 +407,9 @@ public class OrleansTagStateGrainPersistenceTests : IAsyncLifetime
                         SafeWindowMs = 20000
                     });
                     services.AddSekibanDcbNativeRuntime();
+                    services.AddGrainStorage("OrleansStorage", (_, _) => SharedTagStateCacheStorage);
                 })
                 .AddMemoryGrainStorageAsDefault()
-                .AddMemoryGrainStorage("OrleansStorage")
                 .AddMemoryGrainStorage("PubSubStore")
                 .AddMemoryStreams("EventStreamProvider")
                 .AddMemoryGrainStorage("EventStreamProvider");
@@ -444,6 +484,70 @@ public class OrleansTagStateGrainPersistenceTests : IAsyncLifetime
             }
 
             return context.Invoke();
+        }
+    }
+
+    private sealed class CountingTagStateCacheStorage : IGrainStorage
+    {
+        private readonly Dictionary<string, object?> _states = new();
+        private readonly object _gate = new();
+        private int _tagStateWriteCount;
+
+        public int TagStateWriteCount => Volatile.Read(ref _tagStateWriteCount);
+
+        public void Reset()
+        {
+            lock (_gate)
+            {
+                _states.Clear();
+            }
+
+            Interlocked.Exchange(ref _tagStateWriteCount, 0);
+        }
+
+        public void ClearWriteCount() => Interlocked.Exchange(ref _tagStateWriteCount, 0);
+
+        public Task ReadStateAsync<T>(string grainType, GrainId grainId, IGrainState<T> grainState)
+        {
+            lock (_gate)
+            {
+                if (_states.TryGetValue(grainId.ToString(), out var saved) && saved is T typed)
+                {
+                    grainState.State = typed;
+                    grainState.RecordExists = true;
+                }
+                else
+                {
+                    grainState.RecordExists = false;
+                }
+            }
+
+            return Task.CompletedTask;
+        }
+
+        public Task WriteStateAsync<T>(string grainType, GrainId grainId, IGrainState<T> grainState)
+        {
+            lock (_gate)
+            {
+                _states[grainId.ToString()] = grainState.State;
+            }
+
+            if (typeof(T) == typeof(TagStateCacheState))
+            {
+                Interlocked.Increment(ref _tagStateWriteCount);
+            }
+
+            return Task.CompletedTask;
+        }
+
+        public Task ClearStateAsync<T>(string grainType, GrainId grainId, IGrainState<T> grainState)
+        {
+            lock (_gate)
+            {
+                _states.Remove(grainId.ToString());
+            }
+
+            return Task.CompletedTask;
         }
     }
 

--- a/dcb/tests/Sekiban.Dcb.Orleans.Tests/OrleansTagStateGrainPersistenceTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Orleans.Tests/OrleansTagStateGrainPersistenceTests.cs
@@ -1,3 +1,5 @@
+extern alias WithoutResultFacade;
+
 using ResultBoxes;
 using Sekiban.Dcb.Capabilities;
 using Sekiban.Dcb.Common;
@@ -22,6 +24,12 @@ using Microsoft.Extensions.DependencyInjection;
 using System.Reflection;
 using System.Text.Json;
 using Xunit;
+using WithResultExecutor = Sekiban.Dcb.ISekibanExecutor;
+using WithResultInMemoryDcbExecutor = Sekiban.Dcb.InMemory.InMemoryDcbExecutor;
+using WithResultOrleansDcbExecutor = Sekiban.Dcb.Orleans.OrleansDcbExecutor;
+using WithoutResultExecutor = WithoutResultFacade::Sekiban.Dcb.ISekibanExecutor;
+using WithoutResultInMemoryDcbExecutor = WithoutResultFacade::Sekiban.Dcb.InMemory.InMemoryDcbExecutor;
+using WithoutResultOrleansDcbExecutor = WithoutResultFacade::Sekiban.Dcb.Orleans.OrleansDcbExecutor;
 namespace Sekiban.Dcb.Orleans.Tests;
 
 public class OrleansTagStateGrainPersistenceTests : IAsyncLifetime
@@ -250,6 +258,102 @@ public class OrleansTagStateGrainPersistenceTests : IAsyncLifetime
         }
     }
 
+    [Fact]
+    public async Task CancellationTokenRelay_WithResultOrleansExecutor_ReachesWrapperAndGrain()
+    {
+        WithResultExecutor executor = new WithResultOrleansDcbExecutor(
+            _client,
+            SharedEventStore,
+            TestSiloConfigurator.CreateDomainTypes());
+
+        await AssertOrleansExecutorCancellationRelayAsync(
+            _client,
+            async (tagStateId, cancellationToken) =>
+            {
+                var result = await executor.GetTagStateAsync(tagStateId, cancellationToken);
+                Assert.False(result.IsSuccess);
+                Assert.IsAssignableFrom<OperationCanceledException>(result.GetException());
+            },
+            async tagStateId =>
+            {
+                var result = await executor.GetTagStateAsync(tagStateId);
+                Assert.True(result.IsSuccess, result.IsSuccess ? string.Empty : result.GetException().ToString());
+                Assert.Equal(2, result.GetValue().Version);
+            });
+    }
+
+    [Fact]
+    public async Task CancellationTokenRelay_WithoutResultOrleansExecutor_ReachesWrapperAndGrain()
+    {
+        WithoutResultExecutor executor = new WithoutResultOrleansDcbExecutor(
+            _client,
+            SharedEventStore,
+            TestSiloConfigurator.CreateDomainTypes());
+
+        await AssertOrleansExecutorCancellationRelayAsync(
+            _client,
+            async (tagStateId, cancellationToken) =>
+            {
+                await Assert.ThrowsAnyAsync<OperationCanceledException>(
+                    () => executor.GetTagStateAsync(tagStateId, cancellationToken));
+            },
+            async tagStateId =>
+            {
+                var state = await executor.GetTagStateAsync(tagStateId);
+                Assert.Equal(2, state.Version);
+            });
+    }
+
+    [Fact]
+    public async Task CancellationTokenRelay_WithResultInMemoryExecutor_ReachesNativeStream()
+    {
+        var eventStore = new CountingEventStore();
+#pragma warning disable CS0618
+        WithResultExecutor executor = new WithResultInMemoryDcbExecutor(
+            TestSiloConfigurator.CreateDomainTypes(),
+            eventStore);
+#pragma warning restore CS0618
+
+        await AssertInMemoryExecutorCancellationRelayAsync(
+            eventStore,
+            async (tagStateId, cancellationToken) =>
+            {
+                var result = await executor.GetTagStateAsync(tagStateId, cancellationToken);
+                Assert.False(result.IsSuccess);
+                Assert.IsAssignableFrom<OperationCanceledException>(result.GetException());
+            },
+            async tagStateId =>
+            {
+                var result = await executor.GetTagStateAsync(tagStateId);
+                Assert.True(result.IsSuccess, result.IsSuccess ? string.Empty : result.GetException().ToString());
+                Assert.Equal(2, result.GetValue().Version);
+            });
+    }
+
+    [Fact]
+    public async Task CancellationTokenRelay_WithoutResultInMemoryExecutor_ReachesNativeStream()
+    {
+        var eventStore = new CountingEventStore();
+#pragma warning disable CS0618
+        WithoutResultExecutor executor = new WithoutResultInMemoryDcbExecutor(
+            TestSiloConfigurator.CreateDomainTypes(),
+            eventStore);
+#pragma warning restore CS0618
+
+        await AssertInMemoryExecutorCancellationRelayAsync(
+            eventStore,
+            async (tagStateId, cancellationToken) =>
+            {
+                await Assert.ThrowsAnyAsync<OperationCanceledException>(
+                    () => executor.GetTagStateAsync(tagStateId, cancellationToken));
+            },
+            async tagStateId =>
+            {
+                var state = await executor.GetTagStateAsync(tagStateId);
+                Assert.Equal(2, state.Version);
+            });
+    }
+
     private static async Task AssertPreCancelledTokenAsync(IClusterClient client)
     {
         ResetSharedState();
@@ -319,6 +423,102 @@ public class OrleansTagStateGrainPersistenceTests : IAsyncLifetime
         Assert.Equal(1, SharedTagStateCacheStorage.TagStateWriteCount);
     }
 
+    private static async Task AssertOrleansExecutorCancellationRelayAsync(
+        IClusterClient client,
+        Func<TagStateId, CancellationToken, Task> cancelledRead,
+        Func<TagStateId, Task> recovery)
+    {
+        ResetSharedState();
+        var aggregateId = Guid.NewGuid();
+        var tagStateId = BuildTagStateId(aggregateId);
+        var tag = BuildTag(aggregateId);
+        var grain = GetTagStateGrain(client, tagStateId);
+
+        await SharedEventStore.WriteEventsAsync(
+            new[]
+            {
+                CreateEvent(new CounterIncremented(1), tag, "001"),
+                CreateEvent(new CounterIncremented(2), tag, "002")
+            });
+
+        // Prime the actual grain, then clear its persistence cache so the public executor must relay into a stream.
+        await WaitForStateAsync(grain, 2, TimeSpan.FromSeconds(10));
+        await grain.ClearCacheAsync();
+        SharedEventStore.ClearCounts();
+        SharedGrainRequestCounter.Clear();
+        SharedTagStateCacheStorage.ClearWriteCount();
+        var firstRowGate = SharedEventStore.GateFirstStreamRow();
+
+        using var cancellation = new CancellationTokenSource();
+        var stateTask = cancelledRead(tagStateId, cancellation.Token);
+        try
+        {
+            await firstRowGate.FirstRowReached.WaitAsync(TimeSpan.FromSeconds(10));
+            cancellation.Cancel();
+            await firstRowGate.GrainSideCancellationObserved.WaitAsync(TimeSpan.FromSeconds(10));
+        }
+        finally
+        {
+            firstRowGate.AbortForCleanup();
+        }
+
+        await stateTask.WaitAsync(TimeSpan.FromSeconds(10));
+        Assert.Equal(1, SharedGrainRequestCounter.GetStateRequestCount);
+        Assert.Equal(1, SharedEventStore.StreamRowsRead);
+        Assert.Equal(0, SharedEventStore.StreamCallbackCount);
+        Assert.True(firstRowGate.ReceivedCancelableGrainToken);
+        Assert.Equal(0, SharedTagStateCacheStorage.TagStateWriteCount);
+
+        SharedEventStore.ClearCounts();
+        await recovery(tagStateId);
+        Assert.Equal(1, SharedEventStore.StreamSerializableEventsByTagCallCount);
+        Assert.Equal(2, SharedEventStore.StreamRowsRead);
+        Assert.Equal(1, SharedTagStateCacheStorage.TagStateWriteCount);
+    }
+
+    private static async Task AssertInMemoryExecutorCancellationRelayAsync(
+        CountingEventStore eventStore,
+        Func<TagStateId, CancellationToken, Task> cancelledRead,
+        Func<TagStateId, Task> recovery)
+    {
+        eventStore.Clear();
+        eventStore.ClearCounts();
+        var aggregateId = Guid.NewGuid();
+        var tagStateId = BuildTagStateId(aggregateId);
+        var tag = BuildTag(aggregateId);
+
+        await eventStore.WriteEventsAsync(
+            new[]
+            {
+                CreateEvent(new CounterIncremented(1), tag, "001"),
+                CreateEvent(new CounterIncremented(2), tag, "002")
+            });
+
+        var firstRowGate = eventStore.GateFirstStreamRow();
+        using var cancellation = new CancellationTokenSource();
+        var stateTask = cancelledRead(tagStateId, cancellation.Token);
+        try
+        {
+            await firstRowGate.FirstRowReached.WaitAsync(TimeSpan.FromSeconds(10));
+            cancellation.Cancel();
+            await firstRowGate.GrainSideCancellationObserved.WaitAsync(TimeSpan.FromSeconds(10));
+        }
+        finally
+        {
+            firstRowGate.AbortForCleanup();
+        }
+
+        await stateTask.WaitAsync(TimeSpan.FromSeconds(10));
+        Assert.Equal(1, eventStore.StreamRowsRead);
+        Assert.Equal(0, eventStore.StreamCallbackCount);
+        Assert.True(firstRowGate.ReceivedCancelableGrainToken);
+
+        eventStore.ClearCounts();
+        await recovery(tagStateId);
+        Assert.Equal(1, eventStore.StreamSerializableEventsByTagCallCount);
+        Assert.Equal(2, eventStore.StreamRowsRead);
+    }
+
     private ITagStateGrain GetTagStateGrain(TagStateId id) =>
         GetTagStateGrain(_client, id);
 
@@ -374,6 +574,16 @@ public class OrleansTagStateGrainPersistenceTests : IAsyncLifetime
     {
         public static bool WaitForCancellationAcknowledgement { get; set; } = true;
 
+        public static DcbDomainTypes CreateDomainTypes() =>
+            new(
+                eventTypes: BuildEventTypes(),
+                tagTypes: BuildTagTypes(),
+                tagProjectorTypes: BuildTagProjectorTypes(),
+                tagStatePayloadTypes: BuildTagStatePayloadTypes(),
+                multiProjectorTypes: BuildMultiProjectorTypes(),
+                queryTypes: new SimpleQueryTypes(),
+                new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
         public void Configure(ISiloBuilder siloBuilder)
         {
             siloBuilder
@@ -382,18 +592,7 @@ public class OrleansTagStateGrainPersistenceTests : IAsyncLifetime
                 .AddIncomingGrainCallFilter(SharedGrainRequestCounter)
                 .ConfigureServices(services =>
                 {
-                    services.AddSingleton<DcbDomainTypes>(provider =>
-                    {
-                        var domainTypes = new DcbDomainTypes(
-                            eventTypes: BuildEventTypes(),
-                            tagTypes: BuildTagTypes(),
-                            tagProjectorTypes: BuildTagProjectorTypes(),
-                            tagStatePayloadTypes: BuildTagStatePayloadTypes(),
-                            multiProjectorTypes: BuildMultiProjectorTypes(),
-                            queryTypes: new SimpleQueryTypes(),
-                            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
-                        return domainTypes;
-                    });
+                    services.AddSingleton<DcbDomainTypes>(_ => CreateDomainTypes());
 
                     services.AddSingleton<IEventStore>(SharedEventStore);
                     services.AddSingleton<IMultiProjectionStateStore, Sekiban.Dcb.Testing.InMemoryMultiProjectionStateStore>();

--- a/dcb/tests/Sekiban.Dcb.Orleans.Tests/OrleansTagStateGrainPersistenceTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Orleans.Tests/OrleansTagStateGrainPersistenceTests.cs
@@ -31,30 +31,44 @@ public class OrleansTagStateGrainPersistenceTests : IAsyncLifetime
 
     public async Task InitializeAsync()
     {
-        var builder = new TestClusterBuilder();
-        builder.Options.InitialSilosCount = 1;
-        var uniqueId = Guid.NewGuid().ToString("N")[..8];
-        builder.Options.ClusterId = $"TestCluster-Counter-{uniqueId}";
-        builder.Options.ServiceId = $"TestService-Counter-{uniqueId}";
-        var portBase = 20_000 + (Environment.ProcessId % 5_000) * 4;
-        builder.PortAllocator = new FixedPortAllocator(portBase, portBase + 100);
-        builder.Options.BaseSiloPort = portBase;
-        builder.Options.BaseGatewayPort = portBase + 1;
-        builder.AddSiloBuilderConfigurator<TestSiloConfigurator>();
-        builder.AddClientBuilderConfigurator<TestClientConfigurator>();
-
-        _cluster = builder.Build();
-        await _cluster.DeployAsync();
-
-        SharedEventStore.Clear();
-        SharedEventStore.ClearCounts();
-        SharedGrainRequestCounter.Clear();
+        _cluster = await CreateClusterAsync(waitForCancellationAcknowledgement: true, portOffset: 0);
+        ResetSharedState();
     }
 
     public async Task DisposeAsync()
     {
         await _cluster.StopAllSilosAsync();
         _cluster.Dispose();
+    }
+
+    private static async Task<TestCluster> CreateClusterAsync(
+        bool waitForCancellationAcknowledgement,
+        int portOffset)
+    {
+        TestSiloConfigurator.WaitForCancellationAcknowledgement = waitForCancellationAcknowledgement;
+        TestClientConfigurator.WaitForCancellationAcknowledgement = waitForCancellationAcknowledgement;
+        var builder = new TestClusterBuilder();
+        builder.Options.InitialSilosCount = 1;
+        var uniqueId = Guid.NewGuid().ToString("N")[..8];
+        builder.Options.ClusterId = $"TestCluster-Counter-{uniqueId}";
+        builder.Options.ServiceId = $"TestService-Counter-{uniqueId}";
+        var portBase = 20_000 + (Environment.ProcessId % 5_000) * 4 + portOffset;
+        builder.PortAllocator = new FixedPortAllocator(portBase, portBase + 100);
+        builder.Options.BaseSiloPort = portBase;
+        builder.Options.BaseGatewayPort = portBase + 1;
+        builder.AddSiloBuilderConfigurator<TestSiloConfigurator>();
+        builder.AddClientBuilderConfigurator<TestClientConfigurator>();
+
+        var cluster = builder.Build();
+        await cluster.DeployAsync();
+        return cluster;
+    }
+
+    private static void ResetSharedState()
+    {
+        SharedEventStore.Clear();
+        SharedEventStore.ClearCounts();
+        SharedGrainRequestCounter.Clear();
     }
 
     [Fact]
@@ -183,9 +197,35 @@ public class OrleansTagStateGrainPersistenceTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task CancellationTokenProbe_PreCancelledToken_DoesNotDispatchOrRead()
+    public Task CancellationTokenProbe_AckTrue_PreCancelledToken_DoesNotDispatchOrRead() =>
+        AssertPreCancelledTokenAsync(_client);
+
+    [Fact]
+    public Task CancellationTokenProbe_AckTrue_PostDispatchCancellationAcknowledgedByGrainTokenStopsAfterFirstRow() =>
+        AssertPostDispatchCancellationAsync(_client);
+
+    [Fact]
+    public async Task CancellationTokenProbe_AckFalse_CoversPreCancelledAndPostDispatchCancellation()
     {
-        var grain = GetTagStateGrain(BuildTagStateId(Guid.NewGuid()));
+        var cluster = await CreateClusterAsync(waitForCancellationAcknowledgement: false, portOffset: 2_000);
+        try
+        {
+            await AssertPreCancelledTokenAsync(cluster.Client);
+            await AssertPostDispatchCancellationAsync(cluster.Client);
+        }
+        finally
+        {
+            await cluster.StopAllSilosAsync();
+            cluster.Dispose();
+            TestSiloConfigurator.WaitForCancellationAcknowledgement = true;
+            TestClientConfigurator.WaitForCancellationAcknowledgement = true;
+        }
+    }
+
+    private static async Task AssertPreCancelledTokenAsync(IClusterClient client)
+    {
+        ResetSharedState();
+        var grain = GetTagStateGrain(client, BuildTagStateId(Guid.NewGuid()));
         using var cancellation = new CancellationTokenSource();
         cancellation.Cancel();
 
@@ -198,13 +238,13 @@ public class OrleansTagStateGrainPersistenceTests : IAsyncLifetime
         Assert.Equal(0, SharedEventStore.StreamCallbackCount);
     }
 
-    [Fact]
-    public async Task CancellationTokenProbe_PostDispatchCancellationAcknowledgedByGrainTokenStopsAfterFirstRow()
+    private static async Task AssertPostDispatchCancellationAsync(IClusterClient client)
     {
+        ResetSharedState();
         var aggregateId = Guid.NewGuid();
         var tagStateId = BuildTagStateId(aggregateId);
         var tag = BuildTag(aggregateId);
-        var grain = GetTagStateGrain(tagStateId);
+        var grain = GetTagStateGrain(client, tagStateId);
 
         await SharedEventStore.WriteEventsAsync(
             new[]
@@ -225,37 +265,25 @@ public class OrleansTagStateGrainPersistenceTests : IAsyncLifetime
         try
         {
             await firstRowGate.FirstRowReached.WaitAsync(TimeSpan.FromSeconds(10));
-            Assert.Equal(1, SharedGrainRequestCounter.GetStateRequestCount);
-            Assert.Equal(1, SharedEventStore.StreamSerializableEventsByTagCallCount);
-            Assert.Equal(1, SharedEventStore.StreamRowsRead);
-
             cancellation.Cancel();
-            var cancellationSignal = firstRowGate.GrainSideCancellationObserved;
-            if (await Task.WhenAny(cancellationSignal, Task.Delay(TimeSpan.FromSeconds(10))) != cancellationSignal)
-            {
-                throw new TimeoutException(
-                    $"Grain-side cancellation was not observed after caller cancellation. " +
-                    $"incomingGetState={SharedGrainRequestCounter.GetStateRequestCount}, " +
-                    $"streamCalls={SharedEventStore.StreamSerializableEventsByTagCallCount}, " +
-                    $"providerRows={SharedEventStore.StreamRowsRead}, " +
-                    $"callbacks={SharedEventStore.StreamCallbackCount}, " +
-                    $"cancelableGrainToken={firstRowGate.ReceivedCancelableGrainToken}.");
-            }
+            await firstRowGate.GrainSideCancellationObserved.WaitAsync(TimeSpan.FromSeconds(10));
         }
         finally
         {
-            // The provider may advance only after the grain-side cancellation callback has run.
-            firstRowGate.ReleaseFirstRow();
+            firstRowGate.AbortForCleanup();
         }
 
-        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await stateTask);
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await stateTask.WaitAsync(TimeSpan.FromSeconds(10)));
         Assert.Equal(1, SharedEventStore.StreamRowsRead);
         Assert.Equal(0, SharedEventStore.StreamCallbackCount);
         Assert.True(firstRowGate.ReceivedCancelableGrainToken);
     }
 
     private ITagStateGrain GetTagStateGrain(TagStateId id) =>
-        _client.GetGrain<ITagStateGrain>(id.GetTagStateId());
+        GetTagStateGrain(_client, id);
+
+    private static ITagStateGrain GetTagStateGrain(IClusterClient client, TagStateId id) =>
+        client.GetGrain<ITagStateGrain>(id.GetTagStateId());
 
     private static TagStateId BuildTagStateId(Guid id) => new TagStateId(BuildTag(id), "CounterProjector");
 
@@ -272,7 +300,7 @@ public class OrleansTagStateGrainPersistenceTests : IAsyncLifetime
             new List<string> { tag.GetTag() });
     }
 
-    private async Task<SerializableTagState> WaitForStateAsync(
+    private static async Task<SerializableTagState> WaitForStateAsync(
         ITagStateGrain grain,
         int minVersion,
         TimeSpan? timeout = null)
@@ -304,10 +332,13 @@ public class OrleansTagStateGrainPersistenceTests : IAsyncLifetime
 
     private class TestSiloConfigurator : ISiloConfigurator
     {
+        public static bool WaitForCancellationAcknowledgement { get; set; } = true;
+
         public void Configure(ISiloBuilder siloBuilder)
         {
             siloBuilder
-                .Configure<SiloMessagingOptions>(options => options.WaitForCancellationAcknowledgement = true)
+                .Configure<SiloMessagingOptions>(
+                    options => options.WaitForCancellationAcknowledgement = WaitForCancellationAcknowledgement)
                 .AddIncomingGrainCallFilter(SharedGrainRequestCounter)
                 .ConfigureServices(services =>
                 {
@@ -380,10 +411,12 @@ public class OrleansTagStateGrainPersistenceTests : IAsyncLifetime
 
     private sealed class TestClientConfigurator : IClientBuilderConfigurator
     {
+        public static bool WaitForCancellationAcknowledgement { get; set; } = true;
+
         public void Configure(IConfiguration configuration, IClientBuilder clientBuilder)
         {
             clientBuilder.Configure<ClientMessagingOptions>(
-                options => options.WaitForCancellationAcknowledgement = true);
+                options => options.WaitForCancellationAcknowledgement = WaitForCancellationAcknowledgement);
         }
     }
 
@@ -543,27 +576,30 @@ public class OrleansTagStateGrainPersistenceTests : IAsyncLifetime
         {
             StreamSerializableEventsByTagCallCount++;
             var firstRowGate = _firstRowGate;
-            using var grainCancellationRegistration = firstRowGate is null
-                ? default(CancellationTokenRegistration)
-                : cancellationToken.Register(static state => ((FirstRowGate)state!).ObserveGrainSideCancellation(), firstRowGate);
-
-            return await ((IStreamingTaggedSerializableEventStore)_inner).StreamSerializableEventsByTagAsync(
-                tag,
-                since,
-                until,
-                async serializableEvent =>
-                {
-                    Interlocked.Increment(ref _streamRowsRead);
-                    if (firstRowGate?.TryReachFirstRow(cancellationToken) == true)
+            try
+            {
+                return await ((IStreamingTaggedSerializableEventStore)_inner).StreamSerializableEventsByTagAsync(
+                    tag,
+                    since,
+                    until,
+                    async serializableEvent =>
                     {
-                        await firstRowGate.WaitForReleaseAsync(cancellationToken);
-                    }
+                        Interlocked.Increment(ref _streamRowsRead);
+                        if (firstRowGate?.TryReachFirstRow(cancellationToken) == true)
+                        {
+                            await firstRowGate.WaitForReleaseAsync(cancellationToken);
+                        }
 
-                    cancellationToken.ThrowIfCancellationRequested();
-                    Interlocked.Increment(ref _streamCallbackCount);
-                    await onEvent(serializableEvent);
-                },
-                cancellationToken);
+                        cancellationToken.ThrowIfCancellationRequested();
+                        Interlocked.Increment(ref _streamCallbackCount);
+                        await onEvent(serializableEvent);
+                    },
+                    cancellationToken);
+            }
+            finally
+            {
+                firstRowGate?.DisposeCancellationRegistration();
+            }
         }
 
         public Task<ResultBox<(IReadOnlyList<SerializableEvent> Events, IReadOnlyList<TagWriteResult> TagWrites)>> WriteSerializableEventsAsync(
@@ -577,6 +613,8 @@ public class OrleansTagStateGrainPersistenceTests : IAsyncLifetime
             private readonly TaskCompletionSource<bool> _releaseFirstRow = new(TaskCreationOptions.RunContinuationsAsynchronously);
             private int _firstRowReachedOnce;
             private int _receivedCancelableGrainToken;
+            private int _cancellationRegistrationCreated;
+            private CancellationTokenRegistration _cancellationRegistration;
 
             public Task FirstRowReached => _firstRowReached.Task;
             public Task GrainSideCancellationObserved => _grainSideCancellationObserved.Task;
@@ -598,12 +636,30 @@ public class OrleansTagStateGrainPersistenceTests : IAsyncLifetime
                 return true;
             }
 
-            public Task WaitForReleaseAsync(CancellationToken cancellationToken) =>
-                _releaseFirstRow.Task.WaitAsync(cancellationToken);
+            public Task WaitForReleaseAsync(CancellationToken cancellationToken)
+            {
+                // WaitAsync registers its cancellation callback first. The observation callback then runs before it
+                // when the token is cancelled, records the grain-side observation, and releases this gate itself.
+                var wait = _releaseFirstRow.Task.WaitAsync(cancellationToken);
+                if (Interlocked.CompareExchange(ref _cancellationRegistrationCreated, 1, 0) == 0)
+                {
+                    _cancellationRegistration = cancellationToken.Register(
+                        static state => ((FirstRowGate)state!).ObserveAndRelease(),
+                        this);
+                }
 
-            public void ObserveGrainSideCancellation() => _grainSideCancellationObserved.TrySetResult(true);
+                return wait;
+            }
 
-            public void ReleaseFirstRow() => _releaseFirstRow.TrySetResult(true);
+            public void ObserveAndRelease()
+            {
+                _grainSideCancellationObserved.TrySetResult(true);
+                _releaseFirstRow.TrySetResult(true);
+            }
+
+            public void AbortForCleanup() => _releaseFirstRow.TrySetResult(true);
+
+            public void DisposeCancellationRegistration() => _cancellationRegistration.Dispose();
         }
     }
 }

--- a/dcb/tests/Sekiban.Dcb.Orleans.Tests/OrleansTagStateGrainPersistenceTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Orleans.Tests/OrleansTagStateGrainPersistenceTests.cs
@@ -10,7 +10,11 @@ using Sekiban.Dcb.Orleans.Grains;
 using Sekiban.Dcb.Storage;
 using Sekiban.Dcb.Tags;
 using Sekiban.Dcb.Testing;
+using Microsoft.Extensions.Configuration;
 using Orleans.TestingHost;
+using Orleans;
+using Orleans.Configuration;
+using Orleans.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using System.Text.Json;
 using Xunit;
@@ -20,6 +24,7 @@ public class OrleansTagStateGrainPersistenceTests : IAsyncLifetime
 {
     // Shared in-memory store per test run to keep state deterministic and inspectable
     private static readonly CountingEventStore SharedEventStore = new();
+    private static readonly TagStateGrainRequestCounter SharedGrainRequestCounter = new();
 
     private TestCluster _cluster = null!;
     private IClusterClient _client => _cluster.Client;
@@ -31,13 +36,19 @@ public class OrleansTagStateGrainPersistenceTests : IAsyncLifetime
         var uniqueId = Guid.NewGuid().ToString("N")[..8];
         builder.Options.ClusterId = $"TestCluster-Counter-{uniqueId}";
         builder.Options.ServiceId = $"TestService-Counter-{uniqueId}";
+        var portBase = 20_000 + (Environment.ProcessId % 5_000) * 4;
+        builder.PortAllocator = new FixedPortAllocator(portBase, portBase + 100);
+        builder.Options.BaseSiloPort = portBase;
+        builder.Options.BaseGatewayPort = portBase + 1;
         builder.AddSiloBuilderConfigurator<TestSiloConfigurator>();
+        builder.AddClientBuilderConfigurator<TestClientConfigurator>();
 
         _cluster = builder.Build();
         await _cluster.DeployAsync();
 
         SharedEventStore.Clear();
         SharedEventStore.ClearCounts();
+        SharedGrainRequestCounter.Clear();
     }
 
     public async Task DisposeAsync()
@@ -171,6 +182,78 @@ public class OrleansTagStateGrainPersistenceTests : IAsyncLifetime
         Assert.Equal(0, SharedEventStore.StreamSerializableEventsByTagCallCount);
     }
 
+    [Fact]
+    public async Task CancellationTokenProbe_PreCancelledToken_DoesNotDispatchOrRead()
+    {
+        var grain = GetTagStateGrain(BuildTagStateId(Guid.NewGuid()));
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await grain.GetStateAsync(cancellation.Token));
+
+        Assert.Equal(0, SharedGrainRequestCounter.GetStateRequestCount);
+        Assert.Equal(0, SharedEventStore.ReadSerializableEventsByTagCallCount);
+        Assert.Equal(0, SharedEventStore.StreamSerializableEventsByTagCallCount);
+        Assert.Equal(0, SharedEventStore.StreamRowsRead);
+        Assert.Equal(0, SharedEventStore.StreamCallbackCount);
+    }
+
+    [Fact]
+    public async Task CancellationTokenProbe_PostDispatchCancellationAcknowledgedByGrainTokenStopsAfterFirstRow()
+    {
+        var aggregateId = Guid.NewGuid();
+        var tagStateId = BuildTagStateId(aggregateId);
+        var tag = BuildTag(aggregateId);
+        var grain = GetTagStateGrain(tagStateId);
+
+        await SharedEventStore.WriteEventsAsync(
+            new[]
+            {
+                CreateEvent(new CounterIncremented(1), tag, "001"),
+                CreateEvent(new CounterIncremented(2), tag, "002")
+            });
+
+        // Prime the tag-consistent actor, then clear the cache so the measured request must stream both rows.
+        await WaitForStateAsync(grain, 2, TimeSpan.FromSeconds(10));
+        await grain.ClearCacheAsync();
+        SharedEventStore.ClearCounts();
+        SharedGrainRequestCounter.Clear();
+        var firstRowGate = SharedEventStore.GateFirstStreamRow();
+
+        using var cancellation = new CancellationTokenSource();
+        var stateTask = grain.GetStateAsync(cancellation.Token);
+        try
+        {
+            await firstRowGate.FirstRowReached.WaitAsync(TimeSpan.FromSeconds(10));
+            Assert.Equal(1, SharedGrainRequestCounter.GetStateRequestCount);
+            Assert.Equal(1, SharedEventStore.StreamSerializableEventsByTagCallCount);
+            Assert.Equal(1, SharedEventStore.StreamRowsRead);
+
+            cancellation.Cancel();
+            var cancellationSignal = firstRowGate.GrainSideCancellationObserved;
+            if (await Task.WhenAny(cancellationSignal, Task.Delay(TimeSpan.FromSeconds(10))) != cancellationSignal)
+            {
+                throw new TimeoutException(
+                    $"Grain-side cancellation was not observed after caller cancellation. " +
+                    $"incomingGetState={SharedGrainRequestCounter.GetStateRequestCount}, " +
+                    $"streamCalls={SharedEventStore.StreamSerializableEventsByTagCallCount}, " +
+                    $"providerRows={SharedEventStore.StreamRowsRead}, " +
+                    $"callbacks={SharedEventStore.StreamCallbackCount}, " +
+                    $"cancelableGrainToken={firstRowGate.ReceivedCancelableGrainToken}.");
+            }
+        }
+        finally
+        {
+            // The provider may advance only after the grain-side cancellation callback has run.
+            firstRowGate.ReleaseFirstRow();
+        }
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await stateTask);
+        Assert.Equal(1, SharedEventStore.StreamRowsRead);
+        Assert.Equal(0, SharedEventStore.StreamCallbackCount);
+        Assert.True(firstRowGate.ReceivedCancelableGrainToken);
+    }
+
     private ITagStateGrain GetTagStateGrain(TagStateId id) =>
         _client.GetGrain<ITagStateGrain>(id.GetTagStateId());
 
@@ -224,6 +307,8 @@ public class OrleansTagStateGrainPersistenceTests : IAsyncLifetime
         public void Configure(ISiloBuilder siloBuilder)
         {
             siloBuilder
+                .Configure<SiloMessagingOptions>(options => options.WaitForCancellationAcknowledgement = true)
+                .AddIncomingGrainCallFilter(SharedGrainRequestCounter)
                 .ConfigureServices(services =>
                 {
                     services.AddSingleton<DcbDomainTypes>(provider =>
@@ -291,6 +376,42 @@ public class OrleansTagStateGrainPersistenceTests : IAsyncLifetime
             var multiProjectorTypes = new SimpleMultiProjectorTypes();
             return multiProjectorTypes;
         }
+        }
+
+    private sealed class TestClientConfigurator : IClientBuilderConfigurator
+    {
+        public void Configure(IConfiguration configuration, IClientBuilder clientBuilder)
+        {
+            clientBuilder.Configure<ClientMessagingOptions>(
+                options => options.WaitForCancellationAcknowledgement = true);
+        }
+    }
+
+    private sealed class FixedPortAllocator(int baseSiloPort, int baseGatewayPort) : ITestClusterPortAllocator
+    {
+        public (int, int) AllocateConsecutivePortPairs(int numPorts) => (baseSiloPort, baseGatewayPort);
+
+        public void Dispose() { }
+    }
+
+    private sealed class TagStateGrainRequestCounter : IIncomingGrainCallFilter
+    {
+        private int _getStateRequestCount;
+
+        public int GetStateRequestCount => Volatile.Read(ref _getStateRequestCount);
+
+        public void Clear() => Interlocked.Exchange(ref _getStateRequestCount, 0);
+
+        public Task Invoke(IIncomingGrainCallContext context)
+        {
+            if (context.Grain is TagStateGrain &&
+                context.InterfaceMethod.Name == nameof(ITagStateGrain.GetStateAsync))
+            {
+                Interlocked.Increment(ref _getStateRequestCount);
+            }
+
+            return context.Invoke();
+        }
     }
 
     public record CounterIncremented(int Delta) : IEventPayload;
@@ -333,15 +454,30 @@ public class OrleansTagStateGrainPersistenceTests : IAsyncLifetime
         ITaggedStreamCapabilityProvider
     {
         private readonly InMemoryEventStore _inner = CreateInnerStore();
+        private FirstRowGate? _firstRowGate;
+        private int _streamRowsRead;
+        private int _streamCallbackCount;
 
         public void Clear() => _inner.Clear();
         public int ReadSerializableEventsByTagCallCount { get; private set; }
         public int StreamSerializableEventsByTagCallCount { get; private set; }
+        public int StreamRowsRead => Volatile.Read(ref _streamRowsRead);
+        public int StreamCallbackCount => Volatile.Read(ref _streamCallbackCount);
 
         public void ClearCounts()
         {
             ReadSerializableEventsByTagCallCount = 0;
             StreamSerializableEventsByTagCallCount = 0;
+            Interlocked.Exchange(ref _streamRowsRead, 0);
+            Interlocked.Exchange(ref _streamCallbackCount, 0);
+            _firstRowGate = null;
+        }
+
+        public FirstRowGate GateFirstStreamRow()
+        {
+            var gate = new FirstRowGate();
+            _firstRowGate = gate;
+            return gate;
         }
 
         public TaggedStreamCapabilityDescriptor DescribeTaggedStream() =>
@@ -398,7 +534,7 @@ public class OrleansTagStateGrainPersistenceTests : IAsyncLifetime
         public Task<ResultBox<SerializableEvent>> ReadSerializableEventAsync(Guid eventId)
             => _inner.ReadSerializableEventAsync(eventId);
 
-        public Task<ResultBox<SerializableEventStreamReadResult>> StreamSerializableEventsByTagAsync(
+        public async Task<ResultBox<SerializableEventStreamReadResult>> StreamSerializableEventsByTagAsync(
             ITag tag,
             SortableUniqueId? since,
             SortableUniqueId? until,
@@ -406,16 +542,68 @@ public class OrleansTagStateGrainPersistenceTests : IAsyncLifetime
             CancellationToken cancellationToken = default)
         {
             StreamSerializableEventsByTagCallCount++;
-            return ((IStreamingTaggedSerializableEventStore)_inner).StreamSerializableEventsByTagAsync(
+            var firstRowGate = _firstRowGate;
+            using var grainCancellationRegistration = firstRowGate is null
+                ? default(CancellationTokenRegistration)
+                : cancellationToken.Register(static state => ((FirstRowGate)state!).ObserveGrainSideCancellation(), firstRowGate);
+
+            return await ((IStreamingTaggedSerializableEventStore)_inner).StreamSerializableEventsByTagAsync(
                 tag,
                 since,
                 until,
-                onEvent,
+                async serializableEvent =>
+                {
+                    Interlocked.Increment(ref _streamRowsRead);
+                    if (firstRowGate?.TryReachFirstRow(cancellationToken) == true)
+                    {
+                        await firstRowGate.WaitForReleaseAsync(cancellationToken);
+                    }
+
+                    cancellationToken.ThrowIfCancellationRequested();
+                    Interlocked.Increment(ref _streamCallbackCount);
+                    await onEvent(serializableEvent);
+                },
                 cancellationToken);
         }
 
         public Task<ResultBox<(IReadOnlyList<SerializableEvent> Events, IReadOnlyList<TagWriteResult> TagWrites)>> WriteSerializableEventsAsync(
             IEnumerable<SerializableEvent> events)
             => _inner.WriteSerializableEventsAsync(events);
+
+        public sealed class FirstRowGate
+        {
+            private readonly TaskCompletionSource<bool> _firstRowReached = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            private readonly TaskCompletionSource<bool> _grainSideCancellationObserved = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            private readonly TaskCompletionSource<bool> _releaseFirstRow = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            private int _firstRowReachedOnce;
+            private int _receivedCancelableGrainToken;
+
+            public Task FirstRowReached => _firstRowReached.Task;
+            public Task GrainSideCancellationObserved => _grainSideCancellationObserved.Task;
+            public bool ReceivedCancelableGrainToken => Volatile.Read(ref _receivedCancelableGrainToken) == 1;
+
+            public bool TryReachFirstRow(CancellationToken grainSideCancellationToken)
+            {
+                if (Interlocked.CompareExchange(ref _firstRowReachedOnce, 1, 0) != 0)
+                {
+                    return false;
+                }
+
+                if (grainSideCancellationToken.CanBeCanceled)
+                {
+                    Interlocked.Exchange(ref _receivedCancelableGrainToken, 1);
+                }
+
+                _firstRowReached.TrySetResult(true);
+                return true;
+            }
+
+            public Task WaitForReleaseAsync(CancellationToken cancellationToken) =>
+                _releaseFirstRow.Task.WaitAsync(cancellationToken);
+
+            public void ObserveGrainSideCancellation() => _grainSideCancellationObserved.TrySetResult(true);
+
+            public void ReleaseFirstRow() => _releaseFirstRow.TrySetResult(true);
+        }
     }
 }

--- a/dcb/tests/Sekiban.Dcb.Orleans.Tests/Sekiban.Dcb.Orleans.Tests.csproj
+++ b/dcb/tests/Sekiban.Dcb.Orleans.Tests/Sekiban.Dcb.Orleans.Tests.csproj
@@ -36,6 +36,23 @@
         <ProjectReference Include="..\..\internalUsages\Dcb.Domain\Dcb.Domain.csproj"/>
         <ProjectReference Include="..\Sekiban.Dcb.WithResult.Tests\Sekiban.Dcb.WithResult.Tests.csproj"/>
         <ProjectReference Include="..\..\src\Sekiban.Dcb.Core.Testing\Sekiban.Dcb.Core.Testing.csproj" />
+        <!-- Build the pre-SEK-G55 grain client separately and copy only its output so the v10.18 package graph does
+             not participate in this test project's compile-time dependency resolution. -->
+        <ProjectReference Include="..\Sekiban.Dcb.TagStateCancellation.Legacy1018Fixture\Sekiban.Dcb.TagStateCancellation.Legacy1018Fixture.csproj"
+                          ReferenceOutputAssembly="false" />
     </ItemGroup>
+
+    <Target Name="CopyTagStateCancellationLegacy1018Fixture"
+            AfterTargets="Build"
+            Condition="'$(TargetFramework)' != ''">
+        <MSBuild Projects="$(MSBuildProjectDirectory)/../Sekiban.Dcb.TagStateCancellation.Legacy1018Fixture/Sekiban.Dcb.TagStateCancellation.Legacy1018Fixture.csproj"
+                 Targets="Build;GetTargetPath"
+                 Properties="Configuration=$(Configuration);TargetFramework=$(TargetFramework);ArtifactsPath=$(ArtifactsPath)">
+            <Output TaskParameter="TargetOutputs" ItemName="_TagStateCancellationLegacy1018FixtureOutput" />
+        </MSBuild>
+        <Copy SourceFiles="@(_TagStateCancellationLegacy1018FixtureOutput)"
+              DestinationFolder="$(OutputPath)"
+              SkipUnchangedFiles="true" />
+    </Target>
 
 </Project>

--- a/dcb/tests/Sekiban.Dcb.Orleans.Tests/Sekiban.Dcb.Orleans.Tests.csproj
+++ b/dcb/tests/Sekiban.Dcb.Orleans.Tests/Sekiban.Dcb.Orleans.Tests.csproj
@@ -30,6 +30,9 @@
 
     <ItemGroup>
         <ProjectReference Include="..\..\src\Sekiban.Dcb.Orleans.WithResult\Sekiban.Dcb.Orleans.WithResult.csproj"/>
+        <ProjectReference Include="..\..\src\Sekiban.Dcb.Orleans.WithoutResult\Sekiban.Dcb.Orleans.WithoutResult.csproj" Aliases="WithoutResultFacade" />
+        <ProjectReference Include="..\..\src\Sekiban.Dcb.WithoutResult\Sekiban.Dcb.WithoutResult.csproj" Aliases="WithoutResultFacade" />
+        <ProjectReference Include="..\..\src\Sekiban.Dcb.WithoutResult.Model\Sekiban.Dcb.WithoutResult.Model.csproj" Aliases="WithoutResultFacade" />
         <ProjectReference Include="..\..\src\Sekiban.Dcb.MaterializedView.Orleans\Sekiban.Dcb.MaterializedView.Orleans.csproj"/>
         <ProjectReference Include="..\..\src\Sekiban.Dcb.Core\Sekiban.Dcb.Core.csproj"/>
         <ProjectReference Include="..\..\src\Sekiban.Dcb.Postgres\Sekiban.Dcb.Postgres.csproj"/>

--- a/dcb/tests/Sekiban.Dcb.TagStateCancellation.Legacy1018Fixture/Legacy1018TagStateActor.cs
+++ b/dcb/tests/Sekiban.Dcb.TagStateCancellation.Legacy1018Fixture/Legacy1018TagStateActor.cs
@@ -1,0 +1,40 @@
+using Sekiban.Dcb.Actors;
+using Sekiban.Dcb.Orleans.Grains;
+using Sekiban.Dcb.Tags;
+
+namespace Sekiban.Dcb.TagStateCancellation.Legacy1018Fixture;
+
+/// <summary>
+///     A real binary compiled before SEK-G55. It intentionally implements only the original interface members.
+/// </summary>
+public sealed class Legacy1018TagStateActor : ITagStateActorCommon
+{
+    public int GetStateCalls { get; private set; }
+
+    public Task<SerializableTagState> GetStateAsync()
+    {
+        GetStateCalls++;
+        return Task.FromResult(
+            new SerializableTagState(
+                Array.Empty<byte>(),
+                0,
+                string.Empty,
+                "Legacy",
+                "binary",
+                "Projector",
+                nameof(EmptyTagStatePayload),
+                string.Empty,
+                nameof(EmptyTagStatePayload)));
+    }
+
+    public Task<string> GetTagStateActorIdAsync() => Task.FromResult("Legacy:binary:Projector");
+}
+
+/// <summary>
+///     A pre-SEK-G55 client call-site. Its assembly reference has no knowledge of the cancellation overloads, so this
+///     call proves the unchanged token-less grain method remains dispatchable against the new silo.
+/// </summary>
+public static class Legacy1018TagStateGrainClient
+{
+    public static Task<SerializableTagState> GetStateAsync(ITagStateGrain grain) => grain.GetStateAsync();
+}

--- a/dcb/tests/Sekiban.Dcb.TagStateCancellation.Legacy1018Fixture/Sekiban.Dcb.TagStateCancellation.Legacy1018Fixture.csproj
+++ b/dcb/tests/Sekiban.Dcb.TagStateCancellation.Legacy1018Fixture/Sekiban.Dcb.TagStateCancellation.Legacy1018Fixture.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <!--
+      This assembly deliberately compiles against the published pre-SEK-G55 contract. It knows only the token-less
+      ITagStateActorCommon member, so loading it against the current runtime proves that the additive default member
+      remains binary compatible and delegates exactly once.
+    -->
+    <PropertyGroup>
+        <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+        <LangVersion>preview</LangVersion>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+        <GenerateSBOM>false</GenerateSBOM>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Sekiban.Dcb.Core" Version="10.18.0" />
+        <PackageReference Include="Sekiban.Dcb.Core.Model" Version="10.18.0" />
+        <PackageReference Include="Sekiban.Dcb.Orleans.Core" Version="10.18.0" />
+    </ItemGroup>
+
+</Project>

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/GeneralTagStateActorPersistenceTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/GeneralTagStateActorPersistenceTests.cs
@@ -228,6 +228,183 @@ public class GeneralTagStateActorPersistenceTests
     }
 
     [Fact]
+    public async Task CancellationToken_StopsTheActorStreamBeforeCachePublication_AndTheNextCallRebuilds()
+    {
+        var domainTypes = BuildDomainTypes();
+        var baseEventStore = new CoreInMemoryEventStore(domainTypes.EventTypes);
+        var eventStore = new GatedStreamingEventStore(baseEventStore);
+        var actorAccessor = new TestActorAccessor();
+        actorAccessor.SetLatestSortableUniqueId("TestTag:cancel", "002");
+        var persistent = new InMemorySerializableTagStatePersistent();
+        var tag = new TestTag("cancel");
+
+        await baseEventStore.WriteEventsAsync(
+            new[]
+            {
+                CreateEvent(new TestEvent { Value = 10 }, tag, "001"),
+                CreateEvent(new IncrementEvent { Increment = 2 }, tag, "002")
+            },
+            domainTypes.EventTypes);
+
+        var actor = new GeneralTagStateActor(
+            "TestTag:cancel:TestIncrementalProjector",
+            eventStore,
+            domainTypes.EventTypes,
+            domainTypes.TagProjectorTypes,
+            domainTypes.TagTypes,
+            domainTypes.TagStatePayloadTypes,
+            new TagStateOptions(),
+            actorAccessor,
+            persistent);
+
+        using var cancellation = new CancellationTokenSource();
+        var cancelledRead = actor.GetStateAsync(cancellation.Token);
+        try
+        {
+            await eventStore.FirstRowReached.WaitAsync(TimeSpan.FromSeconds(10));
+            cancellation.Cancel();
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await cancelledRead);
+        }
+        finally
+        {
+            eventStore.ReleaseFirstRow();
+        }
+
+        Assert.Equal(cancellation.Token, eventStore.ReceivedCancellationToken);
+        Assert.Equal(1, eventStore.RowsRead);
+        Assert.Equal(0, eventStore.ConsumerCallbacks);
+        Assert.Equal(0, persistent.SaveSerializableStateCalls);
+        Assert.Null(persistent.SavedState);
+
+        var recovered = await actor.GetStateAsync();
+        Assert.Equal(2, recovered.Version);
+        Assert.Equal(12, Assert.IsType<TestIncrementalState>(
+            domainTypes.TagStatePayloadTypes.DeserializePayload(recovered.ResolvedPayloadName, recovered.Payload).GetValue()).Total);
+        Assert.Equal(1, persistent.SaveSerializableStateCalls);
+    }
+
+    [Fact]
+    public async Task PreCancelledToken_DoesNotReachTheActorStreamingProvider()
+    {
+        var domainTypes = BuildDomainTypes();
+        var baseEventStore = new CoreInMemoryEventStore(domainTypes.EventTypes);
+        var eventStore = new GatedStreamingEventStore(baseEventStore);
+        var actorAccessor = new TestActorAccessor();
+        actorAccessor.SetLatestSortableUniqueId("TestTag:pre-cancel", "001");
+        var actor = new GeneralTagStateActor(
+            "TestTag:pre-cancel:TestIncrementalProjector",
+            eventStore,
+            domainTypes.EventTypes,
+            domainTypes.TagProjectorTypes,
+            domainTypes.TagTypes,
+            domainTypes.TagStatePayloadTypes,
+            new TagStateOptions(),
+            actorAccessor,
+            new InMemorySerializableTagStatePersistent());
+
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await actor.GetStateAsync(cancellation.Token));
+        Assert.Equal(0, eventStore.StreamCallCount);
+        Assert.Equal(0, eventStore.RowsRead);
+    }
+
+    [Fact]
+    public async Task TokenlessNoneAndLiveToken_ProduceIdenticalTaggedStreamStateAndProviderCounts()
+    {
+        var domainTypes = BuildDomainTypes();
+        var baseEventStore = new CoreInMemoryEventStore(domainTypes.EventTypes);
+        var tag = new TestTag("cancellation-parity");
+        await baseEventStore.WriteEventsAsync(
+            [
+                CreateEvent(new TestEvent { Value = 10 }, tag, "001"),
+                CreateEvent(new IncrementEvent { Increment = 2 }, tag, "002")
+            ],
+            domainTypes.EventTypes);
+
+        using var liveCancellation = new CancellationTokenSource();
+        var results = new List<(SerializableTagState State, int StreamCalls, int ListCalls)>();
+        foreach (var getState in new Func<GeneralTagStateActor, Task<SerializableTagState>>[]
+                 {
+                     actor => actor.GetStateAsync(),
+                     actor => actor.GetStateAsync(CancellationToken.None),
+                     actor => actor.GetStateAsync(liveCancellation.Token)
+                 })
+        {
+            var eventStore = new StreamingCountingEventStore(baseEventStore);
+            var actorAccessor = new TestActorAccessor();
+            actorAccessor.SetLatestSortableUniqueId("TestTag:cancellation-parity", "002");
+            var actor = new GeneralTagStateActor(
+                "TestTag:cancellation-parity:TestIncrementalProjector",
+                eventStore,
+                domainTypes.EventTypes,
+                domainTypes.TagProjectorTypes,
+                domainTypes.TagTypes,
+                domainTypes.TagStatePayloadTypes,
+                new TagStateOptions(),
+                actorAccessor,
+                new InMemorySerializableTagStatePersistent());
+
+            var state = await getState(actor);
+            results.Add((state, eventStore.StreamCallCount, eventStore.ReadEventsByTagCallCount));
+        }
+
+        var baseline = results[0];
+        Assert.All(results, result =>
+        {
+            Assert.Equal(baseline.State.Payload, result.State.Payload);
+            Assert.Equal(baseline.State.Version, result.State.Version);
+            Assert.Equal(baseline.State.LastSortedUniqueId, result.State.LastSortedUniqueId);
+            Assert.Equal(1, result.StreamCalls);
+            Assert.Equal(0, result.ListCalls);
+        });
+    }
+
+    [Fact]
+    public async Task CancellationDuringFinalSerialization_PreventsTheActorCacheWrite()
+    {
+        using var cancellation = new CancellationTokenSource();
+        var serializingPayloadTypes = new CountingTagStatePayloadTypes(new SimpleTagStatePayloadTypes());
+        serializingPayloadTypes.RegisterPayloadType<TestIncrementalState>();
+        serializingPayloadTypes.OnSerializePayload = cancellation.Cancel;
+        var domainTypes = BuildDomainTypes(tagStatePayloadTypes: serializingPayloadTypes);
+        var eventStore = new CoreInMemoryEventStore(domainTypes.EventTypes);
+        var actorAccessor = new TestActorAccessor();
+        actorAccessor.SetLatestSortableUniqueId("TestTag:cancel-before-save", "001");
+        var persistent = new InMemorySerializableTagStatePersistent();
+        var tag = new TestTag("cancel-before-save");
+
+        await eventStore.WriteEventsAsync(
+            [CreateEvent(new TestEvent { Value = 7 }, tag, "001")],
+            domainTypes.EventTypes);
+
+        var actor = new GeneralTagStateActor(
+            "TestTag:cancel-before-save:TestIncrementalProjector",
+            eventStore,
+            domainTypes.EventTypes,
+            domainTypes.TagProjectorTypes,
+            domainTypes.TagTypes,
+            domainTypes.TagStatePayloadTypes,
+            new TagStateOptions(),
+            actorAccessor,
+            persistent);
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
+            await actor.GetStateAsync(cancellation.Token));
+
+        Assert.Equal(1, serializingPayloadTypes.SerializePayloadCount);
+        Assert.Equal(0, persistent.SaveSerializableStateCalls);
+        Assert.Null(persistent.SavedState);
+
+        var recovered = await actor.GetStateAsync();
+        Assert.Equal(1, recovered.Version);
+        Assert.Equal(7, Assert.IsType<TestIncrementalState>(
+            domainTypes.TagStatePayloadTypes.DeserializePayload(recovered.ResolvedPayloadName, recovered.Payload).GetValue()).Total);
+        Assert.Equal(1, persistent.SaveSerializableStateCalls);
+    }
+
+    [Fact]
     public async Task OutOfOrderTaggedStream_FailsBeforeThePartialProjectionCanBeCached()
     {
         var domainTypes = BuildDomainTypes();
@@ -491,6 +668,56 @@ public class GeneralTagStateActorPersistenceTests
         }
     }
 
+    private sealed class GatedStreamingEventStore(IEventStore inner) : CountingEventStore(inner),
+        IStreamingTaggedSerializableEventStore, ITaggedStreamCapabilityProvider
+    {
+        private readonly TaskCompletionSource _firstRowReached = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource _releaseFirstRow = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private int _streamCallCount;
+        private int _rowsRead;
+        private int _consumerCallbacks;
+
+        public int StreamCallCount => _streamCallCount;
+        public int RowsRead => _rowsRead;
+        public int ConsumerCallbacks => _consumerCallbacks;
+        public CancellationToken ReceivedCancellationToken { get; private set; }
+        public Task FirstRowReached => _firstRowReached.Task;
+
+        public TaggedStreamCapabilityDescriptor DescribeTaggedStream() =>
+            TaggedStreamCapabilityDescriptor.Native("cancellation gate");
+
+        public async Task<ResultBox<SerializableEventStreamReadResult>> StreamSerializableEventsByTagAsync(
+            ITag tag,
+            SortableUniqueId? since,
+            SortableUniqueId? until,
+            Func<SerializableEvent, ValueTask> onEvent,
+            CancellationToken cancellationToken = default)
+        {
+            Interlocked.Increment(ref _streamCallCount);
+            ReceivedCancellationToken = cancellationToken;
+            return await ((IStreamingTaggedSerializableEventStore)Inner).StreamSerializableEventsByTagAsync(
+                tag,
+                since,
+                until,
+                async serializableEvent =>
+                {
+                    var row = Interlocked.Increment(ref _rowsRead);
+                    if (row == 1)
+                    {
+                        _firstRowReached.TrySetResult();
+                        await _releaseFirstRow.Task.WaitAsync(cancellationToken);
+                    }
+
+                    cancellationToken.ThrowIfCancellationRequested();
+                    Interlocked.Increment(ref _consumerCallbacks);
+                    await onEvent(serializableEvent);
+                },
+                cancellationToken);
+        }
+
+        public void ReleaseFirstRow() => _releaseFirstRow.TrySetResult();
+    }
+
     private sealed class OutOfOrderStreamingStore(IEventStore inner) : CountingEventStore(inner),
         IStreamingTaggedSerializableEventStore, ITaggedStreamCapabilityProvider
     {
@@ -543,6 +770,7 @@ public class GeneralTagStateActorPersistenceTests
         private readonly ITagStatePayloadTypes _inner = inner;
         public int SerializePayloadCount { get; private set; }
         public int DeserializePayloadCount { get; private set; }
+        public Action? OnSerializePayload { get; set; }
 
         public Type? GetPayloadType(string payloadName) => _inner.GetPayloadType(payloadName);
 
@@ -557,7 +785,9 @@ public class GeneralTagStateActorPersistenceTests
         public ResultBox<byte[]> SerializePayload(ITagStatePayload payload)
         {
             SerializePayloadCount++;
-            return _inner.SerializePayload(payload);
+            var serialized = _inner.SerializePayload(payload);
+            OnSerializePayload?.Invoke();
+            return serialized;
         }
 
         public void RegisterPayloadType<TPayload>() where TPayload : class, ITagStatePayload =>
@@ -568,10 +798,14 @@ public class GeneralTagStateActorPersistenceTests
     {
         private SerializableTagState? _state;
 
+        public int SaveSerializableStateCalls { get; private set; }
+        public SerializableTagState? SavedState => _state;
+
         public Task<SerializableTagState?> LoadSerializableStateAsync() => Task.FromResult(_state);
 
         public Task SaveSerializableStateAsync(SerializableTagState state)
         {
+            SaveSerializableStateCalls++;
             _state = state;
             return Task.CompletedTask;
         }

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/Sekiban.Dcb.WithResult.Tests.csproj
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/Sekiban.Dcb.WithResult.Tests.csproj
@@ -48,6 +48,10 @@
              old package graph never participates in this project's compile-time dependency resolution. -->
         <ProjectReference Include="..\Sekiban.Dcb.TagStateAccumulator.Legacy1018Fixture\Sekiban.Dcb.TagStateAccumulator.Legacy1018Fixture.csproj"
                           ReferenceOutputAssembly="false" />
+        <!-- A separately compiled pre-SEK-G55 actor implementor. Its output is loaded by reflection so the old
+             package graph never participates in this test project's compile-time dependency resolution. -->
+        <ProjectReference Include="..\Sekiban.Dcb.TagStateCancellation.Legacy1018Fixture\Sekiban.Dcb.TagStateCancellation.Legacy1018Fixture.csproj"
+                          ReferenceOutputAssembly="false" />
     </ItemGroup>
 
     <Target Name="BuildStreamingRestoreLegacy1018FixtureForCurrentTarget"
@@ -79,6 +83,19 @@
             <Output TaskParameter="TargetOutputs" ItemName="_TagStateAccumulatorLegacy1018FixtureOutput" />
         </MSBuild>
         <Copy SourceFiles="@(_TagStateAccumulatorLegacy1018FixtureOutput)"
+              DestinationFolder="$(OutputPath)"
+              SkipUnchangedFiles="true" />
+    </Target>
+
+    <Target Name="CopyTagStateCancellationLegacy1018Fixture"
+            AfterTargets="Build"
+            Condition="'$(TargetFramework)' != ''">
+        <MSBuild Projects="$(MSBuildProjectDirectory)/../Sekiban.Dcb.TagStateCancellation.Legacy1018Fixture/Sekiban.Dcb.TagStateCancellation.Legacy1018Fixture.csproj"
+                 Targets="Build;GetTargetPath"
+                 Properties="Configuration=$(Configuration);TargetFramework=$(TargetFramework);ArtifactsPath=$(ArtifactsPath)">
+            <Output TaskParameter="TargetOutputs" ItemName="_TagStateCancellationLegacy1018FixtureOutput" />
+        </MSBuild>
+        <Copy SourceFiles="@(_TagStateCancellationLegacy1018FixtureOutput)"
               DestinationFolder="$(OutputPath)"
               SkipUnchangedFiles="true" />
     </Target>

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/TagStateCancellationCompatibilityTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/TagStateCancellationCompatibilityTests.cs
@@ -1,0 +1,254 @@
+using System.Reflection;
+using Dcb.Domain;
+using ResultBoxes;
+using Sekiban.Dcb.Actors;
+using Sekiban.Dcb.Commands;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.MultiProjections;
+using Sekiban.Dcb.Orleans.Grains;
+using Sekiban.Dcb.Queries;
+using Sekiban.Dcb.Storage;
+using Sekiban.Dcb.Tags;
+using Xunit;
+using CoreTagStateService = Sekiban.Dcb.Services.TagStateService;
+using CoreInMemoryEventStore = Sekiban.Dcb.Testing.InMemoryEventStore;
+using SqliteTagStateService = Sekiban.Dcb.Sqlite.Services.TagStateService;
+
+namespace Sekiban.Dcb.Tests;
+
+/// <summary>
+///     API and dispatch contract for SEK-G55. The token-less implementations below deliberately model downstream code
+///     compiled before the additive members existed: if a default body is deleted or made abstract, this fixture no
+///     longer builds; if it stops delegating, the exactly-once assertions fail.
+/// </summary>
+public class TagStateCancellationCompatibilityTests
+{
+    [Fact]
+    public async Task TokenlessActorAndExecutor_UseTheDefaultCompatibilityFallbackExactlyOnce()
+    {
+        ITagStateActorCommon actor = new TokenlessActor();
+        var actorState = await actor.GetStateAsync(new CancellationTokenSource().Token);
+        Assert.Equal(1, ((TokenlessActor)actor).GetStateCalls);
+        Assert.Equal("Legacy", actorState.TagGroup);
+
+        ISekibanExecutor executor = new TokenlessExecutor();
+        var tagState = await executor.GetTagStateAsync(
+            TagStateId.Parse("Legacy:executor:Projector"),
+            new CancellationTokenSource().Token);
+        Assert.True(tagState.IsSuccess, tagState.IsSuccess ? string.Empty : tagState.GetException().ToString());
+        Assert.Equal(1, ((TokenlessExecutor)executor).GetTagStateCalls);
+    }
+
+    [Fact]
+    public async Task Frozen_1018_actor_binary_loads_and_default_cancellation_member_delegates_once()
+    {
+        var fixturePath = Path.Combine(
+            AppContext.BaseDirectory,
+            "Sekiban.Dcb.TagStateCancellation.Legacy1018Fixture.dll");
+        var assembly = Assembly.LoadFrom(fixturePath);
+        var type = assembly.GetType(
+            "Sekiban.Dcb.TagStateCancellation.Legacy1018Fixture.Legacy1018TagStateActor",
+            throwOnError: true)!;
+        var concrete = Activator.CreateInstance(type)!;
+        var actor = Assert.IsAssignableFrom<ITagStateActorCommon>(concrete);
+
+        var state = await actor.GetStateAsync(new CancellationTokenSource().Token);
+
+        Assert.Equal("Legacy", state.TagGroup);
+        Assert.Equal(1, (int)type.GetProperty("GetStateCalls")!.GetValue(concrete)!);
+    }
+
+    [Fact]
+    public async Task BuiltInResultExecutor_PreservesTheCallerTokenToTheActor()
+    {
+        var domainTypes = DomainType.GetDomainTypes();
+        var actor = new TokenTrackingActor();
+        var executor = new Sekiban.Dcb.Actors.GeneralSekibanExecutor(
+            new CoreInMemoryEventStore(domainTypes.EventTypes),
+            new TokenTrackingActorAccessor(actor),
+            domainTypes);
+        using var cancellation = new CancellationTokenSource();
+
+        var result = await executor.GetTagStateAsync(
+            TagStateId.Parse("Student:relay:StudentProjector"),
+            cancellation.Token);
+
+        Assert.True(result.IsSuccess, result.IsSuccess ? string.Empty : result.GetException().ToString());
+        Assert.Equal(cancellation.Token, actor.ReceivedCancellationToken);
+    }
+
+    [Fact]
+    public void PublicSurface_PreservesLegacyMembers_AndAddsOnlyTheExpectedCancellationOverloads()
+    {
+        AssertDefaultMember(typeof(ITagStateActorCommon), "GetStateAsync", typeof(CancellationToken));
+        AssertMethod(typeof(ITagStateActorCommon), "GetStateAsync");
+        AssertMethod(typeof(ISekibanExecutor), "GetTagStateAsync", typeof(TagStateId));
+        AssertDefaultMember(typeof(ISekibanExecutor), "GetTagStateAsync", typeof(TagStateId), typeof(CancellationToken));
+        Assert.Contains(
+            typeof(ISekibanExecutor).GetMethods(),
+            method => method.Name == "GetTagStateAsync" && method.IsGenericMethodDefinition &&
+                      method.GetParameters().Select(parameter => parameter.ParameterType)
+                          .SequenceEqual(new[] { typeof(ITag), typeof(CancellationToken) }) && !method.IsAbstract);
+
+        // Orleans cancellation must be a real grain method, not a default interface member. Existing token-less calls
+        // remain present for C# binary compatibility.
+        AssertMethod(typeof(ITagStateGrain), "GetStateAsync");
+        AssertMethod(typeof(ITagStateGrain), "GetTagStateAsync");
+        AssertAbstractGrainMethod(typeof(ITagStateGrain), "GetStateAsync", typeof(CancellationToken));
+        AssertAbstractGrainMethod(typeof(ITagStateGrain), "GetTagStateAsync", typeof(CancellationToken));
+
+        AssertMethod(typeof(CoreTagStateService), "ProjectTagStateAsync", typeof(string), typeof(string));
+        AssertMethod(typeof(CoreTagStateService), "ProjectTagStateAsync", typeof(string));
+        AssertMethod(typeof(CoreTagStateService), "ProjectTagStateAsync", typeof(ITag));
+        AssertMethod(typeof(CoreTagStateService), "ProjectTagStateAsync", typeof(ITag), typeof(string));
+        AssertMethod(typeof(CoreTagStateService), "ProjectTagStateAsync", typeof(string), typeof(string), typeof(CancellationToken));
+        AssertMethod(typeof(CoreTagStateService), "ProjectTagStateAsync", typeof(string), typeof(CancellationToken));
+        AssertMethod(typeof(CoreTagStateService), "ProjectTagStateAsync", typeof(ITag), typeof(CancellationToken));
+        AssertMethod(typeof(CoreTagStateService), "ProjectTagStateAsync", typeof(ITag), typeof(string), typeof(CancellationToken));
+        AssertMethod(typeof(SqliteTagStateService), "ProjectTagStateAsync", typeof(string), typeof(string), typeof(CancellationToken));
+        AssertMethod(typeof(SqliteTagStateService), "ProjectTagStateAsync", typeof(string), typeof(CancellationToken));
+        AssertMethod(typeof(SqliteTagStateService), "ProjectTagStateAsync", typeof(ITag), typeof(CancellationToken));
+        AssertMethod(typeof(SqliteTagStateService), "ProjectTagStateAsync", typeof(ITag), typeof(string), typeof(CancellationToken));
+
+        Assert.Null(typeof(CoreTagStateService).GetMethod(
+            "GetLatestTagStateAsync",
+            [typeof(ITag), typeof(CancellationToken)]));
+        Assert.Null(typeof(CoreTagStateService).GetMethod(
+            "GetLatestTagStateByStringAsync",
+            [typeof(string), typeof(CancellationToken)]));
+    }
+
+    [Theory]
+    [InlineData(typeof(Sekiban.Dcb.Actors.GeneralSekibanExecutor))]
+    [InlineData(typeof(Sekiban.Dcb.Orleans.OrleansDcbExecutor))]
+    public void BuiltInResultExecutors_OverrideTheCancellationRelay(Type executorType)
+    {
+        Assert.NotNull(executorType.GetMethod(
+            "GetTagStateAsync",
+            BindingFlags.Instance | BindingFlags.Public | BindingFlags.DeclaredOnly,
+            [typeof(TagStateId), typeof(CancellationToken)]));
+    }
+
+    private static void AssertDefaultMember(Type type, string name, params Type[] parameterTypes)
+    {
+        var method = type.GetMethod(name, parameterTypes);
+        Assert.NotNull(method);
+        Assert.False(method!.IsAbstract);
+        Assert.NotNull(method.GetMethodBody());
+    }
+
+    private static void AssertAbstractGrainMethod(Type type, string name, params Type[] parameterTypes)
+    {
+        var method = type.GetMethod(name, parameterTypes);
+        Assert.NotNull(method);
+        Assert.True(method!.IsAbstract);
+        Assert.Null(method.GetMethodBody());
+    }
+
+    private static void AssertMethod(Type type, string name, params Type[] parameterTypes) =>
+        Assert.NotNull(type.GetMethod(name, parameterTypes));
+
+    private sealed class TokenlessActor : ITagStateActorCommon
+    {
+        public int GetStateCalls { get; private set; }
+
+        public Task<SerializableTagState> GetStateAsync()
+        {
+            GetStateCalls++;
+            return Task.FromResult(new SerializableTagState(
+                Array.Empty<byte>(),
+                0,
+                string.Empty,
+                "Legacy",
+                "actor",
+                "Projector",
+                nameof(EmptyTagStatePayload),
+                string.Empty,
+                nameof(EmptyTagStatePayload)));
+        }
+
+        public Task<string> GetTagStateActorIdAsync() => Task.FromResult("Legacy:actor:Projector");
+    }
+
+    private sealed class TokenlessExecutor : ISekibanExecutor
+    {
+        public int GetTagStateCalls { get; private set; }
+
+        public Task<ResultBox<TagState>> GetTagStateAsync(TagStateId tagStateId)
+        {
+            GetTagStateCalls++;
+            return Task.FromResult(ResultBox.FromValue(TagState.GetEmpty(tagStateId)));
+        }
+
+        public Task<ResultBox<ExecutionResult>> ExecuteAsync<TCommand>(
+            TCommand command,
+            Func<TCommand, ICommandContext, Task<ResultBox<EventOrNone>>> handlerFunc,
+            CancellationToken cancellationToken = default) where TCommand : ICommand =>
+            throw new NotSupportedException();
+
+        public Task<ResultBox<ExecutionResult>> ExecuteCommandAsync(
+            Func<ICommandContext, Task<ResultBox<EventOrNone>>> handlerFunc,
+            CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public Task<ResultBox<ExecutionResult>> ExecuteAsync<TCommand>(
+            TCommand command,
+            CancellationToken cancellationToken = default) where TCommand : ICommandWithHandler<TCommand> =>
+            throw new NotSupportedException();
+
+        public Task<ResultBox<TResult>> QueryAsync<TResult>(IQueryCommon<TResult> queryCommon) where TResult : notnull =>
+            throw new NotSupportedException();
+
+        public Task<ResultBox<ListQueryResult<TResult>>> QueryAsync<TResult>(IListQueryCommon<TResult> queryCommon)
+            where TResult : notnull =>
+            throw new NotSupportedException();
+
+        public Task<ResultBox<string>> GetLatestSortableUniqueIdAsync() => throw new NotSupportedException();
+
+        public Task<ResultBox<ProjectionHeadStatus>> GetProjectionHeadStatusAsync(
+            string projectorName,
+            string? expectedProjectorVersion = null) =>
+            throw new NotSupportedException();
+
+        public Task<ResultBox<EventStoreHeadStatus>> GetEventStoreHeadStatusAsync(bool includeTotalEventCount = false) =>
+            throw new NotSupportedException();
+    }
+
+    private sealed class TokenTrackingActor : ITagStateActorCommon
+    {
+        public CancellationToken ReceivedCancellationToken { get; private set; }
+
+        public Task<SerializableTagState> GetStateAsync() =>
+            Task.FromResult(EmptyState());
+
+        public Task<SerializableTagState> GetStateAsync(CancellationToken cancellationToken)
+        {
+            ReceivedCancellationToken = cancellationToken;
+            return Task.FromResult(EmptyState());
+        }
+
+        public Task<string> GetTagStateActorIdAsync() => Task.FromResult("Student:relay:StudentProjector");
+
+        private static SerializableTagState EmptyState() =>
+            new(
+                Array.Empty<byte>(),
+                0,
+                string.Empty,
+                "Student",
+                "relay",
+                "StudentProjector",
+                nameof(EmptyTagStatePayload),
+                string.Empty,
+                nameof(EmptyTagStatePayload));
+    }
+
+    private sealed class TokenTrackingActorAccessor(TokenTrackingActor actor) : IActorObjectAccessor
+    {
+        public Task<ResultBox<T>> GetActorAsync<T>(string actorId) where T : class =>
+            typeof(T) == typeof(ITagStateActorCommon)
+                ? Task.FromResult(ResultBox.FromValue((T)(object)actor))
+                : Task.FromResult(ResultBox.Error<T>(new NotSupportedException()));
+
+        public Task<bool> ActorExistsAsync(string actorId) => Task.FromResult(true);
+    }
+}

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/TaggedStreamContractTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/TaggedStreamContractTests.cs
@@ -507,6 +507,56 @@ public class TaggedStreamContractTests
     }
 
     [Fact]
+    public async Task CoreAndSqliteTagStateServices_PropagateCancellationToTheNativeStream()
+    {
+        var eventTypes = new SimpleEventTypes();
+        eventTypes.RegisterEventType<ServiceCounterAdded>();
+        var tagTypes = new SimpleTagTypes();
+        var projectors = new SimpleTagProjectorTypes();
+        projectors.RegisterProjector<ServiceCounterProjector>();
+        var tag = new StreamTag("service-cancellation");
+        var events = new[]
+        {
+            new SerializableEvent(
+                JsonSerializer.SerializeToUtf8Bytes(new ServiceCounterAdded(3)),
+                P1,
+                Guid.NewGuid(),
+                new EventMetadata("cause", "correlation", "user"),
+                new List<string> { tag.GetTag() },
+                nameof(ServiceCounterAdded)),
+            new SerializableEvent(
+                JsonSerializer.SerializeToUtf8Bytes(new ServiceCounterAdded(4)),
+                P2,
+                Guid.NewGuid(),
+                new EventMetadata("cause", "correlation", "user"),
+                new List<string> { tag.GetTag() },
+                nameof(ServiceCounterAdded))
+        };
+
+        var coreStore = new GatedServiceStreamStore(events);
+        var core = new CoreTagStateService(
+            coreStore,
+            eventTypes,
+            tagTypes,
+            projectors,
+            new JsonSerializerOptions());
+        await AssertServiceCancellationAsync(
+            coreStore,
+            cancellationToken => core.ProjectTagStateAsync(tag, ServiceCounterProjector.ProjectorName, cancellationToken));
+
+        var sqliteStore = new GatedServiceStreamStore(events);
+        var sqlite = new SqliteTagStateService(
+            sqliteStore,
+            eventTypes,
+            tagTypes,
+            projectors,
+            new JsonSerializerOptions());
+        await AssertServiceCancellationAsync(
+            sqliteStore,
+            cancellationToken => sqlite.ProjectTagStateAsync(tag, ServiceCounterProjector.ProjectorName, cancellationToken));
+    }
+
+    [Fact]
     public void DcbWorkflow_ObservesEveryTouchedProviderAndSetsTheTaggedStreamControlledMemoryGate()
     {
         var assembly = typeof(TaggedStreamContractTests).Assembly;
@@ -520,11 +570,17 @@ public class TaggedStreamContractTests
         foreach (var requiredPath in new[]
                  {
                      "dcb/src/Sekiban.Dcb.Core/**",
+                     "dcb/src/Sekiban.Dcb.WithResult/**",
+                     "dcb/src/Sekiban.Dcb.WithoutResult/**",
                      "dcb/src/Sekiban.Dcb.Orleans.Core/**",
+                     "dcb/src/Sekiban.Dcb.Orleans.WithResult/**",
+                     "dcb/src/Sekiban.Dcb.Orleans.WithoutResult/**",
                      "dcb/src/Sekiban.Dcb.Postgres/**",
                      "dcb/src/Sekiban.Dcb.Sqlite/**",
                      "dcb/src/Sekiban.Dcb.ColdStorage/**",
                      "dcb/tests/Sekiban.Dcb.WithResult.Tests/**",
+                     "dcb/tests/Sekiban.Dcb.WithoutResult.Tests/**",
+                     "dcb/tests/Sekiban.Dcb.TagStateCancellation.Legacy1018Fixture/**",
                      "dcb/tests/Sekiban.Dcb.Orleans.Tests/**",
                      "dcb/tests/Sekiban.Dcb.Postgres.Tests/**",
                      "dcb/tests/Sekiban.Dcb.ColdEvents.Tests/**"
@@ -535,6 +591,12 @@ public class TaggedStreamContractTests
 
         Assert.Contains("SEKIBAN_TAG_STREAM_CONTROLLED_CEILING: '1'", workflow, StringComparison.Ordinal);
         Assert.DoesNotContain("SEKIBAN_STREAM_RESTORE_CONTROLLED_CEILING", workflow, StringComparison.Ordinal);
+        Assert.Contains(
+            "dotnet test dcb/tests/Sekiban.Dcb.Orleans.Tests/Sekiban.Dcb.Orleans.Tests.csproj",
+            workflow,
+            StringComparison.Ordinal);
+        Assert.Contains("-f net9.0", workflow, StringComparison.Ordinal);
+        Assert.Contains("-f net10.0", workflow, StringComparison.Ordinal);
     }
 
     private static SerializableEvent Event(string sortableUniqueId, ITag tag) =>
@@ -547,6 +609,37 @@ public class TaggedStreamContractTests
             new EventMetadata("cause", "correlation", "user"),
             new List<string> { tag.GetTag() },
             nameof(StudentCreated));
+
+    private static async Task AssertServiceCancellationAsync<TProjection>(
+        GatedServiceStreamStore store,
+        Func<CancellationToken, Task<ResultBox<TProjection>>> project)
+        where TProjection : notnull
+    {
+        using (var preCancelled = new CancellationTokenSource())
+        {
+            preCancelled.Cancel();
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await project(preCancelled.Token));
+            Assert.Equal(0, store.StreamCalls);
+            Assert.Equal(0, store.RowsRead);
+        }
+
+        using var cancellation = new CancellationTokenSource();
+        var projectTask = project(cancellation.Token);
+        try
+        {
+            await store.FirstRowReached.WaitAsync(TimeSpan.FromSeconds(10));
+            cancellation.Cancel();
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await projectTask);
+        }
+        finally
+        {
+            store.ReleaseFirstRow();
+        }
+
+        Assert.Equal(cancellation.Token, store.ReceivedCancellationToken);
+        Assert.Equal(1, store.RowsRead);
+        Assert.Equal(0, store.ConsumerCallbacks);
+    }
 
     private sealed class StreamTag(string content) : ITag
     {
@@ -644,6 +737,58 @@ public class TaggedStreamContractTests
 
             return ResultBox.FromValue(new SerializableEventStreamReadResult(count, lastId));
         }
+    }
+
+    private sealed class GatedServiceStreamStore(IReadOnlyList<SerializableEvent> events) : EmptyStore,
+        IStreamingTaggedSerializableEventStore, ITaggedStreamCapabilityProvider
+    {
+        private readonly IReadOnlyList<SerializableEvent> _events = events;
+        private readonly TaskCompletionSource _firstRowReached = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource _releaseFirstRow = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private int _streamCalls;
+        private int _rowsRead;
+        private int _consumerCallbacks;
+
+        public int StreamCalls => _streamCalls;
+        public int RowsRead => _rowsRead;
+        public int ConsumerCallbacks => _consumerCallbacks;
+        public CancellationToken ReceivedCancellationToken { get; private set; }
+        public Task FirstRowReached => _firstRowReached.Task;
+
+        public TaggedStreamCapabilityDescriptor DescribeTaggedStream() =>
+            TaggedStreamCapabilityDescriptor.Native("service cancellation gate");
+
+        public async Task<ResultBox<SerializableEventStreamReadResult>> StreamSerializableEventsByTagAsync(
+            ITag tag,
+            SortableUniqueId? since,
+            SortableUniqueId? until,
+            Func<SerializableEvent, ValueTask> onEvent,
+            CancellationToken cancellationToken = default)
+        {
+            Interlocked.Increment(ref _streamCalls);
+            ReceivedCancellationToken = cancellationToken;
+            var count = 0;
+            string? lastSortableUniqueId = null;
+            foreach (var serializableEvent in _events)
+            {
+                var row = Interlocked.Increment(ref _rowsRead);
+                if (row == 1)
+                {
+                    _firstRowReached.TrySetResult();
+                    await _releaseFirstRow.Task.WaitAsync(cancellationToken);
+                }
+
+                cancellationToken.ThrowIfCancellationRequested();
+                Interlocked.Increment(ref _consumerCallbacks);
+                await onEvent(serializableEvent);
+                count++;
+                lastSortableUniqueId = serializableEvent.SortableUniqueIdValue;
+            }
+
+            return ResultBox.FromValue(new SerializableEventStreamReadResult(count, lastSortableUniqueId));
+        }
+
+        public void ReleaseFirstRow() => _releaseFirstRow.TrySetResult();
     }
 
     private sealed record ServiceCounterAdded(int Delta) : IEventPayload;

--- a/dcb/tests/Sekiban.Dcb.WithoutResult.Tests/TagStateCancellationCompatibilityTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithoutResult.Tests/TagStateCancellationCompatibilityTests.cs
@@ -1,0 +1,171 @@
+using System.Reflection;
+using Dcb.Domain.WithoutResult;
+using ResultBoxes;
+using Sekiban.Dcb.Actors;
+using Sekiban.Dcb.Boundaries;
+using Sekiban.Dcb.Commands;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.MultiProjections;
+using Sekiban.Dcb.Queries;
+using Sekiban.Dcb.Storage;
+using Sekiban.Dcb.Tags;
+using Xunit;
+using CoreInMemoryEventStore = Sekiban.Dcb.Testing.InMemoryEventStore;
+
+namespace Sekiban.Dcb.Tests;
+
+/// <summary>
+///     Exception-surface compatibility checks for SEK-G55. The token-less implementation is intentionally complete
+///     enough to compile as a downstream pre-change implementor, exercising the default interface fallback.
+/// </summary>
+public class TagStateCancellationCompatibilityTests
+{
+    [Fact]
+    public async Task TokenlessExecutor_UsesTheDefaultCompatibilityFallbackExactlyOnce()
+    {
+        ISekibanExecutor executor = new TokenlessExecutor();
+        var state = await executor.GetTagStateAsync(
+            TagStateId.Parse("Legacy:without-result:Projector"),
+            new CancellationTokenSource().Token);
+
+        Assert.Equal("Legacy", state.TagGroup);
+        Assert.Equal(1, ((TokenlessExecutor)executor).GetTagStateCalls);
+    }
+
+    [Fact]
+    public async Task GuardedUnwrap_RethrowsTheOriginalCancellationException()
+    {
+        var cancellation = new OperationCanceledException("expected cancellation");
+        var result = Task.FromResult(ResultBox.Error<TagState>(cancellation));
+
+        var observed = await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
+            await GuardedUnwrap.UnwrapAsync(
+                result,
+                new BoundaryContext("ISekibanExecutor.GetTagStateAsync", "Legacy:without-result:Projector")));
+
+        Assert.Same(cancellation, observed);
+    }
+
+    [Fact]
+    public async Task BuiltInExceptionExecutor_PreservesTheCallerTokenToTheActor()
+    {
+        var domainTypes = DomainType.GetDomainTypes();
+        var actor = new TokenTrackingActor();
+        var executor = new Sekiban.Dcb.Actors.GeneralSekibanExecutor(
+            new CoreInMemoryEventStore(domainTypes.EventTypes),
+            new TokenTrackingActorAccessor(actor),
+            domainTypes);
+        using var cancellation = new CancellationTokenSource();
+
+        var state = await executor.GetTagStateAsync(
+            TagStateId.Parse("Student:relay:StudentProjector"),
+            cancellation.Token);
+
+        Assert.Equal("Student", state.TagGroup);
+        Assert.Equal(cancellation.Token, actor.ReceivedCancellationToken);
+    }
+
+    [Theory]
+    [InlineData(typeof(Sekiban.Dcb.Actors.GeneralSekibanExecutor))]
+    [InlineData(typeof(Sekiban.Dcb.Orleans.OrleansDcbExecutor))]
+    public void BuiltInExceptionExecutors_OverrideTheCancellationRelay(Type executorType)
+    {
+        var method = executorType.GetMethod(
+            "GetTagStateAsync",
+            BindingFlags.Instance | BindingFlags.Public | BindingFlags.DeclaredOnly,
+            [typeof(TagStateId), typeof(CancellationToken)]);
+        Assert.NotNull(method);
+    }
+
+    [Fact]
+    public void CancellationMember_RemainsADefaultInterfaceMember()
+    {
+        var method = typeof(ISekibanExecutor).GetMethod(
+            "GetTagStateAsync",
+            [typeof(TagStateId), typeof(CancellationToken)]);
+        Assert.NotNull(method);
+        Assert.False(method!.IsAbstract);
+        Assert.NotNull(method.GetMethodBody());
+    }
+
+    private sealed class TokenlessExecutor : ISekibanExecutor
+    {
+        public int GetTagStateCalls { get; private set; }
+
+        public Task<TagState> GetTagStateAsync(TagStateId tagStateId)
+        {
+            GetTagStateCalls++;
+            return Task.FromResult(TagState.GetEmpty(tagStateId));
+        }
+
+        public Task<ExecutionResult> ExecuteAsync<TCommand>(
+            TCommand command,
+            Func<TCommand, ICommandContext, Task<EventOrNone>> handlerFunc,
+            CancellationToken cancellationToken = default) where TCommand : ICommand =>
+            throw new NotSupportedException();
+
+        public Task<ExecutionResult> ExecuteCommandAsync(
+            Func<ICommandContext, Task<EventOrNone>> handlerFunc,
+            CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public Task<ExecutionResult> ExecuteAsync<TCommand>(
+            TCommand command,
+            CancellationToken cancellationToken = default) where TCommand : ICommandWithHandler<TCommand> =>
+            throw new NotSupportedException();
+
+        public Task<TResult> QueryAsync<TResult>(IQueryCommon<TResult> queryCommon) where TResult : notnull =>
+            throw new NotSupportedException();
+
+        public Task<ListQueryResult<TResult>> QueryAsync<TResult>(IListQueryCommon<TResult> queryCommon)
+            where TResult : notnull =>
+            throw new NotSupportedException();
+
+        public Task<string> GetLatestSortableUniqueIdAsync() => throw new NotSupportedException();
+
+        public Task<ProjectionHeadStatus> GetProjectionHeadStatusAsync(
+            string projectorName,
+            string? expectedProjectorVersion = null) =>
+            throw new NotSupportedException();
+
+        public Task<EventStoreHeadStatus> GetEventStoreHeadStatusAsync(bool includeTotalEventCount = false) =>
+            throw new NotSupportedException();
+    }
+
+    private sealed class TokenTrackingActor : ITagStateActorCommon
+    {
+        public CancellationToken ReceivedCancellationToken { get; private set; }
+
+        public Task<SerializableTagState> GetStateAsync() => Task.FromResult(EmptyState());
+
+        public Task<SerializableTagState> GetStateAsync(CancellationToken cancellationToken)
+        {
+            ReceivedCancellationToken = cancellationToken;
+            return Task.FromResult(EmptyState());
+        }
+
+        public Task<string> GetTagStateActorIdAsync() => Task.FromResult("Student:relay:StudentProjector");
+
+        private static SerializableTagState EmptyState() =>
+            new(
+                Array.Empty<byte>(),
+                0,
+                string.Empty,
+                "Student",
+                "relay",
+                "StudentProjector",
+                nameof(EmptyTagStatePayload),
+                string.Empty,
+                nameof(EmptyTagStatePayload));
+    }
+
+    private sealed class TokenTrackingActorAccessor(TokenTrackingActor actor) : IActorObjectAccessor
+    {
+        public Task<ResultBox<T>> GetActorAsync<T>(string actorId) where T : class =>
+            typeof(T) == typeof(ITagStateActorCommon)
+                ? Task.FromResult(ResultBox.FromValue((T)(object)actor))
+                : Task.FromResult(ResultBox.Error<T>(new NotSupportedException()));
+
+        public Task<bool> ActorExistsAsync(string actorId) => Task.FromResult(true);
+    }
+}

--- a/docs/dcb_llm/11_storage_providers.md
+++ b/docs/dcb_llm/11_storage_providers.md
@@ -174,9 +174,24 @@ continue to use the list fallback without recompilation.
 - Capability selection is fail-closed: a store must implement the optional interface **and** declare native tagged
   streaming through the live-instance descriptor. `HybridEventStore` forwards only a verified hot-store stream and
   returns an unsupported `ResultBox` without reading its hot list API otherwise.
-- Current tag-state public operations do not expose cancellation and intentionally pass `CancellationToken.None`.
-  Direct provider callers can cancel a tagged stream; cancellation propagates as `OperationCanceledException`, while
-  other read or callback failures are returned as `ResultBox.Error`.
+- **Optional tag-state cancellation entry paths (SEK-G55).** Existing token-less members remain unchanged. Callers
+  that need cancellation can use `ISekibanExecutor.GetTagStateAsync(TagStateId, CancellationToken)` (including its
+  generic convenience form), `ITagStateActorCommon.GetStateAsync(CancellationToken)`, the Core/SQLite
+  `TagStateService.ProjectTagStateAsync` overloads, or the Orleans `ITagStateGrain.GetStateAsync(CancellationToken)` /
+  `GetTagStateAsync(CancellationToken)` grain methods. The executor and in-process actor additions are default
+  interface fallbacks to their token-less members, so a downstream implementation compiled before SEK-G55 keeps
+  working but does **not** thereby promise cancellation. Sekiban's built-in implementations override the fallback and
+  pass the caller token to the native stream. The Orleans members are ordinary grain methods rather than default
+  interface members so Orleans 10 can dispatch post-request cancellation; no `Reentrant`, `AlwaysInterleave`, or
+  `GrainCancellationToken` is required.
+- A streaming provider receives the exact caller token and stops before its next row/callback once cancellation is
+  observed. The frozen list fallback cannot interrupt its already-started provider read; it observes cancellation
+  immediately after that read and before each projected event. A cancelled rebuild discards its local fold and checks
+  again immediately before actor/grain cache publication, so cancellation observed before a write starts produces no
+  cache write or successful partial result (a write already in progress is not rolled back).
+- `WithResult` exposes cancellation as a `ResultBox.Error` holding `OperationCanceledException`; `WithoutResult`,
+  actor, grain, and service callers observe `OperationCanceledException`. `GetLatestTagState*` intentionally has no
+  cosmetic token overload because its frozen `IEventStore` read has no cancellation parameter.
 
 ## Passive projection status registry (SEK-G24 / dcb-v10.10.0)
 

--- a/docs/dcb_llm_ja/11_storage_providers.md
+++ b/docs/dcb_llm_ja/11_storage_providers.md
@@ -178,9 +178,24 @@ downstream の store は再コンパイルなしで従来の list fallback を�
 - capability 選択は fail-closed です。store は optional interface の実装に加え、live-instance descriptor で native
   tagged streaming を宣言する必要があります。`HybridEventStore` は検証済み hot-store stream だけを forward し、それ
   以外では hot の list API を読まずに unsupported `ResultBox` を返します。
-- 現在の tag-state public operation は cancellation を公開していないため、意図的に `CancellationToken.None` を渡します。
-  provider の直接 caller は tagged stream を cancel でき、cancellation は `OperationCanceledException` として伝播します。
-  それ以外の read/callback failure は `ResultBox.Error` で返されます。
+- **任意の tag-state cancellation entry path (SEK-G55)。** 既存の token なし member は変更されません。cancel が必要な
+  caller は `ISekibanExecutor.GetTagStateAsync(TagStateId, CancellationToken)`（generic convenience form を含む）、
+  `ITagStateActorCommon.GetStateAsync(CancellationToken)`、Core/SQLite の
+  `TagStateService.ProjectTagStateAsync` overload、または Orleans の通常の grain method
+  `ITagStateGrain.GetStateAsync(CancellationToken)` / `GetTagStateAsync(CancellationToken)` を使えます。executor と
+  in-process actor の追加 member は token なし member へ委譲する default interface fallback です。そのため SEK-G55 より前に
+  compile した downstream 実装も動き続けますが、それ自体が cancellation 対応を意味するわけではありません。Sekiban の
+  built-in 実装は fallback を override し、caller token を native stream まで渡します。Orleans member は request 後の
+  cancellation を Orleans 10 が dispatch できる通常の grain method であり、`Reentrant`、`AlwaysInterleave`、
+  `GrainCancellationToken` は不要です。
+- streaming provider には caller と同一の token が渡され、cancellation を観測すると次の row/callback より前で停止します。
+  凍結された list fallback は開始済み provider read を中断できませんが、その read の直後と各 event の projection 前で
+  cancellation を観測します。cancel 済み rebuild は local fold を破棄し、actor/grain cache publish の直前にも再確認するため、
+  write 開始前に観測した cancellation では cache write も partial result の成功返却も行いません（開始済み write は rollback
+  しません）。
+- `WithResult` では `OperationCanceledException` を持つ `ResultBox.Error` として、`WithoutResult`、actor、grain、service
+  caller では `OperationCanceledException` として cancellation が見えます。凍結された `IEventStore` read に cancellation
+  parameter がないため、`GetLatestTagState*` には見かけだけの token overload を追加していません。
 
 ## 受動的なプロジェクション状態レジストリ (SEK-G24 / dcb-v10.10.0)
 


### PR DESCRIPTION
## Summary

- Adds additive CancellationToken tag-state read overloads while preserving every token-less public signature.
- Propagates caller cancellation through built-in executor, actor, Orleans grain, service, stream, and cache-publication paths.
- Adds real Orleans 10.0.1 TestCluster coverage for pre-cancel, post-dispatch cancellation (ack enabled and disabled), and a frozen v10.18 token-less client.
- Adds executable AC2 adapter-relay proofs through both OrleansDcbExecutor facades, OrleansActorObjectAccessor.TagStateGrainWrapper, ITagStateGrain, and both in-memory executor adapters.

## Validation

- Focused WithResult suite: 30 passed on net9.0 and net10.0.
- Focused WithoutResult compatibility suite: 6 passed on net9.0 and net10.0.
- Orleans tag-state persistence/TestCluster suite: 13 passed on net9.0 and net10.0.
- Executed adapter-relay mutations replace the WithResult and WithoutResult Orleans relays, the shared wrapper relay, and the WithResult and WithoutResult in-memory relays with CancellationToken.None; each is killed by its gated test.
- Executed mutation checks also cover the pre-write guard, token relay, and default-member compatibility fallback.

Closes #1182