### PR TITLE
SEK-G68 DynamoDB item and operation size gates

### DIFF
--- a/dcb/src/Sekiban.Dcb.Core/SizeGates/SekibanDcbExecutorSizeGateExtensions.cs
+++ b/dcb/src/Sekiban.Dcb.Core/SizeGates/SekibanDcbExecutorSizeGateExtensions.cs
@@ -4,6 +4,8 @@ namespace Sekiban.Dcb.SizeGates;
 
 public static class SekibanDcbExecutorSizeGateExtensions
 {
+    private const string CoreConvenienceMechanism = ExecutorSizeGateRegistrationMarker.CoreConvenience;
+
     /// <summary>
     /// Registers one opt-in executor size policy set. No service is added to the container when this method is not
     /// called, so existing construction remains ungated.
@@ -15,9 +17,11 @@ public static class SekibanDcbExecutorSizeGateExtensions
         ArgumentNullException.ThrowIfNull(services);
         ArgumentNullException.ThrowIfNull(configure);
 
+        ExecutorSizeGateRegistrationMarker.EnsureCompatible(services, CoreConvenienceMechanism);
         var options = new ExecutorSizeGateOptions();
         configure(options);
         options.Validate();
+        ExecutorSizeGateRegistrationMarker.Declare(services, CoreConvenienceMechanism);
         services.AddSingleton(options);
         return services;
     }
@@ -28,8 +32,51 @@ public static class SekibanDcbExecutorSizeGateExtensions
     {
         ArgumentNullException.ThrowIfNull(services);
         ArgumentNullException.ThrowIfNull(options);
+        ExecutorSizeGateRegistrationMarker.EnsureCompatible(services, CoreConvenienceMechanism);
         options.Validate();
+        ExecutorSizeGateRegistrationMarker.Declare(services, CoreConvenienceMechanism);
         services.AddSingleton(options);
         return services;
     }
+}
+
+/// <summary>
+/// Internal registration identity shared by the Core convenience and provider-composable gate helpers.
+/// The marker is held in the caller's service collection so separate registrations cannot silently replace one another.
+/// </summary>
+internal sealed class ExecutorSizeGateRegistrationMarker
+{
+    internal const string CoreConvenience = "Core convenience gate registration";
+    internal const string ProviderComposable = "provider-composable gate registration";
+
+    private ExecutorSizeGateRegistrationMarker(string mechanism)
+    {
+        Mechanism = mechanism;
+    }
+
+    internal string Mechanism { get; }
+
+    internal static void EnsureCompatible(IServiceCollection services, string mechanism)
+    {
+        var existing = Find(services);
+        if (existing is null || existing.Mechanism == mechanism)
+            return;
+
+        throw new InvalidOperationException(
+            $"'{existing.Mechanism}' and '{mechanism}' cannot both configure the executor size gate. " +
+            "Configure every policy through one mechanism: either a single " +
+            "AddSekibanDcbExecutorSizeGate callback that calls the provider policy extensions, " +
+            "or only the AddSekibanDcbDynamoDb*SizeGate helpers.");
+    }
+
+    internal static void Declare(IServiceCollection services, string mechanism)
+    {
+        EnsureCompatible(services, mechanism);
+        if (Find(services) is null)
+            services.AddSingleton(new ExecutorSizeGateRegistrationMarker(mechanism));
+    }
+
+    private static ExecutorSizeGateRegistrationMarker? Find(IServiceCollection services) =>
+        services.FirstOrDefault(descriptor => descriptor.ServiceType == typeof(ExecutorSizeGateRegistrationMarker))
+            ?.ImplementationInstance as ExecutorSizeGateRegistrationMarker;
 }

--- a/dcb/src/Sekiban.Dcb.DynamoDB/DynamoDbEventItemSizeMeasurement.cs
+++ b/dcb/src/Sekiban.Dcb.DynamoDB/DynamoDbEventItemSizeMeasurement.cs
@@ -36,11 +36,7 @@ public sealed class DynamoDbEventItemSizeMeasurement : IExecutorSizeMeasurement
 
         try
         {
-            var mapped = DynamoDbEventItemMapper.FromSerializableEvent(
-                context.SerializedEvent,
-                context.ServiceId,
-                _writeShardCount,
-                timestamp: DateTimeOffset.UtcNow);
+            var mapped = DynamoDbMeasurementContextMapper.Map(context, _writeShardCount);
             return ExecutorSizeMeasurementResult.Exact(
                 DynamoDbItemSizeCalculator.Calculate(mapped.DynamoEvent.ToAttributeValues()));
         }
@@ -49,6 +45,147 @@ public sealed class DynamoDbEventItemSizeMeasurement : IExecutorSizeMeasurement
             return ExecutorSizeMeasurementResult.Unavailable(
                 $"DynamoDB event-item mapping failed with {ex.GetType().Name}");
         }
+    }
+}
+
+/// <summary>
+/// Measures the largest mapped DynamoDB item emitted for one event, including every tag item.
+/// </summary>
+public sealed class DynamoDbMaxWrittenItemSizeMeasurement : IExecutorSizeMeasurement
+{
+    /// <summary>The DynamoDB service item ceiling: 400 KiB.</summary>
+    public const long MaximumItemBytes = DynamoDbEventItemSizeMeasurement.MaximumItemBytes;
+
+    /// <summary>The canonical provider scope for the largest written item.</summary>
+    public const string Scope = "dynamodb-max-written-item";
+
+    private readonly int _writeShardCount;
+
+    /// <summary>Creates a measurement using the provider's configured write-shard count when supplied.</summary>
+    public DynamoDbMaxWrittenItemSizeMeasurement(DynamoDbEventStoreOptions? options = null)
+    {
+        _writeShardCount = Math.Max(1, options?.WriteShardCount ?? 1);
+    }
+
+    /// <summary>Measures the largest event or tag item mapped for the serialized executor boundary.</summary>
+    public ExecutorSizeMeasurementResult Measure(ExecutorSizeMeasurementContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        if (context.Representation != ExecutorSizeRepresentation.StorageItem)
+        {
+            return ExecutorSizeMeasurementResult.Unavailable(
+                "DynamoDB maximum-written-item measurement supports only the StorageItem representation");
+        }
+
+        try
+        {
+            var mapped = DynamoDbMeasurementContextMapper.Map(context, _writeShardCount);
+            var largest = DynamoDbItemSizeCalculator.Calculate(mapped.DynamoEvent.ToAttributeValues());
+            foreach (var tag in mapped.DynamoTags)
+            {
+                largest = Math.Max(largest, DynamoDbItemSizeCalculator.Calculate(tag.ToAttributeValues()));
+            }
+
+            return ExecutorSizeMeasurementResult.Exact(largest);
+        }
+        catch (Exception ex) when (ex is ArgumentException or FormatException or InvalidOperationException or OverflowException)
+        {
+            return ExecutorSizeMeasurementResult.Unavailable(
+                $"DynamoDB maximum-written-item mapping failed with {ex.GetType().Name}");
+        }
+    }
+}
+
+/// <summary>
+/// Measures the provider's conservative transaction-payload contribution for one executor event.
+/// </summary>
+public sealed class DynamoDbWriteOperationSizeMeasurement : IExecutorSizeMeasurement
+{
+    /// <summary>The DynamoDB transaction payload ceiling used by this opt-in application budget.</summary>
+    public const long MaximumTransactionBytes = 4L * 1024L * 1024L;
+
+    /// <summary>The canonical provider scope for the whole write operation contribution.</summary>
+    public const string Scope = "dynamodb-write-operation";
+
+    private readonly int _writeShardCount;
+
+    /// <summary>Creates a measurement using the provider's configured write-shard count when supplied.</summary>
+    public DynamoDbWriteOperationSizeMeasurement(DynamoDbEventStoreOptions? options = null)
+    {
+        _writeShardCount = Math.Max(1, options?.WriteShardCount ?? 1);
+    }
+
+    /// <summary>
+    /// Measures event and tag item bytes plus the production event-Put condition contribution. The result is a
+    /// conservative application budget and is not an exact transaction request-wire certification.
+    /// </summary>
+    public ExecutorSizeMeasurementResult Measure(ExecutorSizeMeasurementContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        if (context.Representation != ExecutorSizeRepresentation.StorageItem)
+        {
+            return ExecutorSizeMeasurementResult.Unavailable(
+                "DynamoDB write-operation measurement supports only the StorageItem representation");
+        }
+
+        try
+        {
+            var mapped = DynamoDbMeasurementContextMapper.Map(context, _writeShardCount);
+            return ExecutorSizeMeasurementResult.Exact(
+                DynamoDbTransactionSizeAccounting.CalculateContribution(mapped));
+        }
+        catch (Exception ex) when (ex is ArgumentException or FormatException or InvalidOperationException or OverflowException)
+        {
+            return ExecutorSizeMeasurementResult.Unavailable(
+                $"DynamoDB write-operation mapping failed with {ex.GetType().Name}");
+        }
+    }
+}
+
+internal static class DynamoDbMeasurementContextMapper
+{
+    public static DynamoDbEventWriteItem Map(ExecutorSizeMeasurementContext context, int writeShardCount)
+    {
+        ArgumentNullException.ThrowIfNull(context.Event);
+        ArgumentNullException.ThrowIfNull(context.SerializedEvent);
+
+        if (context.Event.Id != context.SerializedEvent.Id ||
+            !string.Equals(context.Event.EventType, context.SerializedEvent.EventPayloadName, StringComparison.Ordinal) ||
+            !string.Equals(
+                context.Event.SortableUniqueIdValue,
+                context.SerializedEvent.SortableUniqueIdValue,
+                StringComparison.Ordinal) ||
+            !context.Event.Tags.SequenceEqual(context.SerializedEvent.Tags, StringComparer.Ordinal))
+        {
+            throw new InvalidOperationException(
+                "DynamoDB measurement requires matching event and serialized-event identity and tags");
+        }
+
+        return DynamoDbEventItemMapper.FromSerializableEvent(
+            context.SerializedEvent,
+            context.ServiceId,
+            writeShardCount,
+            timestamp: DateTimeOffset.UtcNow);
+    }
+}
+
+internal static class DynamoDbTransactionSizeAccounting
+{
+    /// <summary>Production event-Put guard shared by conditional and ordinary transaction writers.</summary>
+    internal const string EventPutConditionExpression = "attribute_not_exists(pk)";
+
+    internal static long CalculateContribution(DynamoDbEventWriteItem mapped)
+    {
+        var bytes = DynamoDbItemSizeCalculator.Calculate(mapped.DynamoEvent.ToAttributeValues());
+        bytes = checked(bytes + Encoding.UTF8.GetByteCount(EventPutConditionExpression));
+        foreach (var tag in mapped.DynamoTags)
+        {
+            bytes = checked(bytes + DynamoDbItemSizeCalculator.Calculate(tag.ToAttributeValues()));
+        }
+
+        return bytes;
     }
 }
 

--- a/dcb/src/Sekiban.Dcb.DynamoDB/DynamoDbEventStore.cs
+++ b/dcb/src/Sekiban.Dcb.DynamoDB/DynamoDbEventStore.cs
@@ -75,7 +75,7 @@ public partial class DynamoDbEventStore : IHotEventStore, IStorageDurabilityDesc
                 {
                     TableName = _context.EventsTableName,
                     Item = dynEvent.ToAttributeValues(),
-                    ConditionExpression = "attribute_not_exists(pk)"
+                    ConditionExpression = DynamoDbTransactionSizeAccounting.EventPutConditionExpression
                 }
             }
         };
@@ -902,7 +902,7 @@ public partial class DynamoDbEventStore : IHotEventStore, IStorageDurabilityDesc
                     {
                         TableName = _context.EventsTableName,
                         Item = item.DynamoEvent.ToAttributeValues(),
-                        ConditionExpression = "attribute_not_exists(pk)"
+                        ConditionExpression = DynamoDbTransactionSizeAccounting.EventPutConditionExpression
                     }
                 });
                 eventIdsForToken.Add(item.DynamoEvent.EventId);

--- a/dcb/src/Sekiban.Dcb.DynamoDB/DynamoDbExecutorSizeGateExtensions.cs
+++ b/dcb/src/Sekiban.Dcb.DynamoDB/DynamoDbExecutorSizeGateExtensions.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
 using Sekiban.Dcb.SizeGates;
 
@@ -42,6 +43,57 @@ public static class DynamoDbExecutorSizeGateExtensions
     }
 
     /// <summary>
+    /// Adds the largest-written-item policy. The helper exposes only the per-event quota for this scope.
+    /// </summary>
+    public static ExecutorSizeGateOptions AddDynamoDbMaxWrittenItemPolicy(
+        this ExecutorSizeGateOptions options,
+        DynamoDbEventStoreOptions? storeOptions = null,
+        long? maxBytesPerEvent = null,
+        ExecutorSizeStrictness strictness = ExecutorSizeStrictness.Strict)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        var eventLimit = maxBytesPerEvent ?? DynamoDbMaxWrittenItemSizeMeasurement.MaximumItemBytes;
+        ValidateMaximumItemLimit(eventLimit, nameof(maxBytesPerEvent));
+
+        return options.Add(new ExecutorSizePolicy(
+            DynamoDbMaxWrittenItemSizeMeasurement.Scope,
+            ExecutorSizeRepresentation.StorageItem,
+            maxBytesPerEvent: eventLimit,
+            strictness: strictness,
+            measurement: new DynamoDbMaxWrittenItemSizeMeasurement(storeOptions)));
+    }
+
+    /// <summary>
+    /// Adds the conservative whole-operation DynamoDB transaction-payload policy. The helper exposes only the
+    /// operation quota for this scope.
+    /// </summary>
+    public static ExecutorSizeGateOptions AddDynamoDbWriteOperationPolicy(
+        this ExecutorSizeGateOptions options,
+        DynamoDbEventStoreOptions? storeOptions = null,
+        long? maxBytesPerOperation = null,
+        ExecutorSizeStrictness strictness = ExecutorSizeStrictness.Strict)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        var operationLimit = maxBytesPerOperation ?? DynamoDbWriteOperationSizeMeasurement.MaximumTransactionBytes;
+        if (operationLimit <= 0 || operationLimit > DynamoDbWriteOperationSizeMeasurement.MaximumTransactionBytes)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(maxBytesPerOperation),
+                $"DynamoDB write-operation limit must be between 1 and " +
+                $"{DynamoDbWriteOperationSizeMeasurement.MaximumTransactionBytes} bytes.");
+        }
+
+        return options.Add(new ExecutorSizePolicy(
+            DynamoDbWriteOperationSizeMeasurement.Scope,
+            ExecutorSizeRepresentation.StorageItem,
+            maxBytesPerOperation: operationLimit,
+            strictness: strictness,
+            measurement: new DynamoDbWriteOperationSizeMeasurement(storeOptions)));
+    }
+
+    /// <summary>
     /// Registers a DynamoDB event-item gate that resolves the provider's configured shard mapping from DI.
     /// The method is additive; without this call existing DynamoDB registration remains ungated.
     /// </summary>
@@ -53,15 +105,71 @@ public static class DynamoDbExecutorSizeGateExtensions
     {
         ArgumentNullException.ThrowIfNull(services);
 
-        services.AddSingleton<ExecutorSizeGateOptions>(serviceProvider =>
+        AddDynamoDbGateConfiguration(services, (options, serviceProvider) =>
         {
             var storeOptions = serviceProvider.GetService<IOptions<DynamoDbEventStoreOptions>>()?.Value;
-            return new ExecutorSizeGateOptions().AddDynamoDbEventItemPolicy(
+            options.AddDynamoDbEventItemPolicy(
                 storeOptions,
                 maxBytesPerEvent,
                 maxBytesPerOperation,
                 strictness);
         });
         return services;
+    }
+
+    /// <summary>Registers the largest-written-item policy and preserves other provider size policies.</summary>
+    public static IServiceCollection AddSekibanDcbDynamoDbMaxWrittenItemSizeGate(
+        this IServiceCollection services,
+        long? maxBytesPerEvent = null,
+        ExecutorSizeStrictness strictness = ExecutorSizeStrictness.Strict)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        AddDynamoDbGateConfiguration(services, (options, serviceProvider) =>
+        {
+            var storeOptions = serviceProvider.GetService<IOptions<DynamoDbEventStoreOptions>>()?.Value;
+            options.AddDynamoDbMaxWrittenItemPolicy(storeOptions, maxBytesPerEvent, strictness);
+        });
+        return services;
+    }
+
+    /// <summary>Registers the conservative whole-operation transaction-payload policy.</summary>
+    public static IServiceCollection AddSekibanDcbDynamoDbWriteOperationSizeGate(
+        this IServiceCollection services,
+        long? maxBytesPerOperation = null,
+        ExecutorSizeStrictness strictness = ExecutorSizeStrictness.Strict)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        AddDynamoDbGateConfiguration(services, (options, serviceProvider) =>
+        {
+            var storeOptions = serviceProvider.GetService<IOptions<DynamoDbEventStoreOptions>>()?.Value;
+            options.AddDynamoDbWriteOperationPolicy(storeOptions, maxBytesPerOperation, strictness);
+        });
+        return services;
+    }
+
+    private static void AddDynamoDbGateConfiguration(
+        IServiceCollection services,
+        Action<ExecutorSizeGateOptions, IServiceProvider> configure)
+    {
+        services.AddOptions<ExecutorSizeGateOptions>();
+        services.AddSingleton<IConfigureOptions<ExecutorSizeGateOptions>>(serviceProvider =>
+            new ConfigureNamedOptions<ExecutorSizeGateOptions>(
+                Options.DefaultName,
+                options => configure(options, serviceProvider)));
+        services.TryAddSingleton(serviceProvider =>
+            serviceProvider.GetRequiredService<IOptions<ExecutorSizeGateOptions>>().Value);
+    }
+
+    private static void ValidateMaximumItemLimit(long limit, string parameterName)
+    {
+        if (limit <= 0 || limit > DynamoDbMaxWrittenItemSizeMeasurement.MaximumItemBytes)
+        {
+            throw new ArgumentOutOfRangeException(
+                parameterName,
+                $"DynamoDB maximum-written-item limit must be between 1 and " +
+                $"{DynamoDbMaxWrittenItemSizeMeasurement.MaximumItemBytes} bytes.");
+        }
     }
 }

--- a/dcb/src/Sekiban.Dcb.DynamoDB/DynamoDbExecutorSizeGateExtensions.cs
+++ b/dcb/src/Sekiban.Dcb.DynamoDB/DynamoDbExecutorSizeGateExtensions.cs
@@ -153,6 +153,12 @@ public static class DynamoDbExecutorSizeGateExtensions
         IServiceCollection services,
         Action<ExecutorSizeGateOptions, IServiceProvider> configure)
     {
+        ExecutorSizeGateRegistrationMarker.EnsureCompatible(
+            services,
+            ExecutorSizeGateRegistrationMarker.ProviderComposable);
+        ExecutorSizeGateRegistrationMarker.Declare(
+            services,
+            ExecutorSizeGateRegistrationMarker.ProviderComposable);
         services.AddOptions<ExecutorSizeGateOptions>();
         services.AddSingleton<IConfigureOptions<ExecutorSizeGateOptions>>(serviceProvider =>
             new ConfigureNamedOptions<ExecutorSizeGateOptions>(

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/DynamoDbEventItemSizeMeasurementTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/DynamoDbEventItemSizeMeasurementTests.cs
@@ -324,14 +324,16 @@ public sealed class DynamoDbEventItemSizeMeasurementTests
     private static DynamoDbEventStore NewStore(
         IAmazonDynamoDB client,
         DcbDomainTypes domain,
-        string serviceId)
+        string serviceId,
+        int maxTransactionItems = 100)
     {
         var options = Options.Create(new DynamoDbEventStoreOptions
         {
             AutoCreateTables = false,
             EventsTableName = $"events-{serviceId}",
             TagsTableName = $"tags-{serviceId}",
-            ProjectionStatesTableName = $"projection-{serviceId}"
+            ProjectionStatesTableName = $"projection-{serviceId}",
+            MaxTransactionItems = maxTransactionItems
         });
         return new DynamoDbEventStore(
             new DynamoDbContext(client, options),
@@ -460,12 +462,18 @@ public sealed class DynamoDbEventItemSizeMeasurementTests
     {
         public List<Dictionary<string, AttributeValue>> EventItems { get; } = [];
         public List<Dictionary<string, AttributeValue>> TagItems { get; } = [];
+        public List<BatchWriteItemRequest> BatchRequests { get; } = [];
+        public List<string?> ConditionExpressions { get; } = [];
+        public List<string?> ClientRequestTokens { get; } = [];
         public int WriteDispatches { get; private set; }
 
         public void Clear()
         {
             EventItems.Clear();
             TagItems.Clear();
+            BatchRequests.Clear();
+            ConditionExpressions.Clear();
+            ClientRequestTokens.Clear();
             WriteDispatches = 0;
         }
 
@@ -481,11 +489,14 @@ public sealed class DynamoDbEventItemSizeMeasurementTests
                 {
                     if (item.Put is not { } put)
                         continue;
+                    ConditionExpressions.Add(put.ConditionExpression);
                     if (put.TableName.StartsWith("events-", StringComparison.Ordinal))
                         EventItems.Add(put.Item);
                     else
                         TagItems.Add(put.Item);
                 }
+
+                ClientRequestTokens.Add(transaction.ClientRequestToken);
 
                 return Task.FromResult(new TransactWriteItemsResponse());
             }
@@ -493,6 +504,7 @@ public sealed class DynamoDbEventItemSizeMeasurementTests
             if (arg0 is BatchWriteItemRequest batch && name == nameof(IAmazonDynamoDB.BatchWriteItemAsync))
             {
                 WriteDispatches++;
+                BatchRequests.Add(batch);
                 foreach (var writes in batch.RequestItems.Values)
                 {
                     foreach (var write in writes)

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/DynamoDbLocalWriteOperationTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/DynamoDbLocalWriteOperationTests.cs
@@ -1,15 +1,21 @@
+using System.Globalization;
 using System.Text;
+using System.Text.Json;
+using System.Text.RegularExpressions;
 using Amazon.DynamoDBv2;
 using Amazon.DynamoDBv2.Model;
 using Amazon.Runtime;
 using Dcb.Domain;
 using Dcb.Domain.Student;
+using Sekiban.Dcb.Actors;
+using Sekiban.Dcb.Commands;
 using Microsoft.Extensions.Options;
 using Sekiban.Dcb.Common;
 using Sekiban.Dcb.DynamoDB;
 using Sekiban.Dcb.Events;
 using Sekiban.Dcb.ServiceId;
 using Sekiban.Dcb.SizeGates;
+using Sekiban.Dcb.Testing;
 using Xunit;
 
 namespace Sekiban.Dcb.Tests;
@@ -23,6 +29,7 @@ public sealed class DynamoDbLocalWriteOperationTests
 {
     [Theory]
     [InlineData(4_194_303, true)]
+    [InlineData(4_194_304, true)]
     [InlineData(4_194_305, false)]
     public async Task PinnedLocalCharacterizesUnderAndOverFourMiBOperationContribution(
         long expectedContribution,
@@ -53,7 +60,10 @@ public sealed class DynamoDbLocalWriteOperationTests
             Assert.Equal(expectedSuccess, result.IsSuccess);
             Assert.Equal(expectedSuccess ? events.Count : 0, await CountItemsAsync(client, options.EventsTableName));
             if (!expectedSuccess)
-                Assert.NotNull(result.GetException());
+            {
+                var exception = result.GetException();
+                Assert.Equal(expectedContribution, ReadReportedPayloadSize(exception));
+            }
         }
         finally
         {
@@ -128,6 +138,73 @@ public sealed class DynamoDbLocalWriteOperationTests
         }
     }
 
+    [Fact]
+    public async Task PinnedLocalItemOnlyUndercountMutantAdmitsButServiceRejects()
+    {
+        var endpoint = Environment.GetEnvironmentVariable("SEKIBAN_DYNAMODB_LOCAL_ENDPOINT")
+            ?? "http://127.0.0.1:18000";
+        var suffix = Guid.NewGuid().ToString("N");
+        const string serviceId = "default";
+        var options = CreateOptions(suffix, endpoint);
+        using var client = CreateClient(endpoint);
+        var domain = DomainType.GetDomainTypes();
+        var store = NewStore(client, options, domain, serviceId);
+
+        try
+        {
+            var productionMeasurement = new DynamoDbWriteOperationSizeMeasurement(options);
+            var events = CreateValidExecutorOperationBoundary(productionMeasurement, 4_194_305, serviceId);
+            var productionContribution = events.Sum(serialized => Measure(productionMeasurement, serialized, serviceId));
+            var itemOnlyMeasurement = new ItemOnlyOperationMeasurement(options);
+            var itemOnlyContribution = events.Sum(serialized => Measure(itemOnlyMeasurement, serialized, serviceId));
+            var conditionBytes = Encoding.UTF8.GetByteCount("attribute_not_exists(pk)");
+
+            Assert.Equal(4_194_305, productionContribution);
+            Assert.Equal(productionContribution - (conditionBytes * events.Count), itemOnlyContribution);
+            Assert.InRange(itemOnlyContribution, 1, DynamoDbWriteOperationSizeMeasurement.MaximumTransactionBytes);
+
+            var request = new SerializedCommitRequest(
+                events.Select(e => new SerializableEventCandidate(e.Payload, e.EventPayloadName, e.Tags)).ToArray(),
+                []);
+            var itemOnlyOptions = new ExecutorSizeGateOptions().Add(new ExecutorSizePolicy(
+                "dynamodb-item-only-mutant",
+                ExecutorSizeRepresentation.StorageItem,
+                maxBytesPerOperation: DynamoDbWriteOperationSizeMeasurement.MaximumTransactionBytes,
+                measurement: itemOnlyMeasurement));
+            var itemOnlyExecutor = new GeneralSekibanExecutor(
+                store,
+                new InMemoryObjectAccessor(store, domain),
+                domain,
+                itemOnlyOptions);
+
+            // The item-only mutant admits the operation; the actual provider then rejects the same transaction.
+            var serviceResult = await itemOnlyExecutor.CommitSerializableEventsAsync(request);
+            Assert.False(serviceResult.IsSuccess);
+            Assert.IsNotType<ExecutorSizeLimitExceededException>(serviceResult.GetException());
+            Assert.Equal(productionContribution, ReadReportedPayloadSize(serviceResult.GetException()));
+            Assert.Equal(0, await CountItemsAsync(client, options.EventsTableName));
+            Assert.Equal(0, await CountItemsAsync(client, options.TagsTableName));
+
+            var productionExecutor = new GeneralSekibanExecutor(
+                store,
+                new InMemoryObjectAccessor(store, domain),
+                domain,
+                new ExecutorSizeGateOptions().AddDynamoDbWriteOperationPolicy(options));
+            var productionResult = await productionExecutor.CommitSerializableEventsAsync(request);
+            var gateException = Assert.IsType<ExecutorSizeLimitExceededException>(productionResult.GetException());
+            Assert.Equal(DynamoDbWriteOperationSizeMeasurement.Scope, gateException.Scope);
+            Assert.Equal(productionContribution, gateException.MeasuredBytes);
+            Assert.Equal(0, await CountItemsAsync(client, options.EventsTableName));
+            Assert.Equal(0, await CountItemsAsync(client, options.TagsTableName));
+        }
+        finally
+        {
+            await DeleteTableAsync(client, options.EventsTableName);
+            await DeleteTableAsync(client, options.TagsTableName);
+            await DeleteTableAsync(client, options.ProjectionStatesTableName);
+        }
+    }
+
     private static DynamoDbEventStoreOptions CreateOptions(string suffix, string endpoint) =>
         new()
         {
@@ -182,6 +259,55 @@ public sealed class DynamoDbLocalWriteOperationTests
         return events;
     }
 
+    private static List<SerializableEvent> CreateValidExecutorOperationBoundary(
+        DynamoDbWriteOperationSizeMeasurement measurement,
+        long expectedBytes,
+        string serviceId)
+    {
+        const int fixedEventCount = 10;
+        const int fixedNameLength = 380_000;
+        var events = Enumerable.Range(0, fixedEventCount)
+            .Select(_ => CreateStudentEvent(fixedNameLength))
+            .ToList();
+        var used = events.Sum(serialized => Measure(measurement, serialized, serviceId));
+        var low = 0;
+        var high = 500_000;
+        while (low <= high)
+        {
+            var nameLength = low + ((high - low) / 2);
+            var candidate = CreateStudentEvent(nameLength);
+            var total = used + Measure(measurement, candidate, serviceId);
+            if (total == expectedBytes)
+            {
+                events.Add(candidate);
+                return events;
+            }
+
+            if (total < expectedBytes)
+                low = nameLength + 1;
+            else
+                high = nameLength - 1;
+        }
+
+        throw new Xunit.Sdk.XunitException(
+            $"Could not construct a valid executor operation boundary of {expectedBytes} bytes.");
+    }
+
+    private static SerializableEvent CreateStudentEvent(int nameLength)
+    {
+        var id = Guid.CreateVersion7();
+        var payload = JsonSerializer.SerializeToUtf8Bytes(
+            new StudentCreated(id, new string('x', nameLength), 1),
+            DomainType.GetDomainTypes().JsonSerializerOptions);
+        return new SerializableEvent(
+            payload,
+            SortableUniqueId.GenerateNew(),
+            id,
+            new EventMetadata(id.ToString(), "SerializedCommit", "SerializedSekibanExecutor"),
+            [],
+            nameof(StudentCreated));
+    }
+
     private static SerializableEvent CreateSerializedEvent(byte[] payload, string eventType) =>
         new(
             payload,
@@ -192,7 +318,7 @@ public sealed class DynamoDbLocalWriteOperationTests
             eventType);
 
     private static long Measure(
-        DynamoDbWriteOperationSizeMeasurement measurement,
+        IExecutorSizeMeasurement measurement,
         SerializableEvent serialized,
         string serviceId)
     {
@@ -212,6 +338,28 @@ public sealed class DynamoDbLocalWriteOperationTests
             null));
         Assert.True(result.IsAvailable, result.Reason);
         return Assert.IsType<long>(result.Bytes);
+    }
+
+    private static long ReadReportedPayloadSize(Exception exception)
+    {
+        for (var current = exception; current is not null; current = current.InnerException)
+        {
+            var match = Regex.Match(
+                current.Message,
+                @"Payload\s+Size:\s*([0-9,]+)",
+                RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+            if (match.Success && long.TryParse(
+                    match.Groups[1].Value.Replace(",", string.Empty, StringComparison.Ordinal),
+                    NumberStyles.Integer,
+                    CultureInfo.InvariantCulture,
+                    out var payloadSize))
+            {
+                return payloadSize;
+            }
+        }
+
+        throw new Xunit.Sdk.XunitException(
+            $"DynamoDB Local did not report a transaction payload size. Exception tree: {exception}");
     }
 
     private static Dictionary<string, AttributeValue> EventKey(string serviceId, Guid eventId) =>
@@ -294,5 +442,21 @@ public sealed class DynamoDbLocalWriteOperationTests
     private sealed class FixedServiceIdProvider(string serviceId) : IServiceIdProvider
     {
         public string GetCurrentServiceId() => serviceId;
+    }
+
+    private sealed class ItemOnlyOperationMeasurement(DynamoDbEventStoreOptions options) : IExecutorSizeMeasurement
+    {
+        private readonly DynamoDbWriteOperationSizeMeasurement _productionMeasurement =
+            new(options);
+
+        public ExecutorSizeMeasurementResult Measure(ExecutorSizeMeasurementContext context)
+        {
+            var result = _productionMeasurement.Measure(context);
+            if (!result.IsAvailable || result.Bytes is not { } bytes)
+                return result;
+
+            return ExecutorSizeMeasurementResult.Exact(
+                bytes - Encoding.UTF8.GetByteCount("attribute_not_exists(pk)"));
+        }
     }
 }

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/DynamoDbLocalWriteOperationTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/DynamoDbLocalWriteOperationTests.cs
@@ -1,0 +1,298 @@
+using System.Text;
+using Amazon.DynamoDBv2;
+using Amazon.DynamoDBv2.Model;
+using Amazon.Runtime;
+using Dcb.Domain;
+using Dcb.Domain.Student;
+using Microsoft.Extensions.Options;
+using Sekiban.Dcb.Common;
+using Sekiban.Dcb.DynamoDB;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.ServiceId;
+using Sekiban.Dcb.SizeGates;
+using Xunit;
+
+namespace Sekiban.Dcb.Tests;
+
+/// <summary>
+/// Real AmazonDynamoDBClient evidence against the pinned DynamoDB Local service used by CI.
+/// The tests do not use a request fake for the persisted-map or aggregate transaction proof.
+/// </summary>
+[Trait("Category", "DynamoDbLocal")]
+public sealed class DynamoDbLocalWriteOperationTests
+{
+    [Theory]
+    [InlineData(4_194_303, true)]
+    [InlineData(4_194_305, false)]
+    public async Task PinnedLocalCharacterizesUnderAndOverFourMiBOperationContribution(
+        long expectedContribution,
+        bool expectedSuccess)
+    {
+        var endpoint = Environment.GetEnvironmentVariable("SEKIBAN_DYNAMODB_LOCAL_ENDPOINT")
+            ?? "http://127.0.0.1:18000";
+        var suffix = Guid.NewGuid().ToString("N");
+        var serviceId = "g68-local";
+        var options = CreateOptions(suffix, endpoint);
+        using var client = CreateClient(endpoint);
+        var domain = DomainType.GetDomainTypes();
+        var store = NewStore(client, options, domain, serviceId);
+
+        try
+        {
+            var measurement = new DynamoDbWriteOperationSizeMeasurement(options);
+            var events = CreateOperationBoundary(measurement, expectedContribution, serviceId);
+            Assert.Equal(expectedContribution, events.Sum(serialized => Measure(measurement, serialized, serviceId)));
+            Assert.All(events, serialized => Assert.InRange(
+                Measure(measurement, serialized, serviceId),
+                1,
+                DynamoDbMaxWrittenItemSizeMeasurement.MaximumItemBytes +
+                Encoding.UTF8.GetByteCount("attribute_not_exists(pk)")));
+
+            var result = await store.WriteSerializableEventsAsync(events);
+
+            Assert.Equal(expectedSuccess, result.IsSuccess);
+            Assert.Equal(expectedSuccess ? events.Count : 0, await CountItemsAsync(client, options.EventsTableName));
+            if (!expectedSuccess)
+                Assert.NotNull(result.GetException());
+        }
+        finally
+        {
+            await DeleteTableAsync(client, options.EventsTableName);
+            await DeleteTableAsync(client, options.TagsTableName);
+            await DeleteTableAsync(client, options.ProjectionStatesTableName);
+        }
+    }
+
+    [Fact]
+    public async Task PinnedLocalPersistedMapsMatchBothG68Measurements()
+    {
+        var endpoint = Environment.GetEnvironmentVariable("SEKIBAN_DYNAMODB_LOCAL_ENDPOINT")
+            ?? "http://127.0.0.1:18000";
+        var suffix = Guid.NewGuid().ToString("N");
+        var serviceId = "g68-map";
+        var options = CreateOptions(suffix, endpoint);
+        using var client = CreateClient(endpoint);
+        var domain = DomainType.GetDomainTypes();
+        var store = NewStore(client, options, domain, serviceId);
+        var eventId = Guid.CreateVersion7();
+        var @event = new Event(
+            new StudentCreated(eventId, "東京😀", 21),
+            SortableUniqueId.GenerateNew(),
+            nameof(StudentCreated),
+            eventId,
+            new EventMetadata("cause", "correlation", "user"),
+            [$"Student:{eventId}"]);
+        var serialized = @event.ToSerializableEvent(domain.EventTypes);
+
+        try
+        {
+            Assert.True((await store.WriteSerializableEventsAsync([serialized])).IsSuccess);
+            var eventItem = (await client.GetItemAsync(new GetItemRequest
+            {
+                TableName = options.EventsTableName,
+                Key = EventKey(serviceId, serialized.Id),
+                ConsistentRead = true
+            })).Item;
+            var tagItem = (await client.GetItemAsync(new GetItemRequest
+            {
+                TableName = options.TagsTableName,
+                Key = TagKey(serviceId, serialized.Tags[0], serialized.SortableUniqueIdValue, serialized.Id),
+                ConsistentRead = true
+            })).Item;
+
+            Assert.NotEmpty(eventItem);
+            Assert.NotEmpty(tagItem);
+            var context = new ExecutorSizeMeasurementContext(
+                DynamoDbWriteOperationSizeMeasurement.Scope,
+                ExecutorSizeRepresentation.StorageItem,
+                @event,
+                serialized,
+                serviceId,
+                null,
+                null);
+            var max = Assert.IsType<long>(new DynamoDbMaxWrittenItemSizeMeasurement(options).Measure(context).Bytes);
+            var operation = Assert.IsType<long>(new DynamoDbWriteOperationSizeMeasurement(options).Measure(context).Bytes);
+            var eventBytes = CountedItemBytes(eventItem);
+            var tagBytes = CountedItemBytes(tagItem);
+
+            Assert.Equal(Math.Max(eventBytes, tagBytes), max);
+            Assert.Equal(
+                eventBytes + tagBytes + Encoding.UTF8.GetByteCount("attribute_not_exists(pk)"),
+                operation);
+        }
+        finally
+        {
+            await DeleteTableAsync(client, options.EventsTableName);
+            await DeleteTableAsync(client, options.TagsTableName);
+            await DeleteTableAsync(client, options.ProjectionStatesTableName);
+        }
+    }
+
+    private static DynamoDbEventStoreOptions CreateOptions(string suffix, string endpoint) =>
+        new()
+        {
+            EventsTableName = $"G68Events{suffix}",
+            TagsTableName = $"G68Tags{suffix}",
+            ProjectionStatesTableName = $"G68Projection{suffix}",
+            AutoCreateTables = true,
+            ServiceUrl = new Uri(endpoint),
+            MaxRetryAttempts = 2,
+            MaxRetryDelay = TimeSpan.FromMilliseconds(100)
+        };
+
+    private static AmazonDynamoDBClient CreateClient(string endpoint) =>
+        new(
+            new BasicAWSCredentials("fakeMyKeyId", "fakeSecretAccessKey"),
+            new AmazonDynamoDBConfig
+            {
+                ServiceURL = endpoint,
+                AuthenticationRegion = "us-east-1"
+            });
+
+    private static DynamoDbEventStore NewStore(
+        IAmazonDynamoDB client,
+        DynamoDbEventStoreOptions options,
+        DcbDomainTypes domain,
+        string serviceId) =>
+        new(
+            new DynamoDbContext(client, Options.Create(options)),
+            domain.EventTypes,
+            new FixedServiceIdProvider(serviceId));
+
+    private static List<SerializableEvent> CreateOperationBoundary(
+        DynamoDbWriteOperationSizeMeasurement measurement,
+        long expectedBytes,
+        string serviceId)
+    {
+        const int fixedEventCount = 10;
+        const int fixedPayloadLength = 380_000;
+        var events = Enumerable.Range(0, fixedEventCount)
+            .Select(_ => CreateSerializedEvent(
+                Enumerable.Repeat((byte)'x', fixedPayloadLength).ToArray(),
+                "OperationEvent"))
+            .ToList();
+        var used = events.Sum(serialized => Measure(measurement, serialized, serviceId));
+        var emptyLast = CreateSerializedEvent([], "OperationEvent");
+        var lastPayloadLength = checked((int)(expectedBytes - used - Measure(measurement, emptyLast, serviceId)));
+        Assert.InRange(lastPayloadLength, 0, (int)DynamoDbMaxWrittenItemSizeMeasurement.MaximumItemBytes);
+        events.Add(emptyLast with
+        {
+            Payload = Enumerable.Repeat((byte)'x', lastPayloadLength).ToArray()
+        });
+        return events;
+    }
+
+    private static SerializableEvent CreateSerializedEvent(byte[] payload, string eventType) =>
+        new(
+            payload,
+            SortableUniqueId.GenerateNew(),
+            Guid.CreateVersion7(),
+            new EventMetadata("cause", "correlation", "user"),
+            [],
+            eventType);
+
+    private static long Measure(
+        DynamoDbWriteOperationSizeMeasurement measurement,
+        SerializableEvent serialized,
+        string serviceId)
+    {
+        var result = measurement.Measure(new ExecutorSizeMeasurementContext(
+            DynamoDbWriteOperationSizeMeasurement.Scope,
+            ExecutorSizeRepresentation.StorageItem,
+            new Event(
+                new StudentCreated(Guid.CreateVersion7(), "measurement", 1),
+                serialized.SortableUniqueIdValue,
+                serialized.EventPayloadName,
+                serialized.Id,
+                serialized.EventMetadata,
+                serialized.Tags),
+            serialized,
+            serviceId,
+            null,
+            null));
+        Assert.True(result.IsAvailable, result.Reason);
+        return Assert.IsType<long>(result.Bytes);
+    }
+
+    private static Dictionary<string, AttributeValue> EventKey(string serviceId, Guid eventId) =>
+        new()
+        {
+            ["pk"] = new AttributeValue { S = $"SERVICE#{serviceId}#EVENT#{eventId}" },
+            ["sk"] = new AttributeValue { S = $"EVENT#{eventId}" }
+        };
+
+    private static Dictionary<string, AttributeValue> TagKey(
+        string serviceId,
+        string tag,
+        string sortableUniqueId,
+        Guid eventId) =>
+        new()
+        {
+            ["pk"] = new AttributeValue { S = $"SERVICE#{serviceId}#TAG#{tag}" },
+            ["sk"] = new AttributeValue { S = $"{sortableUniqueId}#{eventId}" }
+        };
+
+    private static long CountedItemBytes(IReadOnlyDictionary<string, AttributeValue> item) =>
+        item.Sum(pair => Encoding.UTF8.GetByteCount(pair.Key) + CountedValueBytes(pair.Value));
+
+    private static long CountedValueBytes(AttributeValue value)
+    {
+        if (value.S is not null)
+            return Encoding.UTF8.GetByteCount(value.S);
+        if (value.N is not null)
+            return Encoding.UTF8.GetByteCount(value.N);
+        if (value.L is { Count: > 0 })
+            return 3 + value.L.Sum(item => 1 + CountedValueBytes(item));
+        if (value.L is not null)
+            return 3;
+        if (value.M is { Count: > 0 })
+            return 3 + value.M.Sum(pair => 1 + Encoding.UTF8.GetByteCount(pair.Key) + CountedValueBytes(pair.Value));
+        if (value.M is not null)
+            return 3;
+        if (value.B is not null)
+            return value.B.Length;
+        if (value.SS is not null)
+            return value.SS.Sum(Encoding.UTF8.GetByteCount);
+        if (value.NS is not null)
+            return value.NS.Sum(Encoding.UTF8.GetByteCount);
+        if (value.BS is not null)
+            return value.BS.Sum(stream => stream.Length);
+        return value.NULL == true || value.IsBOOLSet ? 1 : 0;
+    }
+
+    private static async Task<int> CountItemsAsync(IAmazonDynamoDB client, string tableName)
+    {
+        var total = 0;
+        Dictionary<string, AttributeValue>? lastKey = null;
+        do
+        {
+            var result = await client.ScanAsync(new ScanRequest
+            {
+                TableName = tableName,
+                ExclusiveStartKey = lastKey
+            });
+            total += result.Count ?? result.Items.Count;
+            lastKey = result.LastEvaluatedKey;
+        }
+        while (lastKey is { Count: > 0 });
+
+        return total;
+    }
+
+    private static async Task DeleteTableAsync(IAmazonDynamoDB client, string tableName)
+    {
+        try
+        {
+            await client.DeleteTableAsync(tableName);
+        }
+        catch (ResourceNotFoundException)
+        {
+            // The test may have failed before the store created the table.
+        }
+    }
+
+    private sealed class FixedServiceIdProvider(string serviceId) : IServiceIdProvider
+    {
+        public string GetCurrentServiceId() => serviceId;
+    }
+}

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/DynamoDbSizeGateRegistrationTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/DynamoDbSizeGateRegistrationTests.cs
@@ -1,0 +1,275 @@
+using System.Reflection;
+using Dcb.Domain.Student;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Sekiban.Dcb.Common;
+using Sekiban.Dcb.DynamoDB;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.SizeGates;
+
+namespace Sekiban.Dcb.Tests;
+
+public sealed class DynamoDbSizeGateRegistrationTests
+{
+    [Theory]
+    [InlineData(false, false, 0)]
+    [InlineData(false, false, 1)]
+    [InlineData(false, false, 2)]
+    [InlineData(true, false, 0)]
+    [InlineData(true, false, 1)]
+    [InlineData(true, false, 2)]
+    [InlineData(false, true, 0)]
+    [InlineData(false, true, 1)]
+    [InlineData(false, true, 2)]
+    [InlineData(true, true, 0)]
+    [InlineData(true, true, 1)]
+    [InlineData(true, true, 2)]
+    public void MixedCoreAndProviderRegistrationIsRejectedInEveryOrderWithoutMutation(
+        bool coreUsesInstance,
+        bool providerFirst,
+        int providerHelper)
+    {
+        var services = new ServiceCollection();
+        var callbackInvoked = false;
+
+        if (providerFirst)
+        {
+            RegisterProvider(services, providerHelper);
+            var before = services.ToArray();
+
+            var exception = Assert.Throws<InvalidOperationException>(() =>
+                RegisterCore(services, coreUsesInstance, () => callbackInvoked = true));
+
+            Assert.False(callbackInvoked);
+            Assert.Equal(before, services.ToArray());
+            AssertConflictMessage(exception);
+            return;
+        }
+
+        RegisterCore(services, coreUsesInstance, () => callbackInvoked = true);
+        Assert.True(coreUsesInstance || callbackInvoked);
+        var coreBeforeProvider = services.ToArray();
+
+        var providerException = Assert.Throws<InvalidOperationException>(() =>
+            RegisterProvider(services, providerHelper));
+
+        Assert.Equal(coreBeforeProvider, services.ToArray());
+        AssertConflictMessage(providerException);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void InvalidCoreRegistrationLeavesCollectionUntouchedAndProviderCanRegister(bool useInstance)
+    {
+        var services = new ServiceCollection();
+        var before = services.ToArray();
+        var invalid = new ExecutorSizeGateOptions()
+            .Add(new ExecutorSizePolicy(
+                "invalid",
+                ExecutorSizeRepresentation.LogicalSerializedEventUtf8,
+                maxBytesPerEvent: 0));
+
+        Assert.Throws<ArgumentException>(() =>
+            RegisterInvalidCore(services, useInstance, invalid));
+
+        Assert.Equal(before, services.ToArray());
+        RegisterProvider(services, 0);
+
+        using var provider = services.BuildServiceProvider();
+        Assert.Single(provider.GetRequiredService<ExecutorSizeGateOptions>().Policies);
+    }
+
+    [Fact]
+    public void CoreRegistrationIsLastWinsAndPreservesSuppliedInstanceIdentity()
+    {
+        var first = ValidCoreOptions("first");
+        var second = ValidCoreOptions("second");
+        var services = new ServiceCollection()
+            .AddSekibanDcbExecutorSizeGate(first)
+            .AddSekibanDcbExecutorSizeGate(second);
+
+        using var provider = services.BuildServiceProvider();
+        var resolved = provider.GetRequiredService<ExecutorSizeGateOptions>();
+
+        Assert.Same(second, resolved);
+        Assert.Equal("second", Assert.Single(resolved.Policies).Scope);
+        Assert.Equal(
+            2,
+            services.Count(descriptor => descriptor.ServiceType == typeof(ExecutorSizeGateOptions)));
+    }
+
+    [Fact]
+    public void ProviderHelpersAccumulateAndPreserveTheirExistingPolicyOrder()
+    {
+        using var provider = new ServiceCollection()
+            .AddSekibanDcbDynamoDbEventItemSizeGate()
+            .AddSekibanDcbDynamoDbMaxWrittenItemSizeGate()
+            .AddSekibanDcbDynamoDbWriteOperationSizeGate()
+            .BuildServiceProvider();
+
+        var gate = provider.GetRequiredService<ExecutorSizeGateOptions>();
+        Assert.Equal(
+            [
+                DynamoDbEventItemSizeMeasurement.Scope,
+                DynamoDbMaxWrittenItemSizeMeasurement.Scope,
+                DynamoDbWriteOperationSizeMeasurement.Scope
+            ],
+            gate.Policies.Select(policy => policy.Scope));
+    }
+
+    [Fact]
+    public void NoGateRegistrationRemainsUngatedAndAddsNoInternalMarker()
+    {
+        var services = new ServiceCollection();
+
+        Assert.DoesNotContain(
+            services,
+            descriptor => descriptor.ServiceType == typeof(ExecutorSizeGateOptions));
+        Assert.DoesNotContain(
+            typeof(SekibanDcbExecutorSizeGateExtensions).Assembly.GetTypes(),
+            type => type.Name == "ExecutorSizeGateRegistrationMarker" && type.IsPublic);
+    }
+
+    [Fact]
+    public void CoreAndProviderRegistrationUseTheSameShardOptionsForMigrationParity()
+    {
+        var storeOptions = new DynamoDbEventStoreOptions { WriteShardCount = 2 };
+        var context = CreateContext();
+
+        using var coreProvider = new ServiceCollection()
+            .AddSekibanDcbExecutorSizeGate(options => options.AddDynamoDbEventItemPolicy(storeOptions))
+            .BuildServiceProvider();
+        using var providerProvider = new ServiceCollection()
+            .AddSingleton<IOptions<DynamoDbEventStoreOptions>>(Options.Create(storeOptions))
+            .AddSekibanDcbDynamoDbEventItemSizeGate()
+            .BuildServiceProvider();
+
+        var coreMeasurement = Assert.IsType<DynamoDbEventItemSizeMeasurement>(
+            Assert.Single(coreProvider.GetRequiredService<ExecutorSizeGateOptions>().Policies).Measurement);
+        var providerMeasurement = Assert.IsType<DynamoDbEventItemSizeMeasurement>(
+            Assert.Single(providerProvider.GetRequiredService<ExecutorSizeGateOptions>().Policies).Measurement);
+        var omittedOptionsMeasurement = new DynamoDbEventItemSizeMeasurement();
+
+        Assert.Equal(
+            coreMeasurement.Measure(context).Bytes,
+            providerMeasurement.Measure(context).Bytes);
+        Assert.Equal(
+            coreMeasurement.Measure(context).Bytes!.Value - 2,
+            omittedOptionsMeasurement.Measure(context).Bytes);
+    }
+
+    [Fact]
+    public void CorePublicAbiRemainsTwoOverloadsAndMarkerIsNotPublic()
+    {
+        var methods = typeof(SekibanDcbExecutorSizeGateExtensions)
+            .GetMethods(BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly)
+            .Where(method => method.Name == nameof(SekibanDcbExecutorSizeGateExtensions.AddSekibanDcbExecutorSizeGate))
+            .ToArray();
+
+        Assert.Equal(2, methods.Length);
+        Assert.Contains(methods, method => method.GetParameters().Select(p => p.ParameterType)
+            .SequenceEqual([typeof(IServiceCollection), typeof(Action<ExecutorSizeGateOptions>)]));
+        Assert.Contains(methods, method => method.GetParameters().Select(p => p.ParameterType)
+            .SequenceEqual([typeof(IServiceCollection), typeof(ExecutorSizeGateOptions)]));
+        Assert.DoesNotContain(
+            typeof(SekibanDcbExecutorSizeGateExtensions).Assembly.GetExportedTypes(),
+            type => type.Name == "ExecutorSizeGateRegistrationMarker");
+    }
+
+    private static void RegisterCore(
+        IServiceCollection services,
+        bool useInstance,
+        Action callbackInvoked)
+    {
+        if (useInstance)
+        {
+            services.AddSekibanDcbExecutorSizeGate(ValidCoreOptions("core"));
+            return;
+        }
+
+        services.AddSekibanDcbExecutorSizeGate(options =>
+        {
+            callbackInvoked();
+            options.Add(new ExecutorSizePolicy(
+                "core",
+                ExecutorSizeRepresentation.LogicalSerializedEventUtf8,
+                maxBytesPerEvent: 1024));
+        });
+    }
+
+    private static void RegisterInvalidCore(
+        IServiceCollection services,
+        bool useInstance,
+        ExecutorSizeGateOptions invalid)
+    {
+        if (useInstance)
+        {
+            services.AddSekibanDcbExecutorSizeGate(invalid);
+            return;
+        }
+
+        services.AddSekibanDcbExecutorSizeGate(options =>
+            options.Add(new ExecutorSizePolicy(
+                "invalid",
+                ExecutorSizeRepresentation.LogicalSerializedEventUtf8,
+                maxBytesPerEvent: 0)));
+    }
+
+    private static void RegisterProvider(IServiceCollection services, int providerHelper)
+    {
+        switch (providerHelper)
+        {
+            case 0:
+                services.AddSekibanDcbDynamoDbEventItemSizeGate();
+                break;
+            case 1:
+                services.AddSekibanDcbDynamoDbMaxWrittenItemSizeGate();
+                break;
+            case 2:
+                services.AddSekibanDcbDynamoDbWriteOperationSizeGate();
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(providerHelper));
+        }
+    }
+
+    private static ExecutorSizeGateOptions ValidCoreOptions(string scope) =>
+        new ExecutorSizeGateOptions().Add(new ExecutorSizePolicy(
+            scope,
+            ExecutorSizeRepresentation.LogicalSerializedEventUtf8,
+            maxBytesPerEvent: 1024));
+
+    private static void AssertConflictMessage(InvalidOperationException exception)
+    {
+        Assert.Contains("cannot both configure the executor size gate", exception.Message);
+        Assert.Contains("Configure every policy through one mechanism", exception.Message);
+        Assert.Contains("AddSekibanDcbExecutorSizeGate", exception.Message);
+        Assert.Contains("AddSekibanDcbDynamoDb", exception.Message);
+    }
+
+    private static ExecutorSizeMeasurementContext CreateContext()
+    {
+        var serialized = new SerializableEvent(
+            [],
+            SortableUniqueId.GenerateNew(),
+            Guid.CreateVersion7(),
+            new EventMetadata("cause", "correlation", "user"),
+            [],
+            nameof(StudentCreated));
+        return new ExecutorSizeMeasurementContext(
+            DynamoDbEventItemSizeMeasurement.Scope,
+            ExecutorSizeRepresentation.StorageItem,
+            new Event(
+                new StudentCreated(Guid.CreateVersion7(), "migration", 1),
+                serialized.SortableUniqueIdValue,
+                serialized.EventPayloadName,
+                serialized.Id,
+                serialized.EventMetadata,
+                serialized.Tags),
+            serialized,
+            "g68-registration",
+            null,
+            null);
+    }
+}

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/DynamoDbSizeGateSurfaceTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/DynamoDbSizeGateSurfaceTests.cs
@@ -30,9 +30,25 @@ public sealed class DynamoDbSizeGateSurfaceTests
         AssertPublicConstructor(
             typeof(DynamoDbEventItemSizeMeasurement),
             typeof(DynamoDbEventStoreOptions));
+        AssertPublicConstructor(
+            typeof(DynamoDbMaxWrittenItemSizeMeasurement),
+            typeof(DynamoDbEventStoreOptions));
+        AssertPublicConstructor(
+            typeof(DynamoDbWriteOperationSizeMeasurement),
+            typeof(DynamoDbEventStoreOptions));
         AssertPublicMethod(
             typeof(DynamoDbEventItemSizeMeasurement),
             nameof(DynamoDbEventItemSizeMeasurement.Measure),
+            typeof(ExecutorSizeMeasurementResult),
+            typeof(ExecutorSizeMeasurementContext));
+        AssertPublicMethod(
+            typeof(DynamoDbMaxWrittenItemSizeMeasurement),
+            nameof(DynamoDbMaxWrittenItemSizeMeasurement.Measure),
+            typeof(ExecutorSizeMeasurementResult),
+            typeof(ExecutorSizeMeasurementContext));
+        AssertPublicMethod(
+            typeof(DynamoDbWriteOperationSizeMeasurement),
+            nameof(DynamoDbWriteOperationSizeMeasurement.Measure),
             typeof(ExecutorSizeMeasurementResult),
             typeof(ExecutorSizeMeasurementContext));
 
@@ -58,6 +74,36 @@ public sealed class DynamoDbSizeGateSurfaceTests
             typeof(IServiceCollection),
             typeof(IServiceCollection),
             typeof(Nullable<long>),
+            typeof(Nullable<long>),
+            typeof(ExecutorSizeStrictness));
+        AssertPublicMethod(
+            typeof(DynamoDbExecutorSizeGateExtensions),
+            nameof(DynamoDbExecutorSizeGateExtensions.AddDynamoDbMaxWrittenItemPolicy),
+            typeof(ExecutorSizeGateOptions),
+            typeof(ExecutorSizeGateOptions),
+            typeof(DynamoDbEventStoreOptions),
+            typeof(Nullable<long>),
+            typeof(ExecutorSizeStrictness));
+        AssertPublicMethod(
+            typeof(DynamoDbExecutorSizeGateExtensions),
+            nameof(DynamoDbExecutorSizeGateExtensions.AddDynamoDbWriteOperationPolicy),
+            typeof(ExecutorSizeGateOptions),
+            typeof(ExecutorSizeGateOptions),
+            typeof(DynamoDbEventStoreOptions),
+            typeof(Nullable<long>),
+            typeof(ExecutorSizeStrictness));
+        AssertPublicMethod(
+            typeof(DynamoDbExecutorSizeGateExtensions),
+            nameof(DynamoDbExecutorSizeGateExtensions.AddSekibanDcbDynamoDbMaxWrittenItemSizeGate),
+            typeof(IServiceCollection),
+            typeof(IServiceCollection),
+            typeof(Nullable<long>),
+            typeof(ExecutorSizeStrictness));
+        AssertPublicMethod(
+            typeof(DynamoDbExecutorSizeGateExtensions),
+            nameof(DynamoDbExecutorSizeGateExtensions.AddSekibanDcbDynamoDbWriteOperationSizeGate),
+            typeof(IServiceCollection),
+            typeof(IServiceCollection),
             typeof(Nullable<long>),
             typeof(ExecutorSizeStrictness));
 

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/DynamoDbWriteOperationSizeMeasurementTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/DynamoDbWriteOperationSizeMeasurementTests.cs
@@ -114,7 +114,7 @@ public sealed class DynamoDbWriteOperationSizeMeasurementTests
     public void LargestTagItemBoundary_IsMeasuredExactly(long expectedBytes)
     {
         var measurement = new DynamoDbMaxWrittenItemSizeMeasurement();
-        var sized = CreateTagLargestBoundary(measurement, expectedBytes, "tag-boundary");
+        var sized = DynamoDbG68TestData.CreateTagLargestBoundary(measurement, expectedBytes, "tag-boundary");
 
         Assert.Equal(expectedBytes, Measure(measurement, sized, "tag-boundary"));
         var mapped = CaptureSerializedWrite(sized, "tag-boundary");
@@ -122,6 +122,9 @@ public sealed class DynamoDbWriteOperationSizeMeasurementTests
             expectedBytes,
             mapped.EventItems.Concat(mapped.TagItems).Max(IndependentItemBytes));
         Assert.True(mapped.TagItems.Max(IndependentItemBytes) > mapped.EventItems.Max(IndependentItemBytes));
+        Assert.All(
+            mapped.EventItems.Concat(mapped.TagItems),
+            AssertDynamoDbKeyLimits);
     }
 
     [Theory]
@@ -468,35 +471,6 @@ public sealed class DynamoDbWriteOperationSizeMeasurementTests
         Assert.Empty((await store.ReadAllSerializableEventsAsync()).GetValue());
     }
 
-    private static SerializableEvent CreateTagLargestBoundary(
-        DynamoDbMaxWrittenItemSizeMeasurement measurement,
-        long expectedBytes,
-        string serviceId)
-    {
-        for (var typeLength = 1; typeLength <= 256; typeLength++)
-        {
-            var eventType = "T" + new string('e', typeLength - 1);
-            var seed = CreateSerializedEvent([], ["Tag:"], eventType);
-            var low = 0;
-            var high = 500_000;
-            while (low <= high)
-            {
-                var suffixLength = low + ((high - low) / 2);
-                var candidate = seed with { Tags = ["Tag:" + new string('x', suffixLength)] };
-                var measured = Measure(measurement, candidate, serviceId);
-                if (measured == expectedBytes)
-                    return candidate;
-
-                if (measured < expectedBytes)
-                    low = suffixLength + 1;
-                else
-                    high = suffixLength - 1;
-            }
-        }
-
-        throw new Xunit.Sdk.XunitException($"Could not construct a tag boundary of {expectedBytes} bytes.");
-    }
-
     private static List<SerializableEvent> CreateOperationBoundary(
         DynamoDbWriteOperationSizeMeasurement measurement,
         long expectedBytes)
@@ -618,6 +592,16 @@ public sealed class DynamoDbWriteOperationSizeMeasurementTests
     private static long IndependentItemBytes(IReadOnlyDictionary<string, AttributeValue> item) =>
         item.Sum(pair => Encoding.UTF8.GetByteCount(pair.Key) + IndependentValueBytes(pair.Value));
 
+    private static void AssertDynamoDbKeyLimits(IReadOnlyDictionary<string, AttributeValue> item)
+    {
+        Assert.True(item.TryGetValue("pk", out var partitionKey));
+        Assert.True(item.TryGetValue("sk", out var sortKey));
+        Assert.NotNull(partitionKey.S);
+        Assert.NotNull(sortKey.S);
+        Assert.InRange(Encoding.UTF8.GetByteCount(partitionKey.S!), 1, 2_048);
+        Assert.InRange(Encoding.UTF8.GetByteCount(sortKey.S!), 1, 1_024);
+    }
+
     private static long IndependentValueBytes(AttributeValue value)
     {
         if (value.S is not null)
@@ -663,4 +647,75 @@ public sealed class DynamoDbWriteOperationSizeMeasurementTests
     {
         public const string ExpectedCondition = "attribute_not_exists(pk)";
     }
+}
+
+internal static class DynamoDbG68TestData
+{
+    public static SerializableEvent CreateTagLargestBoundary(
+        DynamoDbMaxWrittenItemSizeMeasurement measurement,
+        long expectedBytes,
+        string serviceId)
+    {
+        const string eventTypePrefix = "TagBoundaryEvent";
+        // The tag is part of the tag-row partition key. Keep it comfortably below DynamoDB's 2,048-byte
+        // UTF-8 partition-key limit and vary the event type, which is stored in both event and tag rows.
+        var legalTag = "Tag:" + new string('x', 1_900);
+        var seed = CreateSerializedEvent([], [legalTag], eventTypePrefix);
+        var low = eventTypePrefix.Length;
+        var high = 500_000;
+        while (low <= high)
+        {
+            var typeLength = low + ((high - low) / 2);
+            var eventType = eventTypePrefix + new string('e', typeLength - eventTypePrefix.Length);
+            var candidate = seed with { EventPayloadName = eventType };
+            var measured = Measure(measurement, candidate, serviceId);
+            if (measured == expectedBytes)
+                return candidate;
+
+            if (measured < expectedBytes)
+                low = typeLength + 1;
+            else
+                high = typeLength - 1;
+        }
+
+        throw new Xunit.Sdk.XunitException($"Could not construct a legal-key tag boundary of {expectedBytes} bytes.");
+    }
+
+    private static long Measure(
+        IExecutorSizeMeasurement measurement,
+        SerializableEvent serialized,
+        string serviceId)
+    {
+        var result = measurement.Measure(new ExecutorSizeMeasurementContext(
+            measurement is DynamoDbMaxWrittenItemSizeMeasurement
+                ? DynamoDbMaxWrittenItemSizeMeasurement.Scope
+                : DynamoDbWriteOperationSizeMeasurement.Scope,
+            ExecutorSizeRepresentation.StorageItem,
+            new Event(
+                new StudentCreated(Guid.CreateVersion7(), "measurement", 1),
+                serialized.SortableUniqueIdValue,
+                serialized.EventPayloadName,
+                serialized.Id,
+                serialized.EventMetadata,
+                serialized.Tags),
+            serialized,
+            serviceId,
+            null,
+            null));
+        if (!result.IsAvailable || result.Bytes is null)
+            throw new Xunit.Sdk.XunitException(result.Reason ?? "DynamoDB test measurement was unavailable.");
+        return result.Bytes.Value;
+    }
+
+    private static SerializableEvent CreateSerializedEvent(
+        byte[] payload,
+        IReadOnlyList<string> tags,
+        string eventType) =>
+        new(
+            payload,
+            SortableUniqueId.GenerateNew(),
+            Guid.CreateVersion7(),
+            new EventMetadata("cause", "correlation", "user"),
+            tags.ToList(),
+            eventType);
 }

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/DynamoDbWriteOperationSizeMeasurementTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/DynamoDbWriteOperationSizeMeasurementTests.cs
@@ -1,0 +1,666 @@
+using System.Text;
+using System.Text.Encodings.Web;
+using System.Text.Json;
+using Amazon.DynamoDBv2;
+using Amazon.DynamoDBv2.Model;
+using Amazon.DynamoDBv2.Model.Internal.MarshallTransformations;
+using Amazon.Runtime.Internal;
+using Dcb.Domain;
+using Dcb.Domain.Student;
+using Dcb.Domain.Weather;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Sekiban.Dcb.Actors;
+using Sekiban.Dcb.Commands;
+using Sekiban.Dcb.DynamoDB;
+using Sekiban.Dcb.Domains;
+using Sekiban.Dcb.Common;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.ServiceId;
+using Sekiban.Dcb.SizeGates;
+using Sekiban.Dcb.Storage;
+using Sekiban.Dcb.Testing;
+using CoreInMemoryEventStore = Sekiban.Dcb.Testing.InMemoryEventStore;
+using Xunit;
+
+namespace Sekiban.Dcb.Tests;
+
+/// <summary>
+/// G68 provider accounting proofs. The production mapper is exercised through the store and the independent oracle
+/// counts the captured AttributeValue maps rather than reconstructing a second provider model.
+/// </summary>
+public sealed class DynamoDbWriteOperationSizeMeasurementTests
+{
+    [Fact]
+    public void NewPoliciesExposeOnlyTheirRelevantQuotaAndCanCoexist()
+    {
+        var options = new ExecutorSizeGateOptions()
+            .AddDynamoDbMaxWrittenItemPolicy(maxBytesPerEvent: 1234)
+            .AddDynamoDbWriteOperationPolicy(maxBytesPerOperation: 5678);
+
+        Assert.Collection(
+            options.Policies,
+            item =>
+            {
+                Assert.Equal(DynamoDbMaxWrittenItemSizeMeasurement.Scope, item.Scope);
+                Assert.Equal(1234, item.MaxBytesPerEvent);
+                Assert.Null(item.MaxBytesPerOperation);
+            },
+            operation =>
+            {
+                Assert.Equal(DynamoDbWriteOperationSizeMeasurement.Scope, operation.Scope);
+                Assert.Null(operation.MaxBytesPerEvent);
+                Assert.Equal(5678, operation.MaxBytesPerOperation);
+            });
+
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            new ExecutorSizeGateOptions().AddDynamoDbMaxWrittenItemPolicy(
+                maxBytesPerEvent: DynamoDbMaxWrittenItemSizeMeasurement.MaximumItemBytes + 1));
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            new ExecutorSizeGateOptions().AddDynamoDbWriteOperationPolicy(
+                maxBytesPerOperation: DynamoDbWriteOperationSizeMeasurement.MaximumTransactionBytes + 1));
+    }
+
+    [Fact]
+    public void DiRegistrationAggregatesG67AndBothG68PoliciesWithStoreOptions()
+    {
+        var client = System.Reflection.DispatchProxy.Create<IAmazonDynamoDB,
+            DynamoDbEventItemSizeMeasurementTests.CapturingDynamoDb>();
+        using var provider = new ServiceCollection()
+            .AddSekibanDcbDynamoDb(client, options => options.WriteShardCount = 2)
+            .AddSekibanDcbDynamoDbEventItemSizeGate()
+            .AddSekibanDcbDynamoDbMaxWrittenItemSizeGate()
+            .AddSekibanDcbDynamoDbWriteOperationSizeGate()
+            .BuildServiceProvider();
+
+        var gate = provider.GetRequiredService<ExecutorSizeGateOptions>();
+        Assert.Equal(
+            [
+                DynamoDbEventItemSizeMeasurement.Scope,
+                DynamoDbMaxWrittenItemSizeMeasurement.Scope,
+                DynamoDbWriteOperationSizeMeasurement.Scope
+            ],
+            gate.Policies.Select(policy => policy.Scope));
+
+        var context = CreateContext(CreateSerializedEvent([], tags: []));
+        var operation = Assert.IsType<DynamoDbWriteOperationSizeMeasurement>(
+            gate.Policies.Single(policy => policy.Scope == DynamoDbWriteOperationSizeMeasurement.Scope).Measurement);
+        Assert.True(operation.Measure(context).IsAvailable);
+    }
+
+    [Theory]
+    [InlineData(409599)]
+    [InlineData(409600)]
+    [InlineData(409601)]
+    public void LargestEventItemBoundary_IsMeasuredExactly(long expectedBytes)
+    {
+        var measurement = new DynamoDbMaxWrittenItemSizeMeasurement();
+        var empty = CreateSerializedEvent([], tags: []);
+        var emptyBytes = Measure(measurement, empty);
+        var sized = empty with
+        {
+            Payload = Enumerable.Repeat(
+                (byte)'x',
+                checked((int)(expectedBytes - emptyBytes))).ToArray()
+        };
+
+        Assert.Equal(expectedBytes, Measure(measurement, sized));
+    }
+
+    [Theory]
+    [InlineData(409599)]
+    [InlineData(409600)]
+    [InlineData(409601)]
+    public void LargestTagItemBoundary_IsMeasuredExactly(long expectedBytes)
+    {
+        var measurement = new DynamoDbMaxWrittenItemSizeMeasurement();
+        var sized = CreateTagLargestBoundary(measurement, expectedBytes, "tag-boundary");
+
+        Assert.Equal(expectedBytes, Measure(measurement, sized, "tag-boundary"));
+        var mapped = CaptureSerializedWrite(sized, "tag-boundary");
+        Assert.Equal(
+            expectedBytes,
+            mapped.EventItems.Concat(mapped.TagItems).Max(IndependentItemBytes));
+        Assert.True(mapped.TagItems.Max(IndependentItemBytes) > mapped.EventItems.Max(IndependentItemBytes));
+    }
+
+    [Theory]
+    [InlineData(4194303)]
+    [InlineData(4194304)]
+    [InlineData(4194305)]
+    public void OperationBoundaryIncludesEveryItemAndTheProductionCondition(long expectedBytes)
+    {
+        var measurement = new DynamoDbWriteOperationSizeMeasurement();
+        var events = CreateOperationBoundary(measurement, expectedBytes);
+
+        Assert.All(events, serialized =>
+            Assert.InRange(
+                Measure(measurement, serialized),
+                1,
+                DynamoDbMaxWrittenItemSizeMeasurement.MaximumItemBytes +
+                Encoding.UTF8.GetByteCount(DynamoDbTransactionSizeAccountingForTest.ExpectedCondition)));
+        Assert.Equal(expectedBytes, events.Sum(serialized => Measure(measurement, serialized)));
+    }
+
+    [Fact]
+    public async Task BatchWriteSdkBodyCanExceedSixteenMiBWhileTwentyFiveStoredItemsRemainLegal()
+    {
+        var domain = DomainType.GetDomainTypes();
+        var client = System.Reflection.DispatchProxy.Create<IAmazonDynamoDB,
+            DynamoDbEventItemSizeMeasurementTests.CapturingDynamoDb>();
+        var capture = (DynamoDbEventItemSizeMeasurementTests.CapturingDynamoDb)(object)client;
+        var store = NewStore(client, domain, "batch-wire", maxTransactionItems: 0);
+        var escapedJsonPayload = JsonSerializer.SerializeToUtf8Bytes(
+            new string('é', 194_000),
+            new JsonSerializerOptions { Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping });
+        var events = Enumerable.Range(0, 25)
+            .Select(_ => CreateSerializedEvent(escapedJsonPayload, [], "BatchWireEvent"))
+            .ToArray();
+
+        var result = await store.WriteSerializableEventsAsync(events);
+
+        Assert.True(result.IsSuccess);
+        var request = Assert.Single(capture.BatchRequests);
+        var requests = Assert.Single(request.RequestItems).Value;
+        Assert.Equal(25, requests.Count);
+        var storedItems = requests
+            .Select(write =>
+            {
+                Assert.NotNull(write.PutRequest);
+                return write.PutRequest!.Item;
+            })
+            .ToArray();
+        Assert.All(storedItems, item => Assert.InRange(
+            IndependentItemBytes(item),
+            1,
+            DynamoDbMaxWrittenItemSizeMeasurement.MaximumItemBytes));
+        Assert.InRange(
+            storedItems.Sum(IndependentItemBytes),
+            1,
+            16 * 1024 * 1024 - 1);
+
+        var sdkRequest = BatchWriteItemRequestMarshaller.Instance.Marshall(request);
+        Assert.True(
+            sdkRequest.ContentStream is not null || sdkRequest.Content is not null,
+            $"Marshaller returned no content; parameters={sdkRequest.Parameters.Count}, set={sdkRequest.SetContentFromParameters}.");
+        var bodyBytes = sdkRequest.ContentStream is not null
+            ? ReadStream(sdkRequest.ContentStream)
+            : sdkRequest.Content!;
+        Assert.True(
+            bodyBytes.Length > 16 * 1024 * 1024,
+            $"SDK BatchWriteItem body was {bodyBytes.Length} bytes.");
+    }
+
+    private static byte[] ReadStream(Stream stream)
+    {
+        if (stream.CanSeek)
+            stream.Position = 0;
+        using var copy = new MemoryStream();
+        stream.CopyTo(copy);
+        return copy.ToArray();
+    }
+
+    [Fact]
+    public async Task TypedSerializedAndConditionalMapsShareOperationAccountingAndConditionLiteral()
+    {
+        var domain = DomainType.GetDomainTypes();
+        var @event = new Event(
+            new StudentCreated(Guid.CreateVersion7(), "東京😀", 21),
+            SortableUniqueId.GenerateNew(),
+            nameof(StudentCreated),
+            Guid.CreateVersion7(),
+            new EventMetadata("cause", "correlation", "user"),
+            ["Student:東京😀", "tag"]);
+        var serialized = @event.ToSerializableEvent(domain.EventTypes);
+        var client = System.Reflection.DispatchProxy.Create<IAmazonDynamoDB,
+            DynamoDbEventItemSizeMeasurementTests.CapturingDynamoDb>();
+        var capture = (DynamoDbEventItemSizeMeasurementTests.CapturingDynamoDb)(object)client;
+        var store = NewStore(client, domain, "operation-shape");
+        var measurement = new DynamoDbWriteOperationSizeMeasurement();
+
+        Assert.True((await store.WriteEventsAsync([@event])).IsSuccess);
+        var typedEvent = capture.EventItems.Single();
+        var typedTags = capture.TagItems.ToArray();
+        Assert.Contains(
+            DynamoDbTransactionSizeAccountingForTest.ExpectedCondition,
+            capture.ConditionExpressions);
+        Assert.Equal(
+            capture.TagItems.Count,
+            capture.ConditionExpressions.Count(condition => condition is null));
+        Assert.NotEmpty(capture.ClientRequestTokens);
+        capture.Clear();
+
+        Assert.True((await store.WriteSerializableEventsAsync([serialized])).IsSuccess);
+        var serializedEvent = capture.EventItems.Single();
+        var serializedTags = capture.TagItems.ToArray();
+        capture.Clear();
+
+        Assert.True((await store.AppendIfUniqueAsync(
+            new ConditionalAppendRequest("operation-shape", serialized))).IsSuccess);
+        var conditionalEvent = capture.EventItems.Single();
+        var conditionalTags = capture.TagItems.ToArray();
+        Assert.Equal([null], capture.ClientRequestTokens);
+        Assert.Contains(
+            DynamoDbTransactionSizeAccountingForTest.ExpectedCondition,
+            capture.ConditionExpressions);
+        Assert.Equal(
+            capture.TagItems.Count,
+            capture.ConditionExpressions.Count(condition => condition is null));
+
+        Assert.Equal(Normalize(typedEvent), Normalize(serializedEvent));
+        Assert.Equal(Normalize(typedEvent), Normalize(conditionalEvent));
+        Assert.Equal(
+            typedTags.Select(Normalize),
+            serializedTags.Select(Normalize));
+        Assert.Equal(
+            typedTags.Select(Normalize),
+            conditionalTags.Select(Normalize));
+
+        var measured = Measure(measurement, serialized, "operation-shape");
+        var expected = IndependentItemBytes(serializedEvent)
+            + typedTags.Sum(IndependentItemBytes)
+            + Encoding.UTF8.GetByteCount(DynamoDbTransactionSizeAccountingForTest.ExpectedCondition);
+        Assert.Equal(expected, measured);
+    }
+
+    [Fact]
+    public async Task ConditionalRouteWithManyLegalTagRowsCountsLargeEventTypeInTheAggregate()
+    {
+        const int tagPayloadLength = 1_000;
+        var eventType = "ConditionalAggregateEvent" + new string('e', 40_000);
+        var tags = Enumerable.Range(0, 99)
+            .Select(index => $"ConditionalTag{index}-" + new string('x', tagPayloadLength))
+            .ToArray();
+        var domain = DomainType.GetDomainTypes();
+        var eventTypes = new SimpleEventTypes(domain.JsonSerializerOptions);
+        eventTypes.RegisterEventType<StudentCreated>(eventType);
+        var serialized = CreateSerializedEvent(
+            JsonSerializer.SerializeToUtf8Bytes(
+                new StudentCreated(Guid.CreateVersion7(), "conditional", 1),
+                domain.JsonSerializerOptions),
+            tags,
+            eventType);
+        var client = System.Reflection.DispatchProxy.Create<IAmazonDynamoDB,
+            DynamoDbEventItemSizeMeasurementTests.CapturingDynamoDb>();
+        var capture = (DynamoDbEventItemSizeMeasurementTests.CapturingDynamoDb)(object)client;
+        var store = NewStore(client, domain, "conditional-aggregate", eventTypes: eventTypes);
+
+        var append = await store.AppendIfUniqueAsync(
+            new ConditionalAppendRequest("conditional-aggregate-key", serialized));
+        if (!append.IsSuccess)
+            Assert.Fail(append.GetException().ToString());
+
+        var eventItem = Assert.Single(capture.EventItems);
+        Assert.Equal(tags.Length, capture.TagItems.Count);
+        Assert.Equal(
+            DynamoDbTransactionSizeAccountingForTest.ExpectedCondition,
+            Assert.Single(capture.ConditionExpressions, condition => condition is not null));
+        Assert.All(capture.EventItems.Concat(capture.TagItems), item => Assert.InRange(
+            IndependentItemBytes(item),
+            1,
+            DynamoDbMaxWrittenItemSizeMeasurement.MaximumItemBytes));
+
+        var measured = new DynamoDbWriteOperationSizeMeasurement().Measure(
+            new ExecutorSizeMeasurementContext(
+                DynamoDbWriteOperationSizeMeasurement.Scope,
+                ExecutorSizeRepresentation.StorageItem,
+                new Event(
+                    new StudentCreated(Guid.CreateVersion7(), "conditional", 1),
+                    serialized.SortableUniqueIdValue,
+                    eventType,
+                    serialized.Id,
+                    serialized.EventMetadata,
+                    tags.ToList()),
+                serialized,
+                "conditional-aggregate",
+                null,
+                null));
+
+        Assert.True(measured.IsAvailable, measured.Reason);
+        var expected = IndependentItemBytes(eventItem)
+            + capture.TagItems.Sum(IndependentItemBytes)
+            + Encoding.UTF8.GetByteCount(DynamoDbTransactionSizeAccountingForTest.ExpectedCondition);
+        Assert.Equal(expected, measured.Bytes);
+        Assert.True(measured.Bytes > DynamoDbWriteOperationSizeMeasurement.MaximumTransactionBytes);
+    }
+
+    [Fact]
+    public void NonStorageRepresentationIsUnavailableForBothNewCapabilities()
+    {
+        var context = CreateContext(CreateSerializedEvent([], tags: [])) with
+        {
+            Representation = ExecutorSizeRepresentation.LogicalSerializedEventUtf8
+        };
+
+        var max = new DynamoDbMaxWrittenItemSizeMeasurement().Measure(context);
+        var operation = new DynamoDbWriteOperationSizeMeasurement().Measure(context);
+
+        Assert.False(max.IsAvailable);
+        Assert.False(operation.IsAvailable);
+        Assert.Contains("StorageItem", max.Reason);
+        Assert.Contains("StorageItem", operation.Reason);
+    }
+
+    [Theory]
+    [InlineData(false, "dynamodb-max-written-item")]
+    [InlineData(true, "dynamodb-max-written-item")]
+    [InlineData(false, "dynamodb-write-operation")]
+    [InlineData(true, "dynamodb-write-operation")]
+    public async Task NewCapabilityUnavailableBehaviorIsStrictOrDiagnosticWithoutChangingWrites(
+        bool strict,
+        string scope)
+    {
+        var domain = DomainType.GetDomainTypes();
+        var store = new CoreInMemoryEventStore(domain.EventTypes);
+        IExecutorSizeMeasurement measurement = scope == DynamoDbMaxWrittenItemSizeMeasurement.Scope
+            ? new DynamoDbMaxWrittenItemSizeMeasurement()
+            : new DynamoDbWriteOperationSizeMeasurement();
+        var policy = new ExecutorSizePolicy(
+            scope,
+            ExecutorSizeRepresentation.LogicalSerializedEventUtf8,
+            maxBytesPerEvent: 1024,
+            strictness: strict ? ExecutorSizeStrictness.Strict : ExecutorSizeStrictness.NonStrict,
+            measurement: measurement);
+        var executor = new GeneralSekibanExecutor(
+            store,
+            new InMemoryObjectAccessor(store, domain),
+            domain,
+            new ExecutorSizeGateOptions().Add(policy));
+
+        var result = await executor.CommitSerializableEventsAsync(
+            new SerializedCommitRequest([CreateCandidate([], "capability")], []));
+
+        if (strict)
+        {
+            var exception = Assert.IsType<ExecutorSizeCapabilityException>(result.GetException());
+            Assert.Equal(scope, exception.Scope);
+            Assert.Empty((await store.ReadAllSerializableEventsAsync()).GetValue());
+        }
+        else
+        {
+            Assert.True(result.IsSuccess);
+            var diagnostic = Assert.Single(result.GetValue().SizeGateDiagnostics);
+            Assert.Equal(scope, diagnostic.Scope);
+            Assert.Contains("StorageItem", diagnostic.Reason);
+            Assert.Single((await store.ReadAllSerializableEventsAsync()).GetValue());
+        }
+    }
+
+    [Fact]
+    public async Task MaxWrittenItemPolicyRejectsBeforeAnyDynamoDbDispatch()
+    {
+        var domain = DomainType.GetDomainTypes();
+        var client = System.Reflection.DispatchProxy.Create<IAmazonDynamoDB,
+            DynamoDbEventItemSizeMeasurementTests.CapturingDynamoDb>();
+        var capture = (DynamoDbEventItemSizeMeasurementTests.CapturingDynamoDb)(object)client;
+        var store = NewStore(client, domain, "max-dispatch");
+        var executor = new GeneralSekibanExecutor(
+            store,
+            new InMemoryObjectAccessor(new CoreInMemoryEventStore(domain.EventTypes), domain),
+            domain,
+            new ExecutorSizeGateOptions().AddDynamoDbMaxWrittenItemPolicy());
+
+        var oversized = CreateCandidate(
+            Enumerable.Repeat((byte)'x', (int)DynamoDbMaxWrittenItemSizeMeasurement.MaximumItemBytes).ToArray(),
+            "oversized");
+        var result = await executor.CommitSerializableEventsAsync(
+            new SerializedCommitRequest([oversized], []));
+
+        var exception = Assert.IsType<ExecutorSizeLimitExceededException>(result.GetException());
+        Assert.Equal(DynamoDbMaxWrittenItemSizeMeasurement.Scope, exception.Scope);
+        Assert.False(exception.IsOperationLimit);
+        Assert.Equal(0, capture.WriteDispatches);
+        Assert.Empty(capture.EventItems);
+        Assert.Empty(capture.TagItems);
+    }
+
+    [Fact]
+    public async Task WriteOperationPolicyRejectsLastEventBeforeAnyDynamoDbDispatch()
+    {
+        var domain = DomainType.GetDomainTypes();
+        var client = System.Reflection.DispatchProxy.Create<IAmazonDynamoDB,
+            DynamoDbEventItemSizeMeasurementTests.CapturingDynamoDb>();
+        var capture = (DynamoDbEventItemSizeMeasurementTests.CapturingDynamoDb)(object)client;
+        var store = NewStore(client, domain, "operation-dispatch");
+        var executor = new GeneralSekibanExecutor(
+            store,
+            new InMemoryObjectAccessor(new CoreInMemoryEventStore(domain.EventTypes), domain),
+            domain,
+            new ExecutorSizeGateOptions().AddDynamoDbWriteOperationPolicy());
+
+        var first = CreateCandidate([], "first");
+        var oversized = CreateCandidate(
+            Enumerable.Repeat((byte)'x', 4 * 1024 * 1024).ToArray(),
+            "oversized");
+        var result = await executor.CommitSerializableEventsAsync(
+            new SerializedCommitRequest([first, oversized], []));
+
+        var exception = Assert.IsType<ExecutorSizeLimitExceededException>(result.GetException());
+        Assert.Equal(DynamoDbWriteOperationSizeMeasurement.Scope, exception.Scope);
+        Assert.True(exception.IsOperationLimit);
+        Assert.InRange(exception.EventIndex, 0, 1);
+        Assert.Equal(0, capture.WriteDispatches);
+        Assert.Empty(capture.EventItems);
+        Assert.Empty(capture.TagItems);
+    }
+
+    [Fact]
+    public async Task WholeOperationBudgetRejectsAggregateEvenWhenIndividualItemsAreLegal()
+    {
+        var domain = DomainType.GetDomainTypes();
+        var store = new CoreInMemoryEventStore(domain.EventTypes);
+        var executor = new GeneralSekibanExecutor(
+            store,
+            new InMemoryObjectAccessor(store, domain),
+            domain,
+            new ExecutorSizeGateOptions().Add(new ExecutorSizePolicy(
+                DynamoDbWriteOperationSizeMeasurement.Scope,
+                ExecutorSizeRepresentation.StorageItem,
+                maxBytesPerOperation: 100,
+                measurement: new FixedMeasurement(60))));
+
+        var result = await executor.CommitSerializableEventsAsync(
+            new SerializedCommitRequest([CreateCandidate([], "one"), CreateCandidate([], "two")], []));
+
+        var exception = Assert.IsType<ExecutorSizeLimitExceededException>(result.GetException());
+        Assert.True(exception.IsOperationLimit);
+        Assert.Equal(120, exception.MeasuredBytes);
+        Assert.Empty((await store.ReadAllSerializableEventsAsync()).GetValue());
+    }
+
+    private static SerializableEvent CreateTagLargestBoundary(
+        DynamoDbMaxWrittenItemSizeMeasurement measurement,
+        long expectedBytes,
+        string serviceId)
+    {
+        for (var typeLength = 1; typeLength <= 256; typeLength++)
+        {
+            var eventType = "T" + new string('e', typeLength - 1);
+            var seed = CreateSerializedEvent([], ["Tag:"], eventType);
+            var low = 0;
+            var high = 500_000;
+            while (low <= high)
+            {
+                var suffixLength = low + ((high - low) / 2);
+                var candidate = seed with { Tags = ["Tag:" + new string('x', suffixLength)] };
+                var measured = Measure(measurement, candidate, serviceId);
+                if (measured == expectedBytes)
+                    return candidate;
+
+                if (measured < expectedBytes)
+                    low = suffixLength + 1;
+                else
+                    high = suffixLength - 1;
+            }
+        }
+
+        throw new Xunit.Sdk.XunitException($"Could not construct a tag boundary of {expectedBytes} bytes.");
+    }
+
+    private static List<SerializableEvent> CreateOperationBoundary(
+        DynamoDbWriteOperationSizeMeasurement measurement,
+        long expectedBytes)
+    {
+        const int fixedEventCount = 10;
+        const int fixedPayloadLength = 380_000;
+        var events = Enumerable.Range(0, fixedEventCount)
+            .Select(_ => CreateSerializedEvent(
+                Enumerable.Repeat((byte)'x', fixedPayloadLength).ToArray(),
+                [],
+                "OperationEvent"))
+            .ToList();
+        var used = events.Sum(serialized => Measure(measurement, serialized));
+        var emptyLast = CreateSerializedEvent([], [], "OperationEvent");
+        var lastPayloadLength = checked((int)(expectedBytes - used - Measure(measurement, emptyLast)));
+        Assert.InRange(lastPayloadLength, 0, (int)DynamoDbMaxWrittenItemSizeMeasurement.MaximumItemBytes);
+        events.Add(emptyLast with
+        {
+            Payload = Enumerable.Repeat((byte)'x', lastPayloadLength).ToArray()
+        });
+        return events;
+    }
+
+    private static long Measure(
+        IExecutorSizeMeasurement measurement,
+        SerializableEvent serialized,
+        string serviceId = "operation-test")
+    {
+        var result = measurement.Measure(CreateContext(serialized, serviceId));
+        Assert.True(result.IsAvailable, result.Reason);
+        return Assert.IsType<long>(result.Bytes);
+    }
+
+    private static DynamoDbEventItemSizeMeasurementTests.CapturingDynamoDb CaptureSerializedWrite(
+        SerializableEvent serialized,
+        string serviceId)
+    {
+        var domain = DomainType.GetDomainTypes();
+        var client = System.Reflection.DispatchProxy.Create<IAmazonDynamoDB,
+            DynamoDbEventItemSizeMeasurementTests.CapturingDynamoDb>();
+        var capture = (DynamoDbEventItemSizeMeasurementTests.CapturingDynamoDb)(object)client;
+        Assert.True(NewStore(client, domain, serviceId).WriteSerializableEventsAsync([serialized]).Result.IsSuccess);
+        return capture;
+    }
+
+    private static DynamoDbEventStore NewStore(
+        IAmazonDynamoDB client,
+        DcbDomainTypes domain,
+        string serviceId,
+        int maxTransactionItems = 100,
+        IEventTypes? eventTypes = null)
+    {
+        var options = Options.Create(new DynamoDbEventStoreOptions
+        {
+            AutoCreateTables = false,
+            EventsTableName = $"events-{serviceId}",
+            TagsTableName = $"tags-{serviceId}",
+            ProjectionStatesTableName = $"projection-{serviceId}",
+            MaxTransactionItems = maxTransactionItems
+        });
+        return new DynamoDbEventStore(
+            new DynamoDbContext(client, options),
+            eventTypes ?? domain.EventTypes,
+            new FixedServiceIdProvider(serviceId));
+    }
+
+    private static ExecutorSizeMeasurementContext CreateContext(
+        SerializableEvent serialized,
+        string serviceId = "operation-test") =>
+        new(
+            DynamoDbWriteOperationSizeMeasurement.Scope,
+            ExecutorSizeRepresentation.StorageItem,
+            new Event(
+                new StudentCreated(Guid.CreateVersion7(), "measurement", 1),
+                serialized.SortableUniqueIdValue,
+                serialized.EventPayloadName,
+                serialized.Id,
+                serialized.EventMetadata,
+                serialized.Tags),
+            serialized,
+            serviceId,
+            null,
+            null);
+
+    private static SerializableEvent CreateSerializedEvent(
+        byte[] payload,
+        IReadOnlyList<string> tags,
+        string eventType = nameof(StudentCreated)) =>
+        new(
+            payload,
+            SortableUniqueId.GenerateNew(),
+            Guid.CreateVersion7(),
+            new EventMetadata("cause", "correlation", "user"),
+            tags.ToList(),
+            eventType);
+
+    private static SerializableEventCandidate CreateCandidate(byte[] sizeHint, string tag)
+    {
+        var summary = sizeHint.Length == 0 ? tag : new string('x', sizeHint.Length);
+        var payload = JsonSerializer.SerializeToUtf8Bytes(
+            new WeatherForecastCreated(
+                Guid.CreateVersion7(),
+                "Tokyo",
+                new DateOnly(2026, 9, 10),
+                21,
+                summary),
+            DomainType.GetDomainTypes().JsonSerializerOptions);
+        return new SerializableEventCandidate(
+            payload,
+            nameof(WeatherForecastCreated),
+            [$"WeatherForecast:{tag}"]);
+    }
+
+    private static Dictionary<string, string> Normalize(IReadOnlyDictionary<string, AttributeValue> item) =>
+        item
+            .Where(pair => pair.Key is not "pk" and not "sk" and not "eventId" and not "timestamp" and not "createdAt")
+            .ToDictionary(pair => pair.Key, pair => ValueSignature(pair.Value), StringComparer.Ordinal);
+
+    private static long IndependentItemBytes(IReadOnlyDictionary<string, AttributeValue> item) =>
+        item.Sum(pair => Encoding.UTF8.GetByteCount(pair.Key) + IndependentValueBytes(pair.Value));
+
+    private static long IndependentValueBytes(AttributeValue value)
+    {
+        if (value.S is not null)
+            return Encoding.UTF8.GetByteCount(value.S);
+        if (value.N is not null)
+            return Encoding.UTF8.GetByteCount(value.N);
+        if (value.L is not null)
+            return 3 + value.L.Sum(item => 1 + IndependentValueBytes(item));
+        if (value.M is not null)
+            return 3 + value.M.Sum(pair => 1 + Encoding.UTF8.GetByteCount(pair.Key) + IndependentValueBytes(pair.Value));
+        if (value.B is not null)
+            return value.B.Length;
+        if (value.SS is not null)
+            return value.SS.Sum(Encoding.UTF8.GetByteCount);
+        if (value.NS is not null)
+            return value.NS.Sum(Encoding.UTF8.GetByteCount);
+        if (value.BS is not null)
+            return value.BS.Sum(stream => stream.Length);
+        return value.NULL == true || value.IsBOOLSet ? 1 : 0;
+    }
+
+    private static string ValueSignature(AttributeValue value) =>
+        value.S is not null
+            ? $"S:{value.S}"
+            : value.L is not null
+                ? $"L:[{string.Join(",", value.L.Select(ValueSignature))}]"
+                : value.N is not null
+                    ? $"N:{value.N}"
+                    : "other";
+
+    private sealed class FixedServiceIdProvider(string serviceId) : IServiceIdProvider
+    {
+        public string GetCurrentServiceId() => serviceId;
+    }
+
+    private sealed class FixedMeasurement(long bytes) : IExecutorSizeMeasurement
+    {
+        public ExecutorSizeMeasurementResult Measure(ExecutorSizeMeasurementContext context) =>
+            ExecutorSizeMeasurementResult.Exact(bytes);
+    }
+
+    private static class DynamoDbTransactionSizeAccountingForTest
+    {
+        public const string ExpectedCondition = "attribute_not_exists(pk)";
+    }
+}

--- a/docs/dcb_llm/03_aggregate_command_events.md
+++ b/docs/dcb_llm/03_aggregate_command_events.md
@@ -288,3 +288,27 @@ provider cannot measure the requested representation, strict mode returns `Execu
 mode records a named unvalidated diagnostic and continues. `MaxBytesPerOperation` is the sum of the measured copies in
 the current operation. A `Destination` policy instead evaluates each captured destination copy independently; that
 fan-out accounting is neither a DynamoDB database-footprint guarantee nor an Azure Queue batch/wire-envelope guarantee.
+
+### DynamoDB written-item and operation gates (SEK-G68)
+
+G68 adds two independent opt-in provider scopes. Register only the scopes the application needs; they may be registered
+together and keep the configured `WriteShardCount` mapping:
+
+```csharp
+services.AddSekibanDcbDynamoDb(dynamoDbClient, options => options.WriteShardCount = 2);
+services.AddSekibanDcbDynamoDbMaxWrittenItemSizeGate(); // default: 409600 bytes per event
+services.AddSekibanDcbDynamoDbWriteOperationSizeGate(); // default: 4194304 bytes per operation
+```
+
+`dynamodb-max-written-item` measures the maximum of the mapped event item and every mapped tag item for each event.
+`dynamodb-write-operation` sums every mapped event and tag item plus the UTF-8 bytes of the production event-Put
+condition expression. The latter is a conservative application budget over the whole executor operation, including the
+condition contribution when the provider falls back to `BatchWriteItem`; it is not an exact transaction-wire or
+BatchWrite envelope certification. Each scope uses the provider's typed, serialized, and conditional mapper independently.
+
+Both helpers default to the respective service ceiling and allow a smaller caller quota, but reject a larger helper quota.
+An over-limit result is `ExecutorSizeLimitExceededException`; an unavailable strict capability is
+`ExecutorSizeCapabilityException` before persistence, while non-strict mode continues with a named unvalidated diagnostic.
+The gates do not change grouping, atomicity, retry behavior, ClientRequestToken handling, item-count validation, GSI or
+billing accounting, wire escaping, or historical data. They are not a destination fan-out rule and do not include future
+outbox/head items or other providers.

--- a/docs/dcb_llm/03_aggregate_command_events.md
+++ b/docs/dcb_llm/03_aggregate_command_events.md
@@ -312,3 +312,22 @@ An over-limit result is `ExecutorSizeLimitExceededException`; an unavailable str
 The gates do not change grouping, atomicity, retry behavior, ClientRequestToken handling, item-count validation, GSI or
 billing accounting, wire escaping, or historical data. They are not a destination fan-out rule and do not include future
 outbox/head items or other providers.
+
+Use exactly one service-registration mechanism for the gate. The provider-composable helpers above may be repeated to
+accumulate their three DynamoDB scopes. Alternatively, a single Core callback may compose provider policies directly:
+
+```csharp
+var storeOptions = new DynamoDbEventStoreOptions { WriteShardCount = 2 };
+services.AddSingleton<IOptions<DynamoDbEventStoreOptions>>(Options.Create(storeOptions));
+services.AddSekibanDcbDynamoDb(dynamoDbClient);
+services.AddSekibanDcbExecutorSizeGate(options =>
+    options.AddDynamoDbEventItemPolicy(storeOptions));
+```
+
+The `storeOptions` instance supplied to the policy must be the same instance used by the store; omitting it can
+undercount shard-dependent bytes. Mixing a Core helper with any `AddSekibanDcbDynamoDb*SizeGate` helper in either order
+throws `InvalidOperationException` before the rejected call changes the service collection. The exception says that
+`Core convenience gate registration` and `provider-composable gate registration` cannot both configure the executor
+size gate and directs the caller to choose one mechanism. Repeating Core registration keeps its existing last-wins
+behavior; repeating provider helpers keeps their accumulated policies. Manually adding `ExecutorSizeGateOptions` to DI
+does not participate in this guard and makes the provider-helper guarantees the caller's responsibility.

--- a/docs/dcb_llm/11_storage_providers.md
+++ b/docs/dcb_llm/11_storage_providers.md
@@ -915,6 +915,36 @@ An item over the configured limit produces `ExecutorSizeLimitExceededException`;
 the current operation. This is distinct from a `Destination` fan-out policy, which checks each destination copy
 independently; neither rule is a DynamoDB database-footprint guarantee or an Azure Queue batch/wire-envelope guarantee.
 
+## SEK-G68 DynamoDB written-item and operation size gates
+
+G68 provides two additive opt-in registrations. They can coexist, but each scope maps the provider payload independently;
+register only the scopes required by the application:
+
+```csharp
+services.AddSekibanDcbDynamoDb(dynamoDbClient, options => options.WriteShardCount = 2);
+services.AddSekibanDcbDynamoDbMaxWrittenItemSizeGate(); // 409600 bytes per event by default
+services.AddSekibanDcbDynamoDbWriteOperationSizeGate(); // 4194304 bytes per executor operation by default
+```
+
+`dynamodb-max-written-item` measures the maximum mapped size of the event item and all tag items emitted for one event.
+`dynamodb-write-operation` measures the sum of every mapped event item and tag item in the executor operation, plus the
+UTF-8 byte contribution of the shared production event-Put condition expression (`attribute_not_exists(pk)`). This is a
+conservative application budget; it also charges that condition contribution when existing provider fallback uses
+`BatchWriteItem`, and it is not an exact transaction-request wire or BatchWrite envelope certification. The measurement
+uses the same provider mapper as typed, serialized, and conditional writes, including service identity, shard mapping,
+payload/type/metadata, tags, and timestamp shape.
+
+The helper ceilings are DynamoDB's 400 KiB item (`409600`) and 4 MiB transaction (`4194304`) values. Smaller caller quotas
+are supported; a helper quota above its ceiling is rejected. A breach raises `ExecutorSizeLimitExceededException`; an
+unavailable strict provider capability raises `ExecutorSizeCapabilityException` before persistence. Non-strict mode keeps
+the write path and adds an explicit named unvalidated diagnostic. The five executor admission routes are checked before
+durable event/tag/head mutation or publication/enqueue. Existing grouping, atomicity, retry, ClientRequestToken behavior,
+item-count validation, GSI/billing footprint, wire escaping, and historical repair are unchanged.
+
+These scopes cover only currently emitted event and tag `Put` items. They do not certify a DynamoDB wire envelope, the
+`BatchWriteItem` 25-item/16 MiB request limit, future outbox/head items, or another provider. A `Destination` fan-out
+policy remains separate and checks each captured destination copy independently.
+
 ## Related
 
 For the current internal-use cold event export, hybrid read, and catch-up worker setup, see [Cold Events and Catch-up](19_cold_events.md).

--- a/docs/dcb_llm/11_storage_providers.md
+++ b/docs/dcb_llm/11_storage_providers.md
@@ -945,6 +945,26 @@ These scopes cover only currently emitted event and tag `Put` items. They do not
 `BatchWriteItem` 25-item/16 MiB request limit, future outbox/head items, or another provider. A `Destination` fan-out
 policy remains separate and checks each captured destination copy independently.
 
+Choose one gate-registration mechanism for a service collection. The three DynamoDB helpers are provider-composable and
+accumulate their scopes. A Core callback is the alternative when the application wants to compose provider policies in
+one validated options object:
+
+```csharp
+var storeOptions = new DynamoDbEventStoreOptions { WriteShardCount = 2 };
+services.AddSingleton<IOptions<DynamoDbEventStoreOptions>>(Options.Create(storeOptions));
+services.AddSekibanDcbDynamoDb(dynamoDbClient);
+services.AddSekibanDcbExecutorSizeGate(options =>
+    options.AddDynamoDbEventItemPolicy(storeOptions));
+```
+
+The policy must receive the same `storeOptions` instance used by the store; an omitted options value can undercount
+shard-dependent bytes. Registering a Core helper and an `AddSekibanDcbDynamoDb*SizeGate` helper in either order throws
+`InvalidOperationException` before the rejected registration mutates the service collection. Its message names
+`Core convenience gate registration` and `provider-composable gate registration` and directs the caller to choose one
+mechanism. Repeated Core registrations retain last-wins behavior, while repeated provider helpers accumulate policies.
+Manual `AddSingleton<ExecutorSizeGateOptions>` registration bypasses this guard and does not claim provider helper
+validation or measurement parity.
+
 ## Related
 
 For the current internal-use cold event export, hybrid read, and catch-up worker setup, see [Cold Events and Catch-up](19_cold_events.md).

--- a/docs/dcb_llm_ja/03_aggregate_command_events.md
+++ b/docs/dcb_llm_ja/03_aggregate_command_events.md
@@ -294,3 +294,23 @@ helper quota は拒否されます。上限超過は `ExecutorSizeLimitExceededE
 永続化前に `ExecutorSizeCapabilityException` です。non-strict は名前付きの未検証診断を付けて継続します。
 ゲートは grouping、atomicity、retry、ClientRequestToken、item-count validation、GSI/billing、wire の escaping、
 過去データを変更しません。Destination fan-out のルールでもなく、将来の outbox/head item や他 provider は含みません。
+
+サービスコレクションでは、ゲート登録方式を 1 つだけ選んでください。上記の DynamoDB helper 3 つは provider-
+composable で、繰り返すと scope を蓄積します。もう 1 つの方式は、1 つの Core callback 内で provider policy を
+組み立てる移行方式です。
+
+```csharp
+var storeOptions = new DynamoDbEventStoreOptions { WriteShardCount = 2 };
+services.AddSingleton<IOptions<DynamoDbEventStoreOptions>>(Options.Create(storeOptions));
+services.AddSekibanDcbDynamoDb(dynamoDbClient);
+services.AddSekibanDcbExecutorSizeGate(options =>
+    options.AddDynamoDbEventItemPolicy(storeOptions));
+```
+
+policy に渡す `storeOptions` は store が使う同じ instance でなければなりません。省略すると shard に依存する
+byte を undercount することがあります。Core helper と `AddSekibanDcbDynamoDb*SizeGate` helper をどちらの順で
+登録しても、2 回目の呼び出しは service collection を変更する前に `InvalidOperationException` になります。
+メッセージは `Core convenience gate registration` と `provider-composable gate registration` の混在を示し、
+一方の方式を選ぶよう案内します。Core の繰り返し登録は従来どおり last-wins、provider helper の繰り返しは
+policy を蓄積します。`AddSingleton<ExecutorSizeGateOptions>` を手動で追加する方式はこの guard の対象外で、
+provider helper の検証や測定 parity は caller の責任です。

--- a/docs/dcb_llm_ja/03_aggregate_command_events.md
+++ b/docs/dcb_llm_ja/03_aggregate_command_events.md
@@ -271,3 +271,26 @@ mapped item が大きすぎる場合は `ExecutorSizeLimitExceededException` を
 `MaxBytesPerOperation` は現在の operation に含まれる測定済みコピーの合計です。一方、`Destination` policy は
 捕捉した各 destination copy を個別に検査します。この fan-out の数え方は DynamoDB の database footprint 保証でも、
 Azure Queue の batch/wire-envelope 保証でもありません。
+
+### DynamoDB の written-item / operation ゲート（SEK-G68）
+
+G68 では、provider 固有の opt-in scope を 2 つ追加します。必要な scope だけを登録してください。両方を同時に
+登録してもよく、設定済みの `WriteShardCount` mapping は維持されます。
+
+```csharp
+services.AddSekibanDcbDynamoDb(dynamoDbClient, options => options.WriteShardCount = 2);
+services.AddSekibanDcbDynamoDbMaxWrittenItemSizeGate(); // 既定: event ごとに 409600 byte
+services.AddSekibanDcbDynamoDbWriteOperationSizeGate(); // 既定: operation ごとに 4194304 byte
+```
+
+`dynamodb-max-written-item` は各 event について、mapped event item と全 mapped tag item の最大値を測定します。
+`dynamodb-write-operation` は、mapped event/tag item の全 byte と production の event-Put condition expression の UTF-8
+byte を合計します。後者は `BatchWriteItem` fallback でも condition contribution を保守的に課金する、executor operation
+全体の application budget です。exact な transaction wire や BatchWrite envelope の保証ではありません。両方の
+scope は typed・serialized・conditional で同じ provider mapper を使いますが、それぞれ独立に測定されます。
+
+両 helper の既定値はそれぞれの service ceiling で、caller はより小さい quota を指定できます。ceiling を超える
+helper quota は拒否されます。上限超過は `ExecutorSizeLimitExceededException`、測定できない strict capability は
+永続化前に `ExecutorSizeCapabilityException` です。non-strict は名前付きの未検証診断を付けて継続します。
+ゲートは grouping、atomicity、retry、ClientRequestToken、item-count validation、GSI/billing、wire の escaping、
+過去データを変更しません。Destination fan-out のルールでもなく、将来の outbox/head item や他 provider は含みません。

--- a/docs/dcb_llm_ja/11_storage_providers.md
+++ b/docs/dcb_llm_ja/11_storage_providers.md
@@ -922,6 +922,36 @@ services.AddSekibanDcbDynamoDbEventItemSizeGate();
 event-item copy の合計です。これは `Destination` の fan-out policy（各 destination copy を個別に検査）とは異なり、
 DynamoDB の database footprint 保証でも Azure Queue の batch/wire-envelope 保証でもありません。
 
+## SEK-G68 DynamoDB written-item / operation サイズゲート
+
+G68 は additive な opt-in 登録を 2 つ提供します。両方は共存できますが、各 scope は provider payload を独立に
+mapping するため、アプリケーションで必要な scope だけを登録してください。
+
+```csharp
+services.AddSekibanDcbDynamoDb(dynamoDbClient, options => options.WriteShardCount = 2);
+services.AddSekibanDcbDynamoDbMaxWrittenItemSizeGate(); // 既定: event ごとに 409600 byte
+services.AddSekibanDcbDynamoDbWriteOperationSizeGate(); // 既定: executor operation ごとに 4194304 byte
+```
+
+`dynamodb-max-written-item` は 1 event について provider が出力する event item と全 tag item の mapped size の最大値を
+測定します。`dynamodb-write-operation` は operation 内の全 mapped event/tag item と、共通 production event-Put
+condition expression（`attribute_not_exists(pk)`）の UTF-8 byte を合計します。後者は既存の `BatchWriteItem` fallback
+でも condition contribution を課金する保守的な application budget であり、exact な transaction request wire や
+BatchWrite envelope の保証ではありません。typed・serialized・conditional write で、service identity、shard mapping、
+payload/type/metadata、tag、timestamp の形状を含む同一 mapper を使います。
+
+helper の ceiling は DynamoDB の 400 KiB item（`409600`）と 4 MiB transaction（`4194304`）です。より小さい caller
+quota は指定できますが、ceiling より大きい helper quota は拒否されます。超過は
+`ExecutorSizeLimitExceededException`、利用できない strict provider capability は永続化前に
+`ExecutorSizeCapabilityException` になります。non-strict は write path を維持し、明示的な名前付き未検証診断を追加
+します。5 つの executor admission route は event/tag/head の永続化や publish/enqueue より前に検査されます。
+既存の grouping、atomicity、retry、ClientRequestToken、item-count validation、GSI/billing、wire escaping、過去データの
+repair は変更されません。
+
+対象は現在 mapper が出力する event/tag の `Put` item だけです。DynamoDB の wire envelope、`BatchWriteItem` の 25 item/
+16 MiB request limit、将来の outbox/head item、他 provider は保証しません。`Destination` fan-out policy は別契約で、
+捕捉した各 destination copy を個別に検査します。
+
 ## 関連資料
 
 現在のインターナルユースで使っているコールドイベントの書き出し、ハイブリッドリード、キャッチアップワーカー構成については [コールドイベントとキャッチアップ](19_cold_events.md) を参照してください。

--- a/docs/dcb_llm_ja/11_storage_providers.md
+++ b/docs/dcb_llm_ja/11_storage_providers.md
@@ -952,6 +952,26 @@ repair は変更されません。
 16 MiB request limit、将来の outbox/head item、他 provider は保証しません。`Destination` fan-out policy は別契約で、
 捕捉した各 destination copy を個別に検査します。
 
+サービスコレクションでは、ゲートの登録方式を 1 つだけ選びます。3 つの DynamoDB helper は provider-composable
+で、繰り返し登録して scope を蓄積できます。Core callback は別の方式で、provider policy を 1 つの options に
+まとめます。
+
+```csharp
+var storeOptions = new DynamoDbEventStoreOptions { WriteShardCount = 2 };
+services.AddSingleton<IOptions<DynamoDbEventStoreOptions>>(Options.Create(storeOptions));
+services.AddSekibanDcbDynamoDb(dynamoDbClient);
+services.AddSekibanDcbExecutorSizeGate(options =>
+    options.AddDynamoDbEventItemPolicy(storeOptions));
+```
+
+policy に渡す `storeOptions` は store が実際に使う同じ instance でなければなりません。省略した options は
+shard 依存 byte を undercount することがあります。Core helper と `AddSekibanDcbDynamoDb*SizeGate` helper を
+どちらの順で混在させても、拒否される呼び出しは service collection を変更する前に
+`InvalidOperationException` になります。例外メッセージは `Core convenience gate registration` と
+`provider-composable gate registration` の衝突を名前で示し、どちらか一方を使うよう案内します。Core の
+同方式の再登録は last-wins、provider helper の再登録は policy の蓄積を保ちます。手動の
+`AddSingleton<ExecutorSizeGateOptions>` は guard 外であり、provider helper の検証・測定 parity を保証しません。
+
 ## 関連資料
 
 現在のインターナルユースで使っているコールドイベントの書き出し、ハイブリッドリード、キャッチアップワーカー構成については [コールドイベントとキャッチアップ](19_cold_events.md) を参照してください。


### PR DESCRIPTION
Closes #1209

## Summary
- Adds opt-in `dynamodb-max-written-item` and `dynamodb-write-operation` StorageItem measurements using the production mapper/calculator.
- Shares the production event-Put condition expression and UTF-8 contribution across both transaction writer sites and operation accounting.
- Adds additive policy/DI helpers, preserves G67 coexistence and all existing executor admission routes, and documents EN/JA scope, strictness, stored-vs-wire limits, and exclusions.
- Adds provider-shaped typed, serialized, conditional, BatchWrite exclusion, zero-dispatch, boundary, conservative aggregate, compatibility, and DI proofs.

## Validation
- `dotnet build .../Sekiban.Dcb.WithResult.Tests.csproj -c Release --no-restore -f net9.0 /p:UseSharedCompilation=false`: succeeded, 0 errors.
- Same build for `net10.0`: succeeded, 0 errors.
- Focused measurement/surface/event-item tests: net9 39/39 passed; net10 39/39 passed.
- Pinned DynamoDB Local `amazon/dynamodb-local:2.6.1@sha256:1856c05cc66a0e49dc1099e483ad2851477eeebe2135250ac11a1d1227db54b1`: net10 G67/G68 Local tests 4/4 passed, including 4 MiB under/over and persisted-map parity.
- The bounded net9 Local attempt is recorded as an environment limitation: macOS .NET/AWS SDK initialization failed before a request with `System.TypeInitializationException` / `CookieContainer` inner `InvalidOperationException: GetDomainName: -1`; no product assertion was reached.
- `git diff --check`: passed.

The operation budget remains a conservative application contribution, not wire-size certification; BatchWrite 25-item wire evidence is an explicit exclusion discriminator. No MaxBatchWriteItems validation or other transport/provider scope is included.

## Final review and compatibility note

Exact head c55b7c02f5403fb9059bc060ba7ef7f53d22fe45 passed independent Opus5 re-review with F1-F4 and AC1-AC9 closed. Required CI passed on net9/net10, including all46 G68-suite cases per framework and real SDK/pinned DynamoDB Local evidence.

G67 `dynamodb-event-item` now returns `Unavailable` for hand-built measurement contexts whose `Event` and `SerializedEvent` disagree on id, event type, sortable-unique id or tags (strict mode raises `ExecutorSizeCapabilityException`). Production context-construction paths preserve this identity. Mixing Core convenience registration with provider-specific DI helpers now throws at registration instead of silently discarding policies; use one supported mechanism and preserve the same store options.
