### PR TITLE
feat: add native materialized-view table bindings

### DIFF
--- a/.github/workflows/run_test_dcb.yml
+++ b/.github/workflows/run_test_dcb.yml
@@ -100,9 +100,20 @@ jobs:
         run: |
           trx_dir="$RUNNER_TEMP/g73-materialized-view-trx/net9"
           mkdir -p "$trx_dir"
-          dotnet test dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests.csproj -c Release --no-build -f net9.0 --filter 'FullyQualifiedName~PostgresMvFreshProjectorApplyTests' --logger 'trx;LogFileName=mv-postgres-net9.trx' --results-directory "$trx_dir" -- RunConfiguration.MaxCpuCount=1
-          dotnet test dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests.csproj -c Release --no-build -f net9.0 --filter 'FullyQualifiedName~SqlServerMvFreshProjectorApplyTests' --logger 'trx;LogFileName=mv-sqlserver-net9.trx' --results-directory "$trx_dir" -- RunConfiguration.MaxCpuCount=1
+          dotnet test dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests.csproj -c Release --no-build -f net9.0 --filter 'FullyQualifiedName~PostgresMvFreshProjectorApplyTests|FullyQualifiedName~PostgresMvG73AcceptanceTests' --logger 'trx;LogFileName=mv-postgres-net9.trx' --results-directory "$trx_dir" -- RunConfiguration.MaxCpuCount=1
+          dotnet test dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests.csproj -c Release --no-build -f net9.0 --filter 'FullyQualifiedName~SqlServerMvFreshProjectorApplyTests|FullyQualifiedName~SqlServerMvG73AcceptanceTests' --logger 'trx;LogFileName=mv-sqlserver-net9.trx' --results-directory "$trx_dir" -- RunConfiguration.MaxCpuCount=1
           ./eng/audit-mv-trx-results.sh --trx-dir "$trx_dir" --manifest eng/materialized-view-required-cases.txt --tfm net9.0
+          swap_dir="$(mktemp -d)"
+          cp "$trx_dir"/* "$swap_dir"/
+          mv "$swap_dir/mv-postgres-net9.trx" "$swap_dir/postgres.tmp.trx"
+          mv "$swap_dir/mv-sqlserver-net9.trx" "$swap_dir/mv-postgres-net9.trx"
+          mv "$swap_dir/postgres.tmp.trx" "$swap_dir/mv-sqlserver-net9.trx"
+          if ./eng/audit-mv-trx-results.sh --trx-dir "$swap_dir" --manifest eng/materialized-view-required-cases.txt --tfm net9.0; then
+            echo 'ERROR: swapped provider TRX unexpectedly passed the class-qualified audit'
+            exit 1
+          else
+            echo 'swapped provider TRX correctly rejected by class-qualified audit'
+          fi
 
       - name: dotnet test DCB projects sequentially (net9.0)
         run: |
@@ -186,9 +197,20 @@ jobs:
         run: |
           trx_dir="$RUNNER_TEMP/g73-materialized-view-trx/net10"
           mkdir -p "$trx_dir"
-          dotnet test dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests.csproj -c Release --no-build -f net10.0 --filter 'FullyQualifiedName~PostgresMvFreshProjectorApplyTests' --logger 'trx;LogFileName=mv-postgres-net10.trx' --results-directory "$trx_dir" -- RunConfiguration.MaxCpuCount=1
-          dotnet test dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests.csproj -c Release --no-build -f net10.0 --filter 'FullyQualifiedName~SqlServerMvFreshProjectorApplyTests' --logger 'trx;LogFileName=mv-sqlserver-net10.trx' --results-directory "$trx_dir" -- RunConfiguration.MaxCpuCount=1
+          dotnet test dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests.csproj -c Release --no-build -f net10.0 --filter 'FullyQualifiedName~PostgresMvFreshProjectorApplyTests|FullyQualifiedName~PostgresMvG73AcceptanceTests' --logger 'trx;LogFileName=mv-postgres-net10.trx' --results-directory "$trx_dir" -- RunConfiguration.MaxCpuCount=1
+          dotnet test dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests.csproj -c Release --no-build -f net10.0 --filter 'FullyQualifiedName~SqlServerMvFreshProjectorApplyTests|FullyQualifiedName~SqlServerMvG73AcceptanceTests' --logger 'trx;LogFileName=mv-sqlserver-net10.trx' --results-directory "$trx_dir" -- RunConfiguration.MaxCpuCount=1
           ./eng/audit-mv-trx-results.sh --trx-dir "$trx_dir" --manifest eng/materialized-view-required-cases.txt --tfm net10.0
+          swap_dir="$(mktemp -d)"
+          cp "$trx_dir"/* "$swap_dir"/
+          mv "$swap_dir/mv-postgres-net10.trx" "$swap_dir/postgres.tmp.trx"
+          mv "$swap_dir/mv-sqlserver-net10.trx" "$swap_dir/mv-postgres-net10.trx"
+          mv "$swap_dir/postgres.tmp.trx" "$swap_dir/mv-sqlserver-net10.trx"
+          if ./eng/audit-mv-trx-results.sh --trx-dir "$swap_dir" --manifest eng/materialized-view-required-cases.txt --tfm net10.0; then
+            echo 'ERROR: swapped provider TRX unexpectedly passed the class-qualified audit'
+            exit 1
+          else
+            echo 'swapped provider TRX correctly rejected by class-qualified audit'
+          fi
 
       - name: dotnet test DCB projects sequentially (net10.0)
         run: |

--- a/.github/workflows/run_test_dcb.yml
+++ b/.github/workflows/run_test_dcb.yml
@@ -96,6 +96,14 @@ jobs:
           docker logs sekiban-g67-dynamodb-local
           exit 1
 
+      - name: Audit native apply binding cases on PostgreSQL and SQL Server (net9.0)
+        run: |
+          trx_dir="$RUNNER_TEMP/g73-materialized-view-trx/net9"
+          mkdir -p "$trx_dir"
+          dotnet test dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests.csproj -c Release --no-build -f net9.0 --filter 'FullyQualifiedName~PostgresMvFreshProjectorApplyTests' --logger 'trx;LogFileName=mv-postgres-net9.trx' --results-directory "$trx_dir" -- RunConfiguration.MaxCpuCount=1
+          dotnet test dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests.csproj -c Release --no-build -f net9.0 --filter 'FullyQualifiedName~SqlServerMvFreshProjectorApplyTests' --logger 'trx;LogFileName=mv-sqlserver-net9.trx' --results-directory "$trx_dir" -- RunConfiguration.MaxCpuCount=1
+          ./eng/audit-mv-trx-results.sh --trx-dir "$trx_dir" --manifest eng/materialized-view-required-cases.txt --tfm net9.0
+
       - name: dotnet test DCB projects sequentially (net9.0)
         run: |
           dotnet test dcb/tests/Sekiban.Dcb.Orleans.Tests/Sekiban.Dcb.Orleans.Tests.csproj -c Release --no-build -f net9.0 --verbosity normal --collect:"XPlat Code Coverage" -- RunConfiguration.MaxCpuCount=1
@@ -173,6 +181,14 @@ jobs:
           done
           docker logs sekiban-g67-dynamodb-local
           exit 1
+
+      - name: Audit native apply binding cases on PostgreSQL and SQL Server (net10.0)
+        run: |
+          trx_dir="$RUNNER_TEMP/g73-materialized-view-trx/net10"
+          mkdir -p "$trx_dir"
+          dotnet test dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests.csproj -c Release --no-build -f net10.0 --filter 'FullyQualifiedName~PostgresMvFreshProjectorApplyTests' --logger 'trx;LogFileName=mv-postgres-net10.trx' --results-directory "$trx_dir" -- RunConfiguration.MaxCpuCount=1
+          dotnet test dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests.csproj -c Release --no-build -f net10.0 --filter 'FullyQualifiedName~SqlServerMvFreshProjectorApplyTests' --logger 'trx;LogFileName=mv-sqlserver-net10.trx' --results-directory "$trx_dir" -- RunConfiguration.MaxCpuCount=1
+          ./eng/audit-mv-trx-results.sh --trx-dir "$trx_dir" --manifest eng/materialized-view-required-cases.txt --tfm net10.0
 
       - name: dotnet test DCB projects sequentially (net10.0)
         run: |

--- a/dcb/internalUsages/Dcb.Domain.WithoutResult/MaterializedViews/OrderSummaryMvV1.cs
+++ b/dcb/internalUsages/Dcb.Domain.WithoutResult/MaterializedViews/OrderSummaryMvV1.cs
@@ -88,22 +88,37 @@ public sealed class OrderSummaryMvV1 : IMaterializedViewProjector, IMvSchemaRequ
         IMvApplyContext ctx,
         CancellationToken cancellationToken = default)
     {
+        var tables = RequireApplyTables(ctx);
         return ev.Payload switch
         {
-            OrderCreated created => [UpsertOrder(created, ctx.CurrentSortableUniqueId)],
-            OrderItemAdded added => await ApplyItemAddedAsync(added, ctx, cancellationToken).ConfigureAwait(false),
-            OrderCancelled cancelled => [CancelOrder(cancelled, ctx.CurrentSortableUniqueId)],
+            OrderCreated created => [UpsertOrder(created, tables.Orders, ctx.CurrentSortableUniqueId)],
+            OrderItemAdded added => await ApplyItemAddedAsync(added, tables, ctx, cancellationToken).ConfigureAwait(false),
+            OrderCancelled cancelled => [CancelOrder(cancelled, tables.Orders, ctx.CurrentSortableUniqueId)],
             _ => []
         };
     }
 
+    private static ApplyTableNames RequireApplyTables(IMvApplyContext ctx)
+    {
+        if (ctx is not IMvApplyTableBindings bindings ||
+            !bindings.TryGetPhysicalName("orders", out var orders) ||
+            !bindings.TryGetPhysicalName("items", out var items))
+        {
+            throw new InvalidOperationException(
+                "The native apply context did not provide the required own-table bindings for OrderSummary.");
+        }
+
+        return new ApplyTableNames(orders, items);
+    }
+
     private async Task<IReadOnlyList<MvSqlStatement>> ApplyItemAddedAsync(
         OrderItemAdded added,
+        ApplyTableNames tables,
         IMvApplyContext ctx,
         CancellationToken cancellationToken)
     {
         var orderExists = await ctx.ExecuteScalarAsync<int>(
-            $"SELECT COUNT(*) FROM {Orders.PhysicalName} WHERE id = @Id",
+            $"SELECT COUNT(*) FROM {tables.Orders} WHERE id = @Id",
             new { Id = added.OrderId },
             cancellationToken).ConfigureAwait(false);
 
@@ -114,15 +129,15 @@ public sealed class OrderSummaryMvV1 : IMaterializedViewProjector, IMvSchemaRequ
 
         return
         [
-            InsertItem(added, ctx.CurrentSortableUniqueId),
-            UpdateOrderTotal(added.OrderId, added.Quantity * added.UnitPrice, ctx.CurrentSortableUniqueId)
+            InsertItem(added, tables.Items, ctx.CurrentSortableUniqueId),
+            UpdateOrderTotal(added.OrderId, tables.Orders, added.Quantity * added.UnitPrice, ctx.CurrentSortableUniqueId)
         ];
     }
 
-    private MvSqlStatement UpsertOrder(OrderCreated created, string sortableUniqueId) =>
+    private MvSqlStatement UpsertOrder(OrderCreated created, string tableName, string sortableUniqueId) =>
         new(
             $"""
-             INSERT INTO {Orders.PhysicalName}
+             INSERT INTO {tableName}
                  (id, status, total, created_at, _last_sortable_unique_id, _last_applied_at)
              VALUES
                  (@OrderId, @Status, @Total, @CreatedAt, @SortableUniqueId, NOW())
@@ -132,7 +147,7 @@ public sealed class OrderSummaryMvV1 : IMaterializedViewProjector, IMvSchemaRequ
                  created_at = EXCLUDED.created_at,
                  _last_sortable_unique_id = EXCLUDED._last_sortable_unique_id,
                  _last_applied_at = EXCLUDED._last_applied_at
-             WHERE {Orders.PhysicalName}._last_sortable_unique_id < EXCLUDED._last_sortable_unique_id;
+             WHERE {tableName}._last_sortable_unique_id < EXCLUDED._last_sortable_unique_id;
              """,
             new
             {
@@ -143,10 +158,10 @@ public sealed class OrderSummaryMvV1 : IMaterializedViewProjector, IMvSchemaRequ
                 SortableUniqueId = sortableUniqueId
             });
 
-    private MvSqlStatement InsertItem(OrderItemAdded added, string sortableUniqueId) =>
+    private MvSqlStatement InsertItem(OrderItemAdded added, string tableName, string sortableUniqueId) =>
         new(
             $"""
-             INSERT INTO {Items.PhysicalName}
+             INSERT INTO {tableName}
                  (id, order_id, product_name, quantity, unit_price, _last_sortable_unique_id, _last_applied_at)
              VALUES
                  (@ItemId, @OrderId, @ProductName, @Quantity, @UnitPrice, @SortableUniqueId, NOW())
@@ -157,7 +172,7 @@ public sealed class OrderSummaryMvV1 : IMaterializedViewProjector, IMvSchemaRequ
                  unit_price = EXCLUDED.unit_price,
                  _last_sortable_unique_id = EXCLUDED._last_sortable_unique_id,
                  _last_applied_at = EXCLUDED._last_applied_at
-             WHERE {Items.PhysicalName}._last_sortable_unique_id < EXCLUDED._last_sortable_unique_id;
+             WHERE {tableName}._last_sortable_unique_id < EXCLUDED._last_sortable_unique_id;
              """,
             new
             {
@@ -169,10 +184,10 @@ public sealed class OrderSummaryMvV1 : IMaterializedViewProjector, IMvSchemaRequ
                 SortableUniqueId = sortableUniqueId
             });
 
-    private MvSqlStatement UpdateOrderTotal(Guid orderId, decimal delta, string sortableUniqueId) =>
+    private MvSqlStatement UpdateOrderTotal(Guid orderId, string tableName, decimal delta, string sortableUniqueId) =>
         new(
             $"""
-             UPDATE {Orders.PhysicalName}
+             UPDATE {tableName}
              SET total = total + @Delta,
                  _last_sortable_unique_id = @SortableUniqueId,
                  _last_applied_at = NOW()
@@ -186,10 +201,10 @@ public sealed class OrderSummaryMvV1 : IMaterializedViewProjector, IMvSchemaRequ
                 SortableUniqueId = sortableUniqueId
             });
 
-    private MvSqlStatement CancelOrder(OrderCancelled cancelled, string sortableUniqueId) =>
+    private MvSqlStatement CancelOrder(OrderCancelled cancelled, string tableName, string sortableUniqueId) =>
         new(
             $"""
-             UPDATE {Orders.PhysicalName}
+             UPDATE {tableName}
              SET status = @Status,
                  _last_sortable_unique_id = @SortableUniqueId,
                  _last_applied_at = NOW()
@@ -202,6 +217,8 @@ public sealed class OrderSummaryMvV1 : IMaterializedViewProjector, IMvSchemaRequ
                 Status = "Cancelled",
                 SortableUniqueId = sortableUniqueId
             });
+
+    private sealed record ApplyTableNames(string Orders, string Items);
 }
 
 public sealed record OrderRow(

--- a/dcb/internalUsages/Dcb.Domain.WithoutResult/MaterializedViews/OrderSummaryMvV1.cs
+++ b/dcb/internalUsages/Dcb.Domain.WithoutResult/MaterializedViews/OrderSummaryMvV1.cs
@@ -88,37 +88,22 @@ public sealed class OrderSummaryMvV1 : IMaterializedViewProjector, IMvSchemaRequ
         IMvApplyContext ctx,
         CancellationToken cancellationToken = default)
     {
-        var tables = RequireApplyTables(ctx);
         return ev.Payload switch
         {
-            OrderCreated created => [UpsertOrder(created, tables.Orders, ctx.CurrentSortableUniqueId)],
-            OrderItemAdded added => await ApplyItemAddedAsync(added, tables, ctx, cancellationToken).ConfigureAwait(false),
-            OrderCancelled cancelled => [CancelOrder(cancelled, tables.Orders, ctx.CurrentSortableUniqueId)],
+            OrderCreated created => [UpsertOrder(created, ctx.CurrentSortableUniqueId)],
+            OrderItemAdded added => await ApplyItemAddedAsync(added, ctx, cancellationToken).ConfigureAwait(false),
+            OrderCancelled cancelled => [CancelOrder(cancelled, ctx.CurrentSortableUniqueId)],
             _ => []
         };
     }
 
-    private static ApplyTableNames RequireApplyTables(IMvApplyContext ctx)
-    {
-        if (ctx is not IMvApplyTableBindings bindings ||
-            !bindings.TryGetPhysicalName("orders", out var orders) ||
-            !bindings.TryGetPhysicalName("items", out var items))
-        {
-            throw new InvalidOperationException(
-                "The native apply context did not provide the required own-table bindings for OrderSummary.");
-        }
-
-        return new ApplyTableNames(orders, items);
-    }
-
     private async Task<IReadOnlyList<MvSqlStatement>> ApplyItemAddedAsync(
         OrderItemAdded added,
-        ApplyTableNames tables,
         IMvApplyContext ctx,
         CancellationToken cancellationToken)
     {
         var orderExists = await ctx.ExecuteScalarAsync<int>(
-            $"SELECT COUNT(*) FROM {tables.Orders} WHERE id = @Id",
+            $"SELECT COUNT(*) FROM {Orders.PhysicalName} WHERE id = @Id",
             new { Id = added.OrderId },
             cancellationToken).ConfigureAwait(false);
 
@@ -129,15 +114,15 @@ public sealed class OrderSummaryMvV1 : IMaterializedViewProjector, IMvSchemaRequ
 
         return
         [
-            InsertItem(added, tables.Items, ctx.CurrentSortableUniqueId),
-            UpdateOrderTotal(added.OrderId, tables.Orders, added.Quantity * added.UnitPrice, ctx.CurrentSortableUniqueId)
+            InsertItem(added, ctx.CurrentSortableUniqueId),
+            UpdateOrderTotal(added.OrderId, added.Quantity * added.UnitPrice, ctx.CurrentSortableUniqueId)
         ];
     }
 
-    private MvSqlStatement UpsertOrder(OrderCreated created, string tableName, string sortableUniqueId) =>
+    private MvSqlStatement UpsertOrder(OrderCreated created, string sortableUniqueId) =>
         new(
             $"""
-             INSERT INTO {tableName}
+             INSERT INTO {Orders.PhysicalName}
                  (id, status, total, created_at, _last_sortable_unique_id, _last_applied_at)
              VALUES
                  (@OrderId, @Status, @Total, @CreatedAt, @SortableUniqueId, NOW())
@@ -147,7 +132,7 @@ public sealed class OrderSummaryMvV1 : IMaterializedViewProjector, IMvSchemaRequ
                  created_at = EXCLUDED.created_at,
                  _last_sortable_unique_id = EXCLUDED._last_sortable_unique_id,
                  _last_applied_at = EXCLUDED._last_applied_at
-             WHERE {tableName}._last_sortable_unique_id < EXCLUDED._last_sortable_unique_id;
+             WHERE {Orders.PhysicalName}._last_sortable_unique_id < EXCLUDED._last_sortable_unique_id;
              """,
             new
             {
@@ -158,10 +143,10 @@ public sealed class OrderSummaryMvV1 : IMaterializedViewProjector, IMvSchemaRequ
                 SortableUniqueId = sortableUniqueId
             });
 
-    private MvSqlStatement InsertItem(OrderItemAdded added, string tableName, string sortableUniqueId) =>
+    private MvSqlStatement InsertItem(OrderItemAdded added, string sortableUniqueId) =>
         new(
             $"""
-             INSERT INTO {tableName}
+             INSERT INTO {Items.PhysicalName}
                  (id, order_id, product_name, quantity, unit_price, _last_sortable_unique_id, _last_applied_at)
              VALUES
                  (@ItemId, @OrderId, @ProductName, @Quantity, @UnitPrice, @SortableUniqueId, NOW())
@@ -172,7 +157,7 @@ public sealed class OrderSummaryMvV1 : IMaterializedViewProjector, IMvSchemaRequ
                  unit_price = EXCLUDED.unit_price,
                  _last_sortable_unique_id = EXCLUDED._last_sortable_unique_id,
                  _last_applied_at = EXCLUDED._last_applied_at
-             WHERE {tableName}._last_sortable_unique_id < EXCLUDED._last_sortable_unique_id;
+             WHERE {Items.PhysicalName}._last_sortable_unique_id < EXCLUDED._last_sortable_unique_id;
              """,
             new
             {
@@ -184,10 +169,10 @@ public sealed class OrderSummaryMvV1 : IMaterializedViewProjector, IMvSchemaRequ
                 SortableUniqueId = sortableUniqueId
             });
 
-    private MvSqlStatement UpdateOrderTotal(Guid orderId, string tableName, decimal delta, string sortableUniqueId) =>
+    private MvSqlStatement UpdateOrderTotal(Guid orderId, decimal delta, string sortableUniqueId) =>
         new(
             $"""
-             UPDATE {tableName}
+             UPDATE {Orders.PhysicalName}
              SET total = total + @Delta,
                  _last_sortable_unique_id = @SortableUniqueId,
                  _last_applied_at = NOW()
@@ -201,10 +186,10 @@ public sealed class OrderSummaryMvV1 : IMaterializedViewProjector, IMvSchemaRequ
                 SortableUniqueId = sortableUniqueId
             });
 
-    private MvSqlStatement CancelOrder(OrderCancelled cancelled, string tableName, string sortableUniqueId) =>
+    private MvSqlStatement CancelOrder(OrderCancelled cancelled, string sortableUniqueId) =>
         new(
             $"""
-             UPDATE {tableName}
+             UPDATE {Orders.PhysicalName}
              SET status = @Status,
                  _last_sortable_unique_id = @SortableUniqueId,
                  _last_applied_at = NOW()
@@ -217,8 +202,6 @@ public sealed class OrderSummaryMvV1 : IMaterializedViewProjector, IMvSchemaRequ
                 Status = "Cancelled",
                 SortableUniqueId = sortableUniqueId
             });
-
-    private sealed record ApplyTableNames(string Orders, string Items);
 }
 
 public sealed record OrderRow(

--- a/dcb/src/Sekiban.Dcb.MaterializedView/MvApplyHostSupport.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView/MvApplyHostSupport.cs
@@ -1,4 +1,5 @@
 using System.Collections;
+using System.Collections.ObjectModel;
 using System.Reflection;
 using System.Text.Json;
 using Sekiban.Dcb.Domains;
@@ -44,6 +45,55 @@ public sealed class MvTableBindings : IMvTableBindings
         _logicalToPhysical[logicalName] = table.PhysicalName;
         _tableList.Add(table);
         return table;
+    }
+}
+
+internal sealed class MvOwnTableSnapshot : IMvApplyTableBindings
+{
+    private readonly IReadOnlyDictionary<string, string> _ownTables;
+
+    private MvOwnTableSnapshot(Dictionary<string, string> ownTables)
+    {
+        _ownTables = new ReadOnlyDictionary<string, string>(ownTables);
+    }
+
+    public IReadOnlyDictionary<string, string> OwnTables => _ownTables;
+
+    public bool TryGetPhysicalName(
+        string logicalName,
+        [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out string? physicalName) =>
+        _ownTables.TryGetValue(logicalName, out physicalName);
+
+    public static MvOwnTableSnapshot Capture(IMvTableBindings bindings)
+    {
+        ArgumentNullException.ThrowIfNull(bindings);
+
+        var owned = new Dictionary<string, string>(StringComparer.Ordinal);
+        if (bindings is MvTableBindings concreteBindings)
+        {
+            foreach (var table in concreteBindings.Tables)
+            {
+                Add(owned, table.LogicalName, table.PhysicalName);
+            }
+        }
+        else
+        {
+            foreach (var pair in bindings.LogicalToPhysical)
+            {
+                Add(owned, pair.Key, pair.Value);
+            }
+        }
+
+        return new MvOwnTableSnapshot(owned);
+    }
+
+    private static void Add(Dictionary<string, string> owned, string logicalName, string physicalName)
+    {
+        if (!owned.TryAdd(logicalName, physicalName))
+        {
+            throw new InvalidOperationException(
+                $"Duplicate materialized-view logical table binding '{logicalName}'.");
+        }
     }
 }
 
@@ -246,6 +296,7 @@ public sealed class NativeMvApplyHost : IMvApplyHost
         string sortableUniqueId,
         CancellationToken ct)
     {
+        var ownTableSnapshot = MvOwnTableSnapshot.Capture(tables);
         var eventResult = ev.ToEvent(_eventTypes);
         if (!eventResult.IsSuccess)
         {
@@ -256,7 +307,8 @@ public sealed class NativeMvApplyHost : IMvApplyHost
             eventResult.GetValue(),
             sortableUniqueId,
             queryPort,
-            _databaseType);
+            _databaseType,
+            ownTableSnapshot);
         var statements = await _projector.ApplyToViewAsync(eventResult.GetValue(), applyContext, ct).ConfigureAwait(false);
         return statements.Select(statement => new MvSqlStatementDto(statement.Sql, MvParamConverter.FromObject(statement.Parameters))).ToList();
     }
@@ -286,24 +338,32 @@ public sealed class NativeMvApplyHost : IMvApplyHost
         }
     }
 
-    private sealed class NativeMvApplyContextAdapter : IMvApplyContext
+    private sealed class NativeMvApplyContextAdapter : IMvApplyContext, IMvApplyTableBindings
     {
         private readonly MvDbType _databaseType;
         private readonly IMvApplyQueryPort _queryPort;
+        private readonly IMvApplyTableBindings _tableBindings;
 
         public NativeMvApplyContextAdapter(
             Event currentEvent,
             string sortableUniqueId,
             IMvApplyQueryPort queryPort,
-            MvDbType databaseType)
+            MvDbType databaseType,
+            IMvApplyTableBindings tableBindings)
         {
             CurrentEvent = currentEvent;
             CurrentSortableUniqueId = sortableUniqueId;
             _queryPort = queryPort;
             _databaseType = databaseType;
+            _tableBindings = tableBindings;
         }
 
         public MvDbType DatabaseType => _databaseType;
+        public IReadOnlyDictionary<string, string> OwnTables => _tableBindings.OwnTables;
+        public bool TryGetPhysicalName(
+            string logicalName,
+            [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out string? physicalName) =>
+            _tableBindings.TryGetPhysicalName(logicalName, out physicalName);
         public System.Data.IDbConnection Connection =>
             _queryPort is IMvApplyDbConnectionPort dbConnectionPort
                 ? dbConnectionPort.Connection

--- a/dcb/src/Sekiban.Dcb.MaterializedView/MvContracts.cs
+++ b/dcb/src/Sekiban.Dcb.MaterializedView/MvContracts.cs
@@ -1,4 +1,5 @@
 using System.Data;
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Sekiban.Dcb.Events;
@@ -179,6 +180,20 @@ public interface IMvTableBindings
     string GetPhysicalName(string logicalName);
     IReadOnlyDictionary<string, string> LogicalToPhysical { get; }
     MvTable RegisterTable(string logicalName, string? physicalName = null);
+}
+
+/// <summary>
+///     Additive apply-time capability exposing the immutable logical-to-physical bindings owned by the current
+///     invocation. Native hosts provide a fresh snapshot for every apply call; existing apply contexts remain valid
+///     without implementing this optional capability.
+/// </summary>
+public interface IMvApplyTableBindings
+{
+    IReadOnlyDictionary<string, string> OwnTables { get; }
+
+    bool TryGetPhysicalName(
+        string logicalName,
+        [NotNullWhen(true)] out string? physicalName);
 }
 
 public interface IMvApplyQueryPort

--- a/dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/MultiProviderFixtures.cs
+++ b/dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/MultiProviderFixtures.cs
@@ -33,6 +33,7 @@ public sealed class CrossProviderWeatherForecastMvV1 : IMaterializedViewProjecto
     public int ViewVersion => 1;
 
     public MvTable Forecasts { get; private set; } = default!;
+    public int InitializeCallCount { get; private set; }
 
     public IReadOnlyList<MvSchemaTableRequirement> GetSchemaRequirements(
         MvDbType databaseType,
@@ -56,6 +57,7 @@ public sealed class CrossProviderWeatherForecastMvV1 : IMaterializedViewProjecto
 
     public async Task InitializeAsync(IMvInitContext ctx, CancellationToken cancellationToken = default)
     {
+        InitializeCallCount++;
         Forecasts = ctx.RegisterTable("forecasts");
         await ctx.ExecuteAsync(CreateTableSql(ctx.DatabaseType, Forecasts.PhysicalName), cancellationToken: cancellationToken)
             .ConfigureAwait(false);
@@ -64,18 +66,28 @@ public sealed class CrossProviderWeatherForecastMvV1 : IMaterializedViewProjecto
     public Task<IReadOnlyList<MvSqlStatement>> ApplyToViewAsync(
         Event ev,
         IMvApplyContext ctx,
-        CancellationToken cancellationToken = default) =>
-        Task.FromResult<IReadOnlyList<MvSqlStatement>>(
+        CancellationToken cancellationToken = default)
+    {
+        if (ctx is not IMvApplyTableBindings bindings ||
+            !bindings.TryGetPhysicalName("forecasts", out var physicalName))
+        {
+            throw new InvalidOperationException(
+                "The native apply context did not provide the required own-table binding 'forecasts'.");
+        }
+
+        return Task.FromResult<IReadOnlyList<MvSqlStatement>>(
             ev.Payload switch
             {
-                WeatherForecastCreated created => [BuildUpsert(ctx.DatabaseType, created.ForecastId, created.Location, created.Date, created.TemperatureC, created.Summary, false, ctx.CurrentSortableUniqueId)],
-                WeatherForecastUpdated updated => [BuildUpsert(ctx.DatabaseType, updated.ForecastId, updated.Location, updated.Date, updated.TemperatureC, updated.Summary, false, ctx.CurrentSortableUniqueId)],
-                WeatherForecastDeleted deleted => [BuildDelete(ctx.DatabaseType, deleted.ForecastId, ctx.CurrentSortableUniqueId)],
+                WeatherForecastCreated created => [BuildUpsert(ctx.DatabaseType, physicalName, created.ForecastId, created.Location, created.Date, created.TemperatureC, created.Summary, false, ctx.CurrentSortableUniqueId)],
+                WeatherForecastUpdated updated => [BuildUpsert(ctx.DatabaseType, physicalName, updated.ForecastId, updated.Location, updated.Date, updated.TemperatureC, updated.Summary, false, ctx.CurrentSortableUniqueId)],
+                WeatherForecastDeleted deleted => [BuildDelete(ctx.DatabaseType, physicalName, deleted.ForecastId, ctx.CurrentSortableUniqueId)],
                 _ => []
             });
+    }
 
     private MvSqlStatement BuildUpsert(
         MvDbType dbType,
+        string tableName,
         Guid forecastId,
         string location,
         DateOnly date,
@@ -98,7 +110,7 @@ public sealed class CrossProviderWeatherForecastMvV1 : IMaterializedViewProjecto
         return new MvSqlStatement(dbType switch
         {
             MvDbType.Postgres => $"""
-                INSERT INTO {Forecasts.PhysicalName}
+                INSERT INTO {tableName}
                     (forecast_id, location, forecast_date, temperature_c, summary, is_deleted, _last_sortable_unique_id, _last_applied_at)
                 VALUES
                     (@ForecastId, @Location, @ForecastDate, @TemperatureC, @Summary, @IsDeleted, @SortableUniqueId, CURRENT_TIMESTAMP)
@@ -110,10 +122,10 @@ public sealed class CrossProviderWeatherForecastMvV1 : IMaterializedViewProjecto
                     is_deleted = EXCLUDED.is_deleted,
                     _last_sortable_unique_id = EXCLUDED._last_sortable_unique_id,
                     _last_applied_at = CURRENT_TIMESTAMP
-                WHERE {Forecasts.PhysicalName}._last_sortable_unique_id < EXCLUDED._last_sortable_unique_id;
+                WHERE {tableName}._last_sortable_unique_id < EXCLUDED._last_sortable_unique_id;
                 """,
             MvDbType.SqlServer => $"""
-                MERGE {Forecasts.PhysicalName} AS target
+                MERGE {tableName} AS target
                 USING (
                     SELECT
                         @ForecastId AS forecast_id,
@@ -139,7 +151,7 @@ public sealed class CrossProviderWeatherForecastMvV1 : IMaterializedViewProjecto
                     VALUES (source.forecast_id, source.location, source.forecast_date, source.temperature_c, source.summary, source.is_deleted, source._last_sortable_unique_id, SYSUTCDATETIME());
                 """,
             MvDbType.MySql => $"""
-                INSERT INTO {Forecasts.PhysicalName}
+                INSERT INTO {tableName}
                     (forecast_id, location, forecast_date, temperature_c, summary, is_deleted, _last_sortable_unique_id, _last_applied_at)
                 VALUES
                     (@ForecastId, @Location, @ForecastDate, @TemperatureC, @Summary, @IsDeleted, @SortableUniqueId, CURRENT_TIMESTAMP(6))
@@ -153,7 +165,7 @@ public sealed class CrossProviderWeatherForecastMvV1 : IMaterializedViewProjecto
                     _last_applied_at = IF(_last_sortable_unique_id < VALUES(_last_sortable_unique_id), CURRENT_TIMESTAMP(6), _last_applied_at);
                 """,
             MvDbType.Sqlite => $"""
-                INSERT INTO {Forecasts.PhysicalName}
+                INSERT INTO {tableName}
                     (forecast_id, location, forecast_date, temperature_c, summary, is_deleted, _last_sortable_unique_id, _last_applied_at)
                 VALUES
                     (@ForecastId, @Location, @ForecastDate, @TemperatureC, @Summary, @IsDeleted, @SortableUniqueId, CURRENT_TIMESTAMP)
@@ -165,7 +177,7 @@ public sealed class CrossProviderWeatherForecastMvV1 : IMaterializedViewProjecto
                     is_deleted = excluded.is_deleted,
                     _last_sortable_unique_id = excluded._last_sortable_unique_id,
                     _last_applied_at = CURRENT_TIMESTAMP
-                WHERE {Forecasts.PhysicalName}._last_sortable_unique_id < excluded._last_sortable_unique_id;
+                WHERE {tableName}._last_sortable_unique_id < excluded._last_sortable_unique_id;
                 """,
             _ => throw new NotSupportedException($"Database type '{dbType}' is not supported.")
         }, parameters);
@@ -228,11 +240,11 @@ public sealed class CrossProviderWeatherForecastMvV1 : IMaterializedViewProjecto
             _ => throw new NotSupportedException($"Database type '{dbType}' is not supported.")
         };
 
-    private MvSqlStatement BuildDelete(MvDbType dbType, Guid forecastId, string sortableUniqueId) =>
+    private MvSqlStatement BuildDelete(MvDbType dbType, string tableName, Guid forecastId, string sortableUniqueId) =>
         new(dbType switch
         {
             MvDbType.Postgres => $"""
-                UPDATE {Forecasts.PhysicalName}
+                UPDATE {tableName}
                 SET is_deleted = TRUE,
                     _last_sortable_unique_id = @SortableUniqueId,
                     _last_applied_at = CURRENT_TIMESTAMP
@@ -240,7 +252,7 @@ public sealed class CrossProviderWeatherForecastMvV1 : IMaterializedViewProjecto
                   AND _last_sortable_unique_id < @SortableUniqueId;
                 """,
             MvDbType.SqlServer => $"""
-                UPDATE {Forecasts.PhysicalName}
+                UPDATE {tableName}
                 SET is_deleted = 1,
                     _last_sortable_unique_id = @SortableUniqueId,
                     _last_applied_at = SYSUTCDATETIME()
@@ -248,7 +260,7 @@ public sealed class CrossProviderWeatherForecastMvV1 : IMaterializedViewProjecto
                   AND _last_sortable_unique_id < @SortableUniqueId;
                 """,
             MvDbType.MySql => $"""
-                UPDATE {Forecasts.PhysicalName}
+                UPDATE {tableName}
                 SET is_deleted = TRUE,
                     _last_sortable_unique_id = @SortableUniqueId,
                     _last_applied_at = CURRENT_TIMESTAMP(6)
@@ -256,7 +268,7 @@ public sealed class CrossProviderWeatherForecastMvV1 : IMaterializedViewProjecto
                   AND _last_sortable_unique_id < @SortableUniqueId;
                 """,
             MvDbType.Sqlite => $"""
-                UPDATE {Forecasts.PhysicalName}
+                UPDATE {tableName}
                 SET is_deleted = 1,
                     _last_sortable_unique_id = @SortableUniqueId,
                     _last_applied_at = CURRENT_TIMESTAMP

--- a/dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/MultiProviderFixtures.cs
+++ b/dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/MultiProviderFixtures.cs
@@ -34,6 +34,7 @@ public sealed class CrossProviderWeatherForecastMvV1 : IMaterializedViewProjecto
 
     public MvTable Forecasts { get; private set; } = default!;
     public int InitializeCallCount { get; private set; }
+    public int ApplyCallCount { get; private set; }
 
     public IReadOnlyList<MvSchemaTableRequirement> GetSchemaRequirements(
         MvDbType databaseType,
@@ -68,6 +69,7 @@ public sealed class CrossProviderWeatherForecastMvV1 : IMaterializedViewProjecto
         IMvApplyContext ctx,
         CancellationToken cancellationToken = default)
     {
+        ApplyCallCount++;
         if (ctx is not IMvApplyTableBindings bindings ||
             !bindings.TryGetPhysicalName("forecasts", out var physicalName))
         {

--- a/dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/MvFreshProjectorApplyTests.cs
+++ b/dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/MvFreshProjectorApplyTests.cs
@@ -1,0 +1,221 @@
+using Dapper;
+using Dcb.Domain.WithoutResult;
+using Dcb.Domain.WithoutResult.Weather;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Sekiban.Dcb;
+using Sekiban.Dcb.Common;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.MaterializedView;
+using Sekiban.Dcb.MaterializedView.Postgres;
+using Sekiban.Dcb.MaterializedView.SqlServer;
+using Sekiban.Dcb.Storage;
+using Xunit;
+
+namespace Sekiban.Dcb.MaterializedView.MultiProvider.Tests;
+
+public sealed record FreshProjectorBindingScenario(string Name)
+{
+    public override string ToString() => Name;
+}
+
+[Collection(nameof(PostgresMvCollection))]
+public sealed class PostgresMvFreshProjectorApplyTests(PostgresMvFixture fixture)
+{
+    [SkippableTheory]
+    [InlineData("default")]
+    [InlineData("prefix")]
+    [InlineData("resolver")]
+    [InlineData("explicit")]
+    public Task FreshProjector_VerifyAndExecuteUsesApplyTimeOwnTables(string scenario) =>
+        FreshProjectorApplyAssertions.AssertAsync(fixture, new FreshProjectorBindingScenario(scenario));
+}
+
+[Collection(nameof(SqlServerMvCollection))]
+public sealed class SqlServerMvFreshProjectorApplyTests(SqlServerMvFixture fixture)
+{
+    [SkippableTheory]
+    [InlineData("default")]
+    [InlineData("prefix")]
+    [InlineData("resolver")]
+    [InlineData("explicit")]
+    public Task FreshProjector_VerifyAndExecuteUsesApplyTimeOwnTables(string scenario) =>
+        FreshProjectorApplyAssertions.AssertAsync(fixture, new FreshProjectorBindingScenario(scenario));
+}
+
+internal static class FreshProjectorApplyAssertions
+{
+    private const string ViewName = "WeatherForecastPortable";
+    private const int Version = 1;
+
+    public static async Task AssertAsync(
+        MultiProviderFixtureBase fixture,
+        FreshProjectorBindingScenario scenario)
+    {
+        Skip.IfNot(fixture.IsAvailable, fixture.AvailabilityMessage ?? "Integration fixture is unavailable.");
+
+        var preparationOptions = CreateOptions(scenario);
+        preparationOptions.InitializationMode = MvInitializationMode.CreateOrEnsure;
+        var tableName = MvPhysicalName.Resolve(preparationOptions, ViewName, Version, "forecasts");
+        await fixture.ResetAsync().ConfigureAwait(false);
+        await DropTableAsync(fixture, tableName).ConfigureAwait(false);
+
+        var storageInfo = fixture.Services.GetRequiredService<IMvStorageInfoProvider>().GetStorageInfo();
+        using (var preparationProvider = CreateProjectorProvider(storageInfo))
+        {
+            var preparationProjector = preparationProvider.GetRequiredService<CrossProviderWeatherForecastMvV1>();
+            var preparationFactory = preparationProvider.GetRequiredService<IMvApplyHostFactory>();
+            var preparationHost = preparationFactory.Create(
+                ViewName,
+                Version);
+            var preparationExecutor = CreateExecutor(fixture, preparationOptions);
+
+            await preparationExecutor.InitializeAsync(preparationHost).ConfigureAwait(false);
+            Assert.Equal(1, preparationProjector.InitializeCallCount);
+        }
+
+        var serializableEvent = CreateEvent(fixture);
+        var writeResult = await fixture.EventStore.WriteSerializableEventsAsync([serializableEvent]).ConfigureAwait(false);
+        Assert.True(writeResult.IsSuccess, writeResult.IsSuccess ? string.Empty : writeResult.GetException().Message);
+
+        using (var executionProvider = CreateProjectorProvider(storageInfo))
+        {
+            var executionProjector = executionProvider.GetRequiredService<CrossProviderWeatherForecastMvV1>();
+            var executionFactory = executionProvider.GetRequiredService<IMvApplyHostFactory>();
+            var executionHost = executionFactory.Create(
+                ViewName,
+                Version);
+            var executionOptions = CreateOptions(scenario);
+            executionOptions.InitializationMode = MvInitializationMode.VerifyAndExecute;
+            executionOptions.SqlStatementPolicyMode = MvSqlStatementPolicyMode.Enforced;
+            executionOptions.SqlStatementPolicy = PermitAllPolicy.Instance;
+            if (fixture.DatabaseTypeForTests == MvDbType.SqlServer)
+            {
+                executionOptions.SqlServerInspectionConnectionString =
+                    fixture.InspectionConnectionStringForTests;
+            }
+            var executionExecutor = CreateExecutor(fixture, executionOptions);
+
+            var applied = await executionExecutor.ApplySerializableEventsAsync(
+                    executionHost,
+                    [serializableEvent],
+                    MultiProviderFixtureBase.ServiceId)
+                .ConfigureAwait(false);
+
+            Assert.Equal(1, applied);
+            Assert.Equal(0, executionProjector.InitializeCallCount);
+
+            var registryStore = fixture.Services.GetRequiredService<IMvRegistryStore>();
+            var entry = Assert.Single(await registryStore.GetEntriesAsync(
+                    MultiProviderFixtureBase.ServiceId,
+                    ViewName,
+                    Version)
+                .ConfigureAwait(false));
+            Assert.Equal(tableName, entry.PhysicalTable);
+            Assert.Equal(serializableEvent.SortableUniqueIdValue, entry.CurrentCheckpointTruth.PositionValue);
+
+            await using var connection = await fixture.OpenConnectionAsync().ConfigureAwait(false);
+            var rowCount = await connection.ExecuteScalarAsync<long>(
+                    $"SELECT COUNT(*) FROM {entry.PhysicalTable} WHERE forecast_id = @ForecastId;",
+                    new { ForecastId = ForecastId.ToString("D") })
+                .ConfigureAwait(false);
+            Assert.Equal(1, rowCount);
+        }
+    }
+
+    private static ServiceProvider CreateProjectorProvider(MvStorageInfo storageInfo)
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton(DomainType.GetDomainTypes());
+        services.AddSingleton<IMvStorageInfoProvider>(new FixedStorageInfoProvider(storageInfo));
+        services.AddSekibanDcbMaterializedView();
+        services.AddMaterializedView<CrossProviderWeatherForecastMvV1>();
+        return services.BuildServiceProvider();
+    }
+
+    private static IMvExecutor CreateExecutor(MultiProviderFixtureBase fixture, MvOptions options) =>
+        fixture.DatabaseTypeForTests switch
+        {
+            MvDbType.Postgres => new PostgresMvExecutor(
+                fixture.EventStoreFactory,
+                new PostgresMvRegistryStore(fixture.ConnectionStringForTests),
+                Options.Create(options),
+                NullLogger<PostgresMvExecutor>.Instance,
+                fixture.ConnectionStringForTests),
+            MvDbType.SqlServer => new SqlServerMvExecutor(
+                fixture.EventStoreFactory,
+                new SqlServerMvRegistryStore(
+                    fixture.ConnectionStringForTests,
+                    null,
+                    null,
+                    options.SqlServerInspectionConnectionString),
+                Options.Create(options),
+                NullLogger<SqlServerMvExecutor>.Instance,
+                fixture.ConnectionStringForTests),
+            _ => throw new NotSupportedException($"Unsupported provider '{fixture.DatabaseTypeForTests}'.")
+        };
+
+    private static MvOptions CreateOptions(FreshProjectorBindingScenario scenario) =>
+        new()
+        {
+            ServiceId = MultiProviderFixtureBase.ServiceId,
+            SafeWindowMs = 0,
+            TablePrefix = scenario.Name == "prefix" ? "g73_custom_prefix" : MvOptions.DefaultTablePrefix,
+            PhysicalNameResolver = scenario.Name switch
+            {
+                "resolver" => (_, _, logical) => $"g73_resolved_{logical}",
+                "explicit" => (_, _, _) => "g73_explicit_forecasts",
+                _ => null
+            }
+        };
+
+    private static readonly Guid ForecastId = Guid.Parse("cccccccc-cccc-cccc-cccc-cccccccccccc");
+
+    private static SerializableEvent CreateEvent(MultiProviderFixtureBase fixture)
+    {
+        var eventId = Guid.Parse("dddddddd-dddd-dddd-dddd-dddddddddddd");
+        var value = new Event(
+            new WeatherForecastCreated(
+                ForecastId,
+                "G73",
+                new DateOnly(2026, 9, 10),
+                21,
+                "Own table binding"),
+            SortableUniqueId.Generate(DateTime.UtcNow.AddMinutes(-1), eventId),
+            nameof(WeatherForecastCreated),
+            eventId,
+            new EventMetadata("g73", "g73", "fresh-projector"),
+            []);
+        return value.ToSerializableEvent(fixture.DomainTypes.EventTypes);
+    }
+
+    private static async Task DropTableAsync(MultiProviderFixtureBase fixture, string tableName)
+    {
+        if (tableName == MultiProviderFixtureBase.ForecastTable)
+        {
+            return;
+        }
+
+        await using var connection = await fixture.OpenConnectionAsync().ConfigureAwait(false);
+        var sql = fixture.DatabaseTypeForTests == MvDbType.SqlServer
+            ? $"IF OBJECT_ID(N'{tableName}', N'U') IS NOT NULL DROP TABLE {tableName};"
+            : $"DROP TABLE IF EXISTS {tableName};";
+        await connection.ExecuteAsync(sql).ConfigureAwait(false);
+    }
+
+    private sealed class FixedStorageInfoProvider(MvStorageInfo storageInfo) : IMvStorageInfoProvider
+    {
+        public MvStorageInfo GetStorageInfo() => storageInfo;
+    }
+
+    private sealed class PermitAllPolicy : IMvSqlStatementPolicy
+    {
+        public static PermitAllPolicy Instance { get; } = new();
+
+        public ValueTask<MvSqlPolicyDecision> EvaluateAsync(
+            MvSqlStatementContext context,
+            CancellationToken cancellationToken = default) =>
+            ValueTask.FromResult(MvSqlPolicyDecision.Allow());
+    }
+}

--- a/dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/MvFreshProjectorApplyTests.cs
+++ b/dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/MvFreshProjectorApplyTests.cs
@@ -89,7 +89,9 @@ internal static class FreshProjectorApplyAssertions
             var executionOptions = CreateOptions(scenario);
             executionOptions.InitializationMode = MvInitializationMode.VerifyAndExecute;
             executionOptions.SqlStatementPolicyMode = MvSqlStatementPolicyMode.Enforced;
-            executionOptions.SqlStatementPolicy = PermitAllPolicy.Instance;
+            executionOptions.SqlStatementPolicy = new OwnTablesOnlyPolicy();
+            var executionAudit = new VerifiedBatchExecutionAudit();
+            executionOptions.ExecutionObserver = executionAudit;
             if (fixture.DatabaseTypeForTests == MvDbType.SqlServer)
             {
                 executionOptions.SqlServerInspectionConnectionString =
@@ -105,6 +107,12 @@ internal static class FreshProjectorApplyAssertions
 
             Assert.Equal(1, applied);
             Assert.Equal(0, executionProjector.InitializeCallCount);
+            Assert.Equal(1, executionProjector.ApplyCallCount);
+            Assert.Equal(1, executionAudit.TransactionCommitCount);
+            Assert.NotEmpty(executionAudit.ProjectorCommandExecutionAttempts);
+            Assert.All(
+                executionAudit.ProjectorCommandExecutionAttempts,
+                sql => Assert.Contains(tableName, sql, StringComparison.OrdinalIgnoreCase));
 
             var registryStore = fixture.Services.GetRequiredService<IMvRegistryStore>();
             var entry = Assert.Single(await registryStore.GetEntriesAsync(
@@ -209,13 +217,4 @@ internal static class FreshProjectorApplyAssertions
         public MvStorageInfo GetStorageInfo() => storageInfo;
     }
 
-    private sealed class PermitAllPolicy : IMvSqlStatementPolicy
-    {
-        public static PermitAllPolicy Instance { get; } = new();
-
-        public ValueTask<MvSqlPolicyDecision> EvaluateAsync(
-            MvSqlStatementContext context,
-            CancellationToken cancellationToken = default) =>
-            ValueTask.FromResult(MvSqlPolicyDecision.Allow());
-    }
 }

--- a/dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/MvG73AcceptanceTests.cs
+++ b/dcb/tests/Sekiban.Dcb.MaterializedView.MultiProvider.Tests/MvG73AcceptanceTests.cs
@@ -1,0 +1,488 @@
+using System.Data;
+using Dapper;
+using Dcb.Domain.WithoutResult;
+using Dcb.Domain.WithoutResult.Weather;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Sekiban.Dcb.Common;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.MaterializedView;
+using Sekiban.Dcb.MaterializedView.Postgres;
+using Sekiban.Dcb.MaterializedView.SqlServer;
+using Sekiban.Dcb.Storage;
+using Xunit;
+
+namespace Sekiban.Dcb.MaterializedView.MultiProvider.Tests;
+
+public sealed record G73PreparedCase(
+    CrossProviderWeatherForecastMvV1 Projector,
+    NativeMvApplyHost Host,
+    MvOptions Options,
+    string TableName,
+    string ServiceId);
+
+[Collection(nameof(PostgresMvCollection))]
+public sealed class PostgresMvG73AcceptanceTests(PostgresMvFixture fixture)
+{
+    [SkippableFact]
+    public Task RegistryMismatch_FailsClosedBeforeApply() => G73AcceptanceAssertions.RegistryMismatchAsync(fixture);
+
+    [SkippableFact]
+    public Task VerifyOnly_AfterSuccessfulVerification_RefusesBeforeApply() => G73AcceptanceAssertions.VerifyOnlyAsync(fixture);
+
+    [SkippableFact]
+    public Task AbsentSchema_FailsVerificationBeforeProjectorApply() => G73AcceptanceAssertions.AbsentSchemaAsync(fixture);
+
+    [SkippableFact]
+    public Task InvalidPolicy_FailsBeforeRegistryOrProjectorEffects() => G73AcceptanceAssertions.InvalidPolicyAsync(fixture);
+
+    [SkippableFact]
+    public Task PositiveControls_RecordProvisioningAndReadOnlyVerification() => G73AcceptanceAssertions.PositiveControlsAsync(fixture);
+
+    [SkippableFact]
+    public Task VerifyAndExecute_MultiEventBatchUsesWholeBatchPath() => G73AcceptanceAssertions.MultiEventBatchAsync(fixture);
+
+    [SkippableFact]
+    public Task CreateOrEnsure_ExplicitApplyUsesLegacyPerEventPath() => G73AcceptanceAssertions.CreateOrEnsureApplyAsync(fixture);
+
+    [SkippableFact]
+    public Task IndependentViewsKeepOwnBindingsAndCheckpoints() => G73AcceptanceAssertions.IndependentViewsAsync(fixture);
+}
+
+[Collection(nameof(SqlServerMvCollection))]
+public sealed class SqlServerMvG73AcceptanceTests(SqlServerMvFixture fixture)
+{
+    [SkippableFact]
+    public Task RegistryMismatch_FailsClosedBeforeApply() => G73AcceptanceAssertions.RegistryMismatchAsync(fixture);
+
+    [SkippableFact]
+    public Task VerifyOnly_AfterSuccessfulVerification_RefusesBeforeApply() => G73AcceptanceAssertions.VerifyOnlyAsync(fixture);
+
+    [SkippableFact]
+    public Task AbsentSchema_FailsVerificationBeforeProjectorApply() => G73AcceptanceAssertions.AbsentSchemaAsync(fixture);
+
+    [SkippableFact]
+    public Task InvalidPolicy_FailsBeforeRegistryOrProjectorEffects() => G73AcceptanceAssertions.InvalidPolicyAsync(fixture);
+
+    [SkippableFact]
+    public Task PositiveControls_RecordProvisioningAndReadOnlyVerification() => G73AcceptanceAssertions.PositiveControlsAsync(fixture);
+
+    [SkippableFact]
+    public Task VerifyAndExecute_MultiEventBatchUsesWholeBatchPath() => G73AcceptanceAssertions.MultiEventBatchAsync(fixture);
+
+    [SkippableFact]
+    public Task CreateOrEnsure_ExplicitApplyUsesLegacyPerEventPath() => G73AcceptanceAssertions.CreateOrEnsureApplyAsync(fixture);
+
+    [SkippableFact]
+    public Task IndependentViewsKeepOwnBindingsAndCheckpoints() => G73AcceptanceAssertions.IndependentViewsAsync(fixture);
+}
+
+internal static class G73AcceptanceAssertions
+{
+    private const string ViewName = "WeatherForecastPortable";
+    private const int ViewVersion = 1;
+    private const string DefaultServiceId = MultiProviderFixtureBase.ServiceId;
+
+    public static async Task RegistryMismatchAsync(MultiProviderFixtureBase fixture)
+    {
+        var prepared = await PrepareAsync(fixture).ConfigureAwait(false);
+        await using (var connection = await fixture.OpenConnectionAsync().ConfigureAwait(false))
+        {
+            await connection.ExecuteAsync(
+                "UPDATE sekiban_mv_registry SET physical_table = @PhysicalTable WHERE service_id = @ServiceId AND view_name = @ViewName AND view_version = @ViewVersion;",
+                new { PhysicalTable = prepared.TableName + "_wrong", ServiceId = prepared.ServiceId, ViewName, ViewVersion })
+                .ConfigureAwait(false);
+        }
+
+        var audit = new VerifiedBatchExecutionAudit();
+        var registry = new CountingRegistryStore(CreateStore(fixture));
+        var executor = CreateExecutor(fixture, CreateOptions(prepared.ServiceId, MvInitializationMode.VerifyAndExecute, audit), registry);
+        var host = CreateHost(fixture);
+        var exception = await Assert.ThrowsAsync<MvInitializationException>(() => executor.ApplySerializableEventsAsync(
+                host,
+                [CreateEvent(fixture, 0)],
+                prepared.ServiceId))
+            .ConfigureAwait(false);
+
+        Assert.Equal(MvInitializationFailureReason.MissingSchemaContract, exception.Failure.Reason);
+        Assert.Contains(exception.Failure.Mismatches, mismatch => mismatch.Code == MvSchemaMismatchCode.BindingMismatch);
+        Assert.Equal(0, registry.EnsureCalls);
+        Assert.Empty(audit.ProjectorCommandExecutionAttempts);
+        Assert.Equal(0, audit.TransactionCommitCount);
+    }
+
+    public static async Task VerifyOnlyAsync(MultiProviderFixtureBase fixture)
+    {
+        var prepared = await PrepareAsync(fixture).ConfigureAwait(false);
+        var audit = new VerifiedBatchExecutionAudit();
+        var registry = new CountingRegistryStore(CreateStore(fixture));
+        var options = CreateOptions(prepared.ServiceId, MvInitializationMode.VerifyOnly, audit);
+        var executor = CreateExecutor(fixture, options, registry);
+        var host = CreateHost(fixture);
+
+        await executor.InitializeAsync(host, prepared.ServiceId).ConfigureAwait(false);
+        Assert.True(registry.VerifySchemaCalls > 0);
+        var exception = await Assert.ThrowsAsync<MvTransitionNotAllowedException>(() => executor.ApplySerializableEventsAsync(
+                host,
+                [CreateEvent(fixture, 0)],
+                prepared.ServiceId))
+            .ConfigureAwait(false);
+
+        Assert.Equal(MvTransitionNotAllowedReason.VerifyOnly, exception.Reason);
+        Assert.Equal(0, registry.EnsureCalls);
+        Assert.Empty(audit.ProjectorCommandExecutionAttempts);
+        Assert.Equal(0, audit.TransactionCommitCount);
+    }
+
+    public static async Task AbsentSchemaAsync(MultiProviderFixtureBase fixture)
+    {
+        var prepared = await PrepareAsync(fixture).ConfigureAwait(false);
+        await using (var connection = await fixture.OpenConnectionAsync().ConfigureAwait(false))
+        {
+            var drop = fixture.DatabaseTypeForTests == MvDbType.SqlServer
+                ? $"IF OBJECT_ID(N'{prepared.TableName}', N'U') IS NOT NULL DROP TABLE {prepared.TableName};"
+                : $"DROP TABLE IF EXISTS {prepared.TableName};";
+            await connection.ExecuteAsync(drop).ConfigureAwait(false);
+        }
+
+        var audit = new VerifiedBatchExecutionAudit();
+        var registry = new CountingRegistryStore(CreateStore(fixture));
+        var executor = CreateExecutor(fixture, CreateOptions(prepared.ServiceId, MvInitializationMode.VerifyAndExecute, audit), registry);
+        var exception = await Assert.ThrowsAsync<MvInitializationException>(() => executor.ApplySerializableEventsAsync(
+                CreateHost(fixture),
+                [CreateEvent(fixture, 0)],
+                prepared.ServiceId))
+            .ConfigureAwait(false);
+
+        Assert.Equal(MvInitializationFailureReason.MissingSchemaObject, exception.Failure.Reason);
+        Assert.Equal(0, registry.EnsureCalls);
+        Assert.Empty(audit.ProjectorCommandExecutionAttempts);
+        Assert.Equal(0, audit.TransactionCommitCount);
+    }
+
+    public static async Task InvalidPolicyAsync(MultiProviderFixtureBase fixture)
+    {
+        var prepared = await PrepareAsync(fixture).ConfigureAwait(false);
+        var audit = new VerifiedBatchExecutionAudit();
+        var registry = new CountingRegistryStore(CreateStore(fixture));
+        var options = CreateOptions(prepared.ServiceId, MvInitializationMode.VerifyAndExecute, audit);
+        options.SqlStatementPolicyMode = MvSqlStatementPolicyMode.Legacy;
+        options.SqlStatementPolicy = MvAllowAllSqlStatementPolicy.Instance;
+        var executor = CreateExecutor(fixture, options, registry);
+        var exception = await Assert.ThrowsAsync<MvVerifiedExecutionConfigurationException>(() => executor.ApplySerializableEventsAsync(
+                CreateHost(fixture),
+                [CreateEvent(fixture, 0)],
+                prepared.ServiceId))
+            .ConfigureAwait(false);
+
+        Assert.Equal(0, registry.EnsureCalls);
+        Assert.Empty(audit.ProjectorCommandExecutionAttempts);
+        Assert.Equal(0, audit.TransactionCommitCount);
+        Assert.Equal(MvTransitionNotAllowedReason.VerifiedExecutionPolicyRequired, exception.Reason);
+    }
+
+    public static async Task PositiveControlsAsync(MultiProviderFixtureBase fixture)
+    {
+        await fixture.ResetAsync().ConfigureAwait(false);
+        var createAudit = new VerifiedBatchExecutionAudit();
+        var createRegistry = new CountingRegistryStore(CreateStore(fixture));
+        var createOptions = CreateOptions(DefaultServiceId, MvInitializationMode.CreateOrEnsure, createAudit);
+        var createProjector = new CrossProviderWeatherForecastMvV1();
+        var createHost = new NativeMvApplyHost(createProjector, fixture.DomainTypes.EventTypes, fixture.DatabaseTypeForTests);
+        var createExecutor = CreateExecutor(fixture, createOptions, createRegistry);
+        await createExecutor.InitializeAsync(createHost, DefaultServiceId).ConfigureAwait(false);
+
+        Assert.True(createRegistry.EnsureCalls > 0);
+        Assert.Equal(1, createProjector.InitializeCallCount);
+        Assert.True(createAudit.ProjectorCommandExecutionAttempts.Count > 0);
+        Assert.Equal(1, createAudit.TransactionCommitCount);
+
+        var verifyRegistry = new CountingRegistryStore(CreateStore(fixture));
+        var verifyExecutor = CreateExecutor(
+            fixture,
+            CreateOptions(DefaultServiceId, MvInitializationMode.VerifyOnly, new VerifiedBatchExecutionAudit()),
+            verifyRegistry);
+        var verification = await ((IMvInitializationVerifier)verifyExecutor).VerifyInitializationAsync(
+                CreateHost(fixture),
+                DefaultServiceId)
+            .ConfigureAwait(false);
+        Assert.True(verification.IsCompatible, verification.ToString());
+        Assert.True(verifyRegistry.VerifySchemaCalls > 0);
+        Assert.Equal(0, verifyRegistry.EnsureCalls);
+    }
+
+    public static async Task MultiEventBatchAsync(MultiProviderFixtureBase fixture)
+    {
+        var prepared = await PrepareAsync(fixture).ConfigureAwait(false);
+        var audit = new VerifiedBatchExecutionAudit();
+        var policy = new OwnTablesOnlyPolicy();
+        var options = CreateOptions(prepared.ServiceId, MvInitializationMode.VerifyAndExecute, audit);
+        options.SqlStatementPolicy = policy;
+        options.SqlStatementPolicyMode = MvSqlStatementPolicyMode.Enforced;
+        var executor = CreateExecutor(fixture, options, CreateStore(fixture));
+        var result = await executor.ApplySerializableEventsAsync(
+                CreateHost(fixture),
+                [CreateEvent(fixture, 0), CreateEvent(fixture, 1)],
+                prepared.ServiceId)
+            .ConfigureAwait(false);
+
+        Assert.Equal(2, result);
+        Assert.Equal(1, audit.TransactionCommitCount);
+        Assert.Equal(2, audit.ProjectorCommandExecutionAttempts.Count);
+        Assert.All(policy.Contexts, context => Assert.Contains(prepared.TableName, context.Sql, StringComparison.OrdinalIgnoreCase));
+        var wrongTable = await policy.EvaluateAsync(
+                new MvSqlStatementContext(
+                    prepared.ServiceId,
+                    ViewName,
+                    ViewVersion,
+                    MvSqlStatementPhase.Apply,
+                    [new MvTable("forecasts", prepared.TableName, ViewName, ViewVersion)],
+                    "UPDATE g73_wrong_table SET value = 1",
+                    []))
+            .ConfigureAwait(false);
+        Assert.False(wrongTable.IsAllowed);
+        await using var connection = await fixture.OpenConnectionAsync().ConfigureAwait(false);
+        Assert.Equal(2, await connection.ExecuteScalarAsync<long>($"SELECT COUNT(*) FROM {prepared.TableName};").ConfigureAwait(false));
+    }
+
+    public static async Task CreateOrEnsureApplyAsync(MultiProviderFixtureBase fixture)
+    {
+        await fixture.ResetAsync().ConfigureAwait(false);
+        var audit = new VerifiedBatchExecutionAudit();
+        var options = CreateOptions(DefaultServiceId, MvInitializationMode.CreateOrEnsure, audit);
+        var projector = new CrossProviderWeatherForecastMvV1();
+        var host = new NativeMvApplyHost(projector, fixture.DomainTypes.EventTypes, fixture.DatabaseTypeForTests);
+        var executor = CreateExecutor(fixture, options, CreateStore(fixture));
+        await executor.InitializeAsync(host, DefaultServiceId).ConfigureAwait(false);
+        var result = await executor.ApplySerializableEventsAsync(host, [CreateEvent(fixture, 0)], DefaultServiceId).ConfigureAwait(false);
+
+        Assert.Equal(1, result);
+        Assert.True(audit.ProjectorCommandExecutionAttempts.Count > 0);
+        Assert.True(audit.TransactionCommitCount >= 2);
+        Assert.Equal(1, projector.InitializeCallCount);
+    }
+
+    public static async Task IndependentViewsAsync(MultiProviderFixtureBase fixture)
+    {
+        await fixture.ResetAsync().ConfigureAwait(false);
+        var first = await PrepareAsync(fixture, "g73-view-a", "g73_a", reset: false).ConfigureAwait(false);
+        var second = await PrepareAsync(fixture, "g73-view-b", "g73_b", reset: false).ConfigureAwait(false);
+        var firstResult = await CreateExecutor(fixture, CreateOptions(first.ServiceId, MvInitializationMode.CreateOrEnsure, null), CreateStore(fixture))
+            .ApplySerializableEventsAsync(CreateHost(fixture), [CreateEvent(fixture, 0)], first.ServiceId)
+            .ConfigureAwait(false);
+        var secondResult = await CreateExecutor(fixture, CreateOptions(second.ServiceId, MvInitializationMode.CreateOrEnsure, null), CreateStore(fixture))
+            .ApplySerializableEventsAsync(CreateHost(fixture), [CreateEvent(fixture, 1)], second.ServiceId)
+            .ConfigureAwait(false);
+
+        Assert.Equal(1, firstResult);
+        Assert.Equal(1, secondResult);
+        Assert.NotEqual(first.TableName, second.TableName);
+        var registry = CreateStore(fixture);
+        var firstEntry = Assert.Single(await registry.GetEntriesAsync(first.ServiceId, ViewName, ViewVersion).ConfigureAwait(false));
+        var secondEntry = Assert.Single(await registry.GetEntriesAsync(second.ServiceId, ViewName, ViewVersion).ConfigureAwait(false));
+        Assert.Equal(first.TableName, firstEntry.PhysicalTable);
+        Assert.Equal(second.TableName, secondEntry.PhysicalTable);
+        Assert.NotEqual(firstEntry.CurrentCheckpointTruth.PositionValue, secondEntry.CurrentCheckpointTruth.PositionValue);
+    }
+
+    private static async Task<G73PreparedCase> PrepareAsync(
+        MultiProviderFixtureBase fixture,
+        string serviceId = DefaultServiceId,
+        string tablePrefix = MvOptions.DefaultTablePrefix,
+        bool reset = true)
+    {
+        Skip.IfNot(fixture.IsAvailable, fixture.AvailabilityMessage ?? "Integration fixture is unavailable.");
+        if (reset)
+        {
+            await fixture.ResetAsync().ConfigureAwait(false);
+        }
+
+        var projector = new CrossProviderWeatherForecastMvV1();
+        var options = CreateOptions(serviceId, MvInitializationMode.CreateOrEnsure, null);
+        options.TablePrefix = tablePrefix;
+        var host = new NativeMvApplyHost(projector, fixture.DomainTypes.EventTypes, fixture.DatabaseTypeForTests);
+        var executor = CreateExecutor(fixture, options, CreateStore(fixture));
+        await executor.InitializeAsync(host, serviceId).ConfigureAwait(false);
+        var tableName = MvPhysicalName.Resolve(options, ViewName, ViewVersion, "forecasts");
+        Assert.Equal(1, projector.InitializeCallCount);
+        return new G73PreparedCase(projector, host, options, tableName, serviceId);
+    }
+
+    private static IMvRegistryStore CreateStore(MultiProviderFixtureBase fixture) =>
+        fixture.DatabaseTypeForTests switch
+        {
+            MvDbType.Postgres => new PostgresMvRegistryStore(fixture.ConnectionStringForTests),
+            MvDbType.SqlServer => new SqlServerMvRegistryStore(
+                fixture.ConnectionStringForTests,
+                null,
+                null,
+                fixture.InspectionConnectionStringForTests),
+            _ => throw new NotSupportedException($"Unsupported provider '{fixture.DatabaseTypeForTests}'.")
+        };
+
+    private static IMvExecutor CreateExecutor(
+        MultiProviderFixtureBase fixture,
+        MvOptions options,
+        IMvRegistryStore registry) =>
+        fixture.DatabaseTypeForTests switch
+        {
+            MvDbType.Postgres => new PostgresMvExecutor(
+                fixture.EventStoreFactory,
+                registry,
+                Options.Create(options),
+                NullLogger<PostgresMvExecutor>.Instance,
+                fixture.ConnectionStringForTests),
+            MvDbType.SqlServer => new SqlServerMvExecutor(
+                fixture.EventStoreFactory,
+                registry,
+                Options.Create(options),
+                NullLogger<SqlServerMvExecutor>.Instance,
+                fixture.ConnectionStringForTests),
+            _ => throw new NotSupportedException($"Unsupported provider '{fixture.DatabaseTypeForTests}'.")
+        };
+
+    private static MvOptions CreateOptions(string serviceId, MvInitializationMode mode, IMvExecutionObserver? observer) =>
+        new()
+        {
+            ServiceId = serviceId,
+            InitializationMode = mode,
+            SafeWindowMs = 0,
+            BatchSize = 100,
+            SqlStatementPolicyMode = MvSqlStatementPolicyMode.Enforced,
+            SqlStatementPolicy = new OwnTablesOnlyPolicy(),
+            ExecutionObserver = observer
+        };
+
+    private static NativeMvApplyHost CreateHost(MultiProviderFixtureBase fixture)
+    {
+        var projector = new CrossProviderWeatherForecastMvV1();
+        return new NativeMvApplyHost(projector, fixture.DomainTypes.EventTypes, fixture.DatabaseTypeForTests);
+    }
+
+    private static SerializableEvent CreateEvent(MultiProviderFixtureBase fixture, int ordinal)
+    {
+        var eventId = Guid.Parse($"{ordinal + 1:D8}-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+        var value = new Event(
+            new WeatherForecastCreated(
+                Guid.Parse($"{ordinal + 1:D8}-bbbb-bbbb-bbbb-bbbbbbbbbbbb"),
+                $"G73-{ordinal}",
+                new DateOnly(2026, 9, 10),
+                21 + ordinal,
+                "Native apply"),
+            SortableUniqueId.Generate(DateTime.UtcNow.AddMinutes(-2).AddSeconds(ordinal), eventId),
+            nameof(WeatherForecastCreated),
+            eventId,
+            new EventMetadata("g73", "g73", "acceptance"),
+            []);
+        return value.ToSerializableEvent(fixture.DomainTypes.EventTypes);
+    }
+}
+
+internal sealed class CountingRegistryStore(IMvRegistryStore inner) : IMvRegistryStore, IMvReadOnlyMvInspector
+{
+    public int EnsureCalls { get; private set; }
+    public int VerifySchemaCalls { get; private set; }
+    public int ReadRegistryCalls { get; private set; }
+    public int ReadActiveCalls { get; private set; }
+
+    public Task EnsureInfrastructureAsync(CancellationToken cancellationToken = default)
+    {
+        EnsureCalls++;
+        return inner.EnsureInfrastructureAsync(cancellationToken);
+    }
+
+    public Task RegisterAsync(MvRegistryEntry entry, IDbTransaction? transaction = null, CancellationToken cancellationToken = default) =>
+        inner.RegisterAsync(entry, transaction, cancellationToken);
+
+    public Task UpdatePositionAsync(MvPositionUpdate update, IDbTransaction? transaction = null, CancellationToken cancellationToken = default) =>
+        inner.UpdatePositionAsync(update, transaction, cancellationToken);
+
+    public Task MarkStreamReceivedAsync(string serviceId, string viewName, int viewVersion, string sortableUniqueId, DateTimeOffset receivedAt, IDbTransaction? transaction = null, CancellationToken cancellationToken = default) =>
+        inner.MarkStreamReceivedAsync(serviceId, viewName, viewVersion, sortableUniqueId, receivedAt, transaction, cancellationToken);
+
+    public Task UpdateStatusAsync(string serviceId, string viewName, int viewVersion, MvStatus status, IDbTransaction? transaction = null, CancellationToken cancellationToken = default) =>
+        inner.UpdateStatusAsync(serviceId, viewName, viewVersion, status, transaction, cancellationToken);
+
+    public Task<IReadOnlyList<MvRegistryEntry>> GetEntriesAsync(string serviceId, string viewName, int viewVersion, CancellationToken cancellationToken = default) =>
+        inner.GetEntriesAsync(serviceId, viewName, viewVersion, cancellationToken);
+
+    public Task<MvActiveEntry?> GetActiveAsync(string serviceId, string viewName, CancellationToken cancellationToken = default) =>
+        inner.GetActiveAsync(serviceId, viewName, cancellationToken);
+
+    public Task SetTargetCheckpointAsync(
+        string serviceId,
+        string viewName,
+        int viewVersion,
+        MvCheckpointTruth targetCheckpointTruth,
+        IDbTransaction? transaction = null,
+        CancellationToken cancellationToken = default) =>
+        inner.SetTargetCheckpointAsync(serviceId, viewName, viewVersion, targetCheckpointTruth, transaction, cancellationToken);
+
+    public Task<MvActivationResult> TryActivateAsync(
+        MvActivationRequest request,
+        IDbTransaction? transaction = null,
+        CancellationToken cancellationToken = default) =>
+        inner.TryActivateAsync(request, transaction, cancellationToken);
+
+    public Task<MvActivationResult> TryForceReverseAsync(
+        MvForcedReverseRequest request,
+        IDbTransaction? transaction = null,
+        CancellationToken cancellationToken = default) =>
+        inner.TryForceReverseAsync(request, transaction, cancellationToken);
+
+    public Task<MvActivationResult> TryRestoreActiveStatusAsync(
+        MvActiveStatusRestoreRequest request,
+        IDbTransaction? transaction = null,
+        CancellationToken cancellationToken = default) =>
+        inner.TryRestoreActiveStatusAsync(request, transaction, cancellationToken);
+
+    public Task SetActiveAsync(string serviceId, string viewName, int activeVersion, IDbTransaction? transaction = null, CancellationToken cancellationToken = default) =>
+        inner.SetActiveAsync(serviceId, viewName, activeVersion, transaction, cancellationToken);
+
+    public Task<MvSchemaVerificationResult> VerifySchemaAsync(IReadOnlyList<MvSchemaTableRequirement> requirements, CancellationToken cancellationToken = default)
+    {
+        VerifySchemaCalls++;
+        return ((IMvReadOnlyMvInspector)inner).VerifySchemaAsync(requirements, cancellationToken);
+    }
+
+    public Task<IReadOnlyList<MvRegistryEntry>> ReadRegistryEntriesAsync(string serviceId, string viewName, int viewVersion, CancellationToken cancellationToken = default)
+    {
+        ReadRegistryCalls++;
+        return ((IMvReadOnlyMvInspector)inner).ReadRegistryEntriesAsync(serviceId, viewName, viewVersion, cancellationToken);
+    }
+
+    public Task<MvActiveEntry?> ReadActiveAsync(string serviceId, string viewName, CancellationToken cancellationToken = default)
+    {
+        ReadActiveCalls++;
+        return ((IMvReadOnlyMvInspector)inner).ReadActiveAsync(serviceId, viewName, cancellationToken);
+    }
+}
+
+internal sealed class OwnTablesOnlyPolicy : IMvSqlStatementPolicy
+{
+    public List<MvSqlStatementContext> Contexts { get; } = [];
+
+    public ValueTask<MvSqlPolicyDecision> EvaluateAsync(
+        MvSqlStatementContext context,
+        CancellationToken cancellationToken = default)
+    {
+        Contexts.Add(context);
+        if (context.Phase == MvSqlStatementPhase.Initialization)
+        {
+            return ValueTask.FromResult(MvSqlPolicyDecision.Allow("initialization"));
+        }
+
+        if (context.Sql.TrimStart().StartsWith("CREATE", StringComparison.OrdinalIgnoreCase) ||
+            context.Sql.TrimStart().StartsWith("ALTER", StringComparison.OrdinalIgnoreCase) ||
+            context.Sql.TrimStart().StartsWith("DROP", StringComparison.OrdinalIgnoreCase))
+        {
+            return ValueTask.FromResult(MvSqlPolicyDecision.Reject("DDL is not permitted by OwnTablesOnlyPolicy."));
+        }
+
+        var ownsADeclaredTable = context.Tables.Any(table =>
+            context.Sql.Contains(table.PhysicalName, StringComparison.OrdinalIgnoreCase));
+        return ValueTask.FromResult(ownsADeclaredTable
+            ? MvSqlPolicyDecision.Allow("own-table")
+            : MvSqlPolicyDecision.Reject("The SQL does not target a declared own table.", "wrong-table"));
+    }
+}

--- a/dcb/tests/Sekiban.Dcb.MaterializedView.Tests/MaterializedViewUnitTests.cs
+++ b/dcb/tests/Sekiban.Dcb.MaterializedView.Tests/MaterializedViewUnitTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using Dcb.Domain.WithoutResult;
 using Dcb.Domain.WithoutResult.MaterializedViews;
 using Dcb.Domain.WithoutResult.Order;
@@ -360,6 +361,141 @@ public class MaterializedViewUnitTests
         Assert.Equal(1, host.ViewVersion);
     }
 
+    [Fact]
+    public async Task NativeMvApplyHost_SnapshotsConcreteBindingsAtEachApplyBoundary()
+    {
+        var domainTypes = DomainType.GetDomainTypes();
+        var projector = new BindingProbeProjector();
+        var host = new NativeMvApplyHost(projector, domainTypes.EventTypes);
+        var bindings = new MvTableBindings("BindingProbe", 1, new MvOptions());
+        await host.InitializeAsync(bindings, CancellationToken.None);
+
+        ((IDictionary<string, string>)bindings.LogicalToPhysical)["map-only"] = "map_only_should_not_escape";
+        await host.ApplyEventAsync(
+                CreateBindingProbeEvent(domainTypes),
+                bindings,
+                new FakeApplyQueryPort(),
+                "100",
+                CancellationToken.None);
+
+        var first = Assert.Single(projector.CapturedBindings);
+        Assert.Equal(
+            ["items", "orders"],
+            first.OwnTables.Keys.Order(StringComparer.Ordinal).ToArray());
+        Assert.False(first.TryGetPhysicalName("map-only", out _));
+        Assert.Throws<NotSupportedException>(() =>
+            ((IDictionary<string, string>)first.OwnTables).Add("escape", "escape"));
+
+        bindings.RegisterTable("after-capture");
+        Assert.False(first.OwnTables.ContainsKey("after-capture"));
+
+        await host.ApplyEventAsync(
+                CreateBindingProbeEvent(domainTypes),
+                bindings,
+                new FakeApplyQueryPort(),
+                "101",
+                CancellationToken.None);
+
+        Assert.Equal(2, projector.CapturedBindings.Count);
+        Assert.True(projector.CapturedBindings[1].TryGetPhysicalName("after-capture", out var physicalName));
+        Assert.Equal("sekiban_mv_bindingprobe_v1_after_capture", physicalName);
+        Assert.False(first.TryGetPhysicalName("missing", out var missing));
+        Assert.Null(missing);
+        Assert.Throws<KeyNotFoundException>(() => _ = first.OwnTables["missing"]);
+    }
+
+    [Fact]
+    public async Task NativeMvApplyHost_ForeignBindingsUseOwnedFallbackAndRejectDuplicateNames()
+    {
+        var domainTypes = DomainType.GetDomainTypes();
+        var projector = new BindingProbeProjector();
+        var host = new NativeMvApplyHost(projector, domainTypes.EventTypes);
+        var foreign = new ForeignBindings(
+            new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["orders"] = "foreign_orders",
+                ["items"] = "foreign_items"
+            });
+
+        await host.ApplyEventAsync(
+                CreateBindingProbeEvent(domainTypes),
+                foreign,
+                new FakeApplyQueryPort(),
+                "100",
+                CancellationToken.None);
+
+        var captured = Assert.Single(projector.CapturedBindings);
+        Assert.Equal("foreign_orders", captured.OwnTables["orders"]);
+        Assert.False(ReferenceEquals(captured.OwnTables, foreign.LogicalToPhysical));
+
+        var duplicateHost = new NativeMvApplyHost(new BindingProbeProjector(), domainTypes.EventTypes);
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => duplicateHost.ApplyEventAsync(
+                CreateBindingProbeEvent(domainTypes),
+                new ForeignBindings(new DuplicateReadOnlyDictionary(
+                [
+                    new KeyValuePair<string, string>("orders", "orders_a"),
+                    new KeyValuePair<string, string>("orders", "orders_b")
+                ])),
+                new FakeApplyQueryPort(),
+                "100",
+                CancellationToken.None));
+
+        Assert.Contains("Duplicate materialized-view logical table binding 'orders'", exception.Message);
+
+        var nullException = await Assert.ThrowsAsync<ArgumentNullException>(() => duplicateHost.ApplyEventAsync(
+                CreateBindingProbeEvent(domainTypes),
+                null!,
+                new FakeApplyQueryPort(),
+                "100",
+                CancellationToken.None));
+        Assert.Equal("bindings", nullException.ParamName);
+    }
+
+    [Fact]
+    public async Task NativeMvApplyHost_ConcurrentApplyCallsKeepDistinctBindingSnapshots()
+    {
+        var domainTypes = DomainType.GetDomainTypes();
+        var projector = new ConcurrentBindingProbeProjector();
+        var host = new NativeMvApplyHost(projector, domainTypes.EventTypes);
+        var queryPort = new FakeApplyQueryPort();
+        var eventValue = CreateBindingProbeEvent(domainTypes);
+        var first = new ForeignBindings(
+            new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["orders"] = "orders_first",
+                ["items"] = "items_first"
+            });
+        var second = new ForeignBindings(
+            new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["orders"] = "orders_second",
+                ["items"] = "items_second"
+            });
+
+        var firstApply = host.ApplyEventAsync(eventValue, first, queryPort, "100", CancellationToken.None);
+        var secondApply = host.ApplyEventAsync(eventValue, second, queryPort, "101", CancellationToken.None);
+        await projector.BothEntered.WaitAsync(TimeSpan.FromSeconds(1));
+        projector.Release();
+        await Task.WhenAll(firstApply, secondApply);
+
+        Assert.Equal(
+            ["orders_first", "orders_second"],
+            projector.CapturedOrderNames.Order(StringComparer.Ordinal).ToArray());
+    }
+
+    private static SerializableEvent CreateBindingProbeEvent(DcbDomainTypes domainTypes)
+    {
+        var eventId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+        return new Event(
+                new OrderCreated(Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"), DateTimeOffset.UtcNow),
+                "100",
+                nameof(OrderCreated),
+                eventId,
+                new EventMetadata("native-bindings", "native-bindings", "test"),
+                [])
+            .ToSerializableEvent(domainTypes.EventTypes);
+    }
+
     private sealed record RecordTarget(
         [property: MvColumn("id")] Guid Id,
         [property: MvColumn("name")] string Name,
@@ -429,15 +565,26 @@ public class MaterializedViewUnitTests
         public Task ExecuteAsync(string sql, object? param = null, CancellationToken cancellationToken = default) => Task.CompletedTask;
     }
 
-    private sealed class FakeApplyContext : IMvApplyContext
+    private sealed class FakeApplyContext : IMvApplyContext, IMvApplyTableBindings
     {
         public Dictionary<string, IMvRow> SingleResults { get; } = new(StringComparer.OrdinalIgnoreCase);
         public Dictionary<string, object> ScalarResults { get; } = new(StringComparer.OrdinalIgnoreCase);
+        public IReadOnlyDictionary<string, string> OwnTables { get; } =
+            new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["orders"] = "sekiban_mv_ordersummary_v1_orders",
+                ["items"] = "sekiban_mv_ordersummary_v1_items"
+            };
         public MvDbType DatabaseType => MvDbType.Postgres;
         public System.Data.IDbConnection Connection => throw new NotSupportedException();
         public System.Data.IDbTransaction Transaction => throw new NotSupportedException();
         public Event CurrentEvent => throw new NotSupportedException();
         public string CurrentSortableUniqueId => "999";
+
+        public bool TryGetPhysicalName(
+            string logicalName,
+            [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out string? physicalName) =>
+            OwnTables.TryGetValue(logicalName, out physicalName);
 
         public Task<IMvRow?> QuerySingleOrDefaultRowAsync(string sql, object? param = null, CancellationToken cancellationToken = default) =>
             Task.FromResult(SingleResults.TryGetValue(sql, out var row) ? row : null);
@@ -450,6 +597,92 @@ public class MaterializedViewUnitTests
 
         public MvTable GetDependencyViewTable(string viewName, string logicalTable) => throw new NotSupportedException();
         public MvTable GetDependencyViewTable<TView>(string logicalTable) where TView : IMaterializedViewProjector => throw new NotSupportedException();
+    }
+
+    private sealed class BindingProbeProjector : IMaterializedViewProjector
+    {
+        public string ViewName => "BindingProbe";
+        public int ViewVersion => 1;
+        public List<IMvApplyTableBindings> CapturedBindings { get; } = [];
+
+        public Task InitializeAsync(IMvInitContext ctx, CancellationToken cancellationToken = default)
+        {
+            ctx.RegisterTable("orders");
+            ctx.RegisterTable("items");
+            return Task.CompletedTask;
+        }
+
+        public Task<IReadOnlyList<MvSqlStatement>> ApplyToViewAsync(
+            Event ev,
+            IMvApplyContext ctx,
+            CancellationToken cancellationToken = default)
+        {
+            CapturedBindings.Add(Assert.IsAssignableFrom<IMvApplyTableBindings>(ctx));
+            return Task.FromResult<IReadOnlyList<MvSqlStatement>>([]);
+        }
+    }
+
+    private sealed class ConcurrentBindingProbeProjector : IMaterializedViewProjector
+    {
+        private readonly TaskCompletionSource<bool> _bothEntered =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource<bool> _release =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private int _entered;
+
+        public string ViewName => "ConcurrentBindingProbe";
+        public int ViewVersion => 1;
+        public Task BothEntered => _bothEntered.Task;
+        public ConcurrentQueue<string> CapturedOrderNames { get; } = new();
+
+        public Task InitializeAsync(IMvInitContext ctx, CancellationToken cancellationToken = default) =>
+            Task.CompletedTask;
+
+        public async Task<IReadOnlyList<MvSqlStatement>> ApplyToViewAsync(
+            Event ev,
+            IMvApplyContext ctx,
+            CancellationToken cancellationToken = default)
+        {
+            var bindings = Assert.IsAssignableFrom<IMvApplyTableBindings>(ctx);
+            Assert.True(bindings.TryGetPhysicalName("orders", out var physicalName));
+            CapturedOrderNames.Enqueue(physicalName);
+            if (Interlocked.Increment(ref _entered) == 2)
+            {
+                _bothEntered.TrySetResult(true);
+            }
+
+            await _release.Task.WaitAsync(TimeSpan.FromSeconds(1), cancellationToken);
+            return [];
+        }
+
+        public void Release() => _release.TrySetResult(true);
+    }
+
+    private sealed class ForeignBindings(IReadOnlyDictionary<string, string> map) : IMvTableBindings
+    {
+        public string GetPhysicalName(string logicalName) => map[logicalName];
+        public IReadOnlyDictionary<string, string> LogicalToPhysical => map;
+        public MvTable RegisterTable(string logicalName, string? physicalName = null) =>
+            new(logicalName, physicalName ?? map[logicalName], "BindingProbe", 1);
+    }
+
+    private sealed class DuplicateReadOnlyDictionary(IReadOnlyList<KeyValuePair<string, string>> entries)
+        : IReadOnlyDictionary<string, string>
+    {
+        public IEnumerable<string> Keys => entries.Select(entry => entry.Key);
+        public IEnumerable<string> Values => entries.Select(entry => entry.Value);
+        public int Count => entries.Count;
+        public string this[string key] => entries.First(entry => entry.Key == key).Value;
+        public bool ContainsKey(string key) => entries.Any(entry => entry.Key == key);
+        public bool TryGetValue(string key, out string value)
+        {
+            var match = entries.FirstOrDefault(entry => entry.Key == key);
+            value = match.Value;
+            return ContainsKey(key);
+        }
+
+        public IEnumerator<KeyValuePair<string, string>> GetEnumerator() => entries.GetEnumerator();
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => GetEnumerator();
     }
 
     private sealed class FakeMvRowSet(IReadOnlyList<IMvRow> rows) : IMvRowSet

--- a/dcb/tests/Sekiban.Dcb.MaterializedView.Tests/MaterializedViewUnitTests.cs
+++ b/dcb/tests/Sekiban.Dcb.MaterializedView.Tests/MaterializedViewUnitTests.cs
@@ -362,6 +362,29 @@ public class MaterializedViewUnitTests
     }
 
     [Fact]
+    public async Task NativeMvApplyHost_ConcreteBindingsRemainAvailableBeforeInitialization()
+    {
+        var domainTypes = DomainType.GetDomainTypes();
+        var projector = new BindingProbeProjector();
+        var host = new NativeMvApplyHost(projector, domainTypes.EventTypes);
+        var bindings = new MvTableBindings("BindingProbe", 1, new MvOptions());
+        bindings.RegisterTable("orders", "explicit_orders");
+
+        await host.ApplyEventAsync(
+                CreateBindingProbeEvent(domainTypes),
+                bindings,
+                new FakeApplyQueryPort(),
+                "100",
+                CancellationToken.None)
+            .ConfigureAwait(false);
+
+        var captured = Assert.Single(projector.CapturedBindings);
+        Assert.True(captured.TryGetPhysicalName("orders", out var physicalName));
+        Assert.Equal("explicit_orders", physicalName);
+        Assert.Empty(host.LogicalTables);
+    }
+
+    [Fact]
     public async Task NativeMvApplyHost_SnapshotsConcreteBindingsAtEachApplyBoundary()
     {
         var domainTypes = DomainType.GetDomainTypes();
@@ -565,26 +588,15 @@ public class MaterializedViewUnitTests
         public Task ExecuteAsync(string sql, object? param = null, CancellationToken cancellationToken = default) => Task.CompletedTask;
     }
 
-    private sealed class FakeApplyContext : IMvApplyContext, IMvApplyTableBindings
+    private sealed class FakeApplyContext : IMvApplyContext
     {
         public Dictionary<string, IMvRow> SingleResults { get; } = new(StringComparer.OrdinalIgnoreCase);
         public Dictionary<string, object> ScalarResults { get; } = new(StringComparer.OrdinalIgnoreCase);
-        public IReadOnlyDictionary<string, string> OwnTables { get; } =
-            new Dictionary<string, string>(StringComparer.Ordinal)
-            {
-                ["orders"] = "sekiban_mv_ordersummary_v1_orders",
-                ["items"] = "sekiban_mv_ordersummary_v1_items"
-            };
         public MvDbType DatabaseType => MvDbType.Postgres;
         public System.Data.IDbConnection Connection => throw new NotSupportedException();
         public System.Data.IDbTransaction Transaction => throw new NotSupportedException();
         public Event CurrentEvent => throw new NotSupportedException();
         public string CurrentSortableUniqueId => "999";
-
-        public bool TryGetPhysicalName(
-            string logicalName,
-            [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out string? physicalName) =>
-            OwnTables.TryGetValue(logicalName, out physicalName);
 
         public Task<IMvRow?> QuerySingleOrDefaultRowAsync(string sql, object? param = null, CancellationToken cancellationToken = default) =>
             Task.FromResult(SingleResults.TryGetValue(sql, out var row) ? row : null);

--- a/docs/dcb_llm/20_materialized_view.md
+++ b/docs/dcb_llm/20_materialized_view.md
@@ -640,6 +640,10 @@ apply and concurrent applies do not share aliases. A fresh projector instance ca
 executor still verifies first and requires the configured enforced SQL policy. `VerifyOnly` does not invoke projector
 apply and refuses execution, so it cannot use this capability to perform writes.
 
+Adopting this capability requires updating projector code to read its own apply-time bindings; it does not require a
+stored-data migration. The SQL statement policy can enforce the declared table contract, but this capability does not
+promise arbitrary query SQL safety in custom projector code; hosts must still choose and validate their own policy.
+
 ## Querying the Tables
 
 Applications should not hardcode the physical table name. Use `IMvOrleansQueryAccessor` to resolve it.

--- a/docs/dcb_llm/20_materialized_view.md
+++ b/docs/dcb_llm/20_materialized_view.md
@@ -617,6 +617,29 @@ verification. Candidate preparation does not move the serving pointer or repair 
 The N+1 acceptance test checks corrected candidate content while the serving pointer, checkpoint and corruption
 remain unchanged. No cursor rewind, table deletion/reset or automatic version selection is introduced.
 
+## Apply-time own-table bindings
+
+The native apply host exposes the additive `IMvApplyTableBindings` capability on each apply context. It is an
+immutable, per-invocation snapshot of the logical-to-physical bindings owned by that host; it is not a second table
+registration API and it does not change `IMvTableBindings`, `IMvApplyContext`, or existing constructors. A projector
+that needs its own physical names can use the optional capability and fail before emitting SQL when a binding is absent:
+
+```csharp
+if (ctx is not IMvApplyTableBindings ownTables ||
+    !ownTables.TryGetPhysicalName("orders", out var ordersTable))
+{
+    throw new InvalidOperationException("The required own-table binding 'orders' is unavailable.");
+}
+
+var sameTable = ownTables.OwnTables["orders"]; // a missing key throws KeyNotFoundException
+```
+
+The host captures the snapshot before projector code runs, so later registration changes do not mutate an in-flight
+apply and concurrent applies do not share aliases. A fresh projector instance can therefore run
+`VerifyAndExecute` against bindings prepared by another projector instance without calling `InitializeAsync`; the
+executor still verifies first and requires the configured enforced SQL policy. `VerifyOnly` does not invoke projector
+apply and refuses execution, so it cannot use this capability to perform writes.
+
 ## Querying the Tables
 
 Applications should not hardcode the physical table name. Use `IMvOrleansQueryAccessor` to resolve it.

--- a/docs/dcb_llm_ja/20_materialized_view.md
+++ b/docs/dcb_llm_ja/20_materialized_view.md
@@ -627,6 +627,10 @@ projector instance は `InitializeAsync` を呼ばずに `VerifyAndExecute` を�
 configured な enforced SQL policy を要求します。`VerifyOnly` は projector apply を呼ばず実行を拒否するため、この
 capability による write も行いません。
 
+この capability を採用するには projector code が apply-time binding を読むよう更新しますが、保存済みデータの migration
+は必要ありません。SQL statement policy は宣言した table contract を検査できますが、custom projector code 内の任意の
+query SQL が安全になることを保証する機能ではありません。host は利用する policy を選択し、引き続き検証してください。
+
 ## テーブルのクエリ方法
 
 物理テーブル名をアプリ側で決め打ちしないでください。`IMvOrleansQueryAccessor` を使って解決します。

--- a/docs/dcb_llm_ja/20_materialized_view.md
+++ b/docs/dcb_llm_ja/20_materialized_view.md
@@ -604,6 +604,29 @@ candidate の準備だけでは serving pointer は動かず、serving generatio
 serving pointer、checkpoint、破損状態を維持したまま candidate の内容が正しくなることを確認します。
 cursor rewind、table の delete/reset、version の自動選択は追加しません。
 
+## apply 時の own-table binding
+
+native apply host は、各 apply context に加法的な `IMvApplyTableBindings` capability を公開します。これは host
+が所有する logical-to-physical binding の、呼び出し単位で不変な snapshot です。第二の table 登録 API ではなく、
+`IMvTableBindings`、`IMvApplyContext`、既存の constructor は変更しません。projector が自分の physical name を必要と
+する場合は optional capability を調べ、binding がない場合は SQL を出力する前に失敗できます。
+
+```csharp
+if (ctx is not IMvApplyTableBindings ownTables ||
+    !ownTables.TryGetPhysicalName("orders", out var ordersTable))
+{
+    throw new InvalidOperationException("The required own-table binding 'orders' is unavailable.");
+}
+
+var sameTable = ownTables.OwnTables["orders"]; // key がなければ KeyNotFoundException
+```
+
+host は projector code の前に snapshot を取得するため、後から行われる登録は実行中の apply を変更せず、並行する
+apply 同士も alias を共有しません。したがって、別の projector instance が provision した binding に対して、新しい
+projector instance は `InitializeAsync` を呼ばずに `VerifyAndExecute` を実行できます。ただし executor は先に検証を行い、
+configured な enforced SQL policy を要求します。`VerifyOnly` は projector apply を呼ばず実行を拒否するため、この
+capability による write も行いません。
+
 ## テーブルのクエリ方法
 
 物理テーブル名をアプリ側で決め打ちしないでください。`IMvOrleansQueryAccessor` を使って解決します。

--- a/eng/audit-mv-trx-results.sh
+++ b/eng/audit-mv-trx-results.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+    echo "usage: $0 --trx-dir <directory> --manifest <file> [--tfm <target-framework>]" >&2
+    exit 2
+}
+
+trx_dir=
+manifest=
+tfm_filter=
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --trx-dir)
+            [[ $# -ge 2 ]] || usage
+            trx_dir=$2
+            shift 2
+            ;;
+        --manifest)
+            [[ $# -ge 2 ]] || usage
+            manifest=$2
+            shift 2
+            ;;
+        --tfm)
+            [[ $# -ge 2 ]] || usage
+            tfm_filter=$2
+            shift 2
+            ;;
+        *)
+            usage
+            ;;
+    esac
+done
+
+[[ -n "$trx_dir" && -n "$manifest" ]] || usage
+
+python3 - "$trx_dir" "$manifest" "$tfm_filter" <<'PY'
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+trx_dir = Path(sys.argv[1])
+manifest = Path(sys.argv[2])
+tfm_filter = sys.argv[3]
+failures = []
+audited_cases = 0
+
+def local_name(tag):
+    return tag.rsplit("}", 1)[-1]
+
+def read_results(path):
+    root = ET.parse(path).getroot()
+    return [
+        element
+        for element in root.iter()
+        if local_name(element.tag) == "UnitTestResult"
+    ]
+
+for line_number, raw_line in enumerate(manifest.read_text().splitlines(), 1):
+    line = raw_line.strip()
+    if not line or line.startswith("#"):
+        continue
+    fields = line.split("|")
+    if len(fields) != 5:
+        failures.append(f"manifest line {line_number}: expected 5 pipe-separated fields")
+        continue
+    trx_name, engine, tfm, test_name, expected_count_text = fields
+    if tfm_filter and tfm != tfm_filter:
+        continue
+    audited_cases += 1
+    try:
+        expected_count = int(expected_count_text)
+    except ValueError:
+        failures.append(f"manifest line {line_number}: invalid expected count {expected_count_text!r}")
+        continue
+
+    path = trx_dir / trx_name
+    if not path.is_file():
+        failures.append(f"missing TRX for engine={engine} tfm={tfm}: {path}")
+        continue
+
+    results = read_results(path)
+    if len(results) != expected_count:
+        failures.append(
+            f"unexpected result count engine={engine} tfm={tfm} file={path.name}: "
+            f"expected {expected_count}, found {len(results)}"
+        )
+    for result in results:
+        outcome = result.attrib.get("outcome")
+        if outcome != "Passed":
+            failures.append(
+                f"non-passing result engine={engine} tfm={tfm} "
+                f"test={result.attrib.get('testName')} outcome={outcome}"
+            )
+    matching = [
+        result for result in results
+        if test_name in result.attrib.get("testName", "")
+    ]
+    if len(matching) != expected_count:
+        failures.append(
+            f"wrong case count engine={engine} tfm={tfm} file={path.name}: "
+            f"expected {expected_count}, found {len(matching)}"
+        )
+    if len({result.attrib.get("testId") for result in matching}) != len(matching):
+        failures.append(f"duplicate test id engine={engine} tfm={tfm} file={path.name}")
+    for result in matching:
+        outcome = result.attrib.get("outcome")
+        if outcome != "Passed":
+            failures.append(
+                f"non-passing required case engine={engine} tfm={tfm} "
+                f"test={result.attrib.get('testName')} outcome={outcome}"
+            )
+    if matching and len(matching) == expected_count and all(
+        result.attrib.get("outcome") == "Passed" for result in matching
+    ):
+        print(f"verified engine={engine} tfm={tfm} file={path.name} cases={len(matching)}")
+
+if failures:
+    for failure in failures:
+        print(f"ERROR: {failure}", file=sys.stderr)
+    raise SystemExit(1)
+if audited_cases == 0:
+    print(f"ERROR: manifest has no cases for TFM filter {tfm_filter!r}", file=sys.stderr)
+    raise SystemExit(1)
+PY

--- a/eng/audit-mv-trx-results.sh
+++ b/eng/audit-mv-trx-results.sh
@@ -44,6 +44,7 @@ manifest = Path(sys.argv[2])
 tfm_filter = sys.argv[3]
 failures = []
 audited_cases = 0
+groups = {}
 
 def local_name(tag):
     return tag.rsplit("}", 1)[-1]
@@ -67,23 +68,28 @@ for line_number, raw_line in enumerate(manifest.read_text().splitlines(), 1):
     trx_name, engine, tfm, test_name, expected_count_text = fields
     if tfm_filter and tfm != tfm_filter:
         continue
-    audited_cases += 1
     try:
         expected_count = int(expected_count_text)
     except ValueError:
         failures.append(f"manifest line {line_number}: invalid expected count {expected_count_text!r}")
         continue
 
+    key = (trx_name, engine, tfm)
+    groups.setdefault(key, []).append((line_number, test_name, expected_count))
+
+for (trx_name, engine, tfm), entries in groups.items():
+    audited_cases += 1
     path = trx_dir / trx_name
     if not path.is_file():
         failures.append(f"missing TRX for engine={engine} tfm={tfm}: {path}")
         continue
 
     results = read_results(path)
-    if len(results) != expected_count:
+    expected_total = sum(entry[2] for entry in entries)
+    if len(results) != expected_total:
         failures.append(
             f"unexpected result count engine={engine} tfm={tfm} file={path.name}: "
-            f"expected {expected_count}, found {len(results)}"
+            f"expected {expected_total}, found {len(results)}"
         )
     for result in results:
         outcome = result.attrib.get("outcome")
@@ -92,28 +98,31 @@ for line_number, raw_line in enumerate(manifest.read_text().splitlines(), 1):
                 f"non-passing result engine={engine} tfm={tfm} "
                 f"test={result.attrib.get('testName')} outcome={outcome}"
             )
-    matching = [
-        result for result in results
-        if test_name in result.attrib.get("testName", "")
-    ]
-    if len(matching) != expected_count:
-        failures.append(
-            f"wrong case count engine={engine} tfm={tfm} file={path.name}: "
-            f"expected {expected_count}, found {len(matching)}"
-        )
-    if len({result.attrib.get("testId") for result in matching}) != len(matching):
-        failures.append(f"duplicate test id engine={engine} tfm={tfm} file={path.name}")
-    for result in matching:
-        outcome = result.attrib.get("outcome")
-        if outcome != "Passed":
+    verified = len(results) == expected_total
+    for line_number, test_name, expected_count in entries:
+        matching = [
+            result for result in results
+            if test_name in result.attrib.get("testName", "")
+        ]
+        if len(matching) != expected_count:
             failures.append(
-                f"non-passing required case engine={engine} tfm={tfm} "
-                f"test={result.attrib.get('testName')} outcome={outcome}"
+                f"wrong case count engine={engine} tfm={tfm} file={path.name} manifest line={line_number}: "
+                f"expected {expected_count}, found {len(matching)}"
             )
-    if matching and len(matching) == expected_count and all(
-        result.attrib.get("outcome") == "Passed" for result in matching
-    ):
-        print(f"verified engine={engine} tfm={tfm} file={path.name} cases={len(matching)}")
+            verified = False
+        if len({result.attrib.get("testId") for result in matching}) != len(matching):
+            failures.append(f"duplicate test id engine={engine} tfm={tfm} file={path.name} manifest line={line_number}")
+            verified = False
+        for result in matching:
+            outcome = result.attrib.get("outcome")
+            if outcome != "Passed":
+                failures.append(
+                    f"non-passing required case engine={engine} tfm={tfm} "
+                    f"test={result.attrib.get('testName')} outcome={outcome}"
+                )
+                verified = False
+    if verified and all(result.attrib.get("outcome") == "Passed" for result in results):
+        print(f"verified engine={engine} tfm={tfm} file={path.name} cases={len(results)}")
 
 if failures:
     for failure in failures:

--- a/eng/materialized-view-required-cases.txt
+++ b/eng/materialized-view-required-cases.txt
@@ -1,5 +1,9 @@
-# trx file|provider identity|TFM|required test-name substring|expected theory cases
-mv-postgres-net9.trx|postgres|net9.0|FreshProjector_VerifyAndExecuteUsesApplyTimeOwnTables|4
-mv-sqlserver-net9.trx|sqlserver|net9.0|FreshProjector_VerifyAndExecuteUsesApplyTimeOwnTables|4
-mv-postgres-net10.trx|postgres|net10.0|FreshProjector_VerifyAndExecuteUsesApplyTimeOwnTables|4
-mv-sqlserver-net10.trx|sqlserver|net10.0|FreshProjector_VerifyAndExecuteUsesApplyTimeOwnTables|4
+# trx file|provider identity|TFM|required class/test-name substring|expected cases
+mv-postgres-net9.trx|postgres|net9.0|PostgresMvFreshProjectorApplyTests.FreshProjector_VerifyAndExecuteUsesApplyTimeOwnTables|4
+mv-postgres-net9.trx|postgres|net9.0|PostgresMvG73AcceptanceTests|8
+mv-sqlserver-net9.trx|sqlserver|net9.0|SqlServerMvFreshProjectorApplyTests.FreshProjector_VerifyAndExecuteUsesApplyTimeOwnTables|4
+mv-sqlserver-net9.trx|sqlserver|net9.0|SqlServerMvG73AcceptanceTests|8
+mv-postgres-net10.trx|postgres|net10.0|PostgresMvFreshProjectorApplyTests.FreshProjector_VerifyAndExecuteUsesApplyTimeOwnTables|4
+mv-postgres-net10.trx|postgres|net10.0|PostgresMvG73AcceptanceTests|8
+mv-sqlserver-net10.trx|sqlserver|net10.0|SqlServerMvFreshProjectorApplyTests.FreshProjector_VerifyAndExecuteUsesApplyTimeOwnTables|4
+mv-sqlserver-net10.trx|sqlserver|net10.0|SqlServerMvG73AcceptanceTests|8

--- a/eng/materialized-view-required-cases.txt
+++ b/eng/materialized-view-required-cases.txt
@@ -1,0 +1,5 @@
+# trx file|provider identity|TFM|required test-name substring|expected theory cases
+mv-postgres-net9.trx|postgres|net9.0|FreshProjector_VerifyAndExecuteUsesApplyTimeOwnTables|4
+mv-sqlserver-net9.trx|sqlserver|net9.0|FreshProjector_VerifyAndExecuteUsesApplyTimeOwnTables|4
+mv-postgres-net10.trx|postgres|net10.0|FreshProjector_VerifyAndExecuteUsesApplyTimeOwnTables|4
+mv-sqlserver-net10.trx|sqlserver|net10.0|FreshProjector_VerifyAndExecuteUsesApplyTimeOwnTables|4


### PR DESCRIPTION
Closes #1220

## Summary

- Adds the additive public `IMvApplyTableBindings` capability for immutable, per-apply own-table snapshots.
- Captures concrete `MvTableBindings.Tables` (and copies foreign binding maps with duplicate detection) before projector execution.
- Updates the cached-init-handle OrderSummary projector and the real PostgreSQL/SQL Server multi-provider projector to resolve physical names from the apply-time capability.
- Adds native unit coverage, concurrent snapshot isolation coverage, real PostgreSQL/SQL Server fresh-projector coverage, and an explicit TRX audit in both DCB TFM jobs.
- Documents the capability and VerifyOnly/VerifyAndExecute boundaries in English and Japanese.

## Acceptance criteria evidence

### AC1–AC3: immutable native capability and snapshot isolation

`IMvApplyTableBindings` is additive; existing `IMvTableBindings`, `IMvApplyContext`, and constructors remain unchanged. The native host takes a fresh read-only snapshot before event binding/projector execution. Unit tests cover concrete-table capture, map-only exclusion, missing-key/indexer semantics, source mutation isolation, foreign-map copying, duplicate logical names, null bindings, and two concurrent applies with distinct aliases.

```text
dotnet test dcb/tests/Sekiban.Dcb.MaterializedView.Tests/Sekiban.Dcb.MaterializedView.Tests.csproj --no-restore -f net9.0 --filter 'FullyQualifiedName~NativeMvApplyHost_|FullyQualifiedName~OrderSummaryMvV1_ReturnsExpectedStatements'
Passed! Failed: 0, Passed: 5, Skipped: 0, Total: 5

dotnet test dcb/tests/Sekiban.Dcb.MaterializedView.Tests/Sekiban.Dcb.MaterializedView.Tests.csproj --no-restore -f net10.0 --filter 'FullyQualifiedName~NativeMvApplyHost_|FullyQualifiedName~OrderSummaryMvV1_ReturnsExpectedStatements'
Passed! Failed: 0, Passed: 5, Skipped: 0, Total: 5
```

### AC4–AC7: real provider fresh-projector execution

The fresh projector is a separate DI provider/projector instance. Provider A provisions with CreateOrEnsure and is disposed; provider B uses VerifyAndExecute with an enforced policy, does not call InitializeAsync, applies through the real provider executor, verifies the registry checkpoint/table and row, and covers default, prefix, resolver, and explicit physical-name scenarios. The release-mode tests ran against the real PostgreSQL and SQL Server Testcontainers on both TFMs:

```text
PostgresMvFreshProjectorApplyTests net9.0: Passed! Failed: 0, Passed: 4, Skipped: 0, Total: 4
SqlServerMvFreshProjectorApplyTests net9.0: Passed! Failed: 0, Passed: 4, Skipped: 0, Total: 4
PostgresMvFreshProjectorApplyTests net10.0: Passed! Failed: 0, Passed: 4, Skipped: 0, Total: 4
SqlServerMvFreshProjectorApplyTests net10.0: Passed! Failed: 0, Passed: 4, Skipped: 0, Total: 4
```

The required TRX audit rejects missing files, wrong case counts, duplicate test IDs, skipped results, failed results, and extra results. Final release audit output:

```text
verified engine=postgres tfm=net9.0 file=mv-postgres-net9.trx cases=4
verified engine=sqlserver tfm=net9.0 file=mv-sqlserver-net9.trx cases=4
verified engine=postgres tfm=net10.0 file=mv-postgres-net10.trx cases=4
verified engine=sqlserver tfm=net10.0 file=mv-sqlserver-net10.trx cases=4
```

### AC8: compatibility

The additive interface preserves the existing public surface. The published-package binary consumer and additions-only API verifier pass, and the current-version consumer still observes the typed VerifyAndExecute policy refusal. The materialized-view library also builds for net9.0 and net10.0.

```text
api-surface-additions-only-ok:134:134
binary-consumer-ok:binary-consumer:Sekiban.Dcb.MaterializedView.IMvExecutor:Task`1:Task`1
new-version-consumer-ok:2:VerifiedExecutionPolicyRequired
```

### AC9–AC10: documentation and scope

`docs/dcb_llm/20_materialized_view.md` and `docs/dcb_llm_ja/20_materialized_view.md` describe the optional capability, immutable per-invocation semantics, missing-key behavior, fresh projector flow, VerifyOnly refusal, and enforced policy requirement. No executor, transport, migration, release, or unrelated provider behavior was changed.

