### PR TITLE
Fix DCB packaged-consumer omission mutant version

### DIFF
--- a/dcb/tests/Sekiban.Dcb.Postgres.Tests/run-packaged-consumer.sh
+++ b/dcb/tests/Sekiban.Dcb.Postgres.Tests/run-packaged-consumer.sh
@@ -44,7 +44,7 @@ run_net10() { (cd "$net10_host" && dotnet "$@"); }
 
 short_head="$(git -C "$repo_root" rev-parse --short=12 HEAD)"
 version="${G62_PACKAGE_VERSION:-10.0.2-g62.${short_head}}"
-mutant_version="${version}.omission"
+mutant_version="${version}-omission"
 feed="$temp_root/candidate-feed"
 mutant_feed="$temp_root/mutant-feed"
 mkdir -p "$feed" "$mutant_feed"


### PR DESCRIPTION
## Summary

- Change the PostgreSQL packaged-consumer omission mutant suffix from \${version}.omission to \${version}-omission, which is valid NuGet/SemVer for stable and prerelease candidate versions.
- Keep omission-mutant behavior unchanged: remove only the two direct EF Core Relational references and require the expected missing-assembly failure.
- No Sonar suppression, exclusion, threshold, workflow, template, Orleans, #1185, #1169, or #1193 change.

## Sonar evidence

The public SonarCloud main analysis at 1b3e88d45aa886edd72206e8a7c31ca6f28a8d83 reports previous_version new-code baseline 2024-09-14, projectVersion not provided for recent analyses, 405 new security hotspots, 20.0% new duplicated lines density, and 430644 new lines. The repository contains no Sonar workflow or project configuration. This child PR does not waive or suppress those findings; correcting the Sonar project baseline/new-code configuration is an external Architect/administrator duty.

## Validation

    bash -n dcb/tests/Sekiban.Dcb.Postgres.Tests/run-packaged-consumer.sh
    git diff --check
    G62_PACKAGE_VERSION=10.21.0 TMPDIR=/private/tmp/sek-dcb-10-21-sonar-pg-tmp bash dcb/tests/Sekiban.Dcb.Postgres.Tests/run-packaged-consumer.sh --repo-root "$PWD"

The packaged-consumer command completed successfully:
- positive net9.0 and net10.0 consumers: 0 warnings, 0 errors; six model entities and Relational 9.0.13 / 10.0.3.
- mutant packages: 10.21.0-omission for all three packages.
- mutant net9.0 and net10.0: expected FileNotFoundException for Microsoft.EntityFrameworkCore.Relational.
- final output: G62 packaged consumer regression passed for net9.0 and net10.0.
