### PR TITLE
Snapshot DynamoDB batch-write size per operation

### DIFF
--- a/dcb/src/Sekiban.Dcb.DynamoDB/DynamoDbEventStore.cs
+++ b/dcb/src/Sekiban.Dcb.DynamoDB/DynamoDbEventStore.cs
@@ -931,6 +931,7 @@ public partial class DynamoDbEventStore : IHotEventStore, IStorageDurabilityDesc
 
     private async Task WriteEventsWithBatchAsync(List<DynamoDbEventWriteItem> eventItems)
     {
+        var chunkSize = ResolveBatchWriteChunkSize();
         var eventWrites = eventItems
             .Select(item => new WriteRequest
             {
@@ -946,11 +947,11 @@ public partial class DynamoDbEventStore : IHotEventStore, IStorageDurabilityDesc
             })
             .ToList();
 
-        await ExecuteBatchWriteWithRetryAsync(_context.EventsTableName, eventWrites).ConfigureAwait(false);
+        await ExecuteBatchWriteWithRetryAsync(_context.EventsTableName, eventWrites, chunkSize).ConfigureAwait(false);
 
         try
         {
-            await ExecuteBatchWriteWithRetryAsync(_context.TagsTableName, tagWrites).ConfigureAwait(false);
+            await ExecuteBatchWriteWithRetryAsync(_context.TagsTableName, tagWrites, chunkSize).ConfigureAwait(false);
         }
         catch
         {
@@ -963,18 +964,35 @@ public partial class DynamoDbEventStore : IHotEventStore, IStorageDurabilityDesc
                     })
                     .ToList();
 
-                await ExecuteBatchWriteWithRetryAsync(_context.EventsTableName, deleteRequests).ConfigureAwait(false);
+                await ExecuteBatchWriteWithRetryAsync(_context.EventsTableName, deleteRequests, chunkSize).ConfigureAwait(false);
             }
 
             throw;
         }
     }
 
-    private async Task ExecuteBatchWriteWithRetryAsync(string tableName, List<WriteRequest> requests)
+    private int ResolveBatchWriteChunkSize()
     {
-        for (var i = 0; i < requests.Count; i += _options.MaxBatchWriteItems)
+        var chunkSize = _options.MaxBatchWriteItems;
+        if (chunkSize is < 1 or > 25)
         {
-            var batch = requests.Skip(i).Take(_options.MaxBatchWriteItems).ToList();
+            throw new ArgumentOutOfRangeException(
+                nameof(DynamoDbEventStoreOptions.MaxBatchWriteItems),
+                chunkSize,
+                "DynamoDB batch writes require between 1 and 25 items per request.");
+        }
+
+        return chunkSize;
+    }
+
+    private async Task ExecuteBatchWriteWithRetryAsync(
+        string tableName,
+        List<WriteRequest> requests,
+        int chunkSize)
+    {
+        for (var i = 0; i < requests.Count; i += chunkSize)
+        {
+            var batch = requests.Skip(i).Take(chunkSize).ToList();
             var pending = new Dictionary<string, List<WriteRequest>>
             {
                 [tableName] = batch

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/DynamoDbBatchWriteSnapshotTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/DynamoDbBatchWriteSnapshotTests.cs
@@ -2,11 +2,14 @@ using Amazon.DynamoDBv2;
 using Amazon.DynamoDBv2.Model;
 using Dcb.Domain;
 using Dcb.Domain.Student;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Sekiban.Dcb.Common;
 using Sekiban.Dcb.DynamoDB;
+using Sekiban.Dcb.Domains;
 using Sekiban.Dcb.Events;
 using Sekiban.Dcb.ServiceId;
+using Sekiban.Dcb.Storage;
 using Xunit;
 
 namespace Sekiban.Dcb.Tests;
@@ -43,7 +46,7 @@ public sealed class DynamoDbBatchWriteSnapshotTests
     [InlineData(25)]
     public async Task ValidBatchWriteSizes_AreUsedForEventAndTagRequests(int chunkSize)
     {
-        var (store, options, client) = NewStore(maxTransactionItems: 1);
+        var (store, options, client) = NewStore(maxTransactionItems: 100);
         options.MaxBatchWriteItems = chunkSize;
 
         var result = await store.WriteSerializableEventsAsync([CreateSerializedEvent(
@@ -75,6 +78,25 @@ public sealed class DynamoDbBatchWriteSnapshotTests
         Assert.Equal([25, 1], RequestSizes(client, options.EventsTableName));
         Assert.Equal([25, 25, 25, 25, 25], RequestSizes(client, options.TagsTableName));
         Assert.Equal(0, options.MaxBatchWriteItems);
+    }
+
+    [Fact]
+    public async Task MidOperationOptionMutationTo26_DoesNotSilentlyDropTheLastEvent()
+    {
+        var (store, options, client) = NewStore(maxTransactionItems: 100);
+        options.MaxBatchWriteItems = 25;
+        client.AfterBatchWrite = (tableName, dispatchNumber) =>
+        {
+            if (dispatchNumber == 1 && tableName == options.EventsTableName)
+                options.MaxBatchWriteItems = 26;
+        };
+
+        var result = await store.WriteSerializableEventsAsync(CreateMultiEventBatch());
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal([25, 1], RequestSizes(client, options.EventsTableName));
+        Assert.Equal([25, 25, 25, 25, 25], RequestSizes(client, options.TagsTableName));
+        Assert.Equal(26, client.PersistedEventKeys.Count);
     }
 
     [Fact]
@@ -119,7 +141,7 @@ public sealed class DynamoDbBatchWriteSnapshotTests
     }
 
     [Fact]
-    public async Task InvalidBatchOptionDoesNotAffectTransactionFallbackOrConditionalPaths()
+    public async Task InvalidBatchOptionDoesNotAffectTransactionOrConditionalPaths()
     {
         var (store, options, client) = NewStore(maxTransactionItems: 100);
         options.MaxBatchWriteItems = 0;
@@ -129,6 +151,49 @@ public sealed class DynamoDbBatchWriteSnapshotTests
         Assert.True(result.IsSuccess);
         Assert.Empty(client.BatchRequests);
         Assert.Single(client.TransactionRequests);
+
+        client.ClearRequests();
+        var conditional = await store.AppendIfUniqueAsync(
+            new ConditionalAppendRequest(
+                "g69-conditional",
+                CreateTypedEvent("conditional").ToSerializableEvent(DomainType.GetDomainTypes().EventTypes)));
+
+        Assert.True(
+            conditional.IsSuccess,
+            conditional.IsSuccess ? string.Empty : conditional.GetException().ToString());
+        Assert.Empty(client.BatchRequests);
+        Assert.Single(client.TransactionRequests);
+    }
+
+    [Fact]
+    public async Task DiResolvedOptionsMutationBeforeBatchFallbackIsValidatedWithoutDispatch()
+    {
+        var eventTableName = $"g69-di-events-{Guid.NewGuid():N}";
+        var client = CreateClient();
+        client.EventsTableName = eventTableName;
+
+        using var provider = new ServiceCollection()
+            .AddSingleton(DomainType.GetDomainTypes())
+            .AddSekibanDcbDynamoDb(client.Client, options =>
+            {
+                options.AutoCreateTables = false;
+                options.EventsTableName = eventTableName;
+                options.TagsTableName = $"g69-di-tags-{Guid.NewGuid():N}";
+                options.ProjectionStatesTableName = $"g69-di-projection-{Guid.NewGuid():N}";
+            })
+            .BuildServiceProvider();
+
+        var resolvedOptions = provider.GetRequiredService<IOptions<DynamoDbEventStoreOptions>>().Value;
+        var store = provider.GetRequiredService<DynamoDbEventStore>();
+        resolvedOptions.MaxBatchWriteItems = 0;
+
+        var result = await store.WriteSerializableEventsAsync([
+            CreateSerializedEvent(Enumerable.Range(0, 100).Select(index => $"di-tag-{index}").ToArray())
+        ]);
+
+        AssertInvalidBatchWriteOption(result.GetException(), 0);
+        Assert.Empty(client.BatchRequests);
+        Assert.Empty(client.TransactionRequests);
     }
 
     [Fact]
@@ -171,6 +236,7 @@ public sealed class DynamoDbBatchWriteSnapshotTests
             MaxTransactionItems = maxTransactionItems
         };
         var client = CreateClient();
+        client.EventsTableName = options.EventsTableName;
         var domain = DomainType.GetDomainTypes();
         var store = new DynamoDbEventStore(
             new DynamoDbContext(client.Client, Options.Create(options)),
@@ -240,6 +306,7 @@ public sealed class DynamoDbBatchWriteSnapshotTests
         public List<BatchWriteItemRequest> BatchRequests { get; } = [];
         public List<TransactWriteItemsRequest> TransactionRequests { get; } = [];
         public HashSet<string> PersistedEventKeys { get; } = [];
+        public string EventsTableName { get; set; } = string.Empty;
         public Action<string, int>? AfterBatchWrite { get; set; }
         public Func<string, int, Exception?>? BatchWriteFailure { get; set; }
         public IAmazonDynamoDB Client => (IAmazonDynamoDB)(object)this;
@@ -272,8 +339,11 @@ public sealed class DynamoDbBatchWriteSnapshotTests
                     foreach (var write in writes)
                     {
                         if (write.PutRequest?.Item is { } put)
-                            PersistedEventKeys.Add(ItemKey(put));
-                        else if (write.DeleteRequest?.Key is { } delete)
+                        {
+                            if (tableName == EventsTableName)
+                                PersistedEventKeys.Add(ItemKey(put));
+                        }
+                        else if (write.DeleteRequest?.Key is { } delete && tableName == EventsTableName)
                             PersistedEventKeys.Remove(ItemKey(delete));
                     }
 
@@ -292,7 +362,7 @@ public sealed class DynamoDbBatchWriteSnapshotTests
                 TransactionRequests.Add(transaction);
                 foreach (var item in transaction.TransactItems)
                 {
-                    if (item.Put?.Item is { } put)
+                    if (item.Put?.Item is { } put && item.Put.TableName == EventsTableName)
                         PersistedEventKeys.Add(ItemKey(put));
                 }
 

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/DynamoDbBatchWriteSnapshotTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/DynamoDbBatchWriteSnapshotTests.cs
@@ -1,0 +1,312 @@
+using Amazon.DynamoDBv2;
+using Amazon.DynamoDBv2.Model;
+using Dcb.Domain;
+using Dcb.Domain.Student;
+using Microsoft.Extensions.Options;
+using Sekiban.Dcb.Common;
+using Sekiban.Dcb.DynamoDB;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.ServiceId;
+using Xunit;
+
+namespace Sekiban.Dcb.Tests;
+
+/// <summary>
+/// G69 proofs for the batch-write option snapshot. The guarded client rejects the service-invalid empty and oversized
+/// request shapes, while the operation tests prove that the production path never creates them for a valid snapshot.
+/// </summary>
+public sealed class DynamoDbBatchWriteSnapshotTests
+{
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(26)]
+    public async Task InvalidBatchWriteSizes_AreReturnedForTypedAndSerializedBeforeAnyWrite(int invalidSize)
+    {
+        var (store, options, client) = NewStore(maxTransactionItems: 1);
+        options.MaxBatchWriteItems = invalidSize;
+
+        var typed = await store.WriteEventsAsync([CreateTypedEvent("typed-invalid")]);
+        AssertInvalidBatchWriteOption(typed.GetException(), invalidSize);
+        Assert.Empty(client.BatchRequests);
+        Assert.Empty(client.TransactionRequests);
+
+        client.ClearRequests();
+        var serialized = await store.WriteSerializableEventsAsync([CreateSerializedEvent(["serialized-invalid"])]);
+        AssertInvalidBatchWriteOption(serialized.GetException(), invalidSize);
+        Assert.Empty(client.BatchRequests);
+        Assert.Empty(client.TransactionRequests);
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(25)]
+    public async Task ValidBatchWriteSizes_AreUsedForEventAndTagRequests(int chunkSize)
+    {
+        var (store, options, client) = NewStore(maxTransactionItems: 1);
+        options.MaxBatchWriteItems = chunkSize;
+
+        var result = await store.WriteSerializableEventsAsync([CreateSerializedEvent(
+            Enumerable.Range(0, 100).Select(index => $"tag-{index}").ToArray())]);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal([1], RequestSizes(client, options.EventsTableName));
+        Assert.Equal(
+            Enumerable.Repeat(chunkSize, 100 / chunkSize)
+                .Append(100 % chunkSize)
+                .Where(size => size > 0),
+            RequestSizes(client, options.TagsTableName));
+    }
+
+    [Fact]
+    public async Task MidOperationOptionMutation_UsesOneSnapshotForEventsAndTags()
+    {
+        var (store, options, client) = NewStore(maxTransactionItems: 100);
+        options.MaxBatchWriteItems = 25;
+        client.AfterBatchWrite = (tableName, dispatchNumber) =>
+        {
+            if (dispatchNumber == 1 && tableName == options.EventsTableName)
+                options.MaxBatchWriteItems = 0;
+        };
+
+        var result = await store.WriteSerializableEventsAsync(CreateMultiEventBatch());
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal([25, 1], RequestSizes(client, options.EventsTableName));
+        Assert.Equal([25, 25, 25, 25, 25], RequestSizes(client, options.TagsTableName));
+        Assert.Equal(0, options.MaxBatchWriteItems);
+    }
+
+    [Fact]
+    public async Task TagFailure_RollsBackWithTheSameSnapshotAndPreservesOriginalException()
+    {
+        var (store, options, client) = NewStore(maxTransactionItems: 100);
+        options.MaxBatchWriteItems = 25;
+        var failure = new InvalidOperationException("injected tag failure");
+        client.AfterBatchWrite = (tableName, dispatchNumber) =>
+        {
+            if (dispatchNumber == 1 && tableName == options.EventsTableName)
+                options.MaxBatchWriteItems = 0;
+        };
+        client.BatchWriteFailure = (tableName, _) =>
+            tableName == options.TagsTableName ? failure : null;
+
+        var result = await store.WriteSerializableEventsAsync(CreateMultiEventBatch());
+
+        Assert.False(result.IsSuccess);
+        Assert.Same(failure, result.GetException());
+        Assert.Equal([25, 1, 25, 1], RequestSizes(client, options.EventsTableName));
+        Assert.Equal([25], RequestSizes(client, options.TagsTableName));
+        Assert.Empty(client.PersistedEventKeys);
+    }
+
+    [Fact]
+    public async Task NextOperationReadsAChangedBatchSizeAfterThePreviousOperation()
+    {
+        var (store, options, client) = NewStore(maxTransactionItems: 1);
+        options.MaxBatchWriteItems = 25;
+
+        var first = await store.WriteSerializableEventsAsync([CreateSerializedEvent(["first"]) ]);
+        Assert.True(first.IsSuccess);
+
+        client.ClearRequests();
+        options.MaxBatchWriteItems = 10;
+        var second = await store.WriteSerializableEventsAsync(CreateSimpleEventBatch(26));
+
+        Assert.True(second.IsSuccess);
+        Assert.Equal([10, 10, 6], RequestSizes(client, options.EventsTableName));
+        Assert.Equal([10, 10, 6], RequestSizes(client, options.TagsTableName));
+    }
+
+    [Fact]
+    public async Task InvalidBatchOptionDoesNotAffectTransactionFallbackOrConditionalPaths()
+    {
+        var (store, options, client) = NewStore(maxTransactionItems: 100);
+        options.MaxBatchWriteItems = 0;
+
+        var result = await store.WriteSerializableEventsAsync([CreateSerializedEvent(["transaction"]) ]);
+
+        Assert.True(result.IsSuccess);
+        Assert.Empty(client.BatchRequests);
+        Assert.Single(client.TransactionRequests);
+    }
+
+    [Fact]
+    public async Task GuardedClientRejectsServiceInvalidEmptyAndOversizedBatchRequests()
+    {
+        var client = CreateClient();
+
+        foreach (var count in new[] { 0, 26 })
+        {
+            var request = new BatchWriteItemRequest
+            {
+                RequestItems = new Dictionary<string, List<WriteRequest>>
+                {
+                    ["events"] = Enumerable.Range(0, count)
+                        .Select(_ => new WriteRequest { PutRequest = new PutRequest { Item = [] } })
+                        .ToList()
+                }
+            };
+
+            await Assert.ThrowsAsync<AmazonDynamoDBException>(() => client.Client.BatchWriteItemAsync(request));
+        }
+    }
+
+    private static void AssertInvalidBatchWriteOption(Exception exception, int expectedValue)
+    {
+        var argument = Assert.IsType<ArgumentOutOfRangeException>(exception);
+        Assert.Equal(nameof(DynamoDbEventStoreOptions.MaxBatchWriteItems), argument.ParamName);
+        Assert.Equal(expectedValue, argument.ActualValue);
+    }
+
+    private static (DynamoDbEventStore Store, DynamoDbEventStoreOptions Options, RecordingDynamoDb Client) NewStore(
+        int maxTransactionItems)
+    {
+        var options = new DynamoDbEventStoreOptions
+        {
+            AutoCreateTables = false,
+            EventsTableName = $"g69-events-{Guid.NewGuid():N}",
+            TagsTableName = $"g69-tags-{Guid.NewGuid():N}",
+            ProjectionStatesTableName = $"g69-projection-{Guid.NewGuid():N}",
+            MaxTransactionItems = maxTransactionItems
+        };
+        var client = CreateClient();
+        var domain = DomainType.GetDomainTypes();
+        var store = new DynamoDbEventStore(
+            new DynamoDbContext(client.Client, Options.Create(options)),
+            domain.EventTypes,
+            new FixedServiceIdProvider("g69"));
+        return (store, options, client);
+    }
+
+    private static RecordingDynamoDb CreateClient()
+    {
+        var client = System.Reflection.DispatchProxy.Create<IAmazonDynamoDB, RecordingDynamoDb>();
+        return (RecordingDynamoDb)(object)client;
+    }
+
+    private static List<int> RequestSizes(RecordingDynamoDb client, string tableName) =>
+        client.BatchRequests
+            .Where(request => request.RequestItems.Count == 1 && request.RequestItems.ContainsKey(tableName))
+            .Select(request => request.RequestItems[tableName].Count)
+            .ToList();
+
+    private static List<SerializableEvent> CreateMultiEventBatch()
+    {
+        return Enumerable.Range(0, 26)
+            .Select(index => CreateSerializedEvent(
+                index == 0
+                    ? Enumerable.Range(0, 100).Select(tagIndex => $"large-tag-{tagIndex}").ToArray()
+                    : [$"tag-{index}"],
+                $"event-{index}"))
+            .ToList();
+    }
+
+    private static List<SerializableEvent> CreateSimpleEventBatch(int count) =>
+        Enumerable.Range(0, count)
+            .Select(index => CreateSerializedEvent([$"next-{index}"]))
+            .ToList();
+
+    private static Event CreateTypedEvent(string tag)
+    {
+        var id = Guid.CreateVersion7();
+        return new Event(
+            new StudentCreated(id, "g69", 1),
+            SortableUniqueId.GenerateNew(),
+            nameof(StudentCreated),
+            id,
+            new EventMetadata("cause", "correlation", "user"),
+            [tag]);
+    }
+
+    private static SerializableEvent CreateSerializedEvent(
+        IReadOnlyList<string> tags,
+        string eventType = nameof(StudentCreated)) =>
+        new(
+            [],
+            SortableUniqueId.GenerateNew(),
+            Guid.CreateVersion7(),
+            new EventMetadata("cause", "correlation", "user"),
+            tags.ToList(),
+            eventType);
+
+    private sealed class FixedServiceIdProvider(string serviceId) : IServiceIdProvider
+    {
+        public string GetCurrentServiceId() => serviceId;
+    }
+
+    public class RecordingDynamoDb : System.Reflection.DispatchProxy
+    {
+        public List<BatchWriteItemRequest> BatchRequests { get; } = [];
+        public List<TransactWriteItemsRequest> TransactionRequests { get; } = [];
+        public HashSet<string> PersistedEventKeys { get; } = [];
+        public Action<string, int>? AfterBatchWrite { get; set; }
+        public Func<string, int, Exception?>? BatchWriteFailure { get; set; }
+        public IAmazonDynamoDB Client => (IAmazonDynamoDB)(object)this;
+
+        public void ClearRequests()
+        {
+            BatchRequests.Clear();
+            TransactionRequests.Clear();
+        }
+
+        protected override object? Invoke(System.Reflection.MethodInfo? targetMethod, object?[]? args)
+        {
+            var name = targetMethod?.Name ?? string.Empty;
+            var argument = args is { Length: > 0 } ? args[0] : null;
+
+            if (name == nameof(IAmazonDynamoDB.BatchWriteItemAsync) && argument is BatchWriteItemRequest batch)
+            {
+                BatchRequests.Add(batch);
+                var dispatchNumber = BatchRequests.Count;
+                foreach (var (tableName, writes) in batch.RequestItems)
+                {
+                    if (writes.Count is < 1 or > 25)
+                        throw new AmazonDynamoDBException(
+                            $"BatchWriteItem request for {tableName} contained {writes.Count} items.");
+
+                    var failure = BatchWriteFailure?.Invoke(tableName, dispatchNumber);
+                    if (failure is not null)
+                        throw failure;
+
+                    foreach (var write in writes)
+                    {
+                        if (write.PutRequest?.Item is { } put)
+                            PersistedEventKeys.Add(ItemKey(put));
+                        else if (write.DeleteRequest?.Key is { } delete)
+                            PersistedEventKeys.Remove(ItemKey(delete));
+                    }
+
+                    AfterBatchWrite?.Invoke(tableName, dispatchNumber);
+                }
+
+                return Task.FromResult(new BatchWriteItemResponse
+                {
+                    UnprocessedItems = new Dictionary<string, List<WriteRequest>>()
+                });
+            }
+
+            if (name == nameof(IAmazonDynamoDB.TransactWriteItemsAsync) &&
+                argument is TransactWriteItemsRequest transaction)
+            {
+                TransactionRequests.Add(transaction);
+                foreach (var item in transaction.TransactItems)
+                {
+                    if (item.Put?.Item is { } put)
+                        PersistedEventKeys.Add(ItemKey(put));
+                }
+
+                return Task.FromResult(new TransactWriteItemsResponse());
+            }
+
+            if (name == "Dispose" || name.StartsWith("get_", StringComparison.Ordinal))
+                return null;
+
+            throw new NotSupportedException($"RecordingDynamoDb does not support {name}");
+        }
+
+        private static string ItemKey(IReadOnlyDictionary<string, AttributeValue> item) =>
+            string.Join("|", item.TryGetValue("pk", out var pk) ? pk.S : string.Empty,
+                item.TryGetValue("sk", out var sk) ? sk.S : string.Empty);
+    }
+}

--- a/docs/dcb_llm/11_storage_providers.md
+++ b/docs/dcb_llm/11_storage_providers.md
@@ -965,6 +965,15 @@ mechanism. Repeated Core registrations retain last-wins behavior, while repeated
 Manual `AddSingleton<ExecutorSizeGateOptions>` registration bypasses this guard and does not claim provider helper
 validation or measurement parity.
 
+The DynamoDB `BatchWriteItem` fallback validates `MaxBatchWriteItems` only when that fallback operation begins; valid
+values are `1` through `25`. An invalid value returns the existing `ResultBox` error with an
+`ArgumentOutOfRangeException` naming `MaxBatchWriteItems` and its captured value before any batch write dispatch. The
+validated value is snapshotted once for the operation and reused for event puts, tag puts, and rollback deletes; a
+configuration change during dispatch is observed only by the next operation. This batch-only validation does not alter
+`MaxBatchGetItems`, `MaxRetryAttempts`, transaction or conditional paths, or their retry/rollback behavior. With
+`AutoCreateTables = true`, table initialization can still occur before the batch validation, so zero write dispatches
+does not mean zero table-creation DDL.
+
 ## Related
 
 For the current internal-use cold event export, hybrid read, and catch-up worker setup, see [Cold Events and Catch-up](19_cold_events.md).

--- a/docs/dcb_llm_ja/11_storage_providers.md
+++ b/docs/dcb_llm_ja/11_storage_providers.md
@@ -972,6 +972,14 @@ shard 依存 byte を undercount することがあります。Core helper と `
 同方式の再登録は last-wins、provider helper の再登録は policy の蓄積を保ちます。手動の
 `AddSingleton<ExecutorSizeGateOptions>` は guard 外であり、provider helper の検証・測定 parity を保証しません。
 
+DynamoDB の `BatchWriteItem` fallback は、その fallback operation の開始時だけ `MaxBatchWriteItems` を検証します。
+有効値は `1` から `25` です。無効値の場合は、batch write を dispatch する前に、`MaxBatchWriteItems` と取得した値を示す
+`ArgumentOutOfRangeException` を既存の `ResultBox` error として返します。検証済みの値は operation ごとに一度だけ
+snapshot され、event put、tag put、rollback delete のすべてで再利用されます。dispatch 中の設定変更は次の operation
+からだけ反映されます。この batch 専用検証は `MaxBatchGetItems`、`MaxRetryAttempts`、transaction/conditional path、
+およびそれらの retry/rollback 挙動を変更しません。`AutoCreateTables = true` の場合、batch 検証より先に table 初期化が
+行われることがあるため、write dispatch が 0 件でも table 作成 DDL が 0 件とは限りません。
+
 ## 関連資料
 
 現在のインターナルユースで使っているコールドイベントの書き出し、ハイブリッドリード、キャッチアップワーカー構成については [コールドイベントとキャッチアップ](19_cold_events.md) を参照してください。


### PR DESCRIPTION
Closes #1211

## Summary
- Validate MaxBatchWriteItems once at the start of each batch-write fallback operation.
- Reuse the captured 1..25 chunk size for event puts, tag puts, and rollback deletes without changing transaction or conditional paths.
- Add guarded mock coverage for invalid values, mutation during dispatch, rollback, next-operation reread, and service-invalid request shapes.
- Document timing, per-operation snapshot behavior, and table-initialization caveat in English and Japanese.

## Validation
- DynamoDbBatchWriteSnapshotTests: 10/10 on net9.0 and 10/10 on net10.0.
- Existing DynamoDB event-item, write-operation, and conditional-append suites: 52/52 on each TFM.
- DynamoDB provider builds: net9.0 and net10.0 succeeded with 0 warnings and 0 errors.
- git diff --check: clean.