### PR TITLE
Implement G70 DynamoDB batch-read snapshot

### DIFF
--- a/dcb/src/Sekiban.Dcb.DynamoDB/DynamoDbEventStore.TaggedStream.cs
+++ b/dcb/src/Sekiban.Dcb.DynamoDB/DynamoDbEventStore.TaggedStream.cs
@@ -46,7 +46,7 @@ public partial class DynamoDbEventStore
         {
             cancellationToken.ThrowIfCancellationRequested();
             var pageSize = ValidateTaggedStreamPageSize();
-            var batchSize = ValidateTaggedStreamBatchSize();
+            var batchSize = ResolveBatchGetChunkSize();
             await _context.EnsureTablesAsync(cancellationToken).ConfigureAwait(false);
 
             var serviceId = CurrentServiceId;
@@ -274,17 +274,20 @@ public partial class DynamoDbEventStore
         return _options.QueryPageSize;
     }
 
-    private int ValidateTaggedStreamBatchSize()
+    // Shared by the normal tag readers and the callback stream so every non-empty read invocation
+    // uses one validated MaxBatchGetItems snapshot. The empty normal-read return remains before this resolver.
+    private int ResolveBatchGetChunkSize()
     {
-        if (_options.MaxBatchGetItems is < 1 or > 100)
+        var batchSize = _options.MaxBatchGetItems;
+        if (batchSize is < 1 or > 100)
         {
             throw new ArgumentOutOfRangeException(
                 nameof(_options.MaxBatchGetItems),
-                _options.MaxBatchGetItems,
-                "Native tagged streaming requires MaxBatchGetItems to be between 1 and 100.");
+                batchSize,
+                "DynamoDB batch reads require between 1 and 100 keys per request.");
         }
 
-        return _options.MaxBatchGetItems;
+        return batchSize;
     }
 
     private static string ToExclusiveAfterSortKey(string sortableUniqueId) =>

--- a/dcb/src/Sekiban.Dcb.DynamoDB/DynamoDbEventStore.cs
+++ b/dcb/src/Sekiban.Dcb.DynamoDB/DynamoDbEventStore.cs
@@ -803,9 +803,10 @@ public partial class DynamoDbEventStore : IHotEventStore, IStorageDurabilityDesc
         if (eventIds.Count == 0)
             return results;
 
-        for (var i = 0; i < eventIds.Count; i += _options.MaxBatchGetItems)
+        var batchSize = ResolveBatchGetChunkSize();
+        for (var i = 0; i < eventIds.Count; i += batchSize)
         {
-            var chunk = eventIds.Skip(i).Take(_options.MaxBatchGetItems).ToList();
+            var chunk = eventIds.Skip(i).Take(batchSize).ToList();
             var keys = chunk
                 .Select(id => BuildEventKey(serviceId, id))
                 .ToList();

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/RemoteTaggedStreamTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/RemoteTaggedStreamTests.cs
@@ -2,6 +2,7 @@ using Amazon.DynamoDBv2;
 using Amazon.DynamoDBv2.Model;
 using Amazon.Runtime;
 using Dcb.Domain;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using ResultBoxes;
 using Sekiban.Dcb.Actors;
@@ -710,6 +711,329 @@ public sealed class RemoteTaggedStreamTests
         Assert.Empty(client.BatchGetTokens);
     }
 
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(101)]
+    public async Task DynamoTagReads_InvalidBatchSizeReturnsCapturedErrorWithoutBatchGet(int invalidSize)
+    {
+        var domain = BuildParityDomain();
+        var client = new NativeTaggedStreamDynamoClient();
+        var options = NewDynamoReadOptions(invalidSize);
+        var store = NewDynamoStore(client, options, domain);
+        var tag = new RemoteParityTag($"dynamo-invalid-{invalidSize}");
+        SeedDynamo(client, tag, ReadFixture(domain, tag, 1));
+
+        var typed = await store.ReadEventsByTagAsync(tag);
+        Assert.False(typed.IsSuccess);
+        AssertInvalidBatchReadOption(typed.GetException(), invalidSize);
+
+        var serialized = await store.ReadSerializableEventsByTagAsync(tag);
+        Assert.False(serialized.IsSuccess);
+        AssertInvalidBatchReadOption(serialized.GetException(), invalidSize);
+
+        Assert.Empty(client.BatchGetRequestSizes);
+    }
+
+    [Theory]
+    [InlineData(100, false)]
+    [InlineData(100, true)]
+    [InlineData(1, false)]
+    [InlineData(1, true)]
+    public async Task DynamoTagReads_UseOneValidSnapshotForTypedAndSerializedEntries(
+        int batchSize,
+        bool serialized)
+    {
+        var domain = BuildParityDomain();
+        var client = new NativeTaggedStreamDynamoClient();
+        var options = NewDynamoReadOptions(batchSize);
+        options.UseConsistentReads = true;
+        var store = NewDynamoStore(client, options, domain);
+        var tag = new RemoteParityTag($"dynamo-valid-{batchSize}-{serialized}");
+        var events = ReadFixture(domain, tag, 250);
+        SeedDynamo(client, tag, events);
+
+        var ids = await ReadTagIdsAsync(store, tag, serialized);
+
+        Assert.Equal(events.Select(@event => @event.SortableUniqueIdValue), ids);
+        Assert.Equal(
+            batchSize == 100
+                ? new[] { 100, 100, 50 }
+                : Enumerable.Repeat(1, 250),
+            client.BatchGetRequestSizes);
+        Assert.All(client.BatchGetConsistentReads, Assert.True);
+    }
+
+    [Theory]
+    [InlineData(0, false)]
+    [InlineData(0, true)]
+    [InlineData(101, false)]
+    [InlineData(101, true)]
+    public async Task DynamoTagReads_MutationDuringFirstDispatchDoesNotChangeTheSnapshot(
+        int mutatedSize,
+        bool serialized)
+    {
+        var domain = BuildParityDomain();
+        var client = new NativeTaggedStreamDynamoClient();
+        var options = NewDynamoReadOptions(100);
+        var store = NewDynamoStore(client, options, domain);
+        var tag = new RemoteParityTag($"dynamo-mutate-{mutatedSize}-{serialized}");
+        var events = ReadFixture(domain, tag, 150);
+        SeedDynamo(client, tag, events);
+        client.AfterBatchGet = dispatchNumber =>
+        {
+            if (dispatchNumber == 1)
+                options.MaxBatchGetItems = mutatedSize;
+        };
+
+        var ids = await ReadTagIdsAsync(store, tag, serialized);
+
+        Assert.Equal(events.Select(@event => @event.SortableUniqueIdValue), ids);
+        Assert.Equal(new[] { 100, 50 }, client.BatchGetRequestSizes);
+        Assert.Equal(mutatedSize, options.MaxBatchGetItems);
+        Assert.Equal(events.Count, ids.Distinct(StringComparer.Ordinal).Count());
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task DynamoTagReads_NextOperationRereadsTheMutableOption(bool serialized)
+    {
+        var domain = BuildParityDomain();
+        var client = new NativeTaggedStreamDynamoClient();
+        var options = NewDynamoReadOptions(100);
+        var store = NewDynamoStore(client, options, domain);
+        var tag = new RemoteParityTag($"dynamo-next-operation-{serialized}");
+        var events = ReadFixture(domain, tag, 25);
+        SeedDynamo(client, tag, events);
+
+        await ReadTagIdsAsync(store, tag, serialized);
+        client.ClearReadRequests();
+        options.MaxBatchGetItems = 10;
+
+        var ids = await ReadTagIdsAsync(store, tag, serialized);
+
+        Assert.Equal(events.Select(@event => @event.SortableUniqueIdValue), ids);
+        Assert.Equal(new[] { 10, 10, 5 }, client.BatchGetRequestSizes);
+    }
+
+    [Fact]
+    public async Task DynamoTagReads_NoTagRowsRemainNoOpWithAnInvalidBatchSize()
+    {
+        var domain = BuildParityDomain();
+        var client = new NativeTaggedStreamDynamoClient();
+        var options = NewDynamoReadOptions(0);
+        var store = NewDynamoStore(client, options, domain);
+        var tag = new RemoteParityTag("dynamo-no-tag-rows");
+
+        var typed = await store.ReadEventsByTagAsync(tag);
+        var serialized = await store.ReadSerializableEventsByTagAsync(tag);
+
+        Assert.True(typed.IsSuccess, typed.IsSuccess ? string.Empty : typed.GetException().ToString());
+        Assert.True(serialized.IsSuccess, serialized.IsSuccess ? string.Empty : serialized.GetException().ToString());
+        Assert.Empty(typed.GetValue());
+        Assert.Empty(serialized.GetValue());
+        Assert.Empty(client.BatchGetRequestSizes);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(101)]
+    public async Task DynamoNativeTaggedStream_InvalidBatchSizeFailsBeforeQuery(int invalidSize)
+    {
+        var client = new NativeTaggedStreamDynamoClient();
+        var options = NewDynamoReadOptions(invalidSize);
+        var store = NewDynamoStore(client, options);
+
+        var result = await store.StreamSerializableEventsByTagAsync(
+            new RemoteParityTag($"dynamo-stream-invalid-{invalidSize}"),
+            null,
+            null,
+            _ => ValueTask.CompletedTask);
+
+        Assert.False(result.IsSuccess);
+        AssertInvalidBatchReadOption(result.GetException(), invalidSize);
+        Assert.Empty(client.Queries);
+        Assert.Empty(client.BatchGetRequestSizes);
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(100)]
+    public async Task DynamoNativeTaggedStream_ValidBatchSizesPreserveCallbackOrder(int batchSize)
+    {
+        var domain = BuildParityDomain();
+        var client = new NativeTaggedStreamDynamoClient();
+        var options = NewDynamoReadOptions(batchSize);
+        var store = NewDynamoStore(client, options, domain);
+        var tag = new RemoteParityTag($"dynamo-stream-valid-{batchSize}");
+        var events = ReadFixture(domain, tag, 5);
+        SeedDynamo(client, tag, events);
+        var emitted = new List<string>();
+
+        var result = await store.StreamSerializableEventsByTagAsync(
+            tag,
+            null,
+            null,
+            @event =>
+            {
+                emitted.Add(@event.SortableUniqueIdValue);
+                return ValueTask.CompletedTask;
+            });
+
+        Assert.True(result.IsSuccess, result.IsSuccess ? string.Empty : result.GetException().ToString());
+        Assert.Equal(events.Select(@event => @event.SortableUniqueIdValue), emitted);
+        Assert.Equal(batchSize == 100 ? new[] { 5 } : Enumerable.Repeat(1, 5), client.BatchGetRequestSizes);
+    }
+
+    [Fact]
+    public async Task DynamoNativeTaggedStream_MutationDuringFirstDispatchKeepsTheWholeStreamSnapshot()
+    {
+        var domain = BuildParityDomain();
+        var client = new NativeTaggedStreamDynamoClient();
+        var options = NewDynamoReadOptions(2);
+        options.QueryPageSize = 2;
+        var store = NewDynamoStore(client, options, domain);
+        var tag = new RemoteParityTag("dynamo-stream-snapshot");
+        var events = ReadFixture(domain, tag, 5);
+        SeedDynamo(client, tag, events);
+        client.AfterBatchGet = dispatchNumber =>
+        {
+            if (dispatchNumber == 1)
+                options.MaxBatchGetItems = 1;
+        };
+        var emitted = new List<string>();
+
+        var result = await store.StreamSerializableEventsByTagAsync(
+            tag,
+            null,
+            null,
+            @event =>
+            {
+                emitted.Add(@event.SortableUniqueIdValue);
+                return ValueTask.CompletedTask;
+            });
+
+        Assert.True(result.IsSuccess, result.IsSuccess ? string.Empty : result.GetException().ToString());
+        Assert.Equal(events.Select(@event => @event.SortableUniqueIdValue), emitted);
+        Assert.Equal(new[] { 2, 2, 1 }, client.BatchGetRequestSizes);
+        Assert.Equal(3, client.Queries.Count);
+        Assert.All(client.Queries, query => Assert.Equal(2, query.Limit));
+        Assert.Equal(1, options.MaxBatchGetItems);
+    }
+
+    [Fact]
+    public async Task DynamoNativeTaggedStream_UnprocessedKeysRetryOnlyTheReturnedKeys()
+    {
+        var domain = BuildParityDomain();
+        var client = new NativeTaggedStreamDynamoClient { ReturnOneUnprocessedKeyOnce = true };
+        var options = NewDynamoReadOptions(2);
+        options.MaxRetryAttempts = 1;
+        var store = NewDynamoStore(client, options, domain);
+        var tag = new RemoteParityTag("dynamo-stream-retry");
+        var events = ReadFixture(domain, tag, 2);
+        SeedDynamo(client, tag, events);
+        var emitted = new List<string>();
+
+        var result = await store.StreamSerializableEventsByTagAsync(
+            tag,
+            null,
+            null,
+            @event =>
+            {
+                emitted.Add(@event.SortableUniqueIdValue);
+                return ValueTask.CompletedTask;
+            });
+
+        Assert.True(result.IsSuccess, result.IsSuccess ? string.Empty : result.GetException().ToString());
+        Assert.Equal(events.Select(@event => @event.SortableUniqueIdValue), emitted);
+        Assert.Equal(new[] { 2, 1 }, client.BatchGetRequestSizes);
+        Assert.Single(client.BatchGetRequestEventIds[1]);
+        Assert.Equal(client.BatchGetRequestEventIds[0][1], client.BatchGetRequestEventIds[1][0]);
+    }
+
+    [Fact]
+    public async Task DynamoNativeTaggedStream_RetryLimitRemainsPerAttempt()
+    {
+        var domain = BuildParityDomain();
+        var client = new NativeTaggedStreamDynamoClient { ReturnOneUnprocessedKeyOnce = true };
+        var options = NewDynamoReadOptions(2);
+        options.MaxRetryAttempts = 0;
+        var store = NewDynamoStore(client, options, domain);
+        var tag = new RemoteParityTag("dynamo-stream-retry-limit");
+        SeedDynamo(client, tag, ReadFixture(domain, tag, 2));
+
+        var result = await store.StreamSerializableEventsByTagAsync(
+            tag,
+            null,
+            null,
+            _ => ValueTask.CompletedTask);
+
+        Assert.False(result.IsSuccess);
+        Assert.IsType<InvalidOperationException>(result.GetException());
+        Assert.Equal(new[] { 2 }, client.BatchGetRequestSizes);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(101)]
+    public async Task DynamoTaggedStreamHarnessRejectsServiceInvalidBatchGetShapes(int keyCount)
+    {
+        var client = new NativeTaggedStreamDynamoClient();
+        var request = new BatchGetItemRequest
+        {
+            RequestItems = new Dictionary<string, KeysAndAttributes>
+            {
+                [EventsTable] = new KeysAndAttributes
+                {
+                    Keys = Enumerable.Range(0, keyCount)
+                        .Select(index => new Dictionary<string, AttributeValue>
+                        {
+                            ["pk"] = new() { S = $"pk-{index}" },
+                            ["sk"] = new() { S = $"sk-{index}" }
+                        })
+                        .ToList()
+                }
+            }
+        };
+
+        await Assert.ThrowsAsync<AmazonDynamoDBException>(() => client.BatchGetItemAsync(request));
+    }
+
+    [Fact]
+    public async Task DynamoTagReads_DiResolvedOptionsMutationIsUsedAfterStoreConstruction()
+    {
+        var domain = BuildParityDomain();
+        var client = new NativeTaggedStreamDynamoClient();
+        var tag = new RemoteParityTag("dynamo-di-options");
+        var events = ReadFixture(domain, tag, 25);
+        SeedDynamo(client, tag, events);
+
+        using var provider = new ServiceCollection()
+            .AddSingleton(domain)
+            .AddSingleton<IServiceIdProvider>(new FixedServiceIdProvider(ServiceId))
+            .AddSekibanDcbDynamoDb(client, options =>
+            {
+                options.AutoCreateTables = false;
+                options.EventsTableName = EventsTable;
+                options.TagsTableName = TagsTable;
+                options.ProjectionStatesTableName = "g70-projection";
+            })
+            .BuildServiceProvider();
+
+        var resolvedOptions = provider.GetRequiredService<IOptions<DynamoDbEventStoreOptions>>().Value;
+        var store = provider.GetRequiredService<DynamoDbEventStore>();
+        resolvedOptions.MaxBatchGetItems = 10;
+
+        var result = await store.ReadSerializableEventsByTagAsync(tag);
+
+        Assert.True(result.IsSuccess, result.IsSuccess ? string.Empty : result.GetException().ToString());
+        Assert.Equal(events.Select(@event => @event.SortableUniqueIdValue),
+            result.GetValue().Select(@event => @event.SortableUniqueIdValue));
+        Assert.Equal(new[] { 10, 10, 5 }, client.BatchGetRequestSizes);
+    }
+
     [Fact]
     public void TaggedStreamInterfaceSignature_RemainsTheG53FrozenCapabilityContract()
     {
@@ -783,6 +1107,63 @@ public sealed class RemoteTaggedStreamTests
         DcbDomainTypes domain) =>
         new(new DynamoDbContext(client, Options.Create(options)), domain.EventTypes,
             new FixedServiceIdProvider(ServiceId));
+
+    private static DynamoDbEventStoreOptions NewDynamoReadOptions(int maxBatchGetItems) =>
+        new()
+        {
+            AutoCreateTables = false,
+            EventsTableName = EventsTable,
+            TagsTableName = TagsTable,
+            QueryPageSize = 1000,
+            MaxBatchGetItems = maxBatchGetItems
+        };
+
+    private static async Task<IReadOnlyList<string>> ReadTagIdsAsync(
+        DynamoDbEventStore store,
+        ITag tag,
+        bool serialized)
+    {
+        if (serialized)
+        {
+            var result = await store.ReadSerializableEventsByTagAsync(tag);
+            Assert.True(result.IsSuccess, result.IsSuccess ? string.Empty : result.GetException().ToString());
+            return result.GetValue().Select(@event => @event.SortableUniqueIdValue).ToList();
+        }
+
+        var typed = await store.ReadEventsByTagAsync(tag);
+        Assert.True(typed.IsSuccess, typed.IsSuccess ? string.Empty : typed.GetException().ToString());
+        return typed.GetValue().Select(@event => @event.SortableUniqueIdValue).ToList();
+    }
+
+    private static IReadOnlyList<SerializableEvent> ReadFixture(
+        DcbDomainTypes domain,
+        ITag tag,
+        int count)
+    {
+        return Enumerable.Range(0, count)
+            .Select(index =>
+            {
+                var id = Guid.Parse($"00000000-0000-0000-0000-{index + 1000:D12}");
+                return new Event(
+                    new RemoteParityAdded(index),
+                    SortableUniqueId.Generate(BaseTime.AddSeconds(index), id),
+                    nameof(RemoteParityAdded),
+                    id,
+                    new EventMetadata("cause", "correlation", "user"),
+                    [tag.GetTag()])
+                    .ToSerializableEvent(domain.EventTypes);
+            })
+            .ToList();
+    }
+
+    private static void AssertInvalidBatchReadOption(Exception exception, int expectedValue)
+    {
+        var argument = Assert.IsType<ArgumentOutOfRangeException>(exception);
+        Assert.Equal(nameof(DynamoDbEventStoreOptions.MaxBatchGetItems), argument.ParamName);
+        Assert.Equal(expectedValue, argument.ActualValue);
+        Assert.Contains("DynamoDB batch reads require between 1 and 100 keys per request", argument.Message,
+            StringComparison.Ordinal);
+    }
 
     private static async Task<RemoteParityResult> RunParityRoutesAsync(
         IEventStore provider,
@@ -1131,12 +1512,29 @@ public sealed class RemoteTaggedStreamTests
         }
 
         public bool ReverseBatchResponses { get; set; }
+        public bool ReturnOneUnprocessedKeyOnce { get; set; }
         public Action? AfterQuery { get; set; }
+        public Action<int>? AfterBatchGet { get; set; }
         public List<QueryRequest> Queries { get; } = new();
         public List<CancellationToken> QueryTokens { get; } = new();
         public List<CancellationToken> BatchGetTokens { get; } = new();
+        public List<int> BatchGetRequestSizes { get; } = new();
+        public List<bool> BatchGetConsistentReads { get; } = new();
+        public List<IReadOnlyList<string>> BatchGetRequestEventIds { get; } = new();
         public int MaximumQueryRows { get; private set; }
         public int MaximumBatchKeys { get; private set; }
+
+        public void ClearReadRequests()
+        {
+            Queries.Clear();
+            QueryTokens.Clear();
+            BatchGetTokens.Clear();
+            BatchGetRequestSizes.Clear();
+            BatchGetConsistentReads.Clear();
+            BatchGetRequestEventIds.Clear();
+            MaximumQueryRows = 0;
+            MaximumBatchKeys = 0;
+        }
 
         public void Seed(string table, Dictionary<string, AttributeValue> item)
         {
@@ -1169,9 +1567,21 @@ public sealed class RemoteTaggedStreamTests
             lock (_gate)
             {
                 BatchGetTokens.Add(cancellationToken);
-                var keys = request.RequestItems[EventsTable].Keys;
+                var keyRequest = request.RequestItems[EventsTable];
+                var keys = keyRequest.Keys;
+                if (keys.Count is 0 or > 100)
+                    throw new AmazonDynamoDBException(
+                        $"BatchGetItem request contained {keys.Count} keys; DynamoDB permits 1 through 100.");
+
+                var dispatchNumber = BatchGetRequestSizes.Count + 1;
+                BatchGetRequestSizes.Add(keys.Count);
+                BatchGetConsistentReads.Add(keyRequest.ConsistentRead == true);
+                BatchGetRequestEventIds.Add(keys.Select(key => key["sk"].S).ToList());
                 MaximumBatchKeys = Math.Max(MaximumBatchKeys, keys.Count);
-                var rows = keys
+                var responseKeys = ReturnOneUnprocessedKeyOnce && dispatchNumber == 1
+                    ? keys.Take(keys.Count - 1).ToList()
+                    : keys;
+                var rows = responseKeys
                     .Select(key => _items.TryGetValue((EventsTable, key["pk"].S, key["sk"].S), out var item)
                         ? Clone(item)
                         : null)
@@ -1183,13 +1593,25 @@ public sealed class RemoteTaggedStreamTests
                     rows.Reverse();
                 }
 
+                var unprocessed = ReturnOneUnprocessedKeyOnce && dispatchNumber == 1
+                    ? new Dictionary<string, KeysAndAttributes>
+                    {
+                        [EventsTable] = new KeysAndAttributes
+                        {
+                            Keys = [keys[^1]],
+                            ConsistentRead = keyRequest.ConsistentRead
+                        }
+                    }
+                    : new Dictionary<string, KeysAndAttributes>();
+                AfterBatchGet?.Invoke(dispatchNumber);
+
                 return Task.FromResult(new BatchGetItemResponse
                 {
                     Responses = new Dictionary<string, List<Dictionary<string, AttributeValue>>>
                     {
                         [EventsTable] = rows
                     },
-                    UnprocessedKeys = new Dictionary<string, KeysAndAttributes>(),
+                    UnprocessedKeys = unprocessed,
                     ConsumedCapacity = [new ConsumedCapacity { CapacityUnits = 1d }]
                 });
             }

--- a/docs/dcb_llm/11_storage_providers.md
+++ b/docs/dcb_llm/11_storage_providers.md
@@ -974,6 +974,19 @@ configuration change during dispatch is observed only by the next operation. Thi
 `AutoCreateTables = true`, table initialization can still occur before the batch validation, so zero write dispatches
 does not mean zero table-creation DDL.
 
+## SEK-G70 DynamoDB batch-read snapshot
+
+`MaxBatchGetItems` is validated by one shared private resolver for both public tag-list reads and the callback-native tag
+stream. A non-empty invocation reads the mutable option once, accepts only `1` through `100`, and reuses that snapshot for
+every `BatchGetItem` chunk. An invalid value returns `ArgumentOutOfRangeException` with parameter `MaxBatchGetItems` and
+the captured `ActualValue`; it is not clamped. The callback stream retains that snapshot across all query pages.
+
+The two public list methods keep their no-tag-rows early return: an empty tag query succeeds without validating
+`MaxBatchGetItems` or dispatching a batch read. The callback stream keeps eager validation after cancellation and
+`QueryPageSize` validation and before table/query I/O. `MaxRetryAttempts` is still read for each retry attempt,
+`UseConsistentReads` is still applied to each request chunk, `QueryPageSize` still controls query pages, and write paths
+are unchanged. This is a per-read-invocation snapshot, not global options validation or retry rechunking.
+
 ## Related
 
 For the current internal-use cold event export, hybrid read, and catch-up worker setup, see [Cold Events and Catch-up](19_cold_events.md).

--- a/docs/dcb_llm_ja/11_storage_providers.md
+++ b/docs/dcb_llm_ja/11_storage_providers.md
@@ -980,6 +980,21 @@ snapshot され、event put、tag put、rollback delete のすべてで再利用
 およびそれらの retry/rollback 挙動を変更しません。`AutoCreateTables = true` の場合、batch 検証より先に table 初期化が
 行われることがあるため、write dispatch が 0 件でも table 作成 DDL が 0 件とは限りません。
 
+## SEK-G70 DynamoDB batch-read snapshot
+
+`MaxBatchGetItems` は、公開されている tag list read と callback-native tag stream の両方で、1 つの shared private
+resolver により検証されます。空でない 1 回の invocation では mutable な option を 1 回だけ読み取り、`1` から
+`100` だけを受け付け、その snapshot をすべての `BatchGetItem` chunk で再利用します。無効値は clamp せず、
+parameter が `MaxBatchGetItems`、取得した `ActualValue` を含む `ArgumentOutOfRangeException` を返します。callback
+stream では query page をまたぐ全 invocation がその snapshot を保持します。
+
+2 つの公開 list method には no-tag-rows の早期 return が残ります。tag query が空なら、`MaxBatchGetItems` を検証せず
+batch read を dispatch せずに成功します。callback stream は cancellation と `QueryPageSize` の検証後、table/query I/O
+より前に eager validation を行います。`MaxRetryAttempts` は各 retry attempt ごとに読み取られ、
+`UseConsistentReads` は各 request chunk に適用され、`QueryPageSize` は引き続き query page を制御し、write path は
+変更されません。これは read invocation ごとの snapshot であり、global option validation や retry 時の再 chunking
+ではありません。
+
 ## 関連資料
 
 現在のインターナルユースで使っているコールドイベントの書き出し、ハイブリッドリード、キャッチアップワーカー構成については [コールドイベントとキャッチアップ](19_cold_events.md) を参照してください。


### PR DESCRIPTION
Closes #1213

## Summary

- Add one validated `MaxBatchGetItems` snapshot for non-empty DynamoDB tag-list reads and callback-native tag streams.
- Preserve the no-tag-rows early return, per-attempt retry reads, consistent-read setting, query page sizing, write paths, and public APIs.
- Add typed/serialized, stream, mutation, retry, no-op, DI, and provider-boundary regression coverage, plus EN/JA storage documentation.

## Validation

- `RemoteTaggedStreamTests`: 45/45 on net9.0 and net10.0.
- Focused provider/compatibility set: 92/92 on net9.0 and net10.0.
- `git diff --check`: passed.
