### PR TITLE
SEK-G63 pre-provisioned PostgreSQL projection status

### DIFF
--- a/dcb/src/Sekiban.Dcb.Core/ProjectionStatus/ProjectionStatusModels.cs
+++ b/dcb/src/Sekiban.Dcb.Core/ProjectionStatus/ProjectionStatusModels.cs
@@ -372,6 +372,16 @@ public enum ProjectionStatusVersionMatch
     Mismatch = 2
 }
 
+/// <summary>
+///     Controls who is allowed to create or migrate the PostgreSQL projection-status registry.
+///     The legacy value preserves the historical runtime auto-provisioning behavior.
+/// </summary>
+public enum ProjectionStatusProvisioningMode
+{
+    LegacyAutoProvision = 0,
+    PreProvisioned = 1
+}
+
 /// <summary>Configuration for the passive projection status registry and read-side sampling.</summary>
 public class ProjectionStatusOptions
 {
@@ -409,6 +419,25 @@ public class ProjectionStatusOptions
 
     /// <summary>Allows a host to turn the heartbeat writer off while retaining the read surface.</summary>
     public bool Enabled { get; set; } = true;
+
+    /// <summary>
+    ///     Selects whether PostgreSQL status calls may provision the registry. Hosts using a DML-only runtime principal
+    ///     must select <see cref="ProjectionStatusProvisioningMode.PreProvisioned" /> and provision the schema from an
+    ///     owner-controlled startup or migration step first.
+    /// </summary>
+    public ProjectionStatusProvisioningMode ProvisioningMode { get; set; } = ProjectionStatusProvisioningMode.LegacyAutoProvision;
+
+    /// <summary>Rejects unsupported option values before a status read or write starts.</summary>
+    public void Validate()
+    {
+        if (!Enum.IsDefined(ProvisioningMode))
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(ProvisioningMode),
+                ProvisioningMode,
+                "The projection-status provisioning mode is not supported.");
+        }
+    }
 }
 
 /// <summary>Descriptive alias used by hosts that call the feature a registry.</summary>

--- a/dcb/src/Sekiban.Dcb.Postgres/PostgresMultiProjectionStateStore.cs
+++ b/dcb/src/Sekiban.Dcb.Postgres/PostgresMultiProjectionStateStore.cs
@@ -28,15 +28,31 @@ public partial class PostgresMultiProjectionStateStore :
     private readonly IDbContextFactory<SekibanDcbDbContext> _contextFactory;
     private readonly IBlobStorageSnapshotAccessor? _blobAccessor;
     private readonly IServiceIdProvider _serviceIdProvider;
+    private readonly ProjectionStatusOptions _projectionStatusOptions;
 
     public PostgresMultiProjectionStateStore(
         IDbContextFactory<SekibanDcbDbContext> contextFactory,
         IServiceIdProvider serviceIdProvider,
         IBlobStorageSnapshotAccessor? blobAccessor = null)
+        : this(contextFactory, serviceIdProvider, blobAccessor, new ProjectionStatusOptions())
     {
-        _contextFactory = contextFactory;
+    }
+
+    /// <summary>
+    ///     Additive options-aware constructor. The historical constructor above remains the legacy auto-provisioning
+    ///     default; pre-provisioned hosts pass the options explicitly without changing the public old ABI.
+    /// </summary>
+    public PostgresMultiProjectionStateStore(
+        IDbContextFactory<SekibanDcbDbContext> contextFactory,
+        IServiceIdProvider serviceIdProvider,
+        IBlobStorageSnapshotAccessor? blobAccessor,
+        ProjectionStatusOptions projectionStatusOptions)
+    {
+        _contextFactory = contextFactory ?? throw new ArgumentNullException(nameof(contextFactory));
         _serviceIdProvider = serviceIdProvider ?? throw new ArgumentNullException(nameof(serviceIdProvider));
         _blobAccessor = blobAccessor;
+        _projectionStatusOptions = projectionStatusOptions ?? throw new ArgumentNullException(nameof(projectionStatusOptions));
+        _projectionStatusOptions.Validate();
     }
 
     private string CurrentServiceId => _serviceIdProvider.GetCurrentServiceId();

--- a/dcb/src/Sekiban.Dcb.Postgres/PostgresMultiProjectionStateStoreFactory.cs
+++ b/dcb/src/Sekiban.Dcb.Postgres/PostgresMultiProjectionStateStoreFactory.cs
@@ -17,18 +17,34 @@ public sealed class PostgresMultiProjectionStateStoreFactory : IMultiProjectionS
 
     private readonly IDbContextFactory<SekibanDcbDbContext> _contextFactory;
     private readonly IBlobStorageSnapshotAccessor? _blobAccessor;
+    private readonly ProjectionStatusOptions _projectionStatusOptions;
 
     public PostgresMultiProjectionStateStoreFactory(
         IDbContextFactory<SekibanDcbDbContext> contextFactory,
         IBlobStorageSnapshotAccessor? blobAccessor = null)
+        : this(contextFactory, blobAccessor, new ProjectionStatusOptions())
+    {
+    }
+
+    /// <summary>Additive options-aware constructor for pre-provisioned status deployments.</summary>
+    public PostgresMultiProjectionStateStoreFactory(
+        IDbContextFactory<SekibanDcbDbContext> contextFactory,
+        IBlobStorageSnapshotAccessor? blobAccessor,
+        ProjectionStatusOptions projectionStatusOptions)
     {
         _contextFactory = contextFactory ?? throw new ArgumentNullException(nameof(contextFactory));
         _blobAccessor = blobAccessor;
+        _projectionStatusOptions = projectionStatusOptions ?? throw new ArgumentNullException(nameof(projectionStatusOptions));
+        _projectionStatusOptions.Validate();
     }
 
     public IMultiProjectionStateStore CreateForService(string serviceId)
     {
         var provider = new FixedServiceIdProvider(serviceId);
-        return new PostgresMultiProjectionStateStore(_contextFactory, provider, _blobAccessor);
+        return new PostgresMultiProjectionStateStore(
+            _contextFactory,
+            provider,
+            _blobAccessor,
+            _projectionStatusOptions);
     }
 }

--- a/dcb/src/Sekiban.Dcb.Postgres/PostgresProjectionStatusSchema.cs
+++ b/dcb/src/Sekiban.Dcb.Postgres/PostgresProjectionStatusSchema.cs
@@ -1,0 +1,40 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace Sekiban.Dcb.Postgres;
+
+internal static class PostgresProjectionStatusSchema
+{
+    internal const string Sql = """
+        CREATE TABLE IF NOT EXISTS dcb_projection_statuses (
+            service_id varchar(64) NOT NULL,
+            projector_name varchar(256) NOT NULL,
+            projector_version varchar(128) NOT NULL,
+            cluster_id varchar(256) NOT NULL,
+            activation_id varchar(128) NOT NULL,
+            sequence bigint NOT NULL,
+            applied_event_count bigint NOT NULL,
+            last_applied_sortable_unique_id varchar(100) NULL,
+            last_traversed_sortable_unique_id varchar(100) NULL,
+            recorded_at_utc timestamp with time zone NOT NULL,
+            phase varchar(64) NULL,
+            lease_expires_at_utc timestamp with time zone NULL,
+            is_faulted boolean NOT NULL DEFAULT FALSE,
+            fault_message varchar(2048) NULL,
+            switch_kind varchar(32) NULL,
+            switch_reason varchar(1024) NULL,
+            switched_at_utc timestamp with time zone NULL,
+            CONSTRAINT pk_dcb_projection_statuses PRIMARY KEY
+                (service_id, projector_name, projector_version, cluster_id)
+        );
+        CREATE INDEX IF NOT EXISTS ix_dcb_projection_statuses_projector
+            ON dcb_projection_statuses (service_id, projector_name, projector_version, cluster_id);
+        ALTER TABLE dcb_projection_statuses ADD COLUMN IF NOT EXISTS switch_kind varchar(32) NULL;
+        ALTER TABLE dcb_projection_statuses ADD COLUMN IF NOT EXISTS switch_reason varchar(1024) NULL;
+        ALTER TABLE dcb_projection_statuses ADD COLUMN IF NOT EXISTS switched_at_utc timestamp with time zone NULL;
+        """;
+
+    internal static Task ProvisionAsync(
+        SekibanDcbDbContext context,
+        CancellationToken cancellationToken = default) =>
+        context.Database.ExecuteSqlRawAsync(Sql, cancellationToken);
+}

--- a/dcb/src/Sekiban.Dcb.Postgres/PostgresProjectionStatusStore.cs
+++ b/dcb/src/Sekiban.Dcb.Postgres/PostgresProjectionStatusStore.cs
@@ -6,35 +6,6 @@ namespace Sekiban.Dcb.Postgres;
 
 public partial class PostgresMultiProjectionStateStore
 {
-    private const string ProjectionStatusSchemaSql = """
-        CREATE TABLE IF NOT EXISTS dcb_projection_statuses (
-            service_id varchar(64) NOT NULL,
-            projector_name varchar(256) NOT NULL,
-            projector_version varchar(128) NOT NULL,
-            cluster_id varchar(256) NOT NULL,
-            activation_id varchar(128) NOT NULL,
-            sequence bigint NOT NULL,
-            applied_event_count bigint NOT NULL,
-            last_applied_sortable_unique_id varchar(100) NULL,
-            last_traversed_sortable_unique_id varchar(100) NULL,
-            recorded_at_utc timestamp with time zone NOT NULL,
-            phase varchar(64) NULL,
-            lease_expires_at_utc timestamp with time zone NULL,
-            is_faulted boolean NOT NULL DEFAULT FALSE,
-            fault_message varchar(2048) NULL,
-            switch_kind varchar(32) NULL,
-            switch_reason varchar(1024) NULL,
-            switched_at_utc timestamp with time zone NULL,
-            CONSTRAINT pk_dcb_projection_statuses PRIMARY KEY
-                (service_id, projector_name, projector_version, cluster_id)
-        );
-        CREATE INDEX IF NOT EXISTS ix_dcb_projection_statuses_projector
-            ON dcb_projection_statuses (service_id, projector_name, projector_version, cluster_id);
-        ALTER TABLE dcb_projection_statuses ADD COLUMN IF NOT EXISTS switch_kind varchar(32) NULL;
-        ALTER TABLE dcb_projection_statuses ADD COLUMN IF NOT EXISTS switch_reason varchar(1024) NULL;
-        ALTER TABLE dcb_projection_statuses ADD COLUMN IF NOT EXISTS switched_at_utc timestamp with time zone NULL;
-        """;
-
     public async Task<ResultBox<ProjectionStatusWriteResult>> UpsertAsync(
         ProjectionStatusHeartbeat heartbeat,
         long expectedSequence,
@@ -43,6 +14,7 @@ public partial class PostgresMultiProjectionStateStore
         ArgumentNullException.ThrowIfNull(heartbeat);
         try
         {
+            _projectionStatusOptions.Validate();
             var serviceId = CurrentServiceId;
             if (!string.Equals(heartbeat.ServiceId, serviceId, StringComparison.Ordinal))
             {
@@ -57,7 +29,7 @@ public partial class PostgresMultiProjectionStateStore
             }
 
             await using var context = await _contextFactory.CreateDbContextAsync(cancellationToken);
-            await EnsureProjectionStatusSchemaAsync(context, cancellationToken).ConfigureAwait(false);
+            await EnsureProjectionStatusSchemaIfAllowedAsync(context, cancellationToken).ConfigureAwait(false);
             await using var connection = context.Database.GetDbConnection();
             if (connection.State != System.Data.ConnectionState.Open)
             {
@@ -157,8 +129,9 @@ public partial class PostgresMultiProjectionStateStore
     {
         try
         {
+            _projectionStatusOptions.Validate();
             await using var context = await _contextFactory.CreateDbContextAsync(cancellationToken);
-            await EnsureProjectionStatusSchemaAsync(context, cancellationToken).ConfigureAwait(false);
+            await EnsureProjectionStatusSchemaIfAllowedAsync(context, cancellationToken).ConfigureAwait(false);
             await using var connection = context.Database.GetDbConnection();
             if (connection.State != System.Data.ConnectionState.Open)
             {
@@ -198,11 +171,14 @@ public partial class PostgresMultiProjectionStateStore
         }
     }
 
-    private static async Task EnsureProjectionStatusSchemaAsync(
+    private async Task EnsureProjectionStatusSchemaIfAllowedAsync(
         SekibanDcbDbContext context,
         CancellationToken cancellationToken)
     {
-        await context.Database.ExecuteSqlRawAsync(ProjectionStatusSchemaSql, cancellationToken).ConfigureAwait(false);
+        if (_projectionStatusOptions.ProvisioningMode == ProjectionStatusProvisioningMode.LegacyAutoProvision)
+        {
+            await PostgresProjectionStatusSchema.ProvisionAsync(context, cancellationToken).ConfigureAwait(false);
+        }
     }
 
     private static void AddParameter(DbCommand command, string name, object value)

--- a/dcb/src/Sekiban.Dcb.Postgres/SekibanDcbPostgresExtensions.cs
+++ b/dcb/src/Sekiban.Dcb.Postgres/SekibanDcbPostgresExtensions.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.Logging;
 using Sekiban.Dcb.Actors;
 using Sekiban.Dcb.Domains;
 using Sekiban.Dcb.ServiceId;
+using Sekiban.Dcb.Snapshots;
 using Sekiban.Dcb.Storage;
 using System.Text.Json;
 namespace Sekiban.Dcb.Postgres;
@@ -39,6 +40,27 @@ public static class SekibanDcbPostgresExtensions
 
         return services;
     }
+
+    /// <summary>
+    ///     Provisions the PostgreSQL projection-status registry from an owner-controlled startup or migration step.
+    ///     Runtime stores configured for <see cref="ProjectionStatusProvisioningMode.PreProvisioned" /> never invoke
+    ///     this operation themselves.
+    /// </summary>
+    public static async Task ProvisionProjectionStatusSchemaAsync(
+        this IDbContextFactory<SekibanDcbDbContext> contextFactory,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(contextFactory);
+        await using var context = await contextFactory.CreateDbContextAsync(cancellationToken);
+        await PostgresProjectionStatusSchema.ProvisionAsync(context, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>Owner convenience overload for hosts that already have a service provider.</summary>
+    public static Task ProvisionProjectionStatusSchemaAsync(
+        this IServiceProvider serviceProvider,
+        CancellationToken cancellationToken = default) =>
+        serviceProvider.GetRequiredService<IDbContextFactory<SekibanDcbDbContext>>()
+            .ProvisionProjectionStatusSchemaAsync(cancellationToken);
 
     /// <summary>
     ///     Aspire環境でSekiban DCB PostgreSQLを設定し、マイグレーション機能を含める
@@ -105,14 +127,7 @@ public static class SekibanDcbPostgresExtensions
         });
         services.AddSingleton<IEventTypes>(sp => sp.GetRequiredService<DcbDomainTypes>().EventTypes);
 
-        // IEventStore実装を登録
-        services.AddSingleton<IServiceIdProvider, DefaultServiceIdProvider>();
-        services.TryAddSingleton<IEventStoreFactory, PostgresEventStoreFactory>();
-        services.AddEventStoreAliases<PostgresEventStore>();
-        services.AddConditionalEventStoreCapabilities();
-        services.AddSingleton<IMultiProjectionStateStore, PostgresMultiProjectionStateStore>();
-        services.AddSingleton<IProjectionStatusStore>(sp => (sp.GetService<IMultiProjectionStateStore>() as IProjectionStatusStore)!);
-        services.AddSekibanDcbProjectionStatusReader();
+        AddPostgresEventStoreServices(services);
 
         return services;
     }
@@ -329,7 +344,19 @@ public static class SekibanDcbPostgresExtensions
         services.TryAddSingleton<IEventStoreFactory, PostgresEventStoreFactory>();
         services.AddEventStoreAliases<PostgresEventStore>();
         services.AddConditionalEventStoreCapabilities();
-        services.AddSingleton<IMultiProjectionStateStore, PostgresMultiProjectionStateStore>();
+        services.AddSingleton<PostgresMultiProjectionStateStore>(sp =>
+            new PostgresMultiProjectionStateStore(
+                sp.GetRequiredService<IDbContextFactory<SekibanDcbDbContext>>(),
+                sp.GetRequiredService<IServiceIdProvider>(),
+                sp.GetService<IBlobStorageSnapshotAccessor>(),
+                sp.GetRequiredService<ProjectionStatusOptions>()));
+        services.AddSingleton<IMultiProjectionStateStore>(sp =>
+            sp.GetRequiredService<PostgresMultiProjectionStateStore>());
+        services.AddSingleton<IMultiProjectionStateStoreFactory>(sp =>
+            new PostgresMultiProjectionStateStoreFactory(
+                sp.GetRequiredService<IDbContextFactory<SekibanDcbDbContext>>(),
+                sp.GetService<IBlobStorageSnapshotAccessor>(),
+                sp.GetRequiredService<ProjectionStatusOptions>()));
         services.AddSingleton<IProjectionStatusStore>(sp => (sp.GetService<IMultiProjectionStateStore>() as IProjectionStatusStore)!);
         services.AddSekibanDcbProjectionStatusReader();
     }

--- a/dcb/tests/Sekiban.Dcb.Postgres.Tests/PostgresProjectionStatusStoreTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Postgres.Tests/PostgresProjectionStatusStoreTests.cs
@@ -162,6 +162,52 @@ public sealed class PostgresProjectionStatusStoreTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task PreProvisionedOptions_ReachCreateForServiceAndDiStore_WithoutDdl()
+    {
+        await _fixture.DbContextFactory.ProvisionProjectionStatusSchemaAsync();
+        var runtime = await CreateDmlOnlyRuntimePrincipalAsync(includeStatusTable: true);
+        try
+        {
+            var commands = new List<string>();
+            var factory = new OneContextFactory(runtime.ConnectionString, commands);
+            var options = new ProjectionStatusOptions
+            {
+                ProvisioningMode = ProjectionStatusProvisioningMode.PreProvisioned
+            };
+
+            var factoryStore = new PostgresMultiProjectionStateStoreFactory(factory, null, options);
+            var serviceStore = Assert.IsAssignableFrom<IProjectionStatusStore>(
+                factoryStore.CreateForService("factory-service"));
+            var factoryWrite = await serviceStore.UpsertAsync(
+                Heartbeat("factory-activation", 1) with { ServiceId = "factory-service" },
+                0);
+            Assert.True(factoryWrite.IsSuccess, factoryWrite.IsSuccess ? string.Empty : factoryWrite.GetException().ToString());
+            Assert.True(factoryWrite.GetValue().Committed);
+
+            var services = new ServiceCollection();
+            services.AddSingleton(options);
+            services.AddSekibanDcbPostgres(runtime.ConnectionString);
+            services.AddSingleton<IDbContextFactory<SekibanDcbDbContext>>(_ => factory);
+            using var provider = services.BuildServiceProvider();
+            var diStore = provider.GetRequiredService<IProjectionStatusStore>();
+            var diWrite = await diStore.UpsertAsync(
+                Heartbeat("di-activation", 1) with { ServiceId = DefaultServiceIdProvider.DefaultServiceId },
+                0);
+            Assert.True(diWrite.IsSuccess, diWrite.IsSuccess ? string.Empty : diWrite.GetException().ToString());
+            Assert.True(diWrite.GetValue().Committed);
+
+            // If either path drops PreProvisioned while forwarding options, legacy auto-provisioning attempts DDL
+            // under this non-owner role and the write fails; the recording factory also proves no DDL was issued.
+            Assert.NotEmpty(commands);
+            Assert.DoesNotContain(commands, ContainsDdl);
+        }
+        finally
+        {
+            await DropRuntimePrincipalAsync(runtime.Role);
+        }
+    }
+
+    [Fact]
     public async Task PreProvisionedRuntime_MissingTable_Returns42P01WithoutDdlOrFalseSuccess()
     {
         var runtime = await CreateDmlOnlyRuntimePrincipalAsync(includeStatusTable: false);

--- a/dcb/tests/Sekiban.Dcb.Postgres.Tests/PostgresProjectionStatusStoreTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Postgres.Tests/PostgresProjectionStatusStoreTests.cs
@@ -1,7 +1,12 @@
+using System.Data;
+using System.Data.Common;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Npgsql;
 using Sekiban.Dcb;
 using Sekiban.Dcb.Postgres;
 using Sekiban.Dcb.ServiceId;
+using Sekiban.Dcb.Storage;
 using Xunit;
 
 namespace Sekiban.Dcb.Postgres.Tests;
@@ -91,6 +96,409 @@ public sealed class PostgresProjectionStatusStoreTests : IAsyncLifetime
         Assert.True(afterRebase.GetValue().Committed);
         Assert.Equal(2, afterRebase.GetValue().Current!.Sequence);
     }
+
+    [Fact]
+    public async Task PreProvisionedRuntime_UsesOnlyDml_PreservesCasAndServiceIsolation()
+    {
+        await _fixture.DbContextFactory.ProvisionProjectionStatusSchemaAsync();
+        var runtime = await CreateDmlOnlyRuntimePrincipalAsync(includeStatusTable: true);
+        try
+        {
+            var commands = new List<string>();
+            var factory = new OneContextFactory(runtime.ConnectionString, commands);
+            var options = new ProjectionStatusOptions
+            {
+                ProvisioningMode = ProjectionStatusProvisioningMode.PreProvisioned
+            };
+            var store = new PostgresMultiProjectionStateStore(
+                factory,
+                new FixedServiceIdProvider("svc"),
+                null,
+                options);
+            var first = Heartbeat("activation-a", 1) with
+            {
+                SwitchKind = "candidate",
+                SwitchReason = "g63-proof",
+                SwitchedAtUtc = DateTimeOffset.UtcNow
+            };
+
+            var created = await store.UpsertAsync(first, 0);
+            var listed = await store.ListAsync();
+            var updated = await store.UpsertAsync(first with { Sequence = 2, AppliedEventCount = 2 }, 1);
+            var stale = await store.UpsertAsync(first with { Sequence = 3 }, 1);
+
+            Assert.True(created.IsSuccess, created.IsSuccess ? string.Empty : created.GetException().ToString());
+            Assert.True(created.GetValue().Committed);
+            Assert.True(listed.IsSuccess, listed.IsSuccess ? string.Empty : listed.GetException().ToString());
+            var listedHeartbeat = Assert.Single(listed.GetValue());
+            Assert.Equal(first.SwitchKind, listedHeartbeat.SwitchKind);
+            Assert.Equal(first.SwitchReason, listedHeartbeat.SwitchReason);
+            Assert.Equal(first.SwitchedAtUtc, listedHeartbeat.SwitchedAtUtc);
+            Assert.True(updated.IsSuccess);
+            Assert.True(updated.GetValue().Committed);
+            Assert.Equal(2, updated.GetValue().Current!.Sequence);
+            Assert.True(stale.IsSuccess);
+            Assert.Equal(ProjectionStatusConflictReason.SequenceMismatch, stale.GetValue().ConflictDetails!.Reason);
+
+            var otherService = new PostgresMultiProjectionStateStore(
+                factory,
+                new FixedServiceIdProvider("other"),
+                null,
+                options);
+            var isolated = await otherService.ListAsync();
+            Assert.True(isolated.IsSuccess, isolated.IsSuccess ? string.Empty : isolated.GetException().ToString());
+            Assert.Empty(isolated.GetValue());
+
+            // The runtime role has DML only. Any attempted CREATE/ALTER path would fail with 42501 before this
+            // already-successful DML-only sequence, and the wrapped ADO connection records the command attempts.
+            Assert.NotEmpty(commands);
+            Assert.DoesNotContain(commands, ContainsDdl);
+        }
+        finally
+        {
+            await DropRuntimePrincipalAsync(runtime.Role);
+        }
+    }
+
+    [Fact]
+    public async Task PreProvisionedRuntime_MissingTable_Returns42P01WithoutDdlOrFalseSuccess()
+    {
+        var runtime = await CreateDmlOnlyRuntimePrincipalAsync(includeStatusTable: false);
+        try
+        {
+            var commands = new List<string>();
+            var store = new PostgresMultiProjectionStateStore(
+                new OneContextFactory(runtime.ConnectionString, commands),
+                new FixedServiceIdProvider("svc"),
+                null,
+                new ProjectionStatusOptions { ProvisioningMode = ProjectionStatusProvisioningMode.PreProvisioned });
+
+            var result = await store.UpsertAsync(Heartbeat("activation-missing", 1), 0);
+
+            Assert.False(result.IsSuccess);
+            var failure = Assert.IsType<PostgresException>(result.GetException());
+            Assert.Equal(PostgresErrorCodes.UndefinedTable, failure.SqlState); // SQLSTATE 42P01
+            // A DDL attempt by this role would be 42501; 42P01 is the direct DML failure with no auto-provisioning.
+            Assert.NotEmpty(commands);
+            Assert.DoesNotContain(commands, ContainsDdl);
+            var list = await store.ListAsync();
+            Assert.False(list.IsSuccess);
+            Assert.Equal(PostgresErrorCodes.UndefinedTable, Assert.IsType<PostgresException>(list.GetException()).SqlState);
+        }
+        finally
+        {
+            await DropRuntimePrincipalAsync(runtime.Role);
+        }
+    }
+
+    [Fact]
+    public async Task PreProvisionedRuntime_MissingColumn_Returns42703WithoutDdlOrFalseSuccess()
+    {
+        await _fixture.DbContextFactory.ProvisionProjectionStatusSchemaAsync();
+        await using (var admin = new NpgsqlConnection(_fixture.ConnectionString))
+        {
+            await admin.OpenAsync();
+            await ExecuteAsync(admin, "ALTER TABLE dcb_projection_statuses DROP COLUMN phase");
+        }
+
+        var runtime = await CreateDmlOnlyRuntimePrincipalAsync(includeStatusTable: true);
+        try
+        {
+            var commands = new List<string>();
+            var store = new PostgresMultiProjectionStateStore(
+                new OneContextFactory(runtime.ConnectionString, commands),
+                new FixedServiceIdProvider("svc"),
+                null,
+                new ProjectionStatusOptions { ProvisioningMode = ProjectionStatusProvisioningMode.PreProvisioned });
+
+            var result = await store.UpsertAsync(Heartbeat("activation-missing-column", 1), 0);
+
+            Assert.False(result.IsSuccess);
+            var failure = Assert.IsType<PostgresException>(result.GetException());
+            Assert.Equal(PostgresErrorCodes.UndefinedColumn, failure.SqlState); // SQLSTATE 42703
+            // A DDL attempt by this role would be 42501; 42703 is the direct DML failure with no auto-repair.
+            Assert.NotEmpty(commands);
+            Assert.DoesNotContain(commands, ContainsDdl);
+            var list = await store.ListAsync();
+            Assert.False(list.IsSuccess);
+            Assert.Equal(PostgresErrorCodes.UndefinedColumn, Assert.IsType<PostgresException>(list.GetException()).SqlState);
+        }
+        finally
+        {
+            await DropRuntimePrincipalAsync(runtime.Role);
+        }
+    }
+
+    [Fact]
+    public void LegacyConstructorsAndDiRegistrationRemainAdditive()
+    {
+        var legacyStoreConstructor = typeof(PostgresMultiProjectionStateStore).GetConstructor(
+            [
+                typeof(IDbContextFactory<SekibanDcbDbContext>),
+                typeof(IServiceIdProvider),
+                typeof(Sekiban.Dcb.Snapshots.IBlobStorageSnapshotAccessor)
+            ]);
+        var legacyFactoryConstructor = typeof(PostgresMultiProjectionStateStoreFactory).GetConstructor(
+            [
+                typeof(IDbContextFactory<SekibanDcbDbContext>),
+                typeof(Sekiban.Dcb.Snapshots.IBlobStorageSnapshotAccessor)
+            ]);
+
+        Assert.NotNull(legacyStoreConstructor);
+        Assert.NotNull(legacyFactoryConstructor);
+
+        var services = new ServiceCollection();
+        services.AddSekibanDcbPostgres(_fixture.ConnectionString);
+        services.AddSingleton(new ProjectionStatusOptions
+        {
+            ProvisioningMode = ProjectionStatusProvisioningMode.PreProvisioned
+        });
+        using var provider = services.BuildServiceProvider();
+        Assert.IsType<PostgresMultiProjectionStateStore>(provider.GetRequiredService<IMultiProjectionStateStore>());
+        Assert.IsType<PostgresMultiProjectionStateStoreFactory>(provider.GetRequiredService<IMultiProjectionStateStoreFactory>());
+    }
+
+    [Fact]
+    public void InvalidProvisioningModeIsRejectedBeforeStatusWork()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new PostgresMultiProjectionStateStore(
+            _fixture.DbContextFactory,
+            new FixedServiceIdProvider("svc"),
+            null,
+            new ProjectionStatusOptions { ProvisioningMode = (ProjectionStatusProvisioningMode)99 }));
+    }
+
+    private static async Task ExecuteAsync(NpgsqlConnection connection, string sql)
+    {
+        await using var command = new NpgsqlCommand(sql, connection);
+        await command.ExecuteNonQueryAsync();
+    }
+
+    private static bool ContainsDdl(string sql) =>
+        sql.Contains("CREATE", StringComparison.OrdinalIgnoreCase) ||
+        sql.Contains("ALTER", StringComparison.OrdinalIgnoreCase) ||
+        sql.Contains("DROP", StringComparison.OrdinalIgnoreCase) ||
+        sql.Contains("MIGRAT", StringComparison.OrdinalIgnoreCase);
+
+    private async Task<RuntimePrincipal> CreateDmlOnlyRuntimePrincipalAsync(bool includeStatusTable)
+    {
+        var role = $"g63_runtime_dml_{Guid.NewGuid():N}";
+        var password = $"g63_runtime_{Guid.NewGuid():N}";
+        await using var admin = new NpgsqlConnection(_fixture.ConnectionString);
+        await admin.OpenAsync();
+        await ExecuteAsync(admin, $"CREATE ROLE {role} LOGIN PASSWORD '{password}'");
+        await ExecuteAsync(admin, $"GRANT USAGE ON SCHEMA public TO {role}");
+        if (includeStatusTable)
+        {
+            await ExecuteAsync(admin, $"GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE dcb_projection_statuses TO {role}");
+        }
+
+        var connectionString = new NpgsqlConnectionStringBuilder(_fixture.ConnectionString)
+        {
+            Username = role,
+            Password = password
+        }.ConnectionString;
+        return new RuntimePrincipal(role, connectionString);
+    }
+
+    private async Task DropRuntimePrincipalAsync(string role)
+    {
+        NpgsqlConnection.ClearAllPools();
+        await using var admin = new NpgsqlConnection(_fixture.ConnectionString);
+        await admin.OpenAsync();
+        await ExecuteAsync(admin, $"DROP OWNED BY {role}");
+        await ExecuteAsync(admin, $"DROP ROLE IF EXISTS {role}");
+    }
+
+    private sealed record RuntimePrincipal(string Role, string ConnectionString);
+
+    private sealed class OneContextFactory : IDbContextFactory<SekibanDcbDbContext>
+    {
+        private readonly string _connection;
+        private readonly List<string>? _commands;
+
+        public OneContextFactory(string connection, List<string>? commands = null)
+        {
+            _connection = connection;
+            _commands = commands;
+        }
+
+        public SekibanDcbDbContext CreateDbContext()
+        {
+            var builder = new DbContextOptionsBuilder<SekibanDcbDbContext>();
+            if (_commands is null)
+            {
+                builder.UseNpgsql(_connection);
+            }
+            else
+            {
+                builder.UseNpgsql(new RecordingDbConnection(new NpgsqlConnection(_connection), _commands), true);
+            }
+
+            return new SekibanDcbDbContext(builder.Options);
+        }
+    }
+
+    // The framework's legacy DbConnection/DbCommand setters carry nullable metadata that differs by target TFM;
+    // this test-only delegating observer preserves the provider's concrete command while recording every ADO call.
+#pragma warning disable CS8765
+    private sealed class RecordingDbConnection : DbConnection
+    {
+        private readonly DbConnection _inner;
+        private readonly List<string> _commands;
+
+        public RecordingDbConnection(DbConnection inner, List<string> commands)
+        {
+            _inner = inner;
+            _commands = commands;
+        }
+
+        public override string ConnectionString
+        {
+            get => _inner.ConnectionString;
+            set => _inner.ConnectionString = value;
+        }
+
+        public override string Database => _inner.Database;
+        public override string DataSource => _inner.DataSource;
+        public override string ServerVersion => _inner.ServerVersion;
+        public override ConnectionState State => _inner.State;
+
+        public override void ChangeDatabase(string databaseName) => _inner.ChangeDatabase(databaseName);
+        public override void Close() => _inner.Close();
+        public override void Open() => _inner.Open();
+        public override Task OpenAsync(CancellationToken cancellationToken) => _inner.OpenAsync(cancellationToken);
+
+        protected override DbTransaction BeginDbTransaction(IsolationLevel isolationLevel) =>
+            _inner.BeginTransaction(isolationLevel);
+
+        protected override DbCommand CreateDbCommand() =>
+            new RecordingDbCommand(_inner.CreateCommand(), this, _commands);
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _inner.Dispose();
+            }
+
+            base.Dispose(disposing);
+        }
+    }
+
+    private sealed class RecordingDbCommand : DbCommand
+    {
+        private readonly DbCommand _inner;
+        private readonly DbConnection _connection;
+        private readonly List<string> _commands;
+
+        public RecordingDbCommand(DbCommand inner, DbConnection connection, List<string> commands)
+        {
+            _inner = inner;
+            _connection = connection;
+            _commands = commands;
+        }
+
+        public override string CommandText
+        {
+            get => _inner.CommandText;
+            set => _inner.CommandText = value;
+        }
+
+        public override int CommandTimeout
+        {
+            get => _inner.CommandTimeout;
+            set => _inner.CommandTimeout = value;
+        }
+
+        public override CommandType CommandType
+        {
+            get => _inner.CommandType;
+            set => _inner.CommandType = value;
+        }
+
+        public override bool DesignTimeVisible
+        {
+            get => _inner.DesignTimeVisible;
+            set => _inner.DesignTimeVisible = value;
+        }
+
+        public override UpdateRowSource UpdatedRowSource
+        {
+            get => _inner.UpdatedRowSource;
+            set => _inner.UpdatedRowSource = value;
+        }
+
+        protected override DbConnection DbConnection
+        {
+            get => _connection;
+            set { }
+        }
+
+        protected override DbParameterCollection DbParameterCollection => _inner.Parameters;
+
+        protected override DbTransaction? DbTransaction
+        {
+            get => _inner.Transaction;
+            set => _inner.Transaction = value;
+        }
+
+        public override void Cancel() => _inner.Cancel();
+        public override int ExecuteNonQuery()
+        {
+            Record();
+            return _inner.ExecuteNonQuery();
+        }
+
+        public override object? ExecuteScalar()
+        {
+            Record();
+            return _inner.ExecuteScalar();
+        }
+
+        public override Task<int> ExecuteNonQueryAsync(CancellationToken cancellationToken)
+        {
+            Record();
+            return _inner.ExecuteNonQueryAsync(cancellationToken);
+        }
+
+        public override Task<object?> ExecuteScalarAsync(CancellationToken cancellationToken)
+        {
+            Record();
+            return _inner.ExecuteScalarAsync(cancellationToken);
+        }
+
+        protected override DbDataReader ExecuteDbDataReader(CommandBehavior behavior)
+        {
+            Record();
+            return _inner.ExecuteReader(behavior);
+        }
+
+        protected override Task<DbDataReader> ExecuteDbDataReaderAsync(
+            CommandBehavior behavior,
+            CancellationToken cancellationToken)
+        {
+            Record();
+            return _inner.ExecuteReaderAsync(behavior, cancellationToken);
+        }
+
+        public override void Prepare() => _inner.Prepare();
+
+        protected override DbParameter CreateDbParameter() => _inner.CreateParameter();
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _inner.Dispose();
+            }
+
+            base.Dispose(disposing);
+        }
+
+        private void Record() => _commands.Add(CommandText);
+    }
+#pragma warning restore CS8765
 
     private static ProjectionStatusHeartbeat Heartbeat(string activationId, long sequence) =>
         new(

--- a/dcb/tests/Sekiban.Dcb.Postgres.Tests/PostgresProjectionStatusStoreTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Postgres.Tests/PostgresProjectionStatusStoreTests.cs
@@ -119,7 +119,8 @@ public sealed class PostgresProjectionStatusStoreTests : IAsyncLifetime
             {
                 SwitchKind = "candidate",
                 SwitchReason = "g63-proof",
-                SwitchedAtUtc = DateTimeOffset.UtcNow
+                // PostgreSQL timestamp with time zone stores microseconds; this value is exactly representable.
+                SwitchedAtUtc = new DateTimeOffset(2026, 1, 2, 3, 4, 5, TimeSpan.Zero).AddTicks(1_234_560)
             };
 
             var created = await store.UpsertAsync(first, 0);

--- a/docs/dcb_llm/11_storage_providers.md
+++ b/docs/dcb_llm/11_storage_providers.md
@@ -240,6 +240,38 @@ app.MapGet("/ops/projection-status", async (ISerializedProjectionStatusReader re
 Never use `AllowAnonymous` for this surface. `ISerializedSekibanDcbExecutor` remains untouched. This is the
 dcb-v10.10.0 release-note entry for SEK-G24.
 
+### PostgreSQL projection-status runtime authority (SEK-G63)
+
+PostgreSQL status storage keeps its historical `LegacyAutoProvision` default for existing applications. A deployment
+whose runtime identity is DML-only can opt into `PreProvisioned` without changing the old store or factory
+constructors. An owner-controlled startup or migration step provisions the registry once through the shared schema
+operation, then the runtime registers the explicit mode:
+
+```csharp
+// Run with the schema owner, before granting the runtime principal:
+await ownerServices.ProvisionProjectionStatusSchemaAsync();
+
+// Runtime registration (the default remains LegacyAutoProvision):
+runtimeServices.AddSingleton(new ProjectionStatusOptions
+{
+    ProvisioningMode = ProjectionStatusProvisioningMode.PreProvisioned
+});
+runtimeServices.AddSekibanDcbPostgres(connectionString);
+```
+
+The same `ProjectionStatusOptions` is honored by direct `PostgresMultiProjectionStateStore` construction and by
+`PostgresMultiProjectionStateStoreFactory.CreateForService`. The additive options-aware overloads preserve the
+original public constructor signatures. In pre-provisioned mode `UpsertAsync` and `ListAsync` issue only their
+status DML; they never run `CREATE`, `ALTER`, migration, or repair SQL. The runtime principal needs `CONNECT`,
+schema `USAGE`, and the status table's required `SELECT`/`INSERT`/`UPDATE`/`DELETE` privileges, but not schema or
+table ownership.
+
+Missing or incompatible pre-provisioned schema is fail-closed: a missing table remains a failed `ResultBox` with
+PostgreSQL SQLSTATE `42P01`, and a missing required column remains a failed `ResultBox` with SQLSTATE `42703`.
+Neither case becomes an empty success or a false heartbeat. Expected-sequence CAS, service isolation, cancellation,
+and the switch/mutation discriminator columns remain unchanged. Invalid provisioning modes are rejected before a
+status operation starts.
+
 ### Projection-status heartbeat recovery (SEK-G35 / dcb-v10.16.0)
 
 Projection-status heartbeats now pin the full writer identity at activation: service, projector name, projector

--- a/docs/dcb_llm/11_storage_providers.md
+++ b/docs/dcb_llm/11_storage_providers.md
@@ -271,6 +271,9 @@ PostgreSQL SQLSTATE `42P01`, and a missing required column remains a failed `Res
 Neither case becomes an empty success or a false heartbeat. Expected-sequence CAS, service isolation, cancellation,
 and the switch/mutation discriminator columns remain unchanged. Invalid provisioning modes are rejected before a
 status operation starts.
+When a future status-schema version adds a required column, the schema owner must run
+`ProvisionProjectionStatusSchemaAsync` as the upgrade step, and PostgreSQL `42703` is the observable missing-column
+symptom when that upgrade has not been applied.
 
 ### Projection-status heartbeat recovery (SEK-G35 / dcb-v10.16.0)
 

--- a/docs/dcb_llm_ja/11_storage_providers.md
+++ b/docs/dcb_llm_ja/11_storage_providers.md
@@ -266,6 +266,9 @@ PostgreSQL SQLSTATE `42P01` を保持した failed `ResultBox`、必須 column �
 failed `ResultBox` になります。空の成功や false heartbeat には変換しません。expected-sequence CAS、service
 isolation、cancellation、switch/mutation discriminator の列は従来どおり保持され、無効な provisioning mode は
 status operation 開始前に拒否されます。
+将来の status schema version で必須 column が追加された場合、schema owner は upgrade step として
+`ProvisionProjectionStatusSchemaAsync` を実行する必要があり、PostgreSQL の `42703` はその upgrade が適用されていない
+場合に観測される missing-column の症状です。
 
 ### projection-status heartbeat の回復 (SEK-G35 / dcb-v10.16.0)
 

--- a/docs/dcb_llm_ja/11_storage_providers.md
+++ b/docs/dcb_llm_ja/11_storage_providers.md
@@ -235,6 +235,38 @@ provider から決まり、ホストの endpoint は既定で deny としてく�
 例えば `RequireAuthorization("ProjectionStatusOperator")` を指定します。`AllowAnonymous` は使わず、既存の
 `ISerializedSekibanDcbExecutor` は変更しません。これは dcb-v10.10.0 の SEK-G24 release note です。
 
+### PostgreSQL projection-status の実行時権限 (SEK-G63)
+
+既存アプリケーションとの互換性のため、PostgreSQL の status storage は従来の `LegacyAutoProvision` を既定値
+として維持します。実行時 principal を DML 専用にする場合は、古い store/factory constructor を変更せずに
+`PreProvisioned` を明示できます。まず schema owner の startup または migration で共有の provision API を一度
+実行し、その後 runtime で mode を登録します。
+
+```csharp
+// schema owner で runtime principal に権限を付与する前に実行:
+await ownerServices.ProvisionProjectionStatusSchemaAsync();
+
+// runtime 側（既定値は LegacyAutoProvision のまま）:
+runtimeServices.AddSingleton(new ProjectionStatusOptions
+{
+    ProvisioningMode = ProjectionStatusProvisioningMode.PreProvisioned
+});
+runtimeServices.AddSekibanDcbPostgres(connectionString);
+```
+
+同じ `ProjectionStatusOptions` は、直接生成する `PostgresMultiProjectionStateStore` と
+`PostgresMultiProjectionStateStoreFactory.CreateForService` にも適用されます。加法的な options-aware overload
+を追加していますが、元の public constructor signature は保持しています。pre-provisioned mode の
+`UpsertAsync` と `ListAsync` は status の DML だけを発行し、`CREATE`、`ALTER`、migration、repair SQL は実行しません。
+runtime principal に必要なのは `CONNECT`、schema の `USAGE`、status table の `SELECT`/`INSERT`/`UPDATE`/`DELETE`
+であり、schema や table の owner 権限ではありません。
+
+pre-provisioned schema が存在しない、または互換性がない場合は fail-closed です。table がない場合は
+PostgreSQL SQLSTATE `42P01` を保持した failed `ResultBox`、必須 column がない場合は SQLSTATE `42703` を保持した
+failed `ResultBox` になります。空の成功や false heartbeat には変換しません。expected-sequence CAS、service
+isolation、cancellation、switch/mutation discriminator の列は従来どおり保持され、無効な provisioning mode は
+status operation 開始前に拒否されます。
+
 ### projection-status heartbeat の回復 (SEK-G35 / dcb-v10.16.0)
 
 projection-status heartbeat は activation 時点で writer identity 全体（service、projector 名、projector version、cluster）を


### PR DESCRIPTION
Closes #1203

## Summary

- Adds the additive `ProjectionStatusProvisioningMode` option, preserving `LegacyAutoProvision` as the default.
- Adds the shared owner-only `ProvisionProjectionStatusSchemaAsync` entry point and wires the selected policy through every PostgreSQL registration path, direct store construction, and `CreateForService`.
- Keeps pre-provisioned runtime `ListAsync`/heartbeat `UpsertAsync` on direct DML only, preserving CAS, service ownership/isolation, switch metadata, cancellation, and failed `ResultBox` causes for missing/incompatible schema.
- Documents owner provisioning, least-privilege runtime grants, mode selection, upgrade responsibility, and SQLSTATE diagnosis in English and Japanese.

## Evidence

- Real PostgreSQL DML-only role: first/repeated upsert and list, CAS conflict, service isolation, mutation discriminator round trip, and recorded command trace with no DDL.
- Real PostgreSQL missing-table `42P01` and missing-column `42703` failures for both upsert and list, with no DDL and no fabricated success.
- Reflection/DI checks preserve the old store/factory constructor signatures and resolve the new options-aware registrations.
- `dotnet build dcb/tests/Sekiban.Dcb.Postgres.Tests/Sekiban.Dcb.Postgres.Tests.csproj -c Release -p:GeneratePackageOnBuild=false --no-restore`
- Focused provider/API tests on both `net9.0` and `net10.0`: 10 passed per TFM.
- `git diff --check`
