### PR TITLE
test: harden DynamoDB read ordering and cancellation

### DIFF
--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/RemoteTaggedStreamTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/RemoteTaggedStreamTests.cs
@@ -745,7 +745,7 @@ public sealed class RemoteTaggedStreamTests
         bool serialized)
     {
         var domain = BuildParityDomain();
-        var client = new NativeTaggedStreamDynamoClient();
+        var client = new NativeTaggedStreamDynamoClient { ReverseBatchResponses = true };
         var options = NewDynamoReadOptions(batchSize);
         options.UseConsistentReads = true;
         var store = NewDynamoStore(client, options, domain);
@@ -762,6 +762,33 @@ public sealed class RemoteTaggedStreamTests
                 : Enumerable.Repeat(1, 250),
             client.BatchGetRequestSizes);
         Assert.All(client.BatchGetConsistentReads, Assert.True);
+    }
+
+    [Theory]
+    [InlineData(0, 100)]
+    [InlineData(-1, 100)]
+    [InlineData(1000, 0)]
+    [InlineData(1000, -1)]
+    [InlineData(1000, 101)]
+    public async Task DynamoNativeTaggedStream_PreCancelledInvalidOptionsDoNotIssueAProviderRequest(
+        int queryPageSize,
+        int maxBatchGetItems)
+    {
+        var client = new NativeTaggedStreamDynamoClient();
+        var options = NewDynamoReadOptions(maxBatchGetItems);
+        options.QueryPageSize = queryPageSize;
+        var store = NewDynamoStore(client, options);
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => store.StreamSerializableEventsByTagAsync(
+            new NativeTag($"dynamo-precancel-invalid-{queryPageSize}-{maxBatchGetItems}"),
+            null,
+            null,
+            _ => ValueTask.CompletedTask,
+            cancellation.Token));
+        Assert.Empty(client.Queries);
+        Assert.Empty(client.BatchGetTokens);
     }
 
     [Theory]


### PR DESCRIPTION
Closes #1215

## Summary

- Strengthen both public normal tagged-read entries with reversed BatchGet responses at batch size 100; batch size 1 remains the singleton control.
- Add five isolated pre-cancelled invalid-option cases covering page sizes 0/-1 and batch sizes 0/-1/101. Each asserts cancellation before provider I/O.
- No production files, public APIs, options, retry, write, transport, or documentation changes.

## Evidence

The temporary production mutations were applied only for disposable verification and restored before the final diff.

### M1: normal-read order mutant

Temporary mutation: both normal readers enumerated `eventsById.Values` instead of projecting the ordered tag references.

```text
net9: 4 total, 2 failed at batchSize=100 (typed + serialized), 2 passed at batchSize=1 controls
net10: 4 total, 2 failed at batchSize=100 (typed + serialized), 2 passed at batchSize=1 controls
```

The failures were ordered-ID assertion failures; the final test uses reversed BatchGet responses and therefore kills this dictionary-order mutant.

### Cancellation-order mutants

Mutant A moved cancellation after page validation but before batch validation:

```text
net9 invalid theory: 5 total, 2 failed (P0/P-1), 3 passed (B0/B-1/B101)
net10 invalid theory: 5 total, 2 failed (P0/P-1), 3 passed (B0/B-1/B101)
net9 valid Fact: 1 passed
net10 valid Fact: 1 passed
```

Mutant B moved cancellation after both validators:

```text
net9 invalid theory: 5 total, 5 failed (P0/P-1 page validation and B0/B-1/B101 batch validation preempted cancellation)
net10 invalid theory: 5 total, 5 failed (same split)
net9 valid Fact: 1 passed
net10 valid Fact: 1 passed
```

### Final restored tree

```text
net9  RemoteTaggedStreamTests: 50 passed, 0 failed, 0 skipped
net10 RemoteTaggedStreamTests: 50 passed, 0 failed, 0 skipped
git diff --check: passed
final tracked diff: dcb/tests/Sekiban.Dcb.WithResult.Tests/RemoteTaggedStreamTests.cs only
```
