### PR TITLE
SEK-G67 Add DynamoDB event-item size gate

### DIFF
--- a/.github/workflows/run_test_dcb.yml
+++ b/.github/workflows/run_test_dcb.yml
@@ -48,6 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       SEKIBAN_TAG_STREAM_CONTROLLED_CEILING: '1'
+      SEKIBAN_DYNAMODB_LOCAL_ENDPOINT: http://127.0.0.1:18000
     concurrency:
       group: dcb-tests-net9-${{ github.ref }}
       cancel-in-progress: false
@@ -80,6 +81,21 @@ jobs:
         run: |
           dotnet build -c Release -p:GeneratePackageOnBuild=false --verbosity minimal -m:1
 
+      - name: Start pinned DynamoDB Local for G67
+        run: |
+          docker run --rm -d --name sekiban-g67-dynamodb-local -p 18000:8000 \
+            amazon/dynamodb-local:2.6.1@sha256:1856c05cc66a0e49dc1099e483ad2851477eeebe2135250ac11a1d1227db54b1 \
+            -jar DynamoDBLocal.jar -inMemory -sharedDb
+          for attempt in $(seq 1 30); do
+            http_code="$(curl --silent --output /dev/null --write-out '%{http_code}' http://127.0.0.1:18000/ || true)"
+            if [ "$http_code" != "000" ]; then
+              exit 0
+            fi
+            sleep 1
+          done
+          docker logs sekiban-g67-dynamodb-local
+          exit 1
+
       - name: dotnet test DCB projects sequentially (net9.0)
         run: |
           dotnet test dcb/tests/Sekiban.Dcb.Orleans.Tests/Sekiban.Dcb.Orleans.Tests.csproj -c Release --no-build -f net9.0 --verbosity normal --collect:"XPlat Code Coverage" -- RunConfiguration.MaxCpuCount=1
@@ -90,6 +106,10 @@ jobs:
           dotnet test dcb/tests/Sekiban.Dcb.MaterializedView.Postgres.Tests/Sekiban.Dcb.MaterializedView.Postgres.Tests.csproj -c Release --no-build -f net9.0 --verbosity normal --collect:"XPlat Code Coverage" -- RunConfiguration.MaxCpuCount=1
           dotnet test dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests.csproj -c Release --no-build -f net9.0 --verbosity normal --collect:"XPlat Code Coverage" -- RunConfiguration.MaxCpuCount=1
           dotnet test dcb/tests/Sekiban.Dcb.BlobStorage.AzureStorage.Unit/Sekiban.Dcb.BlobStorage.AzureStorage.Unit.csproj -c Release --no-build -f net9.0 --verbosity normal --collect:"XPlat Code Coverage" -- RunConfiguration.MaxCpuCount=1
+
+      - name: Stop pinned DynamoDB Local
+        if: always()
+        run: docker rm -f sekiban-g67-dynamodb-local || true
 
       - name: Verify 10.14.1 materialized-view binary consumer without rebuild
         run: |
@@ -106,6 +126,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       SEKIBAN_TAG_STREAM_CONTROLLED_CEILING: '1'
+      SEKIBAN_DYNAMODB_LOCAL_ENDPOINT: http://127.0.0.1:18000
     concurrency:
       group: dcb-tests-net10-${{ github.ref }}
       cancel-in-progress: false
@@ -138,6 +159,21 @@ jobs:
         run: |
           dotnet build -c Release -p:GeneratePackageOnBuild=false --verbosity minimal -m:1
 
+      - name: Start pinned DynamoDB Local for G67
+        run: |
+          docker run --rm -d --name sekiban-g67-dynamodb-local -p 18000:8000 \
+            amazon/dynamodb-local:2.6.1@sha256:1856c05cc66a0e49dc1099e483ad2851477eeebe2135250ac11a1d1227db54b1 \
+            -jar DynamoDBLocal.jar -inMemory -sharedDb
+          for attempt in $(seq 1 30); do
+            http_code="$(curl --silent --output /dev/null --write-out '%{http_code}' http://127.0.0.1:18000/ || true)"
+            if [ "$http_code" != "000" ]; then
+              exit 0
+            fi
+            sleep 1
+          done
+          docker logs sekiban-g67-dynamodb-local
+          exit 1
+
       - name: dotnet test DCB projects sequentially (net10.0)
         run: |
           dotnet test dcb/tests/Sekiban.Dcb.Orleans.Tests/Sekiban.Dcb.Orleans.Tests.csproj -c Release --no-build -f net10.0 --verbosity normal --collect:"XPlat Code Coverage" -- RunConfiguration.MaxCpuCount=1
@@ -148,3 +184,7 @@ jobs:
           dotnet test dcb/tests/Sekiban.Dcb.MaterializedView.Postgres.Tests/Sekiban.Dcb.MaterializedView.Postgres.Tests.csproj -c Release --no-build -f net10.0 --verbosity normal --collect:"XPlat Code Coverage" -- RunConfiguration.MaxCpuCount=1
           dotnet test dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests.csproj -c Release --no-build -f net10.0 --verbosity normal --collect:"XPlat Code Coverage" -- RunConfiguration.MaxCpuCount=1
           dotnet test dcb/tests/Sekiban.Dcb.BlobStorage.AzureStorage.Unit/Sekiban.Dcb.BlobStorage.AzureStorage.Unit.csproj -c Release --no-build -f net10.0 --verbosity normal --collect:"XPlat Code Coverage" -- RunConfiguration.MaxCpuCount=1
+
+      - name: Stop pinned DynamoDB Local
+        if: always()
+        run: docker rm -f sekiban-g67-dynamodb-local || true

--- a/dcb/src/Sekiban.Dcb.DynamoDB/DynamoDbEventItemMapper.cs
+++ b/dcb/src/Sekiban.Dcb.DynamoDB/DynamoDbEventItemMapper.cs
@@ -1,0 +1,105 @@
+using System.Security.Cryptography;
+using System.Text;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.DynamoDB.Models;
+
+namespace Sekiban.Dcb.DynamoDB;
+
+/// <summary>
+/// The one provider-owned event-item mapper used by typed, serialized, and conditional writes.
+/// Keeping the mapper at the write boundary makes the measured item the item that the store emits.
+/// </summary>
+internal static class DynamoDbEventItemMapper
+{
+    public static DynamoDbEventWriteItem FromEvent(
+        Event @event,
+        string serializedPayload,
+        string serviceId,
+        int writeShardCount,
+        DateTimeOffset timestamp)
+    {
+        ArgumentNullException.ThrowIfNull(@event);
+        ArgumentNullException.ThrowIfNull(serializedPayload);
+        ArgumentNullException.ThrowIfNull(serviceId);
+
+        var timestampText = timestamp.ToString("O");
+        var dynamoEvent = DynamoEvent.FromEvent(
+            @event,
+            serializedPayload,
+            GetGsiPartitionKey(@event.SortableUniqueIdValue, serviceId, writeShardCount),
+            serviceId);
+        dynamoEvent.Timestamp = timestampText;
+
+        var tags = @event.Tags.Select(tagString =>
+        {
+            var tagGroup = tagString.Contains(':', StringComparison.Ordinal)
+                ? tagString.Split(':')[0]
+                : tagString;
+            var tag = DynamoTag.FromEventTag(
+                serviceId,
+                tagString,
+                BuildStoredTagGroup(serviceId, tagGroup),
+                @event.SortableUniqueIdValue,
+                @event.Id,
+                @event.EventType);
+            tag.CreatedAt = timestampText;
+            return tag;
+        }).ToList();
+
+        return new DynamoDbEventWriteItem(@event, dynamoEvent, tags);
+    }
+
+    public static DynamoDbEventWriteItem FromSerializableEvent(
+        SerializableEvent serializedEvent,
+        string serviceId,
+        int writeShardCount,
+        Guid? eventId = null,
+        DateTimeOffset? timestamp = null)
+    {
+        ArgumentNullException.ThrowIfNull(serializedEvent);
+
+        var helperEvent = new Event(
+            PlaceholderPayload.Instance,
+            serializedEvent.SortableUniqueIdValue,
+            serializedEvent.EventPayloadName,
+            eventId ?? serializedEvent.Id,
+            serializedEvent.EventMetadata,
+            serializedEvent.Tags);
+
+        return FromEvent(
+            helperEvent,
+            Encoding.UTF8.GetString(serializedEvent.Payload),
+            serviceId,
+            writeShardCount,
+            timestamp ?? DateTimeOffset.UtcNow);
+    }
+
+    private static string GetGsiPartitionKey(string sortableUniqueId, string serviceId, int writeShardCount)
+    {
+        if (writeShardCount <= 1)
+            return BuildEventsGsiPartitionKey(serviceId);
+
+        var hash = SHA256.HashData(Encoding.UTF8.GetBytes(sortableUniqueId));
+        var shard = (BitConverter.ToInt32(hash, 0) & int.MaxValue) % writeShardCount;
+        return BuildEventsGsiPartitionKey(serviceId, shard);
+    }
+
+    private static string BuildEventsGsiPartitionKey(string serviceId, int? shard = null)
+    {
+        var baseKey = $"SERVICE#{serviceId}#{DynamoDbContext.EventsGsiPartitionKey}";
+        return shard.HasValue ? $"{baseKey}#{shard.Value}" : baseKey;
+    }
+
+    private static string BuildStoredTagGroup(string serviceId, string tagGroup) =>
+        $"{serviceId}|{tagGroup}";
+
+    private sealed class PlaceholderPayload : IEventPayload
+    {
+        public static readonly PlaceholderPayload Instance = new();
+    }
+}
+
+internal sealed record DynamoDbEventWriteItem(
+    Event Event,
+    DynamoEvent DynamoEvent,
+    List<DynamoTag> DynamoTags);

--- a/dcb/src/Sekiban.Dcb.DynamoDB/DynamoDbEventItemSizeMeasurement.cs
+++ b/dcb/src/Sekiban.Dcb.DynamoDB/DynamoDbEventItemSizeMeasurement.cs
@@ -1,0 +1,110 @@
+using System.Text;
+using Amazon.DynamoDBv2.Model;
+using Sekiban.Dcb.SizeGates;
+
+namespace Sekiban.Dcb.DynamoDB;
+
+/// <summary>
+/// Measures the DynamoDB base event item emitted by this provider.
+/// </summary>
+public sealed class DynamoDbEventItemSizeMeasurement : IExecutorSizeMeasurement
+{
+    /// <summary>The DynamoDB service item ceiling: 400 KiB.</summary>
+    public const long MaximumItemBytes = 400L * 1024L;
+
+    /// <summary>The canonical provider scope for an event item.</summary>
+    public const string Scope = "dynamodb-event-item";
+
+    private readonly int _writeShardCount;
+
+    /// <summary>Creates a measurement using the provider's configured write-shard count when supplied.</summary>
+    public DynamoDbEventItemSizeMeasurement(DynamoDbEventStoreOptions? options = null)
+    {
+        _writeShardCount = Math.Max(1, options?.WriteShardCount ?? 1);
+    }
+
+    /// <summary>Measures the canonical DynamoDB base event item for the serialized executor boundary.</summary>
+    public ExecutorSizeMeasurementResult Measure(ExecutorSizeMeasurementContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        if (context.Representation != ExecutorSizeRepresentation.StorageItem)
+        {
+            return ExecutorSizeMeasurementResult.Unavailable(
+                "DynamoDB event-item measurement supports only the StorageItem representation");
+        }
+
+        try
+        {
+            var mapped = DynamoDbEventItemMapper.FromSerializableEvent(
+                context.SerializedEvent,
+                context.ServiceId,
+                _writeShardCount,
+                timestamp: DateTimeOffset.UtcNow);
+            return ExecutorSizeMeasurementResult.Exact(
+                DynamoDbItemSizeCalculator.Calculate(mapped.DynamoEvent.ToAttributeValues()));
+        }
+        catch (Exception ex) when (ex is ArgumentException or FormatException or InvalidOperationException or OverflowException)
+        {
+            return ExecutorSizeMeasurementResult.Unavailable(
+                $"DynamoDB event-item mapping failed with {ex.GetType().Name}");
+        }
+    }
+}
+
+/// <summary>
+/// AWS DynamoDB item-size accounting for the AttributeValue shapes emitted by the event mapper.
+/// Attribute names and UTF-8 string bytes are counted; a list/map contributes its element bytes plus the
+/// documented three-byte collection overhead. This deliberately excludes billing, GSI projection, and request
+/// envelope overhead because those are not part of the DynamoDB base item limit.
+/// </summary>
+internal static class DynamoDbItemSizeCalculator
+{
+    private const int CollectionOverheadBytes = 3;
+
+    public static long Calculate(IReadOnlyDictionary<string, AttributeValue> item)
+    {
+        ArgumentNullException.ThrowIfNull(item);
+
+        long total = 0;
+        foreach (var pair in item)
+        {
+            total = checked(total + Encoding.UTF8.GetByteCount(pair.Key));
+            total = checked(total + CalculateValue(pair.Value));
+        }
+
+        return total;
+    }
+
+    private static long CalculateValue(AttributeValue value)
+    {
+        if (value.S is not null)
+            return Encoding.UTF8.GetByteCount(value.S);
+        if (value.N is not null)
+            return Encoding.UTF8.GetByteCount(value.N);
+        if (value.B is not null)
+            return value.B.Length;
+        if (value.SS is { Count: > 0 })
+            return value.SS.Sum(Encoding.UTF8.GetByteCount);
+        if (value.NS is { Count: > 0 })
+            return value.NS.Sum(Encoding.UTF8.GetByteCount);
+        if (value.BS is { Count: > 0 })
+            return value.BS.Sum(stream => stream.Length);
+        if (value.L is { Count: > 0 })
+            return checked(CollectionOverheadBytes + value.L.Sum(item => 1 + CalculateValue(item)));
+        if (value.L is not null)
+            return CollectionOverheadBytes;
+        if (value.M is { Count: > 0 })
+        {
+            return checked(CollectionOverheadBytes + value.M.Sum(pair =>
+                1 + Encoding.UTF8.GetByteCount(pair.Key) + CalculateValue(pair.Value)));
+        }
+        if (value.M is not null)
+            return CollectionOverheadBytes;
+
+        if (value.NULL == true || value.IsBOOLSet)
+            return 1;
+
+        return 0;
+    }
+}

--- a/dcb/src/Sekiban.Dcb.DynamoDB/DynamoDbEventStore.cs
+++ b/dcb/src/Sekiban.Dcb.DynamoDB/DynamoDbEventStore.cs
@@ -57,33 +57,13 @@ public partial class DynamoDbEventStore : IHotEventStore, IStorageDurabilityDesc
     {
         await _context.EnsureTablesAsync().ConfigureAwait(false);
         var serviceId = CurrentServiceId;
-        var serializedPayload = Encoding.UTF8.GetString(claimEvent.Payload);
-        var helperEvent = new Event(
-            SerializableEventPlaceholder.Instance,
-            claimEvent.SortableUniqueIdValue,
-            claimEvent.EventPayloadName,
-            deterministicId,
-            claimEvent.EventMetadata,
-            claimEvent.Tags);
-        var dynEvent = DynamoEvent.FromEvent(
-            helperEvent,
-            serializedPayload,
-            GetGsiPartitionKey(claimEvent.SortableUniqueIdValue, serviceId),
-            serviceId);
-        var dynamoTags = claimEvent.Tags.Select(tagString =>
-        {
-            var tagGroup = tagString.Contains(':', StringComparison.Ordinal)
-                ? tagString.Split(':')[0]
-                : tagString;
-            var storedTagGroup = BuildStoredTagGroup(serviceId, tagGroup);
-            return DynamoTag.FromEventTag(
-                serviceId,
-                tagString,
-                storedTagGroup,
-                claimEvent.SortableUniqueIdValue,
-                deterministicId,
-                claimEvent.EventPayloadName);
-        }).ToList();
+        var mapped = DynamoDbEventItemMapper.FromSerializableEvent(
+            claimEvent,
+            serviceId,
+            _options.WriteShardCount,
+            deterministicId);
+        var dynEvent = mapped.DynamoEvent;
+        var dynamoTags = mapped.DynamoTags;
 
         // The event Put is ALWAYS index 0 — only its attribute_not_exists(pk) condition is the claim guard, so only a
         // cancellation reason at index 0 classifies as a conflict (see the catch below).
@@ -393,28 +373,14 @@ public partial class DynamoDbEventStore : IHotEventStore, IStorageDurabilityDesc
                         TagWrites: (IReadOnlyList<TagWriteResult>)Array.Empty<TagWriteResult>()));
             }
 
-            var eventItems = eventsList.Select(ev => new EventWriteItem(
-                ev,
-                DynamoEvent.FromEvent(
+            var eventItems = eventsList
+                .Select(ev => DynamoDbEventItemMapper.FromEvent(
                     ev,
                     SerializeEventPayload(ev.Payload),
-                    GetGsiPartitionKey(ev.SortableUniqueIdValue, serviceId),
-                    serviceId),
-                ev.Tags.Select(tagString =>
-                {
-                    var tagGroup = tagString.Contains(':', StringComparison.Ordinal)
-                        ? tagString.Split(':')[0]
-                        : tagString;
-                    var storedTagGroup = BuildStoredTagGroup(serviceId, tagGroup);
-                    return DynamoTag.FromEventTag(
-                        serviceId,
-                        tagString,
-                        storedTagGroup,
-                        ev.SortableUniqueIdValue,
-                        ev.Id,
-                        ev.EventType);
-                }).ToList()
-            )).ToList();
+                    serviceId,
+                    _options.WriteShardCount,
+                    DateTimeOffset.UtcNow))
+                .ToList();
 
             var batches = BuildTransactionBatches(eventItems);
             if (batches == null)
@@ -892,10 +858,10 @@ public partial class DynamoDbEventStore : IHotEventStore, IStorageDurabilityDesc
         throw new InvalidOperationException("BatchGetItem exceeded retry limit.");
     }
 
-    private List<List<EventWriteItem>>? BuildTransactionBatches(List<EventWriteItem> eventItems)
+    private List<List<DynamoDbEventWriteItem>>? BuildTransactionBatches(List<DynamoDbEventWriteItem> eventItems)
     {
-        var batches = new List<List<EventWriteItem>>();
-        var current = new List<EventWriteItem>();
+        var batches = new List<List<DynamoDbEventWriteItem>>();
+        var current = new List<DynamoDbEventWriteItem>();
         var currentCount = 0;
 
         foreach (var item in eventItems)
@@ -907,7 +873,7 @@ public partial class DynamoDbEventStore : IHotEventStore, IStorageDurabilityDesc
             if (currentCount + itemCount > _options.MaxTransactionItems)
             {
                 batches.Add(current);
-                current = new List<EventWriteItem>();
+                current = new List<DynamoDbEventWriteItem>();
                 currentCount = 0;
             }
 
@@ -921,7 +887,7 @@ public partial class DynamoDbEventStore : IHotEventStore, IStorageDurabilityDesc
         return batches;
     }
 
-    private async Task WriteEventsWithTransactionsAsync(List<List<EventWriteItem>> batches)
+    private async Task WriteEventsWithTransactionsAsync(List<List<DynamoDbEventWriteItem>> batches)
     {
         foreach (var batch in batches)
         {
@@ -963,7 +929,7 @@ public partial class DynamoDbEventStore : IHotEventStore, IStorageDurabilityDesc
         }
     }
 
-    private async Task WriteEventsWithBatchAsync(List<EventWriteItem> eventItems)
+    private async Task WriteEventsWithBatchAsync(List<DynamoDbEventWriteItem> eventItems)
     {
         var eventWrites = eventItems
             .Select(item => new WriteRequest
@@ -1342,40 +1308,13 @@ public partial class DynamoDbEventStore : IHotEventStore, IStorageDurabilityDesc
                         TagWrites: (IReadOnlyList<TagWriteResult>)Array.Empty<TagWriteResult>()));
             }
 
-            var eventItems = eventsList.Select(se =>
-            {
-                var serializedPayload = Encoding.UTF8.GetString(se.Payload);
-                var helperEvent = new Event(
-                    SerializableEventPlaceholder.Instance,
-                    se.SortableUniqueIdValue,
-                    se.EventPayloadName,
-                    se.Id,
-                    se.EventMetadata,
-                    se.Tags);
-
-                var dynEvent = DynamoEvent.FromEvent(
-                    helperEvent,
-                    serializedPayload,
-                    GetGsiPartitionKey(se.SortableUniqueIdValue, serviceId),
-                    serviceId);
-
-                var dynamoTags = se.Tags.Select(tagString =>
-                {
-                    var tagGroup = tagString.Contains(':', StringComparison.Ordinal)
-                        ? tagString.Split(':')[0]
-                        : tagString;
-                    var storedTagGroup = BuildStoredTagGroup(serviceId, tagGroup);
-                    return DynamoTag.FromEventTag(
-                        serviceId,
-                        tagString,
-                        storedTagGroup,
-                        se.SortableUniqueIdValue,
-                        se.Id,
-                        se.EventPayloadName);
-                }).ToList();
-
-                return new EventWriteItem(helperEvent, dynEvent, dynamoTags);
-            }).ToList();
+            var eventItems = eventsList
+                .Select(se => DynamoDbEventItemMapper.FromSerializableEvent(
+                    se,
+                    serviceId,
+                    _options.WriteShardCount,
+                    timestamp: DateTimeOffset.UtcNow))
+                .ToList();
 
             var batches = BuildTransactionBatches(eventItems);
             if (batches == null)
@@ -1465,14 +1404,4 @@ public partial class DynamoDbEventStore : IHotEventStore, IStorageDurabilityDesc
         return events;
     }
 
-    private sealed record EventWriteItem(Event Event, DynamoEvent DynamoEvent, List<DynamoTag> DynamoTags);
-
-    /// <summary>
-    ///     Placeholder payload used when constructing Event objects for serializable event writes.
-    ///     The actual payload is already serialized in the SerializableEvent.
-    /// </summary>
-    private sealed class SerializableEventPlaceholder : IEventPayload
-    {
-        public static readonly SerializableEventPlaceholder Instance = new();
-    }
 }

--- a/dcb/src/Sekiban.Dcb.DynamoDB/DynamoDbExecutorSizeGateExtensions.cs
+++ b/dcb/src/Sekiban.Dcb.DynamoDB/DynamoDbExecutorSizeGateExtensions.cs
@@ -1,0 +1,67 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Sekiban.Dcb.SizeGates;
+
+namespace Sekiban.Dcb.DynamoDB;
+
+/// <summary>Provider-owned opt-in registration for DynamoDB event-item size measurement.</summary>
+public static class DynamoDbExecutorSizeGateExtensions
+{
+    /// <summary>
+    /// Adds the canonical DynamoDB base event-item policy to an existing gate option set.
+    /// The per-event default is the DynamoDB 400 KiB ceiling; a smaller quota is allowed.
+    /// </summary>
+    public static ExecutorSizeGateOptions AddDynamoDbEventItemPolicy(
+        this ExecutorSizeGateOptions options,
+        DynamoDbEventStoreOptions? storeOptions = null,
+        long? maxBytesPerEvent = null,
+        long? maxBytesPerOperation = null,
+        ExecutorSizeStrictness strictness = ExecutorSizeStrictness.Strict)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        var eventLimit = maxBytesPerEvent ?? DynamoDbEventItemSizeMeasurement.MaximumItemBytes;
+        if (eventLimit <= 0 || eventLimit > DynamoDbEventItemSizeMeasurement.MaximumItemBytes)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(maxBytesPerEvent),
+                $"DynamoDB event-item per-event limit must be between 1 and " +
+                $"{DynamoDbEventItemSizeMeasurement.MaximumItemBytes} bytes.");
+        }
+
+        if (maxBytesPerOperation is <= 0)
+            throw new ArgumentOutOfRangeException(nameof(maxBytesPerOperation));
+
+        return options.Add(new ExecutorSizePolicy(
+            DynamoDbEventItemSizeMeasurement.Scope,
+            ExecutorSizeRepresentation.StorageItem,
+            eventLimit,
+            maxBytesPerOperation,
+            strictness,
+            new DynamoDbEventItemSizeMeasurement(storeOptions)));
+    }
+
+    /// <summary>
+    /// Registers a DynamoDB event-item gate that resolves the provider's configured shard mapping from DI.
+    /// The method is additive; without this call existing DynamoDB registration remains ungated.
+    /// </summary>
+    public static IServiceCollection AddSekibanDcbDynamoDbEventItemSizeGate(
+        this IServiceCollection services,
+        long? maxBytesPerEvent = null,
+        long? maxBytesPerOperation = null,
+        ExecutorSizeStrictness strictness = ExecutorSizeStrictness.Strict)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.AddSingleton<ExecutorSizeGateOptions>(serviceProvider =>
+        {
+            var storeOptions = serviceProvider.GetService<IOptions<DynamoDbEventStoreOptions>>()?.Value;
+            return new ExecutorSizeGateOptions().AddDynamoDbEventItemPolicy(
+                storeOptions,
+                maxBytesPerEvent,
+                maxBytesPerOperation,
+                strictness);
+        });
+        return services;
+    }
+}

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/DynamoDbEventItemSizeMeasurementTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/DynamoDbEventItemSizeMeasurementTests.cs
@@ -1,0 +1,314 @@
+using System.Reflection;
+using System.Text;
+using System.Text.Json;
+using Amazon.DynamoDBv2;
+using Amazon.DynamoDBv2.Model;
+using Dcb.Domain;
+using Dcb.Domain.Student;
+using Dcb.Domain.Weather;
+using ResultBoxes;
+using Sekiban.Dcb.Actors;
+using Sekiban.Dcb.Commands;
+using Sekiban.Dcb.Common;
+using Sekiban.Dcb.Domains;
+using Sekiban.Dcb.DynamoDB;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.ServiceId;
+using Sekiban.Dcb.SizeGates;
+using Sekiban.Dcb.Storage;
+using Sekiban.Dcb.Testing;
+using Microsoft.Extensions.Options;
+using CoreInMemoryEventStore = Sekiban.Dcb.Testing.InMemoryEventStore;
+
+namespace Sekiban.Dcb.Tests;
+
+/// <summary>
+/// G67 provider mapping and gate proofs. The expected byte calculation in this file is intentionally independent
+/// from the production calculator; the production map is captured from the real store and the oracle only applies
+/// AWS's AttributeValue accounting to that captured request shape.
+/// </summary>
+public sealed class DynamoDbEventItemSizeMeasurementTests
+{
+    [Fact]
+    public async Task TypedSerializedAndConditionalRoutesShareTheCanonicalEventItemShape()
+    {
+        var domain = DomainType.GetDomainTypes();
+        var eventId = Guid.CreateVersion7();
+        var @event = new Event(
+            new StudentCreated(Guid.CreateVersion7(), "東京😀", 21),
+            SortableUniqueId.GenerateNew(),
+            nameof(StudentCreated),
+            eventId,
+            new EventMetadata("因果", "相関", "ユーザー"),
+            ["Student:東京😀", "タグ"]);
+        var serialized = @event.ToSerializableEvent(domain.EventTypes);
+        var client = DispatchProxy.Create<IAmazonDynamoDB, CapturingDynamoDb>();
+        var capture = (CapturingDynamoDb)(object)client;
+        var store = NewStore(client, domain, "shape");
+
+        Assert.True((await store.WriteEventsAsync([@event])).IsSuccess);
+        var typedEvent = capture.EventItems.Single();
+        capture.Clear();
+
+        Assert.True((await store.WriteSerializableEventsAsync([serialized])).IsSuccess);
+        var serializedEvent = capture.EventItems.Single();
+        Assert.Equal(2, capture.TagItems.Count);
+        capture.Clear();
+
+        var conditional = await store.AppendIfUniqueAsync(
+            new ConditionalAppendRequest("shape-conditional", serialized));
+        Assert.True(conditional.IsSuccess);
+        var conditionalEvent = capture.EventItems.Single();
+
+        Assert.Equal(Normalize(typedEvent, "pk", "sk", "eventId", "timestamp"),
+            Normalize(serializedEvent, "pk", "sk", "eventId", "timestamp"));
+        Assert.Equal(Normalize(typedEvent, "pk", "sk", "eventId", "timestamp"),
+            Normalize(conditionalEvent, "pk", "sk", "eventId", "timestamp"));
+        Assert.Equal(serializedEvent["payload"].S, conditionalEvent["payload"].S);
+        Assert.Equal(serializedEvent["gsi1pk"].S, conditionalEvent["gsi1pk"].S);
+        Assert.Equal(serializedEvent["tags"].L.Select(x => x.S), conditionalEvent["tags"].L.Select(x => x.S));
+    }
+
+    [Fact]
+    public async Task MeasurementMatchesAnIndependentUtf8AndListOracleIncludingOptionalMetadata()
+    {
+        var domain = DomainType.GetDomainTypes();
+        var @event = new Event(
+            new StudentCreated(Guid.CreateVersion7(), "名前😀", 42),
+            SortableUniqueId.GenerateNew(),
+            nameof(StudentCreated),
+            Guid.CreateVersion7(),
+            new EventMetadata("cause-東京", "correlation", "ユーザー"),
+            ["Student:東京", "tag😀"]);
+        var serialized = @event.ToSerializableEvent(domain.EventTypes);
+        var client = DispatchProxy.Create<IAmazonDynamoDB, CapturingDynamoDb>();
+        var capture = (CapturingDynamoDb)(object)client;
+        var store = NewStore(client, domain, "oracle");
+        Assert.True((await store.WriteSerializableEventsAsync([serialized])).IsSuccess);
+
+        var measurement = new DynamoDbEventItemSizeMeasurement(new DynamoDbEventStoreOptions { WriteShardCount = 1 });
+        var measured = measurement.Measure(new ExecutorSizeMeasurementContext(
+            DynamoDbEventItemSizeMeasurement.Scope,
+            ExecutorSizeRepresentation.StorageItem,
+            @event,
+            serialized,
+            "oracle",
+            null,
+            null));
+
+        Assert.True(measured.IsAvailable);
+        Assert.Equal(IndependentItemBytes(capture.EventItems.Single()), measured.Bytes);
+    }
+
+    [Theory]
+    [InlineData(409599)]
+    [InlineData(409600)]
+    [InlineData(409601)]
+    public void MeasurementMatchesTheDynamoDbItemBoundary(long expectedBytes)
+    {
+        var empty = new SerializableEvent(
+            [],
+            SortableUniqueId.GenerateNew(),
+            Guid.CreateVersion7(),
+            new EventMetadata("cause", "correlation", "user"),
+            [],
+            nameof(StudentCreated));
+        var measurement = new DynamoDbEventItemSizeMeasurement();
+        var emptyBytes = MeasureSerialized(measurement, empty);
+        var sized = empty with
+        {
+            Payload = Enumerable.Repeat(
+                (byte)'x',
+                checked((int)(expectedBytes - emptyBytes))).ToArray()
+        };
+
+        Assert.Equal(expectedBytes, MeasureSerialized(measurement, sized));
+    }
+
+    [Fact]
+    public void ProviderRegistrationDefaultsToTheServiceCeilingAndRejectsAnImpossibleQuota()
+    {
+        var options = new ExecutorSizeGateOptions().AddDynamoDbEventItemPolicy();
+        var policy = Assert.Single(options.Policies);
+        Assert.Equal(DynamoDbEventItemSizeMeasurement.Scope, policy.Scope);
+        Assert.Equal(ExecutorSizeRepresentation.StorageItem, policy.Representation);
+        Assert.Equal(DynamoDbEventItemSizeMeasurement.MaximumItemBytes, policy.MaxBytesPerEvent);
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            new ExecutorSizeGateOptions().AddDynamoDbEventItemPolicy(
+                maxBytesPerEvent: DynamoDbEventItemSizeMeasurement.MaximumItemBytes + 1));
+    }
+
+    [Fact]
+    public async Task ProviderMeasurementRejectsAnOversizedLastEventBeforeTheStore()
+    {
+        var domain = DomainType.GetDomainTypes();
+        var store = new CoreInMemoryEventStore(domain.EventTypes);
+        var executor = new GeneralSekibanExecutor(
+            store,
+            new InMemoryObjectAccessor(store, domain),
+            domain,
+            new ExecutorSizeGateOptions().AddDynamoDbEventItemPolicy());
+        var eventId = Guid.CreateVersion7();
+        var payload = JsonSerializer.SerializeToUtf8Bytes(
+            new WeatherForecastCreated(
+                eventId,
+                "東京",
+                new DateOnly(2026, 9, 9),
+                21,
+                new string('x', (int)DynamoDbEventItemSizeMeasurement.MaximumItemBytes))
+            , domain.JsonSerializerOptions);
+        var request = new SerializedCommitRequest(
+            [new SerializableEventCandidate(payload, nameof(WeatherForecastCreated), [])],
+            []);
+
+        var result = await executor.CommitSerializableEventsAsync(request);
+
+        Assert.IsType<ExecutorSizeLimitExceededException>(result.GetException());
+        Assert.Empty((await store.ReadAllSerializableEventsAsync()).GetValue());
+    }
+
+    private static DynamoDbEventStore NewStore(
+        IAmazonDynamoDB client,
+        DcbDomainTypes domain,
+        string serviceId)
+    {
+        var options = Options.Create(new DynamoDbEventStoreOptions
+        {
+            AutoCreateTables = false,
+            EventsTableName = $"events-{serviceId}",
+            TagsTableName = $"tags-{serviceId}",
+            ProjectionStatesTableName = $"projection-{serviceId}"
+        });
+        return new DynamoDbEventStore(
+            new DynamoDbContext(client, options),
+            domain.EventTypes,
+            new FixedServiceIdProvider(serviceId));
+    }
+
+    private static Dictionary<string, string> Normalize(
+        IReadOnlyDictionary<string, AttributeValue> item,
+        params string[] ignored)
+    {
+        var ignoredSet = ignored.ToHashSet(StringComparer.Ordinal);
+        return item
+            .Where(pair => !ignoredSet.Contains(pair.Key))
+            .ToDictionary(pair => pair.Key, pair => ValueSignature(pair.Value), StringComparer.Ordinal);
+    }
+
+    private static string ValueSignature(AttributeValue value) =>
+        value.S is not null
+            ? $"S:{value.S}"
+            : value.L is not null
+                ? $"L:[{string.Join(",", value.L.Select(ValueSignature))}]"
+                : value.N is not null
+                    ? $"N:{value.N}"
+                    : "other";
+
+    private static long IndependentItemBytes(IReadOnlyDictionary<string, AttributeValue> item) =>
+        item.Sum(pair => Encoding.UTF8.GetByteCount(pair.Key) + IndependentValueBytes(pair.Value));
+
+    private static long MeasureSerialized(
+        DynamoDbEventItemSizeMeasurement measurement,
+        SerializableEvent serialized)
+    {
+        var result = measurement.Measure(new ExecutorSizeMeasurementContext(
+            DynamoDbEventItemSizeMeasurement.Scope,
+            ExecutorSizeRepresentation.StorageItem,
+            new Event(
+                new StudentCreated(Guid.CreateVersion7(), "boundary", 1),
+                serialized.SortableUniqueIdValue,
+                serialized.EventPayloadName,
+                serialized.Id,
+                serialized.EventMetadata,
+                serialized.Tags),
+            serialized,
+            "boundary",
+            null,
+            null));
+        Assert.True(result.IsAvailable, result.Reason);
+        return Assert.IsType<long>(result.Bytes);
+    }
+
+    private static long IndependentValueBytes(AttributeValue value)
+    {
+        if (value.S is not null)
+            return Encoding.UTF8.GetByteCount(value.S);
+        if (value.N is not null)
+            return Encoding.UTF8.GetByteCount(value.N);
+        if (value.L is not null)
+            return 3 + value.L.Sum(item => 1 + IndependentValueBytes(item));
+        if (value.M is not null)
+            return 3 + value.M.Sum(pair =>
+                1 + Encoding.UTF8.GetByteCount(pair.Key) + IndependentValueBytes(pair.Value));
+        if (value.B is not null)
+            return value.B.Length;
+        if (value.SS is not null)
+            return value.SS.Sum(Encoding.UTF8.GetByteCount);
+        if (value.NS is not null)
+            return value.NS.Sum(Encoding.UTF8.GetByteCount);
+        if (value.BS is not null)
+            return value.BS.Sum(stream => stream.Length);
+        return value.NULL == true || value.IsBOOLSet ? 1 : 0;
+    }
+
+    private sealed class FixedServiceIdProvider(string serviceId) : IServiceIdProvider
+    {
+        public string GetCurrentServiceId() => serviceId;
+    }
+
+    public class CapturingDynamoDb : DispatchProxy
+    {
+        public List<Dictionary<string, AttributeValue>> EventItems { get; } = [];
+        public List<Dictionary<string, AttributeValue>> TagItems { get; } = [];
+
+        public void Clear()
+        {
+            EventItems.Clear();
+            TagItems.Clear();
+        }
+
+        protected override object? Invoke(MethodInfo? targetMethod, object?[]? args)
+        {
+            var name = targetMethod?.Name ?? string.Empty;
+            var arg0 = args is { Length: > 0 } ? args[0] : null;
+
+            if (arg0 is TransactWriteItemsRequest transaction && name == nameof(IAmazonDynamoDB.TransactWriteItemsAsync))
+            {
+                foreach (var item in transaction.TransactItems)
+                {
+                    if (item.Put is not { } put)
+                        continue;
+                    if (put.TableName.StartsWith("events-", StringComparison.Ordinal))
+                        EventItems.Add(put.Item);
+                    else
+                        TagItems.Add(put.Item);
+                }
+
+                return Task.FromResult(new TransactWriteItemsResponse());
+            }
+
+            if (arg0 is BatchWriteItemRequest batch && name == nameof(IAmazonDynamoDB.BatchWriteItemAsync))
+            {
+                foreach (var writes in batch.RequestItems.Values)
+                {
+                    foreach (var write in writes)
+                    {
+                        if (write.PutRequest is not { } put)
+                            continue;
+                        if (put.Item.ContainsKey("eventType"))
+                            EventItems.Add(put.Item);
+                        else
+                            TagItems.Add(put.Item);
+                    }
+                }
+
+                return Task.FromResult(new BatchWriteItemResponse { UnprocessedItems = [] });
+            }
+
+            if (name == "Dispose" || name.StartsWith("get_", StringComparison.Ordinal))
+                return null;
+
+            throw new NotSupportedException($"CapturingDynamoDb does not support {name}");
+        }
+    }
+}

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/DynamoDbEventItemSizeMeasurementTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/DynamoDbEventItemSizeMeasurementTests.cs
@@ -1,4 +1,3 @@
-using System.Reflection;
 using System.Text;
 using System.Text.Json;
 using Amazon.DynamoDBv2;
@@ -42,7 +41,7 @@ public sealed class DynamoDbEventItemSizeMeasurementTests
             new EventMetadata("因果", "相関", "ユーザー"),
             ["Student:東京😀", "タグ"]);
         var serialized = @event.ToSerializableEvent(domain.EventTypes);
-        var client = DispatchProxy.Create<IAmazonDynamoDB, CapturingDynamoDb>();
+        var client = System.Reflection.DispatchProxy.Create<IAmazonDynamoDB, CapturingDynamoDb>();
         var capture = (CapturingDynamoDb)(object)client;
         var store = NewStore(client, domain, "shape");
 
@@ -81,7 +80,7 @@ public sealed class DynamoDbEventItemSizeMeasurementTests
             new EventMetadata("cause-東京", "correlation", "ユーザー"),
             ["Student:東京", "tag😀"]);
         var serialized = @event.ToSerializableEvent(domain.EventTypes);
-        var client = DispatchProxy.Create<IAmazonDynamoDB, CapturingDynamoDb>();
+        var client = System.Reflection.DispatchProxy.Create<IAmazonDynamoDB, CapturingDynamoDb>();
         var capture = (CapturingDynamoDb)(object)client;
         var store = NewStore(client, domain, "oracle");
         Assert.True((await store.WriteSerializableEventsAsync([serialized])).IsSuccess);
@@ -126,6 +125,34 @@ public sealed class DynamoDbEventItemSizeMeasurementTests
     }
 
     [Fact]
+    public void LogicalPayloadOnlyMutant_FailsTheMappedItemBoundaryOracle()
+    {
+        var empty = new SerializableEvent(
+            [],
+            SortableUniqueId.GenerateNew(),
+            Guid.CreateVersion7(),
+            new EventMetadata("cause", "correlation", "user"),
+            [],
+            nameof(StudentCreated));
+        var measurement = new DynamoDbEventItemSizeMeasurement();
+        var emptyBytes = MeasureSerialized(measurement, empty);
+        var mappedBoundary = empty with
+        {
+            Payload = Enumerable.Repeat(
+                (byte)'x',
+                checked((int)(DynamoDbEventItemSizeMeasurement.MaximumItemBytes + 1 - emptyBytes))).ToArray()
+        };
+
+        var mappedBytes = MeasureSerialized(measurement, mappedBoundary);
+        var logicalPayloadOnlyMutant = mappedBoundary.Payload.Length;
+
+        Assert.Equal(DynamoDbEventItemSizeMeasurement.MaximumItemBytes + 1, mappedBytes);
+        Assert.True(mappedBytes > DynamoDbEventItemSizeMeasurement.MaximumItemBytes);
+        Assert.True(logicalPayloadOnlyMutant <= DynamoDbEventItemSizeMeasurement.MaximumItemBytes);
+        Assert.True(logicalPayloadOnlyMutant < mappedBytes);
+    }
+
+    [Fact]
     public void ProviderRegistrationDefaultsToTheServiceCeilingAndRejectsAnImpossibleQuota()
     {
         var options = new ExecutorSizeGateOptions().AddDynamoDbEventItemPolicy();
@@ -136,6 +163,104 @@ public sealed class DynamoDbEventItemSizeMeasurementTests
         Assert.Throws<ArgumentOutOfRangeException>(() =>
             new ExecutorSizeGateOptions().AddDynamoDbEventItemPolicy(
                 maxBytesPerEvent: DynamoDbEventItemSizeMeasurement.MaximumItemBytes + 1));
+    }
+
+    [Theory]
+    [InlineData(ExecutorSizeRepresentation.LogicalSerializedEventUtf8)]
+    [InlineData(ExecutorSizeRepresentation.Destination)]
+    public void NonStorageRepresentation_IsUnavailable(ExecutorSizeRepresentation representation)
+    {
+        var result = new DynamoDbEventItemSizeMeasurement().Measure(
+            CreateMeasurementContext(representation));
+
+        Assert.False(result.IsAvailable);
+        Assert.Null(result.Bytes);
+        Assert.Contains("only the StorageItem representation", result.Reason);
+    }
+
+    [Fact]
+    public async Task StrictUnavailableDynamoDbCapability_RejectsBeforeAnyStoreWrite()
+    {
+        var domain = DomainType.GetDomainTypes();
+        var store = new CoreInMemoryEventStore(domain.EventTypes);
+        var executor = new GeneralSekibanExecutor(
+            store,
+            new InMemoryObjectAccessor(store, domain),
+            domain,
+            new ExecutorSizeGateOptions().Add(new ExecutorSizePolicy(
+                DynamoDbEventItemSizeMeasurement.Scope,
+                ExecutorSizeRepresentation.LogicalSerializedEventUtf8,
+                maxBytesPerEvent: 1024,
+                measurement: new DynamoDbEventItemSizeMeasurement())));
+
+        var result = await executor.CommitSerializableEventsAsync(
+            new SerializedCommitRequest([CreateCandidate(domain, Guid.NewGuid())], []));
+
+        var exception = Assert.IsType<ExecutorSizeCapabilityException>(result.GetException());
+        Assert.Equal(DynamoDbEventItemSizeMeasurement.Scope, exception.Scope);
+        Assert.Equal(ExecutorSizeRepresentation.LogicalSerializedEventUtf8, exception.Representation);
+        Assert.Contains("only the StorageItem representation", exception.Reason);
+        Assert.Empty((await store.ReadAllSerializableEventsAsync()).GetValue());
+    }
+
+    [Fact]
+    public async Task NonStrictUnavailableDynamoDbCapability_EmitsNamedUnvalidatedDiagnosticAndContinues()
+    {
+        var domain = DomainType.GetDomainTypes();
+        var store = new CoreInMemoryEventStore(domain.EventTypes);
+        var executor = new GeneralSekibanExecutor(
+            store,
+            new InMemoryObjectAccessor(store, domain),
+            domain,
+            new ExecutorSizeGateOptions().Add(new ExecutorSizePolicy(
+                DynamoDbEventItemSizeMeasurement.Scope,
+                ExecutorSizeRepresentation.LogicalSerializedEventUtf8,
+                maxBytesPerEvent: 1024,
+                strictness: ExecutorSizeStrictness.NonStrict,
+                measurement: new DynamoDbEventItemSizeMeasurement())));
+
+        var result = await executor.CommitSerializableEventsAsync(
+            new SerializedCommitRequest([CreateCandidate(domain, Guid.NewGuid())], []));
+
+        Assert.True(result.IsSuccess);
+        var diagnostic = Assert.Single(result.GetValue().SizeGateDiagnostics);
+        Assert.Equal(DynamoDbEventItemSizeMeasurement.Scope, diagnostic.Scope);
+        Assert.Equal(ExecutorSizeRepresentation.LogicalSerializedEventUtf8, diagnostic.Representation);
+        Assert.Contains("only the StorageItem representation", diagnostic.Reason);
+        Assert.Single((await store.ReadAllSerializableEventsAsync()).GetValue());
+    }
+
+    [Theory]
+    [InlineData(409600, true)]
+    [InlineData(409601, false)]
+    public async Task ExecutorGate_UsesTheDynamoDbCeilingAtExactBoundary(long measuredBytes, bool expectedSuccess)
+    {
+        var domain = DomainType.GetDomainTypes();
+        var store = new CoreInMemoryEventStore(domain.EventTypes);
+        var executor = new GeneralSekibanExecutor(
+            store,
+            new InMemoryObjectAccessor(store, domain),
+            domain,
+            new ExecutorSizeGateOptions().Add(new ExecutorSizePolicy(
+                DynamoDbEventItemSizeMeasurement.Scope,
+                ExecutorSizeRepresentation.StorageItem,
+                maxBytesPerEvent: DynamoDbEventItemSizeMeasurement.MaximumItemBytes,
+                measurement: new FixedMeasurement(measuredBytes))));
+
+        var result = await executor.CommitSerializableEventsAsync(
+            new SerializedCommitRequest([CreateCandidate(domain, Guid.NewGuid())], []));
+
+        Assert.Equal(expectedSuccess, result.IsSuccess);
+        if (expectedSuccess)
+        {
+            Assert.Single((await store.ReadAllSerializableEventsAsync()).GetValue());
+        }
+        else
+        {
+            var exception = Assert.IsType<ExecutorSizeLimitExceededException>(result.GetException());
+            Assert.Equal(DynamoDbEventItemSizeMeasurement.MaximumItemBytes + 1, exception.MeasuredBytes);
+            Assert.Empty((await store.ReadAllSerializableEventsAsync()).GetValue());
+        }
     }
 
     [Fact]
@@ -167,6 +292,35 @@ public sealed class DynamoDbEventItemSizeMeasurementTests
         Assert.Empty((await store.ReadAllSerializableEventsAsync()).GetValue());
     }
 
+    [Fact]
+    public async Task ProviderMeasurementRejectsOversizedLastEventWithoutAnyDynamoDbWriteDispatch()
+    {
+        var domain = DomainType.GetDomainTypes();
+        var client = System.Reflection.DispatchProxy.Create<IAmazonDynamoDB, CapturingDynamoDb>();
+        var capture = (CapturingDynamoDb)(object)client;
+        var store = NewStore(client, domain, "last-event");
+        var executor = new GeneralSekibanExecutor(
+            store,
+            new InMemoryObjectAccessor(store, domain),
+            domain,
+            new ExecutorSizeGateOptions().AddDynamoDbEventItemPolicy());
+        var first = CreateCandidate(domain, Guid.NewGuid(), "small");
+        var last = CreateCandidate(
+            domain,
+            Guid.NewGuid(),
+            new string('x', (int)DynamoDbEventItemSizeMeasurement.MaximumItemBytes));
+
+        var result = await executor.CommitSerializableEventsAsync(
+            new SerializedCommitRequest([first, last], []));
+
+        var exception = Assert.IsType<ExecutorSizeLimitExceededException>(result.GetException());
+        Assert.Equal(1, exception.EventIndex);
+        Assert.Equal(DynamoDbEventItemSizeMeasurement.Scope, exception.Scope);
+        Assert.Equal(0, capture.WriteDispatches);
+        Assert.Empty(capture.EventItems);
+        Assert.Empty(capture.TagItems);
+    }
+
     private static DynamoDbEventStore NewStore(
         IAmazonDynamoDB client,
         DcbDomainTypes domain,
@@ -183,6 +337,46 @@ public sealed class DynamoDbEventItemSizeMeasurementTests
             new DynamoDbContext(client, options),
             domain.EventTypes,
             new FixedServiceIdProvider(serviceId));
+    }
+
+    private static ExecutorSizeMeasurementContext CreateMeasurementContext(
+        ExecutorSizeRepresentation representation)
+    {
+        var serialized = new SerializableEvent(
+            Encoding.UTF8.GetBytes("{}"),
+            SortableUniqueId.GenerateNew(),
+            Guid.CreateVersion7(),
+            new EventMetadata("cause", "correlation", "user"),
+            [],
+            nameof(StudentCreated));
+        return new ExecutorSizeMeasurementContext(
+            DynamoDbEventItemSizeMeasurement.Scope,
+            representation,
+            new Event(
+                new StudentCreated(Guid.CreateVersion7(), "context", 1),
+                serialized.SortableUniqueIdValue,
+                serialized.EventPayloadName,
+                serialized.Id,
+                serialized.EventMetadata,
+                serialized.Tags),
+            serialized,
+            "context",
+            null,
+            null);
+    }
+
+    private static SerializableEventCandidate CreateCandidate(
+        DcbDomainTypes domain,
+        Guid id,
+        string summary = "size gate")
+    {
+        var payload = JsonSerializer.SerializeToUtf8Bytes(
+            new WeatherForecastCreated(id, "Tokyo", new DateOnly(2026, 9, 9), 21, summary),
+            domain.JsonSerializerOptions);
+        return new SerializableEventCandidate(
+            payload,
+            nameof(WeatherForecastCreated),
+            [$"WeatherForecast:{id}"]);
     }
 
     private static Dictionary<string, string> Normalize(
@@ -256,24 +450,33 @@ public sealed class DynamoDbEventItemSizeMeasurementTests
         public string GetCurrentServiceId() => serviceId;
     }
 
-    public class CapturingDynamoDb : DispatchProxy
+    private sealed class FixedMeasurement(long bytes) : IExecutorSizeMeasurement
+    {
+        public ExecutorSizeMeasurementResult Measure(ExecutorSizeMeasurementContext context) =>
+            ExecutorSizeMeasurementResult.Exact(bytes);
+    }
+
+    public class CapturingDynamoDb : System.Reflection.DispatchProxy
     {
         public List<Dictionary<string, AttributeValue>> EventItems { get; } = [];
         public List<Dictionary<string, AttributeValue>> TagItems { get; } = [];
+        public int WriteDispatches { get; private set; }
 
         public void Clear()
         {
             EventItems.Clear();
             TagItems.Clear();
+            WriteDispatches = 0;
         }
 
-        protected override object? Invoke(MethodInfo? targetMethod, object?[]? args)
+        protected override object? Invoke(System.Reflection.MethodInfo? targetMethod, object?[]? args)
         {
             var name = targetMethod?.Name ?? string.Empty;
             var arg0 = args is { Length: > 0 } ? args[0] : null;
 
             if (arg0 is TransactWriteItemsRequest transaction && name == nameof(IAmazonDynamoDB.TransactWriteItemsAsync))
             {
+                WriteDispatches++;
                 foreach (var item in transaction.TransactItems)
                 {
                     if (item.Put is not { } put)
@@ -289,6 +492,7 @@ public sealed class DynamoDbEventItemSizeMeasurementTests
 
             if (arg0 is BatchWriteItemRequest batch && name == nameof(IAmazonDynamoDB.BatchWriteItemAsync))
             {
+                WriteDispatches++;
                 foreach (var writes in batch.RequestItems.Values)
                 {
                     foreach (var write in writes)
@@ -304,6 +508,9 @@ public sealed class DynamoDbEventItemSizeMeasurementTests
 
                 return Task.FromResult(new BatchWriteItemResponse { UnprocessedItems = [] });
             }
+
+            if (arg0 is QueryRequest && name == nameof(IAmazonDynamoDB.QueryAsync))
+                return Task.FromResult(new QueryResponse { Items = [] });
 
             if (name == "Dispose" || name.StartsWith("get_", StringComparison.Ordinal))
                 return null;

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/DynamoDbLocalEventItemTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/DynamoDbLocalEventItemTests.cs
@@ -1,0 +1,256 @@
+using System.Text;
+using System.Text.Json;
+using Amazon.DynamoDBv2;
+using Amazon.DynamoDBv2.Model;
+using Amazon.Runtime;
+using Dcb.Domain;
+using Dcb.Domain.Student;
+using Dcb.Domain.Weather;
+using Microsoft.Extensions.Options;
+using Sekiban.Dcb.Actors;
+using Sekiban.Dcb.Commands;
+using Sekiban.Dcb.Common;
+using Sekiban.Dcb.DynamoDB;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.Domains;
+using Sekiban.Dcb.ServiceId;
+using Sekiban.Dcb.SizeGates;
+using Sekiban.Dcb.Storage;
+using Sekiban.Dcb.Testing;
+using CoreInMemoryEventStore = Sekiban.Dcb.Testing.InMemoryEventStore;
+
+namespace Sekiban.Dcb.Tests;
+
+/// <summary>
+/// AC6: real AmazonDynamoDBClient against the pinned DynamoDB Local service started by run_test_dcb.yml.
+/// The test intentionally does not use AWS CLI, a request fake, or a recording client for the boundary proof.
+/// </summary>
+[Trait("Category", "DynamoDbLocal")]
+public sealed class DynamoDbLocalEventItemTests
+{
+    [Fact]
+    public async Task PinnedLocalAcceptsExact400KiBAndExecutorRejectsAboveItWithoutAnotherEvent()
+    {
+        var endpoint = Environment.GetEnvironmentVariable("SEKIBAN_DYNAMODB_LOCAL_ENDPOINT")
+            ?? "http://127.0.0.1:18000";
+        var suffix = Guid.NewGuid().ToString("N");
+        var boundaryTableName = $"G67Boundary{suffix}";
+        var options = new DynamoDbEventStoreOptions
+        {
+            EventsTableName = $"G67Events{suffix}",
+            TagsTableName = $"G67Tags{suffix}",
+            ProjectionStatesTableName = $"G67Projection{suffix}",
+            AutoCreateTables = true,
+            ServiceUrl = new Uri(endpoint),
+            MaxRetryAttempts = 2,
+            MaxRetryDelay = TimeSpan.FromMilliseconds(100)
+        };
+
+        using var client = new AmazonDynamoDBClient(
+            new BasicAWSCredentials("fakeMyKeyId", "fakeSecretAccessKey"),
+            new AmazonDynamoDBConfig
+            {
+                ServiceURL = endpoint,
+                AuthenticationRegion = "us-east-1"
+            });
+        var context = new DynamoDbContext(client, Options.Create(options));
+        var domain = DomainType.GetDomainTypes();
+        var store = new DynamoDbEventStore(context, domain.EventTypes, new FixedServiceIdProvider("g67-local"));
+
+        try
+        {
+            var baseEvent = CreateSerializedEvent(Array.Empty<byte>());
+            var measurement = new DynamoDbEventItemSizeMeasurement(options);
+            await CreateBoundaryTableAsync(client, boundaryTableName);
+            var baseBytes = Measure(measurement, baseEvent);
+            var exact = baseEvent with { Payload = Enumerable.Repeat(
+                (byte)'x',
+                checked((int)(DynamoDbEventItemSizeMeasurement.MaximumItemBytes - baseBytes))).ToArray() };
+
+            Assert.Equal(
+                DynamoDbEventItemSizeMeasurement.MaximumItemBytes,
+                Measure(measurement, exact));
+            var baseWrite = await store.WriteSerializableEventsAsync([baseEvent]);
+            Assert.True(baseWrite.IsSuccess);
+
+            var item = await client.GetItemAsync(new GetItemRequest
+            {
+                TableName = options.EventsTableName,
+                Key = new Dictionary<string, AttributeValue>
+                {
+                    ["pk"] = new() { S = $"SERVICE#g67-local#EVENT#{baseEvent.Id}" },
+                    ["sk"] = new() { S = $"EVENT#{baseEvent.Id}" }
+                },
+                ConsistentRead = true
+            });
+            Assert.NotEmpty(item.Item);
+            item.Item["payload"] = new AttributeValue { S = Encoding.UTF8.GetString(exact.Payload) };
+            Assert.Equal(
+                DynamoDbEventItemSizeMeasurement.MaximumItemBytes,
+                CountedItemBytes(item.Item));
+            await client.PutItemAsync(new PutItemRequest
+            {
+                TableName = boundaryTableName,
+                Item = item.Item
+            });
+
+            var tooLargeItem = item.Item.ToDictionary(pair => pair.Key, pair => pair.Value);
+            tooLargeItem["payload"] = new AttributeValue
+            {
+                S = Encoding.UTF8.GetString(Enumerable.Repeat((byte)'x', exact.Payload.Length + 1).ToArray())
+            };
+            var emulatorRejection = await Assert.ThrowsAsync<AmazonDynamoDBException>(() => client.PutItemAsync(
+                new PutItemRequest
+                {
+                    TableName = boundaryTableName,
+                    Item = tooLargeItem
+                }));
+            Assert.Contains("exceeded", emulatorRejection.Message, StringComparison.OrdinalIgnoreCase);
+
+            var before = await CountItemsAsync(client, options.EventsTableName);
+            var oversizedPayload = JsonSerializer.SerializeToUtf8Bytes(
+                new WeatherForecastCreated(
+                    Guid.CreateVersion7(),
+                    "local",
+                    new DateOnly(2026, 9, 9),
+                    1,
+                    new string('x', (int)DynamoDbEventItemSizeMeasurement.MaximumItemBytes)),
+                domain.JsonSerializerOptions);
+            var oversizedCandidate = new SerializableEventCandidate(
+                oversizedPayload,
+                nameof(WeatherForecastCreated),
+                []);
+            var gateExecutor = new GeneralSekibanExecutor(
+                store,
+                new InMemoryObjectAccessor(new CoreInMemoryEventStore(domain.EventTypes), domain),
+                domain,
+                new ExecutorSizeGateOptions().AddDynamoDbEventItemPolicy(options));
+
+            var rejected = await gateExecutor.CommitSerializableEventsAsync(
+                new SerializedCommitRequest([oversizedCandidate], []));
+
+            var rejection = Assert.IsType<ExecutorSizeLimitExceededException>(rejected.GetException());
+            Assert.Equal(DynamoDbEventItemSizeMeasurement.Scope, rejection.Scope);
+            Assert.Equal(before, await CountItemsAsync(client, options.EventsTableName));
+        }
+        finally
+        {
+            await DeleteTableAsync(client, boundaryTableName);
+            await DeleteTableAsync(client, options.EventsTableName);
+            await DeleteTableAsync(client, options.TagsTableName);
+            await DeleteTableAsync(client, options.ProjectionStatesTableName);
+        }
+    }
+
+    private static SerializableEvent CreateSerializedEvent(byte[] payload)
+    {
+        var id = Guid.CreateVersion7();
+        return new SerializableEvent(
+            payload,
+            SortableUniqueId.GenerateNew(),
+            id,
+            new EventMetadata("cause", "correlation", "user"),
+            [],
+            nameof(StudentCreated));
+    }
+
+    private static long Measure(DynamoDbEventItemSizeMeasurement measurement, SerializableEvent serialized)
+    {
+        var result = measurement.Measure(new ExecutorSizeMeasurementContext(
+            DynamoDbEventItemSizeMeasurement.Scope,
+            ExecutorSizeRepresentation.StorageItem,
+            new Event(
+                new StudentCreated(Guid.CreateVersion7(), "measurement", 1),
+                serialized.SortableUniqueIdValue,
+                serialized.EventPayloadName,
+                serialized.Id,
+                serialized.EventMetadata,
+                serialized.Tags),
+            serialized,
+            "g67-local",
+            null,
+            null));
+        Assert.True(result.IsAvailable, result.Reason);
+        return Assert.IsType<long>(result.Bytes);
+    }
+
+    private static long CountedItemBytes(IReadOnlyDictionary<string, AttributeValue> item) =>
+        item.Sum(pair => Encoding.UTF8.GetByteCount(pair.Key) + CountedValueBytes(pair.Value));
+
+    private static long CountedValueBytes(AttributeValue value)
+    {
+        if (value.S is not null)
+            return Encoding.UTF8.GetByteCount(value.S);
+        if (value.N is not null)
+            return Encoding.UTF8.GetByteCount(value.N);
+        if (value.L is { Count: > 0 })
+            return 3 + value.L.Sum(x => 1 + CountedValueBytes(x));
+        if (value.L is not null)
+            return 3;
+        if (value.M is { Count: > 0 })
+            return 3 + value.M.Sum(x => 1 + Encoding.UTF8.GetByteCount(x.Key) + CountedValueBytes(x.Value));
+        if (value.M is not null)
+            return 3;
+        if (value.B is not null)
+            return value.B.Length;
+        if (value.SS is not null)
+            return value.SS.Sum(Encoding.UTF8.GetByteCount);
+        if (value.NS is not null)
+            return value.NS.Sum(Encoding.UTF8.GetByteCount);
+        if (value.BS is not null)
+            return value.BS.Sum(stream => stream.Length);
+        return value.NULL == true || value.IsBOOLSet ? 1 : 0;
+    }
+
+    private static async Task<int> CountItemsAsync(IAmazonDynamoDB client, string tableName)
+    {
+        var result = await client.ScanAsync(new ScanRequest { TableName = tableName });
+        return result.Count ?? result.Items.Count;
+    }
+
+    private static async Task DeleteTableAsync(IAmazonDynamoDB client, string tableName)
+    {
+        try
+        {
+            await client.DeleteTableAsync(tableName);
+        }
+        catch (ResourceNotFoundException)
+        {
+            // The test may have failed before the store created the table.
+        }
+    }
+
+    private static async Task CreateBoundaryTableAsync(IAmazonDynamoDB client, string tableName)
+    {
+        await client.CreateTableAsync(new CreateTableRequest
+        {
+            TableName = tableName,
+            KeySchema =
+            [
+                new KeySchemaElement("pk", KeyType.HASH),
+                new KeySchemaElement("sk", KeyType.RANGE)
+            ],
+            AttributeDefinitions =
+            [
+                new AttributeDefinition("pk", ScalarAttributeType.S),
+                new AttributeDefinition("sk", ScalarAttributeType.S)
+            ],
+            BillingMode = BillingMode.PAY_PER_REQUEST
+        });
+
+        for (var attempt = 0; attempt < 30; attempt++)
+        {
+            var description = await client.DescribeTableAsync(tableName);
+            if (description.Table.TableStatus == TableStatus.ACTIVE)
+                return;
+            await Task.Delay(TimeSpan.FromMilliseconds(100));
+        }
+
+        throw new InvalidOperationException($"DynamoDB Local table {tableName} did not become active.");
+    }
+
+    private sealed class FixedServiceIdProvider(string serviceId) : IServiceIdProvider
+    {
+        public string GetCurrentServiceId() => serviceId;
+    }
+}

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/DynamoDbSizeGateSurfaceTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/DynamoDbSizeGateSurfaceTests.cs
@@ -1,0 +1,198 @@
+using System.Reflection;
+using Amazon.DynamoDBv2;
+using Dcb.Domain;
+using Dcb.Domain.Student;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using ResultBoxes;
+using Sekiban.Dcb.Capabilities;
+using Sekiban.Dcb.Common;
+using Sekiban.Dcb.Domains;
+using Sekiban.Dcb.DynamoDB;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.ServiceId;
+using Sekiban.Dcb.SizeGates;
+using Sekiban.Dcb.Storage;
+using Sekiban.Dcb.Tags;
+
+namespace Sekiban.Dcb.Tests;
+
+/// <summary>
+/// Focused G67 public-surface and DI propagation inventory. Existing DynamoDB signatures are pinned alongside the
+/// additive measurement/gate API so an evidence-only provider capability cannot silently alter compatibility.
+/// </summary>
+public sealed class DynamoDbSizeGateSurfaceTests
+{
+    [Fact]
+    public void PublicDynamoDbSizeGateAndExistingProviderSurfacesRemainFrozen()
+    {
+        AssertPublicConstructor(
+            typeof(DynamoDbEventItemSizeMeasurement),
+            typeof(DynamoDbEventStoreOptions));
+        AssertPublicMethod(
+            typeof(DynamoDbEventItemSizeMeasurement),
+            nameof(DynamoDbEventItemSizeMeasurement.Measure),
+            typeof(ExecutorSizeMeasurementResult),
+            typeof(ExecutorSizeMeasurementContext));
+
+        var maximumBytes = typeof(DynamoDbEventItemSizeMeasurement).GetField(
+            nameof(DynamoDbEventItemSizeMeasurement.MaximumItemBytes),
+            BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly);
+        Assert.NotNull(maximumBytes);
+        Assert.True(maximumBytes!.IsLiteral);
+        Assert.Equal(DynamoDbEventItemSizeMeasurement.MaximumItemBytes, maximumBytes.GetRawConstantValue());
+
+        AssertPublicMethod(
+            typeof(DynamoDbExecutorSizeGateExtensions),
+            nameof(DynamoDbExecutorSizeGateExtensions.AddDynamoDbEventItemPolicy),
+            typeof(ExecutorSizeGateOptions),
+            typeof(ExecutorSizeGateOptions),
+            typeof(DynamoDbEventStoreOptions),
+            typeof(Nullable<long>),
+            typeof(Nullable<long>),
+            typeof(ExecutorSizeStrictness));
+        AssertPublicMethod(
+            typeof(DynamoDbExecutorSizeGateExtensions),
+            nameof(DynamoDbExecutorSizeGateExtensions.AddSekibanDcbDynamoDbEventItemSizeGate),
+            typeof(IServiceCollection),
+            typeof(IServiceCollection),
+            typeof(Nullable<long>),
+            typeof(Nullable<long>),
+            typeof(ExecutorSizeStrictness));
+
+        AssertPublicConstructor(
+            typeof(DynamoDbEventStore),
+            typeof(DynamoDbContext),
+            typeof(IEventTypes),
+            typeof(IServiceIdProvider),
+            typeof(ILogger<DynamoDbEventStore>));
+        AssertPublicMethod(
+            typeof(DynamoDbEventStore),
+            nameof(DynamoDbEventStore.AppendIfUniqueAsync),
+            typeof(Task<ResultBox<ConditionalAppendReceipt>>),
+            typeof(ConditionalAppendRequest),
+            typeof(CancellationToken));
+        AssertPublicMethod(
+            typeof(DynamoDbEventStore),
+            nameof(DynamoDbEventStore.WriteEventsAsync),
+            typeof(Task<ResultBox<(IReadOnlyList<Event>, IReadOnlyList<TagWriteResult>)>>),
+            typeof(IEnumerable<Event>));
+        AssertPublicMethod(
+            typeof(DynamoDbEventStore),
+            nameof(DynamoDbEventStore.WriteSerializableEventsAsync),
+            typeof(Task<ResultBox<(IReadOnlyList<SerializableEvent>, IReadOnlyList<TagWriteResult>)>>),
+            typeof(IEnumerable<SerializableEvent>));
+        AssertPublicMethod(
+            typeof(DynamoDbEventStore),
+            nameof(DynamoDbEventStore.StreamSerializableEventsByTagAsync),
+            typeof(Task<ResultBox<SerializableEventStreamReadResult>>),
+            typeof(ITag),
+            typeof(SortableUniqueId),
+            typeof(SortableUniqueId),
+            typeof(Func<SerializableEvent, ValueTask>),
+            typeof(CancellationToken));
+
+        AssertPublicConstructor(
+            typeof(DynamoDbEventStoreFactory),
+            typeof(DynamoDbContext),
+            typeof(IEventTypes),
+            typeof(ILoggerFactory));
+        AssertPublicMethod(
+            typeof(DynamoDbEventStoreFactory),
+            nameof(DynamoDbEventStoreFactory.CreateForService),
+            typeof(IEventStore),
+            typeof(string));
+
+        AssertPublicMethod(
+            typeof(SekibanDcbDynamoDbExtensions),
+            nameof(SekibanDcbDynamoDbExtensions.AddSekibanDcbDynamoDb),
+            typeof(IServiceCollection),
+            typeof(IServiceCollection),
+            typeof(IConfiguration));
+        AssertPublicMethod(
+            typeof(SekibanDcbDynamoDbExtensions),
+            nameof(SekibanDcbDynamoDbExtensions.AddSekibanDcbDynamoDb),
+            typeof(IServiceCollection),
+            typeof(IServiceCollection),
+            typeof(IAmazonDynamoDB),
+            typeof(Action<DynamoDbEventStoreOptions>));
+        AssertPublicMethod(
+            typeof(SekibanDcbDynamoDbExtensions),
+            nameof(SekibanDcbDynamoDbExtensions.AddSekibanDcbDynamoDbWithAspire),
+            typeof(IServiceCollection),
+            typeof(IServiceCollection));
+    }
+
+    [Fact]
+    public void DiDynamoOptionsFlowIntoTheGateMeasurement_AndWriteShardsChangeMeasuredBytes()
+    {
+        var client = DispatchProxy.Create<IAmazonDynamoDB, DynamoDbEventItemSizeMeasurementTests.CapturingDynamoDb>();
+        var services = new ServiceCollection()
+            .AddSekibanDcbDynamoDb(client, options => options.WriteShardCount = 2)
+            .AddSekibanDcbDynamoDbEventItemSizeGate();
+
+        using var provider = services.BuildServiceProvider();
+        var gate = provider.GetRequiredService<ExecutorSizeGateOptions>();
+        var policy = Assert.Single(gate.Policies);
+        var diMeasurement = Assert.IsType<DynamoDbEventItemSizeMeasurement>(policy.Measurement);
+        var context = CreateContext();
+        var unsharded = new DynamoDbEventItemSizeMeasurement(
+            new DynamoDbEventStoreOptions { WriteShardCount = 1 }).Measure(context);
+        var sharded = diMeasurement.Measure(context);
+
+        Assert.True(unsharded.IsAvailable, unsharded.Reason);
+        Assert.True(sharded.IsAvailable, sharded.Reason);
+        Assert.Equal(unsharded.Bytes!.Value + 2, sharded.Bytes!.Value);
+    }
+
+    private static ExecutorSizeMeasurementContext CreateContext()
+    {
+        var serialized = new SerializableEvent(
+            System.Text.Encoding.UTF8.GetBytes("{}"),
+            SortableUniqueId.GenerateNew(),
+            Guid.CreateVersion7(),
+            new EventMetadata("cause", "correlation", "user"),
+            [],
+            nameof(StudentCreated));
+        return new ExecutorSizeMeasurementContext(
+            DynamoDbEventItemSizeMeasurement.Scope,
+            ExecutorSizeRepresentation.StorageItem,
+            new Event(
+                new StudentCreated(Guid.CreateVersion7(), "surface", 1),
+                serialized.SortableUniqueIdValue,
+                serialized.EventPayloadName,
+                serialized.Id,
+                serialized.EventMetadata,
+                serialized.Tags),
+            serialized,
+            "g67-surface",
+            null,
+            null);
+    }
+
+    private static void AssertPublicConstructor(Type type, params Type[] parameterTypes)
+    {
+        var matches = type
+            .GetConstructors(BindingFlags.Instance | BindingFlags.Public | BindingFlags.DeclaredOnly)
+            .Where(constructor => constructor.GetParameters().Select(parameter => parameter.ParameterType)
+                .SequenceEqual(parameterTypes))
+            .ToArray();
+        Assert.Single(matches);
+    }
+
+    private static void AssertPublicMethod(
+        Type type,
+        string name,
+        Type returnType,
+        params Type[] parameterTypes)
+    {
+        var matches = type
+            .GetMethods(BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.DeclaredOnly)
+            .Where(method => method.Name == name && method.ReturnType == returnType)
+            .Where(method => method.GetParameters().Select(parameter => parameter.ParameterType)
+                .SequenceEqual(parameterTypes))
+            .ToArray();
+        Assert.Single(matches);
+    }
+}

--- a/docs/dcb_llm/03_aggregate_command_events.md
+++ b/docs/dcb_llm/03_aggregate_command_events.md
@@ -272,3 +272,19 @@ logical or provider measurement. If that binding capability is unavailable, a st
 `ExecutorSizeCapabilityException` before the conditional append; non-strict mode records an explicit unvalidated
 diagnostic and lets the provider conditional operation classify the request. This preserves provider in-doubt and
 conflict exceptions instead of replacing them with a binding failure.
+
+### DynamoDB event-item gate (SEK-G67)
+
+The DynamoDB event-item capability is opt-in and measures the provider's mapped base event item. A typical registration
+keeps the existing store setup and adds the gate explicitly:
+
+```csharp
+services.AddSekibanDcbDynamoDb(dynamoDbClient, options => options.WriteShardCount = 2);
+services.AddSekibanDcbDynamoDbEventItemSizeGate(); // default: 409600 bytes per event
+```
+
+An oversized mapped item returns `ExecutorSizeLimitExceededException` before event, tag, or head persistence. If the
+provider cannot measure the requested representation, strict mode returns `ExecutorSizeCapabilityException`; non-strict
+mode records a named unvalidated diagnostic and continues. `MaxBytesPerOperation` is the sum of the measured copies in
+the current operation. A `Destination` policy instead evaluates each captured destination copy independently; that
+fan-out accounting is neither a DynamoDB database-footprint guarantee nor an Azure Queue batch/wire-envelope guarantee.

--- a/docs/dcb_llm/11_storage_providers.md
+++ b/docs/dcb_llm/11_storage_providers.md
@@ -886,6 +886,23 @@ document, item, or Azure Queue wire-envelope count. Strict unavailable measureme
 non-strict policy proceeds with a named diagnostic. The gate covers the current executor operation only; it does not
 split events, change provider retry/recovery, or repair historical oversized data.
 
+## SEK-G67 DynamoDB event-item size gate
+
+`AddSekibanDcbDynamoDbEventItemSizeGate()` (or
+`ExecutorSizeGateOptions.AddDynamoDbEventItemPolicy(...)`) is an opt-in provider registration for the DynamoDB
+base event item. Its default per-event limit is the DynamoDB 400 KiB service ceiling, `409600` bytes; a configured
+per-event quota may be smaller, but provider registration rejects a quota above that ceiling. An explicit operation
+quota is evaluated by the executor as the sum of the independently measured event items in that operation.
+
+The measurement uses the same provider-owned `AttributeValue` event-item mapper for typed, serialized, and conditional
+writes. It counts UTF-8 bytes for attribute names and string values, binary lengths, and list/map element bytes with
+DynamoDB's collection overhead, including optional event metadata and tags on the base event item. It does not claim
+tag-item fit, key-length validation, GSI projection or billing overhead, the transaction/request envelope, the 4 MiB
+transaction limit, or BatchWrite request sizing. Therefore a passing event-item measurement is not a complete provider
+request-size guarantee. A strict policy rejects an unavailable measurement before persistence; a non-strict policy
+continues with its named unvalidated diagnostic. A hand-constructed core policy bypasses the provider registration and
+its service-ceiling validation, while unregistered legacy DynamoDB writes remain unchanged.
+
 ## Related
 
 For the current internal-use cold event export, hybrid read, and catch-up worker setup, see [Cold Events and Catch-up](19_cold_events.md).

--- a/docs/dcb_llm/11_storage_providers.md
+++ b/docs/dcb_llm/11_storage_providers.md
@@ -903,6 +903,18 @@ request-size guarantee. A strict policy rejects an unavailable measurement befor
 continues with its named unvalidated diagnostic. A hand-constructed core policy bypasses the provider registration and
 its service-ceiling validation, while unregistered legacy DynamoDB writes remain unchanged.
 
+For example, an application can preserve its configured shard mapping while opting into the 400 KiB event-item gate:
+
+```csharp
+services.AddSekibanDcbDynamoDb(dynamoDbClient, options => options.WriteShardCount = 2);
+services.AddSekibanDcbDynamoDbEventItemSizeGate();
+```
+
+An item over the configured limit produces `ExecutorSizeLimitExceededException`; an unavailable strict capability produces
+`ExecutorSizeCapabilityException` before any persistence. `MaxBytesPerOperation` sums the measured event-item copies in
+the current operation. This is distinct from a `Destination` fan-out policy, which checks each destination copy
+independently; neither rule is a DynamoDB database-footprint guarantee or an Azure Queue batch/wire-envelope guarantee.
+
 ## Related
 
 For the current internal-use cold event export, hybrid read, and catch-up worker setup, see [Cold Events and Catch-up](19_cold_events.md).

--- a/docs/dcb_llm_ja/03_aggregate_command_events.md
+++ b/docs/dcb_llm_ja/03_aggregate_command_events.md
@@ -254,3 +254,20 @@ wire envelope、batch、retry、および既に受理されたイベントの re
 が必要になる場合があります。この binding capability を利用できない場合、strict policy は conditional append
 より前に型付き `ExecutorSizeCapabilityException` を返します。non-strict は明示的な未検証診断を記録したうえで
 provider の conditional 操作に判定を委ね、binding failure で provider の in-doubt や conflict 例外を置き換えません。
+
+### DynamoDB event-item ゲート（SEK-G67）
+
+DynamoDB の event-item capability は opt-in で、provider が実際に組み立てる base event item を測定します。既存の
+store 登録に、明示的にゲートを追加します。
+
+```csharp
+services.AddSekibanDcbDynamoDb(dynamoDbClient, options => options.WriteShardCount = 2);
+services.AddSekibanDcbDynamoDbEventItemSizeGate(); // 既定: event ごとに 409600 byte
+```
+
+mapped item が大きすぎる場合は `ExecutorSizeLimitExceededException` を返し、event・tag・head の永続化より前に
+停止します。provider が要求された representation を測定できない場合、strict は
+`ExecutorSizeCapabilityException` を返し、non-strict は名前付きの未検証診断を記録して継続します。
+`MaxBytesPerOperation` は現在の operation に含まれる測定済みコピーの合計です。一方、`Destination` policy は
+捕捉した各 destination copy を個別に検査します。この fan-out の数え方は DynamoDB の database footprint 保証でも、
+Azure Queue の batch/wire-envelope 保証でもありません。

--- a/docs/dcb_llm_ja/11_storage_providers.md
+++ b/docs/dcb_llm_ja/11_storage_providers.md
@@ -893,6 +893,23 @@ executor の storage policy は、provider が `IExecutorSizeMeasurement` を通
 wire envelope のサイズではありません。strict で測定できない場合は永続化前に拒否し、non-strict は名前付き診断を付けて継続します。
 ゲートは現在の executor operation だけを対象にし、event の分割、provider の retry/recovery の変更、過去の oversized data の修復は行いません。
 
+## SEK-G67 DynamoDB event-item サイズゲート
+
+`AddSekibanDcbDynamoDbEventItemSizeGate()`（または
+`ExecutorSizeGateOptions.AddDynamoDbEventItemPolicy(...)`）は、DynamoDB の base event item に対する opt-in の
+provider 登録です。既定の event ごとの上限は DynamoDB service ceiling の 400 KiB、`409600` byte です。
+event ごとの設定値はそれ以下にできますが、provider 登録は ceiling を超える値を拒否します。operation の
+明示的な上限は、executor が各 event item の測定値を個別に測定して合計します。
+
+測定には typed・serialized・conditional write で共通の provider-owned `AttributeValue` event-item mapper を
+使います。attribute 名と string 値の UTF-8 byte、binary の長さ、list/map の要素 byte と DynamoDB の collection
+overhead を数え、optional な event metadata と base event item の tags も含めます。tag item の適合、key 長検証、
+GSI projection または billing overhead、transaction/request envelope、4 MiB transaction limit、BatchWrite の
+request size は保証しません。したがって event-item を通過したことは provider request size 全体の保証では
+ありません。strict policy は測定不能なら永続化前に拒否し、non-strict policy は名前付きの未検証診断を付けて
+継続します。Core の policy を直接構築した場合は provider 登録と service ceiling 検証を迂回します。未登録の
+legacy DynamoDB write は変更されません。
+
 ## 関連資料
 
 現在のインターナルユースで使っているコールドイベントの書き出し、ハイブリッドリード、キャッチアップワーカー構成については [コールドイベントとキャッチアップ](19_cold_events.md) を参照してください。

--- a/docs/dcb_llm_ja/11_storage_providers.md
+++ b/docs/dcb_llm_ja/11_storage_providers.md
@@ -910,6 +910,18 @@ request size は保証しません。したがって event-item を通過した�
 継続します。Core の policy を直接構築した場合は provider 登録と service ceiling 検証を迂回します。未登録の
 legacy DynamoDB write は変更されません。
 
+たとえば、設定した shard mapping を保ったまま 400 KiB の event-item ゲートを opt-in できます。
+
+```csharp
+services.AddSekibanDcbDynamoDb(dynamoDbClient, options => options.WriteShardCount = 2);
+services.AddSekibanDcbDynamoDbEventItemSizeGate();
+```
+
+設定上限を超える item は `ExecutorSizeLimitExceededException`、利用できない strict capability は永続化前に
+`ExecutorSizeCapabilityException` になります。`MaxBytesPerOperation` は現在の operation に含まれる測定済み
+event-item copy の合計です。これは `Destination` の fan-out policy（各 destination copy を個別に検査）とは異なり、
+DynamoDB の database footprint 保証でも Azure Queue の batch/wire-envelope 保証でもありません。
+
 ## 関連資料
 
 現在のインターナルユースで使っているコールドイベントの書き出し、ハイブリッドリード、キャッチアップワーカー構成については [コールドイベントとキャッチアップ](19_cold_events.md) を参照してください。


### PR DESCRIPTION
Closes #1207\n\n## Scope\n- Adds opt-in DynamoDB base event-item measurement through the existing executor size gate.\n- Uses one provider-owned mapper for typed, serialized, and conditional event writes.\n- Counts UTF-8 attribute names/values, binary lengths, and DynamoDB list/map overhead; the provider registration enforces the 409600-byte event-item ceiling.\n- Preserves legacy unregistered writes and excludes tag items, GSI projection/billing overhead, request envelopes, transaction/BatchWrite limits, and other transports.\n\n## Proof\n- Independent captured-map oracle and typed/serialized/conditional parity tests.\n- Boundary tests for 409599/409600/409601 and executor no-write rejection.\n- Real AmazonDynamoDBClient against pinned DynamoDB Local in both CI TFM jobs; the integration proof accepts exact 400 KiB, observes Local rejection above it, and proves gate rejection leaves the event table unchanged.\n- EN/JA storage-provider documentation and pinned CI service setup are included.