### PR TITLE
feat: add durable PostgreSQL-backed Orleans subscriptions

### DIFF
--- a/dcb/src/Sekiban.Dcb.Core/Subscriptions/DurableSubscriptionContracts.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Subscriptions/DurableSubscriptionContracts.cs
@@ -29,8 +29,17 @@ public enum DurableSubscriptionPhase
     CatchingUp,
     Idle,
     Retrying,
-    Standby,
     Halted
+}
+
+/// <summary>Process-local runner status; this is never persisted as durable subscription state.</summary>
+public enum DurableSubscriptionRunnerStatus
+{
+    Starting,
+    Owner,
+    Standby,
+    Halted,
+    Stopped
 }
 
 /// <summary>Normalized service/name identity for a durable subscriber.</summary>
@@ -132,7 +141,12 @@ public sealed record DurableSubscriptionState(
 /// <summary>Lease acquisition result; non-owners receive a state instead of a false healthy result.</summary>
 public sealed record DurableSubscriptionLease(
     bool Acquired,
-    DurableSubscriptionState State);
+    DurableSubscriptionState State)
+{
+    /// <summary>Process-local ownership status associated with this acquisition attempt.</summary>
+    public DurableSubscriptionRunnerStatus Status { get; init; } =
+        Acquired ? DurableSubscriptionRunnerStatus.Owner : DurableSubscriptionRunnerStatus.Standby;
+}
 
 /// <summary>Provider-owned state boundary for a durable subscription.</summary>
 public interface IDurableSubscriptionStore
@@ -160,6 +174,12 @@ public interface IDurableSubscriptionStore
         TimeSpan leaseDuration,
         CancellationToken cancellationToken = default);
 
+    Task<ResultBox<bool>> IsRetryDueAsync(
+        DurableSubscriptionIdentity identity,
+        string ownerId,
+        long ownerGeneration,
+        CancellationToken cancellationToken = default);
+
     Task<ResultBox<DurableSubscriptionState>> AcknowledgeAsync(
         DurableSubscriptionIdentity identity,
         string ownerId,
@@ -184,6 +204,8 @@ public interface IDurableSubscriptionStore
 
     Task<ResultBox<DurableSubscriptionState>> HaltAsync(
         DurableSubscriptionIdentity identity,
+        string ownerId,
+        long ownerGeneration,
         string reason,
         CancellationToken cancellationToken = default);
 
@@ -217,6 +239,7 @@ public sealed record DurableSubscriptionRegistration(
 public interface IDurableSubscriptionHandle : IAsyncDisposable
 {
     DurableSubscriptionIdentity Identity { get; }
+    DurableSubscriptionRunnerStatus Status { get; }
     Task<DurableSubscriptionState> GetStateAsync(CancellationToken cancellationToken = default);
     Task ResumeAsync(CancellationToken cancellationToken = default);
     Task HaltAsync(string reason, CancellationToken cancellationToken = default);

--- a/dcb/src/Sekiban.Dcb.Core/Subscriptions/DurableSubscriptionContracts.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Subscriptions/DurableSubscriptionContracts.cs
@@ -1,0 +1,223 @@
+using Sekiban.Dcb.Common;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.ServiceId;
+using ResultBoxes;
+
+namespace Sekiban.Dcb.Subscriptions;
+
+/// <summary>How the first durable cursor is selected.</summary>
+public enum DurableSubscriptionStartPolicy
+{
+    /// <summary>Start at the current safe tail and process only events written afterwards.</summary>
+    FromNow,
+
+    /// <summary>Start at the beginning of the service event stream.</summary>
+    FromBeginning
+}
+
+/// <summary>Controls whether the provider may create its durable state table at runtime.</summary>
+public enum DurableSubscriptionProvisioningMode
+{
+    LegacyAutoProvision,
+    PreProvisioned
+}
+
+/// <summary>Durable lifecycle phases persisted by the provider.</summary>
+public enum DurableSubscriptionPhase
+{
+    Uninitialized,
+    CatchingUp,
+    Idle,
+    Retrying,
+    Standby,
+    Halted
+}
+
+/// <summary>Normalized service/name identity for a durable subscriber.</summary>
+public sealed record DurableSubscriptionIdentity
+{
+    public DurableSubscriptionIdentity(string serviceId, string name)
+    {
+        ServiceId = ServiceIdValidator.NormalizeAndValidate(serviceId);
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            throw new ArgumentException("Durable subscription name must not be empty.", nameof(name));
+        }
+
+        if (name.Length > 128)
+        {
+            throw new ArgumentException("Durable subscription name must be at most 128 characters.", nameof(name));
+        }
+
+        Name = name.Trim();
+        if (Name.Length == 0 || Name.Any(char.IsControl))
+        {
+            throw new ArgumentException("Durable subscription name contains invalid characters.", nameof(name));
+        }
+    }
+
+    public string ServiceId { get; }
+    public string Name { get; }
+}
+
+/// <summary>Validated bounds and timing for a durable subscriber.</summary>
+public sealed class DurableSubscriptionOptions
+{
+    public string ServiceId { get; set; } = DefaultServiceIdProvider.DefaultServiceId;
+    public string Name { get; set; } = "subscription";
+    public DurableSubscriptionStartPolicy StartPolicy { get; set; } = DurableSubscriptionStartPolicy.FromNow;
+    public DurableSubscriptionProvisioningMode ProvisioningMode { get; set; } = DurableSubscriptionProvisioningMode.LegacyAutoProvision;
+    public TimeSpan SafeWindow { get; set; } = TimeSpan.FromMilliseconds(SortableUniqueId.SafeMilliseconds);
+    public TimeSpan LeaseDuration { get; set; } = TimeSpan.FromSeconds(30);
+    public TimeSpan PollInterval { get; set; } = TimeSpan.FromSeconds(5);
+    public TimeSpan RetryDelay { get; set; } = TimeSpan.FromSeconds(5);
+    public int MaxHandlerAttempts { get; set; } = 4;
+    public int MaxBatchSize { get; set; } = 256;
+
+    public DurableSubscriptionIdentity Identity => new(ServiceId, Name);
+
+    public void Validate()
+    {
+        _ = Identity;
+        if (SafeWindow < TimeSpan.Zero || SafeWindow > TimeSpan.FromDays(7))
+        {
+            throw new ArgumentOutOfRangeException(nameof(SafeWindow), "SafeWindow must be between zero and seven days.");
+        }
+
+        if (LeaseDuration < TimeSpan.FromSeconds(1) || LeaseDuration > TimeSpan.FromHours(1))
+        {
+            throw new ArgumentOutOfRangeException(nameof(LeaseDuration), "LeaseDuration must be between one second and one hour.");
+        }
+
+        if (PollInterval <= TimeSpan.Zero || PollInterval > TimeSpan.FromHours(1))
+        {
+            throw new ArgumentOutOfRangeException(nameof(PollInterval), "PollInterval must be positive and at most one hour.");
+        }
+
+        if (RetryDelay <= TimeSpan.Zero || RetryDelay > TimeSpan.FromHours(1))
+        {
+            throw new ArgumentOutOfRangeException(nameof(RetryDelay), "RetryDelay must be positive and at most one hour.");
+        }
+
+        if (MaxHandlerAttempts < 1 || MaxHandlerAttempts > 16)
+        {
+            throw new ArgumentOutOfRangeException(nameof(MaxHandlerAttempts), "MaxHandlerAttempts must be between one and sixteen.");
+        }
+
+        if (MaxBatchSize < 1 || MaxBatchSize > 10_000)
+        {
+            throw new ArgumentOutOfRangeException(nameof(MaxBatchSize), "MaxBatchSize must be between one and 10,000.");
+        }
+    }
+}
+
+/// <summary>Durable state returned by a provider.</summary>
+public sealed record DurableSubscriptionState(
+    DurableSubscriptionIdentity Identity,
+    bool Initialized,
+    string? AcknowledgedPosition,
+    DurableSubscriptionPhase Phase,
+    string? ActiveFailurePosition,
+    int ActiveFailureCount,
+    string? ActiveFailureReason,
+    DateTimeOffset? NextAttemptAtUtc,
+    string? LastHaltPosition,
+    DateTimeOffset? LastHaltAtUtc,
+    string? LastHaltReason,
+    string? OwnerId,
+    long OwnerGeneration,
+    DateTimeOffset? LeaseExpiresAtUtc,
+    DateTimeOffset UpdatedAtUtc);
+
+/// <summary>Lease acquisition result; non-owners receive a state instead of a false healthy result.</summary>
+public sealed record DurableSubscriptionLease(
+    bool Acquired,
+    DurableSubscriptionState State);
+
+/// <summary>Provider-owned state boundary for a durable subscription.</summary>
+public interface IDurableSubscriptionStore
+{
+    Task<ResultBox<DurableSubscriptionState>> InitializeOrGetAsync(
+        DurableSubscriptionIdentity identity,
+        DurableSubscriptionStartPolicy startPolicy,
+        string safeTail,
+        CancellationToken cancellationToken = default);
+
+    Task<ResultBox<DurableSubscriptionState>> ReadAsync(
+        DurableSubscriptionIdentity identity,
+        CancellationToken cancellationToken = default);
+
+    Task<ResultBox<DurableSubscriptionLease>> TryAcquireAsync(
+        DurableSubscriptionIdentity identity,
+        string ownerId,
+        TimeSpan leaseDuration,
+        CancellationToken cancellationToken = default);
+
+    Task<ResultBox<bool>> RenewAsync(
+        DurableSubscriptionIdentity identity,
+        string ownerId,
+        long ownerGeneration,
+        TimeSpan leaseDuration,
+        CancellationToken cancellationToken = default);
+
+    Task<ResultBox<DurableSubscriptionState>> AcknowledgeAsync(
+        DurableSubscriptionIdentity identity,
+        string ownerId,
+        long ownerGeneration,
+        string position,
+        CancellationToken cancellationToken = default);
+
+    Task<ResultBox<DurableSubscriptionState>> RecordFailureAsync(
+        DurableSubscriptionIdentity identity,
+        string ownerId,
+        long ownerGeneration,
+        string position,
+        string reason,
+        bool conversionFailure,
+        int maxHandlerAttempts,
+        TimeSpan retryDelay,
+        CancellationToken cancellationToken = default);
+
+    Task<ResultBox<DurableSubscriptionState>> ResumeAsync(
+        DurableSubscriptionIdentity identity,
+        CancellationToken cancellationToken = default);
+
+    Task<ResultBox<DurableSubscriptionState>> HaltAsync(
+        DurableSubscriptionIdentity identity,
+        string reason,
+        CancellationToken cancellationToken = default);
+
+    Task<ResultBox<DurableSubscriptionState>> MarkIdleAsync(
+        DurableSubscriptionIdentity identity,
+        string ownerId,
+        long ownerGeneration,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>Orleans or another delivery system can wake a durable runner; it never supplies authoritative data.</summary>
+public interface IDurableSubscriptionNudgeFactory
+{
+    IDurableSubscriptionNudge Create(DurableSubscriptionIdentity identity, Func<ValueTask> onNudge);
+}
+
+/// <summary>Disposable best-effort wake subscription.</summary>
+public interface IDurableSubscriptionNudge : IAsyncDisposable
+{
+}
+
+/// <summary>Delegate used by a durable runner after storage conversion succeeds.</summary>
+public delegate Task DurableSubscriptionHandler(Event @event, CancellationToken cancellationToken);
+
+/// <summary>Registration object used by provider DI extensions.</summary>
+public sealed record DurableSubscriptionRegistration(
+    DurableSubscriptionOptions Options,
+    DurableSubscriptionHandler Handler);
+
+/// <summary>Public handle for an opt-in durable runner.</summary>
+public interface IDurableSubscriptionHandle : IAsyncDisposable
+{
+    DurableSubscriptionIdentity Identity { get; }
+    Task<DurableSubscriptionState> GetStateAsync(CancellationToken cancellationToken = default);
+    Task ResumeAsync(CancellationToken cancellationToken = default);
+    Task HaltAsync(string reason, CancellationToken cancellationToken = default);
+}

--- a/dcb/src/Sekiban.Dcb.Core/Subscriptions/DurableSubscriptionRunner.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Subscriptions/DurableSubscriptionRunner.cs
@@ -1,0 +1,476 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using ResultBoxes;
+using Sekiban.Dcb.Common;
+using Sekiban.Dcb.Domains;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.Storage;
+
+namespace Sekiban.Dcb.Subscriptions;
+
+/// <summary>
+///     Store-driven durable subscriber. Orleans (or another delivery mechanism) only releases the wake gate;
+///     every event and acknowledgement comes from the authoritative event store and durable state store.
+/// </summary>
+public sealed class DurableSubscriptionRunner : BackgroundService
+{
+    private readonly DurableSubscriptionRegistration _registration;
+    private readonly IDurableSubscriptionStore _stateStore;
+    private readonly IEventStoreFactory _eventStoreFactory;
+    private readonly IEventTypes _eventTypes;
+    private readonly IDurableSubscriptionNudgeFactory _nudgeFactory;
+    private readonly ILogger<DurableSubscriptionRunner> _logger;
+    private readonly SemaphoreSlim _wake = new(0, 1);
+    private readonly string _ownerId = $"{Environment.MachineName}:{Environment.ProcessId}:{Guid.NewGuid():N}";
+    private IDurableSubscriptionNudge? _nudge;
+
+    public DurableSubscriptionRunner(
+        DurableSubscriptionRegistration registration,
+        IDurableSubscriptionStore stateStore,
+        IEventStoreFactory eventStoreFactory,
+        IEventTypes eventTypes,
+        IDurableSubscriptionNudgeFactory nudgeFactory,
+        ILogger<DurableSubscriptionRunner> logger)
+    {
+        _registration = registration ?? throw new ArgumentNullException(nameof(registration));
+        _stateStore = stateStore ?? throw new ArgumentNullException(nameof(stateStore));
+        _eventStoreFactory = eventStoreFactory ?? throw new ArgumentNullException(nameof(eventStoreFactory));
+        _eventTypes = eventTypes ?? throw new ArgumentNullException(nameof(eventTypes));
+        _nudgeFactory = nudgeFactory ?? throw new ArgumentNullException(nameof(nudgeFactory));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _registration.Options.Validate();
+    }
+
+    public DurableSubscriptionIdentity Identity => _registration.Options.Identity;
+
+    public Task<DurableSubscriptionState> GetStateAsync(CancellationToken cancellationToken = default) =>
+        GetStateOrThrowAsync(cancellationToken);
+
+    public async Task ResumeAsync(CancellationToken cancellationToken = default)
+    {
+        var result = await _stateStore.ResumeAsync(Identity, cancellationToken).ConfigureAwait(false);
+        if (!result.IsSuccess)
+        {
+            throw result.GetException();
+        }
+
+        _wake.ReleaseIfNeeded();
+    }
+
+    public async Task HaltAsync(string reason, CancellationToken cancellationToken = default)
+    {
+        var result = await _stateStore.HaltAsync(Identity, reason, cancellationToken).ConfigureAwait(false);
+        if (!result.IsSuccess)
+        {
+            throw result.GetException();
+        }
+
+        _wake.ReleaseIfNeeded();
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _registration.Options.Validate();
+        var identity = Identity;
+        var safeTail = DurableSubscriptionSafeTail.Calculate(_registration.Options.SafeWindow);
+        var initialized = await _stateStore.InitializeOrGetAsync(
+                identity,
+                _registration.Options.StartPolicy,
+                safeTail,
+                stoppingToken)
+            .ConfigureAwait(false);
+        if (!initialized.IsSuccess)
+        {
+            _logger.LogError(initialized.GetException(), "Durable subscription {ServiceId}/{Name} could not initialize.", identity.ServiceId, identity.Name);
+            return;
+        }
+
+        // The nudge is attached before the first catch-up read. It is deliberately data-free and can never advance the
+        // durable cursor; this ordering closes the startup notification gap without trusting stream payloads.
+        try
+        {
+            _nudge = _nudgeFactory.Create(identity, () =>
+            {
+                _wake.ReleaseIfNeeded();
+                return ValueTask.CompletedTask;
+            });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Durable subscription {ServiceId}/{Name} nudge attachment failed; polling remains active.", identity.ServiceId, identity.Name);
+        }
+
+        try
+        {
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                await RunOneCycleAsync(stoppingToken).ConfigureAwait(false);
+            }
+        }
+        catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+        {
+        }
+        finally
+        {
+            if (_nudge is not null)
+            {
+                await _nudge.DisposeAsync().ConfigureAwait(false);
+            }
+        }
+    }
+
+    private async Task RunOneCycleAsync(CancellationToken cancellationToken)
+    {
+        var identity = Identity;
+        var observed = await _stateStore.ReadAsync(identity, cancellationToken).ConfigureAwait(false);
+        if (!observed.IsSuccess)
+        {
+            _logger.LogError(observed.GetException(), "Durable subscription {ServiceId}/{Name} state read failed.", identity.ServiceId, identity.Name);
+            await WaitForWakeOrPollAsync(cancellationToken).ConfigureAwait(false);
+            return;
+        }
+
+        var state = observed.GetValue();
+        if (state.Phase == DurableSubscriptionPhase.Halted)
+        {
+            await WaitForWakeOrPollAsync(cancellationToken).ConfigureAwait(false);
+            return;
+        }
+
+        // A row read immediately precedes each acquisition attempt. The provider repeats the predicate under its
+        // transaction, but this read makes standby state observable and prevents an optimistic local lease assumption.
+        var lease = await _stateStore.TryAcquireAsync(
+                identity,
+                _ownerId,
+                _registration.Options.LeaseDuration,
+                cancellationToken)
+            .ConfigureAwait(false);
+        if (!lease.IsSuccess)
+        {
+            _logger.LogError(lease.GetException(), "Durable subscription {ServiceId}/{Name} acquisition failed.", identity.ServiceId, identity.Name);
+            await WaitForWakeOrPollAsync(cancellationToken).ConfigureAwait(false);
+            return;
+        }
+
+        if (!lease.GetValue().Acquired)
+        {
+            await WaitForWakeOrPollAsync(cancellationToken).ConfigureAwait(false);
+            return;
+        }
+
+        state = lease.GetValue().State;
+        var store = _eventStoreFactory.CreateForService(identity.ServiceId);
+        try
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                var currentResult = await _stateStore.ReadAsync(identity, cancellationToken).ConfigureAwait(false);
+                if (!currentResult.IsSuccess)
+                {
+                    _logger.LogError(currentResult.GetException(), "Durable subscription {ServiceId}/{Name} state read failed while owned.", identity.ServiceId, identity.Name);
+                    return;
+                }
+
+                state = currentResult.GetValue();
+                if (!Owns(state) || state.Phase == DurableSubscriptionPhase.Halted)
+                {
+                    return;
+                }
+
+                if (state.Phase == DurableSubscriptionPhase.Retrying &&
+                    state.NextAttemptAtUtc is { } retryAt && retryAt > DateTimeOffset.UtcNow)
+                {
+                    await DelayUntilAsync(retryAt, cancellationToken).ConfigureAwait(false);
+                    continue;
+                }
+
+                var read = await store.ReadAllSerializableEventsAsync(
+                        state.AcknowledgedPosition is null ? null : new SortableUniqueId(state.AcknowledgedPosition),
+                        _registration.Options.MaxBatchSize)
+                    .ConfigureAwait(false);
+                if (!read.IsSuccess)
+                {
+                    _logger.LogError(read.GetException(), "Durable subscription {ServiceId}/{Name} event read failed.", identity.ServiceId, identity.Name);
+                    await WaitForWakeOrPollAsync(cancellationToken).ConfigureAwait(false);
+                    return;
+                }
+
+                var events = read.GetValue().OrderBy(e => e.SortableUniqueIdValue, StringComparer.Ordinal).ToList();
+                if (events.Count == 0)
+                {
+                    var idle = await _stateStore.MarkIdleAsync(identity, _ownerId, state.OwnerGeneration, cancellationToken).ConfigureAwait(false);
+                    if (!idle.IsSuccess)
+                    {
+                        _logger.LogWarning(idle.GetException(), "Durable subscription {ServiceId}/{Name} could not mark idle.", identity.ServiceId, identity.Name);
+                    }
+
+                    await WaitForWakeOrPollAsync(cancellationToken).ConfigureAwait(false);
+                    return;
+                }
+
+                foreach (var serializableEvent in events)
+                {
+                    if (cancellationToken.IsCancellationRequested)
+                    {
+                        return;
+                    }
+
+                    var conversion = serializableEvent.ToEvent(_eventTypes);
+                    if (!conversion.IsSuccess)
+                    {
+                        var failed = await RecordFailureAndStopOrRetryAsync(
+                                serializableEvent,
+                                conversion.GetException().Message,
+                                conversionFailure: true,
+                                state.OwnerGeneration,
+                                cancellationToken)
+                            .ConfigureAwait(false);
+                        if (failed?.Phase == DurableSubscriptionPhase.Retrying)
+                        {
+                            await DelayUntilAsync(failed.NextAttemptAtUtc ?? DateTimeOffset.UtcNow, cancellationToken).ConfigureAwait(false);
+                            continue;
+                        }
+
+                        return;
+                    }
+
+                    var delivery = await InvokeWithLeaseRenewalAsync(
+                            conversion.GetValue(),
+                            state.OwnerGeneration,
+                            cancellationToken)
+                        .ConfigureAwait(false);
+                    if (!delivery.Completed)
+                    {
+                        if (delivery.LeaseLost)
+                        {
+                            return;
+                        }
+
+                        var failed = await RecordFailureAndStopOrRetryAsync(
+                                serializableEvent,
+                                delivery.Error?.ToString() ?? "Durable subscription handler failed.",
+                                conversionFailure: false,
+                                state.OwnerGeneration,
+                                cancellationToken)
+                            .ConfigureAwait(false);
+                        if (failed?.Phase == DurableSubscriptionPhase.Retrying)
+                        {
+                            await DelayUntilAsync(failed.NextAttemptAtUtc ?? DateTimeOffset.UtcNow, cancellationToken).ConfigureAwait(false);
+                            continue;
+                        }
+
+                        return;
+                    }
+
+                    var acknowledged = await _stateStore.AcknowledgeAsync(
+                            identity,
+                            _ownerId,
+                            state.OwnerGeneration,
+                            serializableEvent.SortableUniqueIdValue,
+                            cancellationToken)
+                        .ConfigureAwait(false);
+                    if (!acknowledged.IsSuccess)
+                    {
+                        _logger.LogError(acknowledged.GetException(), "Durable subscription {ServiceId}/{Name} acknowledgement failed.", identity.ServiceId, identity.Name);
+                        return;
+                    }
+                }
+            }
+        }
+        finally
+        {
+            if (store is IDisposable disposable)
+            {
+                disposable.Dispose();
+            }
+        }
+    }
+
+    private async Task<DurableSubscriptionState?> RecordFailureAndStopOrRetryAsync(
+        SerializableEvent serializableEvent,
+        string reason,
+        bool conversionFailure,
+        long ownerGeneration,
+        CancellationToken cancellationToken)
+    {
+        var result = await _stateStore.RecordFailureAsync(
+                Identity,
+                _ownerId,
+                ownerGeneration,
+                serializableEvent.SortableUniqueIdValue,
+                reason,
+                conversionFailure,
+                _registration.Options.MaxHandlerAttempts,
+                _registration.Options.RetryDelay,
+                cancellationToken)
+            .ConfigureAwait(false);
+        if (!result.IsSuccess)
+        {
+            _logger.LogError(result.GetException(), "Durable subscription {ServiceId}/{Name} failure state could not be recorded.", Identity.ServiceId, Identity.Name);
+            return null;
+        }
+
+        var state = result.GetValue();
+        if (state.Phase == DurableSubscriptionPhase.Halted)
+        {
+            _logger.LogError("Durable subscription {ServiceId}/{Name} halted at {Position}: {Reason}", Identity.ServiceId, Identity.Name, state.LastHaltPosition, state.LastHaltReason);
+        }
+
+        return state;
+    }
+
+    private async Task<(bool Completed, bool LeaseLost, Exception? Error)> InvokeWithLeaseRenewalAsync(
+        Event @event,
+        long ownerGeneration,
+        CancellationToken cancellationToken)
+    {
+        using var handlerCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        var leaseLost = 0;
+        var renewTask = RenewLeaseAsync(ownerGeneration, handlerCts, () => Interlocked.Exchange(ref leaseLost, 1));
+        try
+        {
+            await _registration.Handler(@event, handlerCts.Token).ConfigureAwait(false);
+            return (true, false, null);
+        }
+        catch (OperationCanceledException) when (Volatile.Read(ref leaseLost) != 0 && !cancellationToken.IsCancellationRequested)
+        {
+            return (false, true, null);
+        }
+        catch (Exception ex)
+        {
+            return (false, false, ex);
+        }
+        finally
+        {
+            handlerCts.Cancel();
+            try
+            {
+                await renewTask.ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+            }
+        }
+    }
+
+    private async Task RenewLeaseAsync(
+        long ownerGeneration,
+        CancellationTokenSource handlerCts,
+        Action markLeaseLost)
+    {
+        var delay = TimeSpan.FromTicks(Math.Max(TimeSpan.FromMilliseconds(100).Ticks, _registration.Options.LeaseDuration.Ticks / 3));
+        while (!handlerCts.IsCancellationRequested)
+        {
+            await Task.Delay(delay, handlerCts.Token).ConfigureAwait(false);
+            if (handlerCts.IsCancellationRequested)
+            {
+                break;
+            }
+
+            try
+            {
+                var renewed = await _stateStore.RenewAsync(
+                        Identity,
+                        _ownerId,
+                        ownerGeneration,
+                        _registration.Options.LeaseDuration,
+                        handlerCts.Token)
+                    .ConfigureAwait(false);
+                if (!renewed.IsSuccess || !renewed.GetValue())
+                {
+                    markLeaseLost();
+                    handlerCts.Cancel();
+                    break;
+                }
+            }
+            catch (OperationCanceledException) when (handlerCts.IsCancellationRequested)
+            {
+                break;
+            }
+            catch
+            {
+                markLeaseLost();
+                handlerCts.Cancel();
+                break;
+            }
+        }
+    }
+
+    private async Task<DurableSubscriptionState> GetStateOrThrowAsync(CancellationToken cancellationToken)
+    {
+        var result = await _stateStore.ReadAsync(Identity, cancellationToken).ConfigureAwait(false);
+        return result.IsSuccess ? result.GetValue() : throw result.GetException();
+    }
+
+    private bool Owns(DurableSubscriptionState state) =>
+        string.Equals(state.OwnerId, _ownerId, StringComparison.Ordinal) &&
+        state.LeaseExpiresAtUtc is { } expiry && expiry > DateTimeOffset.UtcNow;
+
+    private async Task WaitForWakeOrPollAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            await _wake.WaitAsync(_registration.Options.PollInterval, cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+    }
+
+    private static async Task DelayUntilAsync(DateTimeOffset target, CancellationToken cancellationToken)
+    {
+        var delay = target - DateTimeOffset.UtcNow;
+        if (delay > TimeSpan.Zero)
+        {
+            await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
+        }
+    }
+}
+
+internal static class DurableSubscriptionSafeTail
+{
+    internal static string Calculate(TimeSpan safeWindow)
+    {
+        var timestamp = DateTime.UtcNow.Subtract(safeWindow);
+        return SortableUniqueId.Generate(timestamp, Guid.Empty);
+    }
+}
+
+public sealed class NoOpDurableSubscriptionNudgeFactory : IDurableSubscriptionNudgeFactory
+{
+    public IDurableSubscriptionNudge Create(DurableSubscriptionIdentity identity, Func<ValueTask> onNudge) =>
+        new NoOpDurableSubscriptionNudge();
+}
+
+internal sealed class NoOpDurableSubscriptionNudge : IDurableSubscriptionNudge
+{
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+}
+
+public sealed class DurableSubscriptionHandle : IDurableSubscriptionHandle
+{
+    private readonly DurableSubscriptionRunner _runner;
+
+    public DurableSubscriptionHandle(DurableSubscriptionRunner runner) => _runner = runner;
+
+    public DurableSubscriptionIdentity Identity => _runner.Identity;
+    public Task<DurableSubscriptionState> GetStateAsync(CancellationToken cancellationToken = default) => _runner.GetStateAsync(cancellationToken);
+    public Task ResumeAsync(CancellationToken cancellationToken = default) => _runner.ResumeAsync(cancellationToken);
+    public Task HaltAsync(string reason, CancellationToken cancellationToken = default) => _runner.HaltAsync(reason, cancellationToken);
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+}
+
+internal static class SemaphoreSlimExtensions
+{
+    internal static void ReleaseIfNeeded(this SemaphoreSlim semaphore)
+    {
+        try
+        {
+            semaphore.Release();
+        }
+        catch (SemaphoreFullException)
+        {
+        }
+    }
+}

--- a/dcb/src/Sekiban.Dcb.Core/Subscriptions/DurableSubscriptionRunner.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Subscriptions/DurableSubscriptionRunner.cs
@@ -23,6 +23,8 @@ public sealed class DurableSubscriptionRunner : BackgroundService
     private readonly SemaphoreSlim _wake = new(0, 1);
     private readonly string _ownerId = $"{Environment.MachineName}:{Environment.ProcessId}:{Guid.NewGuid():N}";
     private IDurableSubscriptionNudge? _nudge;
+    private int _status = (int)DurableSubscriptionRunnerStatus.Starting;
+    private long _ownerGeneration;
 
     public DurableSubscriptionRunner(
         DurableSubscriptionRegistration registration,
@@ -43,6 +45,9 @@ public sealed class DurableSubscriptionRunner : BackgroundService
 
     public DurableSubscriptionIdentity Identity => _registration.Options.Identity;
 
+    public DurableSubscriptionRunnerStatus Status =>
+        (DurableSubscriptionRunnerStatus)Volatile.Read(ref _status);
+
     public Task<DurableSubscriptionState> GetStateAsync(CancellationToken cancellationToken = default) =>
         GetStateOrThrowAsync(cancellationToken);
 
@@ -54,17 +59,31 @@ public sealed class DurableSubscriptionRunner : BackgroundService
             throw result.GetException();
         }
 
+        Volatile.Write(ref _status, (int)DurableSubscriptionRunnerStatus.Starting);
         _wake.ReleaseIfNeeded();
     }
 
     public async Task HaltAsync(string reason, CancellationToken cancellationToken = default)
     {
-        var result = await _stateStore.HaltAsync(Identity, reason, cancellationToken).ConfigureAwait(false);
+        var generation = Interlocked.Read(ref _ownerGeneration);
+        if (generation == 0)
+        {
+            throw new InvalidOperationException("The durable subscription runner does not currently own a lease.");
+        }
+
+        var result = await _stateStore.HaltAsync(
+                Identity,
+                _ownerId,
+                generation,
+                reason,
+                cancellationToken)
+            .ConfigureAwait(false);
         if (!result.IsSuccess)
         {
             throw result.GetException();
         }
 
+        Volatile.Write(ref _status, (int)DurableSubscriptionRunnerStatus.Halted);
         _wake.ReleaseIfNeeded();
     }
 
@@ -82,6 +101,7 @@ public sealed class DurableSubscriptionRunner : BackgroundService
         if (!initialized.IsSuccess)
         {
             _logger.LogError(initialized.GetException(), "Durable subscription {ServiceId}/{Name} could not initialize.", identity.ServiceId, identity.Name);
+            Volatile.Write(ref _status, (int)DurableSubscriptionRunnerStatus.Stopped);
             return;
         }
 
@@ -116,6 +136,9 @@ public sealed class DurableSubscriptionRunner : BackgroundService
             {
                 await _nudge.DisposeAsync().ConfigureAwait(false);
             }
+
+            Interlocked.Exchange(ref _ownerGeneration, 0);
+            Volatile.Write(ref _status, (int)DurableSubscriptionRunnerStatus.Stopped);
         }
     }
 
@@ -133,6 +156,7 @@ public sealed class DurableSubscriptionRunner : BackgroundService
         var state = observed.GetValue();
         if (state.Phase == DurableSubscriptionPhase.Halted)
         {
+            Volatile.Write(ref _status, (int)DurableSubscriptionRunnerStatus.Halted);
             await WaitForWakeOrPollAsync(cancellationToken).ConfigureAwait(false);
             return;
         }
@@ -154,11 +178,18 @@ public sealed class DurableSubscriptionRunner : BackgroundService
 
         if (!lease.GetValue().Acquired)
         {
+            Volatile.Write(
+                ref _status,
+                (int)(lease.GetValue().Status == DurableSubscriptionRunnerStatus.Halted
+                    ? DurableSubscriptionRunnerStatus.Halted
+                    : DurableSubscriptionRunnerStatus.Standby));
             await WaitForWakeOrPollAsync(cancellationToken).ConfigureAwait(false);
             return;
         }
 
         state = lease.GetValue().State;
+        Interlocked.Exchange(ref _ownerGeneration, state.OwnerGeneration);
+        Volatile.Write(ref _status, (int)DurableSubscriptionRunnerStatus.Owner);
         var store = _eventStoreFactory.CreateForService(identity.ServiceId);
         try
         {
@@ -172,16 +203,46 @@ public sealed class DurableSubscriptionRunner : BackgroundService
                 }
 
                 state = currentResult.GetValue();
-                if (!Owns(state) || state.Phase == DurableSubscriptionPhase.Halted)
+                if (state.Phase == DurableSubscriptionPhase.Halted)
                 {
+                    Interlocked.Exchange(ref _ownerGeneration, 0);
+                    Volatile.Write(ref _status, (int)DurableSubscriptionRunnerStatus.Halted);
                     return;
                 }
 
-                if (state.Phase == DurableSubscriptionPhase.Retrying &&
-                    state.NextAttemptAtUtc is { } retryAt && retryAt > DateTimeOffset.UtcNow)
+                var renewed = await _stateStore.RenewAsync(
+                        identity,
+                        _ownerId,
+                        state.OwnerGeneration,
+                        _registration.Options.LeaseDuration,
+                        cancellationToken)
+                    .ConfigureAwait(false);
+                if (!renewed.IsSuccess || !renewed.GetValue())
                 {
-                    await DelayUntilAsync(retryAt, cancellationToken).ConfigureAwait(false);
-                    continue;
+                    Interlocked.Exchange(ref _ownerGeneration, 0);
+                    Volatile.Write(ref _status, (int)DurableSubscriptionRunnerStatus.Standby);
+                    return;
+                }
+
+                if (state.Phase == DurableSubscriptionPhase.Retrying)
+                {
+                    var retryDue = await _stateStore.IsRetryDueAsync(
+                            identity,
+                            _ownerId,
+                            state.OwnerGeneration,
+                            cancellationToken)
+                        .ConfigureAwait(false);
+                    if (!retryDue.IsSuccess)
+                    {
+                        _logger.LogError(retryDue.GetException(), "Durable subscription {ServiceId}/{Name} retry timing could not be read.", identity.ServiceId, identity.Name);
+                        return;
+                    }
+
+                    if (!retryDue.GetValue())
+                    {
+                        await WaitForWakeOrPollAsync(cancellationToken).ConfigureAwait(false);
+                        continue;
+                    }
                 }
 
                 var read = await store.ReadAllSerializableEventsAsync(
@@ -205,7 +266,7 @@ public sealed class DurableSubscriptionRunner : BackgroundService
                     }
 
                     await WaitForWakeOrPollAsync(cancellationToken).ConfigureAwait(false);
-                    return;
+                    continue;
                 }
 
                 foreach (var serializableEvent in events)
@@ -227,8 +288,7 @@ public sealed class DurableSubscriptionRunner : BackgroundService
                             .ConfigureAwait(false);
                         if (failed?.Phase == DurableSubscriptionPhase.Retrying)
                         {
-                            await DelayUntilAsync(failed.NextAttemptAtUtc ?? DateTimeOffset.UtcNow, cancellationToken).ConfigureAwait(false);
-                            continue;
+                            return;
                         }
 
                         return;
@@ -243,6 +303,8 @@ public sealed class DurableSubscriptionRunner : BackgroundService
                     {
                         if (delivery.LeaseLost)
                         {
+                            Interlocked.Exchange(ref _ownerGeneration, 0);
+                            Volatile.Write(ref _status, (int)DurableSubscriptionRunnerStatus.Standby);
                             return;
                         }
 
@@ -255,8 +317,7 @@ public sealed class DurableSubscriptionRunner : BackgroundService
                             .ConfigureAwait(false);
                         if (failed?.Phase == DurableSubscriptionPhase.Retrying)
                         {
-                            await DelayUntilAsync(failed.NextAttemptAtUtc ?? DateTimeOffset.UtcNow, cancellationToken).ConfigureAwait(false);
-                            continue;
+                            return;
                         }
 
                         return;
@@ -313,6 +374,8 @@ public sealed class DurableSubscriptionRunner : BackgroundService
         var state = result.GetValue();
         if (state.Phase == DurableSubscriptionPhase.Halted)
         {
+            Interlocked.Exchange(ref _ownerGeneration, 0);
+            Volatile.Write(ref _status, (int)DurableSubscriptionRunnerStatus.Halted);
             _logger.LogError("Durable subscription {ServiceId}/{Name} halted at {Position}: {Reason}", Identity.ServiceId, Identity.Name, state.LastHaltPosition, state.LastHaltReason);
         }
 
@@ -402,10 +465,6 @@ public sealed class DurableSubscriptionRunner : BackgroundService
         return result.IsSuccess ? result.GetValue() : throw result.GetException();
     }
 
-    private bool Owns(DurableSubscriptionState state) =>
-        string.Equals(state.OwnerId, _ownerId, StringComparison.Ordinal) &&
-        state.LeaseExpiresAtUtc is { } expiry && expiry > DateTimeOffset.UtcNow;
-
     private async Task WaitForWakeOrPollAsync(CancellationToken cancellationToken)
     {
         try
@@ -418,14 +477,6 @@ public sealed class DurableSubscriptionRunner : BackgroundService
         }
     }
 
-    private static async Task DelayUntilAsync(DateTimeOffset target, CancellationToken cancellationToken)
-    {
-        var delay = target - DateTimeOffset.UtcNow;
-        if (delay > TimeSpan.Zero)
-        {
-            await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
-        }
-    }
 }
 
 internal static class DurableSubscriptionSafeTail
@@ -455,6 +506,7 @@ public sealed class DurableSubscriptionHandle : IDurableSubscriptionHandle
     public DurableSubscriptionHandle(DurableSubscriptionRunner runner) => _runner = runner;
 
     public DurableSubscriptionIdentity Identity => _runner.Identity;
+    public DurableSubscriptionRunnerStatus Status => _runner.Status;
     public Task<DurableSubscriptionState> GetStateAsync(CancellationToken cancellationToken = default) => _runner.GetStateAsync(cancellationToken);
     public Task ResumeAsync(CancellationToken cancellationToken = default) => _runner.ResumeAsync(cancellationToken);
     public Task HaltAsync(string reason, CancellationToken cancellationToken = default) => _runner.HaltAsync(reason, cancellationToken);

--- a/dcb/src/Sekiban.Dcb.Orleans.Core/SekibanDcbLocalhostExtensions.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.Core/SekibanDcbLocalhostExtensions.cs
@@ -4,6 +4,7 @@ using Orleans.Configuration;
 using Sekiban.Dcb.Actors;
 using Sekiban.Dcb.MultiProjections;
 using Sekiban.Dcb.Orleans.Streams;
+using Sekiban.Dcb.Subscriptions;
 namespace Sekiban.Dcb.Orleans;
 
 /// <summary>
@@ -65,6 +66,7 @@ public static class SekibanDcbLocalhostExtensions
         {
             services.TryAddSingleton<IEventSubscriptionResolver>(
                 new DefaultOrleansEventSubscriptionResolver(streamProviderName, "AllEvents", Guid.Empty));
+            services.TryAddSingleton<IDurableSubscriptionNudgeFactory, Subscriptions.OrleansDurableSubscriptionNudgeFactory>();
             services.TryAddSingleton<IActorObjectAccessor, OrleansActorObjectAccessor>();
             services.TryAddTransient<IMultiProjectionEventStatistics, NoOpMultiProjectionEventStatistics>();
             services.TryAddTransient(_ => new GeneralMultiProjectionActorOptions { SafeWindowMs = safeWindowMs });

--- a/dcb/src/Sekiban.Dcb.Orleans.Core/Subscriptions/OrleansDurableSubscriptionNudge.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.Core/Subscriptions/OrleansDurableSubscriptionNudge.cs
@@ -1,0 +1,84 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Orleans;
+using Orleans.Streams;
+using Sekiban.Dcb.Actors;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.Orleans.ServiceId;
+using Sekiban.Dcb.Orleans.Streams;
+using Sekiban.Dcb.Subscriptions;
+
+namespace Sekiban.Dcb.Orleans.Subscriptions;
+
+/// <summary>Registers Orleans as a data-free wake source for durable store-driven subscribers.</summary>
+public static class OrleansDurableSubscriptionServiceCollectionExtensions
+{
+    public static IServiceCollection AddSekibanDcbOrleansDurableSubscriptionNudges(
+        this IServiceCollection services)
+    {
+        services.AddSingleton<IDurableSubscriptionNudgeFactory, OrleansDurableSubscriptionNudgeFactory>();
+        return services;
+    }
+}
+
+internal sealed class OrleansDurableSubscriptionNudgeFactory : IDurableSubscriptionNudgeFactory
+{
+    private readonly IClusterClient _clusterClient;
+    private readonly IEventSubscriptionResolver _resolver;
+
+    public OrleansDurableSubscriptionNudgeFactory(
+        IClusterClient clusterClient,
+        IEventSubscriptionResolver resolver)
+    {
+        _clusterClient = clusterClient ?? throw new ArgumentNullException(nameof(clusterClient));
+        _resolver = resolver ?? throw new ArgumentNullException(nameof(resolver));
+    }
+
+    public IDurableSubscriptionNudge Create(
+        DurableSubscriptionIdentity identity,
+        Func<ValueTask> onNudge)
+    {
+        ArgumentNullException.ThrowIfNull(onNudge);
+        var stream = _resolver.Resolve(ServiceIdGrainKey.Build(identity.ServiceId, identity.Name)) as OrleansSekibanStream;
+        if (stream is null)
+        {
+            throw new InvalidOperationException("The durable subscription resolver did not return an Orleans stream.");
+        }
+
+        var provider = _clusterClient.GetStreamProvider(stream.ProviderName);
+        var asyncStream = provider.GetStream<SerializableEvent>(StreamId.Create(stream.StreamNamespace, stream.StreamId));
+        return OrleansDurableSubscriptionNudge.CreateAsync(asyncStream, onNudge).GetAwaiter().GetResult();
+    }
+}
+
+internal sealed class OrleansDurableSubscriptionNudge : IDurableSubscriptionNudge
+{
+    private readonly StreamSubscriptionHandle<SerializableEvent> _handle;
+
+    private OrleansDurableSubscriptionNudge(StreamSubscriptionHandle<SerializableEvent> handle) => _handle = handle;
+
+    internal static async Task<OrleansDurableSubscriptionNudge> CreateAsync(
+        IAsyncStream<SerializableEvent> stream,
+        Func<ValueTask> onNudge)
+    {
+        var observer = new NudgeObserver(onNudge);
+        var handle = await stream.SubscribeAsync(observer, null).ConfigureAwait(false);
+        return new OrleansDurableSubscriptionNudge(handle);
+    }
+
+    public async ValueTask DisposeAsync() => await _handle.UnsubscribeAsync().ConfigureAwait(false);
+
+    private sealed class NudgeObserver : IAsyncObserver<SerializableEvent>
+    {
+        private readonly Func<ValueTask> _onNudge;
+
+        internal NudgeObserver(Func<ValueTask> onNudge) => _onNudge = onNudge;
+
+        public Task OnNextAsync(SerializableEvent item, StreamSequenceToken? token = null) =>
+            _onNudge().AsTask();
+
+        public Task OnCompletedAsync() => Task.CompletedTask;
+
+        public Task OnErrorAsync(Exception ex) => _onNudge().AsTask();
+    }
+}

--- a/dcb/src/Sekiban.Dcb.Postgres/PostgresDurableSubscriptionSchema.cs
+++ b/dcb/src/Sekiban.Dcb.Postgres/PostgresDurableSubscriptionSchema.cs
@@ -1,0 +1,34 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace Sekiban.Dcb.Postgres;
+
+internal static class PostgresDurableSubscriptionSchema
+{
+    internal const string Sql = """
+        CREATE TABLE IF NOT EXISTS dcb_durable_subscriptions (
+            service_id varchar(64) NOT NULL,
+            subscription_name varchar(128) NOT NULL,
+            initialized boolean NOT NULL,
+            acknowledged_position varchar(30) NULL,
+            phase varchar(32) NOT NULL,
+            active_failure_position varchar(30) NULL,
+            active_failure_count integer NOT NULL DEFAULT 0,
+            active_failure_reason varchar(2048) NULL,
+            next_attempt_at_utc timestamp with time zone NULL,
+            last_halt_position varchar(30) NULL,
+            last_halt_at_utc timestamp with time zone NULL,
+            last_halt_reason varchar(2048) NULL,
+            owner_id varchar(256) NULL,
+            owner_generation bigint NOT NULL DEFAULT 0,
+            lease_expires_at_utc timestamp with time zone NULL,
+            created_at_utc timestamp with time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            updated_at_utc timestamp with time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            CONSTRAINT pk_dcb_durable_subscriptions PRIMARY KEY (service_id, subscription_name)
+        );
+        CREATE INDEX IF NOT EXISTS ix_dcb_durable_subscriptions_lease
+            ON dcb_durable_subscriptions (service_id, phase, lease_expires_at_utc);
+        """;
+
+    internal static Task ProvisionAsync(SekibanDcbDbContext context, CancellationToken cancellationToken = default) =>
+        context.Database.ExecuteSqlRawAsync(Sql, cancellationToken);
+}

--- a/dcb/src/Sekiban.Dcb.Postgres/PostgresDurableSubscriptionStore.cs
+++ b/dcb/src/Sekiban.Dcb.Postgres/PostgresDurableSubscriptionStore.cs
@@ -50,15 +50,25 @@ public sealed class PostgresDurableSubscriptionStore : IDurableSubscriptionStore
                     FROM dcb_events
                     WHERE "ServiceId" = @service_id
                 ) latest
-                ON CONFLICT (service_id, subscription_name) DO NOTHING;
+                ON CONFLICT (service_id, subscription_name) DO UPDATE
+                    SET subscription_name = EXCLUDED.subscription_name
+                RETURNING service_id, subscription_name, initialized, acknowledged_position, phase,
+                          active_failure_position, active_failure_count, active_failure_reason,
+                          next_attempt_at_utc, last_halt_position, last_halt_at_utc, last_halt_reason,
+                          owner_id, owner_generation, lease_expires_at_utc, updated_at_utc;
                 """;
             AddParameter(command, "service_id", identity.ServiceId);
             AddParameter(command, "subscription_name", identity.Name);
             AddParameter(command, "start_policy", startPolicy.ToString());
             AddParameter(command, "safe_tail", safeTail);
             AddParameter(command, "phase", nameof(DurableSubscriptionPhase.CatchingUp));
-            await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
-            return await ReadCoreAsync(connection, identity, cancellationToken).ConfigureAwait(false);
+            await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+            if (!await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                throw new InvalidOperationException("The durable subscription initialization did not return its state row.");
+            }
+
+            return ResultBox.FromValue(ReadState(reader));
         }
         catch (Exception ex)
         {
@@ -116,9 +126,6 @@ public sealed class PostgresDurableSubscriptionStore : IDurableSubscriptionStore
 
             var initialized = reader.GetBoolean(0);
             var phase = reader.GetString(1);
-            var owner = reader.IsDBNull(2) ? null : reader.GetString(2);
-            var generation = reader.GetInt64(3);
-            var expiry = reader.IsDBNull(4) ? (DateTimeOffset?)null : reader.GetFieldValue<DateTimeOffset>(4);
             await reader.DisposeAsync().ConfigureAwait(false);
 
             if (!initialized || string.Equals(phase, Halted, StringComparison.Ordinal))
@@ -126,17 +133,12 @@ public sealed class PostgresDurableSubscriptionStore : IDurableSubscriptionStore
                 await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
                 var state = await ReadCoreAsync(connection, identity, cancellationToken).ConfigureAwait(false);
                 return state.IsSuccess
-                    ? ResultBox.FromValue(new DurableSubscriptionLease(false, state.GetValue()))
-                    : ResultBox.Error<DurableSubscriptionLease>(state.GetException());
-            }
-
-            var available = owner is null || expiry is null || expiry <= DateTimeOffset.UtcNow;
-            if (!available)
-            {
-                await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
-                var state = await ReadCoreAsync(connection, identity, cancellationToken).ConfigureAwait(false);
-                return state.IsSuccess
-                    ? ResultBox.FromValue(new DurableSubscriptionLease(false, state.GetValue() with { Phase = DurableSubscriptionPhase.Standby }))
+                    ? ResultBox.FromValue(new DurableSubscriptionLease(false, state.GetValue())
+                    {
+                        Status = string.Equals(phase, Halted, StringComparison.Ordinal)
+                            ? DurableSubscriptionRunnerStatus.Halted
+                            : DurableSubscriptionRunnerStatus.Standby
+                    })
                     : ResultBox.Error<DurableSubscriptionLease>(state.GetException());
             }
 
@@ -144,14 +146,14 @@ public sealed class PostgresDurableSubscriptionStore : IDurableSubscriptionStore
             update.Transaction = transaction;
             update.CommandText = """
                 UPDATE dcb_durable_subscriptions
-                SET phase = @phase,
+                SET phase = CASE WHEN phase = @retrying THEN @retrying ELSE @phase END,
                     owner_id = @owner_id,
-                    owner_generation = owner_generation + 1,
+                    owner_generation = CASE WHEN owner_id = @owner_id THEN owner_generation ELSE owner_generation + 1 END,
                     lease_expires_at_utc = CURRENT_TIMESTAMP + (@lease_seconds * INTERVAL '1 second'),
                     updated_at_utc = CURRENT_TIMESTAMP
                 WHERE service_id = @service_id AND subscription_name = @subscription_name
                   AND initialized = TRUE AND phase <> @halted
-                  AND (owner_id IS NULL OR lease_expires_at_utc <= CURRENT_TIMESTAMP)
+                  AND (owner_id = @owner_id OR owner_id IS NULL OR lease_expires_at_utc <= CURRENT_TIMESTAMP)
                 RETURNING service_id, subscription_name, initialized, acknowledged_position, phase,
                           active_failure_position, active_failure_count, active_failure_reason,
                           next_attempt_at_utc, last_halt_position, last_halt_at_utc, last_halt_reason,
@@ -159,6 +161,7 @@ public sealed class PostgresDurableSubscriptionStore : IDurableSubscriptionStore
                 """;
             AddCommonParameters(update, identity);
             AddParameter(update, "phase", nameof(DurableSubscriptionPhase.CatchingUp));
+            AddParameter(update, "retrying", nameof(DurableSubscriptionPhase.Retrying));
             AddParameter(update, "owner_id", ownerId);
             AddParameter(update, "lease_seconds", leaseDuration.TotalSeconds);
             AddParameter(update, "halted", Halted);
@@ -169,7 +172,12 @@ public sealed class PostgresDurableSubscriptionStore : IDurableSubscriptionStore
                 await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
                 var state = await ReadCoreAsync(connection, identity, cancellationToken).ConfigureAwait(false);
                 return state.IsSuccess
-                    ? ResultBox.FromValue(new DurableSubscriptionLease(false, state.GetValue() with { Phase = DurableSubscriptionPhase.Standby }))
+                    ? ResultBox.FromValue(new DurableSubscriptionLease(false, state.GetValue())
+                    {
+                        Status = state.GetValue().Phase == DurableSubscriptionPhase.Halted
+                            ? DurableSubscriptionRunnerStatus.Halted
+                            : DurableSubscriptionRunnerStatus.Standby
+                    })
                     : ResultBox.Error<DurableSubscriptionLease>(state.GetException());
             }
 
@@ -218,6 +226,38 @@ public sealed class PostgresDurableSubscriptionStore : IDurableSubscriptionStore
         }
     }
 
+    public async Task<ResultBox<bool>> IsRetryDueAsync(
+        DurableSubscriptionIdentity identity,
+        string ownerId,
+        long ownerGeneration,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            await using var context = await CreateContextAsync(cancellationToken).ConfigureAwait(false);
+            await EnsureSchemaIfAllowedAsync(context, cancellationToken).ConfigureAwait(false);
+            await using var connection = await OpenConnectionAsync(context, cancellationToken).ConfigureAwait(false);
+            await using var command = connection.CreateCommand();
+            command.CommandText = """
+                SELECT next_attempt_at_utc IS NULL OR next_attempt_at_utc <= CURRENT_TIMESTAMP
+                FROM dcb_durable_subscriptions
+                WHERE service_id = @service_id AND subscription_name = @subscription_name
+                  AND owner_id = @owner_id AND owner_generation = @owner_generation
+                  AND phase = @retrying AND lease_expires_at_utc > CURRENT_TIMESTAMP;
+                """;
+            AddCommonParameters(command, identity);
+            AddParameter(command, "owner_id", ownerId);
+            AddParameter(command, "owner_generation", ownerGeneration);
+            AddParameter(command, "retrying", nameof(DurableSubscriptionPhase.Retrying));
+            var value = await command.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false);
+            return ResultBox.FromValue(value is bool due && due);
+        }
+        catch (Exception ex)
+        {
+            return ResultBox.Error<bool>(ex);
+        }
+    }
+
     public async Task<ResultBox<DurableSubscriptionState>> AcknowledgeAsync(
         DurableSubscriptionIdentity identity,
         string ownerId,
@@ -243,6 +283,7 @@ public sealed class PostgresDurableSubscriptionStore : IDurableSubscriptionStore
                 WHERE service_id = @service_id AND subscription_name = @subscription_name
                   AND owner_id = @owner_id AND owner_generation = @owner_generation
                   AND phase <> @halted AND lease_expires_at_utc > CURRENT_TIMESTAMP
+                  AND (next_attempt_at_utc IS NULL OR next_attempt_at_utc <= CURRENT_TIMESTAMP)
                   AND (acknowledged_position IS NULL OR acknowledged_position < @position)
                 RETURNING service_id, subscription_name, initialized, acknowledged_position, phase,
                           active_failure_position, active_failure_count, active_failure_reason,
@@ -285,32 +326,70 @@ public sealed class PostgresDurableSubscriptionStore : IDurableSubscriptionStore
             await using var context = await CreateContextAsync(cancellationToken).ConfigureAwait(false);
             await EnsureSchemaIfAllowedAsync(context, cancellationToken).ConfigureAwait(false);
             await using var connection = await OpenConnectionAsync(context, cancellationToken).ConfigureAwait(false);
+            await using var transaction = await connection.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
+            await using var due = connection.CreateCommand();
+            due.Transaction = transaction;
+            due.CommandText = """
+                SELECT next_attempt_at_utc IS NULL OR next_attempt_at_utc <= CURRENT_TIMESTAMP
+                FROM dcb_durable_subscriptions
+                WHERE service_id = @service_id AND subscription_name = @subscription_name
+                  AND owner_id = @owner_id AND owner_generation = @owner_generation
+                  AND phase <> @halted AND lease_expires_at_utc > CURRENT_TIMESTAMP
+                FOR UPDATE;
+                """;
+            AddCommonParameters(due, identity);
+            AddParameter(due, "owner_id", ownerId);
+            AddParameter(due, "owner_generation", ownerGeneration);
+            AddParameter(due, "halted", Halted);
+            var retryDue = await due.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false);
+            if (retryDue is not bool || !(bool)retryDue)
+            {
+                throw new InvalidOperationException("The durable subscription retry is not due or the lease was lost.");
+            }
+
             await using var command = connection.CreateCommand();
+            command.Transaction = transaction;
             command.CommandText = """
                 UPDATE dcb_durable_subscriptions
                 SET active_failure_position = @position,
-                    active_failure_count = active_failure_count + 1,
+                    active_failure_count = CASE
+                        WHEN active_failure_position IS DISTINCT FROM @position THEN 1
+                        ELSE active_failure_count + 1 END,
                     active_failure_reason = @reason,
                     next_attempt_at_utc = CASE
-                        WHEN @conversion_failure OR active_failure_count + 1 >= @max_attempts THEN NULL
+                        WHEN @conversion_failure OR
+                             (CASE WHEN active_failure_position IS DISTINCT FROM @position THEN 1
+                                   ELSE active_failure_count + 1 END) >= @max_attempts THEN NULL
                         ELSE CURRENT_TIMESTAMP + (@retry_seconds * INTERVAL '1 second') END,
                     phase = CASE
-                        WHEN @conversion_failure OR active_failure_count + 1 >= @max_attempts THEN @halted
+                        WHEN @conversion_failure OR
+                             (CASE WHEN active_failure_position IS DISTINCT FROM @position THEN 1
+                                   ELSE active_failure_count + 1 END) >= @max_attempts THEN @halted
                         ELSE @retrying END,
                     last_halt_position = CASE
-                        WHEN @conversion_failure OR active_failure_count + 1 >= @max_attempts THEN @position
+                        WHEN @conversion_failure OR
+                             (CASE WHEN active_failure_position IS DISTINCT FROM @position THEN 1
+                                   ELSE active_failure_count + 1 END) >= @max_attempts THEN @position
                         ELSE last_halt_position END,
                     last_halt_at_utc = CASE
-                        WHEN @conversion_failure OR active_failure_count + 1 >= @max_attempts THEN CURRENT_TIMESTAMP
+                        WHEN @conversion_failure OR
+                             (CASE WHEN active_failure_position IS DISTINCT FROM @position THEN 1
+                                   ELSE active_failure_count + 1 END) >= @max_attempts THEN CURRENT_TIMESTAMP
                         ELSE last_halt_at_utc END,
                     last_halt_reason = CASE
-                        WHEN @conversion_failure OR active_failure_count + 1 >= @max_attempts THEN @reason
+                        WHEN @conversion_failure OR
+                             (CASE WHEN active_failure_position IS DISTINCT FROM @position THEN 1
+                                   ELSE active_failure_count + 1 END) >= @max_attempts THEN @reason
                         ELSE last_halt_reason END,
                     owner_id = CASE
-                        WHEN @conversion_failure OR active_failure_count + 1 >= @max_attempts THEN NULL
+                        WHEN @conversion_failure OR
+                             (CASE WHEN active_failure_position IS DISTINCT FROM @position THEN 1
+                                   ELSE active_failure_count + 1 END) >= @max_attempts THEN NULL
                         ELSE owner_id END,
                     lease_expires_at_utc = CASE
-                        WHEN @conversion_failure OR active_failure_count + 1 >= @max_attempts THEN NULL
+                        WHEN @conversion_failure OR
+                             (CASE WHEN active_failure_position IS DISTINCT FROM @position THEN 1
+                                   ELSE active_failure_count + 1 END) >= @max_attempts THEN NULL
                         ELSE lease_expires_at_utc END,
                     updated_at_utc = CURRENT_TIMESTAMP
                 WHERE service_id = @service_id AND subscription_name = @subscription_name
@@ -337,7 +416,10 @@ public sealed class PostgresDurableSubscriptionStore : IDurableSubscriptionStore
                 throw new InvalidOperationException("The durable subscription lease was lost before failure recording.");
             }
 
-            return ResultBox.FromValue(ReadState(reader));
+            var state = ReadState(reader);
+            await reader.DisposeAsync().ConfigureAwait(false);
+            await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+            return ResultBox.FromValue(state);
         }
         catch (Exception ex)
         {
@@ -347,6 +429,8 @@ public sealed class PostgresDurableSubscriptionStore : IDurableSubscriptionStore
 
     public async Task<ResultBox<DurableSubscriptionState>> HaltAsync(
         DurableSubscriptionIdentity identity,
+        string ownerId,
+        long ownerGeneration,
         string reason,
         CancellationToken cancellationToken = default)
     {
@@ -361,22 +445,27 @@ public sealed class PostgresDurableSubscriptionStore : IDurableSubscriptionStore
                 SET phase = @halted,
                     last_halt_at_utc = CURRENT_TIMESTAMP,
                     last_halt_reason = @reason,
+                    last_halt_position = COALESCE(active_failure_position, acknowledged_position),
                     owner_id = NULL,
                     lease_expires_at_utc = NULL,
                     updated_at_utc = CURRENT_TIMESTAMP
                 WHERE service_id = @service_id AND subscription_name = @subscription_name
+                  AND owner_id = @owner_id AND owner_generation = @owner_generation
+                  AND phase <> @halted AND lease_expires_at_utc > CURRENT_TIMESTAMP
                 RETURNING service_id, subscription_name, initialized, acknowledged_position, phase,
                           active_failure_position, active_failure_count, active_failure_reason,
                           next_attempt_at_utc, last_halt_position, last_halt_at_utc, last_halt_reason,
                           owner_id, owner_generation, lease_expires_at_utc, updated_at_utc;
                 """;
             AddCommonParameters(command, identity);
+            AddParameter(command, "owner_id", ownerId);
+            AddParameter(command, "owner_generation", ownerGeneration);
             AddParameter(command, "halted", Halted);
             AddParameter(command, "reason", TruncateReason(reason));
             await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
             if (!await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
             {
-                throw new InvalidOperationException("The durable subscription does not exist.");
+                throw new InvalidOperationException("The durable subscription halt was rejected because the lease was lost or the subscription is already halted.");
             }
 
             return ResultBox.FromValue(ReadState(reader));

--- a/dcb/src/Sekiban.Dcb.Postgres/PostgresDurableSubscriptionStore.cs
+++ b/dcb/src/Sekiban.Dcb.Postgres/PostgresDurableSubscriptionStore.cs
@@ -1,0 +1,558 @@
+using System.Data.Common;
+using Microsoft.EntityFrameworkCore;
+using ResultBoxes;
+using Sekiban.Dcb.Subscriptions;
+
+namespace Sekiban.Dcb.Postgres;
+
+/// <summary>
+///     PostgreSQL durable state boundary for opt-in durable subscribers. Runtime methods use DML only when the table
+///     was explicitly provisioned; legacy mode may provision the table before the first state operation.
+/// </summary>
+public sealed class PostgresDurableSubscriptionStore : IDurableSubscriptionStore
+{
+    private const string Halted = nameof(DurableSubscriptionPhase.Halted);
+    private readonly IDbContextFactory<SekibanDcbDbContext> _contextFactory;
+    private readonly bool _legacyAutoProvision;
+
+    public PostgresDurableSubscriptionStore(
+        IDbContextFactory<SekibanDcbDbContext> contextFactory,
+        bool legacyAutoProvision = false)
+    {
+        _contextFactory = contextFactory ?? throw new ArgumentNullException(nameof(contextFactory));
+        _legacyAutoProvision = legacyAutoProvision;
+    }
+
+    public async Task<ResultBox<DurableSubscriptionState>> InitializeOrGetAsync(
+        DurableSubscriptionIdentity identity,
+        DurableSubscriptionStartPolicy startPolicy,
+        string safeTail,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(identity);
+        try
+        {
+            await using var context = await CreateContextAsync(cancellationToken).ConfigureAwait(false);
+            await EnsureSchemaIfAllowedAsync(context, cancellationToken).ConfigureAwait(false);
+            await using var connection = await OpenConnectionAsync(context, cancellationToken).ConfigureAwait(false);
+            await using var command = connection.CreateCommand();
+            command.CommandText = """
+                INSERT INTO dcb_durable_subscriptions
+                    (service_id, subscription_name, initialized, acknowledged_position, phase,
+                     active_failure_count, owner_generation, created_at_utc, updated_at_utc)
+                SELECT @service_id, @subscription_name, TRUE,
+                       CASE WHEN CAST(@start_policy AS varchar) = 'FromBeginning' THEN NULL
+                            WHEN latest.max_position IS NULL THEN NULL
+                            ELSE LEAST(latest.max_position, @safe_tail) END,
+                       @phase, 0, 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+                FROM (
+                    SELECT MAX("SortableUniqueId") AS max_position
+                    FROM dcb_events
+                    WHERE "ServiceId" = @service_id
+                ) latest
+                ON CONFLICT (service_id, subscription_name) DO NOTHING;
+                """;
+            AddParameter(command, "service_id", identity.ServiceId);
+            AddParameter(command, "subscription_name", identity.Name);
+            AddParameter(command, "start_policy", startPolicy.ToString());
+            AddParameter(command, "safe_tail", safeTail);
+            AddParameter(command, "phase", nameof(DurableSubscriptionPhase.CatchingUp));
+            await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+            return await ReadCoreAsync(connection, identity, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            return ResultBox.Error<DurableSubscriptionState>(ex);
+        }
+    }
+
+    public async Task<ResultBox<DurableSubscriptionState>> ReadAsync(
+        DurableSubscriptionIdentity identity,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            await using var context = await CreateContextAsync(cancellationToken).ConfigureAwait(false);
+            await EnsureSchemaIfAllowedAsync(context, cancellationToken).ConfigureAwait(false);
+            await using var connection = await OpenConnectionAsync(context, cancellationToken).ConfigureAwait(false);
+            return await ReadCoreAsync(connection, identity, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            return ResultBox.Error<DurableSubscriptionState>(ex);
+        }
+    }
+
+    public async Task<ResultBox<DurableSubscriptionLease>> TryAcquireAsync(
+        DurableSubscriptionIdentity identity,
+        string ownerId,
+        TimeSpan leaseDuration,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            await using var context = await CreateContextAsync(cancellationToken).ConfigureAwait(false);
+            await EnsureSchemaIfAllowedAsync(context, cancellationToken).ConfigureAwait(false);
+            await using var connection = await OpenConnectionAsync(context, cancellationToken).ConfigureAwait(false);
+            await using var transaction = await connection.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
+
+            // The row read is intentionally before the update. It makes an existing owner/generation observable and
+            // ensures a missing row is a provider failure rather than an implicit subscription.
+            await using var read = connection.CreateCommand();
+            read.Transaction = transaction;
+            read.CommandText = """
+                SELECT initialized, phase, owner_id, owner_generation, lease_expires_at_utc
+                FROM dcb_durable_subscriptions
+                WHERE service_id = @service_id AND subscription_name = @subscription_name
+                FOR UPDATE;
+                """;
+            AddParameter(read, "service_id", identity.ServiceId);
+            AddParameter(read, "subscription_name", identity.Name);
+            await using var reader = await read.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+            if (!await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                throw new InvalidOperationException($"Durable subscription {identity.ServiceId}/{identity.Name} is not initialized.");
+            }
+
+            var initialized = reader.GetBoolean(0);
+            var phase = reader.GetString(1);
+            var owner = reader.IsDBNull(2) ? null : reader.GetString(2);
+            var generation = reader.GetInt64(3);
+            var expiry = reader.IsDBNull(4) ? (DateTimeOffset?)null : reader.GetFieldValue<DateTimeOffset>(4);
+            await reader.DisposeAsync().ConfigureAwait(false);
+
+            if (!initialized || string.Equals(phase, Halted, StringComparison.Ordinal))
+            {
+                await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+                var state = await ReadCoreAsync(connection, identity, cancellationToken).ConfigureAwait(false);
+                return state.IsSuccess
+                    ? ResultBox.FromValue(new DurableSubscriptionLease(false, state.GetValue()))
+                    : ResultBox.Error<DurableSubscriptionLease>(state.GetException());
+            }
+
+            var available = owner is null || expiry is null || expiry <= DateTimeOffset.UtcNow;
+            if (!available)
+            {
+                await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+                var state = await ReadCoreAsync(connection, identity, cancellationToken).ConfigureAwait(false);
+                return state.IsSuccess
+                    ? ResultBox.FromValue(new DurableSubscriptionLease(false, state.GetValue() with { Phase = DurableSubscriptionPhase.Standby }))
+                    : ResultBox.Error<DurableSubscriptionLease>(state.GetException());
+            }
+
+            await using var update = connection.CreateCommand();
+            update.Transaction = transaction;
+            update.CommandText = """
+                UPDATE dcb_durable_subscriptions
+                SET phase = @phase,
+                    owner_id = @owner_id,
+                    owner_generation = owner_generation + 1,
+                    lease_expires_at_utc = CURRENT_TIMESTAMP + (@lease_seconds * INTERVAL '1 second'),
+                    updated_at_utc = CURRENT_TIMESTAMP
+                WHERE service_id = @service_id AND subscription_name = @subscription_name
+                  AND initialized = TRUE AND phase <> @halted
+                  AND (owner_id IS NULL OR lease_expires_at_utc <= CURRENT_TIMESTAMP)
+                RETURNING service_id, subscription_name, initialized, acknowledged_position, phase,
+                          active_failure_position, active_failure_count, active_failure_reason,
+                          next_attempt_at_utc, last_halt_position, last_halt_at_utc, last_halt_reason,
+                          owner_id, owner_generation, lease_expires_at_utc, updated_at_utc;
+                """;
+            AddCommonParameters(update, identity);
+            AddParameter(update, "phase", nameof(DurableSubscriptionPhase.CatchingUp));
+            AddParameter(update, "owner_id", ownerId);
+            AddParameter(update, "lease_seconds", leaseDuration.TotalSeconds);
+            AddParameter(update, "halted", Halted);
+            await using var updated = await update.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+            if (!await updated.ReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                await updated.DisposeAsync().ConfigureAwait(false);
+                await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+                var state = await ReadCoreAsync(connection, identity, cancellationToken).ConfigureAwait(false);
+                return state.IsSuccess
+                    ? ResultBox.FromValue(new DurableSubscriptionLease(false, state.GetValue() with { Phase = DurableSubscriptionPhase.Standby }))
+                    : ResultBox.Error<DurableSubscriptionLease>(state.GetException());
+            }
+
+            var acquiredState = ReadState(updated);
+            await updated.DisposeAsync().ConfigureAwait(false);
+            await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+            return ResultBox.FromValue(new DurableSubscriptionLease(true, acquiredState));
+        }
+        catch (Exception ex)
+        {
+            return ResultBox.Error<DurableSubscriptionLease>(ex);
+        }
+    }
+
+    public async Task<ResultBox<bool>> RenewAsync(
+        DurableSubscriptionIdentity identity,
+        string ownerId,
+        long ownerGeneration,
+        TimeSpan leaseDuration,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            await using var context = await CreateContextAsync(cancellationToken).ConfigureAwait(false);
+            await EnsureSchemaIfAllowedAsync(context, cancellationToken).ConfigureAwait(false);
+            await using var connection = await OpenConnectionAsync(context, cancellationToken).ConfigureAwait(false);
+            await using var command = connection.CreateCommand();
+            command.CommandText = """
+                UPDATE dcb_durable_subscriptions
+                SET lease_expires_at_utc = CURRENT_TIMESTAMP + (@lease_seconds * INTERVAL '1 second'),
+                    updated_at_utc = CURRENT_TIMESTAMP
+                WHERE service_id = @service_id AND subscription_name = @subscription_name
+                  AND owner_id = @owner_id AND owner_generation = @owner_generation
+                  AND phase <> @halted AND lease_expires_at_utc > CURRENT_TIMESTAMP;
+                """;
+            AddCommonParameters(command, identity);
+            AddParameter(command, "owner_id", ownerId);
+            AddParameter(command, "owner_generation", ownerGeneration);
+            AddParameter(command, "lease_seconds", leaseDuration.TotalSeconds);
+            AddParameter(command, "halted", Halted);
+            return ResultBox.FromValue(await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false) == 1);
+        }
+        catch (Exception ex)
+        {
+            return ResultBox.Error<bool>(ex);
+        }
+    }
+
+    public async Task<ResultBox<DurableSubscriptionState>> AcknowledgeAsync(
+        DurableSubscriptionIdentity identity,
+        string ownerId,
+        long ownerGeneration,
+        string position,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            await using var context = await CreateContextAsync(cancellationToken).ConfigureAwait(false);
+            await EnsureSchemaIfAllowedAsync(context, cancellationToken).ConfigureAwait(false);
+            await using var connection = await OpenConnectionAsync(context, cancellationToken).ConfigureAwait(false);
+            await using var command = connection.CreateCommand();
+            command.CommandText = """
+                UPDATE dcb_durable_subscriptions
+                SET acknowledged_position = @position,
+                    phase = @phase,
+                    active_failure_position = NULL,
+                    active_failure_count = 0,
+                    active_failure_reason = NULL,
+                    next_attempt_at_utc = NULL,
+                    updated_at_utc = CURRENT_TIMESTAMP
+                WHERE service_id = @service_id AND subscription_name = @subscription_name
+                  AND owner_id = @owner_id AND owner_generation = @owner_generation
+                  AND phase <> @halted AND lease_expires_at_utc > CURRENT_TIMESTAMP
+                  AND (acknowledged_position IS NULL OR acknowledged_position < @position)
+                RETURNING service_id, subscription_name, initialized, acknowledged_position, phase,
+                          active_failure_position, active_failure_count, active_failure_reason,
+                          next_attempt_at_utc, last_halt_position, last_halt_at_utc, last_halt_reason,
+                          owner_id, owner_generation, lease_expires_at_utc, updated_at_utc;
+                """;
+            AddCommonParameters(command, identity);
+            AddParameter(command, "owner_id", ownerId);
+            AddParameter(command, "owner_generation", ownerGeneration);
+            AddParameter(command, "position", position);
+            AddParameter(command, "phase", nameof(DurableSubscriptionPhase.CatchingUp));
+            AddParameter(command, "halted", Halted);
+            await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+            if (!await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                throw new InvalidOperationException("The durable subscription lease was lost before acknowledgement.");
+            }
+
+            return ResultBox.FromValue(ReadState(reader));
+        }
+        catch (Exception ex)
+        {
+            return ResultBox.Error<DurableSubscriptionState>(ex);
+        }
+    }
+
+    public async Task<ResultBox<DurableSubscriptionState>> RecordFailureAsync(
+        DurableSubscriptionIdentity identity,
+        string ownerId,
+        long ownerGeneration,
+        string position,
+        string reason,
+        bool conversionFailure,
+        int maxHandlerAttempts,
+        TimeSpan retryDelay,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            await using var context = await CreateContextAsync(cancellationToken).ConfigureAwait(false);
+            await EnsureSchemaIfAllowedAsync(context, cancellationToken).ConfigureAwait(false);
+            await using var connection = await OpenConnectionAsync(context, cancellationToken).ConfigureAwait(false);
+            await using var command = connection.CreateCommand();
+            command.CommandText = """
+                UPDATE dcb_durable_subscriptions
+                SET active_failure_position = @position,
+                    active_failure_count = active_failure_count + 1,
+                    active_failure_reason = @reason,
+                    next_attempt_at_utc = CASE
+                        WHEN @conversion_failure OR active_failure_count + 1 >= @max_attempts THEN NULL
+                        ELSE CURRENT_TIMESTAMP + (@retry_seconds * INTERVAL '1 second') END,
+                    phase = CASE
+                        WHEN @conversion_failure OR active_failure_count + 1 >= @max_attempts THEN @halted
+                        ELSE @retrying END,
+                    last_halt_position = CASE
+                        WHEN @conversion_failure OR active_failure_count + 1 >= @max_attempts THEN @position
+                        ELSE last_halt_position END,
+                    last_halt_at_utc = CASE
+                        WHEN @conversion_failure OR active_failure_count + 1 >= @max_attempts THEN CURRENT_TIMESTAMP
+                        ELSE last_halt_at_utc END,
+                    last_halt_reason = CASE
+                        WHEN @conversion_failure OR active_failure_count + 1 >= @max_attempts THEN @reason
+                        ELSE last_halt_reason END,
+                    owner_id = CASE
+                        WHEN @conversion_failure OR active_failure_count + 1 >= @max_attempts THEN NULL
+                        ELSE owner_id END,
+                    lease_expires_at_utc = CASE
+                        WHEN @conversion_failure OR active_failure_count + 1 >= @max_attempts THEN NULL
+                        ELSE lease_expires_at_utc END,
+                    updated_at_utc = CURRENT_TIMESTAMP
+                WHERE service_id = @service_id AND subscription_name = @subscription_name
+                  AND owner_id = @owner_id AND owner_generation = @owner_generation
+                  AND phase <> @halted AND lease_expires_at_utc > CURRENT_TIMESTAMP
+                RETURNING service_id, subscription_name, initialized, acknowledged_position, phase,
+                          active_failure_position, active_failure_count, active_failure_reason,
+                          next_attempt_at_utc, last_halt_position, last_halt_at_utc, last_halt_reason,
+                          owner_id, owner_generation, lease_expires_at_utc, updated_at_utc;
+                """;
+            AddCommonParameters(command, identity);
+            AddParameter(command, "owner_id", ownerId);
+            AddParameter(command, "owner_generation", ownerGeneration);
+            AddParameter(command, "position", position);
+            AddParameter(command, "reason", TruncateReason(reason));
+            AddParameter(command, "conversion_failure", conversionFailure);
+            AddParameter(command, "max_attempts", maxHandlerAttempts);
+            AddParameter(command, "retry_seconds", retryDelay.TotalSeconds);
+            AddParameter(command, "halted", Halted);
+            AddParameter(command, "retrying", nameof(DurableSubscriptionPhase.Retrying));
+            await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+            if (!await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                throw new InvalidOperationException("The durable subscription lease was lost before failure recording.");
+            }
+
+            return ResultBox.FromValue(ReadState(reader));
+        }
+        catch (Exception ex)
+        {
+            return ResultBox.Error<DurableSubscriptionState>(ex);
+        }
+    }
+
+    public async Task<ResultBox<DurableSubscriptionState>> HaltAsync(
+        DurableSubscriptionIdentity identity,
+        string reason,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            await using var context = await CreateContextAsync(cancellationToken).ConfigureAwait(false);
+            await EnsureSchemaIfAllowedAsync(context, cancellationToken).ConfigureAwait(false);
+            await using var connection = await OpenConnectionAsync(context, cancellationToken).ConfigureAwait(false);
+            await using var command = connection.CreateCommand();
+            command.CommandText = """
+                UPDATE dcb_durable_subscriptions
+                SET phase = @halted,
+                    last_halt_at_utc = CURRENT_TIMESTAMP,
+                    last_halt_reason = @reason,
+                    owner_id = NULL,
+                    lease_expires_at_utc = NULL,
+                    updated_at_utc = CURRENT_TIMESTAMP
+                WHERE service_id = @service_id AND subscription_name = @subscription_name
+                RETURNING service_id, subscription_name, initialized, acknowledged_position, phase,
+                          active_failure_position, active_failure_count, active_failure_reason,
+                          next_attempt_at_utc, last_halt_position, last_halt_at_utc, last_halt_reason,
+                          owner_id, owner_generation, lease_expires_at_utc, updated_at_utc;
+                """;
+            AddCommonParameters(command, identity);
+            AddParameter(command, "halted", Halted);
+            AddParameter(command, "reason", TruncateReason(reason));
+            await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+            if (!await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                throw new InvalidOperationException("The durable subscription does not exist.");
+            }
+
+            return ResultBox.FromValue(ReadState(reader));
+        }
+        catch (Exception ex)
+        {
+            return ResultBox.Error<DurableSubscriptionState>(ex);
+        }
+    }
+
+    public async Task<ResultBox<DurableSubscriptionState>> ResumeAsync(
+        DurableSubscriptionIdentity identity,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            await using var context = await CreateContextAsync(cancellationToken).ConfigureAwait(false);
+            await EnsureSchemaIfAllowedAsync(context, cancellationToken).ConfigureAwait(false);
+            await using var connection = await OpenConnectionAsync(context, cancellationToken).ConfigureAwait(false);
+            await using var command = connection.CreateCommand();
+            command.CommandText = """
+                UPDATE dcb_durable_subscriptions
+                SET phase = @catching_up,
+                    active_failure_position = NULL,
+                    active_failure_count = 0,
+                    active_failure_reason = NULL,
+                    next_attempt_at_utc = NULL,
+                    owner_id = NULL,
+                    owner_generation = owner_generation + 1,
+                    lease_expires_at_utc = NULL,
+                    updated_at_utc = CURRENT_TIMESTAMP
+                WHERE service_id = @service_id AND subscription_name = @subscription_name
+                  AND phase = @halted
+                RETURNING service_id, subscription_name, initialized, acknowledged_position, phase,
+                          active_failure_position, active_failure_count, active_failure_reason,
+                          next_attempt_at_utc, last_halt_position, last_halt_at_utc, last_halt_reason,
+                          owner_id, owner_generation, lease_expires_at_utc, updated_at_utc;
+                """;
+            AddCommonParameters(command, identity);
+            AddParameter(command, "catching_up", nameof(DurableSubscriptionPhase.CatchingUp));
+            AddParameter(command, "halted", Halted);
+            await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+            if (!await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                return await ReadCoreAsync(connection, identity, cancellationToken).ConfigureAwait(false);
+            }
+
+            return ResultBox.FromValue(ReadState(reader));
+        }
+        catch (Exception ex)
+        {
+            return ResultBox.Error<DurableSubscriptionState>(ex);
+        }
+    }
+
+    public async Task<ResultBox<DurableSubscriptionState>> MarkIdleAsync(
+        DurableSubscriptionIdentity identity,
+        string ownerId,
+        long ownerGeneration,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            await using var context = await CreateContextAsync(cancellationToken).ConfigureAwait(false);
+            await EnsureSchemaIfAllowedAsync(context, cancellationToken).ConfigureAwait(false);
+            await using var connection = await OpenConnectionAsync(context, cancellationToken).ConfigureAwait(false);
+            await using var command = connection.CreateCommand();
+            command.CommandText = """
+                UPDATE dcb_durable_subscriptions
+                SET phase = @idle, updated_at_utc = CURRENT_TIMESTAMP
+                WHERE service_id = @service_id AND subscription_name = @subscription_name
+                  AND owner_id = @owner_id AND owner_generation = @owner_generation
+                  AND phase <> @halted AND lease_expires_at_utc > CURRENT_TIMESTAMP
+                RETURNING service_id, subscription_name, initialized, acknowledged_position, phase,
+                          active_failure_position, active_failure_count, active_failure_reason,
+                          next_attempt_at_utc, last_halt_position, last_halt_at_utc, last_halt_reason,
+                          owner_id, owner_generation, lease_expires_at_utc, updated_at_utc;
+                """;
+            AddCommonParameters(command, identity);
+            AddParameter(command, "owner_id", ownerId);
+            AddParameter(command, "owner_generation", ownerGeneration);
+            AddParameter(command, "idle", nameof(DurableSubscriptionPhase.Idle));
+            AddParameter(command, "halted", Halted);
+            await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+            if (!await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                throw new InvalidOperationException("The durable subscription lease was lost before idle recording.");
+            }
+
+            return ResultBox.FromValue(ReadState(reader));
+        }
+        catch (Exception ex)
+        {
+            return ResultBox.Error<DurableSubscriptionState>(ex);
+        }
+    }
+
+    private async Task<SekibanDcbDbContext> CreateContextAsync(CancellationToken cancellationToken) =>
+        await _contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+
+    private async Task EnsureSchemaIfAllowedAsync(SekibanDcbDbContext context, CancellationToken cancellationToken)
+    {
+        if (_legacyAutoProvision)
+        {
+            await PostgresDurableSubscriptionSchema.ProvisionAsync(context, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private static async Task<DbConnection> OpenConnectionAsync(
+        SekibanDcbDbContext context,
+        CancellationToken cancellationToken)
+    {
+        var connection = context.Database.GetDbConnection();
+        if (connection.State != System.Data.ConnectionState.Open)
+        {
+            await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        return connection;
+    }
+
+    private static async Task<ResultBox<DurableSubscriptionState>> ReadCoreAsync(
+        DbConnection connection,
+        DurableSubscriptionIdentity identity,
+        CancellationToken cancellationToken)
+    {
+        await using var command = connection.CreateCommand();
+        command.CommandText = """
+            SELECT service_id, subscription_name, initialized, acknowledged_position, phase,
+                   active_failure_position, active_failure_count, active_failure_reason,
+                   next_attempt_at_utc, last_halt_position, last_halt_at_utc, last_halt_reason,
+                   owner_id, owner_generation, lease_expires_at_utc, updated_at_utc
+            FROM dcb_durable_subscriptions
+            WHERE service_id = @service_id AND subscription_name = @subscription_name;
+            """;
+        AddCommonParameters(command, identity);
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+        return await reader.ReadAsync(cancellationToken).ConfigureAwait(false)
+            ? ResultBox.FromValue(ReadState(reader))
+            : ResultBox.Error<DurableSubscriptionState>(new InvalidOperationException($"Durable subscription {identity.ServiceId}/{identity.Name} is not initialized."));
+    }
+
+    private static DurableSubscriptionState ReadState(DbDataReader reader) => new(
+        new DurableSubscriptionIdentity(reader.GetString(0), reader.GetString(1)),
+        reader.GetBoolean(2),
+        reader.IsDBNull(3) ? null : reader.GetString(3),
+        Enum.Parse<DurableSubscriptionPhase>(reader.GetString(4), ignoreCase: false),
+        reader.IsDBNull(5) ? null : reader.GetString(5),
+        reader.GetInt32(6),
+        reader.IsDBNull(7) ? null : reader.GetString(7),
+        reader.IsDBNull(8) ? null : reader.GetFieldValue<DateTimeOffset>(8),
+        reader.IsDBNull(9) ? null : reader.GetString(9),
+        reader.IsDBNull(10) ? null : reader.GetFieldValue<DateTimeOffset>(10),
+        reader.IsDBNull(11) ? null : reader.GetString(11),
+        reader.IsDBNull(12) ? null : reader.GetString(12),
+        reader.GetInt64(13),
+        reader.IsDBNull(14) ? null : reader.GetFieldValue<DateTimeOffset>(14),
+        reader.GetFieldValue<DateTimeOffset>(15));
+
+    private static void AddCommonParameters(DbCommand command, DurableSubscriptionIdentity identity)
+    {
+        AddParameter(command, "service_id", identity.ServiceId);
+        AddParameter(command, "subscription_name", identity.Name);
+    }
+
+    private static void AddParameter(DbCommand command, string name, object value)
+    {
+        var parameter = command.CreateParameter();
+        parameter.ParameterName = name;
+        parameter.Value = value;
+        command.Parameters.Add(parameter);
+    }
+
+    private static string TruncateReason(string reason)
+    {
+        reason ??= "Unknown durable subscription failure.";
+        return reason.Length <= 2048 ? reason : reason[..2048];
+    }
+}

--- a/dcb/src/Sekiban.Dcb.Postgres/SekibanDcbPostgresDurableSubscriptionExtensions.cs
+++ b/dcb/src/Sekiban.Dcb.Postgres/SekibanDcbPostgresDurableSubscriptionExtensions.cs
@@ -5,6 +5,8 @@ using Sekiban.Dcb.Subscriptions;
 
 namespace Sekiban.Dcb.Postgres;
 
+internal sealed record DurableSubscriptionProvisioningRegistration(bool PreProvisioned);
+
 /// <summary>PostgreSQL registration and owner provisioning for durable Orleans subscribers.</summary>
 public static class SekibanDcbPostgresDurableSubscriptionExtensions
 {
@@ -17,10 +19,26 @@ public static class SekibanDcbPostgresDurableSubscriptionExtensions
         this IServiceCollection services,
         bool preProvisioned = false)
     {
+        var existingMode = services
+            .Where(descriptor => descriptor.ServiceType == typeof(DurableSubscriptionProvisioningRegistration))
+            .Select(descriptor => descriptor.ImplementationInstance)
+            .OfType<DurableSubscriptionProvisioningRegistration>()
+            .SingleOrDefault();
+        if (existingMode is not null && existingMode.PreProvisioned != preProvisioned)
+        {
+            throw new InvalidOperationException(
+                "All durable subscriptions in a service container must use the same PostgreSQL provisioning mode; mixed LegacyAutoProvisioned and PreProvisioned registration is rejected.");
+        }
+
+        if (existingMode is null)
+        {
+            services.AddSingleton(new DurableSubscriptionProvisioningRegistration(preProvisioned));
+        }
+
         services.TryAddSingleton<IDurableSubscriptionStore>(sp =>
             new PostgresDurableSubscriptionStore(
                 sp.GetRequiredService<IDbContextFactory<SekibanDcbDbContext>>(),
-                legacyAutoProvision: !preProvisioned));
+                legacyAutoProvision: !sp.GetRequiredService<DurableSubscriptionProvisioningRegistration>().PreProvisioned));
         services.TryAddSingleton<IDurableSubscriptionNudgeFactory, NoOpDurableSubscriptionNudgeFactory>();
         return services;
     }

--- a/dcb/src/Sekiban.Dcb.Postgres/SekibanDcbPostgresDurableSubscriptionExtensions.cs
+++ b/dcb/src/Sekiban.Dcb.Postgres/SekibanDcbPostgresDurableSubscriptionExtensions.cs
@@ -1,0 +1,92 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Sekiban.Dcb.Subscriptions;
+
+namespace Sekiban.Dcb.Postgres;
+
+/// <summary>PostgreSQL registration and owner provisioning for durable Orleans subscribers.</summary>
+public static class SekibanDcbPostgresDurableSubscriptionExtensions
+{
+    /// <summary>
+    ///     Registers the PostgreSQL durable state store. The default retains compatibility startup provisioning;
+    ///     pass <paramref name="preProvisioned" /> after an owner has run the provisioning method to make runtime
+    ///     state operations DML-only.
+    /// </summary>
+    public static IServiceCollection AddSekibanDcbPostgresDurableSubscriptions(
+        this IServiceCollection services,
+        bool preProvisioned = false)
+    {
+        services.TryAddSingleton<IDurableSubscriptionStore>(sp =>
+            new PostgresDurableSubscriptionStore(
+                sp.GetRequiredService<IDbContextFactory<SekibanDcbDbContext>>(),
+                legacyAutoProvision: !preProvisioned));
+        services.TryAddSingleton<IDurableSubscriptionNudgeFactory, NoOpDurableSubscriptionNudgeFactory>();
+        return services;
+    }
+
+    /// <summary>Registers one opt-in durable subscriber and its hosted runner.</summary>
+    public static IServiceCollection AddSekibanDcbPostgresDurableSubscription(
+        this IServiceCollection services,
+        Action<DurableSubscriptionOptions> configure,
+        DurableSubscriptionHandler handler,
+        bool preProvisioned = false)
+    {
+        ArgumentNullException.ThrowIfNull(configure);
+        ArgumentNullException.ThrowIfNull(handler);
+
+        var options = new DurableSubscriptionOptions();
+        configure(options);
+        options.Validate();
+
+        var registration = new DurableSubscriptionRegistration(options, handler);
+        if (services.Any(descriptor =>
+                descriptor.ServiceType == typeof(DurableSubscriptionRegistration) &&
+                descriptor.ImplementationInstance is DurableSubscriptionRegistration existing &&
+                existing.Options.Identity == options.Identity))
+        {
+            throw new InvalidOperationException(
+                $"Durable subscription '{options.ServiceId}/{options.Name}' is already registered in this service container.");
+        }
+
+        services.AddSekibanDcbPostgresDurableSubscriptions(
+            preProvisioned || options.ProvisioningMode == DurableSubscriptionProvisioningMode.PreProvisioned);
+        services.AddSingleton(registration);
+        services.AddSingleton<DurableSubscriptionRunner>(sp =>
+            new DurableSubscriptionRunner(
+                registration,
+                sp.GetRequiredService<IDurableSubscriptionStore>(),
+                sp.GetRequiredService<Sekiban.Dcb.Storage.IEventStoreFactory>(),
+                sp.GetRequiredService<Sekiban.Dcb.Domains.IEventTypes>(),
+                sp.GetRequiredService<IDurableSubscriptionNudgeFactory>(),
+                sp.GetRequiredService<Microsoft.Extensions.Logging.ILogger<DurableSubscriptionRunner>>()));
+        services.AddSingleton<IDurableSubscriptionHandle>(sp =>
+            new DurableSubscriptionHandle(GetRegisteredRunner(sp, options.Identity)));
+        services.AddSingleton<Microsoft.Extensions.Hosting.IHostedService>(sp =>
+            GetRegisteredRunner(sp, options.Identity));
+        return services;
+    }
+
+    private static DurableSubscriptionRunner GetRegisteredRunner(
+        IServiceProvider serviceProvider,
+        DurableSubscriptionIdentity identity) =>
+        serviceProvider.GetServices<DurableSubscriptionRunner>()
+            .Single(runner => runner.Identity == identity);
+
+    /// <summary>Owner-controlled raw-SQL provisioning for the durable subscriber state table.</summary>
+    public static async Task ProvisionDurableSubscriptionSchemaAsync(
+        this IDbContextFactory<SekibanDcbDbContext> contextFactory,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(contextFactory);
+        await using var context = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+        await PostgresDurableSubscriptionSchema.ProvisionAsync(context, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>Owner convenience overload for applications that already have a service provider.</summary>
+    public static Task ProvisionDurableSubscriptionSchemaAsync(
+        this IServiceProvider serviceProvider,
+        CancellationToken cancellationToken = default) =>
+        serviceProvider.GetRequiredService<IDbContextFactory<SekibanDcbDbContext>>()
+            .ProvisionDurableSubscriptionSchemaAsync(cancellationToken);
+}

--- a/dcb/tests/Sekiban.Dcb.Postgres.Tests/DurableSubscriptionRunnerTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Postgres.Tests/DurableSubscriptionRunnerTests.cs
@@ -1,0 +1,254 @@
+using Dcb.Domain.Weather;
+using Microsoft.Extensions.Logging.Abstractions;
+using ResultBoxes;
+using Sekiban.Dcb.Common;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.InMemory;
+using Sekiban.Dcb.ServiceId;
+using Sekiban.Dcb.Storage;
+using Sekiban.Dcb.Subscriptions;
+using Xunit;
+
+namespace Sekiban.Dcb.Postgres.Tests;
+
+/// <summary>Unit-level runner proofs use an in-memory event source only for deterministic lifecycle sequencing.</summary>
+public sealed class DurableSubscriptionRunnerTests
+{
+    [Fact]
+    public async Task RunnerAttachesNudgeBeforeReadingAndAcknowledgesOnlyAfterHandler()
+    {
+        var domain = global::Dcb.Domain.DomainType.GetDomainTypes();
+        var source = new InMemoryEventStore(domain.EventTypes, new FixedServiceIdProvider("runner-service"));
+        var eventId = SortableUniqueId.GenerateNew();
+        var serializable = new Event(
+                new WeatherForecastCreated(Guid.CreateVersion7(), "runner", DateOnly.FromDateTime(DateTime.UtcNow), 20, "unit"),
+                eventId,
+                nameof(WeatherForecastCreated),
+                Guid.CreateVersion7(),
+                new EventMetadata("runner", "runner", "test"),
+                [])
+            .ToSerializableEvent(domain.EventTypes);
+        var write = await source.WriteSerializableEventsAsync([serializable]);
+        Assert.True(write.IsSuccess, write.IsSuccess ? string.Empty : write.GetException().ToString());
+
+        var nudge = new RecordingNudgeFactory();
+        var stateStore = new ScriptedDurableSubscriptionStore("runner-service", "runner", nudge);
+        var handled = new TaskCompletionSource<Event>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var registration = new DurableSubscriptionRegistration(
+            new DurableSubscriptionOptions
+            {
+                ServiceId = "runner-service",
+                Name = "runner",
+                StartPolicy = DurableSubscriptionStartPolicy.FromBeginning,
+                PollInterval = TimeSpan.FromMilliseconds(10),
+                RetryDelay = TimeSpan.FromMilliseconds(10),
+                LeaseDuration = TimeSpan.FromSeconds(1)
+            },
+            (eventRecord, _) =>
+            {
+                handled.TrySetResult(eventRecord);
+                return Task.CompletedTask;
+            });
+        var runner = new DurableSubscriptionRunner(
+            registration,
+            stateStore,
+            new InMemoryEventStoreFactory(source),
+            domain.EventTypes,
+            nudge,
+            NullLogger<DurableSubscriptionRunner>.Instance);
+
+        using var cancellation = new CancellationTokenSource();
+        await runner.StartAsync(cancellation.Token);
+        var received = await handled.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.Equal(eventId, received.SortableUniqueIdValue);
+        Assert.True(nudge.CreatedBeforeFirstRead);
+        await SpinWaitAsync(() => stateStore.AcknowledgementCount == 1 || stateStore.AcknowledgementError is not null);
+        Assert.Null(stateStore.AcknowledgementError);
+        Assert.Equal(1, stateStore.AcknowledgementCount);
+        Assert.Equal(eventId, stateStore.State.AcknowledgedPosition);
+
+        // A notification is data-free: waking an idle runner causes another authoritative read but cannot invoke the
+        // handler with the notification payload or acknowledge a second event.
+        var readsBeforeNudge = stateStore.ReadCount;
+        await nudge.TriggerAsync();
+        await SpinWaitAsync(() => stateStore.ReadCount > readsBeforeNudge);
+        Assert.Equal(1, stateStore.AcknowledgementCount);
+
+        cancellation.Cancel();
+        await runner.StopAsync(CancellationToken.None);
+    }
+
+    private static async Task SpinWaitAsync(Func<bool> condition)
+    {
+        for (var i = 0; i < 100 && !condition(); i++)
+        {
+            await Task.Delay(10);
+        }
+
+        Assert.True(condition(), "The durable runner did not observe the data-free nudge.");
+    }
+
+    private sealed class RecordingNudgeFactory : IDurableSubscriptionNudgeFactory
+    {
+        private Func<ValueTask>? _onNudge;
+        internal bool CreatedBeforeFirstRead { get; private set; }
+        internal bool FirstReadObserved { get; set; }
+
+        public IDurableSubscriptionNudge Create(DurableSubscriptionIdentity identity, Func<ValueTask> onNudge)
+        {
+            _onNudge = onNudge;
+            CreatedBeforeFirstRead = !FirstReadObserved;
+            return new RecordingNudge();
+        }
+
+        internal ValueTask TriggerAsync() => _onNudge is null ? ValueTask.CompletedTask : _onNudge();
+    }
+
+    private sealed class RecordingNudge : IDurableSubscriptionNudge
+    {
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+
+    private sealed class ScriptedDurableSubscriptionStore : IDurableSubscriptionStore
+    {
+        private readonly DurableSubscriptionIdentity _identity;
+        private readonly RecordingNudgeFactory _nudge;
+        private string? _owner;
+        private long _generation;
+
+        internal ScriptedDurableSubscriptionStore(string serviceId, string name, RecordingNudgeFactory nudge)
+        {
+            _nudge = nudge;
+            _identity = new DurableSubscriptionIdentity(serviceId, name);
+            State = new DurableSubscriptionState(
+                _identity,
+                Initialized: false,
+                AcknowledgedPosition: null,
+                DurableSubscriptionPhase.Uninitialized,
+                null,
+                0,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                0,
+                null,
+                DateTimeOffset.UtcNow);
+        }
+
+        internal DurableSubscriptionState State { get; private set; }
+        internal int ReadCount { get; private set; }
+        internal int AcknowledgementCount { get; private set; }
+        internal Exception? AcknowledgementError { get; private set; }
+
+        public Task<ResultBox<DurableSubscriptionState>> InitializeOrGetAsync(
+            DurableSubscriptionIdentity identity,
+            DurableSubscriptionStartPolicy startPolicy,
+            string safeTail,
+            CancellationToken cancellationToken = default)
+        {
+            State = State with
+            {
+                Initialized = true,
+                AcknowledgedPosition = startPolicy == DurableSubscriptionStartPolicy.FromBeginning ? null : safeTail,
+                Phase = DurableSubscriptionPhase.CatchingUp,
+                UpdatedAtUtc = DateTimeOffset.UtcNow
+            };
+            return Task.FromResult(ResultBox.FromValue(State));
+        }
+
+        public Task<ResultBox<DurableSubscriptionState>> ReadAsync(
+            DurableSubscriptionIdentity identity,
+            CancellationToken cancellationToken = default)
+        {
+            ReadCount++;
+            _nudge.FirstReadObserved = true;
+            return Task.FromResult(ResultBox.FromValue(State));
+        }
+
+        public Task<ResultBox<DurableSubscriptionLease>> TryAcquireAsync(
+            DurableSubscriptionIdentity identity,
+            string ownerId,
+            TimeSpan leaseDuration,
+            CancellationToken cancellationToken = default)
+        {
+            _owner = ownerId;
+            _generation++;
+            State = State with
+            {
+                OwnerId = _owner,
+                OwnerGeneration = _generation,
+                LeaseExpiresAtUtc = DateTimeOffset.UtcNow.Add(leaseDuration),
+                Phase = DurableSubscriptionPhase.CatchingUp,
+                UpdatedAtUtc = DateTimeOffset.UtcNow
+            };
+            return Task.FromResult(ResultBox.FromValue(new DurableSubscriptionLease(true, State)));
+        }
+
+        public Task<ResultBox<bool>> RenewAsync(
+            DurableSubscriptionIdentity identity,
+            string ownerId,
+            long ownerGeneration,
+            TimeSpan leaseDuration,
+            CancellationToken cancellationToken = default) =>
+            Task.FromResult(ResultBox.FromValue(
+                string.Equals(ownerId, _owner, StringComparison.Ordinal) && ownerGeneration == _generation));
+
+        public Task<ResultBox<DurableSubscriptionState>> AcknowledgeAsync(
+            DurableSubscriptionIdentity identity,
+            string ownerId,
+            long ownerGeneration,
+            string position,
+            CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                Assert.Equal(_owner, ownerId);
+                Assert.Equal(_generation, ownerGeneration);
+                AcknowledgementCount++;
+                State = State with { AcknowledgedPosition = position, UpdatedAtUtc = DateTimeOffset.UtcNow };
+                return Task.FromResult(ResultBox.FromValue(State));
+            }
+            catch (Exception ex)
+            {
+                AcknowledgementError = ex;
+                throw;
+            }
+        }
+
+        public Task<ResultBox<DurableSubscriptionState>> RecordFailureAsync(
+            DurableSubscriptionIdentity identity,
+            string ownerId,
+            long ownerGeneration,
+            string position,
+            string reason,
+            bool conversionFailure,
+            int maxHandlerAttempts,
+            TimeSpan retryDelay,
+            CancellationToken cancellationToken = default) =>
+            Task.FromResult(ResultBox.FromValue(State));
+
+        public Task<ResultBox<DurableSubscriptionState>> ResumeAsync(
+            DurableSubscriptionIdentity identity,
+            CancellationToken cancellationToken = default) =>
+            Task.FromResult(ResultBox.FromValue(State));
+
+        public Task<ResultBox<DurableSubscriptionState>> HaltAsync(
+            DurableSubscriptionIdentity identity,
+            string reason,
+            CancellationToken cancellationToken = default) =>
+            Task.FromResult(ResultBox.FromValue(State with { Phase = DurableSubscriptionPhase.Halted }));
+
+        public Task<ResultBox<DurableSubscriptionState>> MarkIdleAsync(
+            DurableSubscriptionIdentity identity,
+            string ownerId,
+            long ownerGeneration,
+            CancellationToken cancellationToken = default)
+        {
+            State = State with { Phase = DurableSubscriptionPhase.Idle, UpdatedAtUtc = DateTimeOffset.UtcNow };
+            return Task.FromResult(ResultBox.FromValue(State));
+        }
+    }
+}

--- a/dcb/tests/Sekiban.Dcb.Postgres.Tests/DurableSubscriptionRunnerTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Postgres.Tests/DurableSubscriptionRunnerTests.cs
@@ -196,6 +196,13 @@ public sealed class DurableSubscriptionRunnerTests
             Task.FromResult(ResultBox.FromValue(
                 string.Equals(ownerId, _owner, StringComparison.Ordinal) && ownerGeneration == _generation));
 
+        public Task<ResultBox<bool>> IsRetryDueAsync(
+            DurableSubscriptionIdentity identity,
+            string ownerId,
+            long ownerGeneration,
+            CancellationToken cancellationToken = default) =>
+            Task.FromResult(ResultBox.FromValue(true));
+
         public Task<ResultBox<DurableSubscriptionState>> AcknowledgeAsync(
             DurableSubscriptionIdentity identity,
             string ownerId,
@@ -237,6 +244,8 @@ public sealed class DurableSubscriptionRunnerTests
 
         public Task<ResultBox<DurableSubscriptionState>> HaltAsync(
             DurableSubscriptionIdentity identity,
+            string ownerId,
+            long ownerGeneration,
             string reason,
             CancellationToken cancellationToken = default) =>
             Task.FromResult(ResultBox.FromValue(State with { Phase = DurableSubscriptionPhase.Halted }));

--- a/dcb/tests/Sekiban.Dcb.Postgres.Tests/DurableSubscriptionRunnerTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Postgres.Tests/DurableSubscriptionRunnerTests.cs
@@ -40,9 +40,9 @@ public sealed class DurableSubscriptionRunnerTests
                 ServiceId = "runner-service",
                 Name = "runner",
                 StartPolicy = DurableSubscriptionStartPolicy.FromBeginning,
-                PollInterval = TimeSpan.FromMilliseconds(10),
+                PollInterval = TimeSpan.FromSeconds(60),
                 RetryDelay = TimeSpan.FromMilliseconds(10),
-                LeaseDuration = TimeSpan.FromSeconds(1)
+                LeaseDuration = TimeSpan.FromSeconds(30)
             },
             (eventRecord, _) =>
             {

--- a/dcb/tests/Sekiban.Dcb.Postgres.Tests/PostgresDurableSubscriptionTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Postgres.Tests/PostgresDurableSubscriptionTests.cs
@@ -1,0 +1,347 @@
+using Npgsql;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Dcb.Domain.Weather;
+using Sekiban.Dcb.Common;
+using Sekiban.Dcb.Domains;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.Postgres;
+using Sekiban.Dcb.ServiceId;
+using Sekiban.Dcb.Storage;
+using Sekiban.Dcb.Subscriptions;
+using Xunit;
+
+namespace Sekiban.Dcb.Postgres.Tests;
+
+/// <summary>
+/// Real PostgreSQL proofs for the opt-in durable subscriber state boundary. These tests intentionally exercise the
+/// provider through its public store registration surface rather than replacing PostgreSQL with a dictionary fake.
+/// </summary>
+public sealed class PostgresDurableSubscriptionTests : PostgresTestBase
+{
+    public PostgresDurableSubscriptionTests(PostgresTestFixture fixture) : base(fixture) { }
+
+    public override async Task InitializeAsync()
+    {
+        await base.InitializeAsync();
+        await using var connection = new NpgsqlConnection(Fixture.ConnectionString);
+        await connection.OpenAsync();
+        await ExecuteAsync(connection, "DROP TABLE IF EXISTS dcb_durable_subscriptions");
+        await Fixture.DbContextFactory.ProvisionDurableSubscriptionSchemaAsync();
+    }
+
+    [Fact]
+    public void Options_ValidateBoundsAndIdentityWithoutChangingLegacyCallbackContracts()
+    {
+        var options = new DurableSubscriptionOptions
+        {
+            ServiceId = "durable-service",
+            Name = "  orders  ",
+            SafeWindow = TimeSpan.FromMinutes(1),
+            LeaseDuration = TimeSpan.FromSeconds(2),
+            PollInterval = TimeSpan.FromSeconds(1),
+            RetryDelay = TimeSpan.FromSeconds(1),
+            MaxHandlerAttempts = 4,
+            MaxBatchSize = 10
+        };
+
+        options.Validate();
+
+        Assert.Equal("durable-service", options.Identity.ServiceId);
+        Assert.Equal("orders", options.Identity.Name);
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            new DurableSubscriptionOptions { MaxBatchSize = 0 }.Validate());
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            new DurableSubscriptionOptions { MaxHandlerAttempts = 17 }.Validate());
+        Assert.Throws<ArgumentException>(() =>
+            new DurableSubscriptionIdentity("service", "bad\nname"));
+    }
+
+    [Fact]
+    public async Task InitializeOrGet_UsesSafeTail_FromNowAndPreservesExistingCursor()
+    {
+        var eventId = await AppendEventAsync("from-now");
+        var identity = new DurableSubscriptionIdentity("default", "from-now");
+        var safeTail = SortableUniqueId.Generate(DateTime.UtcNow.AddMinutes(-1), Guid.Empty);
+        var store = new PostgresDurableSubscriptionStore(Fixture.DbContextFactory, legacyAutoProvision: false);
+
+        var first = await store.InitializeOrGetAsync(
+            identity,
+            DurableSubscriptionStartPolicy.FromNow,
+            safeTail);
+        var second = await store.InitializeOrGetAsync(
+            identity,
+            DurableSubscriptionStartPolicy.FromBeginning,
+            SortableUniqueId.Generate(DateTime.UtcNow, Guid.Empty));
+
+        Assert.True(first.IsSuccess, first.IsSuccess ? string.Empty : first.GetException().ToString());
+        Assert.True(second.IsSuccess, second.IsSuccess ? string.Empty : second.GetException().ToString());
+        Assert.Equal(safeTail, first.GetValue().AcknowledgedPosition);
+        Assert.Equal(first.GetValue().AcknowledgedPosition, second.GetValue().AcknowledgedPosition);
+        Assert.Equal(DurableSubscriptionPhase.CatchingUp, first.GetValue().Phase);
+        Assert.True(string.CompareOrdinal(first.GetValue().AcknowledgedPosition, eventId) < 0);
+    }
+
+    [Fact]
+    public async Task InitializeOrGet_EmptyStoreUsesNullCursor_ForBothStartPolicies()
+    {
+        var store = new PostgresDurableSubscriptionStore(Fixture.DbContextFactory, legacyAutoProvision: false);
+        var fromNow = await store.InitializeOrGetAsync(
+            new DurableSubscriptionIdentity("default", "empty-now"),
+            DurableSubscriptionStartPolicy.FromNow,
+            SortableUniqueId.Generate(DateTime.UtcNow, Guid.Empty));
+        var fromBeginning = await store.InitializeOrGetAsync(
+            new DurableSubscriptionIdentity("default", "empty-beginning"),
+            DurableSubscriptionStartPolicy.FromBeginning,
+            SortableUniqueId.Generate(DateTime.UtcNow, Guid.Empty));
+
+        Assert.True(fromNow.IsSuccess, fromNow.IsSuccess ? string.Empty : fromNow.GetException().ToString());
+        Assert.True(fromBeginning.IsSuccess, fromBeginning.IsSuccess ? string.Empty : fromBeginning.GetException().ToString());
+        Assert.Null(fromNow.GetValue().AcknowledgedPosition);
+        Assert.Null(fromBeginning.GetValue().AcknowledgedPosition);
+    }
+
+    [Fact]
+    public async Task PreProvisionedRuntime_IsDmlOnlyAndMissingTableReturnsProviderFailure()
+    {
+        var store = new PostgresDurableSubscriptionStore(Fixture.DbContextFactory, legacyAutoProvision: false);
+        var identity = new DurableSubscriptionIdentity("default", "missing-table");
+
+        await using (var connection = new NpgsqlConnection(Fixture.ConnectionString))
+        {
+            await connection.OpenAsync();
+            await ExecuteAsync(connection, "DROP TABLE dcb_durable_subscriptions");
+        }
+
+        try
+        {
+            var missing = await store.ReadAsync(identity);
+            Assert.False(missing.IsSuccess);
+            var failure = Assert.IsType<PostgresException>(missing.GetException());
+            Assert.Equal(PostgresErrorCodes.UndefinedTable, failure.SqlState);
+        }
+        finally
+        {
+            await Fixture.DbContextFactory.ProvisionDurableSubscriptionSchemaAsync();
+        }
+
+        var initialized = await store.InitializeOrGetAsync(
+            identity,
+            DurableSubscriptionStartPolicy.FromBeginning,
+            SortableUniqueId.Generate(DateTime.UtcNow, Guid.Empty));
+        Assert.True(initialized.IsSuccess, initialized.IsSuccess ? string.Empty : initialized.GetException().ToString());
+    }
+
+    [Fact]
+    public async Task PreProvisionedRuntime_MissingColumnReturns42703InsteadOfAutoRepair()
+    {
+        await using (var connection = new NpgsqlConnection(Fixture.ConnectionString))
+        {
+            await connection.OpenAsync();
+            await ExecuteAsync(connection, "ALTER TABLE dcb_durable_subscriptions DROP COLUMN phase");
+        }
+
+        try
+        {
+            var store = new PostgresDurableSubscriptionStore(Fixture.DbContextFactory, legacyAutoProvision: false);
+            var result = await store.ReadAsync(new DurableSubscriptionIdentity("default", "missing-column"));
+            Assert.False(result.IsSuccess);
+            var failure = Assert.IsType<PostgresException>(result.GetException());
+            Assert.Equal(PostgresErrorCodes.UndefinedColumn, failure.SqlState);
+        }
+        finally
+        {
+            await using var connection = new NpgsqlConnection(Fixture.ConnectionString);
+            await connection.OpenAsync();
+            await ExecuteAsync(connection, "DROP TABLE dcb_durable_subscriptions");
+            await Fixture.DbContextFactory.ProvisionDurableSubscriptionSchemaAsync();
+        }
+    }
+
+    [Fact]
+    public async Task AcquireRenewAcknowledgeFailureHaltAndResume_PersistStateAndFenceOwner()
+    {
+        var eventId = await AppendEventAsync("lifecycle");
+        var identity = new DurableSubscriptionIdentity("default", "lifecycle");
+        var store = new PostgresDurableSubscriptionStore(Fixture.DbContextFactory, legacyAutoProvision: false);
+        var initialized = await store.InitializeOrGetAsync(
+            identity,
+            DurableSubscriptionStartPolicy.FromBeginning,
+            SortableUniqueId.Generate(DateTime.UtcNow, Guid.Empty));
+        Assert.True(initialized.IsSuccess, initialized.IsSuccess ? string.Empty : initialized.GetException().ToString());
+
+        var lease = await store.TryAcquireAsync(identity, "owner-a", TimeSpan.FromSeconds(30));
+        Assert.True(lease.IsSuccess, lease.IsSuccess ? string.Empty : lease.GetException().ToString());
+        Assert.True(lease.GetValue().Acquired);
+        var generation = lease.GetValue().State.OwnerGeneration;
+
+        var renewed = await store.RenewAsync(identity, "owner-a", generation, TimeSpan.FromSeconds(30));
+        Assert.True(renewed.IsSuccess && renewed.GetValue());
+
+        var acknowledged = await store.AcknowledgeAsync(identity, "owner-a", generation, eventId);
+        Assert.True(acknowledged.IsSuccess, acknowledged.IsSuccess ? string.Empty : acknowledged.GetException().ToString());
+        Assert.Equal(eventId, acknowledged.GetValue().AcknowledgedPosition);
+
+        var retry = await store.RecordFailureAsync(
+            identity, "owner-a", generation, eventId, "transient", conversionFailure: false,
+            maxHandlerAttempts: 3, retryDelay: TimeSpan.FromSeconds(1));
+        Assert.True(retry.IsSuccess, retry.IsSuccess ? string.Empty : retry.GetException().ToString());
+        Assert.Equal(DurableSubscriptionPhase.Retrying, retry.GetValue().Phase);
+        Assert.Equal(1, retry.GetValue().ActiveFailureCount);
+
+        var halted = await store.RecordFailureAsync(
+            identity, "owner-a", generation, eventId, "poison", conversionFailure: false,
+            maxHandlerAttempts: 2, retryDelay: TimeSpan.FromSeconds(1));
+        Assert.True(halted.IsSuccess, halted.IsSuccess ? string.Empty : halted.GetException().ToString());
+        Assert.Equal(DurableSubscriptionPhase.Halted, halted.GetValue().Phase);
+        Assert.Equal(eventId, halted.GetValue().LastHaltPosition);
+        Assert.Null(halted.GetValue().OwnerId);
+
+        var resumed = await store.ResumeAsync(identity);
+        Assert.True(resumed.IsSuccess, resumed.IsSuccess ? string.Empty : resumed.GetException().ToString());
+        Assert.Equal(DurableSubscriptionPhase.CatchingUp, resumed.GetValue().Phase);
+        Assert.Equal(eventId, resumed.GetValue().AcknowledgedPosition);
+        Assert.Null(resumed.GetValue().OwnerId);
+        Assert.True(resumed.GetValue().OwnerGeneration > halted.GetValue().OwnerGeneration);
+
+        var standby = await store.TryAcquireAsync(identity, "owner-b", TimeSpan.FromSeconds(30));
+        Assert.True(standby.IsSuccess, standby.IsSuccess ? string.Empty : standby.GetException().ToString());
+        Assert.True(standby.GetValue().Acquired);
+    }
+
+    [Fact]
+    public async Task LeaseUsesDatabaseTime_StandbyTakeoverAndStaleGenerationAckAreRejected()
+    {
+        var eventId = await AppendEventAsync("fence");
+        var identity = new DurableSubscriptionIdentity("fence-service", "orders");
+        var store = new PostgresDurableSubscriptionStore(Fixture.DbContextFactory, legacyAutoProvision: false);
+        var initialized = await store.InitializeOrGetAsync(
+            identity,
+            DurableSubscriptionStartPolicy.FromBeginning,
+            SortableUniqueId.Generate(DateTime.UtcNow, Guid.Empty));
+        Assert.True(initialized.IsSuccess, initialized.IsSuccess ? string.Empty : initialized.GetException().ToString());
+
+        var first = await store.TryAcquireAsync(identity, "owner-a", TimeSpan.FromSeconds(30));
+        Assert.True(first.IsSuccess && first.GetValue().Acquired);
+        var firstGeneration = first.GetValue().State.OwnerGeneration;
+
+        var standby = await store.TryAcquireAsync(identity, "owner-b", TimeSpan.FromSeconds(30));
+        Assert.True(standby.IsSuccess, standby.IsSuccess ? string.Empty : standby.GetException().ToString());
+        Assert.False(standby.GetValue().Acquired);
+        Assert.Equal(DurableSubscriptionPhase.Standby, standby.GetValue().State.Phase);
+
+        await using (var connection = new NpgsqlConnection(Fixture.ConnectionString))
+        {
+            await connection.OpenAsync();
+            await ExecuteAsync(connection,
+                "UPDATE dcb_durable_subscriptions SET lease_expires_at_utc = CURRENT_TIMESTAMP - INTERVAL '1 second' "
+                + "WHERE service_id = 'fence-service' AND subscription_name = 'orders'");
+        }
+
+        var takeover = await store.TryAcquireAsync(identity, "owner-b", TimeSpan.FromSeconds(30));
+        Assert.True(takeover.IsSuccess && takeover.GetValue().Acquired);
+        Assert.True(takeover.GetValue().State.OwnerGeneration > firstGeneration);
+
+        var staleAck = await store.AcknowledgeAsync(identity, "owner-a", firstGeneration, eventId);
+        Assert.False(staleAck.IsSuccess);
+        Assert.Contains("lease was lost", staleAck.GetException().Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ServiceIdentityIsolated_DurableRegistrationRejectsOnlyInOneContainer()
+    {
+        var store = new PostgresDurableSubscriptionStore(Fixture.DbContextFactory, legacyAutoProvision: false);
+        var first = await store.InitializeOrGetAsync(
+            new DurableSubscriptionIdentity("service-a", "orders"),
+            DurableSubscriptionStartPolicy.FromBeginning,
+            SortableUniqueId.Generate(DateTime.UtcNow, Guid.Empty));
+        var second = await store.InitializeOrGetAsync(
+            new DurableSubscriptionIdentity("service-b", "orders"),
+            DurableSubscriptionStartPolicy.FromBeginning,
+            SortableUniqueId.Generate(DateTime.UtcNow, Guid.Empty));
+        Assert.True(first.IsSuccess && second.IsSuccess);
+
+        var firstContainer = new ServiceCollection();
+        firstContainer.AddSekibanDcbPostgresDurableSubscription(
+            options =>
+            {
+                options.ServiceId = "service-a";
+                options.Name = "orders";
+                options.ProvisioningMode = DurableSubscriptionProvisioningMode.PreProvisioned;
+            },
+            (_, _) => Task.CompletedTask);
+        Assert.Throws<InvalidOperationException>(() => firstContainer.AddSekibanDcbPostgresDurableSubscription(
+            options =>
+            {
+                options.ServiceId = "service-a";
+                options.Name = "orders";
+            },
+            (_, _) => Task.CompletedTask));
+
+        var secondContainer = new ServiceCollection();
+        secondContainer.AddSekibanDcbPostgresDurableSubscription(
+            options =>
+            {
+                options.ServiceId = "service-a";
+                options.Name = "orders";
+            },
+            (_, _) => Task.CompletedTask);
+        Assert.NotEmpty(secondContainer);
+    }
+
+    [Fact]
+    public async Task DifferentDurableIdentitiesResolveTheirOwnHostedRunners()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton(Fixture.DbContextFactory);
+        services.AddSingleton<IEventTypes>(Fixture.DomainTypes.EventTypes);
+        services.AddSingleton<IEventStoreFactory>(
+            new PostgresEventStoreFactory(Fixture.DbContextFactory, Fixture.DomainTypes.EventTypes));
+        services.AddSingleton<IDurableSubscriptionStore>(
+            new PostgresDurableSubscriptionStore(Fixture.DbContextFactory, legacyAutoProvision: false));
+        services.AddSekibanDcbPostgresDurableSubscription(
+            options => options.Name = "first",
+            (_, _) => Task.CompletedTask);
+        services.AddSekibanDcbPostgresDurableSubscription(
+            options => options.Name = "second",
+            (_, _) => Task.CompletedTask);
+
+        await using var provider = services.BuildServiceProvider();
+        var runners = provider.GetServices<DurableSubscriptionRunner>().ToArray();
+        Assert.Equal(2, runners.Length);
+        Assert.Equal(new[] { "first", "second" }, runners.Select(runner => runner.Identity.Name).OrderBy(name => name));
+
+        var handles = provider.GetServices<IDurableSubscriptionHandle>().ToArray();
+        Assert.Equal(2, handles.Length);
+        Assert.Equal(new[] { "first", "second" }, handles.Select(handle => handle.Identity.Name).OrderBy(name => name));
+
+        var hostedRunners = provider.GetServices<IHostedService>().OfType<DurableSubscriptionRunner>().ToArray();
+        Assert.Equal(2, hostedRunners.Length);
+        Assert.Equal(new[] { "first", "second" }, hostedRunners.Select(runner => runner.Identity.Name).OrderBy(name => name));
+    }
+
+    private async Task<string> AppendEventAsync(string marker)
+    {
+        var eventId = SortableUniqueId.GenerateNew();
+        var payload = new WeatherForecastCreated(
+            Guid.CreateVersion7(), marker, DateOnly.FromDateTime(DateTime.UtcNow), 20, marker);
+        var serialized = new Event(
+                payload,
+                eventId,
+                nameof(WeatherForecastCreated),
+                Guid.CreateVersion7(),
+                new EventMetadata("durable-subscription", marker, "test-user"),
+                [])
+            .ToSerializableEvent(Fixture.DomainTypes.EventTypes);
+        var written = await Fixture.EventStore.WriteSerializableEventsAsync([serialized]);
+        Assert.True(written.IsSuccess, written.IsSuccess ? string.Empty : written.GetException().ToString());
+        return eventId;
+    }
+
+    private static async Task ExecuteAsync(NpgsqlConnection connection, string sql)
+    {
+        await using var command = new NpgsqlCommand(sql, connection);
+        await command.ExecuteNonQueryAsync();
+    }
+}

--- a/dcb/tests/Sekiban.Dcb.Postgres.Tests/PostgresDurableSubscriptionTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Postgres.Tests/PostgresDurableSubscriptionTests.cs
@@ -1,6 +1,7 @@
 using Npgsql;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
 using Dcb.Domain.Weather;
 using Sekiban.Dcb.Common;
 using Sekiban.Dcb.Domains;
@@ -181,13 +182,20 @@ public sealed class PostgresDurableSubscriptionTests : PostgresTestBase
         var acknowledged = await store.AcknowledgeAsync(identity, "owner-a", generation, eventId);
         Assert.True(acknowledged.IsSuccess, acknowledged.IsSuccess ? string.Empty : acknowledged.GetException().ToString());
         Assert.Equal(eventId, acknowledged.GetValue().AcknowledgedPosition);
-
         var retry = await store.RecordFailureAsync(
             identity, "owner-a", generation, eventId, "transient", conversionFailure: false,
             maxHandlerAttempts: 3, retryDelay: TimeSpan.FromSeconds(1));
         Assert.True(retry.IsSuccess, retry.IsSuccess ? string.Empty : retry.GetException().ToString());
         Assert.Equal(DurableSubscriptionPhase.Retrying, retry.GetValue().Phase);
         Assert.Equal(1, retry.GetValue().ActiveFailureCount);
+
+        await using (var connection = new NpgsqlConnection(Fixture.ConnectionString))
+        {
+            await connection.OpenAsync();
+            await ExecuteAsync(connection,
+                "UPDATE dcb_durable_subscriptions SET next_attempt_at_utc = CURRENT_TIMESTAMP - INTERVAL '1 second' "
+                + "WHERE service_id = 'default' AND subscription_name = 'lifecycle'");
+        }
 
         var halted = await store.RecordFailureAsync(
             identity, "owner-a", generation, eventId, "poison", conversionFailure: false,
@@ -228,7 +236,8 @@ public sealed class PostgresDurableSubscriptionTests : PostgresTestBase
         var standby = await store.TryAcquireAsync(identity, "owner-b", TimeSpan.FromSeconds(30));
         Assert.True(standby.IsSuccess, standby.IsSuccess ? string.Empty : standby.GetException().ToString());
         Assert.False(standby.GetValue().Acquired);
-        Assert.Equal(DurableSubscriptionPhase.Standby, standby.GetValue().State.Phase);
+        Assert.Equal(DurableSubscriptionRunnerStatus.Standby, standby.GetValue().Status);
+        Assert.Equal(DurableSubscriptionPhase.CatchingUp, standby.GetValue().State.Phase);
 
         await using (var connection = new NpgsqlConnection(Fixture.ConnectionString))
         {
@@ -321,7 +330,413 @@ public sealed class PostgresDurableSubscriptionTests : PostgresTestBase
         Assert.Equal(new[] { "first", "second" }, hostedRunners.Select(runner => runner.Identity.Name).OrderBy(name => name));
     }
 
-    private async Task<string> AppendEventAsync(string marker)
+    [Fact]
+    public async Task PostgresNowControlsOwnership_AndStandbyStatusDoesNotRewriteDurablePhase()
+    {
+        var store = CreateStore();
+        var identity = new DurableSubscriptionIdentity("clock-service", "ownership");
+        var initialized = await store.InitializeOrGetAsync(
+            identity,
+            DurableSubscriptionStartPolicy.FromBeginning,
+            SortableUniqueId.Generate(DateTime.UtcNow, Guid.Empty));
+        Assert.True(initialized.IsSuccess, initialized.IsSuccess ? string.Empty : initialized.GetException().ToString());
+
+        var first = await store.TryAcquireAsync(identity, "owner-a", TimeSpan.FromSeconds(30));
+        Assert.True(first.IsSuccess && first.GetValue().Acquired);
+        Assert.Equal(DurableSubscriptionRunnerStatus.Owner, first.GetValue().Status);
+
+        var standby = await store.TryAcquireAsync(identity, "owner-b", TimeSpan.FromSeconds(30));
+        Assert.True(standby.IsSuccess);
+        Assert.False(standby.GetValue().Acquired);
+        Assert.Equal(DurableSubscriptionRunnerStatus.Standby, standby.GetValue().Status);
+        Assert.Equal(DurableSubscriptionPhase.CatchingUp, standby.GetValue().State.Phase);
+
+        await using (var connection = new NpgsqlConnection(Fixture.ConnectionString))
+        {
+            await connection.OpenAsync();
+            await ExecuteAsync(connection,
+                "UPDATE dcb_durable_subscriptions SET lease_expires_at_utc = CURRENT_TIMESTAMP - INTERVAL '1 second' "
+                + "WHERE service_id = 'clock-service' AND subscription_name = 'ownership'");
+        }
+
+        var takeover = await store.TryAcquireAsync(identity, "owner-b", TimeSpan.FromSeconds(30));
+        Assert.True(takeover.IsSuccess && takeover.GetValue().Acquired);
+        Assert.Equal(first.GetValue().State.OwnerGeneration + 1, takeover.GetValue().State.OwnerGeneration);
+        Assert.Equal(DurableSubscriptionPhase.CatchingUp, (await store.ReadAsync(identity)).GetValue().Phase);
+    }
+
+    [Fact]
+    public async Task FencedHaltPreservesFirstEvidenceAndPosition()
+    {
+        var eventId = await AppendEventAsync("halt-evidence");
+        var store = CreateStore();
+        var identity = new DurableSubscriptionIdentity("halt-service", "orders");
+        var initialized = await store.InitializeOrGetAsync(
+            identity,
+            DurableSubscriptionStartPolicy.FromBeginning,
+            SortableUniqueId.Generate(DateTime.UtcNow, Guid.Empty));
+        Assert.True(initialized.IsSuccess, initialized.IsSuccess ? string.Empty : initialized.GetException().ToString());
+
+        var first = await store.TryAcquireAsync(identity, "owner-a", TimeSpan.FromSeconds(30));
+        Assert.True(first.IsSuccess && first.GetValue().Acquired);
+        var firstGeneration = first.GetValue().State.OwnerGeneration;
+        await using (var connection = new NpgsqlConnection(Fixture.ConnectionString))
+        {
+            await connection.OpenAsync();
+            await ExecuteAsync(connection,
+                "UPDATE dcb_durable_subscriptions SET lease_expires_at_utc = CURRENT_TIMESTAMP - INTERVAL '1 second' "
+                + "WHERE service_id = 'halt-service' AND subscription_name = 'orders'");
+        }
+
+        var second = await store.TryAcquireAsync(identity, "owner-b", TimeSpan.FromSeconds(30));
+        Assert.True(second.IsSuccess && second.GetValue().Acquired);
+        var secondGeneration = second.GetValue().State.OwnerGeneration;
+
+        var staleHalt = await store.HaltAsync(identity, "owner-a", firstGeneration, "stale-halt");
+        Assert.False(staleHalt.IsSuccess);
+        var stillOwned = await store.ReadAsync(identity);
+        Assert.True(stillOwned.IsSuccess);
+        Assert.Equal("owner-b", stillOwned.GetValue().OwnerId);
+        Assert.Equal(DurableSubscriptionPhase.CatchingUp, stillOwned.GetValue().Phase);
+
+        var acknowledged = await store.AcknowledgeAsync(identity, "owner-b", secondGeneration, eventId);
+        Assert.True(acknowledged.IsSuccess, acknowledged.IsSuccess ? string.Empty : acknowledged.GetException().ToString());
+        var halted = await store.HaltAsync(identity, "owner-b", secondGeneration, "first-halt");
+        Assert.True(halted.IsSuccess, halted.IsSuccess ? string.Empty : halted.GetException().ToString());
+        Assert.Equal(eventId, halted.GetValue().LastHaltPosition);
+
+        var repeated = await store.HaltAsync(identity, "owner-b", secondGeneration, "second-halt");
+        Assert.False(repeated.IsSuccess);
+        var final = await store.ReadAsync(identity);
+        Assert.True(final.IsSuccess);
+        Assert.Equal(DurableSubscriptionPhase.Halted, final.GetValue().Phase);
+        Assert.Equal("first-halt", final.GetValue().LastHaltReason);
+        Assert.Equal(eventId, final.GetValue().LastHaltPosition);
+    }
+
+    [Fact]
+    public async Task RetryTimestampAndFailurePositionAreDatabaseGatedAcrossTakeover()
+    {
+        var firstPosition = await AppendEventAsync("retry-first", "retry-service");
+        var secondPosition = await AppendEventAsync("retry-second", "retry-service");
+        var store = CreateStore();
+        var identity = new DurableSubscriptionIdentity("retry-service", "orders");
+        var initialized = await store.InitializeOrGetAsync(
+            identity,
+            DurableSubscriptionStartPolicy.FromBeginning,
+            SortableUniqueId.Generate(DateTime.UtcNow, Guid.Empty));
+        Assert.True(initialized.IsSuccess, initialized.IsSuccess ? string.Empty : initialized.GetException().ToString());
+
+        var first = await store.TryAcquireAsync(identity, "owner-a", TimeSpan.FromSeconds(30));
+        Assert.True(first.IsSuccess && first.GetValue().Acquired);
+        var firstFailure = await store.RecordFailureAsync(
+            identity, "owner-a", first.GetValue().State.OwnerGeneration, firstPosition, "transient",
+            conversionFailure: false, maxHandlerAttempts: 4, retryDelay: TimeSpan.FromMinutes(1));
+        Assert.True(firstFailure.IsSuccess, firstFailure.IsSuccess ? string.Empty : firstFailure.GetException().ToString());
+        Assert.Equal(1, firstFailure.GetValue().ActiveFailureCount);
+        Assert.Equal(DurableSubscriptionPhase.Retrying, firstFailure.GetValue().Phase);
+
+        await using (var connection = new NpgsqlConnection(Fixture.ConnectionString))
+        {
+            await connection.OpenAsync();
+            await ExecuteAsync(connection,
+                "UPDATE dcb_durable_subscriptions SET lease_expires_at_utc = CURRENT_TIMESTAMP - INTERVAL '1 second' "
+                + "WHERE service_id = 'retry-service' AND subscription_name = 'orders'");
+        }
+
+        var takeover = await store.TryAcquireAsync(identity, "owner-b", TimeSpan.FromSeconds(30));
+        Assert.True(takeover.IsSuccess && takeover.GetValue().Acquired);
+        Assert.Equal(DurableSubscriptionPhase.Retrying, takeover.GetValue().State.Phase);
+        Assert.False((await store.IsRetryDueAsync(
+            identity, "owner-b", takeover.GetValue().State.OwnerGeneration)).GetValue());
+
+        var earlyFailure = await store.RecordFailureAsync(
+            identity, "owner-b", takeover.GetValue().State.OwnerGeneration, firstPosition, "too-early",
+            conversionFailure: false, maxHandlerAttempts: 4, retryDelay: TimeSpan.FromMinutes(1));
+        Assert.False(earlyFailure.IsSuccess);
+        var earlyAck = await store.AcknowledgeAsync(
+            identity, "owner-b", takeover.GetValue().State.OwnerGeneration, secondPosition);
+        Assert.False(earlyAck.IsSuccess);
+
+        await using (var connection = new NpgsqlConnection(Fixture.ConnectionString))
+        {
+            await connection.OpenAsync();
+            await ExecuteAsync(connection,
+                "UPDATE dcb_durable_subscriptions SET next_attempt_at_utc = CURRENT_TIMESTAMP - INTERVAL '1 second' "
+                + "WHERE service_id = 'retry-service' AND subscription_name = 'orders'");
+        }
+
+        var differentPosition = await store.RecordFailureAsync(
+            identity, "owner-b", takeover.GetValue().State.OwnerGeneration, secondPosition, "new-position",
+            conversionFailure: false, maxHandlerAttempts: 4, retryDelay: TimeSpan.FromMinutes(1));
+        Assert.True(differentPosition.IsSuccess, differentPosition.IsSuccess ? string.Empty : differentPosition.GetException().ToString());
+        Assert.Equal(1, differentPosition.GetValue().ActiveFailureCount);
+        Assert.Equal(secondPosition, differentPosition.GetValue().ActiveFailurePosition);
+    }
+
+    [Fact]
+    public void MixedProvisioningModesFailClosedInEitherRegistrationOrder()
+    {
+        var legacyThenPreProvisioned = new ServiceCollection();
+        legacyThenPreProvisioned.AddSekibanDcbPostgresDurableSubscription(
+            options => options.Name = "legacy",
+            (_, _) => Task.CompletedTask);
+        Assert.Throws<InvalidOperationException>(() =>
+            legacyThenPreProvisioned.AddSekibanDcbPostgresDurableSubscription(
+                options =>
+                {
+                    options.Name = "pre-provisioned";
+                    options.ProvisioningMode = DurableSubscriptionProvisioningMode.PreProvisioned;
+                },
+                (_, _) => Task.CompletedTask));
+
+        var preProvisionedThenLegacy = new ServiceCollection();
+        preProvisionedThenLegacy.AddSekibanDcbPostgresDurableSubscription(
+            options =>
+            {
+                options.Name = "pre-provisioned";
+                options.ProvisioningMode = DurableSubscriptionProvisioningMode.PreProvisioned;
+            },
+            (_, _) => Task.CompletedTask);
+        Assert.Throws<InvalidOperationException>(() =>
+            preProvisionedThenLegacy.AddSekibanDcbPostgresDurableSubscription(
+                options => options.Name = "legacy",
+                (_, _) => Task.CompletedTask));
+    }
+
+    [Fact]
+    public async Task RestartTakeoverAndReentrantAcquirePreserveTheDurableCursor()
+    {
+        var eventId = await AppendEventAsync("restart", "restart-service");
+        var identity = new DurableSubscriptionIdentity("restart-service", "orders");
+        var firstStore = CreateStore();
+        var initialized = await firstStore.InitializeOrGetAsync(
+            identity,
+            DurableSubscriptionStartPolicy.FromBeginning,
+            SortableUniqueId.Generate(DateTime.UtcNow, Guid.Empty));
+        Assert.True(initialized.IsSuccess, initialized.IsSuccess ? string.Empty : initialized.GetException().ToString());
+        var first = await firstStore.TryAcquireAsync(identity, "owner-a", TimeSpan.FromSeconds(30));
+        Assert.True(first.IsSuccess && first.GetValue().Acquired);
+        var acknowledged = await firstStore.AcknowledgeAsync(
+            identity, "owner-a", first.GetValue().State.OwnerGeneration, eventId);
+        Assert.True(acknowledged.IsSuccess);
+
+        var restartedStore = CreateStore();
+        var afterRestart = await restartedStore.ReadAsync(identity);
+        Assert.True(afterRestart.IsSuccess);
+        Assert.Equal(eventId, afterRestart.GetValue().AcknowledgedPosition);
+
+        await using (var connection = new NpgsqlConnection(Fixture.ConnectionString))
+        {
+            await connection.OpenAsync();
+            await ExecuteAsync(connection,
+                "UPDATE dcb_durable_subscriptions SET lease_expires_at_utc = CURRENT_TIMESTAMP - INTERVAL '1 second' "
+                + "WHERE service_id = 'restart-service' AND subscription_name = 'orders'");
+        }
+
+        var takeover = await restartedStore.TryAcquireAsync(identity, "owner-b", TimeSpan.FromSeconds(30));
+        Assert.True(takeover.IsSuccess && takeover.GetValue().Acquired);
+        var generation = takeover.GetValue().State.OwnerGeneration;
+        var reentrant = await restartedStore.TryAcquireAsync(identity, "owner-b", TimeSpan.FromSeconds(30));
+        Assert.True(reentrant.IsSuccess && reentrant.GetValue().Acquired);
+        Assert.Equal(generation, reentrant.GetValue().State.OwnerGeneration);
+        Assert.Equal(eventId, reentrant.GetValue().State.AcknowledgedPosition);
+    }
+
+    [Fact]
+    public async Task ConversionPoisonHaltsWithoutSkippingAndHaltedRunnerReReads()
+    {
+        var position = await AppendEventAsync("poison", "poison-service");
+        var store = CreateStore();
+        var identity = new DurableSubscriptionIdentity("poison-service", "orders");
+        var initialized = await store.InitializeOrGetAsync(
+            identity,
+            DurableSubscriptionStartPolicy.FromBeginning,
+            SortableUniqueId.Generate(DateTime.UtcNow, Guid.Empty));
+        Assert.True(initialized.IsSuccess, initialized.IsSuccess ? string.Empty : initialized.GetException().ToString());
+        var lease = await store.TryAcquireAsync(identity, "owner-a", TimeSpan.FromSeconds(30));
+        Assert.True(lease.IsSuccess && lease.GetValue().Acquired);
+        var halted = await store.RecordFailureAsync(
+            identity, "owner-a", lease.GetValue().State.OwnerGeneration, position, "conversion-poison",
+            conversionFailure: true, maxHandlerAttempts: 4, retryDelay: TimeSpan.FromSeconds(1));
+        Assert.True(halted.IsSuccess, halted.IsSuccess ? string.Empty : halted.GetException().ToString());
+        Assert.Equal(DurableSubscriptionPhase.Halted, halted.GetValue().Phase);
+        Assert.Null(halted.GetValue().AcknowledgedPosition);
+
+        var reacquire = await store.TryAcquireAsync(identity, "owner-b", TimeSpan.FromSeconds(30));
+        Assert.True(reacquire.IsSuccess);
+        Assert.False(reacquire.GetValue().Acquired);
+        Assert.Equal(DurableSubscriptionRunnerStatus.Halted, reacquire.GetValue().Status);
+
+        var handlerCalls = 0;
+        var nudge = new RecordingNudgeFactory();
+        var runner = CreateRunner(
+            store,
+            identity,
+            nudge,
+            (_, _) =>
+            {
+                Interlocked.Increment(ref handlerCalls);
+                return Task.CompletedTask;
+            });
+        using var cancellation = new CancellationTokenSource();
+        await runner.StartAsync(cancellation.Token);
+        await WaitUntilAsync(() => Task.FromResult(runner.Status == DurableSubscriptionRunnerStatus.Halted));
+        await nudge.TriggerAsync();
+        Assert.Equal(0, handlerCalls);
+        var final = await store.ReadAsync(identity);
+        Assert.Equal(DurableSubscriptionPhase.Halted, final.GetValue().Phase);
+        cancellation.Cancel();
+        await runner.StopAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task IdleDuplicateAndOutOfOrderNudgesReuseLeaseAndCatchUpPromptly()
+    {
+        var firstPosition = await AppendEventAsync("idle-first", "idle-service");
+        var store = CreateStore();
+        var identity = new DurableSubscriptionIdentity("idle-service", "orders");
+        var nudge = new RecordingNudgeFactory();
+        var firstHandled = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var secondHandled = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var calls = 0;
+        var secondPosition = string.Empty;
+        var runner = CreateRunner(
+            store,
+            identity,
+            nudge,
+            (eventRecord, _) =>
+            {
+                Interlocked.Increment(ref calls);
+                if (eventRecord.SortableUniqueIdValue == firstPosition)
+                {
+                    firstHandled.TrySetResult(eventRecord.SortableUniqueIdValue);
+                }
+                else if (eventRecord.SortableUniqueIdValue == secondPosition)
+                {
+                    secondHandled.TrySetResult(eventRecord.SortableUniqueIdValue);
+                }
+
+                return Task.CompletedTask;
+            });
+        using var cancellation = new CancellationTokenSource();
+        await runner.StartAsync(cancellation.Token);
+        Assert.Equal(firstPosition, await firstHandled.Task.WaitAsync(TimeSpan.FromSeconds(5)));
+        await WaitUntilAsync(async () => (await store.ReadAsync(identity)).GetValue().Phase == DurableSubscriptionPhase.Idle);
+        var before = (await store.ReadAsync(identity)).GetValue();
+
+        await nudge.TriggerAsync();
+        await nudge.TriggerAsync();
+        await WaitUntilAsync(async () =>
+        {
+            var observed = await store.ReadAsync(identity);
+            return observed.IsSuccess
+                && observed.GetValue().Phase == DurableSubscriptionPhase.Idle
+                && observed.GetValue().UpdatedAtUtc > before.UpdatedAtUtc;
+        });
+        Assert.Equal(1, calls);
+
+        secondPosition = await AppendEventAsync("idle-second", "idle-service");
+        await nudge.TriggerAsync();
+        Assert.Equal(secondPosition, await secondHandled.Task.WaitAsync(TimeSpan.FromSeconds(3)));
+        await WaitUntilAsync(async () =>
+        {
+            var observed = await store.ReadAsync(identity);
+            return observed.IsSuccess && observed.GetValue().AcknowledgedPosition == secondPosition;
+        });
+        var after = await store.ReadAsync(identity);
+        Assert.True(after.IsSuccess);
+        Assert.Equal(before.OwnerGeneration, after.GetValue().OwnerGeneration);
+        Assert.Equal(secondPosition, after.GetValue().AcknowledgedPosition);
+        Assert.Equal(2, calls);
+
+        cancellation.Cancel();
+        await runner.StopAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task LongHandlerFenceLossCancelsBeforeAcknowledgement()
+    {
+        var position = await AppendEventAsync("long-handler", "fence-runner-service");
+        var store = CreateStore();
+        var identity = new DurableSubscriptionIdentity("fence-runner-service", "orders");
+        var entered = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var cancelled = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var runner = CreateRunner(
+            store,
+            identity,
+            new RecordingNudgeFactory(),
+            async (_, token) =>
+            {
+                entered.TrySetResult(true);
+                try
+                {
+                    await Task.Delay(Timeout.InfiniteTimeSpan, token);
+                }
+                catch (OperationCanceledException)
+                {
+                    cancelled.TrySetResult(true);
+                    throw;
+                }
+            },
+            leaseDuration: TimeSpan.FromSeconds(1));
+        using var cancellation = new CancellationTokenSource();
+        await runner.StartAsync(cancellation.Token);
+        await entered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        var owned = await store.ReadAsync(identity);
+        Assert.Null(owned.GetValue().AcknowledgedPosition);
+        Assert.NotNull(owned.GetValue().OwnerId);
+
+        await using (var connection = new NpgsqlConnection(Fixture.ConnectionString))
+        {
+            await connection.OpenAsync();
+            await ExecuteAsync(connection,
+                "UPDATE dcb_durable_subscriptions SET owner_id = 'fenced-out', "
+                + "owner_generation = owner_generation + 1, lease_expires_at_utc = CURRENT_TIMESTAMP + INTERVAL '30 seconds' "
+                + "WHERE service_id = 'fence-runner-service' AND subscription_name = 'orders'");
+        }
+
+        await cancelled.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        var after = await store.ReadAsync(identity);
+        Assert.True(after.IsSuccess);
+        Assert.Null(after.GetValue().AcknowledgedPosition);
+        cancellation.Cancel();
+        await runner.StopAsync(CancellationToken.None);
+    }
+
+    private PostgresDurableSubscriptionStore CreateStore() =>
+        new(Fixture.DbContextFactory, legacyAutoProvision: false);
+
+    private DurableSubscriptionRunner CreateRunner(
+        IDurableSubscriptionStore store,
+        DurableSubscriptionIdentity identity,
+        RecordingNudgeFactory nudge,
+        DurableSubscriptionHandler handler,
+        TimeSpan? leaseDuration = null)
+    {
+        var registration = new DurableSubscriptionRegistration(
+            new DurableSubscriptionOptions
+            {
+                ServiceId = identity.ServiceId,
+                Name = identity.Name,
+                StartPolicy = DurableSubscriptionStartPolicy.FromBeginning,
+                SafeWindow = TimeSpan.Zero,
+                PollInterval = TimeSpan.FromMilliseconds(25),
+                RetryDelay = TimeSpan.FromMilliseconds(25),
+                LeaseDuration = leaseDuration ?? TimeSpan.FromSeconds(30),
+                MaxHandlerAttempts = 4
+            },
+            handler);
+        return new DurableSubscriptionRunner(
+            registration,
+            store,
+            new PostgresEventStoreFactory(Fixture.DbContextFactory, Fixture.DomainTypes.EventTypes),
+            Fixture.DomainTypes.EventTypes,
+            nudge,
+            NullLogger<DurableSubscriptionRunner>.Instance);
+    }
+
+    private async Task<string> AppendEventAsync(string marker, string serviceId = "default")
     {
         var eventId = SortableUniqueId.GenerateNew();
         var payload = new WeatherForecastCreated(
@@ -334,9 +749,45 @@ public sealed class PostgresDurableSubscriptionTests : PostgresTestBase
                 new EventMetadata("durable-subscription", marker, "test-user"),
                 [])
             .ToSerializableEvent(Fixture.DomainTypes.EventTypes);
-        var written = await Fixture.EventStore.WriteSerializableEventsAsync([serialized]);
+        var eventStore = new PostgresEventStoreFactory(Fixture.DbContextFactory, Fixture.DomainTypes.EventTypes)
+            .CreateForService(serviceId);
+        var written = await eventStore.WriteSerializableEventsAsync([serialized]);
         Assert.True(written.IsSuccess, written.IsSuccess ? string.Empty : written.GetException().ToString());
         return eventId;
+    }
+
+    private static async Task WaitUntilAsync(Func<Task<bool>> condition, TimeSpan? timeout = null)
+    {
+        var deadline = DateTime.UtcNow + (timeout ?? TimeSpan.FromSeconds(5));
+        while (DateTime.UtcNow < deadline)
+        {
+            if (await condition().ConfigureAwait(false))
+            {
+                return;
+            }
+
+            await Task.Delay(TimeSpan.FromMilliseconds(25)).ConfigureAwait(false);
+        }
+
+        Assert.True(await condition().ConfigureAwait(false), "The expected durable PostgreSQL state was not observed before the bounded deadline.");
+    }
+
+    private sealed class RecordingNudgeFactory : IDurableSubscriptionNudgeFactory
+    {
+        private Func<ValueTask>? _onNudge;
+
+        public IDurableSubscriptionNudge Create(DurableSubscriptionIdentity identity, Func<ValueTask> onNudge)
+        {
+            _onNudge = onNudge;
+            return new RecordingNudge();
+        }
+
+        public ValueTask TriggerAsync() => _onNudge?.Invoke() ?? ValueTask.CompletedTask;
+    }
+
+    private sealed class RecordingNudge : IDurableSubscriptionNudge
+    {
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
     }
 
     private static async Task ExecuteAsync(NpgsqlConnection connection, string sql)

--- a/dcb/tests/Sekiban.Dcb.Postgres.Tests/PostgresDurableSubscriptionTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Postgres.Tests/PostgresDurableSubscriptionTests.cs
@@ -2,6 +2,7 @@ using Npgsql;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging.Abstractions;
+using ResultBoxes;
 using Dcb.Domain.Weather;
 using Sekiban.Dcb.Common;
 using Sekiban.Dcb.Domains;
@@ -618,7 +619,8 @@ public sealed class PostgresDurableSubscriptionTests : PostgresTestBase
                 }
 
                 return Task.CompletedTask;
-            });
+            },
+            pollInterval: TimeSpan.FromSeconds(60));
         using var cancellation = new CancellationTokenSource();
         await runner.StartAsync(cancellation.Token);
         Assert.Equal(firstPosition, await firstHandled.Task.WaitAsync(TimeSpan.FromSeconds(5)));
@@ -633,7 +635,7 @@ public sealed class PostgresDurableSubscriptionTests : PostgresTestBase
             return observed.IsSuccess
                 && observed.GetValue().Phase == DurableSubscriptionPhase.Idle
                 && observed.GetValue().UpdatedAtUtc > before.UpdatedAtUtc;
-        });
+        }, TimeSpan.FromSeconds(3));
         Assert.Equal(1, calls);
 
         secondPosition = await AppendEventAsync("idle-second", "idle-service");
@@ -652,6 +654,127 @@ public sealed class PostgresDurableSubscriptionTests : PostgresTestBase
 
         cancellation.Cancel();
         await runner.StopAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task LostNudgeFallsBackToFinitePollingAndAcknowledges()
+    {
+        var store = CreateStore();
+        var identity = new DurableSubscriptionIdentity("lost-nudge-service", "orders");
+        var nudge = new RecordingNudgeFactory();
+        var handled = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var runner = CreateRunner(
+            store,
+            identity,
+            nudge,
+            (eventRecord, _) =>
+            {
+                handled.TrySetResult(eventRecord.SortableUniqueIdValue);
+                return Task.CompletedTask;
+            },
+            pollInterval: TimeSpan.FromMilliseconds(250));
+        using var cancellation = new CancellationTokenSource();
+        try
+        {
+            await runner.StartAsync(cancellation.Token);
+            await WaitUntilAsync(async () =>
+            {
+                var state = await store.ReadAsync(identity);
+                return state.IsSuccess && state.GetValue().Phase == DurableSubscriptionPhase.Idle;
+            });
+
+            var position = await AppendEventAsync("lost-nudge", identity.ServiceId);
+            Assert.Equal(position, await handled.Task.WaitAsync(TimeSpan.FromSeconds(5)));
+            await WaitUntilAsync(async () =>
+            {
+                var state = await store.ReadAsync(identity);
+                return state.IsSuccess && state.GetValue().AcknowledgedPosition == position;
+            });
+            Assert.Equal(0, nudge.TriggerCount);
+        }
+        finally
+        {
+            cancellation.Cancel();
+            await runner.StopAsync(CancellationToken.None);
+        }
+    }
+
+    [Fact]
+    public async Task CrashAfterHandlerBeforeAcknowledgement_ReinvokesSamePositionAndAdvancesCursorOnce()
+    {
+        var position = await AppendEventAsync("crash-boundary", "crash-service");
+        var store = CreateStore();
+        var identity = new DurableSubscriptionIdentity("crash-service", "orders");
+        var crashStore = new FirstAcknowledgeBlockedStore(store);
+        var firstHandled = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var firstRunner = CreateRunner(
+            crashStore,
+            identity,
+            new RecordingNudgeFactory(),
+            (eventRecord, _) =>
+            {
+                firstHandled.TrySetResult(eventRecord.SortableUniqueIdValue);
+                return Task.CompletedTask;
+            });
+        using var firstCancellation = new CancellationTokenSource();
+        try
+        {
+            await firstRunner.StartAsync(firstCancellation.Token);
+            Assert.Equal(position, await firstHandled.Task.WaitAsync(TimeSpan.FromSeconds(5)));
+            await crashStore.FirstAcknowledgeStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            var beforeCancellation = await store.ReadAsync(identity);
+            Assert.True(beforeCancellation.IsSuccess);
+            Assert.Null(beforeCancellation.GetValue().AcknowledgedPosition);
+        }
+        finally
+        {
+            firstCancellation.Cancel();
+            await firstRunner.StopAsync(CancellationToken.None);
+        }
+
+        var afterCrash = await store.ReadAsync(identity);
+        Assert.True(afterCrash.IsSuccess);
+        Assert.Null(afterCrash.GetValue().AcknowledgedPosition);
+
+        await using (var connection = new NpgsqlConnection(Fixture.ConnectionString))
+        {
+            await connection.OpenAsync();
+            await ExecuteAsync(connection,
+                "UPDATE dcb_durable_subscriptions SET lease_expires_at_utc = CURRENT_TIMESTAMP - INTERVAL '1 second' "
+                + "WHERE service_id = 'crash-service' AND subscription_name = 'orders'");
+        }
+
+        var secondHandled = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var secondRunner = CreateRunner(
+            crashStore,
+            identity,
+            new RecordingNudgeFactory(),
+            (eventRecord, _) =>
+            {
+                secondHandled.TrySetResult(eventRecord.SortableUniqueIdValue);
+                return Task.CompletedTask;
+            });
+        using var secondCancellation = new CancellationTokenSource();
+        try
+        {
+            await secondRunner.StartAsync(secondCancellation.Token);
+            Assert.Equal(position, await secondHandled.Task.WaitAsync(TimeSpan.FromSeconds(5)));
+            await WaitUntilAsync(async () =>
+            {
+                var state = await store.ReadAsync(identity);
+                return state.IsSuccess && state.GetValue().AcknowledgedPosition == position;
+            });
+
+            var final = await store.ReadAsync(identity);
+            Assert.True(final.IsSuccess);
+            Assert.Equal(position, final.GetValue().AcknowledgedPosition);
+            Assert.Equal(1, crashStore.SuccessfulAcknowledgementCount);
+        }
+        finally
+        {
+            secondCancellation.Cancel();
+            await secondRunner.StopAsync(CancellationToken.None);
+        }
     }
 
     [Fact]
@@ -712,7 +835,8 @@ public sealed class PostgresDurableSubscriptionTests : PostgresTestBase
         DurableSubscriptionIdentity identity,
         RecordingNudgeFactory nudge,
         DurableSubscriptionHandler handler,
-        TimeSpan? leaseDuration = null)
+        TimeSpan? leaseDuration = null,
+        TimeSpan? pollInterval = null)
     {
         var registration = new DurableSubscriptionRegistration(
             new DurableSubscriptionOptions
@@ -721,7 +845,7 @@ public sealed class PostgresDurableSubscriptionTests : PostgresTestBase
                 Name = identity.Name,
                 StartPolicy = DurableSubscriptionStartPolicy.FromBeginning,
                 SafeWindow = TimeSpan.Zero,
-                PollInterval = TimeSpan.FromMilliseconds(25),
+                PollInterval = pollInterval ?? TimeSpan.FromMilliseconds(25),
                 RetryDelay = TimeSpan.FromMilliseconds(25),
                 LeaseDuration = leaseDuration ?? TimeSpan.FromSeconds(30),
                 MaxHandlerAttempts = 4
@@ -776,18 +900,148 @@ public sealed class PostgresDurableSubscriptionTests : PostgresTestBase
     {
         private Func<ValueTask>? _onNudge;
 
+        public int TriggerCount { get; private set; }
+
         public IDurableSubscriptionNudge Create(DurableSubscriptionIdentity identity, Func<ValueTask> onNudge)
         {
             _onNudge = onNudge;
             return new RecordingNudge();
         }
 
-        public ValueTask TriggerAsync() => _onNudge?.Invoke() ?? ValueTask.CompletedTask;
+        public ValueTask TriggerAsync()
+        {
+            TriggerCount++;
+            return _onNudge?.Invoke() ?? ValueTask.CompletedTask;
+        }
     }
 
     private sealed class RecordingNudge : IDurableSubscriptionNudge
     {
         public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+
+    private sealed class FirstAcknowledgeBlockedStore : IDurableSubscriptionStore
+    {
+        private readonly IDurableSubscriptionStore _inner;
+        private int _firstAcknowledge;
+        private int _successfulAcknowledgementCount;
+
+        public FirstAcknowledgeBlockedStore(IDurableSubscriptionStore inner) => _inner = inner;
+
+        public TaskCompletionSource<bool> FirstAcknowledgeStarted { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public int SuccessfulAcknowledgementCount => Volatile.Read(ref _successfulAcknowledgementCount);
+
+        public Task<ResultBox<DurableSubscriptionState>> InitializeOrGetAsync(
+            DurableSubscriptionIdentity identity,
+            DurableSubscriptionStartPolicy startPolicy,
+            string safeTail,
+            CancellationToken cancellationToken = default) =>
+            _inner.InitializeOrGetAsync(identity, startPolicy, safeTail, cancellationToken);
+
+        public Task<ResultBox<DurableSubscriptionState>> ReadAsync(
+            DurableSubscriptionIdentity identity,
+            CancellationToken cancellationToken = default) =>
+            _inner.ReadAsync(identity, cancellationToken);
+
+        public Task<ResultBox<DurableSubscriptionLease>> TryAcquireAsync(
+            DurableSubscriptionIdentity identity,
+            string ownerId,
+            TimeSpan leaseDuration,
+            CancellationToken cancellationToken = default) =>
+            _inner.TryAcquireAsync(identity, ownerId, leaseDuration, cancellationToken);
+
+        public Task<ResultBox<bool>> RenewAsync(
+            DurableSubscriptionIdentity identity,
+            string ownerId,
+            long ownerGeneration,
+            TimeSpan leaseDuration,
+            CancellationToken cancellationToken = default) =>
+            _inner.RenewAsync(identity, ownerId, ownerGeneration, leaseDuration, cancellationToken);
+
+        public Task<ResultBox<bool>> IsRetryDueAsync(
+            DurableSubscriptionIdentity identity,
+            string ownerId,
+            long ownerGeneration,
+            CancellationToken cancellationToken = default) =>
+            _inner.IsRetryDueAsync(identity, ownerId, ownerGeneration, cancellationToken);
+
+        public async Task<ResultBox<DurableSubscriptionState>> AcknowledgeAsync(
+            DurableSubscriptionIdentity identity,
+            string ownerId,
+            long ownerGeneration,
+            string position,
+            CancellationToken cancellationToken = default)
+        {
+            if (Interlocked.Exchange(ref _firstAcknowledge, 1) == 0)
+            {
+                FirstAcknowledgeStarted.TrySetResult(true);
+                try
+                {
+                    await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+                }
+                catch (OperationCanceledException)
+                {
+                    return ResultBox.Error<DurableSubscriptionState>(
+                        new OperationCanceledException("The test stopped before the first acknowledgement.", cancellationToken));
+                }
+            }
+
+            var result = await _inner.AcknowledgeAsync(
+                identity,
+                ownerId,
+                ownerGeneration,
+                position,
+                cancellationToken);
+            if (result.IsSuccess)
+            {
+                Interlocked.Increment(ref _successfulAcknowledgementCount);
+            }
+
+            return result;
+        }
+
+        public Task<ResultBox<DurableSubscriptionState>> RecordFailureAsync(
+            DurableSubscriptionIdentity identity,
+            string ownerId,
+            long ownerGeneration,
+            string position,
+            string reason,
+            bool conversionFailure,
+            int maxHandlerAttempts,
+            TimeSpan retryDelay,
+            CancellationToken cancellationToken = default) =>
+            _inner.RecordFailureAsync(
+                identity,
+                ownerId,
+                ownerGeneration,
+                position,
+                reason,
+                conversionFailure,
+                maxHandlerAttempts,
+                retryDelay,
+                cancellationToken);
+
+        public Task<ResultBox<DurableSubscriptionState>> ResumeAsync(
+            DurableSubscriptionIdentity identity,
+            CancellationToken cancellationToken = default) =>
+            _inner.ResumeAsync(identity, cancellationToken);
+
+        public Task<ResultBox<DurableSubscriptionState>> HaltAsync(
+            DurableSubscriptionIdentity identity,
+            string ownerId,
+            long ownerGeneration,
+            string reason,
+            CancellationToken cancellationToken = default) =>
+            _inner.HaltAsync(identity, ownerId, ownerGeneration, reason, cancellationToken);
+
+        public Task<ResultBox<DurableSubscriptionState>> MarkIdleAsync(
+            DurableSubscriptionIdentity identity,
+            string ownerId,
+            long ownerGeneration,
+            CancellationToken cancellationToken = default) =>
+            _inner.MarkIdleAsync(identity, ownerId, ownerGeneration, cancellationToken);
     }
 
     private static async Task ExecuteAsync(NpgsqlConnection connection, string sql)

--- a/docs/dcb_llm/10_orleans_setup.md
+++ b/docs/dcb_llm/10_orleans_setup.md
@@ -17,6 +17,7 @@
 > - [ResultBox](14_result_box.md)
 > - [Value Objects](15_value_object.md)
 > - [Deployment Guide](16_deployment.md)
+> - [Durable Orleans Subscriptions](23_durable_orleans_subscriptions.md)
 
 DCB uses Orleans grains to implement TagConsistent actors, TagState caches, and MultiProjections. The sample AppHost
 configures everything via `.UseOrleans` (`internalUsages/DcbOrleans.ApiService/Program.cs`).

--- a/docs/dcb_llm/23_durable_orleans_subscriptions.md
+++ b/docs/dcb_llm/23_durable_orleans_subscriptions.md
@@ -58,6 +58,16 @@ out-of-order Orleans nudge cannot advance the cursor, and a process restart resu
 durable delivery/catch-up boundary, not an exactly-once guarantee for external side effects; handlers should remain
 idempotent.
 
+Lease ownership, expiry, retry eligibility, and halt fencing are evaluated by PostgreSQL time, not by a client clock.
+The persisted `DurableSubscriptionPhase` is deliberately separate from the process-local
+`DurableSubscriptionRunnerStatus` exposed by the handle (`Starting`, `Owner`, `Standby`, `Halted`, or `Stopped`). A
+same-owner nudge or fallback poll retains the lease and generation, and an empty/idle observation does not release it;
+the runner can therefore catch up promptly without waiting for lease expiry or manufacturing a new generation. Retry
+attempts are admitted only when the durable `next_attempt_at_utc` is due in PostgreSQL, including after restart or
+takeover. A stale owner cannot overwrite the first durable halt position, reason, or timestamp. Registration also fails
+closed when `PreProvisioned` and `LegacyAutoProvision` are mixed, regardless of registration order; no partial provider
+registration is left to silently change the provisioning mode.
+
 The Orleans integration follows the DCB-supported `Microsoft.Orleans.*` **10.3.1** line. Upgrade the whole cluster
 together; mixing Orleans versions is not a supported compatibility guarantee. This subscriber is the durable
 store-driven catch-up boundary only. It does not provide a relay/outbox, replay arbitrary external subscriber effects,

--- a/docs/dcb_llm/23_durable_orleans_subscriptions.md
+++ b/docs/dcb_llm/23_durable_orleans_subscriptions.md
@@ -26,7 +26,11 @@ builder.Services.AddSekibanDcbPostgresDurableSubscription(
 
 `FromNow` is the default and starts at the current safe tail; `FromBeginning` starts with a null cursor. Names are
 unique within a service container and duplicate registrations are rejected before the hosted runner is added. The
-legacy `IEventSubscription` callback path is unchanged and is not converted into a durable subscription.
+legacy `IEventSubscription` callback path is unchanged and is not converted into a durable subscription. A durable
+subscription name is not reserved against legacy callbacks because the two paths have no shared declaration registry,
+so the library cannot detect or reject an overlapping name. If an application registers both for the same logical
+subscription, application handling may be invoked twice independently and handlers must already be idempotent; only
+the durable runner reads and advances the durable cursor, and the legacy callback cannot move it.
 
 ## PostgreSQL deployment
 

--- a/docs/dcb_llm/23_durable_orleans_subscriptions.md
+++ b/docs/dcb_llm/23_durable_orleans_subscriptions.md
@@ -1,0 +1,71 @@
+# Durable Orleans Subscriptions
+
+`Sekiban.Dcb.Postgres` provides an opt-in, PostgreSQL-backed subscriber for applications that need a durable cursor
+after an Orleans process restart. The Orleans stream is only a data-free wake-up hint; the PostgreSQL event store is
+the source of truth and the durable runner reads events strictly after its acknowledged position.
+
+## Registration
+
+Register the normal PostgreSQL event store, then add one durable subscription per service/name identity:
+
+```csharp
+builder.Services.AddSekibanDcbPostgres(connectionString);
+builder.Services.AddSekibanDcbPostgresDurableSubscription(
+    options =>
+    {
+        options.ServiceId = "orders";
+        options.Name = "billing";
+        options.StartPolicy = DurableSubscriptionStartPolicy.FromBeginning;
+        options.ProvisioningMode = DurableSubscriptionProvisioningMode.PreProvisioned;
+    },
+    async (eventRecord, cancellationToken) =>
+    {
+        await HandleEventAsync(eventRecord, cancellationToken);
+    });
+```
+
+`FromNow` is the default and starts at the current safe tail; `FromBeginning` starts with a null cursor. Names are
+unique within a service container and duplicate registrations are rejected before the hosted runner is added. The
+legacy `IEventSubscription` callback path is unchanged and is not converted into a durable subscription.
+
+## PostgreSQL deployment
+
+The owner must provision the raw table before using pre-provisioned mode:
+
+```csharp
+await serviceProvider.ProvisionDurableSubscriptionSchemaAsync(cancellationToken);
+```
+
+`PreProvisioned` runtime operations are DML-only. The durable row stores the service/name identity, initialization and
+acknowledged cursor, phase, failure and halt evidence, owner/generation, lease expiry, and retry timing. Missing table
+or schema columns are surfaced as the provider's PostgreSQL error (for example SQLSTATE `42P01` for an absent table or
+`42703` for an absent column); the runner does not silently treat an absent state row as healthy.
+
+The default `LegacyAutoProvision` mode preserves compatibility for applications that allow startup provisioning. Use a
+single owner-controlled provisioning step in deployments where the runtime database principal must not execute DDL.
+
+## Recovery and fencing
+
+Each catch-up cycle reads the durable row before attempting a PostgreSQL lease acquisition. Lease acquisition,
+renewal, acknowledgement, failure recording, resume, and halt are service/name/owner/generation scoped. A successful
+handler invocation is acknowledged only after event conversion and handling complete. A conversion error halts the
+subscription immediately; handler failures retry up to `MaxHandlerAttempts` (four by default), then persist a halted
+phase and the failure position/reason. `ResumeAsync` is explicit, preserves the acknowledged cursor and halt evidence,
+clears retry/lease state, and advances the owner generation.
+
+The runner renews a lease during a long handler and cancels the handler if renewal loses the fence. A duplicate or
+out-of-order Orleans nudge cannot advance the cursor, and a process restart resumes from the PostgreSQL row. This is a
+durable delivery/catch-up boundary, not an exactly-once guarantee for external side effects; handlers should remain
+idempotent.
+
+The Orleans integration follows the DCB-supported `Microsoft.Orleans.*` **10.3.1** line. Upgrade the whole cluster
+together; mixing Orleans versions is not a supported compatibility guarantee. This subscriber is the durable
+store-driven catch-up boundary only. It does not provide a relay/outbox, replay arbitrary external subscriber effects,
+or perform automatic historical repair; those concerns remain a separate later design.
+
+## Limits and observability
+
+`SafeWindow`, `LeaseDuration`, `PollInterval`, `RetryDelay`, `MaxHandlerAttempts`, and `MaxBatchSize` are validated
+before the hosted runner starts. `GetStateAsync`, `ResumeAsync`, and `HaltAsync` expose the persisted phase and halt
+evidence through `IDurableSubscriptionHandle`. Orleans subscription delivery does not provide the authoritative event
+payload to the handler.

--- a/docs/dcb_llm_ja/10_orleans_setup.md
+++ b/docs/dcb_llm_ja/10_orleans_setup.md
@@ -17,6 +17,7 @@
 > - [ResultBox](14_result_box.md)
 > - [バリューオブジェクト](15_value_object.md)
 > - [デプロイガイド](16_deployment.md)
+> - [永続 Orleans サブスクリプション](23_durable_orleans_subscriptions.md)
 
 DCB のアクター実装は Orleans 上で動作します。テンプレートの AppHost は `UseOrleans` を通じてクラスタ設定を構築
 します (`internalUsages/DcbOrleans.ApiService/Program.cs`)。

--- a/docs/dcb_llm_ja/23_durable_orleans_subscriptions.md
+++ b/docs/dcb_llm_ja/23_durable_orleans_subscriptions.md
@@ -57,6 +57,15 @@ halt はサービス/名前/owner/generation の組み合わせで保護され�
 重複または順序が前後した Orleans ヒントがカーソルを進めることはなく、プロセス再起動後は PostgreSQL の行から
 再開します。これは外部副作用に対する exactly-once を保証する境界ではないため、ハンドラーは冪等にしてください。
 
+lease の所有、期限、再試行可能時刻、halt のフェンシングはクライアント時計ではなく PostgreSQL の時刻で判定します。
+永続化される `DurableSubscriptionPhase` と、handle から見えるプロセスローカルな
+`DurableSubscriptionRunnerStatus`（`Starting`、`Owner`、`Standby`、`Halted`、`Stopped`）は分離されています。
+同じ owner からの nudge や fallback poll は lease と generation を保持し、empty/idle の観測でも lease を解放しません。
+そのため lease の期限切れや新しい generation を待たずに速やかに catch-up できます。再試行は、再起動や takeover の後も、
+永続化された `next_attempt_at_utc` が PostgreSQL 上で期限に達した場合だけ許可されます。古い owner は最初に記録された halt の
+位置、理由、時刻を上書きできません。`PreProvisioned` と `LegacyAutoProvision` を混在させた登録は登録順にかかわらず
+fail-closed となり、provider 登録が一部だけ残って provisioning mode が暗黙に変わることもありません。
+
 Orleans 統合は DCB がサポートする `Microsoft.Orleans.*` **10.3.1** 系列に従います。クラスタ全体を同時に更新し、
 Orleans バージョンを混在させないでください。これは durable store を正とする catch-up 境界だけを提供します。
 relay/outbox、任意の外部 subscriber 副作用の replay、または自動的な過去イベント修復は提供しません。これらは

--- a/docs/dcb_llm_ja/23_durable_orleans_subscriptions.md
+++ b/docs/dcb_llm_ja/23_durable_orleans_subscriptions.md
@@ -27,7 +27,12 @@ builder.Services.AddSekibanDcbPostgresDurableSubscription(
 
 既定値の `FromNow` は現在の安全な末尾から開始し、`FromBeginning` は null カーソルから開始します。同一
 サービスコンテナー内の名前は一意であり、重複登録は hosted runner が追加される前に拒否されます。既存の
-`IEventSubscription` コールバック経路は変更されず、Durable subscription へ暗黙変換されません。
+`IEventSubscription` コールバック経路は変更されず、Durable subscription へ暗黙変換されません。Durable
+subscription の名前は legacy コールバックに対して予約・排他されません。両経路には共有の宣言レジストリが
+ないため、ライブラリは重複する名前を検出して拒否できません。同じ論理サブスクリプションに両方を登録すると、
+アプリケーションの処理がそれぞれ独立して呼び出されて二重に実行される可能性があるため、ハンドラーはあらかじめ
+冪等でなければなりません。ただし durable cursor を読み取り進めるのは Durable runner だけであり、legacy
+コールバックがそのカーソルを進めることはありません。
 
 ## PostgreSQL のデプロイ
 

--- a/docs/dcb_llm_ja/23_durable_orleans_subscriptions.md
+++ b/docs/dcb_llm_ja/23_durable_orleans_subscriptions.md
@@ -1,0 +1,69 @@
+# 永続 Orleans サブスクリプション
+
+`Sekiban.Dcb.Postgres` は、Orleans プロセスの再起動後もカーソルを保持したいアプリケーション向けに、
+オプトインの PostgreSQL 永続サブスクライバーを提供します。Orleans ストリームはデータを渡す通知ではなく、
+再読込を促すヒントです。正しいイベント列は PostgreSQL のイベントストアから取得し、永続化された確認済み
+位置より後のイベントだけを Durable runner が読み取ります。
+
+## 登録
+
+通常の PostgreSQL イベントストアを登録してから、サービス ID と名前の組み合わせごとに登録します。
+
+```csharp
+builder.Services.AddSekibanDcbPostgres(connectionString);
+builder.Services.AddSekibanDcbPostgresDurableSubscription(
+    options =>
+    {
+        options.ServiceId = "orders";
+        options.Name = "billing";
+        options.StartPolicy = DurableSubscriptionStartPolicy.FromBeginning;
+        options.ProvisioningMode = DurableSubscriptionProvisioningMode.PreProvisioned;
+    },
+    async (eventRecord, cancellationToken) =>
+    {
+        await HandleEventAsync(eventRecord, cancellationToken);
+    });
+```
+
+既定値の `FromNow` は現在の安全な末尾から開始し、`FromBeginning` は null カーソルから開始します。同一
+サービスコンテナー内の名前は一意であり、重複登録は hosted runner が追加される前に拒否されます。既存の
+`IEventSubscription` コールバック経路は変更されず、Durable subscription へ暗黙変換されません。
+
+## PostgreSQL のデプロイ
+
+Pre-provisioned モードを使う前に、所有者が raw table を作成します。
+
+```csharp
+await serviceProvider.ProvisionDurableSubscriptionSchemaAsync(cancellationToken);
+```
+
+`PreProvisioned` の実行時処理は DML のみです。永続行にはサービス/名前、初期化状態と確認済みカーソル、
+フェーズ、失敗と停止の証跡、所有者/generation、lease の期限、再試行時刻が保存されます。テーブルまたは列が
+存在しない場合は PostgreSQL のプロバイダーエラー（例: テーブル欠落は SQLSTATE `42P01`、列欠落は `42703`）
+として通知され、存在しない状態行を正常扱いしません。
+
+既定の `LegacyAutoProvision` は起動時に provisioning を許可するアプリケーションとの互換性を保ちます。
+実行用 DB principal に DDL を許可しない場合は、所有者による provisioning を一度実行してください。
+
+## 復旧とフェンシング
+
+各 catch-up サイクルは PostgreSQL の lease 取得前に永続行を読み取ります。取得、更新、確認、失敗記録、resume、
+halt はサービス/名前/owner/generation の組み合わせで保護されます。ハンドラーの成功はイベント変換と処理が
+完了した後にだけ確認されます。変換エラーは直ちに halt し、ハンドラーエラーは既定で `MaxHandlerAttempts` 回
+（4 回）まで再試行し、その後に失敗位置/理由を保存して halt します。`ResumeAsync` は明示的な操作であり、
+確認済みカーソルと停止証跡を保持し、再試行/lease をクリアして owner generation を進めます。
+
+長いハンドラーの実行中は lease を更新し、更新によってフェンスを失った場合はハンドラーをキャンセルします。
+重複または順序が前後した Orleans ヒントがカーソルを進めることはなく、プロセス再起動後は PostgreSQL の行から
+再開します。これは外部副作用に対する exactly-once を保証する境界ではないため、ハンドラーは冪等にしてください。
+
+Orleans 統合は DCB がサポートする `Microsoft.Orleans.*` **10.3.1** 系列に従います。クラスタ全体を同時に更新し、
+Orleans バージョンを混在させないでください。これは durable store を正とする catch-up 境界だけを提供します。
+relay/outbox、任意の外部 subscriber 副作用の replay、または自動的な過去イベント修復は提供しません。これらは
+後続の別設計の対象です。
+
+## 制限と状態確認
+
+`SafeWindow`、`LeaseDuration`、`PollInterval`、`RetryDelay`、`MaxHandlerAttempts`、`MaxBatchSize` は hosted runner
+起動前に検証されます。`IDurableSubscriptionHandle` の `GetStateAsync`、`ResumeAsync`、`HaltAsync` で永続化された
+フェーズと停止証跡を確認できます。Orleans の通知は authoritative なイベント payload をハンドラーへ渡しません。


### PR DESCRIPTION
Closes #1225

## Summary

- Adds the opt-in `Sekiban.Dcb.Subscriptions` contracts, durable runner, nudge boundary, and public handle.
- Adds PostgreSQL raw-SQL durable state provisioning and DML-only pre-provisioned runtime operations with service/name, owner/generation, lease, retry, halt, and resume fencing.
- Keeps `IEventSubscription` unchanged; Orleans notifications are data-free wake hints and PostgreSQL is authoritative.
- Documents deployment, safe-window, retry/halt/resume, idempotence, database-clock/fencing, Orleans 10.3.1, and later relay-boundary limits in EN/JA.

## Validation

- Real PostgreSQL Testcontainers focused suite: 10 passed, 0 failed on net9.0 and net10.0.
- Covered initialization (FromNow/FromBeginning and empty history), pre-provisioned missing table `42P01`, missing column `42703`, lease/renew/takeover/fencing, retry/halt/resume, service isolation, distinct DI runners, nudge ordering, and data-free wake behavior.
- `Sekiban.Dcb.Orleans.Tests` builds passed on net9.0 and net10.0.
- Legacy consumer fixture builds passed on net9.0 and net10.0.
- `git diff --check` passed.

The focused build/test commands use the repository's existing package graph and leave only existing dependency/obsolete warnings; no release or package-version changes are included.
