### PR TITLE
Add opt-in executor size gate

### DIFF
--- a/dcb/src/Sekiban.Dcb.Core/Actors/CoreGeneralSekibanExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Actors/CoreGeneralSekibanExecutor.cs
@@ -5,6 +5,7 @@ using Sekiban.Dcb.Events;
 using Sekiban.Dcb.MultiProjections;
 using Sekiban.Dcb.Queries;
 using Sekiban.Dcb.ServiceId;
+using Sekiban.Dcb.SizeGates;
 using Sekiban.Dcb.Storage;
 using Sekiban.Dcb.Tags;
 using Sekiban.Dcb.Validation;
@@ -30,6 +31,7 @@ public class CoreGeneralSekibanExecutor
     private readonly ISortableUniqueIdGenerator _sortableUniqueIdGenerator;
     private readonly SortableUniqueIdSeedCoordinator _sortableUniqueIdSeedCoordinator;
     private readonly SortableUniqueIdWaitPolicy _sortableUniqueIdWaitPolicy;
+    private readonly ExecutorSizeGateOptions? _executorSizeGateOptions;
 
     /// <summary>
     ///     Test seam ONLY (never set in production): the EventId / SortableUniqueId generators used by the serialized
@@ -71,7 +73,32 @@ public class CoreGeneralSekibanExecutor
             ProcessSharedSortableUniqueIdServices.Generator,
             ProcessSharedSortableUniqueIdServices.SeedCoordinator,
             new DefaultServiceIdProvider(),
-            SortableUniqueIdWaitPolicy.System)
+            SortableUniqueIdWaitPolicy.System,
+            null)
+    {
+    }
+
+    /// <summary>
+    /// Additive opt-in constructor. Existing constructors remain unchanged and therefore remain ungated.
+    /// </summary>
+    public CoreGeneralSekibanExecutor(
+        IEventStore eventStore,
+        IActorObjectAccessor actorAccessor,
+        DcbDomainTypes domainTypes,
+        ExecutorSizeGateOptions executorSizeGateOptions,
+        IEventPublisher? eventPublisher = null,
+        IExecutedUserProvider? executedUserProvider = null)
+        : this(
+            eventStore,
+            actorAccessor,
+            domainTypes,
+            eventPublisher,
+            executedUserProvider,
+            ProcessSharedSortableUniqueIdServices.Generator,
+            ProcessSharedSortableUniqueIdServices.SeedCoordinator,
+            new DefaultServiceIdProvider(),
+            SortableUniqueIdWaitPolicy.System,
+            executorSizeGateOptions)
     {
     }
 
@@ -94,7 +121,8 @@ public class CoreGeneralSekibanExecutor
             sortableUniqueIdGenerator,
             sortableUniqueIdSeedCoordinator,
             serviceIdProvider,
-            SortableUniqueIdWaitPolicy.System)
+            SortableUniqueIdWaitPolicy.System,
+            null)
     {
     }
 
@@ -108,6 +136,31 @@ public class CoreGeneralSekibanExecutor
         SortableUniqueIdSeedCoordinator sortableUniqueIdSeedCoordinator,
         IServiceIdProvider serviceIdProvider,
         SortableUniqueIdWaitPolicy sortableUniqueIdWaitPolicy)
+        : this(
+            eventStore,
+            actorAccessor,
+            domainTypes,
+            eventPublisher,
+            executedUserProvider,
+            sortableUniqueIdGenerator,
+            sortableUniqueIdSeedCoordinator,
+            serviceIdProvider,
+            sortableUniqueIdWaitPolicy,
+            null)
+    {
+    }
+
+    internal CoreGeneralSekibanExecutor(
+        IEventStore eventStore,
+        IActorObjectAccessor actorAccessor,
+        DcbDomainTypes domainTypes,
+        IEventPublisher? eventPublisher,
+        IExecutedUserProvider? executedUserProvider,
+        ISortableUniqueIdGenerator sortableUniqueIdGenerator,
+        SortableUniqueIdSeedCoordinator sortableUniqueIdSeedCoordinator,
+        IServiceIdProvider serviceIdProvider,
+        SortableUniqueIdWaitPolicy sortableUniqueIdWaitPolicy,
+        ExecutorSizeGateOptions? executorSizeGateOptions)
     {
         _eventStore = eventStore ?? throw new ArgumentNullException(nameof(eventStore));
         _actorAccessor = actorAccessor ?? throw new ArgumentNullException(nameof(actorAccessor));
@@ -121,6 +174,8 @@ public class CoreGeneralSekibanExecutor
         _serviceIdProvider = serviceIdProvider ?? throw new ArgumentNullException(nameof(serviceIdProvider));
         _sortableUniqueIdWaitPolicy = sortableUniqueIdWaitPolicy ??
                                       throw new ArgumentNullException(nameof(sortableUniqueIdWaitPolicy));
+        _executorSizeGateOptions = executorSizeGateOptions;
+        _executorSizeGateOptions?.Validate();
     }
 
     private Task EnsureSortableUniqueIdSeededAsync(CancellationToken cancellationToken)
@@ -133,6 +188,33 @@ public class CoreGeneralSekibanExecutor
     {
         var value = _executedUserProvider?.GetExecutedUser();
         return string.IsNullOrEmpty(value) ? DefaultExecutedUser : value;
+    }
+
+    private async Task PublishPreparedEventsAsync(
+        IReadOnlyList<PreparedExecutorEvent> preparedEvents,
+        ExecutorSizeGateEvaluation sizeEvaluation)
+    {
+        if (_eventPublisher is null)
+        {
+            return;
+        }
+
+        var publishEvents = preparedEvents
+            .Select(e => (e.Event, e.Tags))
+            .ToList()
+            .AsReadOnly();
+
+        if (sizeEvaluation.DestinationPlans.Count > 0 &&
+            _eventPublisher is IExecutorSizeDestinationPublisher plannedPublisher)
+        {
+            await plannedPublisher.PublishAsync(
+                publishEvents,
+                sizeEvaluation.DestinationPlans,
+                CancellationToken.None);
+            return;
+        }
+
+        await _eventPublisher.PublishAsync(publishEvents, CancellationToken.None);
     }
 
     public Task<ResultBox<ExecutionResult>> ExecuteAsync<TCommand>(
@@ -345,11 +427,23 @@ public class CoreGeneralSekibanExecutor
                             e.Tags.Select(t => t.GetTag()).ToList()));
                 }
 
+                var preparedEvents = events
+                    .Select(e => new PreparedExecutorEvent(
+                        e,
+                        e.ToSerializableEvent(_domainTypes.EventTypes),
+                        e.Tags.Select(_domainTypes.TagTypes.GetTag).ToArray()))
+                    .ToList();
+                var sizeEvaluation = ExecutorSizeGateEvaluator.Evaluate(
+                    _executorSizeGateOptions,
+                    preparedEvents,
+                    ServiceIdValidator.NormalizeAndValidate(_serviceIdProvider.GetCurrentServiceId()),
+                    _eventPublisher);
+
                 IReadOnlyList<Event> writtenEvents;
                 IReadOnlyList<TagWriteResult> tagWriteResults;
                 if (expectedPositionStore is not null && expectedTagPositions is not null)
                 {
-                    var serialized = events.Select(e => e.ToSerializableEvent(_domainTypes.EventTypes)).ToList();
+                    var serialized = preparedEvents.Select(e => e.SerializedEvent).ToList();
                     var writeResult = await expectedPositionStore.WriteSerializableEventsWithExpectedTagPositionsAsync(
                         serialized, expectedTagPositions, cancellationToken);
                     if (!writeResult.IsSuccess)
@@ -385,12 +479,17 @@ public class CoreGeneralSekibanExecutor
 
                 if (_eventPublisher != null)
                 {
-                    var publishEvents = writtenEvents
-                        .Select((we, idx) => (Event: we,
-                            Tags: (IReadOnlyCollection<ITag>)collectedEvents[idx].Tags.AsReadOnly()))
-                        .ToList()
-                        .AsReadOnly();
-                    await _eventPublisher.PublishAsync(publishEvents, CancellationToken.None);
+                    await PublishPreparedEventsAsync(preparedEvents, sizeEvaluation);
+                }
+
+                var metadata = new Dictionary<string, object>
+                {
+                    ["EventCount"] = writtenEvents.Count,
+                    ["TagCount"] = allTags.Count
+                };
+                if (sizeEvaluation.Diagnostics.Count > 0)
+                {
+                    metadata["SizeGateDiagnostics"] = sizeEvaluation.Diagnostics;
                 }
 
                 // Return success result
@@ -401,11 +500,7 @@ public class CoreGeneralSekibanExecutor
                         tagWriteResults.ToList(),
                         stopwatch.Elapsed,
                         writtenEvents,
-                        new Dictionary<string, object>
-                        {
-                            ["EventCount"] = writtenEvents.Count,
-                            ["TagCount"] = allTags.Count
-                        },
+                        metadata,
                         firstEvent.SortableUniqueIdValue));
             }
             catch (Exception)
@@ -732,6 +827,28 @@ public class CoreGeneralSekibanExecutor
                         candidate.EventPayloadName));
                 }
 
+                var preparedEvents = new List<PreparedExecutorEvent>(serializableEvents.Count);
+                foreach (var serializableEvent in serializableEvents)
+                {
+                    var eventResult = serializableEvent.ToEvent(_domainTypes.EventTypes);
+                    if (!eventResult.IsSuccess)
+                    {
+                        await TagReservationHelper.CancelReservationsAsync(_actorAccessor, reservations);
+                        return ResultBox.Error<SerializedCommitResult>(eventResult.GetException());
+                    }
+
+                    var preparedEvent = eventResult.GetValue();
+                    preparedEvents.Add(new PreparedExecutorEvent(
+                        preparedEvent,
+                        serializableEvent,
+                        serializableEvent.Tags.Select(_domainTypes.TagTypes.GetTag).ToArray()));
+                }
+                var sizeEvaluation = ExecutorSizeGateEvaluator.Evaluate(
+                    _executorSizeGateOptions,
+                    preparedEvents,
+                    ServiceIdValidator.NormalizeAndValidate(_serviceIdProvider.GetCurrentServiceId()),
+                    _eventPublisher);
+
                 // Step 5: V2 is store-enforced; legacy/V1 keeps the exact old unconditional call and result shape.
                 IReadOnlyList<SerializableEvent> writtenEvents;
                 IReadOnlyList<TagWriteResult> tagWriteResults;
@@ -771,29 +888,17 @@ public class CoreGeneralSekibanExecutor
 
                 if (_eventPublisher != null && writtenEvents.Count > 0)
                 {
-                    var publishEvents = new List<(Event Event, IReadOnlyCollection<ITag> Tags)>(writtenEvents.Count);
-                    foreach (var writtenEvent in writtenEvents)
-                    {
-                        var eventResult = writtenEvent.ToEvent(_domainTypes.EventTypes);
-                        if (!eventResult.IsSuccess)
-                        {
-                            return ResultBox.Error<SerializedCommitResult>(eventResult.GetException());
-                        }
-
-                        List<ITag> eventTags = writtenEvent.Tags
-                            .Select(_domainTypes.TagTypes.GetTag)
-                            .ToList();
-                        publishEvents.Add((eventResult.GetValue(), eventTags.AsReadOnly()));
-                    }
-
-                    await _eventPublisher.PublishAsync(publishEvents.AsReadOnly(), CancellationToken.None);
+                    await PublishPreparedEventsAsync(preparedEvents, sizeEvaluation);
                 }
 
-                return ResultBox.FromValue(
-                    new SerializedCommitResult(
+                var result = new SerializedCommitResult(
                         writtenEvents,
                         tagWriteResults,
-                        stopwatch.Elapsed));
+                        stopwatch.Elapsed)
+                {
+                    SizeGateDiagnostics = sizeEvaluation.Diagnostics
+                };
+                return ResultBox.FromValue(result);
             }
             catch (Exception)
             {
@@ -1285,15 +1390,27 @@ public class CoreGeneralSekibanExecutor
             var executedUser = GetExecutedUser();
             var eventId = ConditionalEventIdFactory();
             var sortable = _sortableUniqueIdGenerator.GenerateNew();
-            var metadata = new EventMetadata(eventId.ToString(), command.GetType().Name, executedUser);
+            var eventMetadata = new EventMetadata(eventId.ToString(), command.GetType().Name, executedUser);
             var domainEvent = new Event(
                 single.Event,
                 sortable,
                 single.Event.GetType().Name,
                 eventId,
-                metadata,
+                eventMetadata,
                 single.Tags.Select(t => t.GetTag()).ToList());
             var serializable = domainEvent.ToSerializableEvent(_domainTypes.EventTypes);
+            var preparedEvents = new List<PreparedExecutorEvent>
+            {
+                new(
+                    domainEvent,
+                    serializable,
+                    single.Tags.ToArray())
+            };
+            var sizeEvaluation = ExecutorSizeGateEvaluator.Evaluate(
+                _executorSizeGateOptions,
+                preparedEvents,
+                ServiceIdValidator.NormalizeAndValidate(_serviceIdProvider.GetCurrentServiceId()),
+                _eventPublisher);
 
             var appendResult = await conditionalStore.AppendIfUniqueAsync(
                 new ConditionalAppendRequest(conditional.IdempotencyKey, serializable),
@@ -1309,10 +1426,18 @@ public class CoreGeneralSekibanExecutor
 
             if (_eventPublisher != null && isNewlyAppended)
             {
-                await _eventPublisher.PublishAsync(
-                    new List<(Event Event, IReadOnlyCollection<ITag> Tags)> { (domainEvent, single.Tags.AsReadOnly()) }
-                        .AsReadOnly(),
-                    CancellationToken.None);
+                await PublishPreparedEventsAsync(preparedEvents, sizeEvaluation);
+            }
+
+            var metadata = new Dictionary<string, object>
+            {
+                ["ConditionalAppendStatus"] = receipt.Status.ToString(),
+                ["OperationFingerprint"] = receipt.OperationFingerprint,
+                ["WasAlreadyCommitted"] = receipt.WasAlreadyCommitted
+            };
+            if (sizeEvaluation.Diagnostics.Count > 0)
+            {
+                metadata["SizeGateDiagnostics"] = sizeEvaluation.Diagnostics;
             }
 
             return ResultBox.FromValue(
@@ -1322,12 +1447,7 @@ public class CoreGeneralSekibanExecutor
                     new List<TagWriteResult>(),
                     stopwatch.Elapsed,
                     writtenEvents,
-                    new Dictionary<string, object>
-                    {
-                        ["ConditionalAppendStatus"] = receipt.Status.ToString(),
-                        ["OperationFingerprint"] = receipt.OperationFingerprint,
-                        ["WasAlreadyCommitted"] = receipt.WasAlreadyCommitted
-                    },
+                    metadata,
                     receipt.WinnerSortableUniqueId));
         }
         catch (Exception ex)
@@ -1381,6 +1501,24 @@ public class CoreGeneralSekibanExecutor
                 metadata,
                 candidate.Tags.ToList(),
                 candidate.EventPayloadName);
+            var eventResult = serializable.ToEvent(_domainTypes.EventTypes);
+            if (!eventResult.IsSuccess)
+            {
+                return ResultBox.Error<SerializedConditionalCommitResult>(eventResult.GetException());
+            }
+
+            var preparedEvents = new List<PreparedExecutorEvent>
+            {
+                new(
+                    eventResult.GetValue(),
+                    serializable,
+                    serializable.Tags.Select(_domainTypes.TagTypes.GetTag).ToArray())
+            };
+            var sizeEvaluation = ExecutorSizeGateEvaluator.Evaluate(
+                _executorSizeGateOptions,
+                preparedEvents,
+                ServiceIdValidator.NormalizeAndValidate(_serviceIdProvider.GetCurrentServiceId()),
+                _eventPublisher);
 
             var appendResult = await conditionalStore.AppendIfUniqueAsync(
                 new ConditionalAppendRequest(request.IdempotencyKey, serializable),
@@ -1398,26 +1536,21 @@ public class CoreGeneralSekibanExecutor
 
             if (_eventPublisher != null && isNewlyAppended)
             {
-                var eventResult = serializable.ToEvent(_domainTypes.EventTypes);
-                if (eventResult.IsSuccess)
-                {
-                    List<ITag> eventTags = serializable.Tags.Select(_domainTypes.TagTypes.GetTag).ToList();
-                    await _eventPublisher.PublishAsync(
-                        new List<(Event Event, IReadOnlyCollection<ITag> Tags)> { (eventResult.GetValue(), eventTags.AsReadOnly()) }
-                            .AsReadOnly(),
-                        CancellationToken.None);
-                }
+                await PublishPreparedEventsAsync(preparedEvents, sizeEvaluation);
             }
 
-            return ResultBox.FromValue(
-                new SerializedConditionalCommitResult(
+            var result = new SerializedConditionalCommitResult(
                     SerializedConditionalCommitResult.CurrentVersion,
                     receipt.Status,
                     receipt.WinnerEventId,
                     receipt.WinnerSortableUniqueId,
                     receipt.OperationFingerprint,
                     written,
-                    stopwatch.Elapsed));
+                    stopwatch.Elapsed)
+            {
+                SizeGateDiagnostics = sizeEvaluation.Diagnostics
+            };
+            return ResultBox.FromValue(result);
         }
         catch (Exception ex)
         {

--- a/dcb/src/Sekiban.Dcb.Core/Actors/CoreGeneralSekibanExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Actors/CoreGeneralSekibanExecutor.cs
@@ -1506,17 +1506,39 @@ public class CoreGeneralSekibanExecutor
                 var eventResult = serializable.ToEvent(_domainTypes.EventTypes);
                 if (!eventResult.IsSuccess)
                 {
-                    return ResultBox.Error<SerializedConditionalCommitResult>(eventResult.GetException());
-                }
+                    const string bindingCapabilityReason =
+                        "serialized event payload binding capability is unavailable; size validation was not performed";
+                    var strictPolicy = _executorSizeGateOptions.Policies
+                        .FirstOrDefault(policy => policy.Strictness == ExecutorSizeStrictness.Strict);
+                    if (strictPolicy is not null)
+                    {
+                        return ResultBox.Error<SerializedConditionalCommitResult>(
+                            new ExecutorSizeCapabilityException(
+                                strictPolicy.Scope,
+                                strictPolicy.Representation,
+                                bindingCapabilityReason));
+                    }
 
-                preparedEvents =
-                [
-                    new(
-                        eventResult.GetValue(),
-                        serializable,
-                        serializable.Tags.Select(_domainTypes.TagTypes.GetTag).ToArray())
-                ];
-                sizeEvaluation = EvaluateSizeGate(preparedEvents);
+                    sizeEvaluation = new ExecutorSizeGateEvaluation(
+                        _executorSizeGateOptions.Policies
+                            .Select(policy => new ExecutorSizeDiagnostic(
+                                policy.Scope,
+                                policy.Representation,
+                                bindingCapabilityReason))
+                            .ToArray(),
+                        new Dictionary<Guid, ExecutorSizeDestinationPlan>());
+                }
+                else
+                {
+                    preparedEvents =
+                    [
+                        new(
+                            eventResult.GetValue(),
+                            serializable,
+                            serializable.Tags.Select(_domainTypes.TagTypes.GetTag).ToArray())
+                    ];
+                    sizeEvaluation = EvaluateSizeGate(preparedEvents);
+                }
             }
 
             var appendResult = await conditionalStore.AppendIfUniqueAsync(

--- a/dcb/src/Sekiban.Dcb.Core/Actors/CoreGeneralSekibanExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Actors/CoreGeneralSekibanExecutor.cs
@@ -190,6 +190,13 @@ public class CoreGeneralSekibanExecutor
         return string.IsNullOrEmpty(value) ? DefaultExecutedUser : value;
     }
 
+    private ExecutorSizeGateEvaluation EvaluateSizeGate(IReadOnlyList<PreparedExecutorEvent> preparedEvents) =>
+        ExecutorSizeGateEvaluator.Evaluate(
+            _executorSizeGateOptions,
+            preparedEvents,
+            ServiceIdValidator.NormalizeAndValidate(_serviceIdProvider.GetCurrentServiceId()),
+            _eventPublisher);
+
     private async Task PublishPreparedEventsAsync(
         IReadOnlyList<PreparedExecutorEvent> preparedEvents,
         ExecutorSizeGateEvaluation sizeEvaluation)
@@ -433,11 +440,7 @@ public class CoreGeneralSekibanExecutor
                         e.ToSerializableEvent(_domainTypes.EventTypes),
                         e.Tags.Select(_domainTypes.TagTypes.GetTag).ToArray()))
                     .ToList();
-                var sizeEvaluation = ExecutorSizeGateEvaluator.Evaluate(
-                    _executorSizeGateOptions,
-                    preparedEvents,
-                    ServiceIdValidator.NormalizeAndValidate(_serviceIdProvider.GetCurrentServiceId()),
-                    _eventPublisher);
+                var sizeEvaluation = EvaluateSizeGate(preparedEvents);
 
                 IReadOnlyList<Event> writtenEvents;
                 IReadOnlyList<TagWriteResult> tagWriteResults;
@@ -843,11 +846,7 @@ public class CoreGeneralSekibanExecutor
                         serializableEvent,
                         serializableEvent.Tags.Select(_domainTypes.TagTypes.GetTag).ToArray()));
                 }
-                var sizeEvaluation = ExecutorSizeGateEvaluator.Evaluate(
-                    _executorSizeGateOptions,
-                    preparedEvents,
-                    ServiceIdValidator.NormalizeAndValidate(_serviceIdProvider.GetCurrentServiceId()),
-                    _eventPublisher);
+                var sizeEvaluation = EvaluateSizeGate(preparedEvents);
 
                 // Step 5: V2 is store-enforced; legacy/V1 keeps the exact old unconditional call and result shape.
                 IReadOnlyList<SerializableEvent> writtenEvents;
@@ -1406,11 +1405,7 @@ public class CoreGeneralSekibanExecutor
                     serializable,
                     single.Tags.ToArray())
             };
-            var sizeEvaluation = ExecutorSizeGateEvaluator.Evaluate(
-                _executorSizeGateOptions,
-                preparedEvents,
-                ServiceIdValidator.NormalizeAndValidate(_serviceIdProvider.GetCurrentServiceId()),
-                _eventPublisher);
+            var sizeEvaluation = EvaluateSizeGate(preparedEvents);
 
             var appendResult = await conditionalStore.AppendIfUniqueAsync(
                 new ConditionalAppendRequest(conditional.IdempotencyKey, serializable),
@@ -1521,11 +1516,7 @@ public class CoreGeneralSekibanExecutor
                         serializable,
                         serializable.Tags.Select(_domainTypes.TagTypes.GetTag).ToArray())
                 ];
-                sizeEvaluation = ExecutorSizeGateEvaluator.Evaluate(
-                    _executorSizeGateOptions,
-                    preparedEvents,
-                    ServiceIdValidator.NormalizeAndValidate(_serviceIdProvider.GetCurrentServiceId()),
-                    _eventPublisher);
+                sizeEvaluation = EvaluateSizeGate(preparedEvents);
             }
 
             var appendResult = await conditionalStore.AppendIfUniqueAsync(

--- a/dcb/src/Sekiban.Dcb.Core/Actors/CoreGeneralSekibanExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Actors/CoreGeneralSekibanExecutor.cs
@@ -1501,24 +1501,32 @@ public class CoreGeneralSekibanExecutor
                 metadata,
                 candidate.Tags.ToList(),
                 candidate.EventPayloadName);
-            var eventResult = serializable.ToEvent(_domainTypes.EventTypes);
-            if (!eventResult.IsSuccess)
+            // The serialized boundary historically lets the conditional store classify its request before any
+            // optional publisher-side payload binding. Keep that ordering when the opt-in gate is not configured;
+            // otherwise a malformed/private test payload could mask the provider's typed in-doubt result.
+            List<PreparedExecutorEvent>? preparedEvents = null;
+            var sizeEvaluation = ExecutorSizeGateEvaluation.Empty;
+            if (_executorSizeGateOptions is { Policies.Count: > 0 })
             {
-                return ResultBox.Error<SerializedConditionalCommitResult>(eventResult.GetException());
-            }
+                var eventResult = serializable.ToEvent(_domainTypes.EventTypes);
+                if (!eventResult.IsSuccess)
+                {
+                    return ResultBox.Error<SerializedConditionalCommitResult>(eventResult.GetException());
+                }
 
-            var preparedEvents = new List<PreparedExecutorEvent>
-            {
-                new(
-                    eventResult.GetValue(),
-                    serializable,
-                    serializable.Tags.Select(_domainTypes.TagTypes.GetTag).ToArray())
-            };
-            var sizeEvaluation = ExecutorSizeGateEvaluator.Evaluate(
-                _executorSizeGateOptions,
-                preparedEvents,
-                ServiceIdValidator.NormalizeAndValidate(_serviceIdProvider.GetCurrentServiceId()),
-                _eventPublisher);
+                preparedEvents =
+                [
+                    new(
+                        eventResult.GetValue(),
+                        serializable,
+                        serializable.Tags.Select(_domainTypes.TagTypes.GetTag).ToArray())
+                ];
+                sizeEvaluation = ExecutorSizeGateEvaluator.Evaluate(
+                    _executorSizeGateOptions,
+                    preparedEvents,
+                    ServiceIdValidator.NormalizeAndValidate(_serviceIdProvider.GetCurrentServiceId()),
+                    _eventPublisher);
+            }
 
             var appendResult = await conditionalStore.AppendIfUniqueAsync(
                 new ConditionalAppendRequest(request.IdempotencyKey, serializable),
@@ -1536,7 +1544,28 @@ public class CoreGeneralSekibanExecutor
 
             if (_eventPublisher != null && isNewlyAppended)
             {
-                await PublishPreparedEventsAsync(preparedEvents, sizeEvaluation);
+                if (preparedEvents is not null)
+                {
+                    await PublishPreparedEventsAsync(preparedEvents, sizeEvaluation);
+                }
+                else
+                {
+                    // Preserve the legacy publisher behavior for an ungated serialized route: binding failure is
+                    // non-fatal after a successful append, and no binding is attempted before the provider call.
+                    var eventResult = serializable.ToEvent(_domainTypes.EventTypes);
+                    if (eventResult.IsSuccess)
+                    {
+                        var eventTags = serializable.Tags
+                            .Select(_domainTypes.TagTypes.GetTag)
+                            .ToList();
+                        await _eventPublisher.PublishAsync(
+                            new List<(Event Event, IReadOnlyCollection<ITag> Tags)>
+                            {
+                                (eventResult.GetValue(), eventTags.AsReadOnly())
+                            }.AsReadOnly(),
+                            CancellationToken.None);
+                    }
+                }
             }
 
             var result = new SerializedConditionalCommitResult(

--- a/dcb/src/Sekiban.Dcb.Core/Actors/CoreGeneralSekibanExecutorFactory.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Actors/CoreGeneralSekibanExecutorFactory.cs
@@ -1,0 +1,43 @@
+using Sekiban.Dcb.Commands;
+using Sekiban.Dcb.Common;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.ServiceId;
+using Sekiban.Dcb.SizeGates;
+using Sekiban.Dcb.Storage;
+
+namespace Sekiban.Dcb.Actors;
+
+internal static class CoreGeneralSekibanExecutorFactory
+{
+    internal static CoreGeneralSekibanExecutor CreateWithGate(
+        IEventStore eventStore,
+        IActorObjectAccessor actorAccessor,
+        DcbDomainTypes domainTypes,
+        ExecutorSizeGateOptions options,
+        IEventPublisher? eventPublisher,
+        IExecutedUserProvider? executedUserProvider) =>
+        new(eventStore, actorAccessor, domainTypes, options, eventPublisher, executedUserProvider);
+
+    internal static CoreGeneralSekibanExecutor CreateWithServices(
+        IEventStore eventStore,
+        IActorObjectAccessor actorAccessor,
+        DcbDomainTypes domainTypes,
+        IEventPublisher? eventPublisher,
+        IExecutedUserProvider? executedUserProvider,
+        ISortableUniqueIdGenerator sortableUniqueIdGenerator,
+        SortableUniqueIdSeedCoordinator sortableUniqueIdSeedCoordinator,
+        IServiceIdProvider serviceIdProvider,
+        SortableUniqueIdWaitPolicy sortableUniqueIdWaitPolicy,
+        ExecutorSizeGateOptions? options) =>
+        new(
+            eventStore,
+            actorAccessor,
+            domainTypes,
+            eventPublisher,
+            executedUserProvider,
+            sortableUniqueIdGenerator,
+            sortableUniqueIdSeedCoordinator,
+            serviceIdProvider,
+            sortableUniqueIdWaitPolicy,
+            options);
+}

--- a/dcb/src/Sekiban.Dcb.Core/Actors/ExecutorSizeGateEvaluator.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Actors/ExecutorSizeGateEvaluator.cs
@@ -1,0 +1,292 @@
+using System.Text.Encodings.Web;
+using System.Text.Json;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.SizeGates;
+using Sekiban.Dcb.Tags;
+
+namespace Sekiban.Dcb.Actors;
+
+internal sealed record PreparedExecutorEvent(
+    Event Event,
+    SerializableEvent SerializedEvent,
+    IReadOnlyCollection<ITag> Tags);
+
+internal sealed record ExecutorSizeGateEvaluation(
+    IReadOnlyList<ExecutorSizeDiagnostic> Diagnostics,
+    IReadOnlyDictionary<Guid, ExecutorSizeDestinationPlan> DestinationPlans)
+{
+    public static ExecutorSizeGateEvaluation Empty { get; } = new(
+        Array.Empty<ExecutorSizeDiagnostic>(),
+        new Dictionary<Guid, ExecutorSizeDestinationPlan>());
+}
+internal static class ExecutorSizeGateEvaluator
+{
+    private const string LogicalRepresentation = "logical serialized event UTF-8";
+
+    public static ExecutorSizeGateEvaluation Evaluate(
+        ExecutorSizeGateOptions? options,
+        IReadOnlyList<PreparedExecutorEvent> events,
+        string serviceId,
+        IEventPublisher? publisher)
+    {
+        if (options is null || options.Policies.Count == 0)
+        {
+            return ExecutorSizeGateEvaluation.Empty;
+        }
+
+        options.Validate();
+        var diagnostics = new List<ExecutorSizeDiagnostic>();
+        var destinationPlans = new Dictionary<Guid, ExecutorSizeDestinationPlan>();
+
+        foreach (var policy in options.Policies)
+        {
+            var measurements = new List<(PreparedExecutorEvent Prepared, int Index, long Bytes, string? DestinationKey, bool Certified)>();
+            var capabilityFailure = default(string);
+
+            for (var index = 0; index < events.Count; index++)
+            {
+                var prepared = events[index];
+
+                if (policy.Representation == ExecutorSizeRepresentation.Destination)
+                {
+                    if (publisher is not IExecutorSizeDestinationPublisher destinationPublisher)
+                    {
+                        capabilityFailure = "the event publisher does not expose a stable destination-plan capability";
+                        break;
+                    }
+
+                    ExecutorSizeDestinationPlan? plan;
+                    try
+                    {
+                        if (!destinationPlans.TryGetValue(prepared.Event.Id, out plan))
+                        {
+                            plan = destinationPublisher.CaptureDestinationPlan(
+                                prepared.Event,
+                                prepared.Tags,
+                                serviceId);
+                            if (plan is not null)
+                            {
+                                destinationPlans[prepared.Event.Id] = plan;
+                            }
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        capabilityFailure = $"destination-plan resolution failed with {ex.GetType().Name}";
+                        break;
+                    }
+
+                    if (plan is null || plan.DestinationKeys.Count == 0)
+                    {
+                        capabilityFailure = "destination-plan resolution returned no destination";
+                        break;
+                    }
+
+                    if (!string.Equals(plan.ServiceId, serviceId, StringComparison.Ordinal))
+                    {
+                        capabilityFailure = "destination-plan service identity differs from the executor service identity";
+                        break;
+                    }
+
+                    if (policy.Measurement is null)
+                    {
+                        capabilityFailure = "no measurement capability was registered";
+                        break;
+                    }
+
+                    foreach (var destinationKey in plan.DestinationKeys)
+                    {
+                        var measurement = Measure(policy, prepared, serviceId, destinationKey, plan);
+                        if (!measurement.IsAvailable)
+                        {
+                            capabilityFailure = measurement.Reason ?? "measurement capability is unavailable";
+                            break;
+                        }
+
+                        measurements.Add(ToComparable(policy, prepared, index, measurement, destinationKey));
+                    }
+
+                    if (capabilityFailure is not null)
+                    {
+                        break;
+                    }
+
+                    continue;
+                }
+
+                var result = Measure(policy, prepared, serviceId, null, null);
+                if (!result.IsAvailable)
+                {
+                    capabilityFailure = result.Reason ?? "measurement capability is unavailable";
+                    break;
+                }
+
+                measurements.Add(ToComparable(policy, prepared, index, result, null));
+            }
+
+            if (capabilityFailure is not null)
+            {
+                if (policy.Strictness == ExecutorSizeStrictness.Strict)
+                {
+                    throw new ExecutorSizeCapabilityException(
+                        policy.Scope,
+                        policy.Representation,
+                        capabilityFailure);
+                }
+
+                diagnostics.Add(new ExecutorSizeDiagnostic(
+                    policy.Scope,
+                    policy.Representation,
+                    capabilityFailure));
+                continue;
+            }
+
+            var eventTotals = measurements
+                .GroupBy(m => m.Index)
+                .Select(group => group.Sum(m => m.Bytes))
+                .ToArray();
+
+            if (policy.MaxBytesPerEvent is { } eventLimit)
+            {
+                for (var index = 0; index < eventTotals.Length; index++)
+                {
+                    if (eventTotals[index] <= eventLimit)
+                    {
+                        continue;
+                    }
+
+                    var offending = measurements.First(m => m.Index == index);
+                    throw new ExecutorSizeLimitExceededException(
+                        policy.Scope,
+                        policy.Representation,
+                        eventLimit,
+                        eventTotals[index],
+                        offending.Prepared.Event.Id,
+                        index,
+                        false,
+                        offending.DestinationKey,
+                        offending.Certified);
+                }
+            }
+
+            if (policy.MaxBytesPerOperation is { } operationLimit)
+            {
+                long operationBytes;
+                try
+                {
+                    operationBytes = checked(measurements.Sum(m => m.Bytes));
+                }
+                catch (OverflowException)
+                {
+                    operationBytes = long.MaxValue;
+                }
+
+                if (operationBytes > operationLimit)
+                {
+                    var offending = measurements.First();
+                    throw new ExecutorSizeLimitExceededException(
+                        policy.Scope,
+                        policy.Representation,
+                        operationLimit,
+                        operationBytes,
+                        offending.Prepared.Event.Id,
+                        offending.Index,
+                        true,
+                        offending.DestinationKey,
+                        offending.Certified);
+                }
+            }
+        }
+
+        return new ExecutorSizeGateEvaluation(diagnostics, destinationPlans);
+    }
+
+    private static (PreparedExecutorEvent Prepared, int Index, long Bytes, string? DestinationKey, bool Certified)
+        ToComparable(
+            ExecutorSizePolicy policy,
+            PreparedExecutorEvent prepared,
+            int index,
+            ExecutorSizeMeasurementResult result,
+            string? destinationKey)
+    {
+        var bytes = result.ComparableBytes;
+        if (bytes is null || bytes < 0)
+        {
+            throw new ExecutorSizeCapabilityException(
+                policy.Scope,
+                policy.Representation,
+                "measurement returned neither a non-negative exact size nor a certified upper bound");
+        }
+
+        return (prepared, index, bytes.Value, destinationKey, result.Bytes is null);
+    }
+
+    private static ExecutorSizeMeasurementResult Measure(
+        ExecutorSizePolicy policy,
+        PreparedExecutorEvent prepared,
+        string serviceId,
+        string? destinationKey,
+        ExecutorSizeDestinationPlan? destinationPlan)
+    {
+        if (policy.Representation == ExecutorSizeRepresentation.LogicalSerializedEventUtf8 &&
+            policy.Measurement is null)
+        {
+            return ExecutorSizeMeasurementResult.Exact(MeasureLogicalSerializedEvent(prepared.SerializedEvent));
+        }
+
+        if (policy.Measurement is null)
+        {
+            return ExecutorSizeMeasurementResult.Unavailable("no measurement capability was registered");
+        }
+
+        try
+        {
+            return policy.Measurement.Measure(new ExecutorSizeMeasurementContext(
+                policy.Scope,
+                policy.Representation,
+                prepared.Event,
+                prepared.SerializedEvent,
+                serviceId,
+                destinationKey,
+                destinationPlan));
+        }
+        catch (Exception ex)
+        {
+            return ExecutorSizeMeasurementResult.Unavailable(
+                $"measurement capability failed with {ex.GetType().Name}");
+        }
+    }
+
+    private static long MeasureLogicalSerializedEvent(SerializableEvent @event)
+    {
+        using var stream = new MemoryStream();
+        using (var writer = new Utf8JsonWriter(stream, new JsonWriterOptions
+        {
+            Encoder = JavaScriptEncoder.Default,
+            Indented = false
+        }))
+        {
+            writer.WriteStartObject();
+            writer.WriteString("eventPayloadName", @event.EventPayloadName);
+            writer.WriteBase64String("payload", @event.Payload);
+            writer.WriteString("sortableUniqueIdValue", @event.SortableUniqueIdValue);
+            writer.WriteString("id", @event.Id);
+            writer.WriteStartObject("eventMetadata");
+            writer.WriteString("causationId", @event.EventMetadata.CausationId);
+            writer.WriteString("correlationId", @event.EventMetadata.CorrelationId);
+            writer.WriteString("executedUser", @event.EventMetadata.ExecutedUser);
+            writer.WriteEndObject();
+            writer.WriteStartArray("tags");
+            foreach (var tag in @event.Tags)
+            {
+                writer.WriteStringValue(tag);
+            }
+
+            writer.WriteEndArray();
+            writer.WriteEndObject();
+            writer.Flush();
+        }
+
+        return stream.Length;
+    }
+}

--- a/dcb/src/Sekiban.Dcb.Core/Actors/ExecutorSizeGateEvaluator.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Actors/ExecutorSizeGateEvaluator.cs
@@ -141,31 +141,38 @@ internal static class ExecutorSizeGateEvaluator
                 continue;
             }
 
-            var eventTotals = measurements
-                .GroupBy(m => m.Index)
-                .Select(group => group.Sum(m => m.Bytes))
-                .ToArray();
-
             if (policy.MaxBytesPerEvent is { } eventLimit)
             {
-                for (var index = 0; index < eventTotals.Length; index++)
+                // Destination event limits apply to each captured destination independently. A cross-destination
+                // operation budget exists only when the caller explicitly configures MaxBytesPerOperation below.
+                if (policy.Representation == ExecutorSizeRepresentation.Destination)
                 {
-                    if (eventTotals[index] <= eventLimit)
+                    foreach (var measurement in measurements)
                     {
-                        continue;
-                    }
+                        if (measurement.Bytes <= eventLimit)
+                        {
+                            continue;
+                        }
 
-                    var offending = measurements.First(m => m.Index == index);
-                    throw new ExecutorSizeLimitExceededException(
-                        policy.Scope,
-                        policy.Representation,
-                        eventLimit,
-                        eventTotals[index],
-                        offending.Prepared.Event.Id,
-                        index,
-                        false,
-                        offending.DestinationKey,
-                        offending.Certified);
+                        ThrowEventLimitExceeded(policy, eventLimit, measurement);
+                    }
+                }
+                else
+                {
+                    var eventTotals = measurements
+                        .GroupBy(m => m.Index)
+                        .Select(group => group.Sum(m => m.Bytes))
+                        .ToArray();
+
+                    for (var index = 0; index < eventTotals.Length; index++)
+                    {
+                        if (eventTotals[index] <= eventLimit)
+                        {
+                            continue;
+                        }
+
+                        ThrowEventLimitExceeded(policy, eventLimit, measurements.First(m => m.Index == index), eventTotals[index]);
+                    }
                 }
             }
 
@@ -200,6 +207,22 @@ internal static class ExecutorSizeGateEvaluator
 
         return new ExecutorSizeGateEvaluation(diagnostics, destinationPlans);
     }
+
+    private static void ThrowEventLimitExceeded(
+        ExecutorSizePolicy policy,
+        long eventLimit,
+        (PreparedExecutorEvent Prepared, int Index, long Bytes, string? DestinationKey, bool Certified) measurement,
+        long? measuredBytes = null) =>
+        throw new ExecutorSizeLimitExceededException(
+            policy.Scope,
+            policy.Representation,
+            eventLimit,
+            measuredBytes ?? measurement.Bytes,
+            measurement.Prepared.Event.Id,
+            measurement.Index,
+            false,
+            measurement.DestinationKey,
+            measurement.Certified);
 
     private static (PreparedExecutorEvent Prepared, int Index, long Bytes, string? DestinationKey, bool Certified)
         ToComparable(

--- a/dcb/src/Sekiban.Dcb.Core/Actors/GeneralSekibanExecutorConstruction.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Actors/GeneralSekibanExecutorConstruction.cs
@@ -1,0 +1,21 @@
+namespace Sekiban.Dcb.Actors;
+
+/// <summary>
+///     Internal construction state shared by the ResultBox and exception facade assemblies.
+///     Keeping the state transfer here lets both public facades retain their historical constructors without
+///     duplicating the size-gate construction bodies.
+/// </summary>
+internal sealed class GeneralSekibanExecutorConstruction
+{
+    internal GeneralSekibanExecutorConstruction(
+        IActorObjectAccessor actorAccessor,
+        CoreGeneralSekibanExecutor core)
+    {
+        ActorAccessor = actorAccessor;
+        Core = core;
+    }
+
+    internal IActorObjectAccessor ActorAccessor { get; }
+
+    internal CoreGeneralSekibanExecutor Core { get; }
+}

--- a/dcb/src/Sekiban.Dcb.Core/Commands/SerializedCommitResult.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Commands/SerializedCommitResult.cs
@@ -1,4 +1,5 @@
 using Sekiban.Dcb.Events;
+using Sekiban.Dcb.SizeGates;
 using Sekiban.Dcb.Tags;
 namespace Sekiban.Dcb.Commands;
 
@@ -9,4 +10,8 @@ namespace Sekiban.Dcb.Commands;
 public record SerializedCommitResult(
     IReadOnlyList<SerializableEvent> WrittenEvents,
     IReadOnlyList<TagWriteResult> TagWriteResults,
-    TimeSpan Duration);
+    TimeSpan Duration)
+{
+    /// <summary>Structured non-strict size-gate diagnostics; empty means every configured scope validated.</summary>
+    public IReadOnlyList<ExecutorSizeDiagnostic> SizeGateDiagnostics { get; init; } = Array.Empty<ExecutorSizeDiagnostic>();
+}

--- a/dcb/src/Sekiban.Dcb.Core/Commands/SerializedConditionalCommitResult.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Commands/SerializedConditionalCommitResult.cs
@@ -1,4 +1,5 @@
 using Sekiban.Dcb.Events;
+using Sekiban.Dcb.SizeGates;
 using Sekiban.Dcb.Storage;
 namespace Sekiban.Dcb.Commands;
 
@@ -19,4 +20,7 @@ public record SerializedConditionalCommitResult(
     TimeSpan Duration)
 {
     public const int CurrentVersion = 1;
+
+    /// <summary>Structured non-strict size-gate diagnostics; empty means every configured scope validated.</summary>
+    public IReadOnlyList<ExecutorSizeDiagnostic> SizeGateDiagnostics { get; init; } = Array.Empty<ExecutorSizeDiagnostic>();
 }

--- a/dcb/src/Sekiban.Dcb.Core/SizeGates/ExecutorSizeGateContracts.cs
+++ b/dcb/src/Sekiban.Dcb.Core/SizeGates/ExecutorSizeGateContracts.cs
@@ -1,0 +1,217 @@
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.Tags;
+
+namespace Sekiban.Dcb.SizeGates;
+
+/// <summary>
+/// The representation whose size a policy validates. The logical representation is the canonical UTF-8 event
+/// envelope produced by the executor. Storage and destination representations require an explicit capability.
+/// </summary>
+public enum ExecutorSizeRepresentation
+{
+    LogicalSerializedEventUtf8,
+    StorageItem,
+    Destination
+}
+
+public enum ExecutorSizeStrictness
+{
+    Strict,
+    NonStrict
+}
+
+/// <summary>
+/// An opt-in size policy. A policy must set at least one positive limit. The scope is an application/provider label
+/// such as <c>logical-event</c>, <c>postgres-event-row</c>, or <c>azure-queue-destination</c>; it is never used as a
+/// secret-bearing payload field.
+/// </summary>
+public sealed record ExecutorSizePolicy
+{
+    public ExecutorSizePolicy(
+        string scope,
+        ExecutorSizeRepresentation representation,
+        long? maxBytesPerEvent = null,
+        long? maxBytesPerOperation = null,
+        ExecutorSizeStrictness strictness = ExecutorSizeStrictness.Strict,
+        IExecutorSizeMeasurement? measurement = null)
+    {
+        Scope = scope ?? throw new ArgumentNullException(nameof(scope));
+        Representation = representation;
+        MaxBytesPerEvent = maxBytesPerEvent;
+        MaxBytesPerOperation = maxBytesPerOperation;
+        Strictness = strictness;
+        Measurement = measurement;
+    }
+
+    public string Scope { get; }
+    public ExecutorSizeRepresentation Representation { get; }
+    public long? MaxBytesPerEvent { get; }
+    public long? MaxBytesPerOperation { get; }
+    public ExecutorSizeStrictness Strictness { get; }
+    public IExecutorSizeMeasurement? Measurement { get; }
+}
+
+/// <summary>Mutable registration object used by explicit constructors and dependency injection.</summary>
+public sealed class ExecutorSizeGateOptions
+{
+    public IList<ExecutorSizePolicy> Policies { get; } = new List<ExecutorSizePolicy>();
+
+    public ExecutorSizeGateOptions Add(ExecutorSizePolicy policy)
+    {
+        Policies.Add(policy ?? throw new ArgumentNullException(nameof(policy)));
+        return this;
+    }
+
+    internal void Validate()
+    {
+        var scopes = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var policy in Policies)
+        {
+            if (string.IsNullOrWhiteSpace(policy.Scope))
+            {
+                throw new ArgumentException("Executor size policy scope must not be empty.", nameof(Policies));
+            }
+
+            if (!scopes.Add(policy.Scope))
+            {
+                throw new ArgumentException(
+                    $"Executor size policy scope '{policy.Scope}' is registered more than once.",
+                    nameof(Policies));
+            }
+
+            if ((policy.MaxBytesPerEvent is not null && policy.MaxBytesPerEvent <= 0) ||
+                (policy.MaxBytesPerOperation is not null && policy.MaxBytesPerOperation <= 0) ||
+                (policy.MaxBytesPerEvent is null && policy.MaxBytesPerOperation is null))
+            {
+                throw new ArgumentException(
+                    $"Executor size policy '{policy.Scope}' must declare at least one positive byte limit.",
+                    nameof(Policies));
+            }
+        }
+    }
+}
+
+/// <summary>
+/// Provider-neutral measurement hook. Implementations must return an exact byte count or a certified conservative
+/// upper bound for the declared representation; returning raw logical bytes for a storage/destination claim is not a
+/// valid capability.
+/// </summary>
+public interface IExecutorSizeMeasurement
+{
+    ExecutorSizeMeasurementResult Measure(ExecutorSizeMeasurementContext context);
+}
+
+public sealed record ExecutorSizeMeasurementContext(
+    string Scope,
+    ExecutorSizeRepresentation Representation,
+    Event Event,
+    SerializableEvent SerializedEvent,
+    string ServiceId,
+    string? DestinationKey,
+    ExecutorSizeDestinationPlan? DestinationPlan);
+
+public sealed record ExecutorSizeMeasurementResult(
+    bool IsAvailable,
+    long? Bytes,
+    long? CertifiedUpperBound,
+    string? Reason)
+{
+    public long? ComparableBytes => Bytes ?? CertifiedUpperBound;
+
+    public static ExecutorSizeMeasurementResult Exact(long bytes) =>
+        new(true, bytes, null, null);
+
+    public static ExecutorSizeMeasurementResult CertifiedBound(long bytes) =>
+        new(true, null, bytes, null);
+
+    public static ExecutorSizeMeasurementResult Unavailable(string reason) =>
+        new(false, null, null, reason);
+}
+
+/// <summary>
+/// A destination plan captured by the same publisher/resolver that will publish the event. Provider state is opaque to
+/// Core and is consumed only by the publisher that created it.
+/// </summary>
+public sealed record ExecutorSizeDestinationPlan(
+    string ServiceId,
+    IReadOnlyList<string> DestinationKeys,
+    object? ProviderState = null);
+
+/// <summary>
+/// Optional additive publisher capability used by destination policies. It both captures the publication plan and
+/// accepts that captured plan, preventing a resolver change between validation and enqueue.
+/// </summary>
+public interface IExecutorSizeDestinationPublisher
+{
+    ExecutorSizeDestinationPlan? CaptureDestinationPlan(
+        Event @event,
+        IReadOnlyCollection<ITag> tags,
+        string serviceId);
+
+    Task PublishAsync(
+        IReadOnlyCollection<(Event Event, IReadOnlyCollection<ITag> Tags)> events,
+        IReadOnlyDictionary<Guid, ExecutorSizeDestinationPlan> destinationPlans,
+        CancellationToken cancellationToken = default);
+}
+
+public sealed record ExecutorSizeDiagnostic(
+    string Scope,
+    ExecutorSizeRepresentation Representation,
+    string Reason);
+
+public sealed class ExecutorSizeLimitExceededException : Exception
+{
+    public ExecutorSizeLimitExceededException(
+        string scope,
+        ExecutorSizeRepresentation representation,
+        long limitBytes,
+        long measuredBytes,
+        Guid eventId,
+        int eventIndex,
+        bool operationLimit,
+        string? destinationKey = null,
+        bool certifiedUpperBound = false)
+        : base(
+            $"Executor size policy '{scope}' rejected event {eventId} at index {eventIndex}: " +
+            $"{representation} {(operationLimit ? "operation" : "event")} size {measuredBytes} bytes " +
+            $"exceeds limit {limitBytes} bytes.")
+    {
+        Scope = scope;
+        Representation = representation;
+        LimitBytes = limitBytes;
+        MeasuredBytes = measuredBytes;
+        EventId = eventId;
+        EventIndex = eventIndex;
+        IsOperationLimit = operationLimit;
+        DestinationKey = destinationKey;
+        IsCertifiedUpperBound = certifiedUpperBound;
+    }
+
+    public string Scope { get; }
+    public ExecutorSizeRepresentation Representation { get; }
+    public long LimitBytes { get; }
+    public long MeasuredBytes { get; }
+    public Guid EventId { get; }
+    public int EventIndex { get; }
+    public bool IsOperationLimit { get; }
+    public string? DestinationKey { get; }
+    public bool IsCertifiedUpperBound { get; }
+}
+
+public sealed class ExecutorSizeCapabilityException : Exception
+{
+    public ExecutorSizeCapabilityException(
+        string scope,
+        ExecutorSizeRepresentation representation,
+        string reason)
+        : base($"Executor size policy '{scope}' cannot validate {representation}: {reason}")
+    {
+        Scope = scope;
+        Representation = representation;
+        Reason = reason;
+    }
+
+    public string Scope { get; }
+    public ExecutorSizeRepresentation Representation { get; }
+    public string Reason { get; }
+}

--- a/dcb/src/Sekiban.Dcb.Core/SizeGates/SekibanDcbExecutorSizeGateExtensions.cs
+++ b/dcb/src/Sekiban.Dcb.Core/SizeGates/SekibanDcbExecutorSizeGateExtensions.cs
@@ -1,0 +1,35 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Sekiban.Dcb.SizeGates;
+
+public static class SekibanDcbExecutorSizeGateExtensions
+{
+    /// <summary>
+    /// Registers one opt-in executor size policy set. No service is added to the container when this method is not
+    /// called, so existing construction remains ungated.
+    /// </summary>
+    public static IServiceCollection AddSekibanDcbExecutorSizeGate(
+        this IServiceCollection services,
+        Action<ExecutorSizeGateOptions> configure)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(configure);
+
+        var options = new ExecutorSizeGateOptions();
+        configure(options);
+        options.Validate();
+        services.AddSingleton(options);
+        return services;
+    }
+
+    public static IServiceCollection AddSekibanDcbExecutorSizeGate(
+        this IServiceCollection services,
+        ExecutorSizeGateOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(options);
+        options.Validate();
+        services.AddSingleton(options);
+        return services;
+    }
+}

--- a/dcb/src/Sekiban.Dcb.Orleans.Core/OrleansEventPublisher.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.Core/OrleansEventPublisher.cs
@@ -2,6 +2,8 @@ using Microsoft.Extensions.Logging;
 using Sekiban.Dcb.Actors;
 using Sekiban.Dcb.Events;
 using Sekiban.Dcb.Orleans.Streams;
+using Sekiban.Dcb.ServiceId;
+using Sekiban.Dcb.SizeGates;
 using Sekiban.Dcb.Tags;
 using System.Threading.Channels;
 using System.Collections.Concurrent;
@@ -10,12 +12,13 @@ namespace Sekiban.Dcb.Orleans;
 /// <summary>
 ///     Publishes Sekiban Dcb events to Orleans streams using an Orleans cluster client.
 /// </summary>
-public class OrleansEventPublisher : IEventPublisher
+public class OrleansEventPublisher : IEventPublisher, IExecutorSizeDestinationPublisher
 {
     private readonly IClusterClient _clusterClient;
     private readonly ILogger<OrleansEventPublisher> _logger;
     private readonly IStreamDestinationResolver _resolver;
     private readonly DcbDomainTypes _domainTypes;
+    private readonly IServiceIdProvider _serviceIdProvider;
     private readonly Channel<PublishItem> _channel;
     private readonly Task _processor;
 
@@ -26,11 +29,28 @@ public class OrleansEventPublisher : IEventPublisher
         IStreamDestinationResolver resolver,
         DcbDomainTypes domainTypes,
         ILogger<OrleansEventPublisher> logger)
+        : this(
+            clusterClient,
+            resolver,
+            domainTypes,
+            logger,
+            new DefaultServiceIdProvider())
+    {
+    }
+
+    /// <summary>Additive constructor retaining the resolver/service identity used by publication.</summary>
+    public OrleansEventPublisher(
+        IClusterClient clusterClient,
+        IStreamDestinationResolver resolver,
+        DcbDomainTypes domainTypes,
+        ILogger<OrleansEventPublisher> logger,
+        IServiceIdProvider? serviceIdProvider = null)
     {
         _clusterClient = clusterClient;
         _resolver = resolver;
         _domainTypes = domainTypes;
         _logger = logger;
+        _serviceIdProvider = serviceIdProvider ?? throw new ArgumentNullException(nameof(serviceIdProvider));
         // Unbounded channel for simplicity; projection side is idempotent
         _channel = Channel.CreateUnbounded<PublishItem>(new UnboundedChannelOptions
         {
@@ -78,6 +98,76 @@ public class OrleansEventPublisher : IEventPublisher
         // Return immediately; background processor ensures at-least-once with retry and logging
         await Task.CompletedTask;
     }
+
+    public ExecutorSizeDestinationPlan? CaptureDestinationPlan(
+        Event @event,
+        IReadOnlyCollection<ITag> tags,
+        string serviceId)
+    {
+        var destinations = (_resolver.Resolve(@event, tags) ?? Enumerable.Empty<ISekibanStream>())
+            .OfType<OrleansSekibanStream>()
+            .Select(stream => new OrleansDestination(
+                stream.ProviderName,
+                stream.StreamNamespace,
+                stream.StreamId))
+            .ToArray();
+
+        if (destinations.Length == 0)
+        {
+            return null;
+        }
+
+        var resolverServiceId = _serviceIdProvider.GetCurrentServiceId();
+        if (!string.Equals(resolverServiceId, serviceId, StringComparison.Ordinal))
+        {
+            return new ExecutorSizeDestinationPlan(
+                resolverServiceId,
+                destinations.Select(GetDestinationKey).ToArray(),
+                destinations);
+        }
+
+        return new ExecutorSizeDestinationPlan(
+            serviceId,
+            destinations.Select(GetDestinationKey).ToArray(),
+            destinations);
+    }
+
+    public async Task PublishAsync(
+        IReadOnlyCollection<(Event Event, IReadOnlyCollection<ITag> Tags)> events,
+        IReadOnlyDictionary<Guid, ExecutorSizeDestinationPlan> destinationPlans,
+        CancellationToken cancellationToken = default)
+    {
+        foreach (var (evt, _) in events)
+        {
+            if (!destinationPlans.TryGetValue(evt.Id, out var plan) ||
+                plan.ProviderState is not IReadOnlyList<OrleansDestination> destinations)
+            {
+                throw new InvalidOperationException(
+                    $"The captured destination plan for event {evt.Id} is unavailable.");
+            }
+
+            var serializableEvent = evt.ToSerializableEvent(_domainTypes.EventTypes);
+            foreach (var destination in destinations)
+            {
+                _channel.Writer.TryWrite(new PublishItem(
+                    destination.ProviderName,
+                    destination.StreamNamespace,
+                    destination.StreamId,
+                    serializableEvent,
+                    0));
+            }
+        }
+
+        await Task.CompletedTask;
+    }
+
+    private static string GetDestinationKey(OrleansDestination destination) =>
+        $"{destination.ProviderName}|{destination.StreamNamespace}|{destination.StreamId:D}";
+
+    private sealed record OrleansDestination(
+        string ProviderName,
+        string StreamNamespace,
+        Guid StreamId);
 
     private async Task ProcessQueueAsync()
     {

--- a/dcb/src/Sekiban.Dcb.Orleans.Core/Runtimes/OrleansDcbExecutorConstruction.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.Core/Runtimes/OrleansDcbExecutorConstruction.cs
@@ -1,0 +1,132 @@
+using Sekiban.Dcb.Actors;
+using Sekiban.Dcb.Common;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.ServiceId;
+using Sekiban.Dcb.SizeGates;
+using Sekiban.Dcb.Storage;
+
+namespace Sekiban.Dcb.Orleans;
+
+/// <summary>Arguments shared by the two Orleans executor facade constructors.</summary>
+internal sealed class OrleansDcbExecutorConstructionInputs
+{
+    internal OrleansDcbExecutorConstructionInputs(
+        IClusterClient clusterClient,
+        IEventStore eventStore,
+        DcbDomainTypes domainTypes,
+        IEventPublisher? eventPublisher,
+        IServiceIdProvider? serviceIdProvider,
+        IExecutedUserProvider? executedUserProvider,
+        ISortableUniqueIdGenerator sortableUniqueIdGenerator,
+        SortableUniqueIdSeedCoordinator sortableUniqueIdSeedCoordinator,
+        SortableUniqueIdWaitPolicy sortableUniqueIdWaitPolicy,
+        ExecutorSizeGateOptions? executorSizeGateOptions)
+    {
+        ClusterClient = clusterClient;
+        EventStore = eventStore;
+        DomainTypes = domainTypes;
+        EventPublisher = eventPublisher;
+        ServiceIdProvider = serviceIdProvider;
+        ExecutedUserProvider = executedUserProvider;
+        SortableUniqueIdGenerator = sortableUniqueIdGenerator;
+        SortableUniqueIdSeedCoordinator = sortableUniqueIdSeedCoordinator;
+        SortableUniqueIdWaitPolicy = sortableUniqueIdWaitPolicy;
+        ExecutorSizeGateOptions = executorSizeGateOptions;
+    }
+
+    internal IClusterClient ClusterClient { get; }
+
+    internal IEventStore EventStore { get; }
+
+    internal DcbDomainTypes DomainTypes { get; }
+
+    internal IEventPublisher? EventPublisher { get; }
+
+    internal IServiceIdProvider? ServiceIdProvider { get; }
+
+    internal IExecutedUserProvider? ExecutedUserProvider { get; }
+
+    internal ISortableUniqueIdGenerator SortableUniqueIdGenerator { get; }
+
+    internal SortableUniqueIdSeedCoordinator SortableUniqueIdSeedCoordinator { get; }
+
+    internal SortableUniqueIdWaitPolicy SortableUniqueIdWaitPolicy { get; }
+
+    internal ExecutorSizeGateOptions? ExecutorSizeGateOptions { get; }
+}
+
+/// <summary>
+///     Shared validated Orleans dependencies and facade-specific general executor.
+///     The generic result keeps the ResultBox and exception assemblies independent while sharing construction.
+/// </summary>
+internal sealed class OrleansDcbExecutorConstruction<TGeneralExecutor>
+{
+    private OrleansDcbExecutorConstruction(
+        IActorObjectAccessor actorAccessor,
+        IClusterClient clusterClient,
+        DcbDomainTypes domainTypes,
+        IEventStore eventStore,
+        TGeneralExecutor generalExecutor,
+        OrleansProjectionQueryExecutor queryExecutor,
+        IServiceIdProvider serviceIdProvider,
+        SortableUniqueIdWaitPolicy sortableUniqueIdWaitPolicy)
+    {
+        ActorAccessor = actorAccessor;
+        ClusterClient = clusterClient;
+        DomainTypes = domainTypes;
+        EventStore = eventStore;
+        GeneralExecutor = generalExecutor;
+        QueryExecutor = queryExecutor;
+        ServiceIdProvider = serviceIdProvider;
+        SortableUniqueIdWaitPolicy = sortableUniqueIdWaitPolicy;
+    }
+
+    internal static OrleansDcbExecutorConstruction<TGeneralExecutor> Create(
+        OrleansDcbExecutorConstructionInputs inputs,
+        Func<OrleansDcbExecutorConstructionInputs, IActorObjectAccessor, IServiceIdProvider,
+            SortableUniqueIdWaitPolicy, TGeneralExecutor> createGeneralExecutor)
+    {
+        ArgumentNullException.ThrowIfNull(inputs);
+        ArgumentNullException.ThrowIfNull(createGeneralExecutor);
+
+        var clusterClient = inputs.ClusterClient ?? throw new ArgumentNullException(nameof(inputs.ClusterClient));
+        var eventStore = inputs.EventStore ?? throw new ArgumentNullException(nameof(inputs.EventStore));
+        var domainTypes = inputs.DomainTypes ?? throw new ArgumentNullException(nameof(inputs.DomainTypes));
+        var serviceIdProvider = inputs.ServiceIdProvider ?? new DefaultServiceIdProvider();
+        var waitPolicy = inputs.SortableUniqueIdWaitPolicy ??
+                         throw new ArgumentNullException(nameof(inputs.SortableUniqueIdWaitPolicy));
+        var actorAccessor = new OrleansActorObjectAccessor(clusterClient, eventStore, domainTypes, serviceIdProvider);
+        var queryExecutor = new OrleansProjectionQueryExecutor(
+            clusterClient,
+            domainTypes,
+            serviceIdProvider,
+            waitPolicy);
+        var generalExecutor = createGeneralExecutor(inputs, actorAccessor, serviceIdProvider, waitPolicy);
+
+        return new OrleansDcbExecutorConstruction<TGeneralExecutor>(
+            actorAccessor,
+            clusterClient,
+            domainTypes,
+            eventStore,
+            generalExecutor,
+            queryExecutor,
+            serviceIdProvider,
+            waitPolicy);
+    }
+
+    internal IActorObjectAccessor ActorAccessor { get; }
+
+    internal IClusterClient ClusterClient { get; }
+
+    internal DcbDomainTypes DomainTypes { get; }
+
+    internal IEventStore EventStore { get; }
+
+    internal TGeneralExecutor GeneralExecutor { get; }
+
+    internal OrleansProjectionQueryExecutor QueryExecutor { get; }
+
+    internal IServiceIdProvider ServiceIdProvider { get; }
+
+    internal SortableUniqueIdWaitPolicy SortableUniqueIdWaitPolicy { get; }
+}

--- a/dcb/src/Sekiban.Dcb.Orleans.Core/Runtimes/OrleansDcbExecutorConstruction.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.Core/Runtimes/OrleansDcbExecutorConstruction.cs
@@ -61,7 +61,7 @@ internal sealed class OrleansDcbExecutorConstructionInputs
 /// </summary>
 internal sealed class OrleansDcbExecutorConstruction<TGeneralExecutor>
 {
-    private OrleansDcbExecutorConstruction(
+    internal OrleansDcbExecutorConstruction(
         IActorObjectAccessor actorAccessor,
         IClusterClient clusterClient,
         DcbDomainTypes domainTypes,

--- a/dcb/src/Sekiban.Dcb.Orleans.Core/Runtimes/OrleansProjectionQueryExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.Core/Runtimes/OrleansProjectionQueryExecutor.cs
@@ -1,0 +1,123 @@
+using Sekiban.Dcb.Common;
+using Sekiban.Dcb.Orleans.Grains;
+using Sekiban.Dcb.Orleans.Serialization;
+using Sekiban.Dcb.Orleans.ServiceId;
+using Sekiban.Dcb.Queries;
+using Sekiban.Dcb.ServiceId;
+
+namespace Sekiban.Dcb.Orleans;
+
+/// <summary>
+///     Shared Orleans query transport used by both public executor facades. The facades retain their own
+///     result/error conversion; this class owns only grain selection, sortable-id waiting, serialization, and the
+///     provider call.
+/// </summary>
+internal sealed class OrleansProjectionQueryExecutor
+{
+    private readonly IClusterClient _clusterClient;
+    private readonly DcbDomainTypes _domainTypes;
+    private readonly IServiceIdProvider _serviceIdProvider;
+    private readonly SortableUniqueIdWaitPolicy _sortableUniqueIdWaitPolicy;
+
+    internal OrleansProjectionQueryExecutor(
+        IClusterClient clusterClient,
+        DcbDomainTypes domainTypes,
+        IServiceIdProvider serviceIdProvider,
+        SortableUniqueIdWaitPolicy sortableUniqueIdWaitPolicy)
+    {
+        _clusterClient = clusterClient;
+        _domainTypes = domainTypes;
+        _serviceIdProvider = serviceIdProvider;
+        _sortableUniqueIdWaitPolicy = sortableUniqueIdWaitPolicy;
+    }
+
+    internal async Task<SerializableQueryResult> ExecuteQueryAsync(
+        object query,
+        string projectorName,
+        SortableUniqueIdWaitSurface surface)
+    {
+        var grain = GetGrain(projectorName);
+        await WaitForSortableUniqueIdIfNeeded(grain, query, surface);
+
+        var serializableQuery = await SerializableQueryParameter.CreateFromAsync(
+            query,
+            _domainTypes.JsonSerializerOptions);
+
+        return await grain.ExecuteQueryAsync(serializableQuery);
+    }
+
+    internal async Task<SerializableListQueryResult> ExecuteListQueryAsync(
+        object query,
+        string projectorName,
+        SortableUniqueIdWaitSurface surface)
+    {
+        var grain = GetGrain(projectorName);
+        await WaitForSortableUniqueIdIfNeeded(grain, query, surface);
+
+        var serializableQuery = await SerializableQueryParameter.CreateFromAsync(
+            query,
+            _domainTypes.JsonSerializerOptions);
+
+        return await grain.ExecuteListQueryAsync(serializableQuery);
+    }
+
+    private IMultiProjectionGrain GetGrain(string projectorName)
+    {
+        var grainId = ServiceIdGrainKey.Build(_serviceIdProvider.GetCurrentServiceId(), projectorName);
+        return _clusterClient.GetGrain<IMultiProjectionGrain>(grainId);
+    }
+
+    /// <summary>
+    ///     Waits for a sortable unique ID to be processed when the query requests it. Strict marker queries fail
+    ///     before serialization when the wait times out; legacy queries keep their fail-open behavior.
+    /// </summary>
+    private async Task WaitForSortableUniqueIdIfNeeded(
+        IMultiProjectionGrain grain,
+        object query,
+        SortableUniqueIdWaitSurface surface)
+    {
+        if (query is not IWaitForSortableUniqueId waitForQuery ||
+            string.IsNullOrEmpty(waitForQuery.WaitForSortableUniqueId))
+        {
+            return;
+        }
+
+        var sortableUniqueId = waitForQuery.WaitForSortableUniqueId;
+        var strict = query is IStrictWaitForSortableUniqueId;
+        var wait = await _sortableUniqueIdWaitPolicy.WaitAsync(
+            sortableUniqueId,
+            surface,
+            strict ? SortableUniqueIdWaitMode.Strict : SortableUniqueIdWaitMode.Legacy,
+            cancellationToken => ProbeSortableUniqueIdAsync(grain, sortableUniqueId, cancellationToken),
+            strict
+                ? cancellationToken => ReadCurrentSortableUniqueIdAsync(grain, cancellationToken)
+                : null);
+
+        if (strict && wait.TimedOut)
+        {
+            throw new SortableUniqueIdWaitTimeoutException(
+                sortableUniqueId,
+                wait.Timeout,
+                wait.Elapsed,
+                wait.LastObservedSortableUniqueId);
+        }
+    }
+
+    private static async Task<bool> ProbeSortableUniqueIdAsync(
+        IMultiProjectionGrain grain,
+        string sortableUniqueId,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return await grain.IsSortableUniqueIdReceived(sortableUniqueId).ConfigureAwait(false);
+    }
+
+    private static async Task<string?> ReadCurrentSortableUniqueIdAsync(
+        IMultiProjectionGrain grain,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        var status = await grain.GetProjectionHeadStatusAsync().ConfigureAwait(false);
+        return status.CurrentLastSortableUniqueId;
+    }
+}

--- a/dcb/src/Sekiban.Dcb.Orleans.Core/Sekiban.Dcb.Orleans.Core.csproj
+++ b/dcb/src/Sekiban.Dcb.Orleans.Core/Sekiban.Dcb.Orleans.Core.csproj
@@ -32,6 +32,8 @@
     <ItemGroup>
         <!-- Friend access for the Orleans test project to drive internal coordination components directly. -->
         <InternalsVisibleTo Include="Sekiban.Dcb.Orleans.Tests"/>
+        <InternalsVisibleTo Include="Sekiban.Dcb.Orleans.WithResult"/>
+        <InternalsVisibleTo Include="Sekiban.Dcb.Orleans.WithoutResult"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/dcb/src/Sekiban.Dcb.Orleans.WithResult/OrleansDcbExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.WithResult/OrleansDcbExecutor.cs
@@ -9,6 +9,7 @@ using Sekiban.Dcb.Orleans.Grains;
 using Sekiban.Dcb.Orleans.ServiceId;
 using Sekiban.Dcb.Queries;
 using Sekiban.Dcb.ServiceId;
+using Sekiban.Dcb.SizeGates;
 using Sekiban.Dcb.Storage;
 using Sekiban.Dcb.Tags;
 using Sekiban.Dcb.Orleans.Serialization;
@@ -43,6 +44,29 @@ public class OrleansDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecuto
         IEventPublisher? eventPublisher,
         IServiceIdProvider? serviceIdProvider)
         : this(clusterClient, eventStore, domainTypes, eventPublisher, serviceIdProvider, null)
+    {
+    }
+
+    /// <summary>Additive opt-in size-gate constructor; existing Orleans construction remains ungated.</summary>
+    public OrleansDcbExecutor(
+        IClusterClient clusterClient,
+        IEventStore eventStore,
+        DcbDomainTypes domainTypes,
+        ExecutorSizeGateOptions executorSizeGateOptions,
+        IEventPublisher? eventPublisher = null,
+        IServiceIdProvider? serviceIdProvider = null,
+        IExecutedUserProvider? executedUserProvider = null)
+        : this(
+            clusterClient,
+            eventStore,
+            domainTypes,
+            eventPublisher,
+            serviceIdProvider,
+            executedUserProvider,
+            ProcessSharedSortableUniqueIdServices.Generator,
+            ProcessSharedSortableUniqueIdServices.SeedCoordinator,
+            SortableUniqueIdWaitPolicy.System,
+            executorSizeGateOptions)
     {
     }
 
@@ -99,6 +123,31 @@ public class OrleansDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecuto
         ISortableUniqueIdGenerator sortableUniqueIdGenerator,
         SortableUniqueIdSeedCoordinator sortableUniqueIdSeedCoordinator,
         SortableUniqueIdWaitPolicy sortableUniqueIdWaitPolicy)
+        : this(
+            clusterClient,
+            eventStore,
+            domainTypes,
+            eventPublisher,
+            serviceIdProvider,
+            executedUserProvider,
+            sortableUniqueIdGenerator,
+            sortableUniqueIdSeedCoordinator,
+            sortableUniqueIdWaitPolicy,
+            null)
+    {
+    }
+
+    internal OrleansDcbExecutor(
+        IClusterClient clusterClient,
+        IEventStore eventStore,
+        DcbDomainTypes domainTypes,
+        IEventPublisher? eventPublisher,
+        IServiceIdProvider? serviceIdProvider,
+        IExecutedUserProvider? executedUserProvider,
+        ISortableUniqueIdGenerator sortableUniqueIdGenerator,
+        SortableUniqueIdSeedCoordinator sortableUniqueIdSeedCoordinator,
+        SortableUniqueIdWaitPolicy sortableUniqueIdWaitPolicy,
+        ExecutorSizeGateOptions? executorSizeGateOptions)
     {
         _clusterClient = clusterClient ?? throw new ArgumentNullException(nameof(clusterClient));
         _eventStore = eventStore ?? throw new ArgumentNullException(nameof(eventStore));
@@ -116,7 +165,8 @@ public class OrleansDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecuto
             sortableUniqueIdGenerator,
             sortableUniqueIdSeedCoordinator,
             _serviceIdProvider,
-            _sortableUniqueIdWaitPolicy);
+            _sortableUniqueIdWaitPolicy,
+            executorSizeGateOptions);
     }
 
     /// <summary>

--- a/dcb/src/Sekiban.Dcb.Orleans.WithResult/OrleansDcbExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.WithResult/OrleansDcbExecutor.cs
@@ -31,6 +31,7 @@ public class OrleansDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecuto
     private readonly DcbDomainTypes _domainTypes;
     private readonly IEventStore _eventStore;
     private readonly GeneralSekibanExecutor _generalExecutor;
+    private readonly OrleansProjectionQueryExecutor _queryExecutor;
     private readonly IServiceIdProvider _serviceIdProvider;
     private readonly SortableUniqueIdWaitPolicy _sortableUniqueIdWaitPolicy;
 
@@ -136,6 +137,11 @@ public class OrleansDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecuto
         _sortableUniqueIdWaitPolicy = sortableUniqueIdWaitPolicy ??
                                       throw new ArgumentNullException(nameof(sortableUniqueIdWaitPolicy));
         _actorAccessor = new OrleansActorObjectAccessor(clusterClient, eventStore, domainTypes, _serviceIdProvider);
+        _queryExecutor = new OrleansProjectionQueryExecutor(
+            _clusterClient,
+            _domainTypes,
+            _serviceIdProvider,
+            _sortableUniqueIdWaitPolicy);
         _generalExecutor = new GeneralSekibanExecutor(eventStore, _actorAccessor, domainTypes, eventPublisher,
             executedUserProvider, sortableUniqueIdGenerator, sortableUniqueIdSeedCoordinator, _serviceIdProvider,
             _sortableUniqueIdWaitPolicy, executorSizeGateOptions);
@@ -188,21 +194,10 @@ public class OrleansDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecuto
                 return ResultBox.Error<TResult>(projectorNameResult.GetException());
             }
 
-            // Get the multi-projection grain directly
-            var grainId = ServiceIdGrainKey.Build(_serviceIdProvider.GetCurrentServiceId(), projectorNameResult.GetValue());
-            var grain = _clusterClient.GetGrain<IMultiProjectionGrain>(grainId);
-
-            // Wait for sortable unique ID if needed
-            await WaitForSortableUniqueIdIfNeeded(
-                grain,
+            var result = await _queryExecutor.ExecuteQueryAsync(
                 queryCommon,
+                projectorNameResult.GetValue(),
                 SortableUniqueIdWaitSurface.OrleansWithResultSingle);
-
-            var serializableQuery = await SerializableQueryParameter.CreateFromAsync(
-                queryCommon,
-                _domainTypes.JsonSerializerOptions);
-
-            var result = await grain.ExecuteQueryAsync(serializableQuery);
 
             return await DeserializeQueryResultAsync<TResult>(result);
         }
@@ -226,21 +221,10 @@ public class OrleansDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecuto
                 return ResultBox.Error<ListQueryResult<TResult>>(projectorNameResult.GetException());
             }
 
-            // Get the multi-projection grain directly
-            var grainId = ServiceIdGrainKey.Build(_serviceIdProvider.GetCurrentServiceId(), projectorNameResult.GetValue());
-            var grain = _clusterClient.GetGrain<IMultiProjectionGrain>(grainId);
-
-            // Wait for sortable unique ID if needed
-            await WaitForSortableUniqueIdIfNeeded(
-                grain,
+            var result = await _queryExecutor.ExecuteListQueryAsync(
                 queryCommon,
+                projectorNameResult.GetValue(),
                 SortableUniqueIdWaitSurface.OrleansWithResultList);
-
-            var serializableQuery = await SerializableQueryParameter.CreateFromAsync(
-                queryCommon,
-                _domainTypes.JsonSerializerOptions);
-
-            var result = await grain.ExecuteListQueryAsync(serializableQuery);
 
             return await DeserializeListQueryResultAsync<TResult>(result);
         }
@@ -248,60 +232,6 @@ public class OrleansDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecuto
         {
             return ResultBox.Error<ListQueryResult<TResult>>(ex);
         }
-    }
-
-    /// <summary>
-    ///     Wait for a sortable unique ID to be processed if the query implements IWaitForSortableUniqueId.
-    ///     Strict marker queries fail before serialization when the wait times out; legacy queries keep fail-open.
-    /// </summary>
-    private async Task WaitForSortableUniqueIdIfNeeded(
-        IMultiProjectionGrain grain,
-        object query,
-        SortableUniqueIdWaitSurface surface)
-    {
-        if (query is not IWaitForSortableUniqueId waitForQuery ||
-            string.IsNullOrEmpty(waitForQuery.WaitForSortableUniqueId))
-        {
-            return;
-        }
-
-        var sortableUniqueId = waitForQuery.WaitForSortableUniqueId;
-        var strict = query is IStrictWaitForSortableUniqueId;
-        var wait = await _sortableUniqueIdWaitPolicy.WaitAsync(
-            sortableUniqueId,
-            surface,
-            strict ? SortableUniqueIdWaitMode.Strict : SortableUniqueIdWaitMode.Legacy,
-            cancellationToken => ProbeSortableUniqueIdAsync(grain, sortableUniqueId, cancellationToken),
-            strict
-                ? cancellationToken => ReadCurrentSortableUniqueIdAsync(grain, cancellationToken)
-                : null);
-
-        if (strict && wait.TimedOut)
-        {
-            throw new SortableUniqueIdWaitTimeoutException(
-                sortableUniqueId,
-                wait.Timeout,
-                wait.Elapsed,
-                wait.LastObservedSortableUniqueId);
-        }
-    }
-
-    private static async Task<bool> ProbeSortableUniqueIdAsync(
-        IMultiProjectionGrain grain,
-        string sortableUniqueId,
-        CancellationToken cancellationToken)
-    {
-        cancellationToken.ThrowIfCancellationRequested();
-        return await grain.IsSortableUniqueIdReceived(sortableUniqueId).ConfigureAwait(false);
-    }
-
-    private static async Task<string?> ReadCurrentSortableUniqueIdAsync(
-        IMultiProjectionGrain grain,
-        CancellationToken cancellationToken)
-    {
-        cancellationToken.ThrowIfCancellationRequested();
-        var status = await grain.GetProjectionHeadStatusAsync().ConfigureAwait(false);
-        return status.CurrentLastSortableUniqueId;
     }
 
     private async Task<ResultBox<TResult>> DeserializeQueryResultAsync<TResult>(

--- a/dcb/src/Sekiban.Dcb.Orleans.WithResult/OrleansDcbExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.WithResult/OrleansDcbExecutor.cs
@@ -24,16 +24,9 @@ public class OrleansDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecuto
 {
     /// <summary>Commands are executed by Orleans grains across the cluster.</summary>
     public ExecutorRuntimeDescriptor DescribeRuntime() =>
-        SekibanDcbCapabilityResolver.DescribeExecutor(_actorAccessor);
+        SekibanDcbCapabilityResolver.DescribeExecutor(_construction.ActorAccessor);
 
-    private readonly IActorObjectAccessor _actorAccessor;
-    private readonly IClusterClient _clusterClient;
-    private readonly DcbDomainTypes _domainTypes;
-    private readonly IEventStore _eventStore;
-    private readonly GeneralSekibanExecutor _generalExecutor;
-    private readonly OrleansProjectionQueryExecutor _queryExecutor;
-    private readonly IServiceIdProvider _serviceIdProvider;
-    private readonly SortableUniqueIdWaitPolicy _sortableUniqueIdWaitPolicy;
+    private readonly OrleansDcbExecutorConstruction<GeneralSekibanExecutor> _construction;
 
     /// <summary>
     ///     Binary-compatible overload preserved for callers compiled against the pre-SEK-G23 constructor.
@@ -52,9 +45,10 @@ public class OrleansDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecuto
     public OrleansDcbExecutor(IClusterClient clusterClient, IEventStore eventStore, DcbDomainTypes domainTypes,
         ExecutorSizeGateOptions executorSizeGateOptions, IEventPublisher? eventPublisher = null,
         IServiceIdProvider? serviceIdProvider = null, IExecutedUserProvider? executedUserProvider = null)
-        : this(clusterClient, eventStore, domainTypes, eventPublisher, serviceIdProvider, executedUserProvider,
+        : this(CreateResultConstruction(new OrleansDcbExecutorConstructionInputs(
+            clusterClient, eventStore, domainTypes, eventPublisher, serviceIdProvider, executedUserProvider,
             ProcessSharedSortableUniqueIdServices.Generator, ProcessSharedSortableUniqueIdServices.SeedCoordinator,
-            SortableUniqueIdWaitPolicy.System, executorSizeGateOptions)
+            SortableUniqueIdWaitPolicy.System, executorSizeGateOptions)))
     {
     }
 
@@ -111,17 +105,9 @@ public class OrleansDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecuto
         ISortableUniqueIdGenerator sortableUniqueIdGenerator,
         SortableUniqueIdSeedCoordinator sortableUniqueIdSeedCoordinator,
         SortableUniqueIdWaitPolicy sortableUniqueIdWaitPolicy)
-        : this(
-            clusterClient,
-            eventStore,
-            domainTypes,
-            eventPublisher,
-            serviceIdProvider,
-            executedUserProvider,
-            sortableUniqueIdGenerator,
-            sortableUniqueIdSeedCoordinator,
-            sortableUniqueIdWaitPolicy,
-            null)
+        : this(CreateResultConstruction(new OrleansDcbExecutorConstructionInputs(
+            clusterClient, eventStore, domainTypes, eventPublisher, serviceIdProvider, executedUserProvider,
+            sortableUniqueIdGenerator, sortableUniqueIdSeedCoordinator, sortableUniqueIdWaitPolicy, null)))
     {
     }
 
@@ -129,23 +115,36 @@ public class OrleansDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecuto
         IEventPublisher? eventPublisher, IServiceIdProvider? serviceIdProvider, IExecutedUserProvider? executedUserProvider,
         ISortableUniqueIdGenerator sortableUniqueIdGenerator, SortableUniqueIdSeedCoordinator sortableUniqueIdSeedCoordinator,
         SortableUniqueIdWaitPolicy sortableUniqueIdWaitPolicy, ExecutorSizeGateOptions? executorSizeGateOptions)
+        : this(CreateResultConstruction(new OrleansDcbExecutorConstructionInputs(
+            clusterClient, eventStore, domainTypes, eventPublisher, serviceIdProvider, executedUserProvider,
+            sortableUniqueIdGenerator, sortableUniqueIdSeedCoordinator, sortableUniqueIdWaitPolicy,
+            executorSizeGateOptions)))
     {
-        _clusterClient = clusterClient ?? throw new ArgumentNullException(nameof(clusterClient));
-        _eventStore = eventStore ?? throw new ArgumentNullException(nameof(eventStore));
-        _domainTypes = domainTypes ?? throw new ArgumentNullException(nameof(domainTypes));
-        _serviceIdProvider = serviceIdProvider ?? new DefaultServiceIdProvider();
-        _sortableUniqueIdWaitPolicy = sortableUniqueIdWaitPolicy ??
-                                      throw new ArgumentNullException(nameof(sortableUniqueIdWaitPolicy));
-        _actorAccessor = new OrleansActorObjectAccessor(clusterClient, eventStore, domainTypes, _serviceIdProvider);
-        _queryExecutor = new OrleansProjectionQueryExecutor(
-            _clusterClient,
-            _domainTypes,
-            _serviceIdProvider,
-            _sortableUniqueIdWaitPolicy);
-        _generalExecutor = new GeneralSekibanExecutor(eventStore, _actorAccessor, domainTypes, eventPublisher,
-            executedUserProvider, sortableUniqueIdGenerator, sortableUniqueIdSeedCoordinator, _serviceIdProvider,
-            _sortableUniqueIdWaitPolicy, executorSizeGateOptions);
     }
+
+    private OrleansDcbExecutor(OrleansDcbExecutorConstruction<GeneralSekibanExecutor> construction) =>
+        _construction = construction;
+
+    private static OrleansDcbExecutorConstruction<GeneralSekibanExecutor> CreateResultConstruction(
+        OrleansDcbExecutorConstructionInputs inputs) =>
+        OrleansDcbExecutorConstruction<GeneralSekibanExecutor>.Create(inputs, CreateResultGeneralExecutor);
+
+    private static GeneralSekibanExecutor CreateResultGeneralExecutor(
+        OrleansDcbExecutorConstructionInputs inputs,
+        IActorObjectAccessor actorAccessor,
+        IServiceIdProvider serviceIdProvider,
+        SortableUniqueIdWaitPolicy sortableUniqueIdWaitPolicy) =>
+        new(
+            inputs.EventStore,
+            actorAccessor,
+            inputs.DomainTypes,
+            inputs.EventPublisher,
+            inputs.ExecutedUserProvider,
+            inputs.SortableUniqueIdGenerator,
+            inputs.SortableUniqueIdSeedCoordinator,
+            serviceIdProvider,
+            sortableUniqueIdWaitPolicy,
+            inputs.ExecutorSizeGateOptions);
 
     /// <summary>
     ///     Execute a command with its built-in handler
@@ -153,7 +152,7 @@ public class OrleansDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecuto
     public Task<ResultBox<ExecutionResult>> ExecuteAsync<TCommand>(
         TCommand command,
         CancellationToken cancellationToken = default) where TCommand : ICommandWithHandler<TCommand> =>
-        _generalExecutor.ExecuteAsync(command, cancellationToken);
+        _construction.GeneralExecutor.ExecuteAsync(command, cancellationToken);
 
     /// <summary>
     ///     Execute a command with a handler function
@@ -162,7 +161,7 @@ public class OrleansDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecuto
         TCommand command,
         Func<TCommand, ICommandContext, Task<ResultBox<EventOrNone>>> handlerFunc,
         CancellationToken cancellationToken = default) where TCommand : ICommand =>
-        _generalExecutor.ExecuteAsync(command, handlerFunc, cancellationToken);
+        _construction.GeneralExecutor.ExecuteAsync(command, handlerFunc, cancellationToken);
 
     /// <summary>
     ///     Execute a handler function without an explicit command
@@ -170,16 +169,16 @@ public class OrleansDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecuto
     public Task<ResultBox<ExecutionResult>> ExecuteCommandAsync(
         Func<ICommandContext, Task<ResultBox<EventOrNone>>> handlerFunc,
         CancellationToken cancellationToken = default) =>
-        _generalExecutor.ExecuteCommandAsync(handlerFunc, cancellationToken);
+        _construction.GeneralExecutor.ExecuteCommandAsync(handlerFunc, cancellationToken);
 
     /// <summary>
     ///     Get the current state for a specific tag state
     /// </summary>
     public Task<ResultBox<TagState>> GetTagStateAsync(TagStateId tagStateId) =>
-        _generalExecutor.GetTagStateAsync(tagStateId);
+        _construction.GeneralExecutor.GetTagStateAsync(tagStateId);
 
     public Task<ResultBox<TagState>> GetTagStateAsync(TagStateId tagStateId, CancellationToken cancellationToken) =>
-        _generalExecutor.GetTagStateAsync(tagStateId, cancellationToken);
+        _construction.GeneralExecutor.GetTagStateAsync(tagStateId, cancellationToken);
 
     /// <summary>
     ///     Execute a single-result query using Orleans grains
@@ -194,7 +193,7 @@ public class OrleansDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecuto
                 return ResultBox.Error<TResult>(projectorNameResult.GetException());
             }
 
-            var result = await _queryExecutor.ExecuteQueryAsync(
+            var result = await _construction.QueryExecutor.ExecuteQueryAsync(
                 queryCommon,
                 projectorNameResult.GetValue(),
                 SortableUniqueIdWaitSurface.OrleansWithResultSingle);
@@ -221,7 +220,7 @@ public class OrleansDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecuto
                 return ResultBox.Error<ListQueryResult<TResult>>(projectorNameResult.GetException());
             }
 
-            var result = await _queryExecutor.ExecuteListQueryAsync(
+            var result = await _construction.QueryExecutor.ExecuteListQueryAsync(
                 queryCommon,
                 projectorNameResult.GetValue(),
                 SortableUniqueIdWaitSurface.OrleansWithResultList);
@@ -238,7 +237,7 @@ public class OrleansDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecuto
         SerializableQueryResult result)
         where TResult : notnull
     {
-        var generalBox = await result.ToQueryResultAsync(_domainTypes);
+        var generalBox = await result.ToQueryResultAsync(_construction.DomainTypes);
         if (!generalBox.IsSuccess)
         {
             return ResultBox.Error<TResult>(generalBox.GetException());
@@ -251,7 +250,7 @@ public class OrleansDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecuto
         SerializableListQueryResult result)
         where TResult : notnull
     {
-        var listGeneralBox = await result.ToListQueryResultAsync(_domainTypes);
+        var listGeneralBox = await result.ToListQueryResultAsync(_construction.DomainTypes);
         if (!listGeneralBox.IsSuccess)
         {
             return ResultBox.Error<ListQueryResult<TResult>>(listGeneralBox.GetException());
@@ -261,7 +260,7 @@ public class OrleansDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecuto
     }
 
     public Task<ResultBox<string>> GetLatestSortableUniqueIdAsync() =>
-        _generalExecutor.GetLatestSortableUniqueIdAsync();
+        _construction.GeneralExecutor.GetLatestSortableUniqueIdAsync();
 
     public async Task<ResultBox<ProjectionHeadStatus>> GetProjectionHeadStatusAsync(
         string projectorName,
@@ -270,7 +269,7 @@ public class OrleansDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecuto
         try
         {
             var projectorVersionResult = ProjectionHeadStatusUtilities.ValidateProjectorVersion(
-                _domainTypes,
+                _construction.DomainTypes,
                 projectorName,
                 expectedProjectorVersion);
             if (!projectorVersionResult.IsSuccess)
@@ -278,8 +277,8 @@ public class OrleansDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecuto
                 return ResultBox.Error<ProjectionHeadStatus>(projectorVersionResult.GetException());
             }
 
-            var grainId = ServiceIdGrainKey.Build(_serviceIdProvider.GetCurrentServiceId(), projectorName);
-            var grain = _clusterClient.GetGrain<IMultiProjectionGrain>(grainId);
+            var grainId = ServiceIdGrainKey.Build(_construction.ServiceIdProvider.GetCurrentServiceId(), projectorName);
+            var grain = _construction.ClusterClient.GetGrain<IMultiProjectionGrain>(grainId);
             var grainStatus = await grain.GetProjectionHeadStatusAsync();
 
             var projectorNameResult = ProjectionHeadStatusUtilities.EnsureProjectorNameConsistency(
@@ -320,31 +319,31 @@ public class OrleansDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecuto
     }
 
     public Task<ResultBox<EventStoreHeadStatus>> GetEventStoreHeadStatusAsync(bool includeTotalEventCount = false) =>
-        _generalExecutor.GetEventStoreHeadStatusAsync(includeTotalEventCount);
+        _construction.GeneralExecutor.GetEventStoreHeadStatusAsync(includeTotalEventCount);
 
     public Task<ResultBox<SerializableTagState>> GetSerializableTagStateAsync(TagStateId tagStateId) =>
-        _generalExecutor.GetSerializableTagStateAsync(tagStateId);
+        _construction.GeneralExecutor.GetSerializableTagStateAsync(tagStateId);
 
     public Task<ResultBox<SerializedCommitResult>> CommitSerializableEventsAsync(
         SerializedCommitRequest request,
         CancellationToken cancellationToken = default) =>
-        _generalExecutor.CommitSerializableEventsAsync(request, cancellationToken);
+        _construction.GeneralExecutor.CommitSerializableEventsAsync(request, cancellationToken);
 
     /// <summary>Forwards the additive V2 serialized expected-head contract to the common executor/store path.</summary>
     public Task<ResultBox<SerializedCommitResult>> CommitSerializableEventsWithExpectedTagPositionsAsync(
         VersionedExpectedTagPositionSerializedCommitRequest request,
         CancellationToken cancellationToken = default) =>
-        _generalExecutor.CommitSerializableEventsWithExpectedTagPositionsAsync(request, cancellationToken);
+        _construction.GeneralExecutor.CommitSerializableEventsWithExpectedTagPositionsAsync(request, cancellationToken);
 
     private ResultBox<string> ResolveProjectorName(IQueryCommon queryCommon)
     {
-        var projectorTypeResult = _domainTypes.QueryTypes.GetMultiProjectorType(queryCommon);
+        var projectorTypeResult = _construction.DomainTypes.QueryTypes.GetMultiProjectorType(queryCommon);
         return ProjectionHeadStatusUtilities.ResolveProjectorName(projectorTypeResult);
     }
 
     private ResultBox<string> ResolveProjectorName(IListQueryCommon queryCommon)
     {
-        var projectorTypeResult = _domainTypes.QueryTypes.GetMultiProjectorType(queryCommon);
+        var projectorTypeResult = _construction.DomainTypes.QueryTypes.GetMultiProjectorType(queryCommon);
         return ProjectionHeadStatusUtilities.ResolveProjectorName(projectorTypeResult);
     }
 }

--- a/dcb/src/Sekiban.Dcb.Orleans.WithResult/OrleansDcbExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.WithResult/OrleansDcbExecutor.cs
@@ -48,25 +48,12 @@ public class OrleansDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecuto
     }
 
     /// <summary>Additive opt-in size-gate constructor; existing Orleans construction remains ungated.</summary>
-    public OrleansDcbExecutor(
-        IClusterClient clusterClient,
-        IEventStore eventStore,
-        DcbDomainTypes domainTypes,
-        ExecutorSizeGateOptions executorSizeGateOptions,
-        IEventPublisher? eventPublisher = null,
-        IServiceIdProvider? serviceIdProvider = null,
-        IExecutedUserProvider? executedUserProvider = null)
-        : this(
-            clusterClient,
-            eventStore,
-            domainTypes,
-            eventPublisher,
-            serviceIdProvider,
-            executedUserProvider,
-            ProcessSharedSortableUniqueIdServices.Generator,
-            ProcessSharedSortableUniqueIdServices.SeedCoordinator,
-            SortableUniqueIdWaitPolicy.System,
-            executorSizeGateOptions)
+    public OrleansDcbExecutor(IClusterClient clusterClient, IEventStore eventStore, DcbDomainTypes domainTypes,
+        ExecutorSizeGateOptions executorSizeGateOptions, IEventPublisher? eventPublisher = null,
+        IServiceIdProvider? serviceIdProvider = null, IExecutedUserProvider? executedUserProvider = null)
+        : this(clusterClient, eventStore, domainTypes, eventPublisher, serviceIdProvider, executedUserProvider,
+            ProcessSharedSortableUniqueIdServices.Generator, ProcessSharedSortableUniqueIdServices.SeedCoordinator,
+            SortableUniqueIdWaitPolicy.System, executorSizeGateOptions)
     {
     }
 
@@ -137,17 +124,10 @@ public class OrleansDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecuto
     {
     }
 
-    internal OrleansDcbExecutor(
-        IClusterClient clusterClient,
-        IEventStore eventStore,
-        DcbDomainTypes domainTypes,
-        IEventPublisher? eventPublisher,
-        IServiceIdProvider? serviceIdProvider,
-        IExecutedUserProvider? executedUserProvider,
-        ISortableUniqueIdGenerator sortableUniqueIdGenerator,
-        SortableUniqueIdSeedCoordinator sortableUniqueIdSeedCoordinator,
-        SortableUniqueIdWaitPolicy sortableUniqueIdWaitPolicy,
-        ExecutorSizeGateOptions? executorSizeGateOptions)
+    internal OrleansDcbExecutor(IClusterClient clusterClient, IEventStore eventStore, DcbDomainTypes domainTypes,
+        IEventPublisher? eventPublisher, IServiceIdProvider? serviceIdProvider, IExecutedUserProvider? executedUserProvider,
+        ISortableUniqueIdGenerator sortableUniqueIdGenerator, SortableUniqueIdSeedCoordinator sortableUniqueIdSeedCoordinator,
+        SortableUniqueIdWaitPolicy sortableUniqueIdWaitPolicy, ExecutorSizeGateOptions? executorSizeGateOptions)
     {
         _clusterClient = clusterClient ?? throw new ArgumentNullException(nameof(clusterClient));
         _eventStore = eventStore ?? throw new ArgumentNullException(nameof(eventStore));
@@ -156,17 +136,9 @@ public class OrleansDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecuto
         _sortableUniqueIdWaitPolicy = sortableUniqueIdWaitPolicy ??
                                       throw new ArgumentNullException(nameof(sortableUniqueIdWaitPolicy));
         _actorAccessor = new OrleansActorObjectAccessor(clusterClient, eventStore, domainTypes, _serviceIdProvider);
-        _generalExecutor = new GeneralSekibanExecutor(
-            eventStore,
-            _actorAccessor,
-            domainTypes,
-            eventPublisher,
-            executedUserProvider,
-            sortableUniqueIdGenerator,
-            sortableUniqueIdSeedCoordinator,
-            _serviceIdProvider,
-            _sortableUniqueIdWaitPolicy,
-            executorSizeGateOptions);
+        _generalExecutor = new GeneralSekibanExecutor(eventStore, _actorAccessor, domainTypes, eventPublisher,
+            executedUserProvider, sortableUniqueIdGenerator, sortableUniqueIdSeedCoordinator, _serviceIdProvider,
+            _sortableUniqueIdWaitPolicy, executorSizeGateOptions);
     }
 
     /// <summary>

--- a/dcb/src/Sekiban.Dcb.Orleans.WithoutResult/OrleansDcbExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.WithoutResult/OrleansDcbExecutor.cs
@@ -25,16 +25,9 @@ public class OrleansDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecuto
 {
     /// <summary>Commands are executed by Orleans grains across the cluster.</summary>
     public ExecutorRuntimeDescriptor DescribeRuntime() =>
-        SekibanDcbCapabilityResolver.DescribeExecutor(_actorAccessor);
+        SekibanDcbCapabilityResolver.DescribeExecutor(_construction.ActorAccessor);
 
-    private readonly IActorObjectAccessor _actorAccessor;
-    private readonly IClusterClient _clusterClient;
-    private readonly DcbDomainTypes _domainTypes;
-    private readonly IEventStore _eventStore;
-    private readonly GeneralSekibanExecutor _generalExecutor;
-    private readonly OrleansProjectionQueryExecutor _queryExecutor;
-    private readonly IServiceIdProvider _serviceIdProvider;
-    private readonly SortableUniqueIdWaitPolicy _sortableUniqueIdWaitPolicy;
+    private readonly OrleansDcbExecutorConstruction<GeneralSekibanExecutor> _construction;
 
     /// <summary>
     ///     Binary-compatible overload preserved for callers compiled against the pre-SEK-G23 constructor.
@@ -53,9 +46,10 @@ public class OrleansDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecuto
     public OrleansDcbExecutor(IClusterClient clusterClient, IEventStore eventStore, DcbDomainTypes domainTypes,
         ExecutorSizeGateOptions executorSizeGateOptions, IEventPublisher? eventPublisher = null,
         IServiceIdProvider? serviceIdProvider = null, IExecutedUserProvider? executedUserProvider = null)
-        : this(clusterClient, eventStore, domainTypes, eventPublisher, serviceIdProvider, executedUserProvider,
+        : this(CreateExceptionConstruction(new OrleansDcbExecutorConstructionInputs(
+            clusterClient, eventStore, domainTypes, eventPublisher, serviceIdProvider, executedUserProvider,
             ProcessSharedSortableUniqueIdServices.Generator, ProcessSharedSortableUniqueIdServices.SeedCoordinator,
-            SortableUniqueIdWaitPolicy.System, executorSizeGateOptions)
+            SortableUniqueIdWaitPolicy.System, executorSizeGateOptions)))
     {
     }
 
@@ -112,17 +106,9 @@ public class OrleansDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecuto
         ISortableUniqueIdGenerator sortableUniqueIdGenerator,
         SortableUniqueIdSeedCoordinator sortableUniqueIdSeedCoordinator,
         SortableUniqueIdWaitPolicy sortableUniqueIdWaitPolicy)
-        : this(
-            clusterClient,
-            eventStore,
-            domainTypes,
-            eventPublisher,
-            serviceIdProvider,
-            executedUserProvider,
-            sortableUniqueIdGenerator,
-            sortableUniqueIdSeedCoordinator,
-            sortableUniqueIdWaitPolicy,
-            null)
+        : this(CreateExceptionConstruction(new OrleansDcbExecutorConstructionInputs(
+            clusterClient, eventStore, domainTypes, eventPublisher, serviceIdProvider, executedUserProvider,
+            sortableUniqueIdGenerator, sortableUniqueIdSeedCoordinator, sortableUniqueIdWaitPolicy, null)))
     {
     }
 
@@ -130,23 +116,36 @@ public class OrleansDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecuto
         IEventPublisher? eventPublisher, IServiceIdProvider? serviceIdProvider, IExecutedUserProvider? executedUserProvider,
         ISortableUniqueIdGenerator sortableUniqueIdGenerator, SortableUniqueIdSeedCoordinator sortableUniqueIdSeedCoordinator,
         SortableUniqueIdWaitPolicy sortableUniqueIdWaitPolicy, ExecutorSizeGateOptions? executorSizeGateOptions)
+        : this(CreateExceptionConstruction(new OrleansDcbExecutorConstructionInputs(
+            clusterClient, eventStore, domainTypes, eventPublisher, serviceIdProvider, executedUserProvider,
+            sortableUniqueIdGenerator, sortableUniqueIdSeedCoordinator, sortableUniqueIdWaitPolicy,
+            executorSizeGateOptions)))
     {
-        _clusterClient = clusterClient ?? throw new ArgumentNullException(nameof(clusterClient));
-        _eventStore = eventStore ?? throw new ArgumentNullException(nameof(eventStore));
-        _domainTypes = domainTypes ?? throw new ArgumentNullException(nameof(domainTypes));
-        _serviceIdProvider = serviceIdProvider ?? new DefaultServiceIdProvider();
-        _sortableUniqueIdWaitPolicy = sortableUniqueIdWaitPolicy ??
-                                      throw new ArgumentNullException(nameof(sortableUniqueIdWaitPolicy));
-        _actorAccessor = new OrleansActorObjectAccessor(clusterClient, eventStore, domainTypes, _serviceIdProvider);
-        _queryExecutor = new OrleansProjectionQueryExecutor(
-            _clusterClient,
-            _domainTypes,
-            _serviceIdProvider,
-            _sortableUniqueIdWaitPolicy);
-        _generalExecutor = new GeneralSekibanExecutor(eventStore, _actorAccessor, domainTypes, eventPublisher,
-            executedUserProvider, sortableUniqueIdGenerator, sortableUniqueIdSeedCoordinator, _serviceIdProvider,
-            _sortableUniqueIdWaitPolicy, executorSizeGateOptions);
     }
+
+    private OrleansDcbExecutor(OrleansDcbExecutorConstruction<GeneralSekibanExecutor> construction) =>
+        _construction = construction;
+
+    private static OrleansDcbExecutorConstruction<GeneralSekibanExecutor> CreateExceptionConstruction(
+        OrleansDcbExecutorConstructionInputs inputs) =>
+        OrleansDcbExecutorConstruction<GeneralSekibanExecutor>.Create(inputs, CreateExceptionGeneralExecutor);
+
+    private static GeneralSekibanExecutor CreateExceptionGeneralExecutor(
+        OrleansDcbExecutorConstructionInputs inputs,
+        IActorObjectAccessor actorAccessor,
+        IServiceIdProvider serviceIdProvider,
+        SortableUniqueIdWaitPolicy sortableUniqueIdWaitPolicy) =>
+        new(
+            inputs.EventStore,
+            actorAccessor,
+            inputs.DomainTypes,
+            inputs.EventPublisher,
+            inputs.ExecutedUserProvider,
+            inputs.SortableUniqueIdGenerator,
+            inputs.SortableUniqueIdSeedCoordinator,
+            serviceIdProvider,
+            sortableUniqueIdWaitPolicy,
+            inputs.ExecutorSizeGateOptions);
 
     /// <summary>
     ///     Execute a command with its built-in handler
@@ -154,7 +153,7 @@ public class OrleansDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecuto
     public Task<ExecutionResult> ExecuteAsync<TCommand>(
         TCommand command,
         CancellationToken cancellationToken = default) where TCommand : ICommandWithHandler<TCommand> =>
-        _generalExecutor.ExecuteAsync(command, cancellationToken);
+        _construction.GeneralExecutor.ExecuteAsync(command, cancellationToken);
 
     /// <summary>
     ///     Execute a command with a handler function
@@ -163,7 +162,7 @@ public class OrleansDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecuto
         TCommand command,
         Func<TCommand, ICommandContext, Task<EventOrNone>> handlerFunc,
         CancellationToken cancellationToken = default) where TCommand : ICommand =>
-        _generalExecutor.ExecuteAsync(command, handlerFunc, cancellationToken);
+        _construction.GeneralExecutor.ExecuteAsync(command, handlerFunc, cancellationToken);
 
     /// <summary>
     ///     Execute a handler function without an explicit command
@@ -171,16 +170,16 @@ public class OrleansDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecuto
     public Task<ExecutionResult> ExecuteCommandAsync(
         Func<ICommandContext, Task<EventOrNone>> handlerFunc,
         CancellationToken cancellationToken = default) =>
-        _generalExecutor.ExecuteCommandAsync(handlerFunc, cancellationToken);
+        _construction.GeneralExecutor.ExecuteCommandAsync(handlerFunc, cancellationToken);
 
     /// <summary>
     ///     Get the current state for a specific tag state
     /// </summary>
     public Task<TagState> GetTagStateAsync(TagStateId tagStateId) =>
-        _generalExecutor.GetTagStateAsync(tagStateId);
+        _construction.GeneralExecutor.GetTagStateAsync(tagStateId);
 
     public Task<TagState> GetTagStateAsync(TagStateId tagStateId, CancellationToken cancellationToken) =>
-        _generalExecutor.GetTagStateAsync(tagStateId, cancellationToken);
+        _construction.GeneralExecutor.GetTagStateAsync(tagStateId, cancellationToken);
 
     /// <summary>
     ///     Execute a single-result query using Orleans grains
@@ -189,7 +188,7 @@ public class OrleansDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecuto
     {
         var projectorName = ResolveProjectorName(queryCommon);
 
-        var result = await _queryExecutor.ExecuteQueryAsync(
+        var result = await _construction.QueryExecutor.ExecuteQueryAsync(
             queryCommon,
             projectorName,
             SortableUniqueIdWaitSurface.OrleansWithoutResultSingle);
@@ -205,7 +204,7 @@ public class OrleansDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecuto
     {
         var projectorName = ResolveProjectorName(queryCommon);
 
-        var result = await _queryExecutor.ExecuteListQueryAsync(
+        var result = await _construction.QueryExecutor.ExecuteListQueryAsync(
             queryCommon,
             projectorName,
             SortableUniqueIdWaitSurface.OrleansWithoutResultList);
@@ -218,7 +217,7 @@ public class OrleansDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecuto
         where TResult : notnull
     {
         var context = new BoundaryContext("ISekibanExecutor.QueryAsync", typeof(TResult).Name);
-        var general = await GuardedUnwrap.UnwrapAsync(result.ToQueryResultAsync(_domainTypes), context);
+        var general = await GuardedUnwrap.UnwrapAsync(result.ToQueryResultAsync(_construction.DomainTypes), context);
         return GuardedUnwrap.Unwrap(general.ToTypedResult<TResult>(), context);
     }
 
@@ -227,19 +226,19 @@ public class OrleansDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecuto
         where TResult : notnull
     {
         var context = new BoundaryContext("ISekibanExecutor.QueryAsync (list)", typeof(TResult).Name);
-        var listGeneral = await GuardedUnwrap.UnwrapAsync(result.ToListQueryResultAsync(_domainTypes), context);
+        var listGeneral = await GuardedUnwrap.UnwrapAsync(result.ToListQueryResultAsync(_construction.DomainTypes), context);
         return GuardedUnwrap.Unwrap(listGeneral.ToTypedResult<TResult>(), context);
     }
 
     public Task<string> GetLatestSortableUniqueIdAsync() =>
-        _generalExecutor.GetLatestSortableUniqueIdAsync();
+        _construction.GeneralExecutor.GetLatestSortableUniqueIdAsync();
 
     public async Task<ProjectionHeadStatus> GetProjectionHeadStatusAsync(
         string projectorName,
         string? expectedProjectorVersion = null)
     {
         var projectorVersionResult = ProjectionHeadStatusUtilities.ValidateProjectorVersion(
-            _domainTypes,
+            _construction.DomainTypes,
             projectorName,
             expectedProjectorVersion);
         if (!projectorVersionResult.IsSuccess)
@@ -247,8 +246,8 @@ public class OrleansDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecuto
             throw projectorVersionResult.GetException();
         }
 
-        var grainId = ServiceIdGrainKey.Build(_serviceIdProvider.GetCurrentServiceId(), projectorName);
-        var grain = _clusterClient.GetGrain<IMultiProjectionGrain>(grainId);
+        var grainId = ServiceIdGrainKey.Build(_construction.ServiceIdProvider.GetCurrentServiceId(), projectorName);
+        var grain = _construction.ClusterClient.GetGrain<IMultiProjectionGrain>(grainId);
         var grainStatus = await grain.GetProjectionHeadStatusAsync();
 
         var projectorNameResult = ProjectionHeadStatusUtilities.EnsureProjectorNameConsistency(
@@ -284,25 +283,25 @@ public class OrleansDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecuto
     }
 
     public Task<EventStoreHeadStatus> GetEventStoreHeadStatusAsync(bool includeTotalEventCount = false) =>
-        _generalExecutor.GetEventStoreHeadStatusAsync(includeTotalEventCount);
+        _construction.GeneralExecutor.GetEventStoreHeadStatusAsync(includeTotalEventCount);
 
     public Task<ResultBox<SerializableTagState>> GetSerializableTagStateAsync(TagStateId tagStateId) =>
-        _generalExecutor.GetSerializableTagStateAsync(tagStateId);
+        _construction.GeneralExecutor.GetSerializableTagStateAsync(tagStateId);
 
     public Task<ResultBox<SerializedCommitResult>> CommitSerializableEventsAsync(
         SerializedCommitRequest request,
         CancellationToken cancellationToken = default) =>
-        _generalExecutor.CommitSerializableEventsAsync(request, cancellationToken);
+        _construction.GeneralExecutor.CommitSerializableEventsAsync(request, cancellationToken);
 
     /// <summary>Forwards the additive V2 serialized expected-head contract to the common executor/store path.</summary>
     public Task<ResultBox<SerializedCommitResult>> CommitSerializableEventsWithExpectedTagPositionsAsync(
         VersionedExpectedTagPositionSerializedCommitRequest request,
         CancellationToken cancellationToken = default) =>
-        _generalExecutor.CommitSerializableEventsWithExpectedTagPositionsAsync(request, cancellationToken);
+        _construction.GeneralExecutor.CommitSerializableEventsWithExpectedTagPositionsAsync(request, cancellationToken);
 
     private string ResolveProjectorName(IQueryCommon queryCommon)
     {
-        var projectorTypeResult = _domainTypes.QueryTypes.GetMultiProjectorType(queryCommon);
+        var projectorTypeResult = _construction.DomainTypes.QueryTypes.GetMultiProjectorType(queryCommon);
         var projectorNameResult = ProjectionHeadStatusUtilities.ResolveProjectorName(projectorTypeResult);
         if (!projectorNameResult.IsSuccess)
         {
@@ -314,7 +313,7 @@ public class OrleansDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecuto
 
     private string ResolveProjectorName(IListQueryCommon queryCommon)
     {
-        var projectorTypeResult = _domainTypes.QueryTypes.GetMultiProjectorType(queryCommon);
+        var projectorTypeResult = _construction.DomainTypes.QueryTypes.GetMultiProjectorType(queryCommon);
         var projectorNameResult = ProjectionHeadStatusUtilities.ResolveProjectorName(projectorTypeResult);
         if (!projectorNameResult.IsSuccess)
         {

--- a/dcb/src/Sekiban.Dcb.Orleans.WithoutResult/OrleansDcbExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.WithoutResult/OrleansDcbExecutor.cs
@@ -10,6 +10,7 @@ using Sekiban.Dcb.Orleans.Grains;
 using Sekiban.Dcb.Orleans.ServiceId;
 using Sekiban.Dcb.Queries;
 using Sekiban.Dcb.ServiceId;
+using Sekiban.Dcb.SizeGates;
 using Sekiban.Dcb.Storage;
 using Sekiban.Dcb.Tags;
 using Sekiban.Dcb.Orleans.Serialization;
@@ -44,6 +45,29 @@ public class OrleansDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecuto
         IEventPublisher? eventPublisher,
         IServiceIdProvider? serviceIdProvider)
         : this(clusterClient, eventStore, domainTypes, eventPublisher, serviceIdProvider, null)
+    {
+    }
+
+    /// <summary>Additive opt-in size-gate constructor; existing Orleans construction remains ungated.</summary>
+    public OrleansDcbExecutor(
+        IClusterClient clusterClient,
+        IEventStore eventStore,
+        DcbDomainTypes domainTypes,
+        ExecutorSizeGateOptions executorSizeGateOptions,
+        IEventPublisher? eventPublisher = null,
+        IServiceIdProvider? serviceIdProvider = null,
+        IExecutedUserProvider? executedUserProvider = null)
+        : this(
+            clusterClient,
+            eventStore,
+            domainTypes,
+            eventPublisher,
+            serviceIdProvider,
+            executedUserProvider,
+            ProcessSharedSortableUniqueIdServices.Generator,
+            ProcessSharedSortableUniqueIdServices.SeedCoordinator,
+            SortableUniqueIdWaitPolicy.System,
+            executorSizeGateOptions)
     {
     }
 
@@ -100,6 +124,31 @@ public class OrleansDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecuto
         ISortableUniqueIdGenerator sortableUniqueIdGenerator,
         SortableUniqueIdSeedCoordinator sortableUniqueIdSeedCoordinator,
         SortableUniqueIdWaitPolicy sortableUniqueIdWaitPolicy)
+        : this(
+            clusterClient,
+            eventStore,
+            domainTypes,
+            eventPublisher,
+            serviceIdProvider,
+            executedUserProvider,
+            sortableUniqueIdGenerator,
+            sortableUniqueIdSeedCoordinator,
+            sortableUniqueIdWaitPolicy,
+            null)
+    {
+    }
+
+    internal OrleansDcbExecutor(
+        IClusterClient clusterClient,
+        IEventStore eventStore,
+        DcbDomainTypes domainTypes,
+        IEventPublisher? eventPublisher,
+        IServiceIdProvider? serviceIdProvider,
+        IExecutedUserProvider? executedUserProvider,
+        ISortableUniqueIdGenerator sortableUniqueIdGenerator,
+        SortableUniqueIdSeedCoordinator sortableUniqueIdSeedCoordinator,
+        SortableUniqueIdWaitPolicy sortableUniqueIdWaitPolicy,
+        ExecutorSizeGateOptions? executorSizeGateOptions)
     {
         _clusterClient = clusterClient ?? throw new ArgumentNullException(nameof(clusterClient));
         _eventStore = eventStore ?? throw new ArgumentNullException(nameof(eventStore));
@@ -117,7 +166,8 @@ public class OrleansDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecuto
             sortableUniqueIdGenerator,
             sortableUniqueIdSeedCoordinator,
             _serviceIdProvider,
-            _sortableUniqueIdWaitPolicy);
+            _sortableUniqueIdWaitPolicy,
+            executorSizeGateOptions);
     }
 
     /// <summary>

--- a/dcb/src/Sekiban.Dcb.Orleans.WithoutResult/OrleansDcbExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.WithoutResult/OrleansDcbExecutor.cs
@@ -32,6 +32,7 @@ public class OrleansDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecuto
     private readonly DcbDomainTypes _domainTypes;
     private readonly IEventStore _eventStore;
     private readonly GeneralSekibanExecutor _generalExecutor;
+    private readonly OrleansProjectionQueryExecutor _queryExecutor;
     private readonly IServiceIdProvider _serviceIdProvider;
     private readonly SortableUniqueIdWaitPolicy _sortableUniqueIdWaitPolicy;
 
@@ -137,6 +138,11 @@ public class OrleansDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecuto
         _sortableUniqueIdWaitPolicy = sortableUniqueIdWaitPolicy ??
                                       throw new ArgumentNullException(nameof(sortableUniqueIdWaitPolicy));
         _actorAccessor = new OrleansActorObjectAccessor(clusterClient, eventStore, domainTypes, _serviceIdProvider);
+        _queryExecutor = new OrleansProjectionQueryExecutor(
+            _clusterClient,
+            _domainTypes,
+            _serviceIdProvider,
+            _sortableUniqueIdWaitPolicy);
         _generalExecutor = new GeneralSekibanExecutor(eventStore, _actorAccessor, domainTypes, eventPublisher,
             executedUserProvider, sortableUniqueIdGenerator, sortableUniqueIdSeedCoordinator, _serviceIdProvider,
             _sortableUniqueIdWaitPolicy, executorSizeGateOptions);
@@ -183,21 +189,10 @@ public class OrleansDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecuto
     {
         var projectorName = ResolveProjectorName(queryCommon);
 
-        // Get the multi-projection grain directly
-        var grainId = ServiceIdGrainKey.Build(_serviceIdProvider.GetCurrentServiceId(), projectorName);
-        var grain = _clusterClient.GetGrain<IMultiProjectionGrain>(grainId);
-
-        // Wait for sortable unique ID if needed
-        await WaitForSortableUniqueIdIfNeeded(
-            grain,
+        var result = await _queryExecutor.ExecuteQueryAsync(
             queryCommon,
+            projectorName,
             SortableUniqueIdWaitSurface.OrleansWithoutResultSingle);
-
-        var serializableQuery = await SerializableQueryParameter.CreateFromAsync(
-            queryCommon,
-            _domainTypes.JsonSerializerOptions);
-
-        var result = await grain.ExecuteQueryAsync(serializableQuery);
 
         return await DeserializeQueryResultAsync<TResult>(result);
     }
@@ -210,77 +205,12 @@ public class OrleansDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecuto
     {
         var projectorName = ResolveProjectorName(queryCommon);
 
-        // Get the multi-projection grain directly
-        var grainId = ServiceIdGrainKey.Build(_serviceIdProvider.GetCurrentServiceId(), projectorName);
-        var grain = _clusterClient.GetGrain<IMultiProjectionGrain>(grainId);
-
-        // Wait for sortable unique ID if needed
-        await WaitForSortableUniqueIdIfNeeded(
-            grain,
+        var result = await _queryExecutor.ExecuteListQueryAsync(
             queryCommon,
+            projectorName,
             SortableUniqueIdWaitSurface.OrleansWithoutResultList);
 
-        var serializableQuery = await SerializableQueryParameter.CreateFromAsync(
-            queryCommon,
-            _domainTypes.JsonSerializerOptions);
-
-        var result = await grain.ExecuteListQueryAsync(serializableQuery);
-
         return await DeserializeListQueryResultAsync<TResult>(result);
-    }
-
-    /// <summary>
-    ///     Wait for a sortable unique ID to be processed if the query implements IWaitForSortableUniqueId.
-    ///     Strict marker queries fail before serialization when the wait times out; legacy queries keep fail-open.
-    /// </summary>
-    private async Task WaitForSortableUniqueIdIfNeeded(
-        IMultiProjectionGrain grain,
-        object query,
-        SortableUniqueIdWaitSurface surface)
-    {
-        if (query is not IWaitForSortableUniqueId waitForQuery ||
-            string.IsNullOrEmpty(waitForQuery.WaitForSortableUniqueId))
-        {
-            return;
-        }
-
-        var sortableUniqueId = waitForQuery.WaitForSortableUniqueId;
-        var strict = query is IStrictWaitForSortableUniqueId;
-        var wait = await _sortableUniqueIdWaitPolicy.WaitAsync(
-            sortableUniqueId,
-            surface,
-            strict ? SortableUniqueIdWaitMode.Strict : SortableUniqueIdWaitMode.Legacy,
-            cancellationToken => ProbeSortableUniqueIdAsync(grain, sortableUniqueId, cancellationToken),
-            strict
-                ? cancellationToken => ReadCurrentSortableUniqueIdAsync(grain, cancellationToken)
-                : null);
-
-        if (strict && wait.TimedOut)
-        {
-            throw new SortableUniqueIdWaitTimeoutException(
-                sortableUniqueId,
-                wait.Timeout,
-                wait.Elapsed,
-                wait.LastObservedSortableUniqueId);
-        }
-    }
-
-    private static async Task<bool> ProbeSortableUniqueIdAsync(
-        IMultiProjectionGrain grain,
-        string sortableUniqueId,
-        CancellationToken cancellationToken)
-    {
-        cancellationToken.ThrowIfCancellationRequested();
-        return await grain.IsSortableUniqueIdReceived(sortableUniqueId).ConfigureAwait(false);
-    }
-
-    private static async Task<string?> ReadCurrentSortableUniqueIdAsync(
-        IMultiProjectionGrain grain,
-        CancellationToken cancellationToken)
-    {
-        cancellationToken.ThrowIfCancellationRequested();
-        var status = await grain.GetProjectionHeadStatusAsync().ConfigureAwait(false);
-        return status.CurrentLastSortableUniqueId;
     }
 
     private async Task<TResult> DeserializeQueryResultAsync<TResult>(

--- a/dcb/src/Sekiban.Dcb.Orleans.WithoutResult/OrleansDcbExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.WithoutResult/OrleansDcbExecutor.cs
@@ -49,25 +49,12 @@ public class OrleansDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecuto
     }
 
     /// <summary>Additive opt-in size-gate constructor; existing Orleans construction remains ungated.</summary>
-    public OrleansDcbExecutor(
-        IClusterClient clusterClient,
-        IEventStore eventStore,
-        DcbDomainTypes domainTypes,
-        ExecutorSizeGateOptions executorSizeGateOptions,
-        IEventPublisher? eventPublisher = null,
-        IServiceIdProvider? serviceIdProvider = null,
-        IExecutedUserProvider? executedUserProvider = null)
-        : this(
-            clusterClient,
-            eventStore,
-            domainTypes,
-            eventPublisher,
-            serviceIdProvider,
-            executedUserProvider,
-            ProcessSharedSortableUniqueIdServices.Generator,
-            ProcessSharedSortableUniqueIdServices.SeedCoordinator,
-            SortableUniqueIdWaitPolicy.System,
-            executorSizeGateOptions)
+    public OrleansDcbExecutor(IClusterClient clusterClient, IEventStore eventStore, DcbDomainTypes domainTypes,
+        ExecutorSizeGateOptions executorSizeGateOptions, IEventPublisher? eventPublisher = null,
+        IServiceIdProvider? serviceIdProvider = null, IExecutedUserProvider? executedUserProvider = null)
+        : this(clusterClient, eventStore, domainTypes, eventPublisher, serviceIdProvider, executedUserProvider,
+            ProcessSharedSortableUniqueIdServices.Generator, ProcessSharedSortableUniqueIdServices.SeedCoordinator,
+            SortableUniqueIdWaitPolicy.System, executorSizeGateOptions)
     {
     }
 
@@ -138,17 +125,10 @@ public class OrleansDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecuto
     {
     }
 
-    internal OrleansDcbExecutor(
-        IClusterClient clusterClient,
-        IEventStore eventStore,
-        DcbDomainTypes domainTypes,
-        IEventPublisher? eventPublisher,
-        IServiceIdProvider? serviceIdProvider,
-        IExecutedUserProvider? executedUserProvider,
-        ISortableUniqueIdGenerator sortableUniqueIdGenerator,
-        SortableUniqueIdSeedCoordinator sortableUniqueIdSeedCoordinator,
-        SortableUniqueIdWaitPolicy sortableUniqueIdWaitPolicy,
-        ExecutorSizeGateOptions? executorSizeGateOptions)
+    internal OrleansDcbExecutor(IClusterClient clusterClient, IEventStore eventStore, DcbDomainTypes domainTypes,
+        IEventPublisher? eventPublisher, IServiceIdProvider? serviceIdProvider, IExecutedUserProvider? executedUserProvider,
+        ISortableUniqueIdGenerator sortableUniqueIdGenerator, SortableUniqueIdSeedCoordinator sortableUniqueIdSeedCoordinator,
+        SortableUniqueIdWaitPolicy sortableUniqueIdWaitPolicy, ExecutorSizeGateOptions? executorSizeGateOptions)
     {
         _clusterClient = clusterClient ?? throw new ArgumentNullException(nameof(clusterClient));
         _eventStore = eventStore ?? throw new ArgumentNullException(nameof(eventStore));
@@ -157,17 +137,9 @@ public class OrleansDcbExecutor : ISekibanExecutor, ISerializedSekibanDcbExecuto
         _sortableUniqueIdWaitPolicy = sortableUniqueIdWaitPolicy ??
                                       throw new ArgumentNullException(nameof(sortableUniqueIdWaitPolicy));
         _actorAccessor = new OrleansActorObjectAccessor(clusterClient, eventStore, domainTypes, _serviceIdProvider);
-        _generalExecutor = new GeneralSekibanExecutor(
-            eventStore,
-            _actorAccessor,
-            domainTypes,
-            eventPublisher,
-            executedUserProvider,
-            sortableUniqueIdGenerator,
-            sortableUniqueIdSeedCoordinator,
-            _serviceIdProvider,
-            _sortableUniqueIdWaitPolicy,
-            executorSizeGateOptions);
+        _generalExecutor = new GeneralSekibanExecutor(eventStore, _actorAccessor, domainTypes, eventPublisher,
+            executedUserProvider, sortableUniqueIdGenerator, sortableUniqueIdSeedCoordinator, _serviceIdProvider,
+            _sortableUniqueIdWaitPolicy, executorSizeGateOptions);
     }
 
     /// <summary>

--- a/dcb/src/Sekiban.Dcb.WithResult/Actors/GeneralSekibanExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.WithResult/Actors/GeneralSekibanExecutor.cs
@@ -47,22 +47,13 @@ public class GeneralSekibanExecutor : ISekibanExecutor, ISerializedSekibanDcbExe
     }
 
     /// <summary>Additive opt-in size-gate constructor; legacy construction remains ungated.</summary>
-    public GeneralSekibanExecutor(
-        IEventStore eventStore,
-        IActorObjectAccessor actorAccessor,
-        DcbDomainTypes domainTypes,
-        ExecutorSizeGateOptions executorSizeGateOptions,
-        IEventPublisher? eventPublisher = null,
+    public GeneralSekibanExecutor(IEventStore eventStore, IActorObjectAccessor actorAccessor, DcbDomainTypes domainTypes,
+        ExecutorSizeGateOptions executorSizeGateOptions, IEventPublisher? eventPublisher = null,
         IExecutedUserProvider? executedUserProvider = null)
     {
         _actorAccessor = actorAccessor;
-        _core = new CoreGeneralSekibanExecutor(
-            eventStore,
-            actorAccessor,
-            domainTypes,
-            executorSizeGateOptions,
-            eventPublisher,
-            executedUserProvider);
+        _core = CoreGeneralSekibanExecutorFactory.CreateWithGate(
+            eventStore, actorAccessor, domainTypes, executorSizeGateOptions, eventPublisher, executedUserProvider);
     }
 
     /// <summary>Creates an executor using the registered process-wide monotonic id allocator.</summary>
@@ -112,30 +103,16 @@ public class GeneralSekibanExecutor : ISekibanExecutor, ISerializedSekibanDcbExe
     {
     }
 
-    internal GeneralSekibanExecutor(
-        IEventStore eventStore,
-        IActorObjectAccessor actorAccessor,
-        DcbDomainTypes domainTypes,
-        IEventPublisher? eventPublisher,
-        IExecutedUserProvider? executedUserProvider,
-        ISortableUniqueIdGenerator sortableUniqueIdGenerator,
-        SortableUniqueIdSeedCoordinator sortableUniqueIdSeedCoordinator,
-        IServiceIdProvider serviceIdProvider,
-        SortableUniqueIdWaitPolicy sortableUniqueIdWaitPolicy,
+    internal GeneralSekibanExecutor(IEventStore eventStore, IActorObjectAccessor actorAccessor, DcbDomainTypes domainTypes,
+        IEventPublisher? eventPublisher, IExecutedUserProvider? executedUserProvider,
+        ISortableUniqueIdGenerator sortableUniqueIdGenerator, SortableUniqueIdSeedCoordinator sortableUniqueIdSeedCoordinator,
+        IServiceIdProvider serviceIdProvider, SortableUniqueIdWaitPolicy sortableUniqueIdWaitPolicy,
         ExecutorSizeGateOptions? executorSizeGateOptions)
     {
         _actorAccessor = actorAccessor;
-        _core = new CoreGeneralSekibanExecutor(
-            eventStore,
-            actorAccessor,
-            domainTypes,
-            eventPublisher,
-            executedUserProvider,
-            sortableUniqueIdGenerator,
-            sortableUniqueIdSeedCoordinator,
-            serviceIdProvider,
-            sortableUniqueIdWaitPolicy,
-            executorSizeGateOptions);
+        _core = CoreGeneralSekibanExecutorFactory.CreateWithServices(
+            eventStore, actorAccessor, domainTypes, eventPublisher, executedUserProvider, sortableUniqueIdGenerator,
+            sortableUniqueIdSeedCoordinator, serviceIdProvider, sortableUniqueIdWaitPolicy, executorSizeGateOptions);
     }
 
     /// <summary>

--- a/dcb/src/Sekiban.Dcb.WithResult/Actors/GeneralSekibanExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.WithResult/Actors/GeneralSekibanExecutor.cs
@@ -50,10 +50,11 @@ public class GeneralSekibanExecutor : ISekibanExecutor, ISerializedSekibanDcbExe
     public GeneralSekibanExecutor(IEventStore eventStore, IActorObjectAccessor actorAccessor, DcbDomainTypes domainTypes,
         ExecutorSizeGateOptions executorSizeGateOptions, IEventPublisher? eventPublisher = null,
         IExecutedUserProvider? executedUserProvider = null)
+        : this(CreateResultConstruction(
+            actorAccessor,
+            () => CoreGeneralSekibanExecutorFactory.CreateWithGate(
+                eventStore, actorAccessor, domainTypes, executorSizeGateOptions, eventPublisher, executedUserProvider)))
     {
-        _actorAccessor = actorAccessor;
-        _core = CoreGeneralSekibanExecutorFactory.CreateWithGate(
-            eventStore, actorAccessor, domainTypes, executorSizeGateOptions, eventPublisher, executedUserProvider);
     }
 
     /// <summary>Creates an executor using the registered process-wide monotonic id allocator.</summary>
@@ -89,17 +90,12 @@ public class GeneralSekibanExecutor : ISekibanExecutor, ISerializedSekibanDcbExe
         SortableUniqueIdSeedCoordinator sortableUniqueIdSeedCoordinator,
         IServiceIdProvider serviceIdProvider,
         SortableUniqueIdWaitPolicy sortableUniqueIdWaitPolicy)
-        : this(
-            eventStore,
+        : this(CreateResultConstruction(
             actorAccessor,
-            domainTypes,
-            eventPublisher,
-            executedUserProvider,
-            sortableUniqueIdGenerator,
-            sortableUniqueIdSeedCoordinator,
-            serviceIdProvider,
-            sortableUniqueIdWaitPolicy,
-            null)
+            () => CoreGeneralSekibanExecutorFactory.CreateWithServices(
+                eventStore, actorAccessor, domainTypes, eventPublisher, executedUserProvider,
+                sortableUniqueIdGenerator, sortableUniqueIdSeedCoordinator, serviceIdProvider,
+                sortableUniqueIdWaitPolicy, null)))
     {
     }
 
@@ -108,12 +104,25 @@ public class GeneralSekibanExecutor : ISekibanExecutor, ISerializedSekibanDcbExe
         ISortableUniqueIdGenerator sortableUniqueIdGenerator, SortableUniqueIdSeedCoordinator sortableUniqueIdSeedCoordinator,
         IServiceIdProvider serviceIdProvider, SortableUniqueIdWaitPolicy sortableUniqueIdWaitPolicy,
         ExecutorSizeGateOptions? executorSizeGateOptions)
+        : this(CreateResultConstruction(
+            actorAccessor,
+            () => CoreGeneralSekibanExecutorFactory.CreateWithServices(
+                eventStore, actorAccessor, domainTypes, eventPublisher, executedUserProvider,
+                sortableUniqueIdGenerator, sortableUniqueIdSeedCoordinator, serviceIdProvider,
+                sortableUniqueIdWaitPolicy, executorSizeGateOptions)))
     {
-        _actorAccessor = actorAccessor;
-        _core = CoreGeneralSekibanExecutorFactory.CreateWithServices(
-            eventStore, actorAccessor, domainTypes, eventPublisher, executedUserProvider, sortableUniqueIdGenerator,
-            sortableUniqueIdSeedCoordinator, serviceIdProvider, sortableUniqueIdWaitPolicy, executorSizeGateOptions);
     }
+
+    private GeneralSekibanExecutor(GeneralSekibanExecutorConstruction construction)
+    {
+        _actorAccessor = construction.ActorAccessor;
+        _core = construction.Core;
+    }
+
+    private static GeneralSekibanExecutorConstruction CreateResultConstruction(
+        IActorObjectAccessor actorAccessor,
+        Func<CoreGeneralSekibanExecutor> createCore) =>
+        new(actorAccessor, createCore());
 
     /// <summary>
     ///     This executor is whatever its accessor is. It has no runtime of its own — commands go wherever the accessor

--- a/dcb/src/Sekiban.Dcb.WithResult/Actors/GeneralSekibanExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.WithResult/Actors/GeneralSekibanExecutor.cs
@@ -6,6 +6,7 @@ using Sekiban.Dcb.Common;
 using Sekiban.Dcb.Events;
 using Sekiban.Dcb.Queries;
 using Sekiban.Dcb.ServiceId;
+using Sekiban.Dcb.SizeGates;
 using Sekiban.Dcb.Storage;
 using Sekiban.Dcb.Tags;
 namespace Sekiban.Dcb.Actors;
@@ -45,6 +46,25 @@ public class GeneralSekibanExecutor : ISekibanExecutor, ISerializedSekibanDcbExe
         _core = new CoreGeneralSekibanExecutor(eventStore, actorAccessor, domainTypes, eventPublisher, executedUserProvider);
     }
 
+    /// <summary>Additive opt-in size-gate constructor; legacy construction remains ungated.</summary>
+    public GeneralSekibanExecutor(
+        IEventStore eventStore,
+        IActorObjectAccessor actorAccessor,
+        DcbDomainTypes domainTypes,
+        ExecutorSizeGateOptions executorSizeGateOptions,
+        IEventPublisher? eventPublisher = null,
+        IExecutedUserProvider? executedUserProvider = null)
+    {
+        _actorAccessor = actorAccessor;
+        _core = new CoreGeneralSekibanExecutor(
+            eventStore,
+            actorAccessor,
+            domainTypes,
+            executorSizeGateOptions,
+            eventPublisher,
+            executedUserProvider);
+    }
+
     /// <summary>Creates an executor using the registered process-wide monotonic id allocator.</summary>
     public GeneralSekibanExecutor(
         IEventStore eventStore,
@@ -78,6 +98,31 @@ public class GeneralSekibanExecutor : ISekibanExecutor, ISerializedSekibanDcbExe
         SortableUniqueIdSeedCoordinator sortableUniqueIdSeedCoordinator,
         IServiceIdProvider serviceIdProvider,
         SortableUniqueIdWaitPolicy sortableUniqueIdWaitPolicy)
+        : this(
+            eventStore,
+            actorAccessor,
+            domainTypes,
+            eventPublisher,
+            executedUserProvider,
+            sortableUniqueIdGenerator,
+            sortableUniqueIdSeedCoordinator,
+            serviceIdProvider,
+            sortableUniqueIdWaitPolicy,
+            null)
+    {
+    }
+
+    internal GeneralSekibanExecutor(
+        IEventStore eventStore,
+        IActorObjectAccessor actorAccessor,
+        DcbDomainTypes domainTypes,
+        IEventPublisher? eventPublisher,
+        IExecutedUserProvider? executedUserProvider,
+        ISortableUniqueIdGenerator sortableUniqueIdGenerator,
+        SortableUniqueIdSeedCoordinator sortableUniqueIdSeedCoordinator,
+        IServiceIdProvider serviceIdProvider,
+        SortableUniqueIdWaitPolicy sortableUniqueIdWaitPolicy,
+        ExecutorSizeGateOptions? executorSizeGateOptions)
     {
         _actorAccessor = actorAccessor;
         _core = new CoreGeneralSekibanExecutor(
@@ -89,7 +134,8 @@ public class GeneralSekibanExecutor : ISekibanExecutor, ISerializedSekibanDcbExe
             sortableUniqueIdGenerator,
             sortableUniqueIdSeedCoordinator,
             serviceIdProvider,
-            sortableUniqueIdWaitPolicy);
+            sortableUniqueIdWaitPolicy,
+            executorSizeGateOptions);
     }
 
     /// <summary>

--- a/dcb/src/Sekiban.Dcb.WithoutResult/Actors/GeneralSekibanExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.WithoutResult/Actors/GeneralSekibanExecutor.cs
@@ -7,6 +7,7 @@ using Sekiban.Dcb.Common;
 using Sekiban.Dcb.Events;
 using Sekiban.Dcb.Queries;
 using Sekiban.Dcb.ServiceId;
+using Sekiban.Dcb.SizeGates;
 using Sekiban.Dcb.Storage;
 using Sekiban.Dcb.Tags;
 namespace Sekiban.Dcb.Actors;
@@ -46,6 +47,25 @@ public class GeneralSekibanExecutor : ISekibanExecutor, ISerializedSekibanDcbExe
         _core = new CoreGeneralSekibanExecutor(eventStore, actorAccessor, domainTypes, eventPublisher, executedUserProvider);
     }
 
+    /// <summary>Additive opt-in size-gate constructor; legacy construction remains ungated.</summary>
+    public GeneralSekibanExecutor(
+        IEventStore eventStore,
+        IActorObjectAccessor actorAccessor,
+        DcbDomainTypes domainTypes,
+        ExecutorSizeGateOptions executorSizeGateOptions,
+        IEventPublisher? eventPublisher = null,
+        IExecutedUserProvider? executedUserProvider = null)
+    {
+        _actorAccessor = actorAccessor;
+        _core = new CoreGeneralSekibanExecutor(
+            eventStore,
+            actorAccessor,
+            domainTypes,
+            executorSizeGateOptions,
+            eventPublisher,
+            executedUserProvider);
+    }
+
     /// <summary>Creates an executor using the registered process-wide monotonic id allocator.</summary>
     public GeneralSekibanExecutor(
         IEventStore eventStore,
@@ -79,6 +99,31 @@ public class GeneralSekibanExecutor : ISekibanExecutor, ISerializedSekibanDcbExe
         SortableUniqueIdSeedCoordinator sortableUniqueIdSeedCoordinator,
         IServiceIdProvider serviceIdProvider,
         SortableUniqueIdWaitPolicy sortableUniqueIdWaitPolicy)
+        : this(
+            eventStore,
+            actorAccessor,
+            domainTypes,
+            eventPublisher,
+            executedUserProvider,
+            sortableUniqueIdGenerator,
+            sortableUniqueIdSeedCoordinator,
+            serviceIdProvider,
+            sortableUniqueIdWaitPolicy,
+            null)
+    {
+    }
+
+    internal GeneralSekibanExecutor(
+        IEventStore eventStore,
+        IActorObjectAccessor actorAccessor,
+        DcbDomainTypes domainTypes,
+        IEventPublisher? eventPublisher,
+        IExecutedUserProvider? executedUserProvider,
+        ISortableUniqueIdGenerator sortableUniqueIdGenerator,
+        SortableUniqueIdSeedCoordinator sortableUniqueIdSeedCoordinator,
+        IServiceIdProvider serviceIdProvider,
+        SortableUniqueIdWaitPolicy sortableUniqueIdWaitPolicy,
+        ExecutorSizeGateOptions? executorSizeGateOptions)
     {
         _actorAccessor = actorAccessor;
         _core = new CoreGeneralSekibanExecutor(
@@ -90,7 +135,8 @@ public class GeneralSekibanExecutor : ISekibanExecutor, ISerializedSekibanDcbExe
             sortableUniqueIdGenerator,
             sortableUniqueIdSeedCoordinator,
             serviceIdProvider,
-            sortableUniqueIdWaitPolicy);
+            sortableUniqueIdWaitPolicy,
+            executorSizeGateOptions);
     }
 
     /// <summary>

--- a/dcb/src/Sekiban.Dcb.WithoutResult/Actors/GeneralSekibanExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.WithoutResult/Actors/GeneralSekibanExecutor.cs
@@ -51,10 +51,11 @@ public class GeneralSekibanExecutor : ISekibanExecutor, ISerializedSekibanDcbExe
     public GeneralSekibanExecutor(IEventStore eventStore, IActorObjectAccessor actorAccessor, DcbDomainTypes domainTypes,
         ExecutorSizeGateOptions executorSizeGateOptions, IEventPublisher? eventPublisher = null,
         IExecutedUserProvider? executedUserProvider = null)
+        : this(CreateExceptionConstruction(
+            actorAccessor,
+            () => CoreGeneralSekibanExecutorFactory.CreateWithGate(
+                eventStore, actorAccessor, domainTypes, executorSizeGateOptions, eventPublisher, executedUserProvider)))
     {
-        _actorAccessor = actorAccessor;
-        _core = CoreGeneralSekibanExecutorFactory.CreateWithGate(
-            eventStore, actorAccessor, domainTypes, executorSizeGateOptions, eventPublisher, executedUserProvider);
     }
 
     /// <summary>Creates an executor using the registered process-wide monotonic id allocator.</summary>
@@ -90,17 +91,12 @@ public class GeneralSekibanExecutor : ISekibanExecutor, ISerializedSekibanDcbExe
         SortableUniqueIdSeedCoordinator sortableUniqueIdSeedCoordinator,
         IServiceIdProvider serviceIdProvider,
         SortableUniqueIdWaitPolicy sortableUniqueIdWaitPolicy)
-        : this(
-            eventStore,
+        : this(CreateExceptionConstruction(
             actorAccessor,
-            domainTypes,
-            eventPublisher,
-            executedUserProvider,
-            sortableUniqueIdGenerator,
-            sortableUniqueIdSeedCoordinator,
-            serviceIdProvider,
-            sortableUniqueIdWaitPolicy,
-            null)
+            () => CoreGeneralSekibanExecutorFactory.CreateWithServices(
+                eventStore, actorAccessor, domainTypes, eventPublisher, executedUserProvider,
+                sortableUniqueIdGenerator, sortableUniqueIdSeedCoordinator, serviceIdProvider,
+                sortableUniqueIdWaitPolicy, null)))
     {
     }
 
@@ -109,12 +105,25 @@ public class GeneralSekibanExecutor : ISekibanExecutor, ISerializedSekibanDcbExe
         ISortableUniqueIdGenerator sortableUniqueIdGenerator, SortableUniqueIdSeedCoordinator sortableUniqueIdSeedCoordinator,
         IServiceIdProvider serviceIdProvider, SortableUniqueIdWaitPolicy sortableUniqueIdWaitPolicy,
         ExecutorSizeGateOptions? executorSizeGateOptions)
+        : this(CreateExceptionConstruction(
+            actorAccessor,
+            () => CoreGeneralSekibanExecutorFactory.CreateWithServices(
+                eventStore, actorAccessor, domainTypes, eventPublisher, executedUserProvider,
+                sortableUniqueIdGenerator, sortableUniqueIdSeedCoordinator, serviceIdProvider,
+                sortableUniqueIdWaitPolicy, executorSizeGateOptions)))
     {
-        _actorAccessor = actorAccessor;
-        _core = CoreGeneralSekibanExecutorFactory.CreateWithServices(
-            eventStore, actorAccessor, domainTypes, eventPublisher, executedUserProvider, sortableUniqueIdGenerator,
-            sortableUniqueIdSeedCoordinator, serviceIdProvider, sortableUniqueIdWaitPolicy, executorSizeGateOptions);
     }
+
+    private GeneralSekibanExecutor(GeneralSekibanExecutorConstruction construction)
+    {
+        _actorAccessor = construction.ActorAccessor;
+        _core = construction.Core;
+    }
+
+    private static GeneralSekibanExecutorConstruction CreateExceptionConstruction(
+        IActorObjectAccessor actorAccessor,
+        Func<CoreGeneralSekibanExecutor> createCore) =>
+        new(actorAccessor, createCore());
 
     /// <summary>
     ///     This executor is whatever its accessor is. It has no runtime of its own — commands go wherever the accessor

--- a/dcb/src/Sekiban.Dcb.WithoutResult/Actors/GeneralSekibanExecutor.cs
+++ b/dcb/src/Sekiban.Dcb.WithoutResult/Actors/GeneralSekibanExecutor.cs
@@ -48,22 +48,13 @@ public class GeneralSekibanExecutor : ISekibanExecutor, ISerializedSekibanDcbExe
     }
 
     /// <summary>Additive opt-in size-gate constructor; legacy construction remains ungated.</summary>
-    public GeneralSekibanExecutor(
-        IEventStore eventStore,
-        IActorObjectAccessor actorAccessor,
-        DcbDomainTypes domainTypes,
-        ExecutorSizeGateOptions executorSizeGateOptions,
-        IEventPublisher? eventPublisher = null,
+    public GeneralSekibanExecutor(IEventStore eventStore, IActorObjectAccessor actorAccessor, DcbDomainTypes domainTypes,
+        ExecutorSizeGateOptions executorSizeGateOptions, IEventPublisher? eventPublisher = null,
         IExecutedUserProvider? executedUserProvider = null)
     {
         _actorAccessor = actorAccessor;
-        _core = new CoreGeneralSekibanExecutor(
-            eventStore,
-            actorAccessor,
-            domainTypes,
-            executorSizeGateOptions,
-            eventPublisher,
-            executedUserProvider);
+        _core = CoreGeneralSekibanExecutorFactory.CreateWithGate(
+            eventStore, actorAccessor, domainTypes, executorSizeGateOptions, eventPublisher, executedUserProvider);
     }
 
     /// <summary>Creates an executor using the registered process-wide monotonic id allocator.</summary>
@@ -113,30 +104,16 @@ public class GeneralSekibanExecutor : ISekibanExecutor, ISerializedSekibanDcbExe
     {
     }
 
-    internal GeneralSekibanExecutor(
-        IEventStore eventStore,
-        IActorObjectAccessor actorAccessor,
-        DcbDomainTypes domainTypes,
-        IEventPublisher? eventPublisher,
-        IExecutedUserProvider? executedUserProvider,
-        ISortableUniqueIdGenerator sortableUniqueIdGenerator,
-        SortableUniqueIdSeedCoordinator sortableUniqueIdSeedCoordinator,
-        IServiceIdProvider serviceIdProvider,
-        SortableUniqueIdWaitPolicy sortableUniqueIdWaitPolicy,
+    internal GeneralSekibanExecutor(IEventStore eventStore, IActorObjectAccessor actorAccessor, DcbDomainTypes domainTypes,
+        IEventPublisher? eventPublisher, IExecutedUserProvider? executedUserProvider,
+        ISortableUniqueIdGenerator sortableUniqueIdGenerator, SortableUniqueIdSeedCoordinator sortableUniqueIdSeedCoordinator,
+        IServiceIdProvider serviceIdProvider, SortableUniqueIdWaitPolicy sortableUniqueIdWaitPolicy,
         ExecutorSizeGateOptions? executorSizeGateOptions)
     {
         _actorAccessor = actorAccessor;
-        _core = new CoreGeneralSekibanExecutor(
-            eventStore,
-            actorAccessor,
-            domainTypes,
-            eventPublisher,
-            executedUserProvider,
-            sortableUniqueIdGenerator,
-            sortableUniqueIdSeedCoordinator,
-            serviceIdProvider,
-            sortableUniqueIdWaitPolicy,
-            executorSizeGateOptions);
+        _core = CoreGeneralSekibanExecutorFactory.CreateWithServices(
+            eventStore, actorAccessor, domainTypes, eventPublisher, executedUserProvider, sortableUniqueIdGenerator,
+            sortableUniqueIdSeedCoordinator, serviceIdProvider, sortableUniqueIdWaitPolicy, executorSizeGateOptions);
     }
 
     /// <summary>

--- a/dcb/tests/Sekiban.Dcb.MaterializedView.Postgres.Tests/MaterializedViewPostgresOrleansTests.cs
+++ b/dcb/tests/Sekiban.Dcb.MaterializedView.Postgres.Tests/MaterializedViewPostgresOrleansTests.cs
@@ -1070,6 +1070,10 @@ public sealed class MaterializedViewPostgresOrleansTests(MaterializedViewPostgre
             .GetStreamProvider("EventStreamProvider")
             .GetStream<SerializableEvent>(StreamId.Create(streamNamespace, Guid.Empty));
 
+        var holdCatchUpTicks = 0;
+        using var baselineCatchUpGate = MaterializedViewGrain.PushBeforeCatchUpTestGate(
+            _ => Volatile.Read(ref holdCatchUpTicks) != 0);
+
         await stream.OnNextAsync(advancedCreate);
         await stream.OnNextAsync(delayedUpdate);
 
@@ -1122,6 +1126,20 @@ public sealed class MaterializedViewPostgresOrleansTests(MaterializedViewPostgre
                    advancedRow.LastSortableUniqueId == advancedCreate.SortableUniqueIdValue &&
                    receipt.LastStreamReceivedAt is not null &&
                    receipt.LastStreamReceivedSortableUniqueId == delayedUpdate.SortableUniqueIdValue;
+        }, timeoutMs: 15000);
+
+        // The fixture intentionally polls every 50 ms with no safe-window delay. Once the durable rows and receipt
+        // are observed, hold only the scheduler entry point while the current tick drains so the baseline status and
+        // state are one stable observation rather than racing a newly-started idle probe.
+        Volatile.Write(ref holdCatchUpTicks, 1);
+        await WaitUntilAsync(async () =>
+        {
+            var status = await grain.GetStatusAsync();
+            return status.LastCatchUpAttemptAt is not null &&
+                   !status.CatchUpInProgress &&
+                   !status.IsCatchUpActive &&
+                   !status.CatchUpHalted &&
+                   status.BufferedEventCount == 0;
         }, timeoutMs: 15000);
 
         async Task<(RegistryProjectionRow Registry, WeatherProjectionRow? DelayedRow, WeatherProjectionRow? AdvancedRow)> ReadStateAsync()
@@ -1185,6 +1203,8 @@ public sealed class MaterializedViewPostgresOrleansTests(MaterializedViewPostgre
         Assert.Equal(delayedUpdate.SortableUniqueIdValue, beforeDuplicate.DelayedRow.LastSortableUniqueId);
         Assert.NotNull(beforeDuplicate.AdvancedRow);
         Assert.Equal(advancedCreate.SortableUniqueIdValue, beforeDuplicate.AdvancedRow.LastSortableUniqueId);
+
+        Volatile.Write(ref holdCatchUpTicks, 0);
 
         // The predecessor notification is an older duplicate receipt: it must be observable as a receipt without
         // regressing the durable checkpoint, invoking stream DML, or reapplying any event.

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/ExecutorSizeGateCompatibilityTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/ExecutorSizeGateCompatibilityTests.cs
@@ -1,0 +1,69 @@
+using Dcb.Domain;
+using Dcb.Domain.Weather;
+using Microsoft.Extensions.DependencyInjection;
+using Orleans;
+using ResultBoxes;
+using System.Reflection;
+using Sekiban.Dcb.Actors;
+using Sekiban.Dcb.Commands;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.SizeGates;
+using Sekiban.Dcb.Storage;
+using Sekiban.Dcb.Tags;
+using CoreInMemoryEventStore = Sekiban.Dcb.Testing.InMemoryEventStore;
+using OrleansExecutor = Sekiban.Dcb.Orleans.OrleansDcbExecutor;
+
+namespace Sekiban.Dcb.Tests;
+
+public sealed class ExecutorSizeGateCompatibilityTests
+{
+    [Fact]
+    public void WithResultFacades_KeepLegacyConstructorsAndExposeAdditiveGateConstructors()
+    {
+        Assert.Contains(
+            typeof(GeneralSekibanExecutor).GetConstructors(),
+            constructor => constructor.GetParameters().Any(p => p.ParameterType == typeof(ExecutorSizeGateOptions)));
+
+        var orleansType = Assembly.Load("Sekiban.Dcb.Orleans.WithResult")
+            .GetType("Sekiban.Dcb.Orleans.OrleansDcbExecutor");
+        Assert.NotNull(orleansType);
+        Assert.Contains(
+            orleansType!.GetConstructors(BindingFlags.Instance | BindingFlags.Public),
+            constructor => constructor.GetParameters().Any(p => p.ParameterType == typeof(ExecutorSizeGateOptions)));
+    }
+
+    [Fact]
+    public async Task OrleansDi_ResolvesTheOptInGateAndRejectsBeforeTheStore()
+    {
+        var domain = DomainType.GetDomainTypes();
+        var store = new CoreInMemoryEventStore(domain.EventTypes);
+        var services = new ServiceCollection()
+            .AddSingleton(domain)
+            .AddSingleton<IEventStore>(store)
+            .AddSingleton<IClusterClient>(DispatchProxy.Create<IClusterClient, UnusedClusterClientProxy>())
+            .AddSekibanDcbExecutorSizeGate(options => options.Add(new ExecutorSizePolicy(
+                "logical-event",
+                ExecutorSizeRepresentation.LogicalSerializedEventUtf8,
+                maxBytesPerEvent: 1)))
+            .AddTransient<OrleansExecutor>();
+
+        using var provider = services.BuildServiceProvider();
+        var executor = provider.GetRequiredService<OrleansExecutor>();
+        var result = await executor.ExecuteAsync(
+            new OrleansGateCommand(Guid.NewGuid()),
+            (command, _) => Task.FromResult(EventOrNone.Event(
+                new WeatherForecastCreated(command.Id, "Tokyo", new DateOnly(2026, 9, 9), 21, "size gate"),
+                new FallbackTag("gate", command.Id.ToString("N")))));
+
+        Assert.IsType<ExecutorSizeLimitExceededException>(result.GetException());
+        Assert.Empty((await store.ReadAllSerializableEventsAsync()).GetValue());
+    }
+
+    private sealed record OrleansGateCommand(Guid Id) : ICommand;
+
+    private class UnusedClusterClientProxy : DispatchProxy
+    {
+        protected override object? Invoke(MethodInfo? targetMethod, object?[]? args) =>
+            throw new InvalidOperationException($"Unexpected cluster call: {targetMethod?.Name}");
+    }
+}

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/ExecutorSizeGateTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/ExecutorSizeGateTests.cs
@@ -13,6 +13,7 @@ using Sekiban.Dcb.SizeGates;
 using Sekiban.Dcb.Storage;
 using Sekiban.Dcb.Tags;
 using Sekiban.Dcb.Testing;
+using Sekiban.Dcb.TestSupport;
 using CoreInMemoryEventStore = Sekiban.Dcb.Testing.InMemoryEventStore;
 
 namespace Sekiban.Dcb.Tests;
@@ -392,6 +393,72 @@ public sealed class ExecutorSizeGateTests
     }
 
     [Fact]
+    public async Task SerializedConditional_UnbindablePayload_StrictGateFailsBeforeProviderWrite()
+    {
+        var domain = DomainType.GetDomainTypes();
+        var (executor, store) = CreateSerializedConditionalExecutor(
+            domain,
+            ExecutorSizeStrictness.Strict,
+            _ => throw new InvalidOperationException("conditional provider must not be reached"));
+
+        var result = await ((ISerializedConditionalSekibanDcbExecutor)executor)
+            .CommitSerializableEventConditionallyAsync(CreateUnbindableConditionalRequest());
+
+        var exception = Assert.IsType<ExecutorSizeCapabilityException>(result.GetException());
+        Assert.Equal("serialized-conditional", exception.Scope);
+        Assert.Equal(ExecutorSizeRepresentation.LogicalSerializedEventUtf8, exception.Representation);
+        Assert.Contains("binding capability is unavailable", exception.Reason);
+        Assert.Equal(0, store.AppendAttempts);
+    }
+
+    [Fact]
+    public async Task SerializedConditional_UnbindablePayload_NonStrictGatePreservesProviderInDoubt()
+    {
+        var domain = DomainType.GetDomainTypes();
+        var providerException = ConditionalAppendInDoubtException.Create(
+            "TestProvider",
+            "svc-42",
+            Guid.NewGuid(),
+            ConditionalAppendInDoubtReason.AmbiguousAfterWrite,
+            new InvalidOperationException("provider conflict cause"));
+        var (executor, store) = CreateSerializedConditionalExecutor(
+            domain,
+            ExecutorSizeStrictness.NonStrict,
+            _ => ResultBox.Error<ConditionalAppendReceipt>(providerException));
+
+        var result = await ((ISerializedConditionalSekibanDcbExecutor)executor)
+            .CommitSerializableEventConditionallyAsync(CreateUnbindableConditionalRequest());
+
+        Assert.False(result.IsSuccess);
+        Assert.Same(providerException, result.GetException());
+        Assert.Equal(1, store.AppendAttempts);
+    }
+
+    [Fact]
+    public async Task SerializedConditional_UnbindablePayload_NonStrictGateReturnsUnvalidatedDiagnostic()
+    {
+        var domain = DomainType.GetDomainTypes();
+        var (executor, store) = CreateSerializedConditionalExecutor(
+            domain,
+            ExecutorSizeStrictness.NonStrict,
+            _ => ResultBox.FromValue(new ConditionalAppendReceipt(
+                ConditionalAppendStatus.Appended,
+                Guid.NewGuid(),
+                SortableUniqueId.GenerateNew(),
+                "provider-fingerprint")));
+
+        var result = await ((ISerializedConditionalSekibanDcbExecutor)executor)
+            .CommitSerializableEventConditionallyAsync(CreateUnbindableConditionalRequest());
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(1, store.AppendAttempts);
+        var diagnostic = Assert.Single(result.GetValue().SizeGateDiagnostics);
+        Assert.Equal("serialized-conditional", diagnostic.Scope);
+        Assert.Equal(ExecutorSizeRepresentation.LogicalSerializedEventUtf8, diagnostic.Representation);
+        Assert.Contains("binding capability is unavailable", diagnostic.Reason);
+    }
+
+    [Fact]
     public async Task DestinationPolicy_UsesCapturedPlanAndDoesNotResolveAgain()
     {
         var domain = DomainType.GetDomainTypes();
@@ -599,6 +666,34 @@ public sealed class ExecutorSizeGateTests
         IActorObjectAccessor? actorAccessor = null,
         IExecutedUserProvider? executedUserProvider = null) =>
         new(store, actorAccessor ?? new InMemoryObjectAccessor(store, domain), domain, options, publisher, executedUserProvider);
+
+    private static (GeneralSekibanExecutor Executor, OutcomeForcingConditionalEventStore Store)
+        CreateSerializedConditionalExecutor(
+            DcbDomainTypes domain,
+            ExecutorSizeStrictness strictness,
+            Func<ConditionalAppendRequest, ResultBox<ConditionalAppendReceipt>> outcome)
+    {
+        var innerStore = new InMemoryConditionalEventStore(domain.EventTypes);
+        var store = new OutcomeForcingConditionalEventStore(innerStore, outcome);
+        var executor = CreateExecutor(
+            domain,
+            store,
+            new ExecutorSizeGateOptions().Add(new ExecutorSizePolicy(
+                "serialized-conditional",
+                ExecutorSizeRepresentation.LogicalSerializedEventUtf8,
+                maxBytesPerEvent: 1024,
+                strictness: strictness)));
+        return (executor, store);
+    }
+
+    private static SerializedConditionalCommitRequest CreateUnbindableConditionalRequest() =>
+        new(
+            SerializedConditionalCommitRequest.CurrentVersion,
+            new SerializableEventCandidate(
+                JsonSerializer.SerializeToUtf8Bytes(new { Value = "unbound" }),
+                "UnregisteredConditionalPayload",
+                Array.Empty<string>()),
+            $"unbound-conditional-{Guid.NewGuid():N}");
 
     private static SerializedCommitRequest SingleSerializedRequest(DcbDomainTypes domain, Guid id)
     {

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/ExecutorSizeGateTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/ExecutorSizeGateTests.cs
@@ -1,0 +1,580 @@
+using System.Text.Json;
+using Dcb.Domain;
+using Dcb.Domain.Weather;
+using Microsoft.Extensions.DependencyInjection;
+using ResultBoxes;
+using Sekiban.Dcb.Actors;
+using Sekiban.Dcb.Capabilities;
+using Sekiban.Dcb.Commands;
+using Sekiban.Dcb.Common;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.ServiceId;
+using Sekiban.Dcb.SizeGates;
+using Sekiban.Dcb.Storage;
+using Sekiban.Dcb.Tags;
+using Sekiban.Dcb.Testing;
+using CoreInMemoryEventStore = Sekiban.Dcb.Testing.InMemoryEventStore;
+
+namespace Sekiban.Dcb.Tests;
+
+public sealed class ExecutorSizeGateTests
+{
+    [Fact]
+    public async Task LogicalPolicy_RejectsTypedCommandBeforeAnyDurableEvent()
+    {
+        var domain = DomainType.GetDomainTypes();
+        var store = new CoreInMemoryEventStore(domain.EventTypes);
+        var executor = CreateExecutor(
+            domain,
+            store,
+            new ExecutorSizeGateOptions().Add(new ExecutorSizePolicy(
+                "logical-event",
+                ExecutorSizeRepresentation.LogicalSerializedEventUtf8,
+                maxBytesPerEvent: 1)));
+
+        var result = await executor.ExecuteAsync(new CreateWeatherForecast
+        {
+            ForecastId = Guid.NewGuid(),
+            Location = "東京",
+            Date = new DateOnly(2026, 9, 9),
+            TemperatureC = 21,
+            Summary = "サイズゲート"
+        });
+
+        var exception = Assert.IsType<ExecutorSizeLimitExceededException>(result.GetException());
+        Assert.Equal("logical-event", exception.Scope);
+        Assert.Equal(ExecutorSizeRepresentation.LogicalSerializedEventUtf8, exception.Representation);
+        Assert.True(exception.MeasuredBytes > exception.LimitBytes);
+        Assert.Empty((await store.ReadAllSerializableEventsAsync()).GetValue());
+    }
+
+    [Fact]
+    public async Task MeasurementBoundary_AllowsEqualAndRejectsAbove()
+    {
+        var domain = DomainType.GetDomainTypes();
+        var equalStore = new CoreInMemoryEventStore(domain.EventTypes);
+        var equalExecutor = CreateExecutor(
+            domain,
+            equalStore,
+            new ExecutorSizeGateOptions().Add(new ExecutorSizePolicy(
+                "measured-event",
+                ExecutorSizeRepresentation.LogicalSerializedEventUtf8,
+                maxBytesPerEvent: 42,
+                measurement: new DelegateMeasurement(_ => ExecutorSizeMeasurementResult.Exact(42)))));
+
+        var equalResult = await equalExecutor.CommitSerializableEventsAsync(
+            SingleSerializedRequest(domain, Guid.NewGuid()));
+
+        Assert.True(equalResult.IsSuccess);
+        Assert.Single((await equalStore.ReadAllSerializableEventsAsync()).GetValue());
+
+        var aboveStore = new CoreInMemoryEventStore(domain.EventTypes);
+        var aboveExecutor = CreateExecutor(
+            domain,
+            aboveStore,
+            new ExecutorSizeGateOptions().Add(new ExecutorSizePolicy(
+                "measured-event",
+                ExecutorSizeRepresentation.LogicalSerializedEventUtf8,
+                maxBytesPerEvent: 41,
+                measurement: new DelegateMeasurement(_ => ExecutorSizeMeasurementResult.Exact(42)))));
+
+        var aboveResult = await aboveExecutor.CommitSerializableEventsAsync(
+            SingleSerializedRequest(domain, Guid.NewGuid()));
+
+        var exception = Assert.IsType<ExecutorSizeLimitExceededException>(aboveResult.GetException());
+        Assert.Equal(42, exception.MeasuredBytes);
+        Assert.Equal(41, exception.LimitBytes);
+        Assert.Empty((await aboveStore.ReadAllSerializableEventsAsync()).GetValue());
+    }
+
+    [Fact]
+    public async Task AvailableStorageMeasurement_PassesWhileDestinationLimitRejectsBeforeEnqueue()
+    {
+        var domain = DomainType.GetDomainTypes();
+        var storageStore = new CoreInMemoryEventStore(domain.EventTypes);
+        var storageExecutor = CreateExecutor(
+            domain,
+            storageStore,
+            new ExecutorSizeGateOptions().Add(new ExecutorSizePolicy(
+                "provider-row",
+                ExecutorSizeRepresentation.StorageItem,
+                maxBytesPerEvent: 32,
+                measurement: new DelegateMeasurement(_ => ExecutorSizeMeasurementResult.Exact(32)))));
+
+        var storageResult = await storageExecutor.CommitSerializableEventsAsync(
+            SingleSerializedRequest(domain, Guid.NewGuid()));
+
+        Assert.True(storageResult.IsSuccess);
+        Assert.Single((await storageStore.ReadAllSerializableEventsAsync()).GetValue());
+
+        var destinationStore = new CoreInMemoryEventStore(domain.EventTypes);
+        var publisher = new RecordingDestinationPublisher();
+        var destinationExecutor = CreateExecutor(
+            domain,
+            destinationStore,
+            new ExecutorSizeGateOptions().Add(new ExecutorSizePolicy(
+                "destination",
+                ExecutorSizeRepresentation.Destination,
+                maxBytesPerEvent: 9,
+                measurement: new DelegateMeasurement(_ => ExecutorSizeMeasurementResult.Exact(10)))),
+            publisher);
+
+        var destinationResult = await destinationExecutor.ExecuteAsync(new CreateWeatherForecast
+        {
+            ForecastId = Guid.NewGuid(),
+            Location = "Tokyo",
+            Date = new DateOnly(2026, 9, 9),
+            TemperatureC = 21
+        });
+
+        Assert.IsType<ExecutorSizeLimitExceededException>(destinationResult.GetException());
+        Assert.Empty((await destinationStore.ReadAllSerializableEventsAsync()).GetValue());
+        Assert.Equal(0, publisher.PlannedPublishCalls);
+    }
+
+    [Fact]
+    public async Task SerializedBatch_UsesOnePreparedIdentityAndRejectsOperationBeforeWrite()
+    {
+        var domain = DomainType.GetDomainTypes();
+        var store = new CoreInMemoryEventStore(domain.EventTypes);
+        var executor = CreateExecutor(
+            domain,
+            store,
+            new ExecutorSizeGateOptions().Add(new ExecutorSizePolicy(
+                "logical-operation",
+                ExecutorSizeRepresentation.LogicalSerializedEventUtf8,
+                maxBytesPerOperation: 1)));
+        var first = Guid.NewGuid();
+        var second = Guid.NewGuid();
+        var request = new SerializedCommitRequest(
+            [CreateCandidate(domain, first), CreateCandidate(domain, second)],
+            [new ConsistencyTagEntry($"WeatherForecast:{first}", ""), new ConsistencyTagEntry($"WeatherForecast:{second}", "")]);
+
+        var result = await executor.CommitSerializableEventsAsync(request);
+
+        var exception = Assert.IsType<ExecutorSizeLimitExceededException>(result.GetException());
+        Assert.True(exception.IsOperationLimit);
+        Assert.Equal(0, exception.EventIndex);
+        Assert.Empty((await store.ReadAllSerializableEventsAsync()).GetValue());
+    }
+
+    [Fact]
+    public async Task StrictStorageAndDestinationCapabilitiesFailClosedBeforeWrite()
+    {
+        var domain = DomainType.GetDomainTypes();
+        var storageStore = new CoreInMemoryEventStore(domain.EventTypes);
+        var storageExecutor = CreateExecutor(
+            domain,
+            storageStore,
+            new ExecutorSizeGateOptions().Add(new ExecutorSizePolicy(
+                "provider-row",
+                ExecutorSizeRepresentation.StorageItem,
+                maxBytesPerEvent: 1024,
+                measurement: new DelegateMeasurement(_ => ExecutorSizeMeasurementResult.Unavailable("provider encoder not installed")))));
+
+        var storageResult = await storageExecutor.CommitSerializableEventsAsync(
+            SingleSerializedRequest(domain, Guid.NewGuid()));
+
+        var storageException = Assert.IsType<ExecutorSizeCapabilityException>(storageResult.GetException());
+        Assert.Equal(ExecutorSizeRepresentation.StorageItem, storageException.Representation);
+        Assert.Empty((await storageStore.ReadAllSerializableEventsAsync()).GetValue());
+
+        var destinationStore = new CoreInMemoryEventStore(domain.EventTypes);
+        var destinationExecutor = CreateExecutor(
+            domain,
+            destinationStore,
+            new ExecutorSizeGateOptions().Add(new ExecutorSizePolicy(
+                "destination",
+                ExecutorSizeRepresentation.Destination,
+                maxBytesPerEvent: 1024)));
+
+        var destinationResult = await destinationExecutor.ExecuteAsync(new CreateWeatherForecast
+        {
+            ForecastId = Guid.NewGuid(),
+            Location = "Tokyo",
+            Date = new DateOnly(2026, 9, 9),
+            TemperatureC = 21
+        });
+
+        var destinationException = Assert.IsType<ExecutorSizeCapabilityException>(destinationResult.GetException());
+        Assert.Equal(ExecutorSizeRepresentation.Destination, destinationException.Representation);
+        Assert.Empty((await destinationStore.ReadAllSerializableEventsAsync()).GetValue());
+    }
+
+    [Fact]
+    public async Task NonStrictUnavailableMeasurement_WritesWithExplicitDiagnostic()
+    {
+        var domain = DomainType.GetDomainTypes();
+        var store = new CoreInMemoryEventStore(domain.EventTypes);
+        var executor = CreateExecutor(
+            domain,
+            store,
+            new ExecutorSizeGateOptions().Add(new ExecutorSizePolicy(
+                "provider-row",
+                ExecutorSizeRepresentation.StorageItem,
+                maxBytesPerEvent: 1024,
+                strictness: ExecutorSizeStrictness.NonStrict,
+                measurement: new DelegateMeasurement(_ => ExecutorSizeMeasurementResult.Unavailable("not configured")))));
+
+        var result = await executor.CommitSerializableEventsAsync(
+            SingleSerializedRequest(domain, Guid.NewGuid()));
+
+        Assert.True(result.IsSuccess);
+        Assert.Single(result.GetValue().SizeGateDiagnostics);
+        Assert.Equal("provider-row", result.GetValue().SizeGateDiagnostics[0].Scope);
+        Assert.Single((await store.ReadAllSerializableEventsAsync()).GetValue());
+    }
+
+    [Fact]
+    public async Task DestinationPolicy_UsesCapturedPlanAndDoesNotResolveAgain()
+    {
+        var domain = DomainType.GetDomainTypes();
+        var store = new CoreInMemoryEventStore(domain.EventTypes);
+        var publisher = new RecordingDestinationPublisher();
+        var executor = CreateExecutor(
+            domain,
+            store,
+            new ExecutorSizeGateOptions().Add(new ExecutorSizePolicy(
+                "destination",
+                ExecutorSizeRepresentation.Destination,
+                maxBytesPerEvent: 100,
+                measurement: new DelegateMeasurement(context =>
+                {
+                    Assert.Equal("default", context.ServiceId);
+                    Assert.Contains(context.DestinationKey, new[] { "destination-1", "destination-2" });
+                    Assert.NotNull(context.DestinationPlan);
+                    return ExecutorSizeMeasurementResult.Exact(10);
+                }))),
+            publisher);
+
+        var result = await executor.ExecuteAsync(new CreateWeatherForecast
+        {
+            ForecastId = Guid.NewGuid(),
+            Location = "Tokyo",
+            Date = new DateOnly(2026, 9, 9),
+            TemperatureC = 21
+        });
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(1, publisher.CaptureCalls);
+        Assert.Equal(1, publisher.PlannedPublishCalls);
+        Assert.Equal(0, publisher.LegacyPublishCalls);
+        Assert.Equal(["destination-1", "destination-2"], publisher.LastPlanKeys);
+    }
+
+    [Fact]
+    public async Task DestinationServiceIdentityMismatch_IsStrictFailureOrExplicitNonStrictDiagnostic()
+    {
+        var domain = DomainType.GetDomainTypes();
+        var strictStore = new CoreInMemoryEventStore(domain.EventTypes);
+        var strictPublisher = new RecordingDestinationPublisher
+        {
+            CapturedServiceIdOverride = "publication-service"
+        };
+        var strictExecutor = CreateExecutor(
+            domain,
+            strictStore,
+            new ExecutorSizeGateOptions().Add(new ExecutorSizePolicy(
+                "destination",
+                ExecutorSizeRepresentation.Destination,
+                maxBytesPerEvent: 100,
+                measurement: new DelegateMeasurement(_ => ExecutorSizeMeasurementResult.Exact(10)))),
+            strictPublisher);
+
+        var strictResult = await strictExecutor.ExecuteAsync(new CreateWeatherForecast
+        {
+            ForecastId = Guid.NewGuid(),
+            Location = "Tokyo",
+            Date = new DateOnly(2026, 9, 9),
+            TemperatureC = 21
+        });
+
+        Assert.IsType<ExecutorSizeCapabilityException>(strictResult.GetException());
+        Assert.Empty((await strictStore.ReadAllSerializableEventsAsync()).GetValue());
+
+        var nonStrictStore = new CoreInMemoryEventStore(domain.EventTypes);
+        var nonStrictPublisher = new RecordingDestinationPublisher
+        {
+            CapturedServiceIdOverride = "publication-service"
+        };
+        var nonStrictExecutor = CreateExecutor(
+            domain,
+            nonStrictStore,
+            new ExecutorSizeGateOptions().Add(new ExecutorSizePolicy(
+                "destination",
+                ExecutorSizeRepresentation.Destination,
+                maxBytesPerEvent: 100,
+                strictness: ExecutorSizeStrictness.NonStrict,
+                measurement: new DelegateMeasurement(_ => ExecutorSizeMeasurementResult.Exact(10)))),
+            nonStrictPublisher);
+
+        var nonStrictResult = await nonStrictExecutor.ExecuteAsync(new CreateWeatherForecast
+        {
+            ForecastId = Guid.NewGuid(),
+            Location = "Tokyo",
+            Date = new DateOnly(2026, 9, 9),
+            TemperatureC = 21
+        });
+
+        Assert.True(nonStrictResult.IsSuccess);
+        var nonStrictExecution = nonStrictResult.GetValue()!;
+        Assert.True(nonStrictExecution.Metadata!.TryGetValue("SizeGateDiagnostics", out var diagnostics));
+        var diagnosticList = Assert.IsAssignableFrom<IReadOnlyList<ExecutorSizeDiagnostic>>(diagnostics!);
+        Assert.Contains(diagnosticList, diagnostic => diagnostic.Scope == "destination");
+        Assert.Single((await nonStrictStore.ReadAllSerializableEventsAsync()).GetValue());
+        Assert.Equal(1, nonStrictPublisher.PlannedPublishCalls);
+    }
+
+    [Fact]
+    public async Task ConditionalAndExpectedPositionRoutes_RejectBeforeTheirProviderWrite()
+    {
+        var domain = DomainType.GetDomainTypes();
+        var store = new GateOnlyStore();
+        var executor = CreateExecutor(
+            domain,
+            store,
+            new ExecutorSizeGateOptions().Add(new ExecutorSizePolicy(
+                "logical-event",
+                ExecutorSizeRepresentation.LogicalSerializedEventUtf8,
+                maxBytesPerEvent: 1)));
+        var eventId = Guid.NewGuid();
+
+        var handlerCalls = 0;
+        var conditional = await executor.ExecuteAsync(
+            new GateCommand(eventId),
+            (command, context) =>
+            {
+                handlerCalls++;
+                return HandleGateCommand(command, context);
+            },
+            new CommandExecutionOptions { ConditionalAppend = new ConditionalAppendSpecification("gate-key") });
+
+        Assert.IsType<ExecutorSizeLimitExceededException>(conditional.GetException());
+        Assert.Equal(1, handlerCalls);
+        Assert.Equal(0, store.ConditionalAppendCalls);
+
+        var expectedId = Guid.NewGuid();
+        var expectedTag = $"WeatherForecast:{expectedId}";
+        var expected = await executor.CommitSerializableEventsWithExpectedTagPositionsAsync(
+            new VersionedExpectedTagPositionSerializedCommitRequest(
+                VersionedExpectedTagPositionSerializedCommitRequest.CurrentVersion,
+                [CreateCandidate(domain, expectedId)],
+                [new ConsistencyTagEntry(expectedTag, "")],
+                [new TagHeadExpectationEntry("default", expectedTag, TagHeadExpectation.NoEnforcement())]));
+
+        Assert.IsType<ExecutorSizeLimitExceededException>(expected.GetException());
+        Assert.Equal(0, store.ExpectedPositionWriteCalls);
+
+        var serializedConditional = await ((ISerializedConditionalSekibanDcbExecutor)executor)
+            .CommitSerializableEventConditionallyAsync(
+                new SerializedConditionalCommitRequest(
+                    SerializedConditionalCommitRequest.CurrentVersion,
+                    CreateCandidate(domain, Guid.NewGuid()),
+                    "serialized-gate-key"));
+
+        Assert.IsType<ExecutorSizeLimitExceededException>(serializedConditional.GetException());
+        Assert.Equal(0, store.ConditionalAppendCalls);
+    }
+
+    [Fact]
+    public async Task LegacyAndOptInDiResolutionRemainAvailable()
+    {
+        var domain = DomainType.GetDomainTypes();
+        var store = new CoreInMemoryEventStore(domain.EventTypes);
+        var accessor = new InMemoryObjectAccessor(store, domain);
+
+        var legacyServices = new ServiceCollection()
+            .AddSingleton(domain)
+            .AddSingleton<IEventStore>(store)
+            .AddSingleton<IActorObjectAccessor>(accessor)
+            .AddTransient<GeneralSekibanExecutor>();
+        using (var legacyProvider = legacyServices.BuildServiceProvider())
+        {
+            var legacyExecutor = legacyProvider.GetRequiredService<GeneralSekibanExecutor>();
+            var legacyResult = await legacyExecutor.ExecuteAsync(new CreateWeatherForecast
+            {
+                ForecastId = Guid.NewGuid(),
+                Location = "Tokyo",
+                Date = new DateOnly(2026, 9, 9),
+                TemperatureC = 21
+            });
+            Assert.True(legacyResult.IsSuccess);
+        }
+
+        var optInStore = new CoreInMemoryEventStore(domain.EventTypes);
+        var optInAccessor = new InMemoryObjectAccessor(optInStore, domain);
+        var optInServices = new ServiceCollection()
+            .AddSingleton(domain)
+            .AddSingleton<IEventStore>(optInStore)
+            .AddSingleton<IActorObjectAccessor>(optInAccessor)
+            .AddSekibanDcbExecutorSizeGate(options => options.Add(new ExecutorSizePolicy(
+                "logical-event",
+                ExecutorSizeRepresentation.LogicalSerializedEventUtf8,
+                maxBytesPerEvent: 1)))
+            .AddTransient<GeneralSekibanExecutor>();
+        using var optInProvider = optInServices.BuildServiceProvider();
+        Assert.NotNull(optInProvider.GetRequiredService<ExecutorSizeGateOptions>());
+        var optInExecutor = optInProvider.GetRequiredService<GeneralSekibanExecutor>();
+        var optInResult = await optInExecutor.ExecuteAsync(new CreateWeatherForecast
+        {
+            ForecastId = Guid.NewGuid(),
+            Location = "Tokyo",
+            Date = new DateOnly(2026, 9, 9),
+            TemperatureC = 21
+        });
+        Assert.IsType<ExecutorSizeLimitExceededException>(optInResult.GetException());
+    }
+
+    private static GeneralSekibanExecutor CreateExecutor(
+        DcbDomainTypes domain,
+        IEventStore store,
+        ExecutorSizeGateOptions options,
+        IEventPublisher? publisher = null) =>
+        new(store, new InMemoryObjectAccessor(store, domain), domain, options, publisher, null);
+
+    private static SerializedCommitRequest SingleSerializedRequest(DcbDomainTypes domain, Guid id)
+    {
+        var candidate = CreateCandidate(domain, id);
+        return new SerializedCommitRequest(
+            [candidate],
+            [new ConsistencyTagEntry($"WeatherForecast:{id}", "")]);
+    }
+
+    private static SerializableEventCandidate CreateCandidate(DcbDomainTypes domain, Guid id)
+    {
+        var payload = new WeatherForecastCreated(id, "Tokyo", new DateOnly(2026, 9, 9), 21, "size gate");
+        return new SerializableEventCandidate(
+            JsonSerializer.SerializeToUtf8Bytes(payload, domain.JsonSerializerOptions),
+            nameof(WeatherForecastCreated),
+            [$"WeatherForecast:{id}"]);
+    }
+
+    private static Task<ResultBox<EventOrNone>> HandleGateCommand(GateCommand command, ICommandContext _) =>
+        Task.FromResult(EventOrNone.Event(
+            new WeatherForecastCreated(command.Id, "Tokyo", new DateOnly(2026, 9, 9), 21, "size gate"),
+            new WeatherForecastTag(command.Id)));
+
+    private sealed record GateCommand(Guid Id) : ICommand;
+
+    private sealed class DelegateMeasurement(Func<ExecutorSizeMeasurementContext, ExecutorSizeMeasurementResult> measure)
+        : IExecutorSizeMeasurement
+    {
+        public ExecutorSizeMeasurementResult Measure(ExecutorSizeMeasurementContext context) => measure(context);
+    }
+
+    private sealed class RecordingDestinationPublisher : IEventPublisher, IExecutorSizeDestinationPublisher
+    {
+        public string? CapturedServiceIdOverride { get; init; }
+        public int CaptureCalls { get; private set; }
+        public int PlannedPublishCalls { get; private set; }
+        public int LegacyPublishCalls { get; private set; }
+        public IReadOnlyList<string> LastPlanKeys { get; private set; } = [];
+
+        public ExecutorSizeDestinationPlan CaptureDestinationPlan(
+            Event @event,
+            IReadOnlyCollection<ITag> tags,
+            string serviceId)
+        {
+            CaptureCalls++;
+            return new ExecutorSizeDestinationPlan(
+                CapturedServiceIdOverride ?? serviceId,
+                ["destination-1", "destination-2"],
+                new object());
+        }
+
+        public Task PublishAsync(
+            IReadOnlyCollection<(Event Event, IReadOnlyCollection<ITag> Tags)> events,
+            CancellationToken cancellationToken = default)
+        {
+            LegacyPublishCalls++;
+            return Task.CompletedTask;
+        }
+
+        public Task PublishAsync(
+            IReadOnlyCollection<(Event Event, IReadOnlyCollection<ITag> Tags)> events,
+            IReadOnlyDictionary<Guid, ExecutorSizeDestinationPlan> destinationPlans,
+            CancellationToken cancellationToken = default)
+        {
+            PlannedPublishCalls++;
+            LastPlanKeys = destinationPlans.Values.Single().DestinationKeys;
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class GateOnlyStore :
+        IEventStore,
+        IConditionalEventStore,
+        IExpectedTagPositionEventStore,
+        IWriteConditionCapabilityProvider
+    {
+        public int ConditionalAppendCalls { get; private set; }
+        public int ExpectedPositionWriteCalls { get; private set; }
+        public WriteConditionCapabilityDescriptor DescribeWriteConditions() =>
+            WriteConditionCapabilityDescriptor.Supporting(
+                "GateOnly",
+                WriteConditionKind.SingleEventUniqueKey,
+                WriteConditionKind.ExpectedTagPosition);
+
+        public Task<ResultBox<IEnumerable<TagStream>>> ReadTagsAsync(ITag tag) =>
+            Task.FromResult(ResultBox.FromValue<IEnumerable<TagStream>>([]));
+
+        public Task<ResultBox<TagState>> GetLatestTagAsync(ITag tag) =>
+            Task.FromResult(ResultBox.Error<TagState>(new NotSupportedException()));
+
+        public Task<ResultBox<bool>> TagExistsAsync(ITag tag) =>
+            Task.FromResult(ResultBox.FromValue(false));
+
+        public Task<ResultBox<long>> GetEventCountAsync(SortableUniqueId? since = null) =>
+            Task.FromResult(ResultBox.FromValue(0L));
+
+        public Task<ResultBox<IEnumerable<TagInfo>>> GetAllTagsAsync(string? tagGroup = null) =>
+            Task.FromResult(ResultBox.FromValue<IEnumerable<TagInfo>>([]));
+
+        public Task<ResultBox<IEnumerable<SerializableEvent>>> ReadAllSerializableEventsAsync(
+            SortableUniqueId? since = null) =>
+            Task.FromResult(ResultBox.FromValue<IEnumerable<SerializableEvent>>([]));
+
+        public Task<ResultBox<IEnumerable<SerializableEvent>>> ReadAllSerializableEventsAsync(
+            SortableUniqueId? since,
+            int? maxCount) =>
+            Task.FromResult(ResultBox.FromValue<IEnumerable<SerializableEvent>>([]));
+
+        public Task<ResultBox<SerializableEvent>> ReadSerializableEventAsync(Guid eventId) =>
+            Task.FromResult(ResultBox.Error<SerializableEvent>(new NotSupportedException()));
+
+        public Task<ResultBox<IEnumerable<SerializableEvent>>> ReadSerializableEventsByTagAsync(
+            ITag tag,
+            SortableUniqueId? since = null) =>
+            Task.FromResult(ResultBox.FromValue<IEnumerable<SerializableEvent>>([]));
+
+        public Task<ResultBox<(IReadOnlyList<SerializableEvent> Events, IReadOnlyList<TagWriteResult> TagWrites)>>
+            WriteSerializableEventsAsync(IEnumerable<SerializableEvent> events)
+        {
+            throw new InvalidOperationException("The size gate must run before the ordinary provider write.");
+        }
+
+        public Task<ResultBox<string>> GetLatestSortableUniqueIdAsync() =>
+            Task.FromResult(ResultBox.FromValue(string.Empty));
+
+        public Task<ResultBox<ConditionalAppendReceipt>> AppendIfUniqueAsync(
+            ConditionalAppendRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            ConditionalAppendCalls++;
+            throw new InvalidOperationException("The size gate must run before conditional append.");
+        }
+
+        public Task<ResultBox<bool>> EnsureExpectedTagPositionEnforcementEnabledAsync(
+            CancellationToken cancellationToken = default) =>
+            Task.FromResult(ResultBox.FromValue(true));
+
+        public Task<ResultBox<ExpectedTagPositionWriteResult>> WriteSerializableEventsWithExpectedTagPositionsAsync(
+            IReadOnlyList<SerializableEvent> events,
+            ExpectedTagPositionSpecification specification,
+            CancellationToken cancellationToken = default)
+        {
+            ExpectedPositionWriteCalls++;
+            throw new InvalidOperationException("The size gate must run before expected-position write.");
+        }
+    }
+}

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/ExecutorSizeGateTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/ExecutorSizeGateTests.cs
@@ -115,8 +115,9 @@ public sealed class ExecutorSizeGateTests
             new ExecutorSizeGateOptions().Add(new ExecutorSizePolicy(
                 "destination",
                 ExecutorSizeRepresentation.Destination,
-                maxBytesPerEvent: 9,
-                measurement: new DelegateMeasurement(_ => ExecutorSizeMeasurementResult.Exact(10)))),
+                maxBytesPerEvent: 10,
+                measurement: new DelegateMeasurement(context =>
+                    ExecutorSizeMeasurementResult.Exact(context.DestinationKey == "destination-2" ? 11 : 8)))),
             publisher);
 
         var destinationResult = await destinationExecutor.ExecuteAsync(new CreateWeatherForecast
@@ -127,9 +128,174 @@ public sealed class ExecutorSizeGateTests
             TemperatureC = 21
         });
 
-        Assert.IsType<ExecutorSizeLimitExceededException>(destinationResult.GetException());
+        var destinationException = Assert.IsType<ExecutorSizeLimitExceededException>(destinationResult.GetException());
+        Assert.Equal(11, destinationException.MeasuredBytes);
+        Assert.Equal("destination-2", destinationException.DestinationKey);
         Assert.Empty((await destinationStore.ReadAllSerializableEventsAsync()).GetValue());
         Assert.Equal(0, publisher.PlannedPublishCalls);
+    }
+
+    [Fact]
+    public async Task DestinationFanOut_EnforcesEachDestinationIndependently()
+    {
+        var domain = DomainType.GetDomainTypes();
+        var store = new CoreInMemoryEventStore(domain.EventTypes);
+        var publisher = new RecordingDestinationPublisher();
+        var executor = CreateExecutor(
+            domain,
+            store,
+            new ExecutorSizeGateOptions().Add(new ExecutorSizePolicy(
+                "destination",
+                ExecutorSizeRepresentation.Destination,
+                maxBytesPerEvent: 10,
+                measurement: new DelegateMeasurement(_ => ExecutorSizeMeasurementResult.Exact(10)))),
+            publisher);
+
+        var result = await executor.ExecuteAsync(new CreateWeatherForecast
+        {
+            ForecastId = Guid.NewGuid(),
+            Location = "Tokyo",
+            Date = new DateOnly(2026, 9, 9),
+            TemperatureC = 21
+        });
+
+        Assert.True(result.IsSuccess);
+        Assert.Single((await store.ReadAllSerializableEventsAsync()).GetValue());
+        Assert.Equal(1, publisher.PlannedPublishCalls);
+    }
+
+    [Fact]
+    public async Task SerializedBatch_PerEventLimitRejectsTheLastEventBeforeAnyWrite()
+    {
+        var domain = DomainType.GetDomainTypes();
+        var store = new CoreInMemoryEventStore(domain.EventTypes);
+        var first = CreateCandidate(domain, Guid.NewGuid());
+        var last = CreateCandidate(domain, Guid.NewGuid(), summary: new string('x', 256));
+        var publisher = new RecordingDestinationPublisher();
+        var executor = CreateExecutor(
+            domain,
+            store,
+            new ExecutorSizeGateOptions().Add(new ExecutorSizePolicy(
+                "logical-event",
+                ExecutorSizeRepresentation.LogicalSerializedEventUtf8,
+                maxBytesPerEvent: first.Payload.Length,
+                measurement: new DelegateMeasurement(context =>
+                    ExecutorSizeMeasurementResult.Exact(context.SerializedEvent.Payload.Length)))),
+            publisher);
+
+        var result = await executor.CommitSerializableEventsAsync(
+            new SerializedCommitRequest(
+                [first, last],
+                [
+                    new ConsistencyTagEntry(first.Tags[0], ""),
+                    new ConsistencyTagEntry(last.Tags[0], "")
+                ]));
+
+        var exception = Assert.IsType<ExecutorSizeLimitExceededException>(result.GetException());
+        Assert.False(exception.IsOperationLimit);
+        Assert.Equal(1, exception.EventIndex);
+        Assert.Equal(last.Payload.Length, exception.MeasuredBytes);
+        Assert.Empty((await store.ReadAllSerializableEventsAsync()).GetValue());
+        Assert.Equal(0, publisher.PlannedPublishCalls);
+    }
+
+    [Fact]
+    public async Task LogicalUtf8MetadataOverheadChangesTheVerdictAtPinnedBytes()
+    {
+        var domain = DomainType.GetDomainTypes();
+        var policy = new ExecutorSizeGateOptions().Add(new ExecutorSizePolicy(
+            "logical-event",
+            ExecutorSizeRepresentation.LogicalSerializedEventUtf8,
+            maxBytesPerEvent: 1));
+
+        var minimalStore = new CoreInMemoryEventStore(domain.EventTypes);
+        var minimalExecutor = CreateExecutor(
+            domain,
+            minimalStore,
+            policy,
+            executedUserProvider: new FixedExecutedUserProvider("u"));
+        var minimalResult = await minimalExecutor.ExecuteAsync(new CreateWeatherForecast
+        {
+            ForecastId = Guid.Parse("11111111-1111-1111-1111-111111111111"),
+            Location = "Tokyo",
+            Date = new DateOnly(2026, 9, 9),
+            TemperatureC = 21,
+            Summary = "fixed"
+        });
+        var minimalException = Assert.IsType<ExecutorSizeLimitExceededException>(minimalResult.GetException());
+        Assert.Equal(525, minimalException.MeasuredBytes);
+
+        var acceptedStore = new CoreInMemoryEventStore(domain.EventTypes);
+        var acceptedExecutor = CreateExecutor(
+            domain,
+            acceptedStore,
+            new ExecutorSizeGateOptions().Add(new ExecutorSizePolicy(
+                "logical-event",
+                ExecutorSizeRepresentation.LogicalSerializedEventUtf8,
+                maxBytesPerEvent: minimalException.MeasuredBytes)),
+            executedUserProvider: new FixedExecutedUserProvider("u"));
+        var acceptedResult = await acceptedExecutor.ExecuteAsync(new CreateWeatherForecast
+        {
+            ForecastId = Guid.Parse("11111111-1111-1111-1111-111111111111"),
+            Location = "Tokyo",
+            Date = new DateOnly(2026, 9, 9),
+            TemperatureC = 21,
+            Summary = "fixed"
+        });
+        Assert.True(acceptedResult.IsSuccess);
+        Assert.Single((await acceptedStore.ReadAllSerializableEventsAsync()).GetValue());
+
+        var richStore = new CoreInMemoryEventStore(domain.EventTypes);
+        var richExecutor = CreateExecutor(
+            domain,
+            richStore,
+            new ExecutorSizeGateOptions().Add(new ExecutorSizePolicy(
+                "logical-event",
+                ExecutorSizeRepresentation.LogicalSerializedEventUtf8,
+                maxBytesPerEvent: minimalException.MeasuredBytes)),
+            executedUserProvider: new FixedExecutedUserProvider("user-with-metadata-overhead"));
+        var richResult = await richExecutor.ExecuteAsync(new CreateWeatherForecast
+        {
+            ForecastId = Guid.Parse("11111111-1111-1111-1111-111111111111"),
+            Location = "Tokyo",
+            Date = new DateOnly(2026, 9, 9),
+            TemperatureC = 21,
+            Summary = "fixed"
+        });
+
+        var richException = Assert.IsType<ExecutorSizeLimitExceededException>(richResult.GetException());
+        Assert.True(richException.MeasuredBytes > minimalException.MeasuredBytes);
+        Assert.Empty((await minimalStore.ReadAllSerializableEventsAsync()).GetValue());
+        Assert.Empty((await richStore.ReadAllSerializableEventsAsync()).GetValue());
+    }
+
+    [Fact]
+    public async Task SizeRejection_CancelsConsistencyReservations()
+    {
+        var domain = DomainType.GetDomainTypes();
+        var store = new CoreInMemoryEventStore(domain.EventTypes);
+        var accessor = new InMemoryObjectAccessor(store, domain);
+        var executor = CreateExecutor(
+            domain,
+            store,
+            new ExecutorSizeGateOptions().Add(new ExecutorSizePolicy(
+                "logical-event",
+                ExecutorSizeRepresentation.LogicalSerializedEventUtf8,
+                maxBytesPerEvent: 1)),
+            actorAccessor: accessor);
+        var eventId = Guid.NewGuid();
+        var tag = $"WeatherForecast:{eventId}";
+
+        var result = await executor.CommitSerializableEventsAsync(
+            new SerializedCommitRequest(
+                [CreateCandidate(domain, eventId)],
+                [new ConsistencyTagEntry(tag, "")]));
+
+        Assert.IsType<ExecutorSizeLimitExceededException>(result.GetException());
+        var actorResult = await accessor.GetActorAsync<GeneralTagConsistentActor>(tag);
+        Assert.True(actorResult.IsSuccess);
+        Assert.Empty(await actorResult.GetValue().GetActiveReservationsAsync());
+        Assert.Empty((await store.ReadAllSerializableEventsAsync()).GetValue());
     }
 
     [Fact]
@@ -429,8 +595,10 @@ public sealed class ExecutorSizeGateTests
         DcbDomainTypes domain,
         IEventStore store,
         ExecutorSizeGateOptions options,
-        IEventPublisher? publisher = null) =>
-        new(store, new InMemoryObjectAccessor(store, domain), domain, options, publisher, null);
+        IEventPublisher? publisher = null,
+        IActorObjectAccessor? actorAccessor = null,
+        IExecutedUserProvider? executedUserProvider = null) =>
+        new(store, actorAccessor ?? new InMemoryObjectAccessor(store, domain), domain, options, publisher, executedUserProvider);
 
     private static SerializedCommitRequest SingleSerializedRequest(DcbDomainTypes domain, Guid id)
     {
@@ -440,9 +608,12 @@ public sealed class ExecutorSizeGateTests
             [new ConsistencyTagEntry($"WeatherForecast:{id}", "")]);
     }
 
-    private static SerializableEventCandidate CreateCandidate(DcbDomainTypes domain, Guid id)
+    private static SerializableEventCandidate CreateCandidate(
+        DcbDomainTypes domain,
+        Guid id,
+        string summary = "size gate")
     {
-        var payload = new WeatherForecastCreated(id, "Tokyo", new DateOnly(2026, 9, 9), 21, "size gate");
+        var payload = new WeatherForecastCreated(id, "Tokyo", new DateOnly(2026, 9, 9), 21, summary);
         return new SerializableEventCandidate(
             JsonSerializer.SerializeToUtf8Bytes(payload, domain.JsonSerializerOptions),
             nameof(WeatherForecastCreated),
@@ -460,6 +631,11 @@ public sealed class ExecutorSizeGateTests
         : IExecutorSizeMeasurement
     {
         public ExecutorSizeMeasurementResult Measure(ExecutorSizeMeasurementContext context) => measure(context);
+    }
+
+    private sealed class FixedExecutedUserProvider(string value) : IExecutedUserProvider
+    {
+        public string GetExecutedUser() => value;
     }
 
     private sealed class RecordingDestinationPublisher : IEventPublisher, IExecutorSizeDestinationPublisher

--- a/dcb/tests/Sekiban.Dcb.WithoutResult.Tests/ExecutorSizeGateCompatibilityTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithoutResult.Tests/ExecutorSizeGateCompatibilityTests.cs
@@ -1,0 +1,76 @@
+using Dcb.Domain.WithoutResult;
+using Dcb.Domain.WithoutResult.Weather;
+using Microsoft.Extensions.DependencyInjection;
+using System.Reflection;
+using Sekiban.Dcb.Actors;
+using Sekiban.Dcb.SizeGates;
+using Sekiban.Dcb.Storage;
+using Sekiban.Dcb.Testing;
+
+namespace Sekiban.Dcb.WithoutResult.Tests;
+
+public sealed class ExecutorSizeGateCompatibilityTests
+{
+    [Fact]
+    public void WithoutResultFacades_KeepLegacyConstructorsAndExposeAdditiveGateConstructors()
+    {
+        Assert.Contains(
+            typeof(GeneralSekibanExecutor).GetConstructors(),
+            constructor => constructor.GetParameters().Any(p => p.ParameterType == typeof(ExecutorSizeGateOptions)));
+
+        var orleansType = Assembly.Load("Sekiban.Dcb.Orleans.WithoutResult")
+            .GetType("Sekiban.Dcb.Orleans.OrleansDcbExecutor");
+        Assert.NotNull(orleansType);
+        Assert.Contains(
+            orleansType!.GetConstructors(BindingFlags.Instance | BindingFlags.Public),
+            constructor => constructor.GetParameters().Any(p => p.ParameterType == typeof(ExecutorSizeGateOptions)));
+    }
+
+    [Fact]
+    public async Task WithoutResultDi_LeavesLegacyUngatedAndInjectsOptInOptions()
+    {
+        var domain = DomainType.GetDomainTypes();
+        var legacyStore = new InMemoryEventStore(domain.EventTypes);
+        var legacyServices = new ServiceCollection()
+            .AddSingleton(domain)
+            .AddSingleton<IEventStore>(legacyStore)
+            .AddSingleton<IActorObjectAccessor>(new InMemoryObjectAccessor(legacyStore, domain))
+            .AddTransient<GeneralSekibanExecutor>();
+
+        using (var legacyProvider = legacyServices.BuildServiceProvider())
+        {
+            var result = await legacyProvider.GetRequiredService<GeneralSekibanExecutor>().ExecuteAsync(
+                new CreateWeatherForecast
+                {
+                    ForecastId = Guid.NewGuid(),
+                    Location = "Tokyo",
+                    Date = new DateOnly(2026, 9, 9),
+                    TemperatureC = 21
+                });
+            Assert.Single(result.Events);
+        }
+
+        var optInStore = new InMemoryEventStore(domain.EventTypes);
+        var optInServices = new ServiceCollection()
+            .AddSingleton(domain)
+            .AddSingleton<IEventStore>(optInStore)
+            .AddSingleton<IActorObjectAccessor>(new InMemoryObjectAccessor(optInStore, domain))
+            .AddSekibanDcbExecutorSizeGate(options => options.Add(new ExecutorSizePolicy(
+                "logical-event",
+                ExecutorSizeRepresentation.LogicalSerializedEventUtf8,
+                maxBytesPerEvent: 1)))
+            .AddTransient<GeneralSekibanExecutor>();
+
+        using var optInProvider = optInServices.BuildServiceProvider();
+        await Assert.ThrowsAsync<ExecutorSizeLimitExceededException>(() =>
+            optInProvider.GetRequiredService<GeneralSekibanExecutor>().ExecuteAsync(
+                new CreateWeatherForecast
+                {
+                    ForecastId = Guid.NewGuid(),
+                    Location = "Tokyo",
+                    Date = new DateOnly(2026, 9, 9),
+                    TemperatureC = 21
+                }));
+        Assert.Empty((await optInStore.ReadAllSerializableEventsAsync()).GetValue());
+    }
+}

--- a/docs/dcb_llm/03_aggregate_command_events.md
+++ b/docs/dcb_llm/03_aggregate_command_events.md
@@ -266,3 +266,9 @@ default. A strict policy must declare an actual logical UTF-8 measurement or a p
 storage or destination measurement. An unavailable strict capability fails closed; non-strict mode proceeds only with
 a diagnostic. Azure Queue wire-envelope, batching, retries, and previously accepted-event replication remain outside
 this slice.
+
+For the serialized conditional boundary, payload binding is a capability used when a configured policy needs the
+logical or provider measurement. If that binding capability is unavailable, a strict policy returns the typed
+`ExecutorSizeCapabilityException` before the conditional append; non-strict mode records an explicit unvalidated
+diagnostic and lets the provider conditional operation classify the request. This preserves provider in-doubt and
+conflict exceptions instead of replacing them with a binding failure.

--- a/docs/dcb_llm/03_aggregate_command_events.md
+++ b/docs/dcb_llm/03_aggregate_command_events.md
@@ -256,3 +256,13 @@ unchanged.
 - Use helper classes such as `ConsistencyTag` when you need to carry a known `SortableUniqueId` across retries.
 - Prefer small, focused tag payloads. Move aggregations into MultiProjection so TagState actors stay lean.
 - Commands should never mutate state directly—always delegate to events recorded through the executor.
+
+## Optional executor size gate (SEK-G66)
+
+Applications may register `ExecutorSizeGateOptions` with `AddSekibanDcbExecutorSizeGate` to reject an oversized
+prepared event set before event, tag, or head persistence. The gate covers command execution, serialized commits,
+expected-position commits, conditional appends, and serialized conditional appends; it is opt-in and has no global
+default. A strict policy must declare an actual logical UTF-8 measurement or a provider-owned exact/certified
+storage or destination measurement. An unavailable strict capability fails closed; non-strict mode proceeds only with
+a diagnostic. Azure Queue wire-envelope, batching, retries, and previously accepted-event replication remain outside
+this slice.

--- a/docs/dcb_llm/08_api_implementation.md
+++ b/docs/dcb_llm/08_api_implementation.md
@@ -110,3 +110,24 @@ be singleton.
 Register `IEventPublisher` implementations (e.g., `OrleansEventPublisher` in `src/Sekiban.Dcb.Orleans/OrleansEventPublisher.cs`)
 when you need to stream events to Orleans streams or external buses. The API often returns the `SortableUniqueId` so
 clients can follow up with a `waitFor` query.
+
+## Optional executor size gate
+
+The executor has an opt-in `ExecutorSizeGateOptions` policy set in `Sekiban.Dcb.SizeGates`; the default constructors and
+DI registrations remain ungated. Register it with `AddSekibanDcbExecutorSizeGate` and pass the resolved options through
+the additive executor constructor. The gate is evaluated once over the final prepared events for all five durable routes:
+typed commands, serialized batches, expected-tag-position batches, typed conditional append, and serialized conditional
+append. It rejects before the event/tag/head write, keeps the generated event identity, and never invokes a handler twice.
+
+The built-in `LogicalSerializedEventUtf8` representation measures a canonical UTF-8 envelope containing the serialized
+payload, event type, final sortable/id identity, metadata, and tags. Storage-item and destination policies require an
+explicit provider measurement that returns exact bytes or a certified conservative upper bound. Orleans destination
+validation captures the resolver's service-scoped plan and publishes that same plan, so a resolver change cannot bypass
+the decision. Azure Queue wire-envelope/batch bytes, retries, and transport-specific guarantees are intentionally outside
+this core contract.
+
+Strict policies fail with a typed capability or limit exception before durable work. Non-strict policies write an explicit
+`ExecutorSizeDiagnostic` in the successful result metadata when measurement is unavailable; they do not pretend the event
+was validated. The policy is executor-wide, so a `maxBytesPerOperation` limit sums the complete batch. Existing public
+constructors/interfaces and direct APIs remain compatible; the size gate is an additive opt-in and does not perform
+historical repair or add a fallback publisher path.

--- a/docs/dcb_llm/10_orleans_setup.md
+++ b/docs/dcb_llm/10_orleans_setup.md
@@ -180,3 +180,12 @@ Dashboard. Add `app.MapHealthChecks("/health")` for readiness probes.
 
 Use `InMemorySekibanExecutor` (`src/Sekiban.Dcb/InMemory/InMemorySekibanExecutor.cs`) to run commands locally without a
 silo. This executor spins in-process actors and stores events in memory—perfect for unit tests.
+
+## Optional executor size gate on Orleans
+
+Register `AddSekibanDcbExecutorSizeGate` before resolving `OrleansDcbExecutor` when the application wants a strict
+pre-persistence budget. The Orleans publisher captures the resolver's destination plan and service identity once and
+reuses that plan for enqueue, so a strict destination policy is valid only when that capability is available. A
+non-strict unavailable or identity-mismatched destination policy writes an explicit diagnostic. This gate measures
+executor-originated logical events or declared provider capabilities; it does not claim Azure Queue wire-envelope,
+batch, or retry limits and does not change Orleans retry behavior.

--- a/docs/dcb_llm/11_storage_providers.md
+++ b/docs/dcb_llm/11_storage_providers.md
@@ -878,6 +878,14 @@ WRITER and READER is upgraded. On **SQLite**, the legacy `INSERT OR REPLACE` ups
 the row and therefore RESETS the control columns — a pre-G20 writer erases a tombstone. Roll all
 clusters/writers to 10.8.0 before relying on the cross-cluster guarantee.
 
+## Executor size-gate measurement boundary
+
+An executor storage policy is valid only when the provider supplies the actual storage-item encoder or a certified
+conservative upper bound through `IExecutorSizeMeasurement`. The logical serialized-event UTF-8 count is not a row,
+document, item, or Azure Queue wire-envelope count. Strict unavailable measurement rejects before persistence; a
+non-strict policy proceeds with a named diagnostic. The gate covers the current executor operation only; it does not
+split events, change provider retry/recovery, or repair historical oversized data.
+
 ## Related
 
 For the current internal-use cold event export, hybrid read, and catch-up worker setup, see [Cold Events and Catch-up](19_cold_events.md).

--- a/docs/dcb_llm_ja/03_aggregate_command_events.md
+++ b/docs/dcb_llm_ja/03_aggregate_command_events.md
@@ -240,3 +240,12 @@ builder.Services.AddSingleton<IExecutedUserProvider>(sp =>
 
 このように、DCB ではタグを中心にドメインを建て付けます。タグ定義・プロジェクター・コマンドハンドラーを
 組み合わせて一貫した整合性境界を実現してください。
+
+## オプションの executor サイズゲート（SEK-G66）
+
+アプリケーションは `AddSekibanDcbExecutorSizeGate` で `ExecutorSizeGateOptions` を登録し、準備済みイベント集合を
+イベント・タグ・head の永続化前に検査できます。対象はコマンド実行、シリアライズ済み commit、expected-position
+commit、conditional append、シリアライズ済み conditional append の 5 経路で、opt-in でありグローバル既定値は
+ありません。strict policy には実際の論理 UTF-8 測定、または provider が提供する正確な／保守的上限の storage・destination
+測定が必要です。strict の capability 不在は fail-closed、non-strict は診断を付けた場合だけ継続します。Azure Queue の
+wire envelope、batch、retry、および既に受理されたイベントの replication はこのスライスの対象外です。

--- a/docs/dcb_llm_ja/03_aggregate_command_events.md
+++ b/docs/dcb_llm_ja/03_aggregate_command_events.md
@@ -249,3 +249,8 @@ commit、conditional append、シリアライズ済み conditional append の 5 
 ありません。strict policy には実際の論理 UTF-8 測定、または provider が提供する正確な／保守的上限の storage・destination
 測定が必要です。strict の capability 不在は fail-closed、non-strict は診断を付けた場合だけ継続します。Azure Queue の
 wire envelope、batch、retry、および既に受理されたイベントの replication はこのスライスの対象外です。
+
+シリアライズ済み conditional 境界では、設定された policy の論理または provider 測定に payload binding capability
+が必要になる場合があります。この binding capability を利用できない場合、strict policy は conditional append
+より前に型付き `ExecutorSizeCapabilityException` を返します。non-strict は明示的な未検証診断を記録したうえで
+provider の conditional 操作に判定を委ね、binding failure で provider の in-doubt や conflict 例外を置き換えません。

--- a/docs/dcb_llm_ja/08_api_implementation.md
+++ b/docs/dcb_llm_ja/08_api_implementation.md
@@ -99,3 +99,23 @@ builder.Services.AddSingleton<IExecutedUserProvider>(sp =>
 
 `IEventPublisher` を登録すると Orleans ストリームや外部キューにイベントを配信できます。
 `OrleansEventPublisher` (`src/Sekiban.Dcb.Orleans/OrleansEventPublisher.cs`) がその例です。
+
+## オプションの executor サイズゲート
+
+`Sekiban.Dcb.SizeGates` の `ExecutorSizeGateOptions` を使うと、executor のサイズ検査を明示的に有効化できます。
+`AddSekibanDcbExecutorSizeGate` で登録し、加算された executor コンストラクターへ渡してください。既存の
+コンストラクターと DI 登録はゲートなしのままです。検査は最終的に準備されたイベント全体に対して 1 回だけ行われ、
+型付きコマンド、シリアライズ済みバッチ、expected-tag-position バッチ、型付き conditional append、
+シリアライズ済み conditional append の 5 つの永続化経路を対象にします。イベント・タグ・head の書き込み前に拒否し、
+生成済みのイベント ID を保持し、ハンドラーを 2 回呼び出すことはありません。
+
+組み込みの `LogicalSerializedEventUtf8` は、シリアライズ済み payload、イベント型、最終的な sortable/id、metadata、
+タグを含む規約化 UTF-8 エンベロープを測定します。storage-item と destination のポリシーには、正確なバイト数または
+保守的な認証済み上限を返す明示的なプロバイダー測定機能が必要です。Orleans の destination 検査はサービス単位の
+resolver 計画を取得し、同じ計画を publish に使うため、resolver の変更で判定を回避できません。Azure Queue の
+wire envelope/batch サイズ、retry、トランスポート固有の保証はこの core 契約の対象外です。
+
+strict ポリシーは、永続化前に型付き capability または limit 例外として失敗します。non-strict ポリシーは、測定不能時に
+成功結果の metadata へ `ExecutorSizeDiagnostic` を明示的に記録しますが、検証済みとは扱いません。ポリシーは executor
+全体に適用されるため、`maxBytesPerOperation` はバッチ全体を合計します。既存の public constructor/interface と直接 API は
+互換性を保ち、サイズゲートは加算的な opt-in です。過去イベントの自動修復や publisher のフォールバック経路は追加しません。

--- a/docs/dcb_llm_ja/10_orleans_setup.md
+++ b/docs/dcb_llm_ja/10_orleans_setup.md
@@ -170,3 +170,12 @@ builder.Services.AddSingleton<ISekibanExecutor, OrleansDcbExecutor>();
 ## Orleans なしでのテスト
 
 `InMemorySekibanExecutor` を使えばサイロ無しでもコマンド処理を試せます。
+
+## Orleans でのオプション executor サイズゲート
+
+厳密な永続化前の予算を使う場合は、`OrleansDcbExecutor` を解決する前に `AddSekibanDcbExecutorSizeGate` を登録します。
+Orleans publisher は resolver の destination plan と service identity を一度キャプチャし、enqueue に同じ plan を再利用するため、
+strict の destination policy はその capability が利用できる場合だけ成立します。利用できない、または identity が一致しない
+destination policy を non-strict で使う場合は明示的な診断を伴って書き込みます。このゲートが測定するのは executor が生成した
+logical event または宣言済み provider capability であり、Azure Queue の wire envelope・batch・retry の上限は主張せず、Orleans の
+retry 動作も変更しません。

--- a/docs/dcb_llm_ja/11_storage_providers.md
+++ b/docs/dcb_llm_ja/11_storage_providers.md
@@ -886,6 +886,13 @@ reset 必要)。
 リセットするため、pre-G20 の writer が tombstone を消します。cross-cluster 保証に依存する前に全クラスタ/
 writer を 10.8.0 へ更新してください。
 
+## executor サイズゲートの測定境界
+
+executor の storage policy は、provider が `IExecutorSizeMeasurement` を通じて実際の storage-item encoder または
+保守的上限を提供した場合だけ有効です。logical なシリアライズ済み event の UTF-8 サイズは、row・document・item・Azure Queue
+wire envelope のサイズではありません。strict で測定できない場合は永続化前に拒否し、non-strict は名前付き診断を付けて継続します。
+ゲートは現在の executor operation だけを対象にし、event の分割、provider の retry/recovery の変更、過去の oversized data の修復は行いません。
+
 ## 関連資料
 
 現在のインターナルユースで使っているコールドイベントの書き出し、ハイブリッドリード、キャッチアップワーカー構成については [コールドイベントとキャッチアップ](19_cold_events.md) を参照してください。


### PR DESCRIPTION
Closes #1205

## Summary

- Adds an opt-in `ExecutorSizeGateOptions` contract for the five durable executor routes: typed commands, serialized commits, expected-position commits, typed conditional append, and serialized conditional append.
- Measures the final prepared event identities once using logical serialized-event UTF-8 or an explicit provider exact/certified-bound capability; rejects strict unavailable/over-limit operations before event, tag, head, or publisher work.
- Preserves reservation cancellation, conditional receipts, public constructor/interface compatibility, and Orleans destination resolver/service identity by capturing and reusing one destination plan.
- Records explicit diagnostics for non-strict unavailable capabilities and leaves Azure Queue wire envelope, batching, retry, and historical repair outside the contract.
- Adds EN/JA API, command, Orleans, and storage documentation.

## Verification

- `dotnet build dcb/src/Sekiban.Dcb.WithResult/Sekiban.Dcb.WithResult.csproj -c Release --no-restore -p:GeneratePackageOnBuild=false -v:minimal` — net9/net10 succeeded.
- `dotnet build dcb/src/Sekiban.Dcb.WithoutResult/Sekiban.Dcb.WithoutResult.csproj -c Release --no-restore -p:GeneratePackageOnBuild=false -v:minimal` — net9/net10 succeeded.
- `dotnet build dcb/src/Sekiban.Dcb.Orleans.Core/Sekiban.Dcb.Orleans.Core.csproj -c Release --no-restore -p:GeneratePackageOnBuild=false -v:minimal` — net9/net10 succeeded.
- `dotnet build dcb/src/Sekiban.Dcb.Orleans.WithResult/Sekiban.Dcb.Orleans.WithResult.csproj -c Release --no-restore -p:GeneratePackageOnBuild=false -v:minimal` — net9/net10 succeeded.
- `dotnet build dcb/src/Sekiban.Dcb.Orleans.WithoutResult/Sekiban.Dcb.Orleans.WithoutResult.csproj -c Release --no-restore -p:GeneratePackageOnBuild=false -v:minimal` — net9/net10 succeeded.
- Focused `ExecutorSizeGate` tests: WithResult 12/12 and WithoutResult 2/2 on both net9.0 and net10.0.
- Binary compatibility tests: WithResult 13/13 and WithoutResult 8/8 on both net9.0 and net10.0.
- `git diff --check` passed before commit.

The builds report the repository's existing package-vulnerability and obsolete/test-analyzer warnings; no new compiler errors or new nullable warnings remain. CI and independent exact-head review remain required before merge.
