### PR TITLE
feat(dcb): derive expected tag positions from state reads

### DIFF
--- a/dcb/src/Sekiban.Dcb.Core/Actors/CoreGeneralSekibanExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Actors/CoreGeneralSekibanExecutor.cs
@@ -40,6 +40,15 @@ public class CoreGeneralSekibanExecutor
     internal Func<Guid> ConditionalEventIdFactory { get; set; } = Guid.CreateVersion7;
     internal Func<string>? ConditionalSortableIdFactory { get; set; }
 
+    /// <summary>
+    ///     Test-only barrier immediately before the attempt-local state-read evidence is frozen. The custom argument
+    ///     type keeps this seam out of the public API and out of the provider seam inventory.
+    /// </summary>
+    internal Func<DerivedExpectedTagPositionFreezeContext, Task>? BeforeDerivedExpectedTagPositionFreeze { get; set; }
+
+    /// <summary>Test-only observation of the exact specification submitted after the freeze barrier.</summary>
+    internal Action<ExpectedTagPositionSpecification>? DerivedExpectedTagPositionFrozen { get; set; }
+
     private const string DefaultExecutedUser = "GeneralSekibanExecutor";
     private const string SerializedExecutedUser = "SerializedSekibanExecutor";
     private readonly IExecutedUserProvider? _executedUserProvider;
@@ -139,7 +148,7 @@ public class CoreGeneralSekibanExecutor
         TCommand command,
         Func<TCommand, ICoreCommandContext, Task<ResultBox<EventOrNone>>> handlerFunc,
         CancellationToken cancellationToken = default) where TCommand : ICommand =>
-        ExecuteAsyncCore(command, handlerFunc, null, cancellationToken);
+        ExecuteAsyncCore(command, handlerFunc, null, false, cancellationToken);
 
     /// <summary>
     ///     Shared ordinary-batch pipeline. The legacy public call enters with <paramref name="expectedTagPositions" />
@@ -150,6 +159,7 @@ public class CoreGeneralSekibanExecutor
         TCommand command,
         Func<TCommand, ICoreCommandContext, Task<ResultBox<EventOrNone>>> handlerFunc,
         ExpectedTagPositionSpecification? expectedTagPositions,
+        bool deriveExpectedTagPositionsFromStateReads,
         CancellationToken cancellationToken) where TCommand : ICommand
     {
         var stopwatch = Stopwatch.StartNew();
@@ -166,10 +176,11 @@ public class CoreGeneralSekibanExecutor
             // Expected-position is optional, but never best-effort. Validate its discriminated shape and the live
             // descriptor before the handler can allocate ids, reserve a tag, or reach any provider write method.
             IExpectedTagPositionEventStore? expectedPositionStore = null;
-            if (expectedTagPositions is not null)
+            string? currentServiceId = null;
+            if (expectedTagPositions is not null || deriveExpectedTagPositionsFromStateReads)
             {
-                var currentServiceId = ServiceIdValidator.NormalizeAndValidate(_serviceIdProvider.GetCurrentServiceId());
-                expectedTagPositions.ValidateEntryShapes(currentServiceId);
+                currentServiceId = ServiceIdValidator.NormalizeAndValidate(_serviceIdProvider.GetCurrentServiceId());
+                expectedTagPositions?.ValidateEntryShapes(currentServiceId);
 
                 var capability = Sekiban.Dcb.Capabilities.SekibanDcbCapabilityResolver.DescribeWriteConditions(
                     _eventStore, "event store");
@@ -183,7 +194,7 @@ public class CoreGeneralSekibanExecutor
                 }
 
                 expectedPositionStore = resolvedExpectedPositionStore;
-                if (expectedTagPositions.RequiresEnforcement)
+                if (deriveExpectedTagPositionsFromStateReads || expectedTagPositions?.RequiresEnforcement == true)
                 {
                     var enabled = await expectedPositionStore
                         .EnsureExpectedTagPositionEnforcementEnabledAsync(cancellationToken);
@@ -195,7 +206,9 @@ public class CoreGeneralSekibanExecutor
             }
 
             // Step 1: Create command context
-            var commandContext = new CoreCommandContext(_actorAccessor, _domainTypes);
+            var commandContext = currentServiceId is null
+                ? new CoreCommandContext(_actorAccessor, _domainTypes)
+                : new CoreCommandContext(_actorAccessor, _domainTypes, currentServiceId);
 
             // Step 2: Execute handler function with context
             var handlerResult = await handlerFunc(command, commandContext);
@@ -250,10 +263,25 @@ public class CoreGeneralSekibanExecutor
             // Step 3.1: Validate all tags
             TagValidator.ValidateTagsAndThrow(allTags);
 
+            if (deriveExpectedTagPositionsFromStateReads)
+            {
+                if (BeforeDerivedExpectedTagPositionFreeze is not null)
+                {
+                    await BeforeDerivedExpectedTagPositionFreeze(
+                        new DerivedExpectedTagPositionFreezeContext(commandContext, collectedEvents));
+                }
+
+                expectedTagPositions = DeriveExpectedTagPositions(
+                    commandContext,
+                    allTags,
+                    currentServiceId ?? throw new InvalidOperationException("Derived mode did not resolve a service id."));
+                DerivedExpectedTagPositionFrozen?.Invoke(expectedTagPositions);
+            }
+
             if (expectedTagPositions is not null)
             {
                 expectedTagPositions.ValidateFor(
-                    ServiceIdValidator.NormalizeAndValidate(_serviceIdProvider.GetCurrentServiceId()),
+                    currentServiceId ?? ServiceIdValidator.NormalizeAndValidate(_serviceIdProvider.GetCurrentServiceId()),
                     allTags.Where(tag => tag.IsConsistencyTag()).Select(tag => tag.GetTag()));
             }
 
@@ -355,7 +383,14 @@ public class CoreGeneralSekibanExecutor
                     if (!writeResult.IsSuccess)
                     {
                         await TagReservationHelper.CancelReservationsAsync(_actorAccessor, reservations);
-                        return ResultBox.Error<ExecutionResult>(writeResult.GetException());
+                        var writeException = writeResult.GetException();
+                        if (deriveExpectedTagPositionsFromStateReads &&
+                            writeException is ExpectedTagPositionConflictException conflict)
+                        {
+                            await RecoverDerivedStateReadConflictAsync(conflict, currentServiceId!);
+                        }
+
+                        return ResultBox.Error<ExecutionResult>(writeException);
                     }
 
                     // The expected-position store receives a lossless serialization of the exact Event instances above;
@@ -408,10 +443,18 @@ public class CoreGeneralSekibanExecutor
                         },
                         firstEvent.SortableUniqueIdValue));
             }
-            catch (Exception)
+            catch (Exception ex)
             {
                 // If anything fails after reservations, cancel them
                 await TagReservationHelper.CancelReservationsAsync(_actorAccessor, reservations);
+
+                if (deriveExpectedTagPositionsFromStateReads &&
+                    ex is ExpectedTagPositionConflictException conflict &&
+                    conflict.StateReadRecovery == StateReadRecoveryStatus.NotAttempted)
+                {
+                    await RecoverDerivedStateReadConflictAsync(conflict, currentServiceId!);
+                }
+
                 throw;
             }
         }
@@ -419,6 +462,84 @@ public class CoreGeneralSekibanExecutor
         {
             return ResultBox.Error<ExecutionResult>(ex);
         }
+    }
+
+    private static ExpectedTagPositionSpecification DeriveExpectedTagPositions(
+        CoreCommandContext commandContext,
+        IEnumerable<ITag> allTags,
+        string serviceId)
+    {
+        var entries = new List<TagHeadExpectationEntry>();
+        foreach (var tagGroup in allTags
+                     .Where(tag => tag.IsConsistencyTag())
+                     .GroupBy(CommandStateReadLedger.LogicalTag, StringComparer.Ordinal))
+        {
+            var logicalTag = tagGroup.Key;
+            if (!commandContext.StateReadLedger.TryGet(logicalTag, out var evidence) ||
+                !evidence.IsUsable ||
+                !string.Equals(evidence.ServiceId, serviceId, StringComparison.Ordinal))
+            {
+                throw new TagHeadExpectationValidationException(
+                    $"Emitted consistency tag '{logicalTag}' does not have one compatible successful state read in this command attempt.");
+            }
+
+            foreach (var consistencyTag in tagGroup.OfType<ConsistencyTag>())
+            {
+                if (consistencyTag.SortableUniqueId.HasValue &&
+                    !string.Equals(
+                        consistencyTag.SortableUniqueId.GetValue().Value,
+                        evidence.Position,
+                        StringComparison.Ordinal))
+                {
+                    throw new TagHeadExpectationValidationException(
+                        $"Consistency tag '{logicalTag}' carries a sortable unique id that disagrees with its captured state-read position.");
+                }
+            }
+
+            var expectation = string.IsNullOrEmpty(evidence.Position)
+                ? TagHeadExpectation.AssertEmpty()
+                : TagHeadExpectation.Exact(evidence.Position);
+            entries.Add(new TagHeadExpectationEntry(serviceId, logicalTag, expectation));
+        }
+
+        return new ExpectedTagPositionSpecification(entries);
+    }
+
+    private async Task RecoverDerivedStateReadConflictAsync(
+        ExpectedTagPositionConflictException conflict,
+        string serviceId)
+    {
+        var complete = true;
+        var affectedTags = conflict.Pairs
+            .Where(pair => string.Equals(pair.ServiceId, serviceId, StringComparison.Ordinal))
+            .Select(pair => pair.Tag)
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+
+        foreach (var tag in affectedTags)
+        {
+            try
+            {
+                var actorResult = await _actorAccessor.GetActorAsync<ITagConsistentActorCommon>(tag);
+                if (!actorResult.IsSuccess)
+                {
+                    complete = false;
+                    continue;
+                }
+
+                await actorResult.GetValue().NotifyEventWrittenAsync();
+            }
+            catch
+            {
+                // The original expected/observed conflict is authoritative. This bounded recovery signal is
+                // deliberately best-effort per affected tag, but its aggregate outcome is exposed to the caller.
+                complete = false;
+            }
+        }
+
+        conflict.StateReadRecovery = complete
+            ? StateReadRecoveryStatus.InvalidationCompleted
+            : StateReadRecoveryStatus.InvalidationIncomplete;
     }
 
     public Task<ResultBox<TagState>> GetTagStateAsync(TagStateId tagStateId) =>
@@ -1206,16 +1327,29 @@ public class CoreGeneralSekibanExecutor
         // The two independently additive protocols deliberately do not silently compose: conditional append has a
         // single-event idempotency receipt contract while expected positions are a complete multi-tag conflict contract.
         // Reject the ambiguous combination before the handler/provider path rather than dropping the requested fence.
-        if (options?.ConditionalAppend is not null && options.ExpectedTagPositions is not null)
+        if (options?.ConditionalAppend is not null &&
+            (options.ExpectedTagPositions is not null || options.DeriveExpectedTagPositionsFromStateReads))
         {
             return Task.FromResult(ResultBox.Error<ExecutionResult>(
                 new TagHeadExpectationValidationException(
-                    "ConditionalAppend and ExpectedTagPositions cannot be combined in one command. Use one explicit write-condition protocol.")));
+                    "ConditionalAppend cannot be combined with expected tag positions or state-read derivation in one command. Use one explicit write-condition protocol.")));
+        }
+
+        if (options?.DeriveExpectedTagPositionsFromStateReads == true && options.ExpectedTagPositions is not null)
+        {
+            return Task.FromResult(ResultBox.Error<ExecutionResult>(
+                new TagHeadExpectationValidationException(
+                    "DeriveExpectedTagPositionsFromStateReads cannot be combined with explicit ExpectedTagPositions.")));
         }
 
         return options?.ConditionalAppend is { } conditional
             ? ExecuteConditionalAppendAsync(command, handlerFunc, conditional, cancellationToken)
-            : ExecuteAsyncCore(command, handlerFunc, options?.ExpectedTagPositions, cancellationToken);
+            : ExecuteAsyncCore(
+                command,
+                handlerFunc,
+                options?.ExpectedTagPositions,
+                options?.DeriveExpectedTagPositionsFromStateReads == true,
+                cancellationToken);
     }
 
     private async Task<ResultBox<ExecutionResult>> ExecuteConditionalAppendAsync<TCommand>(

--- a/dcb/src/Sekiban.Dcb.Core/Actors/DerivedExpectedTagPositionFreezeContext.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Actors/DerivedExpectedTagPositionFreezeContext.cs
@@ -1,0 +1,12 @@
+using Sekiban.Dcb.Commands;
+using Sekiban.Dcb.Events;
+
+namespace Sekiban.Dcb.Actors;
+
+/// <summary>
+///     Internal test-only context for the derived expected-position freeze barrier. It carries the real command
+///     context and collected event instances; no public callback or production dependency is introduced.
+/// </summary>
+internal sealed record DerivedExpectedTagPositionFreezeContext(
+    CoreGeneralCommandContext CommandContext,
+    IReadOnlyList<EventPayloadWithTags> CollectedEvents);

--- a/dcb/src/Sekiban.Dcb.Core/Commands/CommandExecutionOptions.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Commands/CommandExecutionOptions.cs
@@ -22,6 +22,13 @@ public sealed record CommandExecutionOptions
     ///     one explicitly discriminated entry. Unsupported stores fail closed before their write path is invoked.
     /// </summary>
     public ExpectedTagPositionSpecification? ExpectedTagPositions { get; init; }
+
+    /// <summary>
+    ///     Derives the expected position for each consistency tag emitted by this command from the successful state
+    ///     reads made by this one handler invocation. The opt-in is deliberately false by default and cannot be
+    ///     combined with either explicit expected positions or conditional append.
+    /// </summary>
+    public bool DeriveExpectedTagPositionsFromStateReads { get; init; }
 }
 
 /// <summary>

--- a/dcb/src/Sekiban.Dcb.Core/Commands/CommandStateReadLedger.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Commands/CommandStateReadLedger.cs
@@ -1,0 +1,125 @@
+using Sekiban.Dcb.Tags;
+
+namespace Sekiban.Dcb.Commands;
+
+/// <summary>
+///     Attempt-local state-read evidence. It is intentionally internal: the handler can receive state, but cannot
+///     manufacture or replace the evidence used by the derived expected-position writer.
+/// </summary>
+internal sealed class CommandStateReadLedger
+{
+    private readonly Dictionary<string, Entry> _entries = new(StringComparer.Ordinal);
+    private readonly string _serviceId;
+
+    public CommandStateReadLedger(string serviceId)
+    {
+        _serviceId = serviceId;
+    }
+
+    public void RecordFailure(ITag tag)
+    {
+        var key = LogicalTag(tag);
+        if (!_entries.TryGetValue(key, out var entry))
+        {
+            entry = new Entry(key, _serviceId);
+            _entries.Add(key, entry);
+        }
+
+        entry.HadFailedAttempt = true;
+    }
+
+    public void RecordSuccess(
+        ITag requestedTag,
+        SerializableTagState state,
+        string expectedProjector,
+        string expectedProjectorVersion)
+    {
+        var key = LogicalTag(requestedTag);
+        if (!_entries.TryGetValue(key, out var entry))
+        {
+            entry = new Entry(key, _serviceId);
+            _entries.Add(key, entry);
+        }
+
+        var position = state.LastSortedUniqueId;
+        if (position is null)
+        {
+            entry.IsMalformed = true;
+            position = string.Empty;
+        }
+
+        if (entry.Position is not null && !string.Equals(entry.Position, position, StringComparison.Ordinal))
+        {
+            entry.HasConflictingPositions = true;
+        }
+        else
+        {
+            entry.Position ??= position;
+        }
+
+        entry.HadSuccessfulRead = true;
+        // Different projectors may legitimately read the same logical tag at the same durable position. Preserve their
+        // raw identity/version as validated provenance without making the expected-position decision depend on which
+        // projector happened to be read first.
+        _ = expectedProjector;
+        _ = expectedProjectorVersion;
+        entry.IsMalformed |= state.Version < 0 ||
+                             (state.Version == 0 && position.Length > 0) ||
+                             (state.Version > 0 && position.Length == 0);
+        entry.IsMalformed |= !string.Equals(state.TagGroup, requestedTag.GetTagGroup(), StringComparison.Ordinal) ||
+                             !string.Equals(state.TagContent, requestedTag.GetTagContent(), StringComparison.Ordinal) ||
+                             string.IsNullOrWhiteSpace(state.TagProjector) ||
+                             string.IsNullOrWhiteSpace(state.ProjectorVersion);
+    }
+
+    public bool TryGet(string tag, out CommandStateReadEvidence evidence)
+    {
+        if (_entries.TryGetValue(tag, out var entry))
+        {
+            evidence = new CommandStateReadEvidence(
+                entry.ServiceId,
+                entry.Tag,
+                entry.Position ?? string.Empty,
+                entry.HadSuccessfulRead,
+                entry.HadFailedAttempt,
+                entry.HasConflictingPositions,
+                entry.IsMalformed);
+            return true;
+        }
+
+        evidence = default;
+        return false;
+    }
+
+    internal static string LogicalTag(ITag tag)
+    {
+        var inner = tag is ConsistencyTag consistencyTag ? consistencyTag.InnerTag : tag;
+        return inner.GetTag();
+    }
+
+    private sealed class Entry(string tag, string serviceId)
+    {
+        public string Tag { get; } = tag;
+        public string ServiceId { get; } = serviceId;
+        public string? Position { get; set; }
+        public bool HadSuccessfulRead { get; set; }
+        public bool HadFailedAttempt { get; set; }
+        public bool HasConflictingPositions { get; set; }
+        public bool IsMalformed { get; set; }
+    }
+}
+
+internal readonly record struct CommandStateReadEvidence(
+    string ServiceId,
+    string Tag,
+    string Position,
+    bool HadSuccessfulRead,
+    bool HadFailedAttempt,
+    bool HasConflictingPositions,
+    bool IsMalformed)
+{
+    public bool IsUsable => HadSuccessfulRead &&
+                            !HadFailedAttempt &&
+                            !HasConflictingPositions &&
+                            !IsMalformed;
+}

--- a/dcb/src/Sekiban.Dcb.Core/Commands/CoreGeneralCommandContext.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Commands/CoreGeneralCommandContext.cs
@@ -1,6 +1,7 @@
 using ResultBoxes;
 using Sekiban.Dcb.Actors;
 using Sekiban.Dcb.Events;
+using Sekiban.Dcb.ServiceId;
 using Sekiban.Dcb.Tags;
 namespace Sekiban.Dcb.Commands;
 
@@ -16,12 +17,22 @@ public class CoreGeneralCommandContext : ICoreCommandContext, ICommandContextRes
     private readonly IActorObjectAccessor _actorAccessor;
     private readonly List<EventPayloadWithTags> _appendedEvents = new();
     private readonly DcbDomainTypes _domainTypes;
+    private readonly CommandStateReadLedger _stateReadLedger;
 
     public CoreGeneralCommandContext(IActorObjectAccessor actorAccessor, DcbDomainTypes domainTypes)
+        : this(actorAccessor, domainTypes, DefaultServiceIdProvider.DefaultServiceId)
+    {
+    }
+
+    internal CoreGeneralCommandContext(IActorObjectAccessor actorAccessor, DcbDomainTypes domainTypes, string serviceId)
     {
         _actorAccessor = actorAccessor ?? throw new ArgumentNullException(nameof(actorAccessor));
         _domainTypes = domainTypes ?? throw new ArgumentNullException(nameof(domainTypes));
+        _stateReadLedger = new CommandStateReadLedger(
+            ServiceIdValidator.NormalizeAndValidate(serviceId));
     }
+
+    internal CommandStateReadLedger StateReadLedger => _stateReadLedger;
 
     public async Task<ResultBox<TagStateTyped<TState>>> GetStateAsync<TState, TProjector>(ITag tag)
         where TState : ITagStatePayload where TProjector : ITagProjector<TProjector>
@@ -41,6 +52,7 @@ public class CoreGeneralCommandContext : ICoreCommandContext, ICommandContextRes
             var actorResult = await _actorAccessor.GetActorAsync<ITagStateActorCommon>(tagStateActorId);
             if (!actorResult.IsSuccess)
             {
+                _stateReadLedger.RecordFailure(tag);
                 // If actor doesn't exist, return empty state with EmptyTagStatePayload
                 // We can't cast EmptyTagStatePayload to TState, so we need to handle this differently
                 var emptyPayload = new EmptyTagStatePayload();
@@ -69,6 +81,7 @@ public class CoreGeneralCommandContext : ICoreCommandContext, ICommandContextRes
 
             if (!payloadResult.IsSuccess)
             {
+                _stateReadLedger.RecordFailure(tag);
                 return ResultBox.Error<TagStateTyped<TState>>(payloadResult.GetException());
             }
 
@@ -88,6 +101,11 @@ public class CoreGeneralCommandContext : ICoreCommandContext, ICommandContextRes
             // Check if the payload is of the expected type
             if (payload is TState typedPayload)
             {
+                _stateReadLedger.RecordSuccess(
+                    tag,
+                    serializableState,
+                    TProjector.ProjectorName,
+                    TProjector.ProjectorVersion);
                 return ResultBox.FromValue(
                     new TagStateTyped<TState>(
                         tag,
@@ -98,12 +116,14 @@ public class CoreGeneralCommandContext : ICoreCommandContext, ICommandContextRes
             }
 
             // If payload type doesn't match, return error
+            _stateReadLedger.RecordFailure(tag);
             return ResultBox.Error<TagStateTyped<TState>>(
                 new InvalidCastException(
                     $"Expected state payload of type {typeof(TState).Name} but got {payload.GetType().Name}"));
         }
         catch (Exception ex)
         {
+            _stateReadLedger.RecordFailure(tag);
             return ResultBox.Error<TagStateTyped<TState>>(ex);
         }
     }
@@ -126,6 +146,7 @@ public class CoreGeneralCommandContext : ICoreCommandContext, ICommandContextRes
             var actorResult = await _actorAccessor.GetActorAsync<ITagStateActorCommon>(tagStateActorId);
             if (!actorResult.IsSuccess)
             {
+                _stateReadLedger.RecordFailure(tag);
                 // If actor doesn't exist, return empty state
                 return ResultBox.FromValue(
                     new TagState(
@@ -148,6 +169,7 @@ public class CoreGeneralCommandContext : ICoreCommandContext, ICommandContextRes
 
             if (!payloadResult.IsSuccess)
             {
+                _stateReadLedger.RecordFailure(tag);
                 return ResultBox.Error<TagState>(payloadResult.GetException());
             }
 
@@ -166,10 +188,17 @@ public class CoreGeneralCommandContext : ICoreCommandContext, ICommandContextRes
             // Track the accessed state
             _accessedTagStates[tag] = tagState;
 
+            _stateReadLedger.RecordSuccess(
+                tag,
+                serializableState,
+                TProjector.ProjectorName,
+                TProjector.ProjectorVersion);
+
             return ResultBox.FromValue(tagState);
         }
         catch (Exception ex)
         {
+            _stateReadLedger.RecordFailure(tag);
             return ResultBox.Error<TagState>(ex);
         }
     }

--- a/dcb/src/Sekiban.Dcb.Core/Sekiban.Dcb.Core.csproj
+++ b/dcb/src/Sekiban.Dcb.Core/Sekiban.Dcb.Core.csproj
@@ -83,6 +83,9 @@
         <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
             <_Parameter1>Sekiban.Dcb.SortableUniqueIdWait.WithoutResult.Tests</_Parameter1>
         </AssemblyAttribute>
+        <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+            <_Parameter1>Sekiban.Dcb.Postgres.Tests</_Parameter1>
+        </AssemblyAttribute>
     </ItemGroup>
 
 </Project>

--- a/dcb/src/Sekiban.Dcb.Core/Storage/TagHeadCas/ExpectedTagPositionContracts.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Storage/TagHeadCas/ExpectedTagPositionContracts.cs
@@ -160,6 +160,20 @@ public sealed class ExpectedTagPositionConflictException : Exception
         : base("One or more expected tag positions do not match the durable PostgreSQL heads.") => Pairs = pairs;
 
     public IReadOnlyList<TagHeadExpectedObserved> Pairs { get; }
+
+    /// <summary>
+    ///     Reports whether derived-mode actor invalidation completed after this durable conflict. Legacy and explicit
+    ///     expected-position paths remain <see cref="StateReadRecoveryStatus.NotAttempted" />.
+    /// </summary>
+    public StateReadRecoveryStatus StateReadRecovery { get; internal set; } = StateReadRecoveryStatus.NotAttempted;
+}
+
+/// <summary>Outcome of the bounded between-attempt actor-head invalidation after a derived-mode conflict.</summary>
+public enum StateReadRecoveryStatus
+{
+    NotAttempted = 0,
+    InvalidationCompleted = 1,
+    InvalidationIncomplete = 2
 }
 
 /// <summary>Typed malformed-request failure raised before a write or lazy head creation.</summary>

--- a/dcb/src/Sekiban.Dcb.Orleans.WithResult/OrleansDcbExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.WithResult/OrleansDcbExecutor.cs
@@ -18,7 +18,7 @@ namespace Sekiban.Dcb.Orleans;
 ///     Orleans-specific implementation of ISekibanExecutor
 ///     Uses Orleans grains for distributed command execution and queries
 /// </summary>
-public class OrleansDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecutor,
+public class OrleansDcbExecutor : ISekibanExecutor, IConditionalCommandExecutor, ISerializedSekibanDcbExecutor,
     ISerializedExpectedTagPositionSekibanDcbExecutor, IExecutorRuntimeDescriptorProvider
 {
     /// <summary>Commands are executed by Orleans grains across the cluster.</summary>
@@ -135,6 +135,21 @@ public class OrleansDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecuto
         Func<TCommand, ICommandContext, Task<ResultBox<EventOrNone>>> handlerFunc,
         CancellationToken cancellationToken = default) where TCommand : ICommand =>
         _generalExecutor.ExecuteAsync(command, handlerFunc, cancellationToken);
+
+    /// <summary>Forwards the additive command execution options to the same registered general executor.</summary>
+    public Task<ResultBox<ExecutionResult>> ExecuteAsync<TCommand>(
+        TCommand command,
+        CommandExecutionOptions options,
+        CancellationToken cancellationToken = default) where TCommand : ICommandWithHandler<TCommand> =>
+        _generalExecutor.ExecuteAsync(command, options, cancellationToken);
+
+    /// <summary>Forwards the additive command execution options and handler to the same registered general executor.</summary>
+    public Task<ResultBox<ExecutionResult>> ExecuteAsync<TCommand>(
+        TCommand command,
+        Func<TCommand, ICommandContext, Task<ResultBox<EventOrNone>>> handlerFunc,
+        CommandExecutionOptions options,
+        CancellationToken cancellationToken = default) where TCommand : ICommand =>
+        _generalExecutor.ExecuteAsync(command, handlerFunc, options, cancellationToken);
 
     /// <summary>
     ///     Execute a handler function without an explicit command

--- a/dcb/src/Sekiban.Dcb.Orleans.WithoutResult/OrleansDcbExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.WithoutResult/OrleansDcbExecutor.cs
@@ -19,7 +19,7 @@ namespace Sekiban.Dcb.Orleans;
 ///     Orleans-specific implementation of ISekibanExecutor (exception-based)
 ///     Uses Orleans grains for distributed command execution and queries
 /// </summary>
-public class OrleansDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecutor,
+public class OrleansDcbExecutor : ISekibanExecutor, IConditionalCommandExecutor, ISerializedSekibanDcbExecutor,
     ISerializedExpectedTagPositionSekibanDcbExecutor, IExecutorRuntimeDescriptorProvider
 {
     /// <summary>Commands are executed by Orleans grains across the cluster.</summary>
@@ -136,6 +136,21 @@ public class OrleansDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecuto
         Func<TCommand, ICommandContext, Task<EventOrNone>> handlerFunc,
         CancellationToken cancellationToken = default) where TCommand : ICommand =>
         _generalExecutor.ExecuteAsync(command, handlerFunc, cancellationToken);
+
+    /// <summary>Forwards the additive command execution options to the same registered general executor.</summary>
+    public Task<ExecutionResult> ExecuteAsync<TCommand>(
+        TCommand command,
+        CommandExecutionOptions options,
+        CancellationToken cancellationToken = default) where TCommand : ICommandWithHandler<TCommand> =>
+        _generalExecutor.ExecuteAsync(command, options, cancellationToken);
+
+    /// <summary>Forwards the additive command execution options and handler to the same registered general executor.</summary>
+    public Task<ExecutionResult> ExecuteAsync<TCommand>(
+        TCommand command,
+        Func<TCommand, ICommandContext, Task<EventOrNone>> handlerFunc,
+        CommandExecutionOptions options,
+        CancellationToken cancellationToken = default) where TCommand : ICommand =>
+        _generalExecutor.ExecuteAsync(command, handlerFunc, options, cancellationToken);
 
     /// <summary>
     ///     Execute a handler function without an explicit command

--- a/dcb/tests/Sekiban.Dcb.Postgres.Tests/DerivedExpectedTagPositionTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Postgres.Tests/DerivedExpectedTagPositionTests.cs
@@ -1,0 +1,375 @@
+using Dcb.Domain.Weather;
+using Microsoft.EntityFrameworkCore;
+using ResultBoxes;
+using Sekiban.Dcb.Actors;
+using Sekiban.Dcb.Commands;
+using Sekiban.Dcb.Common;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.Postgres.DbModels;
+using Sekiban.Dcb.ServiceId;
+using Sekiban.Dcb.Storage;
+using Sekiban.Dcb.Tags;
+using Xunit;
+
+namespace Sekiban.Dcb.Postgres.Tests;
+
+/// <summary>
+///     Provider-backed decision-read CAS evidence. The tests deliberately keep the handler, durable writer, and actor
+///     refresh schedules separate: a frozen read ledger is not allowed to become a post-decision head lookup.
+/// </summary>
+public sealed class DerivedExpectedTagPositionTests : PostgresTestBase
+{
+    private const string ServiceId = DefaultServiceIdProvider.DefaultServiceId;
+
+    public DerivedExpectedTagPositionTests(PostgresTestFixture fixture) : base(fixture) { }
+
+    [Fact]
+    public async Task DerivedRead_UsesOneHandlerAndFreezesTheSuccessfulPostgresCursor()
+    {
+        var tag = new WeatherForecastTag(Guid.CreateVersion7());
+        var initialPosition = NewPosition(-120);
+        await EnableEpochAsync();
+        await WriteAsync(initialPosition, new WeatherForecastCreated(
+            tag.ForecastId,
+            "Tokyo",
+            new DateOnly(2026, 9, 9),
+            20,
+            "initial"), tag);
+
+        var executor = new CoreGeneralSekibanExecutor(Fixture.EventStore, Fixture.ActorAccessor, Fixture.DomainTypes);
+        ExpectedTagPositionSpecification? frozen = null;
+        var handlerInvocations = 0;
+        executor.DerivedExpectedTagPositionFrozen = specification => frozen = specification;
+
+        var result = await executor.ExecuteAsync(
+            new DerivedWeatherCommand(),
+            async (_, context) =>
+            {
+                handlerInvocations++;
+                var state = await context.GetStateAsync<WeatherForecastState, WeatherForecastProjector>(tag);
+                Assert.True(state.IsSuccess, state.IsSuccess ? string.Empty : state.GetException().ToString());
+                return await context.AppendEvent(
+                    new WeatherForecastUpdated(
+                        tag.ForecastId,
+                        "Osaka",
+                        new DateOnly(2026, 9, 9),
+                        21,
+                        "derived"),
+                    tag);
+            },
+            new CommandExecutionOptions { DeriveExpectedTagPositionsFromStateReads = true });
+
+        Assert.True(result.IsSuccess, result.IsSuccess ? string.Empty : result.GetException().ToString());
+        Assert.Equal(1, handlerInvocations);
+        var frozenSpecification = frozen ?? throw new InvalidOperationException("The derived specification was not observed.");
+        var entry = Assert.Single(frozenSpecification.Entries);
+        Assert.Equal(ServiceId, entry.ServiceId);
+        Assert.Equal(tag.GetTag(), entry.Tag);
+        Assert.Equal(TagHeadExpectationKind.Exact, entry.Expectation.Kind);
+        Assert.Equal(initialPosition, entry.Expectation.Position);
+
+        var latest = await Fixture.EventStore.GetLatestTagAsync(tag);
+        Assert.True(latest.IsSuccess, latest.IsSuccess ? string.Empty : latest.GetException().ToString());
+        Assert.Equal(result.GetValue().SortableUniqueId, latest.GetValue().LastSortedUniqueId);
+    }
+
+    [Fact]
+    public async Task StoreRefresh_RealPostgresRejectsFrozenReads_AndCompletesEveryTagInvalidation()
+    {
+        var firstTag = new WeatherForecastTag(Guid.CreateVersion7());
+        var secondTag = new WeatherForecastTag(Guid.CreateVersion7());
+        var firstPosition = NewPosition(-120);
+        var secondPosition = NewPosition(-119);
+        var firstLaterPosition = NewPosition(-60);
+        var secondLaterPosition = NewPosition(-59);
+        await EnableEpochAsync();
+        await WriteAsync(firstPosition, new WeatherForecastCreated(
+            firstTag.ForecastId,
+            "Tokyo",
+            new DateOnly(2026, 9, 9),
+            20,
+            "first"), firstTag);
+        await WriteAsync(secondPosition, new WeatherForecastCreated(
+            secondTag.ForecastId,
+            "Kyoto",
+            new DateOnly(2026, 9, 9),
+            22,
+            "second"), secondTag);
+
+        var accessor = new CountingActorAccessor(Fixture.ActorAccessor, null);
+        var executor = new CoreGeneralSekibanExecutor(Fixture.EventStore, accessor, Fixture.DomainTypes);
+        executor.BeforeDerivedExpectedTagPositionFreeze = async _ =>
+        {
+            // This is the independent durable-writer schedule. It advances both PostgreSQL heads after the handler
+            // read but before the attempt-local specification is frozen.
+            await WriteAsync(firstLaterPosition, new WeatherForecastUpdated(
+                firstTag.ForecastId,
+                "Nara",
+                new DateOnly(2026, 9, 9),
+                23,
+                "first-later"), firstTag);
+            await WriteAsync(secondLaterPosition, new WeatherForecastUpdated(
+                secondTag.ForecastId,
+                "Kobe",
+                new DateOnly(2026, 9, 9),
+                24,
+                "second-later"), secondTag);
+        };
+
+        var handlerInvocations = 0;
+        var result = await executor.ExecuteAsync(
+            new DerivedWeatherCommand(),
+            async (_, context) =>
+            {
+                handlerInvocations++;
+                var first = await context.GetStateAsync<WeatherForecastState, WeatherForecastProjector>(firstTag);
+                var second = await context.GetStateAsync<WeatherForecastState, WeatherForecastProjector>(secondTag);
+                Assert.True(first.IsSuccess, first.IsSuccess ? string.Empty : first.GetException().ToString());
+                Assert.True(second.IsSuccess, second.IsSuccess ? string.Empty : second.GetException().ToString());
+                return await context.AppendEvent(
+                    new WeatherForecastUpdated(
+                        firstTag.ForecastId,
+                        "Sapporo",
+                        new DateOnly(2026, 9, 9),
+                        25,
+                        "would-conflict"),
+                    firstTag,
+                    secondTag);
+            },
+            new CommandExecutionOptions { DeriveExpectedTagPositionsFromStateReads = true });
+
+        var conflict = Assert.IsType<ExpectedTagPositionConflictException>(result.GetException());
+        Assert.Equal(StateReadRecoveryStatus.InvalidationCompleted, conflict.StateReadRecovery);
+        Assert.Equal(1, handlerInvocations);
+        Assert.Equal(1, accessor.NotificationCount(firstTag.GetTag()));
+        Assert.Equal(1, accessor.NotificationCount(secondTag.GetTag()));
+        Assert.Equal(firstLaterPosition, conflict.Pairs.Single(pair => pair.Tag == firstTag.GetTag()).ObservedPosition);
+        Assert.Equal(secondLaterPosition, conflict.Pairs.Single(pair => pair.Tag == secondTag.GetTag()).ObservedPosition);
+
+        var allEvents = await Fixture.EventStore.ReadAllSerializableEventsAsync();
+        Assert.True(allEvents.IsSuccess, allEvents.IsSuccess ? string.Empty : allEvents.GetException().ToString());
+        Assert.Equal(4, allEvents.GetValue().Count());
+    }
+
+    [Fact]
+    public async Task NotificationFailure_ContinuesDistinctTagRecovery_AndPreservesTheOriginalConflict()
+    {
+        var firstTag = new WeatherForecastTag(Guid.CreateVersion7());
+        var secondTag = new WeatherForecastTag(Guid.CreateVersion7());
+        var firstPosition = NewPosition(-120);
+        var secondPosition = NewPosition(-119);
+        var firstLaterPosition = NewPosition(-60);
+        var secondLaterPosition = NewPosition(-59);
+        await EnableEpochAsync();
+        await WriteAsync(firstPosition, new WeatherForecastCreated(
+            firstTag.ForecastId,
+            "Tokyo",
+            new DateOnly(2026, 9, 9),
+            20,
+            "first"), firstTag);
+        await WriteAsync(secondPosition, new WeatherForecastCreated(
+            secondTag.ForecastId,
+            "Kyoto",
+            new DateOnly(2026, 9, 9),
+            22,
+            "second"), secondTag);
+
+        var accessor = new CountingActorAccessor(Fixture.ActorAccessor, secondTag.GetTag());
+        var executor = new CoreGeneralSekibanExecutor(Fixture.EventStore, accessor, Fixture.DomainTypes);
+        executor.BeforeDerivedExpectedTagPositionFreeze = async _ =>
+        {
+            await WriteAsync(firstLaterPosition, new WeatherForecastUpdated(
+                firstTag.ForecastId,
+                "Nara",
+                new DateOnly(2026, 9, 9),
+                23,
+                "first-later"), firstTag);
+            await WriteAsync(secondLaterPosition, new WeatherForecastUpdated(
+                secondTag.ForecastId,
+                "Kobe",
+                new DateOnly(2026, 9, 9),
+                24,
+                "second-later"), secondTag);
+        };
+
+        var result = await executor.ExecuteAsync(
+            new DerivedWeatherCommand(),
+            async (_, context) =>
+            {
+                var first = await context.GetStateAsync<WeatherForecastState, WeatherForecastProjector>(firstTag);
+                var second = await context.GetStateAsync<WeatherForecastState, WeatherForecastProjector>(secondTag);
+                Assert.True(first.IsSuccess);
+                Assert.True(second.IsSuccess);
+                return await context.AppendEvent(
+                    new WeatherForecastUpdated(firstTag.ForecastId, "Sapporo", new DateOnly(2026, 9, 9), 25, "blocked"),
+                    firstTag,
+                    secondTag);
+            },
+            new CommandExecutionOptions { DeriveExpectedTagPositionsFromStateReads = true });
+
+        var conflict = Assert.IsType<ExpectedTagPositionConflictException>(result.GetException());
+        Assert.Equal(StateReadRecoveryStatus.InvalidationIncomplete, conflict.StateReadRecovery);
+        Assert.Equal(1, accessor.NotificationCount(firstTag.GetTag()));
+        Assert.Equal(1, accessor.NotificationCount(secondTag.GetTag()));
+        Assert.Equal(2, conflict.Pairs.Count);
+        Assert.Contains(conflict.Pairs, pair => pair.Tag == firstTag.GetTag() && pair.ObservedPosition == firstLaterPosition);
+        Assert.Contains(conflict.Pairs, pair => pair.Tag == secondTag.GetTag() && pair.ObservedPosition == secondLaterPosition);
+    }
+
+    [Fact]
+    public async Task ActorRefresh_RealPostgresDoesNotReplaceTheFrozenSuccessfulRead()
+    {
+        var tag = new WeatherForecastTag(Guid.CreateVersion7());
+        var initialPosition = NewPosition(-120);
+        await EnableEpochAsync();
+        await WriteAsync(initialPosition, new WeatherForecastCreated(
+            tag.ForecastId,
+            "Tokyo",
+            new DateOnly(2026, 9, 9),
+            20,
+            "initial"), tag);
+
+        var refreshExecutor = new CoreGeneralSekibanExecutor(Fixture.EventStore, Fixture.ActorAccessor, Fixture.DomainTypes);
+        var executor = new CoreGeneralSekibanExecutor(Fixture.EventStore, Fixture.ActorAccessor, Fixture.DomainTypes);
+        ExpectedTagPositionSpecification? frozen = null;
+        executor.DerivedExpectedTagPositionFrozen = specification => frozen = specification;
+        executor.BeforeDerivedExpectedTagPositionFreeze = async _ =>
+        {
+            // The second executor is the same actor/store composition. It commits H2 and confirms the shared actor has
+            // refreshed, while the first attempt must continue using its already-successful H evidence.
+            var refresh = await refreshExecutor.ExecuteAsync(
+                new RefreshWeatherCommand(),
+                (_, context) => context.AppendEvent(
+                    new WeatherForecastUpdated(
+                        tag.ForecastId,
+                        "Osaka",
+                        new DateOnly(2026, 9, 9),
+                        21,
+                        "refresh"),
+                    tag));
+            Assert.True(refresh.IsSuccess, refresh.IsSuccess ? string.Empty : refresh.GetException().ToString());
+            var actor = await Fixture.ActorAccessor.GetActorAsync<ITagConsistentActorCommon>(tag.GetTag());
+            Assert.True(actor.IsSuccess, actor.IsSuccess ? string.Empty : actor.GetException().ToString());
+            var current = await actor.GetValue().GetLatestSortableUniqueIdAsync();
+            Assert.True(current.IsSuccess, current.IsSuccess ? string.Empty : current.GetException().ToString());
+            Assert.Equal(refresh.GetValue().SortableUniqueId, current.GetValue());
+        };
+
+        var result = await executor.ExecuteAsync(
+            new DerivedWeatherCommand(),
+            async (_, context) =>
+            {
+                var state = await context.GetStateAsync<WeatherForecastState, WeatherForecastProjector>(tag);
+                Assert.True(state.IsSuccess, state.IsSuccess ? string.Empty : state.GetException().ToString());
+                return await context.AppendEvent(
+                    new WeatherForecastUpdated(tag.ForecastId, "Nagoya", new DateOnly(2026, 9, 9), 22, "stale"),
+                    tag);
+            },
+            new CommandExecutionOptions { DeriveExpectedTagPositionsFromStateReads = true });
+
+        var frozenSpecification = frozen ?? throw new InvalidOperationException("The derived specification was not observed.");
+        var entry = Assert.Single(frozenSpecification.Entries);
+        Assert.Equal(initialPosition, entry.Expectation.Position);
+        Assert.False(result.IsSuccess);
+        Assert.IsNotType<ExpectedTagPositionConflictException>(result.GetException());
+        Assert.Equal(2, (await Fixture.EventStore.ReadAllSerializableEventsAsync()).GetValue().Count());
+    }
+
+    private async Task EnableEpochAsync()
+    {
+        await using var context = await Fixture.GetDbContextAsync();
+        context.TagHeadEnablementEpochs.Add(new DbTagHeadEnablementEpoch
+        {
+            ServiceId = ServiceId,
+            EnabledAtUtc = DateTime.UtcNow
+        });
+        await context.SaveChangesAsync();
+    }
+
+    private async Task WriteAsync(string position, IEventPayload payload, params ITag[] tags)
+    {
+        var ev = new Event(
+            payload,
+            position,
+            payload.GetType().Name,
+            Guid.CreateVersion7(),
+            new EventMetadata(Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), "g65-test"),
+            tags.Select(tag => tag.GetTag()).ToList());
+        var result = await Fixture.EventStore.WriteSerializableEventsAsync([ev.ToSerializableEvent(Fixture.DomainTypes.EventTypes)]);
+        Assert.True(result.IsSuccess, result.IsSuccess ? string.Empty : result.GetException().ToString());
+    }
+
+    private static string NewPosition(int secondsFromNow) =>
+        SortableUniqueId.Generate(DateTime.UtcNow.AddSeconds(secondsFromNow), Guid.CreateVersion7());
+
+    private sealed record DerivedWeatherCommand : ICommand;
+    private sealed record RefreshWeatherCommand : ICommand;
+
+    private sealed class CountingActorAccessor : IActorObjectAccessor
+    {
+        private readonly IActorObjectAccessor _inner;
+        private readonly string? _failingTag;
+        private readonly Dictionary<string, int> _notifications = new(StringComparer.Ordinal);
+
+        public CountingActorAccessor(IActorObjectAccessor inner, string? failingTag)
+        {
+            _inner = inner;
+            _failingTag = failingTag;
+        }
+
+        public int NotificationCount(string tag) => _notifications.TryGetValue(tag, out var count) ? count : 0;
+
+        public async Task<ResultBox<T>> GetActorAsync<T>(string actorId) where T : class
+        {
+            var actor = await _inner.GetActorAsync<T>(actorId);
+            if (!actor.IsSuccess || typeof(T) != typeof(ITagConsistentActorCommon))
+            {
+                return actor;
+            }
+
+            var wrapped = new CountingTagConsistentActor(
+                (ITagConsistentActorCommon)(object)actor.GetValue(),
+                actorId,
+                this);
+            return ResultBox.FromValue((T)(object)wrapped);
+        }
+
+        public Task<bool> ActorExistsAsync(string actorId) => _inner.ActorExistsAsync(actorId);
+
+        private async Task NotifyAsync(string actorId, ITagConsistentActorCommon actor)
+        {
+            _notifications[actorId] = NotificationCount(actorId) + 1;
+            if (_failingTag is not null && string.Equals(actorId, _failingTag, StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException("Injected notification failure for G65 all-tag recovery proof.");
+            }
+
+            await actor.NotifyEventWrittenAsync();
+        }
+
+        private sealed class CountingTagConsistentActor : ITagConsistentActorCommon
+        {
+            private readonly ITagConsistentActorCommon _inner;
+            private readonly string _actorId;
+            private readonly CountingActorAccessor _owner;
+
+            public CountingTagConsistentActor(
+                ITagConsistentActorCommon inner,
+                string actorId,
+                CountingActorAccessor owner)
+            {
+                _inner = inner;
+                _actorId = actorId;
+                _owner = owner;
+            }
+
+            public Task<string> GetTagActorIdAsync() => _inner.GetTagActorIdAsync();
+            public Task<ResultBox<string>> GetLatestSortableUniqueIdAsync() => _inner.GetLatestSortableUniqueIdAsync();
+            public Task<ResultBox<TagWriteReservation>> MakeReservationAsync(string? lastSortableUniqueId) =>
+                _inner.MakeReservationAsync(lastSortableUniqueId);
+            public Task<bool> ConfirmReservationAsync(TagWriteReservation reservation) => _inner.ConfirmReservationAsync(reservation);
+            public Task<bool> CancelReservationAsync(TagWriteReservation reservation) => _inner.CancelReservationAsync(reservation);
+            public Task NotifyEventWrittenAsync() => _owner.NotifyAsync(_actorId, _inner);
+        }
+    }
+}

--- a/dcb/tests/Sekiban.Dcb.Postgres.Tests/GlobalUsings.cs
+++ b/dcb/tests/Sekiban.Dcb.Postgres.Tests/GlobalUsings.cs
@@ -1,0 +1,3 @@
+extern alias WithResultFacade;
+
+global using GeneralSekibanExecutor = WithResultFacade::Sekiban.Dcb.Actors.GeneralSekibanExecutor;

--- a/dcb/tests/Sekiban.Dcb.Postgres.Tests/PostgresTagHeadSurfaceMatrixTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Postgres.Tests/PostgresTagHeadSurfaceMatrixTests.cs
@@ -1,4 +1,5 @@
 extern alias WithoutResultFacade;
+extern alias WithResultFacade;
 
 using System.Text.Json;
 using Dcb.Domain.Student;
@@ -15,6 +16,7 @@ using Sekiban.Dcb.Tags;
 using Xunit;
 using WithoutResultExecutor = WithoutResultFacade::Sekiban.Dcb.Actors.GeneralSekibanExecutor;
 using WithoutResultCommandContext = WithoutResultFacade::Sekiban.Dcb.Commands.ICommandContext;
+using WithResultExecutor = WithResultFacade::Sekiban.Dcb.Actors.GeneralSekibanExecutor;
 
 namespace Sekiban.Dcb.Postgres.Tests;
 
@@ -43,7 +45,7 @@ public sealed class PostgresTagHeadSurfaceMatrixTests : PostgresTestBase
     private async Task AssertWithResultCommandMatrixAsync(string serviceId)
     {
         var store = Store(serviceId);
-        var executor = new GeneralSekibanExecutor(store, new InMemoryObjectAccessor(store, Fixture.DomainTypes), Fixture.DomainTypes);
+        var executor = new WithResultExecutor(store, new InMemoryObjectAccessor(store, Fixture.DomainTypes), Fixture.DomainTypes);
         var noEnforcement = await ExecuteWithResultAsync(executor, serviceId, "with-no-enforcement", TagHeadExpectation.NoEnforcement());
 
         Assert.True(noEnforcement.Result.IsSuccess, noEnforcement.Result.IsSuccess ? "" : noEnforcement.Result.GetException().ToString());
@@ -106,7 +108,7 @@ public sealed class PostgresTagHeadSurfaceMatrixTests : PostgresTestBase
     private async Task AssertLegacySerializedOmissionMatrixAsync(string serviceId)
     {
         var store = Store(serviceId);
-        var executor = new GeneralSekibanExecutor(store, new InMemoryObjectAccessor(store, Fixture.DomainTypes), Fixture.DomainTypes);
+        var executor = new WithResultExecutor(store, new InMemoryObjectAccessor(store, Fixture.DomainTypes), Fixture.DomainTypes);
         var studentId = Guid.CreateVersion7();
         var tag = new StudentTag(studentId).GetTag();
         const string name = "legacy-omission";
@@ -128,7 +130,7 @@ public sealed class PostgresTagHeadSurfaceMatrixTests : PostgresTestBase
     private async Task AssertVersionedSerializedV2MatrixAsync(string serviceId)
     {
         var store = Store(serviceId);
-        var executor = new GeneralSekibanExecutor(store, new InMemoryObjectAccessor(store, Fixture.DomainTypes), Fixture.DomainTypes);
+        var executor = new WithResultExecutor(store, new InMemoryObjectAccessor(store, Fixture.DomainTypes), Fixture.DomainTypes);
         var noEnforcement = await ExecuteV2Async(executor, serviceId, "v2-no-enforcement", TagHeadExpectation.NoEnforcement());
 
         AssertV2Request(noEnforcement.Request, noEnforcement.Candidate, serviceId, noEnforcement.Tag,
@@ -167,7 +169,7 @@ public sealed class PostgresTagHeadSurfaceMatrixTests : PostgresTestBase
     }
 
     private async Task<WithResultStep> ExecuteWithResultAsync(
-        GeneralSekibanExecutor executor,
+        WithResultExecutor executor,
         string serviceId,
         string name,
         TagHeadExpectation expected,
@@ -206,7 +208,7 @@ public sealed class PostgresTagHeadSurfaceMatrixTests : PostgresTestBase
     }
 
     private async Task<V2Step> ExecuteV2Async(
-        GeneralSekibanExecutor executor,
+        WithResultExecutor executor,
         string serviceId,
         string name,
         TagHeadExpectation expected,

--- a/dcb/tests/Sekiban.Dcb.Postgres.Tests/Sekiban.Dcb.Postgres.Tests.csproj
+++ b/dcb/tests/Sekiban.Dcb.Postgres.Tests/Sekiban.Dcb.Postgres.Tests.csproj
@@ -38,6 +38,7 @@
         <ProjectReference Include="..\..\src\Sekiban.Dcb.Sqlite\Sekiban.Dcb.Sqlite.csproj"/>
         <ProjectReference Include="..\..\src\Sekiban.Dcb.WithoutResult\Sekiban.Dcb.WithoutResult.csproj" Aliases="WithoutResultFacade" />
         <ProjectReference Include="..\..\src\Sekiban.Dcb.WithoutResult.Model\Sekiban.Dcb.WithoutResult.Model.csproj" Aliases="WithoutResultFacade" />
+        <ProjectReference Include="..\..\src\Sekiban.Dcb.WithResult\Sekiban.Dcb.WithResult.csproj" Aliases="WithResultFacade" />
         <ProjectReference Include="..\..\internalUsages\Dcb.Domain\Dcb.Domain.csproj"/>
         <ProjectReference Include="..\..\src\Sekiban.Dcb.Core.Testing\Sekiban.Dcb.Core.Testing.csproj" />
         <ProjectReference Include="..\Sekiban.Dcb.TestSupport\Sekiban.Dcb.TestSupport.csproj" />

--- a/dcb/tests/Sekiban.Dcb.Postgres.Tests/TaggedStreamParityMatrixTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Postgres.Tests/TaggedStreamParityMatrixTests.cs
@@ -1,3 +1,5 @@
+extern alias WithResultFacade;
+
 using System.Text.Json;
 using ResultBoxes;
 using Sekiban.Dcb.Actors;
@@ -12,6 +14,7 @@ using Sekiban.Dcb.Storage;
 using Sekiban.Dcb.Tags;
 using CoreInMemoryEventStore = Sekiban.Dcb.Testing.InMemoryEventStore;
 using Xunit;
+using PublicSimpleMultiProjectorTypes = WithResultFacade::Sekiban.Dcb.Domains.SimpleMultiProjectorTypes;
 
 namespace Sekiban.Dcb.Postgres.Tests;
 
@@ -169,7 +172,7 @@ public sealed class TaggedStreamParityMatrixTests : PostgresTestBase
             new SimpleTagTypes(),
             tagProjectors,
             payloads,
-            new SimpleMultiProjectorTypes(),
+            new PublicSimpleMultiProjectorTypes(),
             new SimpleQueryTypes(),
             new JsonSerializerOptions());
     }

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/ExpectedTagPositionCompatibilityInventoryTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/ExpectedTagPositionCompatibilityInventoryTests.cs
@@ -76,6 +76,14 @@ public sealed class ExpectedTagPositionCompatibilityInventoryTests
         AssertConstructor(typeof(ExpectedTagPositionConflictException), [typeof(IReadOnlyList<TagHeadExpectedObserved>)]);
         AssertProperty(typeof(ExpectedTagPositionConflictException), nameof(ExpectedTagPositionConflictException.Pairs),
             typeof(IReadOnlyList<TagHeadExpectedObserved>));
+        AssertProperty(typeof(ExpectedTagPositionConflictException), nameof(ExpectedTagPositionConflictException.StateReadRecovery),
+            typeof(StateReadRecoveryStatus));
+        Assert.Equal(
+            [StateReadRecoveryStatus.NotAttempted, StateReadRecoveryStatus.InvalidationCompleted, StateReadRecoveryStatus.InvalidationIncomplete],
+            Enum.GetValues<StateReadRecoveryStatus>());
+        Assert.Equal(0, (int)StateReadRecoveryStatus.NotAttempted);
+        Assert.Equal(1, (int)StateReadRecoveryStatus.InvalidationCompleted);
+        Assert.Equal(2, (int)StateReadRecoveryStatus.InvalidationIncomplete);
         AssertConstructor(typeof(TagHeadExpectationValidationException), [typeof(string)]);
         AssertConstructor(typeof(TagHeadPositionValidationException), [typeof(string)]);
         AssertConstructor(typeof(TagHeadEnforcementNotEnabledException), [typeof(string)]);
@@ -145,24 +153,31 @@ public sealed class ExpectedTagPositionCompatibilityInventoryTests
 
         Assert.True(typeof(ISerializedExpectedTagPositionSekibanDcbExecutor).IsAssignableFrom(typeof(GeneralSekibanExecutor)));
         Assert.True(typeof(IConditionalCommandExecutor).IsAssignableFrom(typeof(GeneralSekibanExecutor)));
+        Assert.True(typeof(IConditionalCommandExecutor).IsAssignableFrom(typeof(Sekiban.Dcb.Orleans.OrleansDcbExecutor)));
         AssertWithResultConditionalExecutorSignatures(typeof(IConditionalCommandExecutor));
+        AssertWithResultConditionalExecutorSignatures(typeof(Sekiban.Dcb.Orleans.OrleansDcbExecutor));
 
         var optionsProperty = typeof(CommandExecutionOptions).GetProperty(nameof(CommandExecutionOptions.ExpectedTagPositions));
         Assert.NotNull(optionsProperty);
         Assert.Equal(typeof(ExpectedTagPositionSpecification), optionsProperty.PropertyType);
         Assert.True(optionsProperty.SetMethod is not null);
         Assert.Equal(
-            ["ConditionalAppend", "ExpectedTagPositions"],
+            ["ConditionalAppend", "ExpectedTagPositions", "DeriveExpectedTagPositionsFromStateReads"],
             typeof(CommandExecutionOptions).GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
                 .Select(property => property.Name));
         Assert.Equal(typeof(ConditionalAppendSpecification),
             typeof(CommandExecutionOptions).GetProperty(nameof(CommandExecutionOptions.ConditionalAppend))!.PropertyType);
+        Assert.Equal(typeof(bool),
+            typeof(CommandExecutionOptions).GetProperty(nameof(CommandExecutionOptions.DeriveExpectedTagPositionsFromStateReads))!.PropertyType);
         Assert.NotNull(typeof(CommandExecutionOptions).GetConstructor(Type.EmptyTypes));
     }
 
     private static void AssertWithResultConditionalExecutorSignatures(Type surface)
     {
-        var methods = surface.GetMethods().Where(method => method.Name == nameof(IConditionalCommandExecutor.ExecuteAsync)).ToArray();
+        var methods = surface.GetMethods()
+            .Where(method => method.Name == nameof(IConditionalCommandExecutor.ExecuteAsync))
+            .Where(method => method.GetParameters().Any(parameter => parameter.ParameterType == typeof(CommandExecutionOptions)))
+            .ToArray();
         Assert.Equal(2, methods.Length);
 
         var withHandler = Assert.Single(methods, method => method.GetParameters().Length == 4);

--- a/dcb/tests/Sekiban.Dcb.WithoutResult.Tests/ExpectedTagPositionWithoutResultCompatibilityInventoryTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithoutResult.Tests/ExpectedTagPositionWithoutResultCompatibilityInventoryTests.cs
@@ -49,11 +49,24 @@ public sealed class ExpectedTagPositionWithoutResultCompatibilityInventoryTests
         Assert.Contains(typeof(ICommandWithHandler<>).MakeGenericType(selfCommand), selfCommand.GetGenericParameterConstraints());
 
         Assert.True(typeof(IConditionalCommandExecutor).IsAssignableFrom(typeof(GeneralSekibanExecutor)));
+        Assert.True(typeof(IConditionalCommandExecutor).IsAssignableFrom(typeof(Sekiban.Dcb.Orleans.OrleansDcbExecutor)));
         Assert.True(typeof(ISerializedExpectedTagPositionSekibanDcbExecutor).IsAssignableFrom(typeof(GeneralSekibanExecutor)));
         Assert.True(typeof(ISerializedExpectedTagPositionSekibanDcbExecutor)
             .IsAssignableFrom(typeof(Sekiban.Dcb.Orleans.OrleansDcbExecutor)));
         AssertSerializedSurface(typeof(GeneralSekibanExecutor));
         AssertSerializedSurface(typeof(Sekiban.Dcb.Orleans.OrleansDcbExecutor));
+        AssertConditionalSurface(typeof(Sekiban.Dcb.Orleans.OrleansDcbExecutor));
+    }
+
+    private static void AssertConditionalSurface(Type facade)
+    {
+        var methods = facade.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+            .Where(method => method.Name == nameof(IConditionalCommandExecutor.ExecuteAsync))
+            .Where(method => method.GetParameters().Any(parameter => parameter.ParameterType == typeof(CommandExecutionOptions)))
+            .ToArray();
+        Assert.Equal(2, methods.Length);
+        Assert.Contains(methods, method => method.GetParameters().Length == 4 && method.ReturnType == typeof(Task<ExecutionResult>));
+        Assert.Contains(methods, method => method.GetParameters().Length == 3 && method.ReturnType == typeof(Task<ExecutionResult>));
     }
 
     private static void AssertSerializedSurface(Type facade)

--- a/docs/dcb_llm/03_aggregate_command_events.md
+++ b/docs/dcb_llm/03_aggregate_command_events.md
@@ -125,6 +125,24 @@ and every empty-expected path perform no extra read.
 This is a false-rejection fix, not cross-cluster uniqueness. Storage conditional unique-append (G15/G16) remains the
 authority for preventing duplicate writes across clusters; no API, schema, default, or migration changes in 10.8.2.
 
+### Deriving expected tag positions from state reads (SEK-G65)
+
+`CommandExecutionOptions.DeriveExpectedTagPositionsFromStateReads` is an explicit opt-in for a command whose handler
+reads state and then emits consistency-tagged events. The handler is invoked once. Each successful `GetStateAsync`
+observation contributes at most one bounded ledger entry per logical tag (a `ConsistencyTag` is normalized to its inner
+tag); `TagExistsAsync` and latest-position reads are not evidence. Empty state derives `AssertEmpty`, non-empty state
+derives `Exact(position)`, and an unread, failed, malformed, or emitted-but-unread tag remains untrusted and fails
+closed. The same position may be observed through different projectors; conflicting observations for one tag are
+rejected before reservation or store mutation.
+
+The executor validates the live service identity, provider capability, and PostgreSQL enablement epoch before the
+handler, including for a no-event command. Derived mode cannot be combined with explicit `ExpectedTagPositions` or
+`ConditionalAppend`; unrelated non-consistency tags are ignored, and no-event commands perform no derived write.
+Every emitted consistency tag must have exactly one derived expectation, so an extra read is harmless but a missing
+read is not. A derived durable-head conflict cleans up reservations and then makes one best-effort invalidation attempt
+per affected tag, continuing all tags even when one attempt fails; the typed exception exposes whether recovery was
+completed or incomplete. The caller owns a fresh retry, and the contract does not promise exactly-once external effects.
+
 ## Tag State Payloads
 
 Projectors rebuild tag state into `ITagStatePayload` records. Keep them small and immutable.

--- a/docs/dcb_llm/11_storage_providers.md
+++ b/docs/dcb_llm/11_storage_providers.md
@@ -778,6 +778,24 @@ can escape this particular audit if a newer head later overtakes it. This is del
 claim that premature mixed-version enablement is safe. The drain-before-epoch step is the correctness boundary; a zero
 violation count is monitoring evidence, never clean-cutover proof.
 
+### State-read-derived CAS is an explicit command protocol (SEK-G65)
+
+`CommandExecutionOptions.DeriveExpectedTagPositionsFromStateReads` derives the same durable `AssertEmpty` / `Exact`
+protocol from successful raw `GetStateAsync` reads. It is opt-in and uses the live store capability and service-scoped
+enablement epoch; it does not infer safety from actor cache state. The derivation is a bounded ordinal ledger keyed by the
+normalized logical tag. A second successful read of the same position is compatible, including through a different
+projector; an empty/non-empty mismatch, differing position, malformed result, or failed read is a typed fail-closed
+error. `TagExistsAsync` and latest-tag-position reads do not populate the ledger.
+
+The executor preflights service, capability, and epoch before the handler, rejects derived mode combined with explicit
+expected positions or `ConditionalAppend`, and requires exactly one derived expectation for every emitted consistency
+tag. An unsupported provider, missing evidence, or emitted-but-unread tag performs no reservation, handler write, or
+store mutation. A derived `ExpectedTagPositionConflictException` cleans up reservations and then performs one
+invalidation attempt per affected tag, continuing the remaining tags if one attempt fails; its
+`StateReadRecovery` value distinguishes complete from incomplete invalidation. This is recovery diagnostic evidence,
+not an automatic retry or an exactly-once external-effect guarantee. Legacy and explicit expected-position callers retain
+their existing behavior and report `NotAttempted`.
+
 <!-- sek-g44:cas-non-default -->
 ## Expected tag-position CAS is not a template default
 

--- a/docs/dcb_llm_ja/03_aggregate_command_events.md
+++ b/docs/dcb_llm_ja/03_aggregate_command_events.md
@@ -124,6 +124,24 @@ stale な空キャッシュと比較し、正しい更新を誤って拒否し�
 これは誤拒否の修正であり、クラスタ間一意性の追加ではありません。クラスタ間の重複防止は引き続きストレージの条件付き
 ユニーク追加 (G15/G16) が担います。10.8.2 で API・スキーマ・既定値の変更や移行はありません。
 
+### state read からの expected tag position 導出 (SEK-G65)
+
+`CommandExecutionOptions.DeriveExpectedTagPositionsFromStateReads` は、handler が state を読んでから
+consistency tag 付きイベントを出力する command のための明示的な opt-in です。handler は1回だけ呼ばれます。
+成功した `GetStateAsync` の観測だけが、論理タグごとに最大1件の bounded ledger entry を作ります
+（`ConsistencyTag` は inner tag に正規化）。`TagExistsAsync` と最新位置の読み取りは証拠になりません。空状態は
+`AssertEmpty`、非空状態は `Exact(position)` になり、未読・失敗・不正・出力されたのに未読のタグは信頼せず
+fail-closed になります。異なる projector から同じ position を観測することは許容しますが、同一タグで異なる
+観測があれば reservation／store mutation 前に拒否します。
+
+executor は handler 前（イベントが無い command も含む）に、実行時の service identity、provider capability、
+PostgreSQL enablement epoch を検証します。derived mode は明示的な `ExpectedTagPositions` や
+`ConditionalAppend` と併用できません。関係しない non-consistency tag の読み取りは無視されますが、出力した
+consistency tag には必ず1つの derived expectation が必要です。余分な読み取りは問題ありませんが、読み取りの
+無い出力は拒否されます。derived durable-head conflict では reservation を cleanup した後、影響を受けたタグごとに
+1回だけ best-effort invalidation を試み、1件が失敗しても全タグを続けます。型付き例外には recovery 完了／未完了が
+示されます。caller は新しい実行を retry し、外部副作用の exactly-once はこの契約の対象外です。
+
 ## タグ状態ペイロード
 
 タグ状態は `ITagStatePayload` を実装するレコードで表現し、プロジェクターがイベントを適用して更新します。

--- a/docs/dcb_llm_ja/11_storage_providers.md
+++ b/docs/dcb_llm_ja/11_storage_providers.md
@@ -786,6 +786,23 @@ reconciliation が検出できるのは `MAX` query 実行時に既に可視な 
 best-effort detection であり、premature mixed-version enablement が安全という主張ではありません。正しさの境界は
 drain-before-epoch です。violation 0 件は monitoring evidence であって clean cutover の証明ではありません。
 
+### state read 由来 CAS は明示的な command protocol (SEK-G65)
+
+`CommandExecutionOptions.DeriveExpectedTagPositionsFromStateReads` は、成功した raw `GetStateAsync` の読み取りから
+同じ durable `AssertEmpty`／`Exact` protocol を導出します。これは opt-in であり、actor cache ではなく実際の store
+capability と service-scoped enablement epoch を使います。導出は正規化した論理タグをキーとする bounded ordinal ledger
+です。同じタグを別 projector から読んでも position が同じなら互換ですが、空／非空の不一致、position の相違、
+malformed 結果、読み取り失敗は型付き fail-closed error です。`TagExistsAsync` と最新タグ位置の読み取りは ledger を
+埋めません。
+
+executor は handler 前に service、capability、epoch を検証し、derived mode と明示的 expected position／
+`ConditionalAppend` の併用を拒否します。出力されたすべての consistency tag にはちょうど1つの derived expectation
+が必要です。未対応 provider、証拠不足、出力したのに未読のタグでは reservation、handler write、store mutation を
+行いません。derived `ExpectedTagPositionConflictException` は reservation を cleanup した後、影響を受けたタグごとに
+1回だけ invalidation を試み、1件が失敗しても残りを続けます。`StateReadRecovery` は全タグ完了／未完了を区別します。
+これは recovery の診断であり、自動 retry や外部副作用の exactly-once 保証ではありません。legacy と明示的な
+expected-position caller の既存動作は維持され、`NotAttempted` を報告します。
+
 <!-- sek-g44:cas-non-default -->
 ## expected tag-position CAS は template の既定値ではない
 


### PR DESCRIPTION
Closes #1197

## Summary

Adds the explicit `CommandExecutionOptions.DeriveExpectedTagPositionsFromStateReads` protocol. A single handler invocation records successful raw `GetStateAsync` evidence in a bounded ordinal ledger, derives only the emitted consistency-tag `AssertEmpty`/`Exact` expectations, and submits the existing expected-position write unchanged. Missing, failed, malformed, conflicting, or synthetic-empty evidence fails closed before reservation or write.

The executor preflights service identity, provider capability, and the service-scoped enablement epoch before the handler, including no-event attempts. The derived mode is mutually exclusive with explicit expected positions and conditional append. Durable derived conflicts preserve the original typed exception and perform one awaited invalidation attempt per affected tag; `StateReadRecovery` reports complete versus incomplete invalidation without retrying or reinvoking the handler. Both Orleans facades forward the additive options surface through `IConditionalCommandExecutor`.

## Provider and compatibility evidence

- `DerivedExpectedTagPositionTests` against Testcontainers PostgreSQL: 4 passed on net9.0 and 4 passed on net10.0.
  - successful PostgreSQL cursor is frozen after one handler/read;
  - an independent durable store refresh rejects the frozen H read and invalidates both affected tags;
  - injected failure on one tag still attempts both invalidations and reports `InvalidationIncomplete`;
  - a same-composition actor refresh cannot replace the already-frozen successful read.
- WithResult expected-position compatibility inventory: 3/3 passed on net9.0 and 3/3 on net10.0.
- WithoutResult expected-position compatibility inventory: 1/1 passed on net9.0 and 1/1 on net10.0.
- WithResult and WithoutResult Orleans projects build successfully on net9.0 and net10.0; both existing binary consumers run successfully against the published compatibility package.
- `git diff --check` is clean. Restore/build output contains existing package-vulnerability warnings only; no compile or test errors.

No schema, serialized protocol, release/version, unconditional behavior, explicit expected-position behavior, or automatic retry was changed.
