### PR TITLE
fix(dcb): bind nullable materialized-view parameters as CLR null

### DIFF
--- a/dcb/src/Sekiban.Dcb.MaterializedView/MvApplyHostSupport.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView/MvApplyHostSupport.cs
@@ -84,7 +84,7 @@ public static class MvParamConverter
                 $"Materialized view parameter '{param.Name}' has kind '{param.Kind}' but no serialized value.")
             : param.Kind switch
         {
-            MvParamKind.Null => DBNull.Value,
+            MvParamKind.Null => null,
             MvParamKind.String => Deserialize<string>(param.ValueJson),
             MvParamKind.Int32 => Deserialize<int>(param.ValueJson),
             MvParamKind.Int64 => Deserialize<long>(param.ValueJson),

--- a/dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/MultiProviderFixtures.cs
+++ b/dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/MultiProviderFixtures.cs
@@ -446,6 +446,7 @@ public sealed class PostgresMvFixture : MultiProviderFixtureBase
 
     protected override string ResetSql => """
         DROP TABLE IF EXISTS sekiban_mv_nullbinding_v1_rows;
+        DROP TABLE IF EXISTS sekiban_mv_nullbindingnontext_v1_rows;
         DROP TABLE IF EXISTS sekiban_mv_weatherforecastportable_v1_forecasts;
         DROP TABLE IF EXISTS sekiban_mv_active;
         DROP TABLE IF EXISTS sekiban_mv_registry;
@@ -549,6 +550,7 @@ public sealed class MySqlMvFixture : MultiProviderFixtureBase
 
     protected override string ResetSql => """
         DROP TABLE IF EXISTS sekiban_mv_nullbinding_v1_rows;
+        DROP TABLE IF EXISTS sekiban_mv_nullbindingnontext_v1_rows;
         DROP TABLE IF EXISTS sekiban_mv_weatherforecastportable_v1_forecasts;
         DROP TABLE IF EXISTS sekiban_mv_active;
         DROP TABLE IF EXISTS sekiban_mv_registry;
@@ -662,6 +664,7 @@ public sealed class SqlServerMvFixture : MultiProviderFixtureBase
 
     protected override string ResetSql => """
         IF OBJECT_ID(N'sekiban_mv_nullbinding_v1_rows', N'U') IS NOT NULL DROP TABLE sekiban_mv_nullbinding_v1_rows;
+        IF OBJECT_ID(N'sekiban_mv_nullbindingnontext_v1_rows', N'U') IS NOT NULL DROP TABLE sekiban_mv_nullbindingnontext_v1_rows;
         IF OBJECT_ID(N'sekiban_mv_weatherforecastportable_v1_forecasts', N'U') IS NOT NULL DROP TABLE sekiban_mv_weatherforecastportable_v1_forecasts;
         IF OBJECT_ID(N'sekiban_mv_active', N'U') IS NOT NULL DROP TABLE sekiban_mv_active;
         IF OBJECT_ID(N'sekiban_mv_registry', N'U') IS NOT NULL DROP TABLE sekiban_mv_registry;
@@ -759,6 +762,7 @@ public sealed class SqliteMvFixture : MultiProviderFixtureBase
 
     protected override string ResetSql => """
         DROP TABLE IF EXISTS sekiban_mv_nullbinding_v1_rows;
+        DROP TABLE IF EXISTS sekiban_mv_nullbindingnontext_v1_rows;
         DROP TABLE IF EXISTS sekiban_mv_weatherforecastportable_v1_forecasts;
         DROP TABLE IF EXISTS sekiban_mv_policysurface_v1_records;
         DROP TABLE IF EXISTS sekiban_mv_active;

--- a/dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/MultiProviderFixtures.cs
+++ b/dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/MultiProviderFixtures.cs
@@ -445,6 +445,7 @@ public sealed class PostgresMvFixture : MultiProviderFixtureBase
     protected override DbConnection CreateConnection(string connectionString) => new NpgsqlConnection(connectionString);
 
     protected override string ResetSql => """
+        DROP TABLE IF EXISTS sekiban_mv_nullbinding_v1_rows;
         DROP TABLE IF EXISTS sekiban_mv_weatherforecastportable_v1_forecasts;
         DROP TABLE IF EXISTS sekiban_mv_active;
         DROP TABLE IF EXISTS sekiban_mv_registry;
@@ -547,6 +548,7 @@ public sealed class MySqlMvFixture : MultiProviderFixtureBase
     protected override DbConnection CreateConnection(string connectionString) => new MySqlConnection(connectionString);
 
     protected override string ResetSql => """
+        DROP TABLE IF EXISTS sekiban_mv_nullbinding_v1_rows;
         DROP TABLE IF EXISTS sekiban_mv_weatherforecastportable_v1_forecasts;
         DROP TABLE IF EXISTS sekiban_mv_active;
         DROP TABLE IF EXISTS sekiban_mv_registry;
@@ -659,6 +661,7 @@ public sealed class SqlServerMvFixture : MultiProviderFixtureBase
     protected override DbConnection CreateConnection(string connectionString) => new SqlConnection(connectionString);
 
     protected override string ResetSql => """
+        IF OBJECT_ID(N'sekiban_mv_nullbinding_v1_rows', N'U') IS NOT NULL DROP TABLE sekiban_mv_nullbinding_v1_rows;
         IF OBJECT_ID(N'sekiban_mv_weatherforecastportable_v1_forecasts', N'U') IS NOT NULL DROP TABLE sekiban_mv_weatherforecastportable_v1_forecasts;
         IF OBJECT_ID(N'sekiban_mv_active', N'U') IS NOT NULL DROP TABLE sekiban_mv_active;
         IF OBJECT_ID(N'sekiban_mv_registry', N'U') IS NOT NULL DROP TABLE sekiban_mv_registry;
@@ -755,6 +758,7 @@ public sealed class SqliteMvFixture : MultiProviderFixtureBase
     protected override DbConnection CreateConnection(string connectionString) => new SqliteConnection(connectionString);
 
     protected override string ResetSql => """
+        DROP TABLE IF EXISTS sekiban_mv_nullbinding_v1_rows;
         DROP TABLE IF EXISTS sekiban_mv_weatherforecastportable_v1_forecasts;
         DROP TABLE IF EXISTS sekiban_mv_policysurface_v1_records;
         DROP TABLE IF EXISTS sekiban_mv_active;

--- a/dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/MvNullParameterTests.cs
+++ b/dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/MvNullParameterTests.cs
@@ -20,8 +20,16 @@ public sealed class PostgresMvNullParameterTests(PostgresMvFixture fixture, ITes
         MvNullParameterAssertions.AssertNullableTextAsync(fixture, output);
 
     [SkippableFact]
+    public Task StatementOnlyNullableText_IsBoundThroughTheDapperStatementPath() =>
+        MvNullParameterAssertions.AssertStatementOnlyNullableTextAsync(fixture, output);
+
+    [SkippableFact]
     public Task NonInferableScalarNull_IsMeasuredAtThePostgresQueryPort() =>
         MvNullParameterAssertions.AssertPostgresNonInferableScalarAsync(fixture, output);
+
+    [SkippableFact]
+    public Task NonTextNullableStatement_IsBoundThroughTheSerializedStatementPath() =>
+        MvNullParameterAssertions.AssertNonTextStatementAsync(fixture, output);
 }
 
 [Collection(nameof(MySqlMvCollection))]
@@ -38,6 +46,10 @@ public sealed class SqlServerMvNullParameterTests(SqlServerMvFixture fixture, IT
     [SkippableFact]
     public Task NullableText_IsBoundAsSqlNull_AndAllQueryPortsExecute() =>
         MvNullParameterAssertions.AssertNullableTextAsync(fixture, output);
+
+    [SkippableFact]
+    public Task NonTextNullableStatement_IsBoundThroughTheSerializedStatementPath() =>
+        MvNullParameterAssertions.AssertNonTextStatementAsync(fixture, output);
 }
 
 [Collection(nameof(SqliteMvCollection))]
@@ -148,6 +160,54 @@ internal static class MvNullParameterAssertions
         }
     }
 
+    public static async Task AssertStatementOnlyNullableTextAsync(
+        PostgresMvFixture fixture,
+        ITestOutputHelper output)
+    {
+        Skip.IfNot(fixture.IsAvailable, fixture.AvailabilityMessage ?? "PostgreSQL fixture is unavailable.");
+
+        await fixture.ResetAsync().ConfigureAwait(false);
+        var projector = new NullableTextMvProjector(statementOnly: true);
+        var host = new NativeMvApplyHost(projector, fixture.DomainTypes.EventTypes, fixture.DatabaseTypeForTests);
+        await fixture.Executor.InitializeAsync(host).ConfigureAwait(false);
+
+        var executor = new GeneralSekibanExecutor(fixture.EventStore, fixture.ActorAccessor, fixture.DomainTypes);
+        var forecastId = Guid.CreateVersion7();
+        var forecastDate = DateOnly.FromDateTime(DateTime.UtcNow.Date);
+
+        await executor.ExecuteAsync(
+                new CreateWeatherForecast
+                {
+                    ForecastId = forecastId,
+                    Location = "Tokyo",
+                    Date = forecastDate,
+                    TemperatureC = 20,
+                    Summary = "initial"
+                })
+            .ConfigureAwait(false);
+        var firstCatchUp = await fixture.Executor.CatchUpOnceAsync(host).ConfigureAwait(false);
+
+        await executor.ExecuteAsync(
+                new UpdateWeatherForecast
+                {
+                    ForecastId = forecastId,
+                    Location = "Kyoto",
+                    Date = forecastDate.AddDays(1),
+                    TemperatureC = 21,
+                    Summary = null
+                })
+            .ConfigureAwait(false);
+        var nullCatchUp = await fixture.Executor.CatchUpOnceAsync(host).ConfigureAwait(false);
+        var row = await ReadRowAsync(fixture, projector, forecastId).ConfigureAwait(false);
+
+        output.WriteLine($"provider=Postgres; version={await ReadProviderVersionAsync(fixture).ConfigureAwait(false)}");
+        output.WriteLine($"statement-only-command={projector.LastApplySql}");
+
+        Assert.Equal(1, firstCatchUp.AppliedEvents);
+        Assert.Equal(1, nullCatchUp.AppliedEvents);
+        Assert.Null(row.Summary);
+    }
+
     public static async Task AssertPostgresNonInferableScalarAsync(
         PostgresMvFixture fixture,
         ITestOutputHelper output)
@@ -190,6 +250,71 @@ internal static class MvNullParameterAssertions
         }
     }
 
+    public static async Task AssertNonTextStatementAsync(
+        MultiProviderFixtureBase fixture,
+        ITestOutputHelper output)
+    {
+        Skip.IfNot(fixture.IsAvailable, fixture.AvailabilityMessage ?? "Materialized-view fixture is unavailable.");
+        Skip.If(
+            fixture.DatabaseTypeForTests is not (MvDbType.Postgres or MvDbType.SqlServer),
+            $"Non-text nullable statement characterization is only supported on PostgreSQL and SQL Server; actual provider is {fixture.DatabaseTypeForTests}.");
+
+        await fixture.ResetAsync().ConfigureAwait(false);
+        var projector = new NullableNonTextStatementMvProjector();
+        var host = new NativeMvApplyHost(projector, fixture.DomainTypes.EventTypes, fixture.DatabaseTypeForTests);
+        await fixture.Executor.InitializeAsync(host).ConfigureAwait(false);
+
+        var executor = new GeneralSekibanExecutor(fixture.EventStore, fixture.ActorAccessor, fixture.DomainTypes);
+        var forecastId = Guid.CreateVersion7();
+        var forecastDate = new DateOnly(2026, 1, 2);
+
+        await executor.ExecuteAsync(
+                new CreateWeatherForecast
+                {
+                    ForecastId = forecastId,
+                    Location = "Tokyo",
+                    Date = forecastDate,
+                    TemperatureC = 20,
+                    Summary = "seed"
+                })
+            .ConfigureAwait(false);
+        var seedCatchUp = await fixture.Executor.CatchUpOnceAsync(host).ConfigureAwait(false);
+        var seededRow = await ReadNonTextRowAsync(fixture, projector, forecastId).ConfigureAwait(false);
+        Assert.Equal(1, seedCatchUp.AppliedEvents);
+        AssertSeededNonTextValues(fixture.DatabaseTypeForTests, seededRow);
+
+        await executor.ExecuteAsync(
+                new UpdateWeatherForecast
+                {
+                    ForecastId = forecastId,
+                    Location = "Kyoto",
+                    Date = forecastDate.AddDays(1),
+                    TemperatureC = 21,
+                    Summary = null
+                })
+            .ConfigureAwait(false);
+
+        try
+        {
+            var nullCatchUp = await fixture.Executor.CatchUpOnceAsync(host).ConfigureAwait(false);
+            var nullRow = await ReadNonTextRowAsync(fixture, projector, forecastId).ConfigureAwait(false);
+
+            Assert.Equal(1, nullCatchUp.AppliedEvents);
+            AssertPersistedSqlNulls(fixture.DatabaseTypeForTests, nullRow);
+            output.WriteLine(
+                $"provider={fixture.DatabaseTypeForTests}; version={await ReadProviderVersionAsync(fixture).ConfigureAwait(false)}");
+            output.WriteLine(
+                $"characterization={NullableNonTextStatementMvProjector.CharacterizationName}; command={projector.LastNullStatementSql}; outcome=supported: returned statement persisted SQL NULL in every nullable non-text column");
+        }
+        catch (DbException exception)
+        {
+            output.WriteLine(
+                $"provider={fixture.DatabaseTypeForTests}; version={await ReadProviderVersionAsync(fixture).ConfigureAwait(false)}");
+            output.WriteLine(
+                $"characterization={NullableNonTextStatementMvProjector.CharacterizationName}; command={projector.LastNullStatementSql}; outcome=provider-limited: {DescribeProviderException(exception)}");
+        }
+    }
+
     private static void AssertCheckpointAdvanced(MvRegistryEntry entry)
     {
         Assert.True(entry.CurrentCheckpointTruth.IsKnown);
@@ -214,6 +339,76 @@ internal static class MvNullParameterAssertions
                 new { ForecastId = forecastId.ToString("D") })
             .ConfigureAwait(false);
     }
+
+    private static async Task<NullableNonTextRow> ReadNonTextRowAsync(
+        MultiProviderFixtureBase fixture,
+        NullableNonTextStatementMvProjector projector,
+        Guid forecastId)
+    {
+        await using var connection = await fixture.OpenConnectionAsync().ConfigureAwait(false);
+        var sql = fixture.DatabaseTypeForTests switch
+        {
+            MvDbType.Postgres => $"""
+                SELECT uuid_probe AS UuidProbe,
+                       timestamp_probe AS TimestampProbe,
+                       bytes_probe AS BytesProbe
+                FROM {projector.Rows.PhysicalName}
+                WHERE forecast_id = @ForecastId;
+                """,
+            MvDbType.SqlServer => $"""
+                SELECT int_probe AS IntProbe,
+                       bytes_probe AS BytesProbe
+                FROM {projector.Rows.PhysicalName}
+                WHERE forecast_id = @ForecastId;
+                """,
+            _ => throw new NotSupportedException($"Unsupported database type '{fixture.DatabaseTypeForTests}'.")
+        };
+        return await connection.QuerySingleAsync<NullableNonTextRow>(
+                sql,
+                new { ForecastId = forecastId.ToString("D") })
+            .ConfigureAwait(false);
+    }
+
+    private static void AssertSeededNonTextValues(MvDbType databaseType, NullableNonTextRow row)
+    {
+        switch (databaseType)
+        {
+            case MvDbType.Postgres:
+                Assert.Equal(NullableNonTextStatementMvProjector.SeededUuid, row.UuidProbe);
+                Assert.Equal(NullableNonTextStatementMvProjector.SeededTimestamp, row.TimestampProbe);
+                Assert.Equal(NullableNonTextStatementMvProjector.SeededBytes, row.BytesProbe);
+                break;
+            case MvDbType.SqlServer:
+                Assert.Equal(NullableNonTextStatementMvProjector.SeededInt, row.IntProbe);
+                Assert.Equal(NullableNonTextStatementMvProjector.SeededBytes, row.BytesProbe);
+                break;
+            default:
+                throw new NotSupportedException($"Unsupported database type '{databaseType}'.");
+        }
+    }
+
+    private static void AssertPersistedSqlNulls(MvDbType databaseType, NullableNonTextRow row)
+    {
+        switch (databaseType)
+        {
+            case MvDbType.Postgres:
+                Assert.Null(row.UuidProbe);
+                Assert.Null(row.TimestampProbe);
+                Assert.Null(row.BytesProbe);
+                break;
+            case MvDbType.SqlServer:
+                Assert.Null(row.IntProbe);
+                Assert.Null(row.BytesProbe);
+                break;
+            default:
+                throw new NotSupportedException($"Unsupported database type '{databaseType}'.");
+        }
+    }
+
+    private static string DescribeProviderException(DbException exception) =>
+        exception is PostgresException postgresException
+            ? $"{exception.GetType().FullName}; sql-state={postgresException.SqlState}; message={postgresException.MessageText}"
+            : $"{exception.GetType().FullName}; message={exception.Message}";
 
     private static async Task<MvRegistryEntry> ReadRegistryEntryAsync(
         MultiProviderFixtureBase fixture,
@@ -248,13 +443,15 @@ internal sealed class NullableTextMvProjector : IMaterializedViewProjector, IMvS
     public const string InferableTextQuery = "SELECT COALESCE(@Summary, 'query-fallback') AS summary;";
 
     private readonly bool _runNonInferableScalar;
+    private readonly bool _statementOnly;
     private readonly List<NullParameterQueryObservation> _queryObservations = [];
     private readonly List<NullParameterCharacterization> _characterizations = [];
     private bool _characterizationComplete;
 
-    public NullableTextMvProjector(bool runNonInferableScalar = false)
+    public NullableTextMvProjector(bool runNonInferableScalar = false, bool statementOnly = false)
     {
         _runNonInferableScalar = runNonInferableScalar;
+        _statementOnly = statementOnly;
     }
 
     public string ViewName => "NullBinding";
@@ -310,6 +507,21 @@ internal sealed class NullableTextMvProjector : IMaterializedViewProjector, IMvS
                 return [];
         }
 
+        var sql = BuildUpsert(ctx.DatabaseType);
+        var statement = new MvSqlStatement(
+            sql,
+            new
+            {
+                ForecastId = forecastId.ToString("D"),
+                Summary = summary,
+                SortableUniqueId = ctx.CurrentSortableUniqueId
+            });
+        if (_statementOnly)
+        {
+            LastApplySql = sql;
+            return [statement];
+        }
+
         if (_runNonInferableScalar)
         {
             NonInferableScalarResult = await ctx.ExecuteScalarAsync<string?>(
@@ -326,19 +538,8 @@ internal sealed class NullableTextMvProjector : IMaterializedViewProjector, IMvS
             _characterizationComplete = true;
         }
 
-        var sql = BuildUpsert(ctx.DatabaseType);
         LastApplySql = sql;
-        return
-        [
-            new MvSqlStatement(
-                sql,
-                new
-                {
-                    ForecastId = forecastId.ToString("D"),
-                    Summary = summary,
-                    SortableUniqueId = ctx.CurrentSortableUniqueId
-                })
-        ];
+        return [statement];
     }
 
     private async Task ExerciseInferableQueryPortsAsync(
@@ -552,11 +753,224 @@ internal sealed class NullableTextMvProjector : IMaterializedViewProjector, IMvS
     };
 }
 
+internal sealed class NullableNonTextStatementMvProjector :
+    IMaterializedViewProjector,
+    IMvSchemaRequirementsProvider
+{
+    public const string CharacterizationName = "uncast-nullable-nontext-update";
+    public static readonly Guid SeededUuid = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    public static readonly DateTimeOffset SeededTimestamp =
+        new(2026, 1, 2, 3, 4, 5, TimeSpan.Zero);
+    public static readonly byte[] SeededBytes = [1, 2, 3];
+    public const int SeededInt = 42;
+
+    public string ViewName => "NullBindingNonText";
+    public int ViewVersion => 1;
+    public MvTable Rows { get; private set; } = default!;
+    public string LastNullStatementSql { get; private set; } = string.Empty;
+
+    public IReadOnlyList<MvSchemaTableRequirement> GetSchemaRequirements(
+        MvDbType databaseType,
+        IMvTableBindings tables)
+    {
+        var columns = new List<MvSchemaColumnRequirement>
+        {
+            new("forecast_id", MvSchemaTypeFamily.String, false),
+            new("_last_sortable_unique_id", MvSchemaTypeFamily.String, false)
+        };
+
+        switch (databaseType)
+        {
+            case MvDbType.Postgres:
+                columns.Insert(1, new("uuid_probe", MvSchemaTypeFamily.Guid, true));
+                columns.Insert(2, new("timestamp_probe", MvSchemaTypeFamily.DateTime, true));
+                columns.Insert(3, new("bytes_probe", MvSchemaTypeFamily.Binary, true));
+                break;
+            case MvDbType.SqlServer:
+                columns.Insert(1, new("int_probe", MvSchemaTypeFamily.Integer, true));
+                columns.Insert(2, new("bytes_probe", MvSchemaTypeFamily.Binary, true));
+                break;
+            default:
+                throw new NotSupportedException(
+                    $"Nullable non-text statement characterization does not support '{databaseType}'.");
+        }
+
+        return
+        [
+            new MvSchemaTableRequirement(
+                "rows",
+                tables.GetPhysicalName("rows"),
+                columns,
+                ["forecast_id"])
+        ];
+    }
+
+    public async Task InitializeAsync(IMvInitContext ctx, CancellationToken cancellationToken = default)
+    {
+        Rows = ctx.RegisterTable("rows");
+        await ctx.ExecuteAsync(
+                CreateTableSql(ctx.DatabaseType, Rows.PhysicalName),
+                cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    public Task<IReadOnlyList<MvSqlStatement>> ApplyToViewAsync(
+        Event ev,
+        IMvApplyContext ctx,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        return ev.Payload switch
+        {
+            WeatherForecastCreated created => Task.FromResult<IReadOnlyList<MvSqlStatement>>(
+            [
+                new MvSqlStatement(
+                    BuildSeedStatementSql(ctx.DatabaseType),
+                    BuildSeedParameters(created.ForecastId, ctx.CurrentSortableUniqueId, ctx.DatabaseType))
+            ]),
+            WeatherForecastUpdated updated => BuildNullUpdateStatementAsync(
+                ctx.DatabaseType,
+                updated.ForecastId,
+                ctx.CurrentSortableUniqueId),
+            _ => Task.FromResult<IReadOnlyList<MvSqlStatement>>([])
+        };
+    }
+
+    private Task<IReadOnlyList<MvSqlStatement>> BuildNullUpdateStatementAsync(
+        MvDbType databaseType,
+        Guid forecastId,
+        string sortableUniqueId)
+    {
+        LastNullStatementSql = BuildNullUpdateSql(databaseType);
+        object parameters = databaseType switch
+        {
+            MvDbType.Postgres => new
+            {
+                ForecastId = forecastId.ToString("D"),
+                UuidValue = (Guid?)null,
+                TimestampValue = (DateTimeOffset?)null,
+                BytesValue = (byte[]?)null,
+                SortableUniqueId = sortableUniqueId
+            },
+            MvDbType.SqlServer => new
+            {
+                ForecastId = forecastId.ToString("D"),
+                IntValue = (int?)null,
+                BytesValue = (byte[]?)null,
+                SortableUniqueId = sortableUniqueId
+            },
+            _ => throw new NotSupportedException(
+                $"Nullable non-text statement characterization does not support '{databaseType}'.")
+        };
+
+        return Task.FromResult<IReadOnlyList<MvSqlStatement>>(
+        [new MvSqlStatement(LastNullStatementSql, parameters)]);
+    }
+
+    private static object BuildSeedParameters(
+        Guid forecastId,
+        string sortableUniqueId,
+        MvDbType databaseType) => databaseType switch
+    {
+        MvDbType.Postgres => new
+        {
+            ForecastId = forecastId.ToString("D"),
+            UuidValue = SeededUuid,
+            TimestampValue = SeededTimestamp,
+            BytesValue = SeededBytes,
+            SortableUniqueId = sortableUniqueId
+        },
+        MvDbType.SqlServer => new
+        {
+            ForecastId = forecastId.ToString("D"),
+            IntValue = SeededInt,
+            BytesValue = SeededBytes,
+            SortableUniqueId = sortableUniqueId
+        },
+        _ => throw new NotSupportedException(
+            $"Nullable non-text statement characterization does not support '{databaseType}'.")
+    };
+
+    private string BuildSeedStatementSql(MvDbType databaseType) => databaseType switch
+    {
+        MvDbType.Postgres => $"""
+            INSERT INTO {Rows.PhysicalName}
+                (forecast_id, uuid_probe, timestamp_probe, bytes_probe, _last_sortable_unique_id)
+            VALUES
+                (@ForecastId, @UuidValue, @TimestampValue, @BytesValue, @SortableUniqueId);
+            """,
+        MvDbType.SqlServer => $"""
+            INSERT INTO {Rows.PhysicalName}
+                (forecast_id, int_probe, bytes_probe, _last_sortable_unique_id)
+            VALUES
+                (@ForecastId, @IntValue, @BytesValue, @SortableUniqueId);
+            """,
+        _ => throw new NotSupportedException(
+            $"Nullable non-text statement characterization does not support '{databaseType}'.")
+    };
+
+    private string BuildNullUpdateSql(MvDbType databaseType) => databaseType switch
+    {
+        MvDbType.Postgres => $"""
+            UPDATE {Rows.PhysicalName}
+            SET uuid_probe = @UuidValue,
+                timestamp_probe = @TimestampValue,
+                bytes_probe = @BytesValue,
+                _last_sortable_unique_id = @SortableUniqueId
+            WHERE forecast_id = @ForecastId;
+            """,
+        MvDbType.SqlServer => $"""
+            UPDATE {Rows.PhysicalName}
+            SET int_probe = @IntValue,
+                bytes_probe = @BytesValue,
+                _last_sortable_unique_id = @SortableUniqueId
+            WHERE forecast_id = @ForecastId;
+            """,
+        _ => throw new NotSupportedException(
+            $"Nullable non-text statement characterization does not support '{databaseType}'.")
+    };
+
+    private static string CreateTableSql(MvDbType databaseType, string tableName) => databaseType switch
+    {
+        MvDbType.Postgres => $"""
+            CREATE TABLE IF NOT EXISTS {tableName} (
+                forecast_id VARCHAR(36) NOT NULL PRIMARY KEY,
+                uuid_probe UUID NULL,
+                timestamp_probe TIMESTAMPTZ NULL,
+                bytes_probe BYTEA NULL,
+                _last_sortable_unique_id VARCHAR(64) NOT NULL
+            );
+            """,
+        MvDbType.SqlServer => $"""
+            IF OBJECT_ID(N'{tableName}', N'U') IS NULL
+            BEGIN
+                CREATE TABLE {tableName} (
+                    forecast_id NVARCHAR(36) NOT NULL PRIMARY KEY,
+                    int_probe INT NULL,
+                    bytes_probe VARBINARY(MAX) NULL,
+                    _last_sortable_unique_id NVARCHAR(64) NOT NULL
+                );
+            END;
+            """,
+        _ => throw new NotSupportedException(
+            $"Nullable non-text statement characterization does not support '{databaseType}'.")
+    };
+}
+
 internal sealed class NullableTextRow
 {
     public string ForecastId { get; init; } = string.Empty;
     public string? Summary { get; init; }
     public string LastSortableUniqueId { get; init; } = string.Empty;
+}
+
+internal sealed class NullableNonTextRow
+{
+    public Guid? UuidProbe { get; init; }
+    public DateTimeOffset? TimestampProbe { get; init; }
+    public byte[]? BytesProbe { get; init; }
+    public int? IntProbe { get; init; }
 }
 
 internal sealed record NullParameterQueryObservation(string Port, string Input, string Output);

--- a/dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/MvNullParameterTests.cs
+++ b/dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/MvNullParameterTests.cs
@@ -1,0 +1,564 @@
+using System.Data.Common;
+using Dapper;
+using Dcb.Domain.WithoutResult;
+using Dcb.Domain.WithoutResult.Weather;
+using Microsoft.Extensions.DependencyInjection;
+using Npgsql;
+using Sekiban.Dcb.Actors;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.MaterializedView;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Sekiban.Dcb.MaterializedView.MultiProvider.Tests;
+
+[Collection(nameof(PostgresMvCollection))]
+public sealed class PostgresMvNullParameterTests(PostgresMvFixture fixture, ITestOutputHelper output)
+{
+    [SkippableFact]
+    public Task NullableText_IsBoundAsSqlNull_AndAllQueryPortsExecute() =>
+        MvNullParameterAssertions.AssertNullableTextAsync(fixture, output);
+
+    [SkippableFact]
+    public Task NonInferableScalarNull_IsMeasuredAtThePostgresQueryPort() =>
+        MvNullParameterAssertions.AssertPostgresNonInferableScalarAsync(fixture, output);
+}
+
+[Collection(nameof(MySqlMvCollection))]
+public sealed class MySqlMvNullParameterTests(MySqlMvFixture fixture, ITestOutputHelper output)
+{
+    [SkippableFact]
+    public Task NullableText_IsBoundAsSqlNull_AndAllQueryPortsExecute() =>
+        MvNullParameterAssertions.AssertNullableTextAsync(fixture, output);
+}
+
+[Collection(nameof(SqlServerMvCollection))]
+public sealed class SqlServerMvNullParameterTests(SqlServerMvFixture fixture, ITestOutputHelper output)
+{
+    [SkippableFact]
+    public Task NullableText_IsBoundAsSqlNull_AndAllQueryPortsExecute() =>
+        MvNullParameterAssertions.AssertNullableTextAsync(fixture, output);
+}
+
+[Collection(nameof(SqliteMvCollection))]
+public sealed class SqliteMvNullParameterTests(SqliteMvFixture fixture, ITestOutputHelper output)
+{
+    [SkippableFact]
+    public Task NullableText_IsBoundAsSqlNull_AndAllQueryPortsExecute() =>
+        MvNullParameterAssertions.AssertNullableTextAsync(fixture, output);
+}
+
+internal static class MvNullParameterAssertions
+{
+    public static async Task AssertNullableTextAsync(
+        MultiProviderFixtureBase fixture,
+        ITestOutputHelper output)
+    {
+        Skip.IfNot(fixture.IsAvailable, fixture.AvailabilityMessage ?? "Materialized-view fixture is unavailable.");
+
+        await fixture.ResetAsync().ConfigureAwait(false);
+        var projector = new NullableTextMvProjector();
+        var host = new NativeMvApplyHost(projector, fixture.DomainTypes.EventTypes, fixture.DatabaseTypeForTests);
+        await fixture.Executor.InitializeAsync(host).ConfigureAwait(false);
+
+        output.WriteLine($"provider={fixture.DatabaseTypeForTests}");
+        output.WriteLine($"version={await ReadProviderVersionAsync(fixture).ConfigureAwait(false)}");
+        output.WriteLine($"inferable-query={NullableTextMvProjector.InferableTextQuery}");
+
+        var executor = new GeneralSekibanExecutor(fixture.EventStore, fixture.ActorAccessor, fixture.DomainTypes);
+        var forecastId = Guid.CreateVersion7();
+        var forecastDate = DateOnly.FromDateTime(DateTime.UtcNow.Date);
+
+        await executor.ExecuteAsync(
+                new CreateWeatherForecast
+                {
+                    ForecastId = forecastId,
+                    Location = "Tokyo",
+                    Date = forecastDate,
+                    TemperatureC = 20,
+                    Summary = "initial"
+                })
+            .ConfigureAwait(false);
+        var firstCatchUp = await fixture.Executor.CatchUpOnceAsync(host).ConfigureAwait(false);
+        var firstRow = await ReadRowAsync(fixture, projector, forecastId).ConfigureAwait(false);
+        var firstEntry = await ReadRegistryEntryAsync(fixture, projector).ConfigureAwait(false);
+
+        Assert.Equal(1, firstCatchUp.AppliedEvents);
+        Assert.Equal("initial", firstRow.Summary);
+        Assert.Equal(1, firstEntry.AppliedEventVersion);
+        AssertCheckpointAdvanced(firstEntry);
+
+        await executor.ExecuteAsync(
+                new UpdateWeatherForecast
+                {
+                    ForecastId = forecastId,
+                    Location = "Kyoto",
+                    Date = forecastDate.AddDays(1),
+                    TemperatureC = 21,
+                    Summary = null
+                })
+            .ConfigureAwait(false);
+        var nullCatchUp = await fixture.Executor.CatchUpOnceAsync(host).ConfigureAwait(false);
+        var nullRow = await ReadRowAsync(fixture, projector, forecastId).ConfigureAwait(false);
+        var nullEntry = await ReadRegistryEntryAsync(fixture, projector).ConfigureAwait(false);
+
+        Assert.Equal(1, nullCatchUp.AppliedEvents);
+        Assert.Null(nullRow.Summary);
+        Assert.Equal(2, nullEntry.AppliedEventVersion);
+        AssertCheckpointAdvanced(nullEntry);
+
+        await executor.ExecuteAsync(
+                new UpdateWeatherForecast
+                {
+                    ForecastId = forecastId,
+                    Location = "Osaka",
+                    Date = forecastDate.AddDays(2),
+                    TemperatureC = 22,
+                    Summary = "later"
+                })
+            .ConfigureAwait(false);
+        var laterCatchUp = await fixture.Executor.CatchUpOnceAsync(host).ConfigureAwait(false);
+        var laterRow = await ReadRowAsync(fixture, projector, forecastId).ConfigureAwait(false);
+        var laterEntry = await ReadRegistryEntryAsync(fixture, projector).ConfigureAwait(false);
+
+        Assert.Equal(1, laterCatchUp.AppliedEvents);
+        Assert.Equal("later", laterRow.Summary);
+        Assert.Equal(3, laterEntry.AppliedEventVersion);
+        AssertCheckpointAdvanced(laterEntry);
+
+        Assert.Equal(9, projector.QueryObservations.Count);
+        Assert.Equal(3, projector.QueryObservations.Count(observation => observation.Port == "rows"));
+        Assert.Equal(3, projector.QueryObservations.Count(observation => observation.Port == "single"));
+        Assert.Equal(3, projector.QueryObservations.Count(observation => observation.Port == "scalar"));
+        Assert.Contains(
+            projector.QueryObservations,
+            observation => observation.Input == "<null>" && observation.Output == "query-fallback");
+
+        output.WriteLine($"apply-command={projector.LastApplySql}");
+        foreach (var observation in projector.QueryObservations)
+        {
+            output.WriteLine(
+                $"query-port={observation.Port}; input={observation.Input}; output={observation.Output}");
+        }
+
+        foreach (var characterization in projector.Characterizations)
+        {
+            output.WriteLine(
+                $"characterization={characterization.Name}; command={characterization.Command}; outcome={characterization.Outcome}");
+        }
+    }
+
+    public static async Task AssertPostgresNonInferableScalarAsync(
+        PostgresMvFixture fixture,
+        ITestOutputHelper output)
+    {
+        Skip.IfNot(fixture.IsAvailable, fixture.AvailabilityMessage ?? "PostgreSQL fixture is unavailable.");
+
+        await fixture.ResetAsync().ConfigureAwait(false);
+        var projector = new NullableTextMvProjector(runNonInferableScalar: true);
+        var host = new NativeMvApplyHost(projector, fixture.DomainTypes.EventTypes, fixture.DatabaseTypeForTests);
+        await fixture.Executor.InitializeAsync(host).ConfigureAwait(false);
+
+        var executor = new GeneralSekibanExecutor(fixture.EventStore, fixture.ActorAccessor, fixture.DomainTypes);
+        await executor.ExecuteAsync(
+                new CreateWeatherForecast
+                {
+                    ForecastId = Guid.CreateVersion7(),
+                    Location = "Tokyo",
+                    Date = DateOnly.FromDateTime(DateTime.UtcNow.Date),
+                    TemperatureC = 20,
+                    Summary = "probe"
+                })
+            .ConfigureAwait(false);
+
+        const string sql = "SELECT @P;";
+        try
+        {
+            output.WriteLine($"provider=Postgres; version={await ReadProviderVersionAsync(fixture).ConfigureAwait(false)}");
+            var catchUp = await fixture.Executor.CatchUpOnceAsync(host).ConfigureAwait(false);
+            output.WriteLine($"non-inferable-command={sql}; outcome=succeeded; result={(projector.NonInferableScalarResult ?? "<null>")}");
+            Assert.Equal(1, catchUp.AppliedEvents);
+            Assert.Null(projector.NonInferableScalarResult);
+        }
+        catch (PostgresException exception)
+        {
+            output.WriteLine(
+                $"provider=Postgres; version={await ReadProviderVersionAsync(fixture).ConfigureAwait(false)}");
+            output.WriteLine(
+                $"non-inferable-command={sql}; outcome=provider-limited; sql-state={exception.SqlState}; message={exception.MessageText}");
+            Assert.Equal("42P18", exception.SqlState);
+        }
+    }
+
+    private static void AssertCheckpointAdvanced(MvRegistryEntry entry)
+    {
+        Assert.True(entry.CurrentCheckpointTruth.IsKnown);
+        Assert.False(string.IsNullOrWhiteSpace(entry.CurrentCheckpointTruth.PositionValue));
+        Assert.False(string.IsNullOrWhiteSpace(entry.CurrentPosition));
+    }
+
+    private static async Task<NullableTextRow> ReadRowAsync(
+        MultiProviderFixtureBase fixture,
+        NullableTextMvProjector projector,
+        Guid forecastId)
+    {
+        await using var connection = await fixture.OpenConnectionAsync().ConfigureAwait(false);
+        return await connection.QuerySingleAsync<NullableTextRow>(
+                $"""
+                 SELECT forecast_id AS ForecastId,
+                        summary AS Summary,
+                        _last_sortable_unique_id AS LastSortableUniqueId
+                 FROM {projector.Rows.PhysicalName}
+                 WHERE forecast_id = @ForecastId;
+                 """,
+                new { ForecastId = forecastId.ToString("D") })
+            .ConfigureAwait(false);
+    }
+
+    private static async Task<MvRegistryEntry> ReadRegistryEntryAsync(
+        MultiProviderFixtureBase fixture,
+        NullableTextMvProjector projector)
+    {
+        var entries = await fixture.Services.GetRequiredService<IMvRegistryStore>()
+            .GetEntriesAsync(
+                MultiProviderFixtureBase.ServiceId,
+                projector.ViewName,
+                projector.ViewVersion)
+            .ConfigureAwait(false);
+        return Assert.Single(entries);
+    }
+
+    private static async Task<string> ReadProviderVersionAsync(MultiProviderFixtureBase fixture)
+    {
+        await using var connection = await fixture.OpenConnectionAsync().ConfigureAwait(false);
+        var sql = fixture.DatabaseTypeForTests switch
+        {
+            MvDbType.Postgres => "SELECT version();",
+            MvDbType.SqlServer => "SELECT @@VERSION;",
+            MvDbType.MySql => "SELECT VERSION();",
+            MvDbType.Sqlite => "SELECT sqlite_version();",
+            _ => throw new NotSupportedException($"Unsupported database type '{fixture.DatabaseTypeForTests}'.")
+        };
+        return await connection.ExecuteScalarAsync<string>(sql).ConfigureAwait(false) ?? "<null>";
+    }
+}
+
+internal sealed class NullableTextMvProjector : IMaterializedViewProjector, IMvSchemaRequirementsProvider
+{
+    public const string InferableTextQuery = "SELECT COALESCE(@Summary, 'query-fallback') AS summary;";
+
+    private readonly bool _runNonInferableScalar;
+    private readonly List<NullParameterQueryObservation> _queryObservations = [];
+    private readonly List<NullParameterCharacterization> _characterizations = [];
+    private bool _characterizationComplete;
+
+    public NullableTextMvProjector(bool runNonInferableScalar = false)
+    {
+        _runNonInferableScalar = runNonInferableScalar;
+    }
+
+    public string ViewName => "NullBinding";
+    public int ViewVersion => 1;
+    public MvTable Rows { get; private set; } = default!;
+    public string LastApplySql { get; private set; } = string.Empty;
+    public string? NonInferableScalarResult { get; private set; }
+    public IReadOnlyList<NullParameterQueryObservation> QueryObservations => _queryObservations;
+    public IReadOnlyList<NullParameterCharacterization> Characterizations => _characterizations;
+
+    public IReadOnlyList<MvSchemaTableRequirement> GetSchemaRequirements(
+        MvDbType databaseType,
+        IMvTableBindings tables) =>
+    [
+        new MvSchemaTableRequirement(
+            "rows",
+            tables.GetPhysicalName("rows"),
+            [
+                new("forecast_id", MvSchemaTypeFamily.String, false),
+                new("summary", MvSchemaTypeFamily.String, true),
+                new("_last_sortable_unique_id", MvSchemaTypeFamily.String, false)
+            ],
+            ["forecast_id"])
+    ];
+
+    public async Task InitializeAsync(IMvInitContext ctx, CancellationToken cancellationToken = default)
+    {
+        Rows = ctx.RegisterTable("rows");
+        await ctx.ExecuteAsync(
+                CreateTableSql(ctx.DatabaseType, Rows.PhysicalName),
+                cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    public async Task<IReadOnlyList<MvSqlStatement>> ApplyToViewAsync(
+        Event ev,
+        IMvApplyContext ctx,
+        CancellationToken cancellationToken = default)
+    {
+        Guid forecastId;
+        string? summary;
+        switch (ev.Payload)
+        {
+            case WeatherForecastCreated created:
+                forecastId = created.ForecastId;
+                summary = created.Summary;
+                break;
+            case WeatherForecastUpdated updated:
+                forecastId = updated.ForecastId;
+                summary = updated.Summary;
+                break;
+            default:
+                return [];
+        }
+
+        if (_runNonInferableScalar)
+        {
+            NonInferableScalarResult = await ctx.ExecuteScalarAsync<string?>(
+                    "SELECT @P;",
+                    new { P = (string?)null },
+                    cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        await ExerciseInferableQueryPortsAsync(ctx, summary, cancellationToken).ConfigureAwait(false);
+        if (!_characterizationComplete)
+        {
+            await CharacterizeProviderSpecificNullsAsync(ctx, cancellationToken).ConfigureAwait(false);
+            _characterizationComplete = true;
+        }
+
+        var sql = BuildUpsert(ctx.DatabaseType);
+        LastApplySql = sql;
+        return
+        [
+            new MvSqlStatement(
+                sql,
+                new
+                {
+                    ForecastId = forecastId.ToString("D"),
+                    Summary = summary,
+                    SortableUniqueId = ctx.CurrentSortableUniqueId
+                })
+        ];
+    }
+
+    private async Task ExerciseInferableQueryPortsAsync(
+        IMvApplyContext ctx,
+        string? summary,
+        CancellationToken cancellationToken)
+    {
+        var parameters = new { Summary = summary };
+        var expected = summary ?? "query-fallback";
+        var input = summary ?? "<null>";
+
+        var rows = await ctx.QueryRowsAsync(InferableTextQuery, parameters, cancellationToken).ConfigureAwait(false);
+        if (rows.Count != 1)
+        {
+            throw new InvalidOperationException($"Expected one inferable query row, got {rows.Count}.");
+        }
+
+        var rowsValue = rows[0].GetString("summary");
+        if (!string.Equals(rowsValue, expected, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException($"Inferable query rows returned '{rowsValue}', expected '{expected}'.");
+        }
+
+        _queryObservations.Add(new NullParameterQueryObservation("rows", input, rowsValue));
+
+        var single = await ctx.QuerySingleOrDefaultRowAsync(InferableTextQuery, parameters, cancellationToken)
+            .ConfigureAwait(false);
+        if (single is null)
+        {
+            throw new InvalidOperationException("Inferable single-row query returned no row.");
+        }
+
+        var singleValue = single.GetString("summary");
+        if (!string.Equals(singleValue, expected, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException($"Inferable single-row query returned '{singleValue}', expected '{expected}'.");
+        }
+
+        _queryObservations.Add(new NullParameterQueryObservation("single", input, singleValue));
+
+        var scalar = await ctx.ExecuteScalarAsync<string>(InferableTextQuery, parameters, cancellationToken)
+            .ConfigureAwait(false);
+        if (!string.Equals(scalar, expected, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException($"Inferable scalar query returned '{scalar}', expected '{expected}'.");
+        }
+
+        _queryObservations.Add(new NullParameterQueryObservation("scalar", input, scalar));
+    }
+
+    private async Task CharacterizeProviderSpecificNullsAsync(
+        IMvApplyContext ctx,
+        CancellationToken cancellationToken)
+    {
+        switch (ctx.DatabaseType)
+        {
+            case MvDbType.Postgres:
+                await CharacterizeAsync(
+                        ctx,
+                        "postgres-uuid-timestamptz-bytea",
+                        "SELECT CAST(@UuidValue AS uuid) AS uuid_value, CAST(@TimestampValue AS timestamptz) AS timestamp_value, CAST(@BytesValue AS bytea) AS bytes_value;",
+                        new
+                        {
+                            UuidValue = (Guid?)null,
+                            TimestampValue = (DateTimeOffset?)null,
+                            BytesValue = (byte[]?)null
+                        },
+                        ["uuid_value", "timestamp_value", "bytes_value"],
+                        cancellationToken)
+                    .ConfigureAwait(false);
+                break;
+            case MvDbType.SqlServer:
+                await CharacterizeAsync(
+                        ctx,
+                        "sqlserver-int-varbinary",
+                        "SELECT CAST(@IntValue AS int) AS int_value, CAST(@BytesValue AS varbinary(max)) AS bytes_value;",
+                        new
+                        {
+                            IntValue = (int?)null,
+                            BytesValue = (byte[]?)null
+                        },
+                        ["int_value", "bytes_value"],
+                        cancellationToken)
+                    .ConfigureAwait(false);
+                break;
+            case MvDbType.MySql:
+            case MvDbType.Sqlite:
+                _characterizations.Add(
+                    new NullParameterCharacterization(
+                        $"{ctx.DatabaseType.ToString().ToLowerInvariant()}-nullable-text",
+                        InferableTextQuery,
+                        "supported: inferable nullable text returned the fallback value through all three query ports"));
+                break;
+            default:
+                throw new NotSupportedException($"Unsupported database type '{ctx.DatabaseType}'.");
+        }
+    }
+
+    private async Task CharacterizeAsync(
+        IMvApplyContext ctx,
+        string name,
+        string sql,
+        object parameters,
+        IReadOnlyList<string> columns,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var row = await ctx.QuerySingleOrDefaultRowAsync(sql, parameters, cancellationToken).ConfigureAwait(false);
+            if (row is null)
+            {
+                throw new InvalidOperationException("Provider returned no characterization row.");
+            }
+
+            if (columns.Any(column => !row.IsNull(column)))
+            {
+                throw new InvalidOperationException("Provider returned a non-null value for a null cast.");
+            }
+
+            _characterizations.Add(new NullParameterCharacterization(name, sql, "supported: all selected values were SQL NULL"));
+        }
+        catch (DbException exception)
+        {
+            _characterizations.Add(
+                new NullParameterCharacterization(
+                    name,
+                    sql,
+                    $"provider-limited: {exception.GetType().Name}; message={exception.Message}"));
+        }
+    }
+
+    private string BuildUpsert(MvDbType databaseType) => databaseType switch
+    {
+        MvDbType.Postgres => $"""
+            INSERT INTO {Rows.PhysicalName} (forecast_id, summary, _last_sortable_unique_id)
+            VALUES (@ForecastId, @Summary, @SortableUniqueId)
+            ON CONFLICT (forecast_id) DO UPDATE SET
+                summary = EXCLUDED.summary,
+                _last_sortable_unique_id = EXCLUDED._last_sortable_unique_id
+            WHERE {Rows.PhysicalName}._last_sortable_unique_id < EXCLUDED._last_sortable_unique_id;
+            """,
+        MvDbType.SqlServer => $"""
+            MERGE {Rows.PhysicalName} AS target
+            USING (
+                SELECT
+                    @ForecastId AS forecast_id,
+                    @Summary AS summary,
+                    @SortableUniqueId AS _last_sortable_unique_id
+            ) AS source
+            ON target.forecast_id = source.forecast_id
+            WHEN MATCHED AND target._last_sortable_unique_id < source._last_sortable_unique_id THEN
+                UPDATE SET
+                    summary = source.summary,
+                    _last_sortable_unique_id = source._last_sortable_unique_id
+            WHEN NOT MATCHED THEN
+                INSERT (forecast_id, summary, _last_sortable_unique_id)
+                VALUES (source.forecast_id, source.summary, source._last_sortable_unique_id);
+            """,
+        MvDbType.MySql => $"""
+            INSERT INTO {Rows.PhysicalName} (forecast_id, summary, _last_sortable_unique_id)
+            VALUES (@ForecastId, @Summary, @SortableUniqueId)
+            ON DUPLICATE KEY UPDATE
+                summary = IF(_last_sortable_unique_id < VALUES(_last_sortable_unique_id), VALUES(summary), summary),
+                _last_sortable_unique_id = IF(_last_sortable_unique_id < VALUES(_last_sortable_unique_id), VALUES(_last_sortable_unique_id), _last_sortable_unique_id);
+            """,
+        MvDbType.Sqlite => $"""
+            INSERT INTO {Rows.PhysicalName} (forecast_id, summary, _last_sortable_unique_id)
+            VALUES (@ForecastId, @Summary, @SortableUniqueId)
+            ON CONFLICT (forecast_id) DO UPDATE SET
+                summary = excluded.summary,
+                _last_sortable_unique_id = excluded._last_sortable_unique_id
+            WHERE {Rows.PhysicalName}._last_sortable_unique_id < excluded._last_sortable_unique_id;
+            """,
+        _ => throw new NotSupportedException($"Unsupported database type '{databaseType}'.")
+    };
+
+    private static string CreateTableSql(MvDbType databaseType, string tableName) => databaseType switch
+    {
+        MvDbType.Postgres => $"""
+            CREATE TABLE IF NOT EXISTS {tableName} (
+                forecast_id VARCHAR(36) NOT NULL PRIMARY KEY,
+                summary TEXT NULL,
+                _last_sortable_unique_id VARCHAR(64) NOT NULL
+            );
+            """,
+        MvDbType.SqlServer => $"""
+            IF OBJECT_ID(N'{tableName}', N'U') IS NULL
+            BEGIN
+                CREATE TABLE {tableName} (
+                    forecast_id NVARCHAR(36) NOT NULL PRIMARY KEY,
+                    summary NVARCHAR(MAX) NULL,
+                    _last_sortable_unique_id NVARCHAR(64) NOT NULL
+                );
+            END;
+            """,
+        MvDbType.MySql => $"""
+            CREATE TABLE IF NOT EXISTS {tableName} (
+                forecast_id VARCHAR(36) NOT NULL PRIMARY KEY,
+                summary TEXT NULL,
+                _last_sortable_unique_id VARCHAR(64) NOT NULL
+            );
+            """,
+        MvDbType.Sqlite => $"""
+            CREATE TABLE IF NOT EXISTS {tableName} (
+                forecast_id TEXT NOT NULL PRIMARY KEY,
+                summary TEXT NULL,
+                _last_sortable_unique_id TEXT NOT NULL
+            );
+            """,
+        _ => throw new NotSupportedException($"Unsupported database type '{databaseType}'.")
+    };
+}
+
+internal sealed class NullableTextRow
+{
+    public string ForecastId { get; init; } = string.Empty;
+    public string? Summary { get; init; }
+    public string LastSortableUniqueId { get; init; } = string.Empty;
+}
+
+internal sealed record NullParameterQueryObservation(string Port, string Input, string Output);
+
+internal sealed record NullParameterCharacterization(string Name, string Command, string Outcome);

--- a/dcb/tests/Sekiban.Dcb.MaterializedView.Tests/MaterializedViewUnitTests.cs
+++ b/dcb/tests/Sekiban.Dcb.MaterializedView.Tests/MaterializedViewUnitTests.cs
@@ -273,6 +273,28 @@ public class MaterializedViewUnitTests
     }
 
     [Fact]
+    public void MvParamConverter_MapsSerializedNullToClrNull()
+    {
+        var parameters = MvParamConverter.FromObject(new { Summary = (string?)null });
+        var parameter = Assert.Single(parameters);
+
+        Assert.Equal(MvParamKind.Null, parameter.Kind);
+        Assert.Null(parameter.ValueJson);
+        Assert.Null(MvParamConverter.ToClrValue(parameter));
+    }
+
+    [Fact]
+    public void MvParamConverter_PreservesAbsentParametersAndRejectsExplicitDbNull()
+    {
+        Assert.Empty(MvParamConverter.FromObject(null));
+
+        var exception = Assert.Throws<NotSupportedException>(
+            () => MvParamConverter.FromObject(new { Summary = DBNull.Value }));
+
+        Assert.Contains("System.DBNull", exception.Message);
+    }
+
+    [Fact]
     public void MvParamConverter_RejectsNullPayloadForNonNullKind()
     {
         var exception = Assert.Throws<InvalidOperationException>(

--- a/dcb/tests/Sekiban.Dcb.MaterializedView.Tests/MaterializedViewUnitTests.cs
+++ b/dcb/tests/Sekiban.Dcb.MaterializedView.Tests/MaterializedViewUnitTests.cs
@@ -153,9 +153,9 @@ public class MaterializedViewUnitTests
             }),
             NullLogger<MvCatchUpWorker>.Instance);
 
-        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(50));
+        using var cts = new CancellationTokenSource();
         await worker.StartAsync(cts.Token);
-        await Task.Delay(30, cts.Token);
+        await executor.CatchUpObserved.WaitAsync(TimeSpan.FromSeconds(1));
         await worker.StopAsync(CancellationToken.None);
 
         Assert.True(executor.InitializeCalls >= 1);
@@ -464,9 +464,12 @@ public class MaterializedViewUnitTests
     private sealed class FakeMvExecutor(int initializationFailuresBeforeSuccess = 0) : IMvExecutor
     {
         private int _initializationFailuresRemaining = initializationFailuresBeforeSuccess;
+        private readonly TaskCompletionSource<bool> _catchUpObserved =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
         public int InitializeCalls { get; private set; }
         public int CatchUpCalls { get; private set; }
         public List<string?> ServiceIds { get; } = [];
+        public Task CatchUpObserved => _catchUpObserved.Task;
 
         public Task InitializeAsync(
             IMvApplyHost host,
@@ -494,6 +497,7 @@ public class MaterializedViewUnitTests
             CancellationToken cancellationToken = default)
         {
             CatchUpCalls++;
+            _catchUpObserved.TrySetResult(true);
             ServiceIds.Add(serviceId);
             return Task.FromResult(new MvCatchUpResult(0, false));
         }

--- a/docs/dcb_llm/20_materialized_view.md
+++ b/docs/dcb_llm/20_materialized_view.md
@@ -262,9 +262,19 @@ SQL `NULL`.
 
 The wire contract supplies an untyped SQL `NULL`, not a typed-null extension. Nullable text and query shapes that give
 the provider an inferable type are supported. UUID, timestamp, binary, and other non-text shapes are provider/query
-characterizations: add an explicit SQL cast or another type context when required, and measure the result. For example,
-PostgreSQL `SELECT @P` is deliberately non-inferable and must not be assumed to work merely because a nullable text
-column binding does.
+characterizations: add an explicit SQL cast or another type context when required, and measure the result.
+The multi-provider regression measures both the cast query shape and an uncast statement shape through a returned
+`MvSqlStatement` executed by the `NativeMvApplyHost`/`MvExecutor` path. It seeds a matching row and reads it back after
+the nullable update, so a supported result proves persisted SQL `NULL`. PostgreSQL uses
+`SELECT CAST(@UuidValue AS uuid), CAST(@TimestampValue AS timestamptz), CAST(@BytesValue AS bytea)` and
+`UPDATE ... SET uuid_probe = @UuidValue, timestamp_probe = @TimestampValue, bytes_probe = @BytesValue`, while SQL Server
+uses `SELECT CAST(@IntValue AS int), CAST(@BytesValue AS varbinary(max))` and
+`UPDATE ... SET int_probe = @IntValue, bytes_probe = @BytesValue`. In the current SQL Server 2022 fixture, the uncast
+`varbinary(max)` statement is provider-limited and measures the exact
+`Microsoft.Data.SqlClient.SqlException`: `Implicit conversion from data type nvarchar to varbinary(max) is not allowed. Use the CONVERT function to run this query.`
+The characterization retains that provider exception after the catch-up boundary, outside the event transaction. An uncast `UPDATE` assignment has column type context
+and is measured separately from a query such as PostgreSQL `SELECT @P`; the latter returned SQL `NULL` in the current
+PostgreSQL 16.15 fixture, but remains untyped and must not be assumed portable.
 
 ## Pre-Provisioned Schema and Host-Owned SQL Policy
 

--- a/docs/dcb_llm/20_materialized_view.md
+++ b/docs/dcb_llm/20_materialized_view.md
@@ -242,6 +242,30 @@ Projector responsibilities:
 - `ApplyToViewAsync`
   Translate one event into one or more SQL statements.
 
+## SQL Parameters and Nullable Values
+
+`MvParamConverter` preserves the distinction between an absent parameter and a present parameter whose value is null.
+An anonymous object such as `new { Summary = nullableSummary }` serializes a null value as
+`MvParamKind.Null` with no `ValueJson`, then maps it back to CLR `null` at the Dapper boundary. Dapper and the selected
+provider can therefore infer SQL `NULL` from the target column or SQL expression:
+
+```csharp
+return new MvSqlStatement(
+    $"UPDATE {Forecasts.PhysicalName} SET summary = @Summary WHERE forecast_id = @ForecastId",
+    new { ForecastId = forecastId, Summary = nullableSummary });
+```
+
+Do not pass `DBNull.Value` from application projector parameters; explicit `DBNull` input is unsupported. Passing no
+parameter object still means that no parameters are sent, and non-null values retain their existing CLR/wire kinds.
+Malformed non-null wire parameters (a non-`Null` kind with missing `ValueJson`) remain errors rather than being treated as
+SQL `NULL`.
+
+The wire contract supplies an untyped SQL `NULL`, not a typed-null extension. Nullable text and query shapes that give
+the provider an inferable type are supported. UUID, timestamp, binary, and other non-text shapes are provider/query
+characterizations: add an explicit SQL cast or another type context when required, and measure the result. For example,
+PostgreSQL `SELECT @P` is deliberately non-inferable and must not be assumed to work merely because a nullable text
+column binding does.
+
 ## Pre-Provisioned Schema and Host-Owned SQL Policy
 
 Initialization keeps the historical `CreateOrEnsure` behavior by default. Hosts that provision database objects through

--- a/docs/dcb_llm_ja/20_materialized_view.md
+++ b/docs/dcb_llm_ja/20_materialized_view.md
@@ -264,9 +264,19 @@ null の `ValueJson` を持つ非 `Null` kind は SQL `NULL` として扱わず�
 
 wire contract が提供するのは型なしの SQL `NULL` であり、型付き null の拡張ではありません。nullable text と、provider が
 型を推論できる query 形状はサポート対象です。UUID、timestamp、binary などの非 text 形状は provider / query の
-characterization です。必要なら SQL の明示的な cast など型コンテキストを追加し、結果を実測してください。たとえば
-PostgreSQL の `SELECT @P` は意図的に型を推論できない形状なので、nullable text の列バインドが成功するからといって
-動作すると仮定してはいけません。
+characterization です。必要なら SQL の明示的な cast など型コンテキストを追加し、結果を実測してください。
+multi-provider 回帰テストでは、返された `MvSqlStatement` を `NativeMvApplyHost` / `MvExecutor` 経由で実行し、cast query と
+uncast statement の両方を測定します。対応できる場合は一致する行を seed して nullable update 後に読み戻すため、永続化された
+SQL `NULL` を確認できます。PostgreSQL は
+`SELECT CAST(@UuidValue AS uuid), CAST(@TimestampValue AS timestamptz), CAST(@BytesValue AS bytea)` と
+`UPDATE ... SET uuid_probe = @UuidValue, timestamp_probe = @TimestampValue, bytes_probe = @BytesValue`、SQL Server は
+`SELECT CAST(@IntValue AS int), CAST(@BytesValue AS varbinary(max))` と
+`UPDATE ... SET int_probe = @IntValue, bytes_probe = @BytesValue` を使います。current SQL Server 2022 fixture では、uncast
+`varbinary(max)` statement は provider-limited となり、次の exact な
+`Microsoft.Data.SqlClient.SqlException` を測定しました: `Implicit conversion from data type nvarchar to varbinary(max) is not allowed. Use the CONVERT function to run this query.`
+この provider exception は catch-up boundary の後、event transaction の外側で保持します。column assignment を持つ uncast `UPDATE`
+は query とは別に列の型コンテキストを測定します。PostgreSQL の `SELECT @P` は current PostgreSQL 16.15 fixture では
+SQL `NULL` を返しましたが、型なしで portable ではないため、nullable text の列バインドが成功するからといって動作を仮定してはいけません。
 
 ## 事前プロビジョニングしたスキーマとホスト所有 SQL ポリシー
 

--- a/docs/dcb_llm_ja/20_materialized_view.md
+++ b/docs/dcb_llm_ja/20_materialized_view.md
@@ -245,6 +245,29 @@ public sealed class WeatherForecastMvV1 : IMaterializedViewProjector
 - `ApplyToViewAsync`
   1 イベントを 1 個以上の SQL 文へ変換
 
+## SQL パラメーターと nullable 値
+
+`MvParamConverter` は、パラメーターが存在しない場合と、存在するパラメーターの値が null の場合を区別します。
+`new { Summary = nullableSummary }` のような匿名オブジェクトの null 値は、`ValueJson` を持たない
+`MvParamKind.Null` としてシリアライズされ、その後 Dapper 境界で CLR の `null` に戻ります。これにより、Dapper
+と選択した provider は、対象列または SQL 式から SQL `NULL` の型を推論できます。
+
+```csharp
+return new MvSqlStatement(
+    $"UPDATE {Forecasts.PhysicalName} SET summary = @Summary WHERE forecast_id = @ForecastId",
+    new { ForecastId = forecastId, Summary = nullableSummary });
+```
+
+application の projector パラメーターから `DBNull.Value` を渡さないでください。明示的な `DBNull` 入力は未対応です。
+パラメーター object を渡さなければパラメーターは送信されず、null でない値は従来の CLR / wire kind を維持します。
+null の `ValueJson` を持つ非 `Null` kind は SQL `NULL` として扱わず、これまでどおりエラーにします。
+
+wire contract が提供するのは型なしの SQL `NULL` であり、型付き null の拡張ではありません。nullable text と、provider が
+型を推論できる query 形状はサポート対象です。UUID、timestamp、binary などの非 text 形状は provider / query の
+characterization です。必要なら SQL の明示的な cast など型コンテキストを追加し、結果を実測してください。たとえば
+PostgreSQL の `SELECT @P` は意図的に型を推論できない形状なので、nullable text の列バインドが成功するからといって
+動作すると仮定してはいけません。
+
 ## 事前プロビジョニングしたスキーマとホスト所有 SQL ポリシー
 
 初期化の既定値は、従来互換の `CreateOrEnsure` です。deployment migration などで DB オブジェクトを管理する


### PR DESCRIPTION
Closes #1187

## Summary

- Map serialized `MvParamKind.Null` to CLR `null` at the Dapper boundary.
- Cover persisted nullable text create/null/later updates through `NativeMvApplyHost`, the normal executor, all four provider executors, and all three query-port shapes.
- Preserve absent parameters, non-null kinds, malformed non-Null wire values, and explicit `DBNull.Value` rejection.
- Document untyped-null semantics and measured provider/query limitations in the existing EN/JA materialized-view guides.

## Verification evidence

Repair head: `6ecb8f693b85d828e23d4b1aceddd2ac25ac347d` (F1/F2 and timing-sensitive CI test repair). Local results below do not replace exact-head CI/review.

### AC1 and AC5 — converter semantics and discriminating cases

```text
$ dotnet test dcb/tests/Sekiban.Dcb.MaterializedView.Tests/Sekiban.Dcb.MaterializedView.Tests.csproj -c Release -f net9.0 --no-restore
Passed: 85  Failed: 0  Skipped: 0

$ dotnet test dcb/tests/Sekiban.Dcb.MaterializedView.Tests/Sekiban.Dcb.MaterializedView.Tests.csproj -c Release -f net10.0 --no-restore
Passed!  - Failed:     0, Passed:    85, Skipped:     0, Total:    85
```

The unit coverage includes present-null (`MvParamKind.Null` with no `ValueJson`), absent parameters, non-null typed round-trips, explicit `DBNull.Value` rejection, and malformed non-Null kind with null `ValueJson`.

### AC2 — real PostgreSQL persisted-event binding and checkpoint path

```text
provider=Postgres
version=PostgreSQL 16.15 on aarch64-unknown-linux-musl, compiled by gcc (Alpine 15.2.0) 15.2.0, 64-bit
query-port=rows; input=<null>; output=query-fallback
query-port=single; input=<null>; output=query-fallback
query-port=scalar; input=<null>; output=query-fallback
```

The real `NativeMvApplyHost` test applies non-null text, a persisted anonymous nullable-string null, and a later non-null update. It asserts SQL NULL in the materialized row, applied event versions 1/2/3, and a committed known checkpoint after each catch-up.

The isolated statement-only regression skips all query-port probes and returns the `Summary` DML directly through `NativeMvApplyHost` / `MvExecutor`. Temporary converter reversion and restoration produced:

```text
before (MvParamKind.Null => DBNull.Value):
System.NotSupportedException: The member Summary of type System.DBNull cannot be used as a parameter value
stack: Dapper.SqlMapper.LookupDbType -> MvExecutorBase.ApplySerializableEventAsync -> PostgresMvExecutor.CatchUpOnceAsync

after (MvParamKind.Null => null restored):
$ dotnet test dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests.csproj -c Release -f net9.0 --no-restore --filter FullyQualifiedName~StatementOnlyNullableText_IsBoundThroughTheDapperStatementPath
Total tests: 1; Passed: 1; Failed: 0; Skipped: 0
```

### AC3 — four-provider executors and query ports

```text
focused MultiProvider net9.0: Passed 8  Failed 0  Skipped 0
focused MultiProvider net10.0: Passed 8  Failed 0  Skipped 0

provider=Postgres; version=PostgreSQL 16.15
characterization=postgres-uuid-timestamptz-bytea; command=SELECT CAST(@UuidValue AS uuid) AS uuid_value, CAST(@TimestampValue AS timestamptz) AS timestamp_value, CAST(@BytesValue AS bytea) AS bytes_value; outcome=supported: all selected values were SQL NULL

provider=SqlServer; version=Microsoft SQL Server 2022 (RTM-CU24) - 16.0.4245.2
characterization=sqlserver-int-varbinary; command=SELECT CAST(@IntValue AS int) AS int_value, CAST(@BytesValue AS varbinary(max)) AS bytes_value; outcome=supported: all selected values were SQL NULL

provider=MySql; version=8.4.11
characterization=mysql-nullable-text; outcome=supported: inferable nullable text returned the fallback value through all three query ports

provider=Sqlite; version=3.49.1
characterization=sqlite-nullable-text; outcome=supported: inferable nullable text returned the fallback value through all three query ports
```

Each focused run exercised the real Testcontainers-backed fixture, DML executor, and rows/single/scalar query ports with 0 skipped tests.

The separate `NullableNonTextStatementMvProjector` seeds a matching real forecast ID with non-null values, returns `MvSqlStatement` through the serialized-parameter path, and reads back over a fresh connection. No direct anonymous-parameter Dapper shortcut is used for this statement characterization. The exact uncast shapes/outcomes are:

```text
provider=Postgres; version=PostgreSQL 16.15
command=UPDATE sekiban_mv_nullbindingnontext_v1_rows SET uuid_probe = @UuidValue, timestamp_probe = @TimestampValue, bytes_probe = @BytesValue, _last_sortable_unique_id = @SortableUniqueId WHERE forecast_id = @ForecastId;
outcome=supported: seeded UUID, timestamptz and bytea values were read back as persisted SQL NULL

provider=SqlServer; version=Microsoft SQL Server 2022 (RTM-CU24) - 16.0.4245.2
command=UPDATE sekiban_mv_nullbindingnontext_v1_rows SET int_probe = @IntValue, bytes_probe = @BytesValue, _last_sortable_unique_id = @SortableUniqueId WHERE forecast_id = @ForecastId;
outcome=provider-limited: Microsoft.Data.SqlClient.SqlException
Implicit conversion from data type nvarchar to varbinary(max) is not allowed. Use the CONVERT function to run this query.
```

The SQL Server combined uncast shape is **not** claimed supported. The provider exception is retained outside the failed event transaction. Both EN/JA docs distinguish explicit CAST results and this limitation. Focused commands used `-c Release -f net9.0|net10.0 --no-restore --filter FullyQualifiedName~MvNullParameterTests`; each ran 8/8 without skips. Design separately corroborated the net10 matrix (8/8) and unit suite (85/85) using `--no-build --no-restore`.

### AC4 — deliberately non-inferable PostgreSQL scalar

```text
provider=Postgres; version=PostgreSQL 16.15
non-inferable-command=SELECT @P;; outcome=succeeded; result=<null>
```

This result is recorded as measured behavior; the wire contract remains an untyped SQL NULL and no typed-null extension is introduced.

### AC6 — docs, CI coverage, and diff check

```text
$ git diff --check
(no output; exit 0)

CI-covered project:
dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests.csproj
TFMs: net9.0, net10.0
```

The complete net9 MultiProvider suite was attempted but hit the known macOS Orleans limitation before completion:
`System.OverflowException` in `Orleans.TestingHost.TestClusterPortAllocator` at
`System.Net.NetworkInformation.BsdIPGlobalProperties.GetTcpConnections`. The complete suite is not claimed green; the focused provider runs above are the relevant passing proof.

### CI timing-test repair

The prior net10 CI failed `CatchUpWorker_UsesPollDelayWhenNothingProcessed` before the MultiProvider project. Its 30 ms fixed delay / 50 ms cancellation budget was replaced with a `TaskCompletionSource` completion signal and a one-second bound; initialize/catch-up/service-ID assertions remain. The full unit suite reports 85/85 on net9 and net10 after repair. New CI at the repair head remains the full-suite gate.

## Scope note

No package versions, release artifacts, or unrelated issue work were changed.
