### PR TITLE
fix(dcb): reject state reads in verified event batches

### DIFF
--- a/dcb/src/Sekiban.Dcb.MaterializedView/MvApplyHostSupport.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView/MvApplyHostSupport.cs
@@ -348,9 +348,12 @@ public sealed class NativeMvApplyHost : IMvApplyHost
             throw new NotSupportedException("Cross-view reads are not supported by the native MV apply host adapter.");
 
         private Exception RawAccessRejected(string surface) =>
-            _queryPort is MvPolicyEnforcingQueryPort enforcingPort
-                ? enforcingPort.RejectRawAccess($"raw {surface}")
-                : new NotSupportedException($"Native MV apply host does not expose raw {surface}s.");
+            _queryPort switch
+            {
+                MvBatchQueryPortGuard batchGuard => batchGuard.RejectRawAccess($"raw {surface}"),
+                MvPolicyEnforcingQueryPort enforcingPort => enforcingPort.RejectRawAccess($"raw {surface}"),
+                _ => new NotSupportedException($"Native MV apply host does not expose raw {surface}s.")
+            };
     }
 
     private sealed class JsonElementMvRow : IMvRow

--- a/dcb/src/Sekiban.Dcb.MaterializedView/MvContracts.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView/MvContracts.cs
@@ -483,6 +483,9 @@ public sealed record MvCatchUpResult(int AppliedEvents, bool ReachedUnsafeWindow
     /// <summary>Time at which the failure/no-progress observation was recorded.</summary>
     public DateTimeOffset? ObservedAtUtc { get; init; }
 
+    /// <summary>Event count associated with a typed batch-safety failure, when one was observed.</summary>
+    public int? EventCount { get; init; }
+
     public bool IsFailure => Outcome is
         MvCatchUpOutcome.FailedRead or
         MvCatchUpOutcome.PermanentUnsupported or

--- a/dcb/src/Sekiban.Dcb.MaterializedView/MvExecutorBase.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView/MvExecutorBase.cs
@@ -702,6 +702,24 @@ public abstract class MvExecutorBase<TConnection> : IMvExecutor, IMvOrleansCatch
         {
             throw;
         }
+        catch (MvStateReadingBatchNotSupportedException ex)
+        {
+            if (!classifyFailures)
+            {
+                throw;
+            }
+
+            _logger.LogWarning(
+                ex,
+                "Materialized-view catch-up state-reading projector is unsupported for a batch of {EventCount} events; the operation will halt.",
+                ex.EventCount);
+            return CatchUpFailure(
+                MvCatchUpOutcome.PermanentUnsupported,
+                MvStateReadingBatchNotSupportedException.CatchUpErrorCode,
+                MvStateReadingBatchNotSupportedException.CatchUpErrorMessage,
+                isRetryable: false,
+                eventCount: ex.EventCount);
+        }
         catch (NotSupportedException ex)
         {
             if (!classifyFailures)
@@ -780,14 +798,16 @@ public abstract class MvExecutorBase<TConnection> : IMvExecutor, IMvOrleansCatch
         MvCatchUpOutcome outcome,
         string errorCode,
         string errorMessage,
-        bool isRetryable) =>
+        bool isRetryable,
+        int? eventCount = null) =>
         new(0, false)
         {
             Outcome = outcome,
             ErrorCode = errorCode,
             ErrorMessage = errorMessage,
             IsRetryable = isRetryable,
-            ObservedAtUtc = DateTimeOffset.UtcNow
+            ObservedAtUtc = DateTimeOffset.UtcNow,
+            EventCount = eventCount
         };
 
     /// <summary>
@@ -1010,6 +1030,16 @@ public abstract class MvExecutorBase<TConnection> : IMvExecutor, IMvOrleansCatch
             if (!classifyFailures)
             {
                 throw exception;
+            }
+
+            if (exception is MvStateReadingBatchNotSupportedException batchException)
+            {
+                return CatchUpFailure(
+                    MvCatchUpOutcome.PermanentUnsupported,
+                    MvStateReadingBatchNotSupportedException.CatchUpErrorCode,
+                    MvStateReadingBatchNotSupportedException.CatchUpErrorMessage,
+                    isRetryable: false,
+                    eventCount: batchException.EventCount);
             }
 
             if (exception is NotSupportedException)
@@ -1238,7 +1268,7 @@ public abstract class MvExecutorBase<TConnection> : IMvExecutor, IMvOrleansCatch
     {
         await using var connection = await OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
         await using var transaction = await connection.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
-        var queryPort = new MvPolicyEnforcingQueryPort(
+        var policyQueryPort = new MvPolicyEnforcingQueryPort(
             CreateQueryPort(connection, transaction),
             _options.SqlStatementPolicy,
             serviceId,
@@ -1246,6 +1276,10 @@ public abstract class MvExecutorBase<TConnection> : IMvExecutor, IMvOrleansCatch
             host.ViewVersion,
             bindings.Tables,
             DatabaseType);
+        var batchQueryGuard = events.Count > 1
+            ? new MvBatchQueryPortGuard(policyQueryPort, events.Count)
+            : null;
+        IMvApplyQueryPort queryPort = batchQueryGuard is null ? policyQueryPort : batchQueryGuard;
         var prepared = new List<(SerializableEvent Event, IReadOnlyList<MvSqlStatementDto> Statements)>();
 
         try
@@ -1260,6 +1294,11 @@ public abstract class MvExecutorBase<TConnection> : IMvExecutor, IMvOrleansCatch
                         cancellationToken)
                     .ConfigureAwait(false);
                 prepared.Add((serializableEvent, statements));
+            }
+
+            if (batchQueryGuard?.QueryAttempted == true)
+            {
+                throw batchQueryGuard.CreateException();
             }
 
             await AuthorizeStatementsAsync(

--- a/dcb/src/Sekiban.Dcb.MaterializedView/MvSqlStatementPolicy.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView/MvSqlStatementPolicy.cs
@@ -1,5 +1,6 @@
 using System.Security.Cryptography;
 using System.Text;
+using System.Text.Json;
 
 namespace Sekiban.Dcb.MaterializedView;
 
@@ -289,4 +290,62 @@ internal sealed class MvPolicyEnforcingQueryPort : IMvApplyQueryPort
 
     private static IReadOnlyList<MvParam> MetadataOnly(IReadOnlyList<MvParam> parameters) =>
         parameters.Select(parameter => parameter with { ValueJson = null }).ToList();
+}
+
+/// <summary>
+///     Latches every state-reading surface during a verified multi-event preparation pass. The projector may catch
+///     the typed exception and return fallback statements, but the latched attempt is rethrown by the executor before
+///     authorization, DML, or checkpoint mutation can begin.
+/// </summary>
+internal sealed class MvBatchQueryPortGuard : IMvApplyQueryPort
+{
+    private readonly IMvApplyQueryPort _inner;
+    private readonly int _eventCount;
+    private int _queryAttempted;
+
+    public MvBatchQueryPortGuard(IMvApplyQueryPort inner, int eventCount)
+    {
+        _inner = inner;
+        _eventCount = eventCount;
+    }
+
+    public bool QueryAttempted => Volatile.Read(ref _queryAttempted) != 0;
+
+    public Task<IReadOnlyList<JsonElement>> QueryRowsAsync(
+        string sql,
+        IReadOnlyList<MvParam> parameters,
+        CancellationToken ct)
+    {
+        MarkQueryAttempted();
+        return Task.FromException<IReadOnlyList<JsonElement>>(CreateException());
+    }
+
+    public Task<JsonElement?> QuerySingleOrDefaultAsync(
+        string sql,
+        IReadOnlyList<MvParam> parameters,
+        CancellationToken ct)
+    {
+        MarkQueryAttempted();
+        return Task.FromException<JsonElement?>(CreateException());
+    }
+
+    public Task<string?> ExecuteScalarJsonAsync(
+        string sql,
+        IReadOnlyList<MvParam> parameters,
+        CancellationToken ct)
+    {
+        MarkQueryAttempted();
+        return Task.FromException<string?>(CreateException());
+    }
+
+    internal Exception RejectRawAccess(string surface) =>
+        _inner is MvPolicyEnforcingQueryPort enforcingPort
+            ? enforcingPort.RejectRawAccess(surface)
+            : new NotSupportedException($"Native MV apply host does not expose {surface}.");
+
+    public MvStateReadingBatchNotSupportedException CreateException() =>
+        new(_eventCount);
+
+    private void MarkQueryAttempted() =>
+        Interlocked.Exchange(ref _queryAttempted, 1);
 }

--- a/dcb/src/Sekiban.Dcb.MaterializedView/MvStateReadingBatchNotSupportedException.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView/MvStateReadingBatchNotSupportedException.cs
@@ -1,0 +1,26 @@
+namespace Sekiban.Dcb.MaterializedView;
+
+/// <summary>
+///     A materialized-view projector attempted state reading while a verified execution batch contained more than
+///     one event. Querying mutable state for a whole batch cannot be authorized safely because the read result would
+///     be reused across event preparation; callers must use a single-event batch or a query-free projector.
+/// </summary>
+public sealed class MvStateReadingBatchNotSupportedException : NotSupportedException
+{
+    public const string CatchUpErrorCode = "state-reading-batch-not-supported";
+    public const string CatchUpErrorMessage =
+        "State-reading materialized-view projectors are not supported for multi-event execution batches.";
+
+    public MvStateReadingBatchNotSupportedException(int eventCount)
+        : base($"{CatchUpErrorMessage} Observed event count: {eventCount}.")
+    {
+        if (eventCount < 2)
+        {
+            throw new ArgumentOutOfRangeException(nameof(eventCount), eventCount, "The guarded batch must contain at least two events.");
+        }
+
+        EventCount = eventCount;
+    }
+
+    public int EventCount { get; }
+}

--- a/dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/MvVerifiedBatchSafetyTests.cs
+++ b/dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/MvVerifiedBatchSafetyTests.cs
@@ -1,0 +1,523 @@
+using Dapper;
+using Dcb.Domain.WithoutResult.Weather;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Sekiban.Dcb;
+using Sekiban.Dcb.Common;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.MaterializedView;
+using Sekiban.Dcb.MaterializedView.Postgres;
+using Sekiban.Dcb.MaterializedView.Sqlite;
+using Xunit;
+
+namespace Sekiban.Dcb.MaterializedView.MultiProvider.Tests;
+
+public enum VerifiedBatchQuerySurface
+{
+    Rows,
+    Single,
+    Scalar,
+    RowsExtension,
+    SingleExtension
+}
+
+internal sealed class VerifiedBatchCounterProjector(
+    VerifiedBatchQuerySurface querySurface,
+    bool readBeforeWrite) : IMaterializedViewProjector, IMvSchemaRequirementsProvider
+{
+    public const string View = "VerifiedBatchCounter";
+    public const int Version = 1;
+
+    public string ViewName => View;
+    public int ViewVersion => Version;
+    public MvTable Counters { get; private set; } = default!;
+
+    public IReadOnlyList<MvSchemaTableRequirement> GetSchemaRequirements(
+        MvDbType databaseType,
+        IMvTableBindings tables)
+    {
+        Counters = tables.RegisterTable("counters");
+        return
+        [
+            new MvSchemaTableRequirement(
+                "counters",
+                Counters.PhysicalName,
+                [
+                    new("id", MvSchemaTypeFamily.String, false),
+                    new("value", MvSchemaTypeFamily.Integer, false)
+                ],
+                ["id"])
+        ];
+    }
+
+    public async Task InitializeAsync(IMvInitContext ctx, CancellationToken cancellationToken = default)
+    {
+        Counters = ctx.RegisterTable("counters");
+        await ctx.ExecuteAsync(
+                $"CREATE TABLE IF NOT EXISTS {Counters.PhysicalName} (id TEXT NOT NULL PRIMARY KEY, value INTEGER NOT NULL);",
+                cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    public async Task<IReadOnlyList<MvSqlStatement>> ApplyToViewAsync(
+        Event ev,
+        IMvApplyContext ctx,
+        CancellationToken cancellationToken = default)
+    {
+        if (!readBeforeWrite)
+        {
+            return [
+                new MvSqlStatement(
+                    $"INSERT INTO {Counters.PhysicalName} (id, value) VALUES ('counter', 1) " +
+                    $"ON CONFLICT (id) DO UPDATE SET value = {Counters.PhysicalName}.value + 1;")
+            ];
+        }
+
+        var current = await ReadCurrentAsync(ctx, cancellationToken).ConfigureAwait(false);
+        return [
+            new MvSqlStatement(
+                $"INSERT INTO {Counters.PhysicalName} (id, value) VALUES ('counter', @Value) " +
+                "ON CONFLICT (id) DO UPDATE SET value = excluded.value;",
+                new { Value = current + 1 })
+        ];
+    }
+
+    private async Task<int> ReadCurrentAsync(IMvApplyContext ctx, CancellationToken cancellationToken)
+    {
+        var sql = $"SELECT value FROM {Counters.PhysicalName} WHERE id = 'counter';";
+        return querySurface switch
+        {
+            VerifiedBatchQuerySurface.Rows => ReadRows(await ctx.QueryRowsAsync(sql, cancellationToken: cancellationToken).ConfigureAwait(false)),
+            VerifiedBatchQuerySurface.Single => ReadRow(await ctx.QuerySingleOrDefaultRowAsync(sql, cancellationToken: cancellationToken).ConfigureAwait(false)),
+            VerifiedBatchQuerySurface.Scalar => checked((int)await ctx.ExecuteScalarAsync<long>(
+                $"SELECT COALESCE(MAX(value), 0) FROM {Counters.PhysicalName} WHERE id = 'counter';",
+                cancellationToken: cancellationToken).ConfigureAwait(false)),
+            VerifiedBatchQuerySurface.RowsExtension => ReadExtensionRows(await ctx.QueryAsync<CounterRow>(
+                sql,
+                cancellationToken: cancellationToken).ConfigureAwait(false)),
+            VerifiedBatchQuerySurface.SingleExtension => (await ctx.QuerySingleOrDefaultAsync<CounterRow>(
+                sql,
+                cancellationToken: cancellationToken).ConfigureAwait(false))?.Value ?? 0,
+            _ => throw new ArgumentOutOfRangeException()
+        };
+    }
+
+    private static int ReadRows(IMvRowSet rows) => rows.Count == 0 ? 0 : rows[0].GetInt32("value");
+
+    private static int ReadRow(IMvRow? row) => row?.GetInt32("value") ?? 0;
+
+    private static int ReadExtensionRows(IReadOnlyList<CounterRow> rows) => rows.Count == 0 ? 0 : rows[0].Value;
+
+    public sealed class CounterRow
+    {
+        public int Value { get; init; }
+    }
+}
+
+internal sealed class SwallowingQueryHost(IMvApplyHost inner, string fallbackSql) : IMvApplyHost
+{
+    public int CaughtQueryExceptions { get; private set; }
+    public int ApplyEventCalls { get; private set; }
+    public string ViewName => inner.ViewName;
+    public int ViewVersion => inner.ViewVersion;
+    public IReadOnlyList<string> LogicalTables => inner.LogicalTables;
+
+    public Task<IReadOnlyList<MvSqlStatementDto>> InitializeAsync(IMvTableBindings tables, CancellationToken ct) =>
+        inner.InitializeAsync(tables, ct);
+
+    public async Task<IReadOnlyList<MvSqlStatementDto>> ApplyEventAsync(
+        SerializableEvent ev,
+        IMvTableBindings tables,
+        IMvApplyQueryPort queryPort,
+        string sortableUniqueId,
+        CancellationToken ct)
+    {
+        ApplyEventCalls++;
+        try
+        {
+            return await inner.ApplyEventAsync(ev, tables, queryPort, sortableUniqueId, ct).ConfigureAwait(false);
+        }
+        catch (MvStateReadingBatchNotSupportedException)
+        {
+            CaughtQueryExceptions++;
+            return [new MvSqlStatementDto(fallbackSql, [])];
+        }
+    }
+
+    public IReadOnlyList<MvSchemaTableRequirement> GetSchemaRequirements(IMvTableBindings tables) =>
+        inner.GetSchemaRequirements(tables);
+
+    public MvSchemaContract? GetSchemaContract(IMvTableBindings tables) => inner.GetSchemaContract(tables);
+}
+
+internal sealed class RecordingAllowPolicy : IMvSqlStatementPolicy
+{
+    public List<MvSqlStatementContext> Contexts { get; } = [];
+
+    public ValueTask<MvSqlPolicyDecision> EvaluateAsync(
+        MvSqlStatementContext context,
+        CancellationToken cancellationToken = default)
+    {
+        Contexts.Add(context);
+        return ValueTask.FromResult(MvSqlPolicyDecision.Allow());
+    }
+
+    public void Clear() => Contexts.Clear();
+}
+
+internal sealed class VerifiedBatchExecutionAudit : IMvExecutionObserver
+{
+    public List<string> ProjectorCommandExecutionAttempts { get; } = [];
+    public int TransactionCommitCount { get; private set; }
+
+    public void OnProjectorCommandExecutionAttempt(string sql) => ProjectorCommandExecutionAttempts.Add(sql);
+    public void OnTransactionCommitted() => TransactionCommitCount++;
+
+    public void Reset()
+    {
+        ProjectorCommandExecutionAttempts.Clear();
+        TransactionCommitCount = 0;
+    }
+}
+
+internal static class VerifiedBatchSafetySupport
+{
+    public const string ServiceId = MultiProviderFixtureBase.ServiceId;
+
+    public static string CounterTableName() => MvPhysicalName.Resolve(
+        new MvOptions { TablePrefix = MvOptions.DefaultTablePrefix },
+        VerifiedBatchCounterProjector.View,
+        VerifiedBatchCounterProjector.Version,
+        "counters");
+
+    public static NativeMvApplyHost CreateHost(
+        VerifiedBatchCounterProjector projector,
+        DcbDomainTypes domainTypes,
+        MvDbType databaseType) =>
+        new(projector, domainTypes.EventTypes, databaseType);
+
+    public static SerializableEvent CreateEvent(DcbDomainTypes domainTypes, DateTime timestamp)
+    {
+        var eventId = Guid.CreateVersion7();
+        var value = new Event(
+            new WeatherForecastCreated(
+                Guid.CreateVersion7(),
+                "Tokyo",
+                DateOnly.FromDateTime(timestamp),
+                20,
+                "Sunny"),
+            SortableUniqueId.Generate(timestamp, eventId),
+            nameof(WeatherForecastCreated),
+            eventId,
+            new EventMetadata("g64", "g64", "verified-batch"),
+            []);
+        return value.ToSerializableEvent(domainTypes.EventTypes);
+    }
+}
+
+[Collection(nameof(SqliteMvCollection))]
+public sealed class SqliteMvVerifiedBatchSafetyTests(SqliteMvFixture fixture)
+{
+    [SkippableTheory]
+    [InlineData(VerifiedBatchQuerySurface.Rows)]
+    [InlineData(VerifiedBatchQuerySurface.Single)]
+    [InlineData(VerifiedBatchQuerySurface.Scalar)]
+    [InlineData(VerifiedBatchQuerySurface.RowsExtension)]
+    [InlineData(VerifiedBatchQuerySurface.SingleExtension)]
+    public async Task VerifyAndExecute_RejectsEveryStateReadingSurfaceBeforeDml(
+        VerifiedBatchQuerySurface querySurface)
+    {
+        Skip.IfNot(fixture.IsAvailable, fixture.AvailabilityMessage ?? "SQLite fixture is unavailable.");
+        var (projector, host, policy, executor, audit) = await PrepareAsync(querySurface, readBeforeWrite: true);
+        var events = CreateEvents();
+
+        var exception = await Assert.ThrowsAsync<MvStateReadingBatchNotSupportedException>(
+                () => executor.ApplySerializableEventsAsync(host, events))
+            .ConfigureAwait(false);
+
+        Assert.Equal(2, exception.EventCount);
+        Assert.Empty(audit.ProjectorCommandExecutionAttempts);
+        Assert.Equal(0, audit.TransactionCommitCount);
+        Assert.DoesNotContain(policy.Contexts, context =>
+            context.Phase == MvSqlStatementPhase.Apply || context.Origin == MvSqlStatementOrigin.ProjectorQuery);
+        Assert.Equal(0, await ReadCounterAsync(projector).ConfigureAwait(false));
+        Assert.Equal(0, await ReadRegistryAsync(projector).ConfigureAwait(false));
+    }
+
+    [SkippableFact]
+    public async Task VerifyAndExecute_LatchedQueryAttemptCannotBeSwallowedIntoFallback()
+    {
+        Skip.IfNot(fixture.IsAvailable, fixture.AvailabilityMessage ?? "SQLite fixture is unavailable.");
+        var (projector, _, policy, executor, audit) = await PrepareAsync(VerifiedBatchQuerySurface.Rows, readBeforeWrite: true);
+        var swallowingHost = new SwallowingQueryHost(
+            VerifiedBatchSafetySupport.CreateHost(projector, fixture.DomainTypes, MvDbType.Sqlite),
+            $"INSERT INTO {projector.Counters.PhysicalName} (id, value) VALUES ('fallback', 999);");
+        await executor.InitializeAsync(swallowingHost).ConfigureAwait(false);
+        policy.Clear();
+        audit.Reset();
+
+        var exception = await Assert.ThrowsAsync<MvStateReadingBatchNotSupportedException>(
+                () => executor.ApplySerializableEventsAsync(swallowingHost, CreateEvents()))
+            .ConfigureAwait(false);
+
+        Assert.Equal(2, swallowingHost.CaughtQueryExceptions);
+        Assert.Equal(2, swallowingHost.ApplyEventCalls);
+        Assert.Equal(2, exception.EventCount);
+        Assert.Empty(audit.ProjectorCommandExecutionAttempts);
+        Assert.Equal(0, audit.TransactionCommitCount);
+        Assert.DoesNotContain(policy.Contexts, context => context.Phase == MvSqlStatementPhase.Apply);
+        Assert.Equal(0, await ReadCounterAsync(projector).ConfigureAwait(false));
+        Assert.Equal(0, await ReadRegistryAsync(projector).ConfigureAwait(false));
+    }
+
+    [SkippableFact]
+    public async Task VerifyAndExecute_SingleEventStateReadRemainsSupported()
+    {
+        Skip.IfNot(fixture.IsAvailable, fixture.AvailabilityMessage ?? "SQLite fixture is unavailable.");
+        var (projector, host, _, executor, audit) = await PrepareAsync(VerifiedBatchQuerySurface.Rows, readBeforeWrite: true);
+        audit.Reset();
+
+        var applied = await executor.ApplySerializableEventsAsync(host, [CreateEvents()[0]]).ConfigureAwait(false);
+
+        Assert.Equal(1, applied);
+        Assert.Equal(1, await ReadCounterAsync(projector).ConfigureAwait(false));
+        Assert.Single(audit.ProjectorCommandExecutionAttempts);
+        Assert.Equal(1, audit.TransactionCommitCount);
+        Assert.Equal(1, await ReadRegistryAsync(projector).ConfigureAwait(false));
+    }
+
+    [SkippableFact]
+    public async Task VerifyAndExecute_QueryFreeMultiEventFoldRemainsSupported()
+    {
+        Skip.IfNot(fixture.IsAvailable, fixture.AvailabilityMessage ?? "SQLite fixture is unavailable.");
+        var (projector, host, _, executor, audit) = await PrepareAsync(VerifiedBatchQuerySurface.Rows, readBeforeWrite: false);
+        audit.Reset();
+
+        var applied = await executor.ApplySerializableEventsAsync(host, CreateEvents()).ConfigureAwait(false);
+
+        Assert.Equal(2, applied);
+        Assert.Equal(2, await ReadCounterAsync(projector).ConfigureAwait(false));
+        Assert.Equal(2, audit.ProjectorCommandExecutionAttempts.Count);
+        Assert.Equal(1, audit.TransactionCommitCount);
+        Assert.Equal(2, await ReadRegistryAsync(projector).ConfigureAwait(false));
+    }
+
+    [SkippableFact]
+    public async Task OrleansCatchUpBoundary_ClassifiesTheTypedBatchFailureAsPermanent()
+    {
+        Skip.IfNot(fixture.IsAvailable, fixture.AvailabilityMessage ?? "SQLite fixture is unavailable.");
+        var (projector, host, _, executor, audit) = await PrepareAsync(VerifiedBatchQuerySurface.Rows, readBeforeWrite: true);
+        var events = CreateEvents();
+        var write = await fixture.EventStore.WriteSerializableEventsAsync(events).ConfigureAwait(false);
+        Assert.True(write.IsSuccess, write.IsSuccess ? string.Empty : write.GetException().Message);
+        audit.Reset();
+
+        var result = await ((IMvOrleansCatchUpExecutor)executor)
+            .CatchUpOnceForOrleansAsync(host, VerifiedBatchSafetySupport.ServiceId)
+            .ConfigureAwait(false);
+
+        Assert.Equal(MvCatchUpOutcome.PermanentUnsupported, result.Outcome);
+        Assert.Equal(MvStateReadingBatchNotSupportedException.CatchUpErrorCode, result.ErrorCode);
+        Assert.Equal(MvStateReadingBatchNotSupportedException.CatchUpErrorMessage, result.ErrorMessage);
+        Assert.False(result.IsRetryable);
+        Assert.Equal(2, result.EventCount);
+        Assert.Empty(audit.ProjectorCommandExecutionAttempts);
+        Assert.Equal(0, audit.TransactionCommitCount);
+        Assert.Equal(0, await ReadCounterAsync(projector).ConfigureAwait(false));
+        Assert.Equal(0, await ReadRegistryAsync(projector).ConfigureAwait(false));
+    }
+
+    private async Task<(VerifiedBatchCounterProjector Projector, IMvApplyHost Host, RecordingAllowPolicy Policy, SqliteMvExecutor Executor, VerifiedBatchExecutionAudit Audit)> PrepareAsync(
+        VerifiedBatchQuerySurface querySurface,
+        bool readBeforeWrite)
+    {
+        await fixture.ResetAsync().ConfigureAwait(false);
+        await DropCounterTableAsync().ConfigureAwait(false);
+        var projector = new VerifiedBatchCounterProjector(querySurface, readBeforeWrite);
+        var host = VerifiedBatchSafetySupport.CreateHost(projector, fixture.DomainTypes, MvDbType.Sqlite);
+        var policy = new RecordingAllowPolicy();
+        var audit = new VerifiedBatchExecutionAudit();
+        var setup = CreateExecutor(MvInitializationMode.CreateOrEnsure, policy, audit);
+        await setup.InitializeAsync(host).ConfigureAwait(false);
+        var executor = CreateExecutor(MvInitializationMode.VerifyAndExecute, policy, audit);
+        await executor.InitializeAsync(host).ConfigureAwait(false);
+        policy.Clear();
+        audit.Reset();
+        return (projector, host, policy, executor, audit);
+    }
+
+    private SqliteMvExecutor CreateExecutor(
+        MvInitializationMode mode,
+        RecordingAllowPolicy policy,
+        VerifiedBatchExecutionAudit audit) =>
+        new(
+            fixture.EventStoreFactory,
+            new SqliteMvRegistryStore(fixture.ConnectionStringForTests),
+            Options.Create(new MvOptions
+            {
+                ServiceId = VerifiedBatchSafetySupport.ServiceId,
+                InitializationMode = mode,
+                SqlStatementPolicyMode = MvSqlStatementPolicyMode.Enforced,
+                SqlStatementPolicy = policy,
+                SafeWindowMs = 0,
+                BatchSize = 100,
+                ExecutionObserver = audit
+            }),
+            NullLogger<SqliteMvExecutor>.Instance,
+            fixture.ConnectionStringForTests);
+
+    private SerializableEvent[] CreateEvents() =>
+    [
+        VerifiedBatchSafetySupport.CreateEvent(fixture.DomainTypes, DateTime.UtcNow.AddMinutes(-2)),
+        VerifiedBatchSafetySupport.CreateEvent(fixture.DomainTypes, DateTime.UtcNow.AddMinutes(-1))
+    ];
+
+    private async Task DropCounterTableAsync()
+    {
+        await using var connection = await fixture.OpenConnectionAsync().ConfigureAwait(false);
+        await connection.ExecuteAsync($"DROP TABLE IF EXISTS {VerifiedBatchSafetySupport.CounterTableName()};").ConfigureAwait(false);
+    }
+
+    private async Task<int> ReadCounterAsync(VerifiedBatchCounterProjector projector)
+    {
+        await using var connection = await fixture.OpenConnectionAsync().ConfigureAwait(false);
+        return await connection.ExecuteScalarAsync<int>(
+                $"SELECT COALESCE(MAX(value), 0) FROM {projector.Counters.PhysicalName} WHERE id = 'counter';")
+            .ConfigureAwait(false);
+    }
+
+    private async Task<long> ReadRegistryAsync(VerifiedBatchCounterProjector projector)
+    {
+        var registry = new SqliteMvRegistryStore(fixture.ConnectionStringForTests);
+        var entries = await registry.GetEntriesAsync(
+                VerifiedBatchSafetySupport.ServiceId,
+                projector.ViewName,
+                projector.ViewVersion)
+            .ConfigureAwait(false);
+        return entries.Single().AppliedEventVersion;
+    }
+}
+
+[Collection(nameof(PostgresMvCollection))]
+public sealed class PostgresMvVerifiedBatchSafetyTests(PostgresMvFixture fixture)
+{
+    [SkippableFact]
+    public async Task RealPostgres_StateReadingBatchIsRejected_AndSingleEventControlIncrementsTwice()
+    {
+        Skip.IfNot(fixture.IsAvailable, fixture.AvailabilityMessage ?? "PostgreSQL fixture is unavailable.");
+        var (projector, host, _, executor, audit) = await PrepareAsync(VerifiedBatchQuerySurface.Single, readBeforeWrite: true);
+        var events = CreateEvents();
+
+        var exception = await Assert.ThrowsAsync<MvStateReadingBatchNotSupportedException>(
+                () => executor.ApplySerializableEventsAsync(host, events))
+            .ConfigureAwait(false);
+        Assert.Equal(2, exception.EventCount);
+        Assert.Empty(audit.ProjectorCommandExecutionAttempts);
+        Assert.Equal(0, audit.TransactionCommitCount);
+        Assert.Equal(0, await ReadCounterAsync(projector).ConfigureAwait(false));
+        Assert.Equal(0, await ReadRegistryAsync(projector).ConfigureAwait(false));
+
+        var singleExecutor = CreateExecutor(MvInitializationMode.VerifyAndExecute, new RecordingAllowPolicy(), audit, batchSize: 1);
+        audit.Reset();
+        Assert.Equal(1, await singleExecutor.ApplySerializableEventsAsync(host, [events[0]]).ConfigureAwait(false));
+        Assert.Equal(1, await singleExecutor.ApplySerializableEventsAsync(host, [events[1]]).ConfigureAwait(false));
+
+        Assert.Equal(2, await ReadCounterAsync(projector).ConfigureAwait(false));
+        Assert.Equal(2, audit.ProjectorCommandExecutionAttempts.Count);
+        Assert.Equal(2, audit.TransactionCommitCount);
+        var entry = await ReadEntryAsync(projector).ConfigureAwait(false);
+        Assert.Equal(2, entry.AppliedEventVersion);
+        Assert.Equal(events[1].SortableUniqueIdValue, entry.CurrentCheckpointTruth.PositionValue);
+    }
+
+    [SkippableFact]
+    public async Task RealPostgres_QueryFreeMultiEventFoldRemainsSupported()
+    {
+        Skip.IfNot(fixture.IsAvailable, fixture.AvailabilityMessage ?? "PostgreSQL fixture is unavailable.");
+        var (projector, host, _, executor, audit) = await PrepareAsync(VerifiedBatchQuerySurface.Rows, readBeforeWrite: false);
+        audit.Reset();
+        var events = CreateEvents();
+
+        Assert.Equal(2, await executor.ApplySerializableEventsAsync(host, events).ConfigureAwait(false));
+        Assert.Equal(2, await ReadCounterAsync(projector).ConfigureAwait(false));
+        Assert.Equal(2, audit.ProjectorCommandExecutionAttempts.Count);
+        Assert.Equal(1, audit.TransactionCommitCount);
+        var entry = await ReadEntryAsync(projector).ConfigureAwait(false);
+        Assert.Equal(2, entry.AppliedEventVersion);
+        Assert.Equal(events[1].SortableUniqueIdValue, entry.CurrentCheckpointTruth.PositionValue);
+    }
+
+    private async Task<(VerifiedBatchCounterProjector Projector, IMvApplyHost Host, RecordingAllowPolicy Policy, PostgresMvExecutor Executor, VerifiedBatchExecutionAudit Audit)> PrepareAsync(
+        VerifiedBatchQuerySurface querySurface,
+        bool readBeforeWrite)
+    {
+        await fixture.ResetAsync().ConfigureAwait(false);
+        await DropCounterTableAsync().ConfigureAwait(false);
+        var projector = new VerifiedBatchCounterProjector(querySurface, readBeforeWrite);
+        var host = VerifiedBatchSafetySupport.CreateHost(projector, fixture.DomainTypes, MvDbType.Postgres);
+        var policy = new RecordingAllowPolicy();
+        var audit = new VerifiedBatchExecutionAudit();
+        var setup = CreateExecutor(MvInitializationMode.CreateOrEnsure, policy, audit);
+        await setup.InitializeAsync(host).ConfigureAwait(false);
+        var executor = CreateExecutor(MvInitializationMode.VerifyAndExecute, policy, audit);
+        await executor.InitializeAsync(host).ConfigureAwait(false);
+        policy.Clear();
+        audit.Reset();
+        return (projector, host, policy, executor, audit);
+    }
+
+    private PostgresMvExecutor CreateExecutor(
+        MvInitializationMode mode,
+        RecordingAllowPolicy policy,
+        VerifiedBatchExecutionAudit audit,
+        int batchSize = 100) =>
+        new(
+            fixture.EventStoreFactory,
+            new PostgresMvRegistryStore(fixture.ConnectionStringForTests),
+            Options.Create(new MvOptions
+            {
+                ServiceId = VerifiedBatchSafetySupport.ServiceId,
+                InitializationMode = mode,
+                SqlStatementPolicyMode = MvSqlStatementPolicyMode.Enforced,
+                SqlStatementPolicy = policy,
+                SafeWindowMs = 0,
+                BatchSize = batchSize,
+                ExecutionObserver = audit
+            }),
+            NullLogger<PostgresMvExecutor>.Instance,
+            fixture.ConnectionStringForTests);
+
+    private SerializableEvent[] CreateEvents() =>
+    [
+        VerifiedBatchSafetySupport.CreateEvent(fixture.DomainTypes, DateTime.UtcNow.AddMinutes(-2)),
+        VerifiedBatchSafetySupport.CreateEvent(fixture.DomainTypes, DateTime.UtcNow.AddMinutes(-1))
+    ];
+
+    private async Task DropCounterTableAsync()
+    {
+        await using var connection = await fixture.OpenConnectionAsync().ConfigureAwait(false);
+        await connection.ExecuteAsync($"DROP TABLE IF EXISTS {VerifiedBatchSafetySupport.CounterTableName()};").ConfigureAwait(false);
+    }
+
+    private async Task<int> ReadCounterAsync(VerifiedBatchCounterProjector projector)
+    {
+        await using var connection = await fixture.OpenConnectionAsync().ConfigureAwait(false);
+        return await connection.ExecuteScalarAsync<int>(
+                $"SELECT COALESCE(MAX(value), 0) FROM {projector.Counters.PhysicalName} WHERE id = 'counter';")
+            .ConfigureAwait(false);
+    }
+
+    private async Task<long> ReadRegistryAsync(VerifiedBatchCounterProjector projector) =>
+        (await ReadEntryAsync(projector).ConfigureAwait(false)).AppliedEventVersion;
+
+    private async Task<MvRegistryEntry> ReadEntryAsync(VerifiedBatchCounterProjector projector)
+    {
+        var registry = new PostgresMvRegistryStore(fixture.ConnectionStringForTests);
+        var entries = await registry.GetEntriesAsync(
+                VerifiedBatchSafetySupport.ServiceId,
+                projector.ViewName,
+                projector.ViewVersion)
+            .ConfigureAwait(false);
+        return entries.Single();
+    }
+}

--- a/dcb/tests/Sekiban.Dcb.MaterializedView.Postgres.Tests/MaterializedViewPostgresOrleansTests.cs
+++ b/dcb/tests/Sekiban.Dcb.MaterializedView.Postgres.Tests/MaterializedViewPostgresOrleansTests.cs
@@ -659,6 +659,7 @@ public sealed class MaterializedViewPostgresOrleansTests(MaterializedViewPostgre
         MaterializedViewGrainStatus? lastStatus = null;
         var lastRowCount = -1;
         var lastUpdatedLocationCount = -1;
+        string? lastStreamReceivedSortableUniqueId = null;
         var deadline = DateTime.UtcNow.AddSeconds(15);
         while (DateTime.UtcNow < deadline)
         {
@@ -673,9 +674,16 @@ public sealed class MaterializedViewPostgresOrleansTests(MaterializedViewPostgre
                 WHERE is_deleted = FALSE
                   AND location LIKE '%-U';
                 """);
+            lastStreamReceivedSortableUniqueId = await connection.ExecuteScalarAsync<string?>(
+                """
+                SELECT last_stream_received_sortable_unique_id
+                FROM sekiban_mv_registry
+                WHERE view_name = 'WeatherForecast' AND logical_table = 'forecasts';
+                """);
             if (lastStatus.CurrentPosition == latestSortableUniqueId &&
                 lastRowCount == forecastCount &&
-                lastUpdatedLocationCount == forecastCount)
+                lastUpdatedLocationCount == forecastCount &&
+                lastStreamReceivedSortableUniqueId == latestSortableUniqueId)
             {
                 break;
             }
@@ -686,8 +694,9 @@ public sealed class MaterializedViewPostgresOrleansTests(MaterializedViewPostgre
         Assert.True(
             lastStatus?.CurrentPosition == latestSortableUniqueId &&
             lastRowCount == forecastCount &&
-            lastUpdatedLocationCount == forecastCount,
-            $"Expected position={latestSortableUniqueId}, rows={forecastCount}, updatedRows={forecastCount} but got position={lastStatus?.CurrentPosition}, rows={lastRowCount}, updatedRows={lastUpdatedLocationCount}.");
+            lastUpdatedLocationCount == forecastCount &&
+            lastStreamReceivedSortableUniqueId == latestSortableUniqueId,
+            $"Expected position={latestSortableUniqueId}, rows={forecastCount}, updatedRows={forecastCount}, receipt={latestSortableUniqueId} but got position={lastStatus?.CurrentPosition}, rows={lastRowCount}, updatedRows={lastUpdatedLocationCount}, receipt={lastStreamReceivedSortableUniqueId}.");
 
         await using var verifyConnection = await fixture.OpenConnectionAsync();
         var rowCount = await verifyConnection.ExecuteScalarAsync<int>(

--- a/dcb/tests/Sekiban.Dcb.Orleans.Tests/MaterializedViewGrainTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Orleans.Tests/MaterializedViewGrainTests.cs
@@ -620,8 +620,9 @@ public class MaterializedViewGrainTests : IAsyncLifetime
         SharedExecutor.ScriptedCatchUpResults.Enqueue(new MvCatchUpResult(0, false)
         {
             Outcome = MvCatchUpOutcome.PermanentUnsupported,
-            ErrorCode = "unsupported",
-            ErrorMessage = "Catch-up is unsupported by the configured provider or policy."
+            ErrorCode = MvStateReadingBatchNotSupportedException.CatchUpErrorCode,
+            ErrorMessage = MvStateReadingBatchNotSupportedException.CatchUpErrorMessage,
+            EventCount = 2
         });
 
         var grain = await StartServingGrainAsync();
@@ -631,7 +632,8 @@ public class MaterializedViewGrainTests : IAsyncLifetime
         Assert.True(status.CatchUpHalted);
         Assert.False(status.IsCatchUpActive);
         Assert.Null(status.LastCatchUpCompletedAt);
-        Assert.Equal("Catch-up is unsupported by the configured provider or policy.", status.LastError);
+        Assert.Equal(MvStateReadingBatchNotSupportedException.CatchUpErrorMessage, status.LastError);
+        Assert.Contains("multi-event", status.LastError, StringComparison.OrdinalIgnoreCase);
         Assert.Equal(1, SharedExecutor.CatchUpCalls);
         Assert.Equal(0, SharedRegistry.ActiveStatusRestoreCalls);
     }

--- a/docs/dcb_llm/20_materialized_view.md
+++ b/docs/dcb_llm/20_materialized_view.md
@@ -364,6 +364,11 @@ When the Orleans catch-up boundary observes this condition, it returns the perma
 stable error code `state-reading-batch-not-supported`, the safe diagnostic message, and the event count. The grain
 halts visibly with `CatchUpHalted`, leaves the last error observable, and does not synthesize completion or replay.
 
+Callers can configure catch-up with `BatchSize = 1`, and explicit one-event direct calls remain supported. `BatchSize`
+is an executor-wide `MvOptions` setting, so `1` folds events sequentially one at a time and trades throughput for one
+transaction per event. The guard covers reads made through the framework query ports; it does not detect or control
+arbitrary external effects or external-service reads performed by custom user code.
+
 Projectors that support verify-only initialization describe their target schema with the additive, format-versioned
 `MvSchemaContract`/`IMvSchemaRequirementsProvider` contract (format version `1`):
 

--- a/docs/dcb_llm/20_materialized_view.md
+++ b/docs/dcb_llm/20_materialized_view.md
@@ -351,6 +351,19 @@ In mode 2, the executor collects and authorizes the whole apply batch before its
 command. A policy rejection therefore leaves view rows, registry checkpoint/status, and the active pointer unchanged;
 a deny test is expected to become red if a future implementation executes before authorization.
 
+State-reading projectors have one additional whole-batch boundary. After duplicate and current-position filtering, a
+`VerifyAndExecute` batch containing more than one event rejects `QueryRowsAsync`,
+`QuerySingleOrDefaultAsync`, `ExecuteScalarJsonAsync`, and their typed row-mapper extensions through the typed
+`MvStateReadingBatchNotSupportedException`. The exception exposes the observed `EventCount`; no provider query is
+issued. This guard is latched even when a projector catches the exception and returns fallback statements, and the
+executor rethrows it before policy authorization, projector DML, or registry checkpoint mutation. A single-event
+state read remains supported, as does a query-free multi-event projector. The executor does not split, retry, or
+silently fall back to a different projector path.
+
+When the Orleans catch-up boundary observes this condition, it returns the permanent unsupported outcome with the
+stable error code `state-reading-batch-not-supported`, the safe diagnostic message, and the event count. The grain
+halts visibly with `CatchUpHalted`, leaves the last error observable, and does not synthesize completion or replay.
+
 Projectors that support verify-only initialization describe their target schema with the additive, format-versioned
 `MvSchemaContract`/`IMvSchemaRequirementsProvider` contract (format version `1`):
 

--- a/docs/dcb_llm_ja/20_materialized_view.md
+++ b/docs/dcb_llm_ja/20_materialized_view.md
@@ -361,6 +361,11 @@ Orleans catch-up boundary ではこの条件を permanent unsupported として�
 `state-reading-batch-not-supported`、安全な診断文、event count を返します。grain は `CatchUpHalted` を可視化して停止し、
 last error を保持します。synthetic completion や replay は生成しません。
 
+caller は catch-up の `BatchSize = 1` を設定でき、明示的な 1 event の direct call も引き続き利用できます。
+`BatchSize` は executor 全体に適用される `MvOptions` の設定であるため、`1` では event を順番に 1 件ずつ fold し、
+event ごとに transaction を行う性能との trade-off があります。この guard が対象にするのは framework の query port
+経由の read であり、custom user code が行う任意の external effect や external service の read まで検出・制御するものではありません。
+
 verify-only に対応する projector は、format version `1` の追加された `MvSchemaContract` /
 `IMvSchemaRequirementsProvider` 契約で target schema を宣言します。
 

--- a/docs/dcb_llm_ja/20_materialized_view.md
+++ b/docs/dcb_llm_ja/20_materialized_view.md
@@ -349,6 +349,18 @@ mode 2 は最初の projector DML / registry command より前に apply batch �
 場合は view row、registry checkpoint/status、active pointer が変わりません。将来の実装が authorization より先に実行すると、
 この deny test は red になります。
 
+state を読む projector には、whole-batch の追加境界があります。重複と current-position の filter 後に 2 件以上となる
+`VerifyAndExecute` batch では、`QueryRowsAsync`、`QuerySingleOrDefaultAsync`、`ExecuteScalarJsonAsync` と typed row-mapper
+ extension が型付き `MvStateReadingBatchNotSupportedException` で拒否されます。この exception は観測した
+ `EventCount` を持ち、provider query は実行されません。projector が exception を catch して fallback statement を返しても
+ attempt は latch され、executor は policy authorization、projector DML、registry checkpoint mutation の前に再 throw します。
+single-event の state read と、query-free projector の multi-event fold は引き続き利用できます。executor は batch の分割、retry、
+別 projector 経路への暗黙の fallback を行いません。
+
+Orleans catch-up boundary ではこの条件を permanent unsupported として扱い、安定した error code
+`state-reading-batch-not-supported`、安全な診断文、event count を返します。grain は `CatchUpHalted` を可視化して停止し、
+last error を保持します。synthetic completion や replay は生成しません。
+
 verify-only に対応する projector は、format version `1` の追加された `MvSchemaContract` /
 `IMvSchemaRequirementsProvider` 契約で target schema を宣言します。
 


### PR DESCRIPTION
Closes #1201

Implements the conservative whole-batch query-port guard for VerifyAndExecute after dedupe/current-position filtering. Query attempts are typed and latched before provider execution, policy authorization, projector DML, and checkpoint mutation; single-event reads and query-free multi-event folds remain supported. Adds real PostgreSQL and SQLite proofs, Orleans permanent-halt classification coverage, compatibility consumers, and EN/JA documentation.

Focused source/provider tests pass on net9.0 and net10.0. The local broad Orleans TestCluster run remains infrastructure-limited by the host TCP port allocator overflow; CI must provide the Orleans runtime proof.