### PR TITLE
feat: add Azure Queue V2 stream message size gate

### DIFF
--- a/.github/workflows/dcb_azure_queue_packaged_consumer.yml
+++ b/.github/workflows/dcb_azure_queue_packaged_consumer.yml
@@ -1,0 +1,85 @@
+name: DCB Azure Queue packaged-consumer pull-request validation
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/dcb_azure_queue_packaged_consumer.yml'
+      - '.github/workflows/packagesDcb.yml'
+      - 'Directory.Build.props'
+      - 'dcb/src/**'
+      - 'dcb/tests/Sekiban.Dcb.Orleans.Tests/run-packaged-consumer.sh'
+      - 'dcb/tests/Sekiban.Dcb.TemplateValidation/**'
+      - 'global.json'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  packaged-consumer:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET 8
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+
+      - name: Setup .NET 9
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 9.0.x
+
+      - name: Setup .NET 10
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Restore and build DCB
+        run: |
+          dotnet restore dcb/Sekiban.Dcb.slnx -p:NuGetAudit=false
+          dotnet build dcb/Sekiban.Dcb.slnx -c Release --no-restore --nologo
+
+      - name: Pack exhaustive DCB local feed
+        env:
+          VERSION: 10.0.2-pr.${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          rm -rf out
+          mkdir -p out
+          dotnet pack dcb/src/Sekiban.Dcb.Core.Model/Sekiban.Dcb.Core.Model.csproj -c Release -o out -p:PackageVersion="$VERSION" -p:GenerateSBOM=false -p:IncludeSymbols=false -p:GeneratePackageOnBuild=false --no-build --nologo
+          dotnet pack dcb/src/Sekiban.Dcb.Core/Sekiban.Dcb.Core.csproj -c Release -o out -p:PackageVersion="$VERSION" -p:GenerateSBOM=false -p:IncludeSymbols=false -p:GeneratePackageOnBuild=false --no-build --nologo
+          dotnet pack dcb/src/Sekiban.Dcb.ColdStorage/Sekiban.Dcb.ColdStorage.csproj -c Release -o out -p:PackageVersion="$VERSION" -p:GenerateSBOM=false -p:IncludeSymbols=false -p:GeneratePackageOnBuild=false --no-build --nologo
+          dotnet pack dcb/src/Sekiban.Dcb.WithResult.Model/Sekiban.Dcb.WithResult.Model.csproj -c Release -o out -p:PackageVersion="$VERSION" -p:GenerateSBOM=false -p:IncludeSymbols=false -p:GeneratePackageOnBuild=false --no-build --nologo
+          dotnet pack dcb/src/Sekiban.Dcb.WithoutResult.Model/Sekiban.Dcb.WithoutResult.Model.csproj -c Release -o out -p:PackageVersion="$VERSION" -p:GenerateSBOM=false -p:IncludeSymbols=false -p:GeneratePackageOnBuild=false --no-build --nologo
+          dotnet pack dcb/src/Sekiban.Dcb.WithResult/Sekiban.Dcb.WithResult.csproj -c Release -o out -p:PackageVersion="$VERSION" -p:GenerateSBOM=false -p:IncludeSymbols=false -p:GeneratePackageOnBuild=false --no-build --nologo
+          dotnet pack dcb/src/Sekiban.Dcb.WithoutResult/Sekiban.Dcb.WithoutResult.csproj -c Release -o out -p:PackageVersion="$VERSION" -p:GenerateSBOM=false -p:IncludeSymbols=false -p:GeneratePackageOnBuild=false --no-build --nologo
+          dotnet pack dcb/src/Sekiban.Dcb.Core.Testing/Sekiban.Dcb.Core.Testing.csproj -c Release -o out -p:PackageVersion="$VERSION" -p:GenerateSBOM=false -p:IncludeSymbols=false -p:GeneratePackageOnBuild=false --no-build --nologo
+          dotnet pack dcb/src/Sekiban.Dcb.WithResult.Testing/Sekiban.Dcb.WithResult.Testing.csproj -c Release -o out -p:PackageVersion="$VERSION" -p:GenerateSBOM=false -p:IncludeSymbols=false -p:GeneratePackageOnBuild=false --no-build --nologo
+          dotnet pack dcb/src/Sekiban.Dcb.WithoutResult.Testing/Sekiban.Dcb.WithoutResult.Testing.csproj -c Release -o out -p:PackageVersion="$VERSION" -p:GenerateSBOM=false -p:IncludeSymbols=false -p:GeneratePackageOnBuild=false --no-build --nologo
+          dotnet pack dcb/src/Sekiban.Dcb.MaterializedView/Sekiban.Dcb.MaterializedView.csproj -c Release -o out -p:PackageVersion="$VERSION" -p:GenerateSBOM=false -p:IncludeSymbols=false -p:GeneratePackageOnBuild=false --no-build --nologo
+          dotnet pack dcb/src/Sekiban.Dcb.MaterializedView.Postgres/Sekiban.Dcb.MaterializedView.Postgres.csproj -c Release -o out -p:PackageVersion="$VERSION" -p:GenerateSBOM=false -p:IncludeSymbols=false -p:GeneratePackageOnBuild=false --no-build --nologo
+          dotnet pack dcb/src/Sekiban.Dcb.MaterializedView.SqlServer/Sekiban.Dcb.MaterializedView.SqlServer.csproj -c Release -o out -p:PackageVersion="$VERSION" -p:GenerateSBOM=false -p:IncludeSymbols=false -p:GeneratePackageOnBuild=false --no-build --nologo
+          dotnet pack dcb/src/Sekiban.Dcb.MaterializedView.MySql/Sekiban.Dcb.MaterializedView.MySql.csproj -c Release -o out -p:PackageVersion="$VERSION" -p:GenerateSBOM=false -p:IncludeSymbols=false -p:GeneratePackageOnBuild=false --no-build --nologo
+          dotnet pack dcb/src/Sekiban.Dcb.MaterializedView.Sqlite/Sekiban.Dcb.MaterializedView.Sqlite.csproj -c Release -o out -p:PackageVersion="$VERSION" -p:GenerateSBOM=false -p:IncludeSymbols=false -p:GeneratePackageOnBuild=false --no-build --nologo
+          dotnet pack dcb/src/Sekiban.Dcb.MaterializedView.Orleans/Sekiban.Dcb.MaterializedView.Orleans.csproj -c Release -o out -p:PackageVersion="$VERSION" -p:GenerateSBOM=false -p:IncludeSymbols=false -p:GeneratePackageOnBuild=false --no-build --nologo
+          dotnet pack dcb/src/Sekiban.Dcb.Orleans.Core/Sekiban.Dcb.Orleans.Core.csproj -c Release -o out -p:PackageVersion="$VERSION" -p:GenerateSBOM=false -p:IncludeSymbols=false -p:GeneratePackageOnBuild=false --no-build --nologo
+          dotnet pack dcb/src/Sekiban.Dcb.Orleans.AzureQueue/Sekiban.Dcb.Orleans.AzureQueue.csproj -c Release -o out -p:PackageVersion="$VERSION" -p:GenerateSBOM=false -p:IncludeSymbols=false -p:GeneratePackageOnBuild=false --no-build --nologo
+          dotnet pack dcb/src/Sekiban.Dcb.Orleans.WithResult/Sekiban.Dcb.Orleans.WithResult.csproj -c Release -o out -p:PackageVersion="$VERSION" -p:GenerateSBOM=false -p:IncludeSymbols=false -p:GeneratePackageOnBuild=false --no-build --nologo
+          dotnet pack dcb/src/Sekiban.Dcb.Orleans.WithoutResult/Sekiban.Dcb.Orleans.WithoutResult.csproj -c Release -o out -p:PackageVersion="$VERSION" -p:GenerateSBOM=false -p:IncludeSymbols=false -p:GeneratePackageOnBuild=false --no-build --nologo
+          dotnet pack dcb/src/Sekiban.Dcb.Postgres/Sekiban.Dcb.Postgres.csproj -c Release -o out -p:PackageVersion="$VERSION" -p:GenerateSBOM=false -p:IncludeSymbols=false -p:GeneratePackageOnBuild=false --no-build --nologo
+          dotnet pack dcb/src/Sekiban.Dcb.CosmosDb/Sekiban.Dcb.CosmosDb.csproj -c Release -o out -p:PackageVersion="$VERSION" -p:GenerateSBOM=false -p:IncludeSymbols=false -p:GeneratePackageOnBuild=false --no-build --nologo
+          dotnet pack dcb/src/Sekiban.Dcb.Sqlite/Sekiban.Dcb.Sqlite.csproj -c Release -o out -p:PackageVersion="$VERSION" -p:GenerateSBOM=false -p:IncludeSymbols=false -p:GeneratePackageOnBuild=false --no-build --nologo
+          dotnet pack dcb/src/Sekiban.Dcb.BlobStorage.AzureStorage/Sekiban.Dcb.BlobStorage.AzureStorage.csproj -c Release -o out -p:PackageVersion="$VERSION" -p:GenerateSBOM=false -p:IncludeSymbols=false -p:GeneratePackageOnBuild=false --no-build --nologo
+          dotnet pack dcb/src/Sekiban.Dcb.DynamoDB/Sekiban.Dcb.DynamoDB.csproj -c Release -o out -p:PackageVersion="$VERSION" -p:GenerateSBOM=false -p:IncludeSymbols=false -p:GeneratePackageOnBuild=false --no-build --nologo
+          dotnet pack dcb/src/Sekiban.Dcb.BlobStorage.S3/Sekiban.Dcb.BlobStorage.S3.csproj -c Release -o out -p:PackageVersion="$VERSION" -p:GenerateSBOM=false -p:IncludeSymbols=false -p:GeneratePackageOnBuild=false --no-build --nologo
+          test "$(find out -maxdepth 1 -name '*.nupkg' | wc -l | tr -d ' ')" = 26
+
+      - name: Validate manifest, nuspec dependencies, and run isolated consumers
+        env:
+          VERSION: 10.0.2-pr.${{ github.run_id }}
+        run: |
+          dotnet run --project dcb/tests/Sekiban.Dcb.TemplateValidation/Sekiban.Dcb.TemplateValidation.csproj -c Release --no-restore -- workflow --repo-root "$GITHUB_WORKSPACE"
+          bash dcb/tests/Sekiban.Dcb.Orleans.Tests/run-packaged-consumer.sh \
+            --repo-root "$GITHUB_WORKSPACE" --feed "$GITHUB_WORKSPACE/out" --version "$VERSION"

--- a/.github/workflows/dcb_azure_queue_packaged_consumer.yml
+++ b/.github/workflows/dcb_azure_queue_packaged_consumer.yml
@@ -41,6 +41,11 @@ jobs:
           dotnet restore dcb/Sekiban.Dcb.slnx -p:NuGetAudit=false
           dotnet build dcb/Sekiban.Dcb.slnx -c Release --no-restore --nologo
 
+      - name: Restore and build TemplateValidation
+        run: |
+          dotnet restore dcb/tests/Sekiban.Dcb.TemplateValidation/Sekiban.Dcb.TemplateValidation.csproj -p:NuGetAudit=false
+          dotnet build dcb/tests/Sekiban.Dcb.TemplateValidation/Sekiban.Dcb.TemplateValidation.csproj -c Release --no-restore --nologo
+
       - name: Pack exhaustive DCB local feed
         env:
           VERSION: 10.0.2-pr.${{ github.run_id }}
@@ -80,6 +85,18 @@ jobs:
         env:
           VERSION: 10.0.2-pr.${{ github.run_id }}
         run: |
-          dotnet run --project dcb/tests/Sekiban.Dcb.TemplateValidation/Sekiban.Dcb.TemplateValidation.csproj -c Release --no-restore -- workflow --repo-root "$GITHUB_WORKSPACE"
+          dotnet run --project dcb/tests/Sekiban.Dcb.TemplateValidation/Sekiban.Dcb.TemplateValidation.csproj -c Release --no-build --no-restore -- workflow --repo-root "$GITHUB_WORKSPACE"
           bash dcb/tests/Sekiban.Dcb.Orleans.Tests/run-packaged-consumer.sh \
             --repo-root "$GITHUB_WORKSPACE" --feed "$GITHUB_WORKSPACE/out" --version "$VERSION"
+
+      - name: Prove packaged-consumer failures are propagated
+        env:
+          VERSION: 10.0.2-pr.${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          if SEKIBAN_G76_FORCE_CONSUMER_THROW=1 bash dcb/tests/Sekiban.Dcb.Orleans.Tests/run-packaged-consumer.sh \
+            --repo-root "$GITHUB_WORKSPACE" --feed "$GITHUB_WORKSPACE/out" --version "$VERSION"; then
+            echo 'The unconditional consumer-throw probe unexpectedly passed.' >&2
+            exit 1
+          fi
+          echo 'The unconditional consumer-throw probe correctly failed the consumer command.'

--- a/.github/workflows/packagesDcb.yml
+++ b/.github/workflows/packagesDcb.yml
@@ -73,6 +73,11 @@ jobs:
           dotnet pack dcb/src/Sekiban.Dcb.DynamoDB/Sekiban.Dcb.DynamoDB.csproj -c Release -o out -p:PackageVersion=$VERSION --no-build
           dotnet pack dcb/src/Sekiban.Dcb.BlobStorage.S3/Sekiban.Dcb.BlobStorage.S3.csproj -c Release -o out -p:PackageVersion=$VERSION --no-build
 
+      - name: Validate Azure Queue V2 packaged consumer and dependency groups
+        run: |
+          bash dcb/tests/Sekiban.Dcb.Orleans.Tests/run-packaged-consumer.sh \
+            --repo-root "$GITHUB_WORKSPACE" --feed "$GITHUB_WORKSPACE/out" --version "$VERSION"
+
       - name: Push to NuGet.org
         run: dotnet nuget push out/*.nupkg --api-key ${{ secrets.NUGET_APIKEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
 

--- a/.github/workflows/packagesDcb.yml
+++ b/.github/workflows/packagesDcb.yml
@@ -63,6 +63,7 @@ jobs:
           dotnet pack dcb/src/Sekiban.Dcb.MaterializedView.Sqlite/Sekiban.Dcb.MaterializedView.Sqlite.csproj -c Release -o out -p:PackageVersion=$VERSION --no-build
           dotnet pack dcb/src/Sekiban.Dcb.MaterializedView.Orleans/Sekiban.Dcb.MaterializedView.Orleans.csproj -c Release -o out -p:PackageVersion=$VERSION --no-build
           dotnet pack dcb/src/Sekiban.Dcb.Orleans.Core/Sekiban.Dcb.Orleans.Core.csproj -c Release -o out -p:PackageVersion=$VERSION --no-build
+          dotnet pack dcb/src/Sekiban.Dcb.Orleans.AzureQueue/Sekiban.Dcb.Orleans.AzureQueue.csproj -c Release -o out -p:PackageVersion=$VERSION --no-build
           dotnet pack dcb/src/Sekiban.Dcb.Orleans.WithResult/Sekiban.Dcb.Orleans.WithResult.csproj -c Release -o out -p:PackageVersion=$VERSION --no-build
           dotnet pack dcb/src/Sekiban.Dcb.Orleans.WithoutResult/Sekiban.Dcb.Orleans.WithoutResult.csproj -c Release -o out -p:PackageVersion=$VERSION --no-build
           dotnet pack dcb/src/Sekiban.Dcb.Postgres/Sekiban.Dcb.Postgres.csproj -c Release -o out -p:PackageVersion=$VERSION --no-build

--- a/.github/workflows/run_test_dcb.yml
+++ b/.github/workflows/run_test_dcb.yml
@@ -10,6 +10,7 @@ on:
       - 'dcb/src/Sekiban.Dcb.WithResult/**'
       - 'dcb/src/Sekiban.Dcb.WithoutResult/**'
       - 'dcb/src/Sekiban.Dcb.Orleans.Core/**'
+      - 'dcb/src/Sekiban.Dcb.Orleans.AzureQueue/**'
       - 'dcb/OrleansVersion.props'
       - 'dcb/Directory.Build.props'
       - 'dcb/src/Directory.Build.props'

--- a/Sekiban.slnx
+++ b/Sekiban.slnx
@@ -62,6 +62,7 @@
     <Project Path="dcb/src/Sekiban.Dcb.WithResult.Testing/Sekiban.Dcb.WithResult.Testing.csproj" />
     <Project Path="dcb/src/Sekiban.Dcb.WithoutResult.Testing/Sekiban.Dcb.WithoutResult.Testing.csproj" />
     <Project Path="dcb/src/Sekiban.Dcb.Orleans.Core/Sekiban.Dcb.Orleans.Core.csproj" />
+    <Project Path="dcb/src/Sekiban.Dcb.Orleans.AzureQueue/Sekiban.Dcb.Orleans.AzureQueue.csproj" />
     <Project Path="dcb/src/Sekiban.Dcb.Orleans.WithResult/Sekiban.Dcb.Orleans.WithResult.csproj" />
     <Project Path="dcb/src/Sekiban.Dcb.Orleans.WithoutResult/Sekiban.Dcb.Orleans.WithoutResult.csproj" />
     <Project Path="dcb/src/Sekiban.Dcb.Postgres/Sekiban.Dcb.Postgres.csproj" />

--- a/dcb/Sekiban.Dcb.slnx
+++ b/dcb/Sekiban.Dcb.slnx
@@ -21,6 +21,7 @@
     <Project Path="src/Sekiban.Dcb.MaterializedView.Sqlite/Sekiban.Dcb.MaterializedView.Sqlite.csproj" />
     <Project Path="src/Sekiban.Dcb.MaterializedView/Sekiban.Dcb.MaterializedView.csproj" />
     <Project Path="src/Sekiban.Dcb.Orleans.Core/Sekiban.Dcb.Orleans.Core.csproj" />
+    <Project Path="src/Sekiban.Dcb.Orleans.AzureQueue/Sekiban.Dcb.Orleans.AzureQueue.csproj" />
     <Project Path="src/Sekiban.Dcb.Orleans.WithResult/Sekiban.Dcb.Orleans.WithResult.csproj" />
     <Project Path="src/Sekiban.Dcb.Orleans.WithoutResult/Sekiban.Dcb.Orleans.WithoutResult.csproj" />
     <Project Path="src/Sekiban.Dcb.Postgres/Sekiban.Dcb.Postgres.csproj" />

--- a/dcb/src/Sekiban.Dcb.Core/Actors/ExecutorSizeGateEvaluator.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Actors/ExecutorSizeGateEvaluator.cs
@@ -34,8 +34,9 @@ internal static class ExecutorSizeGateEvaluator
 
     private sealed record OperationTotals(
         long ComparableBytes,
-        long MeasuredRepresentationBytes,
-        long CertifiedUpperBoundBytes);
+        long? MeasuredRepresentationBytes,
+        long? CertifiedUpperBoundBytes,
+        bool IsCertifiedUpperBound);
 
     public static ExecutorSizeGateEvaluation Evaluate(
         ExecutorSizeGateOptions? options,
@@ -215,7 +216,7 @@ internal static class ExecutorSizeGateEvaluator
                         offending.Index,
                         true,
                         offending.DestinationKey,
-                        offending.Certified,
+                        operationTotals.IsCertifiedUpperBound,
                         operationTotals.MeasuredRepresentationBytes,
                         operationTotals.CertifiedUpperBoundBytes);
                 }
@@ -236,10 +237,14 @@ internal static class ExecutorSizeGateEvaluator
         IReadOnlyList<ComparableMeasurement> measurements) =>
         new(
             SaturatingSum(measurements.Select(measurement => measurement.Bytes)),
-            SaturatingSum(measurements.Select(measurement =>
-                measurement.MeasuredRepresentationBytes ?? measurement.Bytes)),
-            SaturatingSum(measurements.Select(measurement =>
-                measurement.CertifiedUpperBoundBytes ?? measurement.Bytes)));
+            measurements.All(measurement => measurement.MeasuredRepresentationBytes.HasValue)
+                ? SaturatingSum(measurements.Select(measurement => measurement.MeasuredRepresentationBytes!.Value))
+                : null,
+            measurements.Any(measurement => measurement.Certified)
+                ? SaturatingSum(measurements.Select(measurement =>
+                    measurement.CertifiedUpperBoundBytes ?? measurement.Bytes))
+                : null,
+            measurements.Any(measurement => measurement.Certified));
 
     private static long SaturatingSum(IEnumerable<long> values)
     {
@@ -303,7 +308,7 @@ internal static class ExecutorSizeGateEvaluator
             bytes.Value,
             destinationKey,
             result.Bytes is null,
-            result.MeasuredRepresentationBytes ?? result.Bytes ?? bytes,
+            result.MeasuredRepresentationBytes,
             result.CertifiedUpperBoundBytes ?? result.CertifiedUpperBound);
     }
 

--- a/dcb/src/Sekiban.Dcb.Core/Actors/ExecutorSizeGateEvaluator.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Actors/ExecutorSizeGateEvaluator.cs
@@ -32,6 +32,11 @@ internal static class ExecutorSizeGateEvaluator
         long? MeasuredRepresentationBytes,
         long? CertifiedUpperBoundBytes);
 
+    private sealed record OperationTotals(
+        long ComparableBytes,
+        long MeasuredRepresentationBytes,
+        long CertifiedUpperBoundBytes);
+
     public static ExecutorSizeGateEvaluation Evaluate(
         ExecutorSizeGateOptions? options,
         IReadOnlyList<PreparedExecutorEvent> events,
@@ -196,31 +201,23 @@ internal static class ExecutorSizeGateEvaluator
 
             if (policy.MaxBytesPerOperation is { } operationLimit)
             {
-                long operationBytes;
-                try
-                {
-                    operationBytes = checked(measurements.Sum(m => m.Bytes));
-                }
-                catch (OverflowException)
-                {
-                    operationBytes = long.MaxValue;
-                }
+                var operationTotals = AggregateOperationTotals(measurements);
 
-                if (operationBytes > operationLimit)
+                if (operationTotals.ComparableBytes > operationLimit)
                 {
                     var offending = measurements.First();
                     throw new ExecutorSizeLimitExceededException(
                         policy.Scope,
                         policy.Representation,
                         operationLimit,
-                        operationBytes,
+                        operationTotals.ComparableBytes,
                         offending.Prepared.Event.Id,
                         offending.Index,
                         true,
                         offending.DestinationKey,
                         offending.Certified,
-                        measurements.Sum(m => m.MeasuredRepresentationBytes ?? m.Bytes),
-                        measurements.Sum(m => m.CertifiedUpperBoundBytes ?? m.Bytes));
+                        operationTotals.MeasuredRepresentationBytes,
+                        operationTotals.CertifiedUpperBoundBytes);
                 }
             }
         }
@@ -233,6 +230,36 @@ internal static class ExecutorSizeGateEvaluator
         }
 
         return new ExecutorSizeGateEvaluation(diagnostics, destinationPlans);
+    }
+
+    private static OperationTotals AggregateOperationTotals(
+        IReadOnlyList<ComparableMeasurement> measurements) =>
+        new(
+            SaturatingSum(measurements.Select(measurement => measurement.Bytes)),
+            SaturatingSum(measurements.Select(measurement =>
+                measurement.MeasuredRepresentationBytes ?? measurement.Bytes)),
+            SaturatingSum(measurements.Select(measurement =>
+                measurement.CertifiedUpperBoundBytes ?? measurement.Bytes)));
+
+    private static long SaturatingSum(IEnumerable<long> values)
+    {
+        var total = 0L;
+        foreach (var value in values)
+        {
+            if (value > 0 && total > long.MaxValue - value)
+            {
+                return long.MaxValue;
+            }
+
+            if (value < 0 && total < long.MinValue - value)
+            {
+                return long.MinValue;
+            }
+
+            total += value;
+        }
+
+        return total;
     }
 
     private static void ThrowEventLimitExceeded(

--- a/dcb/src/Sekiban.Dcb.Core/Actors/ExecutorSizeGateEvaluator.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Actors/ExecutorSizeGateEvaluator.cs
@@ -157,6 +157,7 @@ internal static class ExecutorSizeGateEvaluator
                         capabilityFailure);
                 }
 
+                ValidateMeasurementLimits(policy, measurements);
                 diagnostics.Add(new ExecutorSizeDiagnostic(
                     policy.Scope,
                     policy.Representation,
@@ -165,62 +166,7 @@ internal static class ExecutorSizeGateEvaluator
                 continue;
             }
 
-            if (policy.MaxBytesPerEvent is { } eventLimit)
-            {
-                // Destination event limits apply to each captured destination independently. A cross-destination
-                // operation budget exists only when the caller explicitly configures MaxBytesPerOperation below.
-                if (policy.Representation == ExecutorSizeRepresentation.Destination)
-                {
-                    foreach (var measurement in measurements)
-                    {
-                        if (measurement.Bytes <= eventLimit)
-                        {
-                            continue;
-                        }
-
-                        ThrowEventLimitExceeded(policy, eventLimit, measurement);
-                    }
-                }
-                else
-                {
-                    var eventTotals = measurements
-                        .GroupBy(m => m.Index)
-                        .Select(group => group.Sum(m => m.Bytes))
-                        .ToArray();
-
-                    for (var index = 0; index < eventTotals.Length; index++)
-                    {
-                        if (eventTotals[index] <= eventLimit)
-                        {
-                            continue;
-                        }
-
-                        ThrowEventLimitExceeded(policy, eventLimit, measurements.First(m => m.Index == index), eventTotals[index]);
-                    }
-                }
-            }
-
-            if (policy.MaxBytesPerOperation is { } operationLimit)
-            {
-                var operationTotals = AggregateOperationTotals(measurements);
-
-                if (operationTotals.ComparableBytes > operationLimit)
-                {
-                    var offending = measurements.First();
-                    throw new ExecutorSizeLimitExceededException(
-                        policy.Scope,
-                        policy.Representation,
-                        operationLimit,
-                        operationTotals.ComparableBytes,
-                        offending.Prepared.Event.Id,
-                        offending.Index,
-                        true,
-                        offending.DestinationKey,
-                        operationTotals.IsCertifiedUpperBound,
-                        operationTotals.MeasuredRepresentationBytes,
-                        operationTotals.CertifiedUpperBoundBytes);
-                }
-            }
+            ValidateMeasurementLimits(policy, measurements);
         }
 
         if (hadCapabilityFailure)
@@ -231,6 +177,59 @@ internal static class ExecutorSizeGateEvaluator
         }
 
         return new ExecutorSizeGateEvaluation(diagnostics, destinationPlans);
+    }
+
+    private static void ValidateMeasurementLimits(
+        ExecutorSizePolicy policy,
+        IReadOnlyList<ComparableMeasurement> measurements)
+    {
+        if (policy.MaxBytesPerEvent is { } eventLimit)
+        {
+            // Destination event limits apply to each captured destination independently. A cross-destination
+            // operation budget exists only when the caller explicitly configures MaxBytesPerOperation below.
+            if (policy.Representation == ExecutorSizeRepresentation.Destination)
+            {
+                foreach (var measurement in measurements)
+                {
+                    if (measurement.Bytes <= eventLimit)
+                    {
+                        continue;
+                    }
+
+                    ThrowEventLimitExceeded(policy, eventLimit, measurement);
+                }
+            }
+            else
+            {
+                var eventTotals = measurements
+                    .GroupBy(m => m.Index)
+                    .Select(group => SaturatingSum(group.Select(m => m.Bytes)))
+                    .ToArray();
+
+                for (var index = 0; index < eventTotals.Length; index++)
+                {
+                    if (eventTotals[index] <= eventLimit)
+                    {
+                        continue;
+                    }
+
+                    ThrowEventLimitExceeded(policy, eventLimit, measurements.First(m => m.Index == index), eventTotals[index]);
+                }
+            }
+        }
+
+        if (policy.MaxBytesPerOperation is { } operationLimit)
+        {
+            var operationTotals = AggregateOperationTotals(measurements);
+
+            // The partial total is already conclusive when it is non-negative and above the configured limit;
+            // an unavailable later measurement cannot turn a measured excess into a benign fallback.
+            if (operationTotals.ComparableBytes >= 0 && operationTotals.ComparableBytes > operationLimit)
+            {
+                var offending = measurements.First();
+                ThrowOperationLimitExceeded(policy, operationLimit, operationTotals, offending);
+            }
+        }
     }
 
     private static OperationTotals AggregateOperationTotals(
@@ -284,6 +283,24 @@ internal static class ExecutorSizeGateEvaluator
             measurement.Certified,
             measurement.MeasuredRepresentationBytes,
             measurement.CertifiedUpperBoundBytes);
+
+    private static void ThrowOperationLimitExceeded(
+        ExecutorSizePolicy policy,
+        long operationLimit,
+        OperationTotals operationTotals,
+        ComparableMeasurement offending) =>
+        throw new ExecutorSizeLimitExceededException(
+            policy.Scope,
+            policy.Representation,
+            operationLimit,
+            operationTotals.ComparableBytes,
+            offending.Prepared.Event.Id,
+            offending.Index,
+            true,
+            offending.DestinationKey,
+            operationTotals.IsCertifiedUpperBound,
+            operationTotals.MeasuredRepresentationBytes,
+            operationTotals.CertifiedUpperBoundBytes);
 
     private static ComparableMeasurement
         ToComparable(

--- a/dcb/src/Sekiban.Dcb.Core/Actors/ExecutorSizeGateEvaluator.cs
+++ b/dcb/src/Sekiban.Dcb.Core/Actors/ExecutorSizeGateEvaluator.cs
@@ -23,6 +23,15 @@ internal static class ExecutorSizeGateEvaluator
 {
     private const string LogicalRepresentation = "logical serialized event UTF-8";
 
+    private sealed record ComparableMeasurement(
+        PreparedExecutorEvent Prepared,
+        int Index,
+        long Bytes,
+        string? DestinationKey,
+        bool Certified,
+        long? MeasuredRepresentationBytes,
+        long? CertifiedUpperBoundBytes);
+
     public static ExecutorSizeGateEvaluation Evaluate(
         ExecutorSizeGateOptions? options,
         IReadOnlyList<PreparedExecutorEvent> events,
@@ -37,10 +46,11 @@ internal static class ExecutorSizeGateEvaluator
         options.Validate();
         var diagnostics = new List<ExecutorSizeDiagnostic>();
         var destinationPlans = new Dictionary<Guid, ExecutorSizeDestinationPlan>();
+        var hadCapabilityFailure = false;
 
         foreach (var policy in options.Policies)
         {
-            var measurements = new List<(PreparedExecutorEvent Prepared, int Index, long Bytes, string? DestinationKey, bool Certified)>();
+            var measurements = new List<ComparableMeasurement>();
             var capabilityFailure = default(string);
 
             for (var index = 0; index < events.Count; index++)
@@ -60,12 +70,19 @@ internal static class ExecutorSizeGateEvaluator
                     {
                         if (!destinationPlans.TryGetValue(prepared.Event.Id, out plan))
                         {
-                            plan = destinationPublisher.CaptureDestinationPlan(
-                                prepared.Event,
-                                prepared.Tags,
-                                serviceId);
+                            plan = publisher is IExecutorSizePreparedDestinationPublisher preparedPublisher
+                                ? preparedPublisher.CaptureDestinationPlan(
+                                    prepared.Event,
+                                    prepared.SerializedEvent,
+                                    prepared.Tags,
+                                    serviceId)
+                                : destinationPublisher.CaptureDestinationPlan(
+                                    prepared.Event,
+                                    prepared.Tags,
+                                    serviceId);
                             if (plan is not null)
                             {
+                                plan = plan with { PreparedEvent = prepared.SerializedEvent };
                                 destinationPlans[prepared.Event.Id] = plan;
                             }
                         }
@@ -138,6 +155,7 @@ internal static class ExecutorSizeGateEvaluator
                     policy.Scope,
                     policy.Representation,
                     capabilityFailure));
+                hadCapabilityFailure = true;
                 continue;
             }
 
@@ -200,9 +218,18 @@ internal static class ExecutorSizeGateEvaluator
                         offending.Index,
                         true,
                         offending.DestinationKey,
-                        offending.Certified);
+                        offending.Certified,
+                        measurements.Sum(m => m.MeasuredRepresentationBytes ?? m.Bytes),
+                        measurements.Sum(m => m.CertifiedUpperBoundBytes ?? m.Bytes));
                 }
             }
+        }
+
+        if (hadCapabilityFailure)
+        {
+            // A NonStrict capability miss must select the legacy direct publisher for the entire operation. A partial
+            // dictionary would make only the prefix planned and could fail after the store has committed.
+            destinationPlans.Clear();
         }
 
         return new ExecutorSizeGateEvaluation(diagnostics, destinationPlans);
@@ -211,7 +238,7 @@ internal static class ExecutorSizeGateEvaluator
     private static void ThrowEventLimitExceeded(
         ExecutorSizePolicy policy,
         long eventLimit,
-        (PreparedExecutorEvent Prepared, int Index, long Bytes, string? DestinationKey, bool Certified) measurement,
+        ComparableMeasurement measurement,
         long? measuredBytes = null) =>
         throw new ExecutorSizeLimitExceededException(
             policy.Scope,
@@ -222,9 +249,11 @@ internal static class ExecutorSizeGateEvaluator
             measurement.Index,
             false,
             measurement.DestinationKey,
-            measurement.Certified);
+            measurement.Certified,
+            measurement.MeasuredRepresentationBytes,
+            measurement.CertifiedUpperBoundBytes);
 
-    private static (PreparedExecutorEvent Prepared, int Index, long Bytes, string? DestinationKey, bool Certified)
+    private static ComparableMeasurement
         ToComparable(
             ExecutorSizePolicy policy,
             PreparedExecutorEvent prepared,
@@ -241,7 +270,14 @@ internal static class ExecutorSizeGateEvaluator
                 "measurement returned neither a non-negative exact size nor a certified upper bound");
         }
 
-        return (prepared, index, bytes.Value, destinationKey, result.Bytes is null);
+        return new ComparableMeasurement(
+            prepared,
+            index,
+            bytes.Value,
+            destinationKey,
+            result.Bytes is null,
+            result.MeasuredRepresentationBytes ?? result.Bytes ?? bytes,
+            result.CertifiedUpperBoundBytes ?? result.CertifiedUpperBound);
     }
 
     private static ExecutorSizeMeasurementResult Measure(

--- a/dcb/src/Sekiban.Dcb.Core/Sekiban.Dcb.Core.csproj
+++ b/dcb/src/Sekiban.Dcb.Core/Sekiban.Dcb.Core.csproj
@@ -72,6 +72,9 @@
             <_Parameter1>Sekiban.Dcb.Orleans.WithoutResult</_Parameter1>
         </AssemblyAttribute>
         <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+            <_Parameter1>Sekiban.Dcb.Orleans.AzureQueue</_Parameter1>
+        </AssemblyAttribute>
+        <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
             <_Parameter1>Sekiban.Dcb.WithResult</_Parameter1>
         </AssemblyAttribute>
         <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">

--- a/dcb/src/Sekiban.Dcb.Core/SizeGates/ExecutorSizeGateContracts.cs
+++ b/dcb/src/Sekiban.Dcb.Core/SizeGates/ExecutorSizeGateContracts.cs
@@ -116,13 +116,41 @@ public sealed record ExecutorSizeMeasurementResult(
     long? CertifiedUpperBound,
     string? Reason)
 {
-    public long? ComparableBytes => Bytes ?? CertifiedUpperBound;
+    /// <summary>
+    /// The bytes measured at the provider-owned representation boundary. For a certified result this is the value
+    /// which was measured before the conservative transport bound was applied.
+    /// </summary>
+    public long? MeasuredRepresentationBytes { get; init; }
+
+    /// <summary>The certified upper bound used for admission, when the result is not exact.</summary>
+    public long? CertifiedUpperBoundBytes { get; init; }
+
+    public long? ComparableBytes => Bytes ?? CertifiedUpperBoundBytes ?? CertifiedUpperBound;
 
     public static ExecutorSizeMeasurementResult Exact(long bytes) =>
-        new(true, bytes, null, null);
+        new(true, bytes, null, null)
+        {
+            MeasuredRepresentationBytes = bytes
+        };
 
     public static ExecutorSizeMeasurementResult CertifiedBound(long bytes) =>
-        new(true, null, bytes, null);
+        CertifiedBound(bytes, bytes);
+
+    public static ExecutorSizeMeasurementResult CertifiedBound(
+        long measuredRepresentationBytes,
+        long certifiedUpperBoundBytes)
+    {
+        if (measuredRepresentationBytes < 0)
+            throw new ArgumentOutOfRangeException(nameof(measuredRepresentationBytes));
+        if (certifiedUpperBoundBytes < measuredRepresentationBytes)
+            throw new ArgumentOutOfRangeException(nameof(certifiedUpperBoundBytes));
+
+        return new ExecutorSizeMeasurementResult(true, null, certifiedUpperBoundBytes, null)
+        {
+            MeasuredRepresentationBytes = measuredRepresentationBytes,
+            CertifiedUpperBoundBytes = certifiedUpperBoundBytes
+        };
+    }
 
     public static ExecutorSizeMeasurementResult Unavailable(string reason) =>
         new(false, null, null, reason);
@@ -135,7 +163,14 @@ public sealed record ExecutorSizeMeasurementResult(
 public sealed record ExecutorSizeDestinationPlan(
     string ServiceId,
     IReadOnlyList<string> DestinationKeys,
-    object? ProviderState = null);
+    object? ProviderState = null)
+{
+    /// <summary>
+    /// The already prepared serialized event handed from the executor to a destination publisher. This additive
+    /// property lets a provider reuse the event which was admitted instead of binding it a second time.
+    /// </summary>
+    public SerializableEvent? PreparedEvent { get; init; }
+}
 
 /// <summary>
 /// Optional additive publisher capability used by destination policies. It both captures the publication plan and
@@ -154,10 +189,27 @@ public interface IExecutorSizeDestinationPublisher
         CancellationToken cancellationToken = default);
 }
 
+/// <summary>
+/// Additive prepared-event capture seam. Implementations which support it receive the exact serialized event which
+/// the executor is about to persist, while the original destination-publisher interface remains ABI compatible.
+/// </summary>
+internal interface IExecutorSizePreparedDestinationPublisher : IExecutorSizeDestinationPublisher
+{
+    ExecutorSizeDestinationPlan? CaptureDestinationPlan(
+        Event @event,
+        SerializableEvent serializedEvent,
+        IReadOnlyCollection<ITag> tags,
+        string serviceId);
+}
+
 public sealed record ExecutorSizeDiagnostic(
     string Scope,
     ExecutorSizeRepresentation Representation,
-    string Reason);
+    string Reason)
+{
+    public long? MeasuredRepresentationBytes { get; init; }
+    public long? CertifiedUpperBoundBytes { get; init; }
+}
 
 public sealed class ExecutorSizeLimitExceededException : Exception
 {
@@ -171,6 +223,33 @@ public sealed class ExecutorSizeLimitExceededException : Exception
         bool operationLimit,
         string? destinationKey = null,
         bool certifiedUpperBound = false)
+        : this(
+            scope,
+            representation,
+            limitBytes,
+            measuredBytes,
+            eventId,
+            eventIndex,
+            operationLimit,
+            destinationKey,
+            certifiedUpperBound,
+            null,
+            null)
+    {
+    }
+
+    public ExecutorSizeLimitExceededException(
+        string scope,
+        ExecutorSizeRepresentation representation,
+        long limitBytes,
+        long measuredBytes,
+        Guid eventId,
+        int eventIndex,
+        bool operationLimit,
+        string? destinationKey,
+        bool certifiedUpperBound,
+        long? measuredRepresentationBytes,
+        long? certifiedUpperBoundBytes)
         : base(
             $"Executor size policy '{scope}' rejected event {eventId} at index {eventIndex}: " +
             $"{representation} {(operationLimit ? "operation" : "event")} size {measuredBytes} bytes " +
@@ -185,6 +264,8 @@ public sealed class ExecutorSizeLimitExceededException : Exception
         IsOperationLimit = operationLimit;
         DestinationKey = destinationKey;
         IsCertifiedUpperBound = certifiedUpperBound;
+        MeasuredRepresentationBytes = measuredRepresentationBytes;
+        CertifiedUpperBoundBytes = certifiedUpperBoundBytes;
     }
 
     public string Scope { get; }
@@ -196,6 +277,8 @@ public sealed class ExecutorSizeLimitExceededException : Exception
     public bool IsOperationLimit { get; }
     public string? DestinationKey { get; }
     public bool IsCertifiedUpperBound { get; }
+    public long? MeasuredRepresentationBytes { get; }
+    public long? CertifiedUpperBoundBytes { get; }
 }
 
 public sealed class ExecutorSizeCapabilityException : Exception

--- a/dcb/src/Sekiban.Dcb.Core/SizeGates/ExecutorSizeGateContracts.cs
+++ b/dcb/src/Sekiban.Dcb.Core/SizeGates/ExecutorSizeGateContracts.cs
@@ -134,7 +134,10 @@ public sealed record ExecutorSizeMeasurementResult(
         };
 
     public static ExecutorSizeMeasurementResult CertifiedBound(long bytes) =>
-        CertifiedBound(bytes, bytes);
+        new(true, null, bytes, null)
+        {
+            CertifiedUpperBoundBytes = bytes
+        };
 
     public static ExecutorSizeMeasurementResult CertifiedBound(
         long measuredRepresentationBytes,

--- a/dcb/src/Sekiban.Dcb.Orleans.AzureQueue/OrleansAzureQueueExecutorSizeGateExtensions.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.AzureQueue/OrleansAzureQueueExecutorSizeGateExtensions.cs
@@ -1,0 +1,92 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
+using Sekiban.Dcb.SizeGates;
+
+namespace Sekiban.Dcb.Orleans.AzureQueue;
+
+/// <summary>Opt-in Azure Queue V2 destination-message size admission.</summary>
+public static class OrleansAzureQueueExecutorSizeGateExtensions
+{
+    /// <summary>
+    /// Adds the Azure Queue V2 destination-message policy to an existing executor gate option set.
+    /// </summary>
+    public static ExecutorSizeGateOptions AddOrleansAzureQueueStreamMessagePolicy(
+        this ExecutorSizeGateOptions options,
+        string streamProviderName,
+        long? maxBytesPerEvent = null,
+        long? maxBytesPerOperation = null,
+        ExecutorSizeStrictness strictness = ExecutorSizeStrictness.NonStrict)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        OrleansAzureQueueStreamMessageSizeMeasurement.ValidateProviderName(streamProviderName);
+
+        var eventLimit = maxBytesPerEvent ?? OrleansAzureQueueStreamMessageSizeMeasurement.DefaultMaxBytesPerEvent;
+        if (eventLimit <= 0 || eventLimit > OrleansAzureQueueStreamMessageSizeMeasurement.DefaultMaxBytesPerEvent)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(maxBytesPerEvent),
+                $"Azure Queue V2 per-event limit must be between 1 and " +
+                $"{OrleansAzureQueueStreamMessageSizeMeasurement.DefaultMaxBytesPerEvent} bytes.");
+        }
+
+        if (maxBytesPerOperation is <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(maxBytesPerOperation));
+        }
+
+        return options.Add(new ExecutorSizePolicy(
+            OrleansAzureQueueStreamMessageSizeMeasurement.Scope,
+            ExecutorSizeRepresentation.Destination,
+            eventLimit,
+            maxBytesPerOperation,
+            strictness,
+            new OrleansAzureQueueStreamMessageSizeMeasurement(streamProviderName)));
+    }
+
+    /// <summary>
+    /// Registers the Azure Queue V2 policy and its provider-owned capture bridge. The default is NonStrict so hosts
+    /// can adopt the diagnostic before promoting an eligible named provider to Strict.
+    /// </summary>
+    public static IServiceCollection AddSekibanDcbOrleansAzureQueueStreamMessageSizeGate(
+        this IServiceCollection services,
+        string streamProviderName,
+        long? maxBytesPerEvent = null,
+        long? maxBytesPerOperation = null,
+        ExecutorSizeStrictness strictness = ExecutorSizeStrictness.NonStrict)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        OrleansAzureQueueStreamMessageSizeMeasurement.ValidateProviderName(streamProviderName);
+
+        // Validate before touching the service collection. This keeps an invalid provider registration from leaving a
+        // mechanism marker which would make a later valid Core registration fail for an unrelated reason.
+        var validatedOptions = new ExecutorSizeGateOptions();
+        validatedOptions.AddOrleansAzureQueueStreamMessagePolicy(
+            streamProviderName,
+            maxBytesPerEvent,
+            maxBytesPerOperation,
+            strictness);
+
+        ExecutorSizeGateRegistrationMarker.EnsureCompatible(
+            services,
+            ExecutorSizeGateRegistrationMarker.ProviderComposable);
+        ExecutorSizeGateRegistrationMarker.Declare(
+            services,
+            ExecutorSizeGateRegistrationMarker.ProviderComposable);
+
+        services.AddOptions<ExecutorSizeGateOptions>();
+        services.AddSingleton<IConfigureOptions<ExecutorSizeGateOptions>>(serviceProvider =>
+            new ConfigureNamedOptions<ExecutorSizeGateOptions>(
+                Options.DefaultName,
+                options => options.AddOrleansAzureQueueStreamMessagePolicy(
+                    streamProviderName,
+                    maxBytesPerEvent,
+                    maxBytesPerOperation,
+                    strictness)));
+        services.TryAddSingleton(serviceProvider =>
+            serviceProvider.GetRequiredService<IOptions<ExecutorSizeGateOptions>>().Value);
+        services.AddSingleton<IOrleansDestinationMeasurementCapture>(serviceProvider =>
+            new OrleansAzureQueueDestinationMeasurementCapture(serviceProvider, streamProviderName));
+        return services;
+    }
+}

--- a/dcb/src/Sekiban.Dcb.Orleans.AzureQueue/OrleansAzureQueueStreamMessageSizeMeasurement.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.AzureQueue/OrleansAzureQueueStreamMessageSizeMeasurement.cs
@@ -1,0 +1,160 @@
+using System.Text;
+using Azure.Storage.Queues;
+using Microsoft.Extensions.DependencyInjection;
+using Orleans.Configuration;
+using Orleans.Providers.Streams.AzureQueue;
+using Orleans.Providers.Streams.Common;
+using Orleans.Runtime;
+using Orleans.Serialization;
+using Orleans.Streams;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.Orleans;
+using Sekiban.Dcb.SizeGates;
+
+namespace Sekiban.Dcb.Orleans.AzureQueue;
+
+/// <summary>
+/// Measures the text produced by the actual Orleans Azure Queue V2 adapter and returns the conservative SDK envelope
+/// bound. No Azure service or queue is contacted during measurement.
+/// </summary>
+public sealed class OrleansAzureQueueStreamMessageSizeMeasurement : IExecutorSizeMeasurement
+{
+    public const string Scope = "orleans-stream-message";
+    public const long DefaultMaxBytesPerEvent = 65_536;
+
+    private readonly string _streamProviderName;
+
+    public OrleansAzureQueueStreamMessageSizeMeasurement(string streamProviderName)
+    {
+        _streamProviderName = ValidateProviderName(streamProviderName);
+    }
+
+    public ExecutorSizeMeasurementResult Measure(ExecutorSizeMeasurementContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        if (context.Representation != ExecutorSizeRepresentation.Destination)
+        {
+            return ExecutorSizeMeasurementResult.Unavailable(
+                "Orleans Azure Queue V2 measurement supports only the Destination representation");
+        }
+
+        if (context.DestinationPlan?.PreparedEvent is not { } preparedEvent ||
+            preparedEvent.Id != context.SerializedEvent.Id)
+        {
+            return ExecutorSizeMeasurementResult.Unavailable(
+                "the destination plan does not carry the admitted serialized event");
+        }
+
+        if (context.DestinationPlan?.ProviderState is not IReadOnlyList<OrleansDestinationPlanState> destinations)
+        {
+            return ExecutorSizeMeasurementResult.Unavailable(
+                $"provider '{_streamProviderName}' did not provide an Orleans destination capture state");
+        }
+
+        var destination = destinations.FirstOrDefault(item =>
+            string.Equals(item.DestinationKey, context.DestinationKey, StringComparison.Ordinal));
+        if (destination is null)
+        {
+            return ExecutorSizeMeasurementResult.Unavailable(
+                $"provider '{_streamProviderName}' did not provide destination '{context.DestinationKey}'");
+        }
+
+        if (destination.FailureReason is not null)
+        {
+            return ExecutorSizeMeasurementResult.Unavailable(destination.FailureReason);
+        }
+
+        if (!string.Equals(destination.ProviderName, _streamProviderName, StringComparison.Ordinal) ||
+            destination.MeasurementState is not AzureQueueDestinationMeasurementState state)
+        {
+            return ExecutorSizeMeasurementResult.Unavailable(
+                $"provider '{_streamProviderName}' destination is not an Azure Queue V2 adapter state");
+        }
+
+        try
+        {
+            var requestContext = state.RequestContext is null
+                ? null
+                : state.RequestContext.ToDictionary(
+                    pair => pair.Key,
+                    pair => pair.Value,
+                    StringComparer.Ordinal);
+            var adapterText = state.Adapter.ToQueueMessage(
+                state.StreamId,
+                new[] { state.SerializedEvent },
+                token: null,
+                requestContext);
+            var measured = Encoding.UTF8.GetByteCount(adapterText);
+            var certifiedUpperBound = state.MessageEncoding == QueueMessageEncoding.Base64
+                ? checked(4L * ((measured + 2L) / 3L))
+                : measured;
+
+            return ExecutorSizeMeasurementResult.CertifiedBound(
+                measured,
+                Math.Max(measured, certifiedUpperBound));
+        }
+        catch (Exception ex) when (ex is ArgumentException or InvalidOperationException or FormatException or OverflowException)
+        {
+            return ExecutorSizeMeasurementResult.Unavailable(
+                $"Azure Queue V2 adapter measurement failed with {ex.GetType().Name}");
+        }
+    }
+
+    internal static string ValidateProviderName(string streamProviderName) =>
+        string.IsNullOrWhiteSpace(streamProviderName)
+            ? throw new ArgumentException("The Orleans stream provider name must not be empty.", nameof(streamProviderName))
+            : streamProviderName;
+}
+
+internal sealed record AzureQueueDestinationMeasurementState(
+    IQueueDataAdapter<string, IBatchContainer> Adapter,
+    StreamId StreamId,
+    SerializableEvent SerializedEvent,
+    IReadOnlyDictionary<string, object>? RequestContext,
+    QueueMessageEncoding MessageEncoding);
+
+internal sealed class OrleansAzureQueueDestinationMeasurementCapture : IOrleansDestinationMeasurementCapture
+{
+    private readonly IServiceProvider _services;
+    private readonly string _streamProviderName;
+
+    public OrleansAzureQueueDestinationMeasurementCapture(
+        IServiceProvider services,
+        string streamProviderName)
+    {
+        _services = services;
+        _streamProviderName = OrleansAzureQueueStreamMessageSizeMeasurement.ValidateProviderName(streamProviderName);
+    }
+
+    public bool Matches(string providerName) =>
+        string.Equals(providerName, _streamProviderName, StringComparison.Ordinal);
+
+    public object? Capture(
+        string providerName,
+        string streamNamespace,
+        Guid streamId,
+        SerializableEvent serializedEvent,
+        IReadOnlyDictionary<string, object>? requestContext,
+        out string? failureReason)
+    {
+        failureReason = null;
+        var adapter = _services.GetKeyedService<IQueueDataAdapter<string, IBatchContainer>>(providerName) ??
+                      _services.GetService<IQueueDataAdapter<string, IBatchContainer>>();
+        if (adapter is not AzureQueueDataAdapterV2)
+        {
+            failureReason = adapter is null
+                ? $"named provider '{providerName}' has no keyed or unkeyed Azure Queue data adapter"
+                : $"named provider '{providerName}' resolved {adapter.GetType().FullName}, not AzureQueueDataAdapterV2";
+            return null;
+        }
+
+        var options = NamedOptionExtensions.GetOptionsByName<AzureQueueOptions>(_services, providerName);
+        return new AzureQueueDestinationMeasurementState(
+            adapter,
+            StreamId.Create(streamNamespace, streamId),
+            serializedEvent,
+            requestContext,
+            options.ClientOptions.MessageEncoding);
+    }
+}

--- a/dcb/src/Sekiban.Dcb.Orleans.AzureQueue/OrleansAzureQueueStreamMessageSizeMeasurement.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.AzureQueue/OrleansAzureQueueStreamMessageSizeMeasurement.cs
@@ -1,7 +1,5 @@
 using System.Text;
-using Azure.Storage.Queues;
 using Microsoft.Extensions.DependencyInjection;
-using Orleans.Configuration;
 using Orleans.Providers.Streams.AzureQueue;
 using Orleans.Providers.Streams.Common;
 using Orleans.Runtime;
@@ -86,9 +84,10 @@ public sealed class OrleansAzureQueueStreamMessageSizeMeasurement : IExecutorSiz
                 token: null,
                 requestContext);
             var measured = Encoding.UTF8.GetByteCount(adapterText);
-            var certifiedUpperBound = state.MessageEncoding == QueueMessageEncoding.Base64
-                ? checked(4L * ((measured + 2L) / 3L))
-                : measured;
+            // The effective QueueServiceClient encoding is not observable at this provider-neutral capture point.
+            // Always retain the conservative bound for the possible second Base64 transform; a named options value
+            // is not evidence about the client that owns the adapter.
+            var certifiedUpperBound = checked(4L * ((measured + 2L) / 3L));
 
             return ExecutorSizeMeasurementResult.CertifiedBound(
                 measured,
@@ -111,8 +110,7 @@ internal sealed record AzureQueueDestinationMeasurementState(
     IQueueDataAdapter<string, IBatchContainer> Adapter,
     StreamId StreamId,
     SerializableEvent SerializedEvent,
-    IReadOnlyDictionary<string, object>? RequestContext,
-    QueueMessageEncoding MessageEncoding);
+    IReadOnlyDictionary<string, object>? RequestContext);
 
 internal sealed class OrleansAzureQueueDestinationMeasurementCapture : IOrleansDestinationMeasurementCapture
 {
@@ -149,12 +147,10 @@ internal sealed class OrleansAzureQueueDestinationMeasurementCapture : IOrleansD
             return null;
         }
 
-        var options = NamedOptionExtensions.GetOptionsByName<AzureQueueOptions>(_services, providerName);
         return new AzureQueueDestinationMeasurementState(
             adapter,
             StreamId.Create(streamNamespace, streamId),
             serializedEvent,
-            requestContext,
-            options.ClientOptions.MessageEncoding);
+            requestContext);
     }
 }

--- a/dcb/src/Sekiban.Dcb.Orleans.AzureQueue/Sekiban.Dcb.Orleans.AzureQueue.csproj
+++ b/dcb/src/Sekiban.Dcb.Orleans.AzureQueue/Sekiban.Dcb.Orleans.AzureQueue.csproj
@@ -1,0 +1,52 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <LangVersion>preview</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <AssemblyName>Sekiban.Dcb.Orleans.AzureQueue</AssemblyName>
+    <RootNamespace>Sekiban.Dcb.Orleans.AzureQueue</RootNamespace>
+    <PackageId>Sekiban.Dcb.Orleans.AzureQueue</PackageId>
+    <Authors>J-Tech Group</Authors>
+    <Company>J-Tech-Japan</Company>
+    <Copyright>Copyright (c) J-Tech-Japan 2025</Copyright>
+    <PackageDescription>Sekiban DCB Orleans Azure Queue V2 message-size admission</PackageDescription>
+    <RepositoryUrl>https://github.com/J-Tech-Japan/Sekiban</RepositoryUrl>
+    <PackageProjectUrl>https://github.com/J-Tech-Japan/Sekiban</PackageProjectUrl>
+    <PackageVersion>10.0.2-preview03</PackageVersion>
+    <Description>Opt-in certified Azure Queue V2 destination size gate for Sekiban DCB</Description>
+    <PackageTags>event-sourcing;cqrs;ddd;dcb;sekiban;orleans;azure;queue;size-gate</PackageTags>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <GenerateSBOM>true</GenerateSBOM>
+    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="../../README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Sekiban.Dcb.Orleans.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Azure.Storage.Queues" Version="12.25.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Orleans.Streaming.AzureStorage" Version="$(MicrosoftOrleansVersion)" />
+    <PackageReference Include="Microsoft.Sbom.Targets" Version="4.1.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Sekiban.Dcb.Core\Sekiban.Dcb.Core.csproj" />
+    <ProjectReference Include="..\Sekiban.Dcb.Orleans.Core\Sekiban.Dcb.Orleans.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/dcb/src/Sekiban.Dcb.Orleans.Core/OrleansEventPublisher.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.Core/OrleansEventPublisher.cs
@@ -1,4 +1,7 @@
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Orleans.Runtime;
+using Orleans.Serialization;
 using Sekiban.Dcb.Actors;
 using Sekiban.Dcb.Events;
 using Sekiban.Dcb.Orleans.Streams;
@@ -12,17 +15,24 @@ namespace Sekiban.Dcb.Orleans;
 /// <summary>
 ///     Publishes Sekiban Dcb events to Orleans streams using an Orleans cluster client.
 /// </summary>
-public class OrleansEventPublisher : IEventPublisher, IExecutorSizeDestinationPublisher
+public class OrleansEventPublisher : IEventPublisher, IExecutorSizePreparedDestinationPublisher
 {
     private readonly IClusterClient _clusterClient;
     private readonly ILogger<OrleansEventPublisher> _logger;
     private readonly IStreamDestinationResolver _resolver;
     private readonly DcbDomainTypes _domainTypes;
     private readonly IServiceIdProvider _serviceIdProvider;
+    private readonly DeepCopier? _deepCopier;
     private readonly Channel<PublishItem> _channel;
     private readonly Task _processor;
 
-    private record PublishItem(string Provider, string Namespace, Guid StreamId, SerializableEvent Event, int Attempt);
+    private record PublishItem(
+        string Provider,
+        string Namespace,
+        Guid StreamId,
+        SerializableEvent Event,
+        int Attempt,
+        Dictionary<string, object>? RequestContext = null);
 
     public OrleansEventPublisher(
         IClusterClient clusterClient,
@@ -51,6 +61,7 @@ public class OrleansEventPublisher : IEventPublisher, IExecutorSizeDestinationPu
         _domainTypes = domainTypes;
         _logger = logger;
         _serviceIdProvider = serviceIdProvider ?? throw new ArgumentNullException(nameof(serviceIdProvider));
+        _deepCopier = _clusterClient.ServiceProvider.GetService<DeepCopier>();
         // Unbounded channel for simplicity; projection side is idempotent
         _channel = Channel.CreateUnbounded<PublishItem>(new UnboundedChannelOptions
         {
@@ -104,6 +115,23 @@ public class OrleansEventPublisher : IEventPublisher, IExecutorSizeDestinationPu
         IReadOnlyCollection<ITag> tags,
         string serviceId)
     {
+        var serializableEvent = @event.ToSerializableEvent(_domainTypes.EventTypes);
+        return CaptureDestinationPlanCore(@event, serializableEvent, tags, serviceId);
+    }
+
+    ExecutorSizeDestinationPlan? IExecutorSizePreparedDestinationPublisher.CaptureDestinationPlan(
+        Event @event,
+        SerializableEvent serializedEvent,
+        IReadOnlyCollection<ITag> tags,
+        string serviceId)
+        => CaptureDestinationPlanCore(@event, serializedEvent, tags, serviceId);
+
+    private ExecutorSizeDestinationPlan? CaptureDestinationPlanCore(
+        Event @event,
+        SerializableEvent serializedEvent,
+        IReadOnlyCollection<ITag> tags,
+        string serviceId)
+    {
         var destinations = (_resolver.Resolve(@event, tags) ?? Enumerable.Empty<ISekibanStream>())
             .OfType<OrleansSekibanStream>()
             .Select(stream => new OrleansDestination(
@@ -117,19 +145,77 @@ public class OrleansEventPublisher : IEventPublisher, IExecutorSizeDestinationPu
             return null;
         }
 
+        var captures = _clusterClient.ServiceProvider
+            .GetServices<IOrleansDestinationMeasurementCapture>()
+            .ToArray();
+        var destinationStates = new List<OrleansDestinationPlanState>(destinations.Length);
+        foreach (var destination in destinations)
+        {
+            string? failureReason = null;
+            Dictionary<string, object>? requestContext = null;
+            if (_deepCopier is null)
+            {
+                failureReason = "Orleans request-context deep-copy capability is unavailable";
+            }
+            else
+            {
+                try
+                {
+                    requestContext = RequestContextExtensions.Export(_deepCopier);
+                }
+                catch (Exception ex)
+                {
+                    failureReason = $"Orleans request-context capture failed with {ex.GetType().Name}";
+                }
+            }
+
+            var capture = captures.FirstOrDefault(candidate => candidate.Matches(destination.ProviderName));
+            object? providerState = null;
+            if (capture is null)
+            {
+                failureReason ??= $"no destination measurement capability is registered for provider '{destination.ProviderName}'";
+            }
+            else
+            {
+                providerState = capture.Capture(
+                    destination.ProviderName,
+                    destination.StreamNamespace,
+                    destination.StreamId,
+                    serializedEvent,
+                    requestContext,
+                    out var captureFailure);
+                failureReason ??= captureFailure;
+            }
+
+            destinationStates.Add(new OrleansDestinationPlanState(
+                GetDestinationKey(destination),
+                destination.ProviderName,
+                destination.StreamNamespace,
+                destination.StreamId,
+                providerState,
+                requestContext,
+                failureReason));
+        }
+
         var resolverServiceId = _serviceIdProvider.GetCurrentServiceId();
         if (!string.Equals(resolverServiceId, serviceId, StringComparison.Ordinal))
         {
             return new ExecutorSizeDestinationPlan(
                 resolverServiceId,
                 destinations.Select(GetDestinationKey).ToArray(),
-                destinations);
+                destinationStates)
+            {
+                PreparedEvent = serializedEvent
+            };
         }
 
         return new ExecutorSizeDestinationPlan(
             serviceId,
             destinations.Select(GetDestinationKey).ToArray(),
-            destinations);
+            destinationStates)
+        {
+            PreparedEvent = serializedEvent
+        };
     }
 
     public async Task PublishAsync(
@@ -140,13 +226,13 @@ public class OrleansEventPublisher : IEventPublisher, IExecutorSizeDestinationPu
         foreach (var (evt, _) in events)
         {
             if (!destinationPlans.TryGetValue(evt.Id, out var plan) ||
-                plan.ProviderState is not IReadOnlyList<OrleansDestination> destinations)
+                plan.ProviderState is not IReadOnlyList<OrleansDestinationPlanState> destinations)
             {
                 throw new InvalidOperationException(
                     $"The captured destination plan for event {evt.Id} is unavailable.");
             }
 
-            var serializableEvent = evt.ToSerializableEvent(_domainTypes.EventTypes);
+            var serializableEvent = plan.PreparedEvent ?? evt.ToSerializableEvent(_domainTypes.EventTypes);
             foreach (var destination in destinations)
             {
                 _channel.Writer.TryWrite(new PublishItem(
@@ -154,7 +240,13 @@ public class OrleansEventPublisher : IEventPublisher, IExecutorSizeDestinationPu
                     destination.StreamNamespace,
                     destination.StreamId,
                     serializableEvent,
-                    0));
+                    0,
+                    destination.RequestContext is null
+                        ? null
+                        : destination.RequestContext.ToDictionary(
+                            pair => pair.Key,
+                            pair => pair.Value,
+                            StringComparer.Ordinal)));
             }
         }
 
@@ -180,7 +272,27 @@ public class OrleansEventPublisher : IEventPublisher, IExecutorSizeDestinationPu
             {
                 var provider = _clusterClient.GetStreamProvider(item.Provider);
                 var stream = provider.GetStream<SerializableEvent>(StreamId.Create(item.Namespace, item.StreamId));
-                await stream.OnNextAsync(item.Event);
+                var priorContext = _deepCopier is null ? null : RequestContextExtensions.Export(_deepCopier);
+                try
+                {
+                    if (item.RequestContext is not null)
+                    {
+                        RequestContextExtensions.Import(item.RequestContext);
+                    }
+
+                    await stream.OnNextAsync(item.Event);
+                }
+                finally
+                {
+                    if (priorContext is not null)
+                    {
+                        RequestContextExtensions.Import(priorContext);
+                    }
+                    else
+                    {
+                        RequestContext.Clear();
+                    }
+                }
                 if (_logger.IsEnabled(LogLevel.Trace))
                 {
                     _logger.LogTrace("Published event {EventId} to {Provider}/{Namespace}/{StreamId}",

--- a/dcb/src/Sekiban.Dcb.Orleans.Core/OrleansEventPublisher.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.Core/OrleansEventPublisher.cs
@@ -26,6 +26,17 @@ public class OrleansEventPublisher : IEventPublisher, IExecutorSizePreparedDesti
     private readonly Channel<PublishItem> _channel;
     private readonly Task _processor;
 
+    /// <summary>
+    /// Test-only observation of the planned enqueue boundary. This stays internal so production callers cannot
+    /// replace the publisher's retry or context behavior; Orleans tests use it to assert plan identity.
+    /// </summary>
+    internal Action<
+        SerializableEvent,
+        string,
+        string,
+        Guid,
+        IReadOnlyDictionary<string, object>?>? PlannedPublishObserver { get; set; }
+
     private record PublishItem(
         string Provider,
         string Namespace,
@@ -235,18 +246,25 @@ public class OrleansEventPublisher : IEventPublisher, IExecutorSizePreparedDesti
             var serializableEvent = plan.PreparedEvent ?? evt.ToSerializableEvent(_domainTypes.EventTypes);
             foreach (var destination in destinations)
             {
+                var requestContext = destination.RequestContext is null
+                    ? null
+                    : destination.RequestContext.ToDictionary(
+                        pair => pair.Key,
+                        pair => pair.Value,
+                        StringComparer.Ordinal);
+                PlannedPublishObserver?.Invoke(
+                    serializableEvent,
+                    destination.ProviderName,
+                    destination.StreamNamespace,
+                    destination.StreamId,
+                    requestContext);
                 _channel.Writer.TryWrite(new PublishItem(
                     destination.ProviderName,
                     destination.StreamNamespace,
                     destination.StreamId,
                     serializableEvent,
                     0,
-                    destination.RequestContext is null
-                        ? null
-                        : destination.RequestContext.ToDictionary(
-                            pair => pair.Key,
-                            pair => pair.Value,
-                            StringComparer.Ordinal)));
+                    requestContext));
             }
         }
 

--- a/dcb/src/Sekiban.Dcb.Orleans.Core/Sekiban.Dcb.Orleans.Core.csproj
+++ b/dcb/src/Sekiban.Dcb.Orleans.Core/Sekiban.Dcb.Orleans.Core.csproj
@@ -34,6 +34,7 @@
         <InternalsVisibleTo Include="Sekiban.Dcb.Orleans.Tests"/>
         <InternalsVisibleTo Include="Sekiban.Dcb.Orleans.WithResult"/>
         <InternalsVisibleTo Include="Sekiban.Dcb.Orleans.WithoutResult"/>
+        <InternalsVisibleTo Include="Sekiban.Dcb.Orleans.AzureQueue"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/dcb/src/Sekiban.Dcb.Orleans.Core/SizeGates/OrleansDestinationMeasurementContracts.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.Core/SizeGates/OrleansDestinationMeasurementContracts.cs
@@ -1,0 +1,30 @@
+using Sekiban.Dcb.Events;
+
+namespace Sekiban.Dcb.Orleans;
+
+/// <summary>
+/// Internal bridge between Orleans.Core's provider-neutral publisher and a provider package. Provider assemblies may
+/// capture opaque measurement state here, but the shared assembly never references a provider SDK.
+/// </summary>
+internal interface IOrleansDestinationMeasurementCapture
+{
+    bool Matches(string providerName);
+
+    object? Capture(
+        string providerName,
+        string streamNamespace,
+        Guid streamId,
+        SerializableEvent serializedEvent,
+        IReadOnlyDictionary<string, object>? requestContext,
+        out string? failureReason);
+}
+
+/// <summary>Opaque provider state plus the exact context captured for one destination.</summary>
+internal sealed record OrleansDestinationPlanState(
+    string DestinationKey,
+    string ProviderName,
+    string StreamNamespace,
+    Guid StreamId,
+    object? MeasurementState,
+    IReadOnlyDictionary<string, object>? RequestContext,
+    string? FailureReason);

--- a/dcb/src/Sekiban.Dcb.Postgres.MigrationHost/Sekiban.Dcb.Postgres.MigrationHost.csproj
+++ b/dcb/src/Sekiban.Dcb.Postgres.MigrationHost/Sekiban.Dcb.Postgres.MigrationHost.csproj
@@ -5,6 +5,8 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <LangVersion>latest</LangVersion>
+        <!-- This executable is a deployment-time EF migration host, not a distributable DCB package. -->
+        <IsPackable>false</IsPackable>
         <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
         <NoWarn>$(NoWarn);MSB3277</NoWarn>
     </PropertyGroup>

--- a/dcb/tests/Sekiban.Dcb.Orleans.Tests/AzureQueueSizeGateTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Orleans.Tests/AzureQueueSizeGateTests.cs
@@ -1,0 +1,374 @@
+using System.Reflection;
+using System.Text;
+using Azure.Storage.Queues;
+using Microsoft.Extensions.DependencyInjection;
+using Orleans.Runtime;
+using Orleans.Serialization;
+using Orleans.Streams;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.Orleans.AzureQueue;
+using Sekiban.Dcb.SizeGates;
+using Xunit;
+
+namespace Sekiban.Dcb.Orleans.Tests;
+
+public sealed class AzureQueueSizeGateTests
+{
+    [Fact]
+    public void PublicRegistrationApis_HaveTheApprovedAdditiveShape()
+    {
+        var optionsMethod = typeof(OrleansAzureQueueExecutorSizeGateExtensions).GetMethod(
+            nameof(OrleansAzureQueueExecutorSizeGateExtensions.AddOrleansAzureQueueStreamMessagePolicy));
+        Assert.NotNull(optionsMethod);
+        Assert.Equal(typeof(OrleansAzureQueueExecutorSizeGateExtensions), optionsMethod!.DeclaringType);
+        Assert.Equal(typeof(ExecutorSizeGateOptions), optionsMethod!.ReturnType);
+        Assert.Equal(
+            [
+                typeof(ExecutorSizeGateOptions),
+                typeof(string),
+                typeof(long?),
+                typeof(long?),
+                typeof(ExecutorSizeStrictness)
+            ],
+            optionsMethod.GetParameters().Select(parameter => parameter.ParameterType).ToArray());
+        Assert.Equal(
+            ["options", "streamProviderName", "maxBytesPerEvent", "maxBytesPerOperation", "strictness"],
+            optionsMethod.GetParameters().Select(parameter => parameter.Name ?? string.Empty).ToArray());
+        Assert.Equal(ExecutorSizeStrictness.NonStrict, optionsMethod.GetParameters()[4].DefaultValue);
+
+        var servicesMethod = typeof(OrleansAzureQueueExecutorSizeGateExtensions).GetMethod(
+            nameof(OrleansAzureQueueExecutorSizeGateExtensions.AddSekibanDcbOrleansAzureQueueStreamMessageSizeGate));
+        Assert.NotNull(servicesMethod);
+        Assert.Equal(typeof(OrleansAzureQueueExecutorSizeGateExtensions), servicesMethod!.DeclaringType);
+        Assert.Equal(typeof(IServiceCollection), servicesMethod!.ReturnType);
+        Assert.Equal(
+            [
+                typeof(IServiceCollection),
+                typeof(string),
+                typeof(long?),
+                typeof(long?),
+                typeof(ExecutorSizeStrictness)
+            ],
+            servicesMethod.GetParameters().Select(parameter => parameter.ParameterType).ToArray());
+        Assert.Equal(
+            ["services", "streamProviderName", "maxBytesPerEvent", "maxBytesPerOperation", "strictness"],
+            servicesMethod.GetParameters().Select(parameter => parameter.Name ?? string.Empty).ToArray());
+        Assert.Equal(ExecutorSizeStrictness.NonStrict, servicesMethod.GetParameters()[4].DefaultValue);
+    }
+
+    [Fact]
+    public void Registration_UsesOneDestinationPolicyAndProviderComposableMarker()
+    {
+        var services = new ServiceCollection();
+        services.AddSekibanDcbOrleansAzureQueueStreamMessageSizeGate("EventStreamProvider");
+
+        using var provider = services.BuildServiceProvider();
+        var options = provider.GetRequiredService<ExecutorSizeGateOptions>();
+        var policy = Assert.Single(options.Policies);
+        Assert.Equal(OrleansAzureQueueStreamMessageSizeMeasurement.Scope, policy.Scope);
+        Assert.Equal(ExecutorSizeRepresentation.Destination, policy.Representation);
+        Assert.Equal(OrleansAzureQueueStreamMessageSizeMeasurement.DefaultMaxBytesPerEvent, policy.MaxBytesPerEvent);
+        Assert.Equal(ExecutorSizeStrictness.NonStrict, policy.Strictness);
+        Assert.IsType<OrleansAzureQueueStreamMessageSizeMeasurement>(policy.Measurement);
+        var marker = services.Single(descriptor =>
+            descriptor.ServiceType.FullName == "Sekiban.Dcb.SizeGates.ExecutorSizeGateRegistrationMarker").ImplementationInstance;
+        Assert.Equal(
+            "provider-composable gate registration",
+            marker?.GetType().GetProperty("Mechanism", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)?.GetValue(marker));
+    }
+
+    [Fact]
+    public void RegistrationMechanisms_RejectMixedConfigurationInEitherOrder()
+    {
+        var coreOptions = new ExecutorSizeGateOptions()
+            .AddOrleansAzureQueueStreamMessagePolicy("EventStreamProvider");
+        var coreRegistrations = new Action<IServiceCollection>[]
+        {
+            services => services.AddSekibanDcbExecutorSizeGate(options =>
+                options.AddOrleansAzureQueueStreamMessagePolicy("EventStreamProvider")),
+            services => services.AddSekibanDcbExecutorSizeGate(coreOptions)
+        };
+
+        foreach (var coreRegistration in coreRegistrations)
+        {
+            var composed = new ServiceCollection();
+            coreRegistration(composed);
+            using var composedProvider = composed.BuildServiceProvider();
+            Assert.Single(composedProvider.GetRequiredService<ExecutorSizeGateOptions>().Policies);
+
+            var coreThenProvider = new ServiceCollection();
+            coreRegistration(coreThenProvider);
+            Assert.Throws<InvalidOperationException>(() =>
+                coreThenProvider.AddSekibanDcbOrleansAzureQueueStreamMessageSizeGate("EventStreamProvider"));
+
+            var providerThenCore = new ServiceCollection();
+            providerThenCore.AddSekibanDcbOrleansAzureQueueStreamMessageSizeGate("EventStreamProvider");
+            Assert.Throws<InvalidOperationException>(() => coreRegistration(providerThenCore));
+        }
+    }
+
+    [Fact]
+    public void InvalidProviderRegistrationDoesNotLeaveACompatibilityMarker()
+    {
+        var services = new ServiceCollection();
+
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            services.AddSekibanDcbOrleansAzureQueueStreamMessageSizeGate(
+                "EventStreamProvider",
+                maxBytesPerEvent: 65_537));
+        Assert.Empty(services);
+
+        services.AddSekibanDcbExecutorSizeGate(_ => { });
+    }
+
+    [Fact]
+    public void CertifiedBound_ReportsBothBytesAndUsesTheConservativeBase64Formula()
+    {
+        var result = ExecutorSizeMeasurementResult.CertifiedBound(49_152, 65_536);
+
+        Assert.True(result.IsAvailable);
+        Assert.Null(result.Bytes);
+        Assert.Equal(49_152, result.MeasuredRepresentationBytes);
+        Assert.Equal(65_536, result.CertifiedUpperBoundBytes);
+        Assert.Equal(65_536, result.ComparableBytes);
+        Assert.Throws<ArgumentOutOfRangeException>(() => ExecutorSizeMeasurementResult.CertifiedBound(4, 3));
+    }
+
+    [Fact]
+    public void ActualAzureQueueV2Adapter_ProducesMeasuredTextAndBothEncodingBounds()
+    {
+        using var services = new ServiceCollection()
+            .AddSerializer()
+            .BuildServiceProvider();
+        var serializer = services.GetRequiredService<Serializer>();
+        var adapter = new global::Orleans.Providers.Streams.AzureQueue.AzureQueueDataAdapterV2(serializer);
+        var serialized = CreateSerializableEvent(payloadLength: 256);
+        var streamIdGuid = Guid.NewGuid();
+        var streamId = StreamId.Create("AllEvents", streamIdGuid);
+        var text = adapter.ToQueueMessage(streamId, new[] { serialized }, null, null);
+        var measuredTextBytes = Encoding.UTF8.GetByteCount(text);
+
+        var noneResult = Measure(adapter, serialized, streamId, streamIdGuid, Azure.Storage.Queues.QueueMessageEncoding.None);
+        var base64Result = Measure(adapter, serialized, streamId, streamIdGuid, Azure.Storage.Queues.QueueMessageEncoding.Base64);
+
+        Assert.Equal(measuredTextBytes, noneResult.MeasuredRepresentationBytes);
+        Assert.Equal(measuredTextBytes, noneResult.CertifiedUpperBoundBytes);
+        Assert.Equal(
+            4L * ((measuredTextBytes + 2L) / 3L),
+            base64Result.CertifiedUpperBoundBytes);
+        Assert.InRange(
+            (base64Result.CertifiedUpperBoundBytes ?? 0) - (base64Result.MeasuredRepresentationBytes ?? 0),
+            0,
+            measuredTextBytes);
+    }
+
+    [Fact]
+    public void ActualAzureQueueV2Adapter_CertifiedBoundaryRejectsRawSizeMutant()
+    {
+        using var services = new ServiceCollection()
+            .AddSerializer()
+            .BuildServiceProvider();
+        var serializer = services.GetRequiredService<Serializer>();
+        var adapter = new global::Orleans.Providers.Streams.AzureQueue.AzureQueueDataAdapterV2(serializer);
+        var streamIdGuid = Guid.Parse("00000000-0000-0000-0000-000000000002");
+        var streamId = StreamId.Create("AllEvents", streamIdGuid);
+
+        var boundaryEvent = FindEventWithAdapterTextBytes(adapter, streamId, 49_152);
+        var overEvent = FindEventWithAdapterTextBytes(adapter, streamId, 49_156);
+        var boundary = Measure(adapter, boundaryEvent, streamId, streamIdGuid, QueueMessageEncoding.Base64);
+        var over = Measure(adapter, overEvent, streamId, streamIdGuid, QueueMessageEncoding.Base64);
+
+        Assert.Equal(49_152, boundary.MeasuredRepresentationBytes);
+        Assert.Equal(65_536, boundary.CertifiedUpperBoundBytes);
+        Assert.True(boundary.ComparableBytes <= 65_536, "The equal certified quota must remain admissible.");
+        Assert.Equal(49_156, over.MeasuredRepresentationBytes);
+        Assert.Equal(65_544, over.CertifiedUpperBoundBytes);
+        Assert.True(over.ComparableBytes > 65_536, "The conservative certified bound must reject the over-bound case.");
+
+        // A raw-adapter-size mutant would compare 49,156 with the 65,536 quota and incorrectly admit this event.
+        var rawSizeMutant = ExecutorSizeMeasurementResult.Exact(over.MeasuredRepresentationBytes!.Value);
+        Assert.True(rawSizeMutant.ComparableBytes <= 65_536);
+        Assert.True(over.CertifiedUpperBoundBytes > rawSizeMutant.ComparableBytes);
+    }
+
+    [Fact]
+    public void Measurement_UsesActualAdapterWithoutResolvingQueueClientOrSending()
+    {
+        using var services = new ServiceCollection()
+            .AddSerializer()
+            .BuildServiceProvider();
+        Assert.Null(services.GetService<QueueServiceClient>());
+
+        var adapter = new global::Orleans.Providers.Streams.AzureQueue.AzureQueueDataAdapterV2(
+            services.GetRequiredService<Serializer>());
+        var serialized = CreateSerializableEvent(256);
+        var streamIdGuid = Guid.Parse("00000000-0000-0000-0000-000000000003");
+        var result = Measure(
+            adapter,
+            serialized,
+            StreamId.Create("AllEvents", streamIdGuid),
+            streamIdGuid,
+            QueueMessageEncoding.None);
+
+        Assert.True(result.IsAvailable);
+        Assert.NotNull(result.MeasuredRepresentationBytes);
+        Assert.Null(services.GetService<QueueServiceClient>());
+    }
+
+    [Fact]
+    public void CapturedPlan_RetainsPreparedEventAndProviderStateForTheSameMeasurement()
+    {
+        using var services = new ServiceCollection()
+            .AddSerializer()
+            .BuildServiceProvider();
+        var serialized = CreateSerializableEvent(10);
+        var state = new AzureQueueDestinationMeasurementState(
+            new global::Orleans.Providers.Streams.AzureQueue.AzureQueueDataAdapterV2(
+                services.GetRequiredService<Serializer>()),
+            StreamId.Create("AllEvents", serialized.Id),
+            serialized,
+            new Dictionary<string, object> { ["trace"] = "value" },
+            QueueMessageEncoding.None);
+        var destinationState = new OrleansDestinationPlanState(
+            "EventStreamProvider|AllEvents|" + serialized.Id.ToString("D"),
+            "EventStreamProvider",
+            "AllEvents",
+            serialized.Id,
+            state,
+            state.RequestContext,
+            null);
+        var plan = new ExecutorSizeDestinationPlan(
+            "service",
+            [destinationState.DestinationKey],
+            new[] { destinationState })
+        {
+            PreparedEvent = serialized
+        };
+
+        Assert.Same(serialized, plan.PreparedEvent);
+        Assert.Same(state, Assert.Single((IReadOnlyList<OrleansDestinationPlanState>)plan.ProviderState!).MeasurementState);
+        Assert.Same(state.RequestContext, Assert.Single((IReadOnlyList<OrleansDestinationPlanState>)plan.ProviderState!).RequestContext);
+    }
+
+    [Fact]
+    public void UnsupportedDestination_IsNamedUnavailableAndNeverLooksLikeLogicalBytes()
+    {
+        var serialized = CreateSerializableEvent(10);
+        var planState = new OrleansDestinationPlanState(
+            "EventStreamProvider|AllEvents|00000000-0000-0000-0000-000000000001",
+            "EventStreamProvider",
+            "AllEvents",
+            Guid.Parse("00000000-0000-0000-0000-000000000001"),
+            null,
+            null,
+            "named provider 'EventStreamProvider' resolved a custom adapter, not AzureQueueDataAdapterV2");
+        var plan = new ExecutorSizeDestinationPlan(
+            "service",
+            [planState.DestinationKey],
+            new[] { planState })
+        {
+            PreparedEvent = serialized
+        };
+        var result = new OrleansAzureQueueStreamMessageSizeMeasurement("EventStreamProvider").Measure(
+            new ExecutorSizeMeasurementContext(
+                OrleansAzureQueueStreamMessageSizeMeasurement.Scope,
+                ExecutorSizeRepresentation.Destination,
+                CreateEvent(serialized),
+                serialized,
+                "service",
+                planState.DestinationKey,
+                plan));
+
+        Assert.False(result.IsAvailable);
+        Assert.Contains("custom adapter", result.Reason, StringComparison.Ordinal);
+        Assert.Null(result.ComparableBytes);
+    }
+
+    private static ExecutorSizeMeasurementResult Measure(
+        global::Orleans.Streams.IQueueDataAdapter<string, global::Orleans.Streams.IBatchContainer> adapter,
+        SerializableEvent serialized,
+        StreamId streamId,
+        Guid streamIdGuid,
+        Azure.Storage.Queues.QueueMessageEncoding encoding)
+    {
+        var key = $"EventStreamProvider|AllEvents|{streamIdGuid:D}";
+        var state = new AzureQueueDestinationMeasurementState(adapter, streamId, serialized, null, encoding);
+        var destinationState = new OrleansDestinationPlanState(
+            key,
+            "EventStreamProvider",
+            "AllEvents",
+            streamIdGuid,
+            state,
+            null,
+            null);
+        var plan = new ExecutorSizeDestinationPlan("service", [key], new[] { destinationState })
+        {
+            PreparedEvent = serialized
+        };
+        return new OrleansAzureQueueStreamMessageSizeMeasurement("EventStreamProvider").Measure(
+            new ExecutorSizeMeasurementContext(
+                OrleansAzureQueueStreamMessageSizeMeasurement.Scope,
+                ExecutorSizeRepresentation.Destination,
+                CreateEvent(serialized),
+                serialized,
+                "service",
+                key,
+                plan));
+    }
+
+    private static SerializableEvent FindEventWithAdapterTextBytes(
+        global::Orleans.Streams.IQueueDataAdapter<string, global::Orleans.Streams.IBatchContainer> adapter,
+        StreamId streamId,
+        int targetBytes)
+    {
+        var low = 0;
+        var high = 200_000;
+        while (AdapterTextBytes(adapter, streamId, CreateSerializableEvent(high)) < targetBytes)
+        {
+            high *= 2;
+        }
+
+        while (low <= high)
+        {
+            var candidateLength = low + ((high - low) / 2);
+            var candidate = CreateSerializableEvent(candidateLength);
+            var actual = AdapterTextBytes(adapter, streamId, candidate);
+            if (actual == targetBytes)
+                return candidate;
+
+            if (actual < targetBytes)
+                low = candidateLength + 1;
+            else
+                high = candidateLength - 1;
+        }
+
+        throw new Xunit.Sdk.XunitException($"Could not create an adapter message of exactly {targetBytes} bytes.");
+    }
+
+    private static int AdapterTextBytes(
+        global::Orleans.Streams.IQueueDataAdapter<string, global::Orleans.Streams.IBatchContainer> adapter,
+        StreamId streamId,
+        SerializableEvent serialized) =>
+        Encoding.UTF8.GetByteCount(adapter.ToQueueMessage(streamId, new[] { serialized }, null, null));
+
+    private static SerializableEvent CreateSerializableEvent(int payloadLength) =>
+        new(
+            Enumerable.Repeat((byte)0x41, payloadLength).ToArray(),
+            "20260912000000000000000000000000-0000000000000001",
+            Guid.Parse("00000000-0000-0000-0000-000000000004"),
+            new EventMetadata("causation", "correlation", "test"),
+            [],
+            "TestPayload");
+
+    private static Event CreateEvent(SerializableEvent serialized) =>
+        new(
+            new TestPayload(serialized.Payload.Length),
+            serialized.SortableUniqueIdValue,
+            serialized.EventPayloadName,
+            serialized.Id,
+            serialized.EventMetadata,
+            serialized.Tags);
+
+    private sealed record TestPayload(int Length) : IEventPayload;
+
+}

--- a/dcb/tests/Sekiban.Dcb.Orleans.Tests/AzureQueueSizeGateTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Orleans.Tests/AzureQueueSizeGateTests.cs
@@ -375,6 +375,46 @@ public sealed class AzureQueueSizeGateTests
         Assert.Equal(2, (await store.ReadAllSerializableEventsAsync()).GetValue().Count());
     }
 
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task ProductionExecutor_NonStrictSecondCaptureFailureAfterEventExcessRejectsBeforeWrite(
+        bool certified)
+    {
+        var execution = await ExecuteNonStrictPartialFailureAsync(
+            maxBytesPerEvent: 10,
+            maxBytesPerOperation: null,
+            CreatePartialMeasurement(certified, 11));
+
+        await AssertPartialFailureRejectedBeforeWriteAsync(
+            execution,
+            isOperationLimit: false,
+            certified,
+            measuredBytes: 11,
+            measuredRepresentationBytes: certified ? null : 11,
+            certifiedUpperBoundBytes: certified ? 11 : null);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task ProductionExecutor_NonStrictSecondCaptureFailureAfterOperationExcessRejectsBeforeWrite(
+        bool certified)
+    {
+        var execution = await ExecuteNonStrictPartialFailureAsync(
+            maxBytesPerEvent: null,
+            maxBytesPerOperation: 10,
+            CreatePartialMeasurement(certified, 11));
+
+        await AssertPartialFailureRejectedBeforeWriteAsync(
+            execution,
+            isOperationLimit: true,
+            certified,
+            measuredBytes: 11,
+            measuredRepresentationBytes: certified ? null : 11,
+            certifiedUpperBoundBytes: certified ? 11 : null);
+    }
+
     [Fact]
     public async Task ProductionExecutor_StrictCaptureFailure_RejectsOrdinaryRouteBeforeWrite()
     {
@@ -875,6 +915,72 @@ public sealed class AzureQueueSizeGateTests
         Assert.Equal(0, publisher.LegacyPublishCalls);
         return exception;
     }
+
+    private static async Task<NonStrictPartialFailureResult> ExecuteNonStrictPartialFailureAsync(
+        long? maxBytesPerEvent,
+        long? maxBytesPerOperation,
+        ExecutorSizeMeasurementResult firstMeasurement)
+    {
+        var domain = DomainType.GetDomainTypes();
+        var store = new InMemoryEventStore(domain.EventTypes);
+        var publisher = new FailingDestinationPublisher(failOnCapture: 2);
+        var executor = new GeneralSekibanExecutor(
+            store,
+            new InMemoryObjectAccessor(store, domain),
+            domain,
+            new ExecutorSizeGateOptions().Add(new ExecutorSizePolicy(
+                OrleansAzureQueueStreamMessageSizeMeasurement.Scope,
+                ExecutorSizeRepresentation.Destination,
+                maxBytesPerEvent,
+                maxBytesPerOperation,
+                ExecutorSizeStrictness.NonStrict,
+                new DelegateMeasurement(_ => firstMeasurement))),
+            publisher);
+        var first = Guid.NewGuid();
+        var second = Guid.NewGuid();
+
+        var result = await executor.CommitSerializableEventsAsync(
+            new SerializedCommitRequest(
+                [CreateCandidate(domain, first), CreateCandidate(domain, second)],
+                [
+                    new ConsistencyTagEntry($"WeatherForecast:{first}", ""),
+                    new ConsistencyTagEntry($"WeatherForecast:{second}", "")
+                ]));
+
+        return new(
+            Assert.IsType<ExecutorSizeLimitExceededException>(result.GetException()),
+            store,
+            publisher);
+    }
+
+    private static async Task AssertPartialFailureRejectedBeforeWriteAsync(
+        NonStrictPartialFailureResult execution,
+        bool isOperationLimit,
+        bool certified,
+        long measuredBytes,
+        long? measuredRepresentationBytes,
+        long? certifiedUpperBoundBytes)
+    {
+        Assert.Equal(isOperationLimit, execution.Exception.IsOperationLimit);
+        Assert.Equal(certified, execution.Exception.IsCertifiedUpperBound);
+        Assert.Equal(measuredBytes, execution.Exception.MeasuredBytes);
+        Assert.Equal(measuredRepresentationBytes, execution.Exception.MeasuredRepresentationBytes);
+        Assert.Equal(certifiedUpperBoundBytes, execution.Exception.CertifiedUpperBoundBytes);
+        Assert.Empty((await execution.Store.ReadAllSerializableEventsAsync()).GetValue());
+        Assert.Equal(2, execution.Publisher.CaptureCalls);
+        Assert.Equal(0, execution.Publisher.PlannedPublishCalls);
+        Assert.Equal(0, execution.Publisher.LegacyPublishCalls);
+    }
+
+    private static ExecutorSizeMeasurementResult CreatePartialMeasurement(bool certified, long bytes) =>
+        certified
+            ? ExecutorSizeMeasurementResult.CertifiedBound(bytes)
+            : ExecutorSizeMeasurementResult.Exact(bytes);
+
+    private sealed record NonStrictPartialFailureResult(
+        ExecutorSizeLimitExceededException Exception,
+        InMemoryEventStore Store,
+        FailingDestinationPublisher Publisher);
 
     private sealed class CapturingDestinationPublisher(
         DcbDomainTypes domain,

--- a/dcb/tests/Sekiban.Dcb.Orleans.Tests/AzureQueueSizeGateTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Orleans.Tests/AzureQueueSizeGateTests.cs
@@ -161,7 +161,7 @@ public sealed class AzureQueueSizeGateTests
     }
 
     [Fact]
-    public async Task OperationEvidence_SaturatesAllTotalsInsteadOfThrowingOverflow()
+    public async Task OperationEvidence_ExactTotalsSaturateWithoutCertifiedEvidence()
     {
         var domain = DomainType.GetDomainTypes();
         var store = new InMemoryEventStore(domain.EventTypes);
@@ -192,12 +192,43 @@ public sealed class AzureQueueSizeGateTests
 
         var exception = Assert.IsType<ExecutorSizeLimitExceededException>(result.GetException());
         Assert.True(exception.IsOperationLimit);
+        Assert.False(exception.IsCertifiedUpperBound);
         Assert.Equal(long.MaxValue, exception.MeasuredBytes);
         Assert.Equal(long.MaxValue, exception.MeasuredRepresentationBytes);
-        Assert.Equal(long.MaxValue, exception.CertifiedUpperBoundBytes);
+        Assert.Null(exception.CertifiedUpperBoundBytes);
         Assert.Empty((await store.ReadAllSerializableEventsAsync()).GetValue());
         Assert.Equal(0, publisher.PlannedPublishCalls);
         Assert.Equal(0, publisher.LegacyPublishCalls);
+    }
+
+    [Fact]
+    public async Task OperationEvidence_LegacyCertifiedBoundsPreserveCertifiedOnlyEvidence()
+    {
+        var exception = await ExecuteOperationLimitAsync(
+            long.MaxValue - 1,
+            ExecutorSizeMeasurementResult.CertifiedBound(long.MaxValue / 2 + 1),
+            ExecutorSizeMeasurementResult.CertifiedBound(long.MaxValue / 2 + 1));
+
+        Assert.True(exception.IsOperationLimit);
+        Assert.True(exception.IsCertifiedUpperBound);
+        Assert.Equal(long.MaxValue, exception.MeasuredBytes);
+        Assert.Null(exception.MeasuredRepresentationBytes);
+        Assert.Equal(long.MaxValue, exception.CertifiedUpperBoundBytes);
+    }
+
+    [Fact]
+    public async Task OperationEvidence_MixedExactAndCertifiedBoundsPreserveEachAvailableTotal()
+    {
+        var exception = await ExecuteOperationLimitAsync(
+            35,
+            ExecutorSizeMeasurementResult.Exact(10),
+            ExecutorSizeMeasurementResult.CertifiedBound(20, 30));
+
+        Assert.True(exception.IsOperationLimit);
+        Assert.True(exception.IsCertifiedUpperBound);
+        Assert.Equal(40, exception.MeasuredBytes);
+        Assert.Equal(30, exception.MeasuredRepresentationBytes);
+        Assert.Equal(40, exception.CertifiedUpperBoundBytes);
     }
 
     [Fact]
@@ -804,6 +835,45 @@ public sealed class AzureQueueSizeGateTests
             Encoding.UTF8.GetBytes(domain.EventTypes.SerializeEventPayload(payload)),
             nameof(WeatherForecastCreated),
             [$"WeatherForecast:{id}"]);
+    }
+
+    private static async Task<ExecutorSizeLimitExceededException> ExecuteOperationLimitAsync(
+        long operationLimit,
+        params ExecutorSizeMeasurementResult[] measurementResults)
+    {
+        var domain = DomainType.GetDomainTypes();
+        var store = new InMemoryEventStore(domain.EventTypes);
+        var publisher = new FailingDestinationPublisher(failOnCapture: int.MaxValue);
+        var remaining = new Queue<ExecutorSizeMeasurementResult>(measurementResults);
+        var measurement = new DelegateMeasurement(_ => remaining.Dequeue());
+        var executor = new GeneralSekibanExecutor(
+            store,
+            new InMemoryObjectAccessor(store, domain),
+            domain,
+            new ExecutorSizeGateOptions().Add(new ExecutorSizePolicy(
+                OrleansAzureQueueStreamMessageSizeMeasurement.Scope,
+                ExecutorSizeRepresentation.Destination,
+                maxBytesPerOperation: operationLimit,
+                strictness: ExecutorSizeStrictness.Strict,
+                measurement: measurement)),
+            publisher);
+        var first = Guid.NewGuid();
+        var second = Guid.NewGuid();
+
+        var result = await executor.CommitSerializableEventsAsync(
+            new SerializedCommitRequest(
+                [CreateCandidate(domain, first), CreateCandidate(domain, second)],
+                [
+                    new ConsistencyTagEntry($"WeatherForecast:{first}", ""),
+                    new ConsistencyTagEntry($"WeatherForecast:{second}", "")
+                ]));
+
+        var exception = Assert.IsType<ExecutorSizeLimitExceededException>(result.GetException());
+        Assert.Empty(remaining);
+        Assert.Empty((await store.ReadAllSerializableEventsAsync()).GetValue());
+        Assert.Equal(0, publisher.PlannedPublishCalls);
+        Assert.Equal(0, publisher.LegacyPublishCalls);
+        return exception;
     }
 
     private sealed class CapturingDestinationPublisher(

--- a/dcb/tests/Sekiban.Dcb.Orleans.Tests/AzureQueueSizeGateTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Orleans.Tests/AzureQueueSizeGateTests.cs
@@ -43,6 +43,8 @@ public sealed class AzureQueueSizeGateTests
         Assert.Equal(
             ["options", "streamProviderName", "maxBytesPerEvent", "maxBytesPerOperation", "strictness"],
             optionsMethod.GetParameters().Select(parameter => parameter.Name ?? string.Empty).ToArray());
+        Assert.Null(optionsMethod.GetParameters()[2].DefaultValue);
+        Assert.Null(optionsMethod.GetParameters()[3].DefaultValue);
         Assert.Equal(ExecutorSizeStrictness.NonStrict, optionsMethod.GetParameters()[4].DefaultValue);
 
         var servicesMethod = typeof(OrleansAzureQueueExecutorSizeGateExtensions).GetMethod(
@@ -62,6 +64,8 @@ public sealed class AzureQueueSizeGateTests
         Assert.Equal(
             ["services", "streamProviderName", "maxBytesPerEvent", "maxBytesPerOperation", "strictness"],
             servicesMethod.GetParameters().Select(parameter => parameter.Name ?? string.Empty).ToArray());
+        Assert.Null(servicesMethod.GetParameters()[2].DefaultValue);
+        Assert.Null(servicesMethod.GetParameters()[3].DefaultValue);
         Assert.Equal(ExecutorSizeStrictness.NonStrict, servicesMethod.GetParameters()[4].DefaultValue);
     }
 
@@ -131,7 +135,20 @@ public sealed class AzureQueueSizeGateTests
     }
 
     [Fact]
-    public void CertifiedBound_ReportsBothBytesAndUsesTheConservativeBase64Formula()
+    public void CertifiedBound_OneArgumentIsBoundOnlyWithoutMeasuredRepresentation()
+    {
+        var result = ExecutorSizeMeasurementResult.CertifiedBound(123);
+
+        Assert.True(result.IsAvailable);
+        Assert.Null(result.Bytes);
+        Assert.Null(result.MeasuredRepresentationBytes);
+        Assert.Equal(123, result.CertifiedUpperBound);
+        Assert.Equal(123, result.CertifiedUpperBoundBytes);
+        Assert.Equal(123, result.ComparableBytes);
+    }
+
+    [Fact]
+    public void CertifiedBound_TwoArgumentsReportsMeasuredAndCertifiedBytes()
     {
         var result = ExecutorSizeMeasurementResult.CertifiedBound(49_152, 65_536);
 
@@ -141,6 +158,46 @@ public sealed class AzureQueueSizeGateTests
         Assert.Equal(65_536, result.CertifiedUpperBoundBytes);
         Assert.Equal(65_536, result.ComparableBytes);
         Assert.Throws<ArgumentOutOfRangeException>(() => ExecutorSizeMeasurementResult.CertifiedBound(4, 3));
+    }
+
+    [Fact]
+    public async Task OperationEvidence_SaturatesAllTotalsInsteadOfThrowingOverflow()
+    {
+        var domain = DomainType.GetDomainTypes();
+        var store = new InMemoryEventStore(domain.EventTypes);
+        var publisher = new FailingDestinationPublisher(failOnCapture: int.MaxValue);
+        var measurement = new DelegateMeasurement(_ =>
+            ExecutorSizeMeasurementResult.Exact(long.MaxValue / 2 + 1));
+        var executor = new GeneralSekibanExecutor(
+            store,
+            new InMemoryObjectAccessor(store, domain),
+            domain,
+            new ExecutorSizeGateOptions().Add(new ExecutorSizePolicy(
+                OrleansAzureQueueStreamMessageSizeMeasurement.Scope,
+                ExecutorSizeRepresentation.Destination,
+                maxBytesPerOperation: long.MaxValue - 1,
+                strictness: ExecutorSizeStrictness.Strict,
+                measurement: measurement)),
+            publisher);
+        var first = Guid.NewGuid();
+        var second = Guid.NewGuid();
+
+        var result = await executor.CommitSerializableEventsAsync(
+            new SerializedCommitRequest(
+                [CreateCandidate(domain, first), CreateCandidate(domain, second)],
+                [
+                    new ConsistencyTagEntry($"WeatherForecast:{first}", ""),
+                    new ConsistencyTagEntry($"WeatherForecast:{second}", "")
+                ]));
+
+        var exception = Assert.IsType<ExecutorSizeLimitExceededException>(result.GetException());
+        Assert.True(exception.IsOperationLimit);
+        Assert.Equal(long.MaxValue, exception.MeasuredBytes);
+        Assert.Equal(long.MaxValue, exception.MeasuredRepresentationBytes);
+        Assert.Equal(long.MaxValue, exception.CertifiedUpperBoundBytes);
+        Assert.Empty((await store.ReadAllSerializableEventsAsync()).GetValue());
+        Assert.Equal(0, publisher.PlannedPublishCalls);
+        Assert.Equal(0, publisher.LegacyPublishCalls);
     }
 
     [Fact]

--- a/dcb/tests/Sekiban.Dcb.Orleans.Tests/AzureQueueSizeGateTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Orleans.Tests/AzureQueueSizeGateTests.cs
@@ -1,13 +1,22 @@
 using System.Reflection;
 using System.Text;
 using Azure.Storage.Queues;
+using Dcb.Domain;
+using Dcb.Domain.Weather;
 using Microsoft.Extensions.DependencyInjection;
+using Orleans.Configuration;
 using Orleans.Runtime;
 using Orleans.Serialization;
 using Orleans.Streams;
+using Sekiban.Dcb.Actors;
+using Sekiban.Dcb.Commands;
 using Sekiban.Dcb.Events;
+using Sekiban.Dcb.Orleans;
 using Sekiban.Dcb.Orleans.AzureQueue;
 using Sekiban.Dcb.SizeGates;
+using Sekiban.Dcb.Storage;
+using Sekiban.Dcb.Testing;
+using Sekiban.Dcb.Tags;
 using Xunit;
 
 namespace Sekiban.Dcb.Orleans.Tests;
@@ -135,7 +144,7 @@ public sealed class AzureQueueSizeGateTests
     }
 
     [Fact]
-    public void ActualAzureQueueV2Adapter_ProducesMeasuredTextAndBothEncodingBounds()
+    public void ActualAzureQueueV2Adapter_AlwaysUsesConservativeCertifiedBound()
     {
         using var services = new ServiceCollection()
             .AddSerializer()
@@ -148,16 +157,14 @@ public sealed class AzureQueueSizeGateTests
         var text = adapter.ToQueueMessage(streamId, new[] { serialized }, null, null);
         var measuredTextBytes = Encoding.UTF8.GetByteCount(text);
 
-        var noneResult = Measure(adapter, serialized, streamId, streamIdGuid, Azure.Storage.Queues.QueueMessageEncoding.None);
-        var base64Result = Measure(adapter, serialized, streamId, streamIdGuid, Azure.Storage.Queues.QueueMessageEncoding.Base64);
+        var result = Measure(adapter, serialized, streamId, streamIdGuid);
 
-        Assert.Equal(measuredTextBytes, noneResult.MeasuredRepresentationBytes);
-        Assert.Equal(measuredTextBytes, noneResult.CertifiedUpperBoundBytes);
+        Assert.Equal(measuredTextBytes, result.MeasuredRepresentationBytes);
         Assert.Equal(
             4L * ((measuredTextBytes + 2L) / 3L),
-            base64Result.CertifiedUpperBoundBytes);
+            result.CertifiedUpperBoundBytes);
         Assert.InRange(
-            (base64Result.CertifiedUpperBoundBytes ?? 0) - (base64Result.MeasuredRepresentationBytes ?? 0),
+            (result.CertifiedUpperBoundBytes ?? 0) - (result.MeasuredRepresentationBytes ?? 0),
             0,
             measuredTextBytes);
     }
@@ -175,8 +182,8 @@ public sealed class AzureQueueSizeGateTests
 
         var boundaryEvent = FindEventWithAdapterTextBytes(adapter, streamId, 49_152);
         var overEvent = FindEventWithAdapterTextBytes(adapter, streamId, 49_156);
-        var boundary = Measure(adapter, boundaryEvent, streamId, streamIdGuid, QueueMessageEncoding.Base64);
-        var over = Measure(adapter, overEvent, streamId, streamIdGuid, QueueMessageEncoding.Base64);
+        var boundary = Measure(adapter, boundaryEvent, streamId, streamIdGuid);
+        var over = Measure(adapter, overEvent, streamId, streamIdGuid);
 
         Assert.Equal(49_152, boundary.MeasuredRepresentationBytes);
         Assert.Equal(65_536, boundary.CertifiedUpperBoundBytes);
@@ -189,6 +196,300 @@ public sealed class AzureQueueSizeGateTests
         var rawSizeMutant = ExecutorSizeMeasurementResult.Exact(over.MeasuredRepresentationBytes!.Value);
         Assert.True(rawSizeMutant.ComparableBytes <= 65_536);
         Assert.True(over.CertifiedUpperBoundBytes > rawSizeMutant.ComparableBytes);
+    }
+
+    [Theory]
+    [InlineData(49_152, 65_536, true)]
+    [InlineData(49_156, 65_544, false)]
+    public async Task ProductionCaptureAndEvaluator_UsesConservativeBoundBeforePersistence(
+        int adapterTextBytes,
+        long certifiedBytes,
+        bool shouldPass)
+    {
+        var domain = DomainType.GetDomainTypes();
+        using var services = BuildAzureQueueServices();
+        var adapter = services.GetRequiredKeyedService<IQueueDataAdapter<string, IBatchContainer>>("EventStreamProvider");
+        var capture = new OrleansAzureQueueDestinationMeasurementCapture(services, "EventStreamProvider");
+        var publisher = new CapturingDestinationPublisher(domain, capture);
+        var store = new InMemoryEventStore(domain.EventTypes);
+        var executor = new GeneralSekibanExecutor(
+            store,
+            new InMemoryObjectAccessor(store, domain),
+            domain,
+            new ExecutorSizeGateOptions().Add(new ExecutorSizePolicy(
+                OrleansAzureQueueStreamMessageSizeMeasurement.Scope,
+                ExecutorSizeRepresentation.Destination,
+                maxBytesPerEvent: 65_536,
+                strictness: ExecutorSizeStrictness.Strict,
+                measurement: new OrleansAzureQueueStreamMessageSizeMeasurement("EventStreamProvider"))),
+            publisher);
+
+        var candidate = FindCandidateWithAdapterTextBytes(adapter, domain, adapterTextBytes);
+        var result = await executor.CommitSerializableEventsAsync(
+            new SerializedCommitRequest(
+                [candidate],
+                [new ConsistencyTagEntry(candidate.Tags.Single(), "")]));
+
+        Assert.Equal(shouldPass, result.IsSuccess);
+        Assert.Equal(adapterTextBytes, publisher.LastMeasuredBytes);
+        Assert.Equal(certifiedBytes, publisher.LastCertifiedBytes);
+        if (shouldPass)
+        {
+            Assert.Single(result.GetValue().WrittenEvents);
+            Assert.Equal(1, publisher.PlannedPublishCalls);
+        }
+        else
+        {
+            var exception = Assert.IsType<ExecutorSizeLimitExceededException>(result.GetException());
+            Assert.Equal(65_536, exception.LimitBytes);
+            Assert.Equal(certifiedBytes, exception.MeasuredBytes);
+            Assert.Empty((await store.ReadAllSerializableEventsAsync()).GetValue());
+            Assert.Equal(0, publisher.PlannedPublishCalls);
+            Assert.Equal(0, publisher.LegacyPublishCalls);
+        }
+    }
+
+    [Fact]
+    public async Task ProductionExecutor_NonStrictSecondCaptureFailure_UsesLegacyForTheWholeOperation()
+    {
+        var domain = DomainType.GetDomainTypes();
+        var store = new InMemoryEventStore(domain.EventTypes);
+        var publisher = new FailingDestinationPublisher(failOnCapture: 2);
+        var executor = new GeneralSekibanExecutor(
+            store,
+            new InMemoryObjectAccessor(store, domain),
+            domain,
+            new ExecutorSizeGateOptions().Add(new ExecutorSizePolicy(
+                OrleansAzureQueueStreamMessageSizeMeasurement.Scope,
+                ExecutorSizeRepresentation.Destination,
+                maxBytesPerEvent: 65_536,
+                strictness: ExecutorSizeStrictness.NonStrict,
+                measurement: new DelegateMeasurement(_ => ExecutorSizeMeasurementResult.Exact(10)))),
+            publisher);
+        var first = Guid.NewGuid();
+        var second = Guid.NewGuid();
+
+        var result = await executor.CommitSerializableEventsAsync(
+            new SerializedCommitRequest(
+                [CreateCandidate(domain, first), CreateCandidate(domain, second)],
+                [
+                    new ConsistencyTagEntry($"WeatherForecast:{first}", ""),
+                    new ConsistencyTagEntry($"WeatherForecast:{second}", "")
+                ]));
+
+        Assert.True(result.IsSuccess);
+        Assert.Single(result.GetValue().SizeGateDiagnostics);
+        Assert.Equal(2, result.GetValue().WrittenEvents.Count);
+        Assert.Equal(2, publisher.CaptureCalls);
+        Assert.Equal(0, publisher.PlannedPublishCalls);
+        Assert.Equal(1, publisher.LegacyPublishCalls);
+        Assert.Equal(2, publisher.LastLegacyEventCount);
+        Assert.Equal(2, (await store.ReadAllSerializableEventsAsync()).GetValue().Count());
+    }
+
+    [Fact]
+    public async Task ProductionExecutor_StrictCaptureFailure_RejectsOrdinaryRouteBeforeWrite()
+    {
+        var domain = DomainType.GetDomainTypes();
+        var store = new InMemoryEventStore(domain.EventTypes);
+        var publisher = new FailingDestinationPublisher(failOnCapture: 1);
+        var executor = CreateDestinationExecutor(domain, store, ExecutorSizeStrictness.Strict, publisher);
+
+        var result = await executor.ExecuteAsync(new CreateWeatherForecast
+        {
+            ForecastId = Guid.NewGuid(),
+            Location = "Tokyo",
+            Date = new DateOnly(2026, 9, 12),
+            TemperatureC = 21
+        });
+
+        Assert.IsType<ExecutorSizeCapabilityException>(result.GetException());
+        Assert.Empty((await store.ReadAllSerializableEventsAsync()).GetValue());
+        Assert.Equal(0, publisher.PlannedPublishCalls);
+        Assert.Equal(0, publisher.LegacyPublishCalls);
+    }
+
+    [Fact]
+    public async Task ProductionExecutor_StrictCaptureFailure_RejectsSerializedAndConditionalRoutesBeforeWrite()
+    {
+        var domain = DomainType.GetDomainTypes();
+        var serializedStore = new InMemoryEventStore(domain.EventTypes);
+        var serializedPublisher = new FailingDestinationPublisher(failOnCapture: 1);
+        var serializedExecutor = CreateDestinationExecutor(
+            domain, serializedStore, ExecutorSizeStrictness.Strict, serializedPublisher);
+        var serializedId = Guid.NewGuid();
+        var serialized = await serializedExecutor.CommitSerializableEventsAsync(
+            new SerializedCommitRequest(
+                [CreateCandidate(domain, serializedId)],
+                [new ConsistencyTagEntry($"WeatherForecast:{serializedId}", "")]));
+
+        Assert.IsType<ExecutorSizeCapabilityException>(serialized.GetException());
+        Assert.Empty((await serializedStore.ReadAllSerializableEventsAsync()).GetValue());
+
+        var conditionalStore = new InMemoryConditionalEventStore(domain.EventTypes);
+        var conditionalPublisher = new FailingDestinationPublisher(failOnCapture: 1);
+        var conditionalExecutor = CreateDestinationExecutor(
+            domain, conditionalStore, ExecutorSizeStrictness.Strict, conditionalPublisher);
+        var conditional = await ((ISerializedConditionalSekibanDcbExecutor)conditionalExecutor)
+            .CommitSerializableEventConditionallyAsync(
+                new SerializedConditionalCommitRequest(
+                    SerializedConditionalCommitRequest.CurrentVersion,
+                    CreateCandidate(domain, Guid.NewGuid()),
+                    "g76-strict-capture-failure"));
+
+        Assert.IsType<ExecutorSizeCapabilityException>(conditional.GetException());
+        Assert.Empty((await conditionalStore.ReadAllSerializableEventsAsync()).GetValue());
+        Assert.Equal(0, conditionalPublisher.PlannedPublishCalls);
+        Assert.Equal(0, conditionalPublisher.LegacyPublishCalls);
+    }
+
+    [Theory]
+    [InlineData("ordinary", "resolver")]
+    [InlineData("ordinary", "context")]
+    [InlineData("ordinary", "encoder")]
+    [InlineData("serialized", "resolver")]
+    [InlineData("serialized", "context")]
+    [InlineData("serialized", "encoder")]
+    [InlineData("conditional", "resolver")]
+    [InlineData("conditional", "context")]
+    [InlineData("conditional", "encoder")]
+    public async Task ProductionExecutor_StrictCapabilityFailuresRejectEveryRouteBeforeWrite(
+        string route,
+        string failureKind)
+    {
+        var domain = DomainType.GetDomainTypes();
+        var publisher = new FailureModeDestinationPublisher(failureKind);
+        IEventStore store = route == "conditional"
+            ? new InMemoryConditionalEventStore(domain.EventTypes)
+            : new InMemoryEventStore(domain.EventTypes);
+        var executor = CreateDestinationExecutor(
+            domain,
+            store,
+            ExecutorSizeStrictness.Strict,
+            publisher,
+            new FailureModeMeasurement(failureKind));
+
+        var result = await ExecuteFailureRouteAsync(route, executor, domain);
+
+        Assert.IsType<ExecutorSizeCapabilityException>(result.Exception);
+        Assert.Empty((await store.ReadAllSerializableEventsAsync()).GetValue());
+        Assert.Equal(0, publisher.PlannedPublishCalls);
+        Assert.Equal(0, publisher.LegacyPublishCalls);
+    }
+
+    [Theory]
+    [InlineData("ordinary", "resolver")]
+    [InlineData("ordinary", "context")]
+    [InlineData("ordinary", "encoder")]
+    [InlineData("serialized", "resolver")]
+    [InlineData("serialized", "context")]
+    [InlineData("serialized", "encoder")]
+    [InlineData("conditional", "resolver")]
+    [InlineData("conditional", "context")]
+    [InlineData("conditional", "encoder")]
+    public async Task ProductionExecutor_NonStrictCapabilityFailuresUseLegacyForEveryRoute(
+        string route,
+        string failureKind)
+    {
+        var domain = DomainType.GetDomainTypes();
+        var publisher = new FailureModeDestinationPublisher(failureKind);
+        IEventStore store = route == "conditional"
+            ? new InMemoryConditionalEventStore(domain.EventTypes)
+            : new InMemoryEventStore(domain.EventTypes);
+        var executor = CreateDestinationExecutor(
+            domain,
+            store,
+            ExecutorSizeStrictness.NonStrict,
+            publisher,
+            new FailureModeMeasurement(failureKind));
+
+        var result = await ExecuteFailureRouteAsync(route, executor, domain);
+
+        Assert.True(result.IsSuccess, result.Exception?.ToString());
+        Assert.Single(result.Diagnostics);
+        Assert.Single((await store.ReadAllSerializableEventsAsync()).GetValue());
+        Assert.Equal(0, publisher.PlannedPublishCalls);
+        Assert.Equal(1, publisher.LegacyPublishCalls);
+    }
+
+    [Fact]
+    public void ProductionCapture_RejectsMissingAndUnsupportedKeyedOrUnkeyedAdapters()
+    {
+        var serialized = CreateSerializableEvent(10);
+        var configurations = new[]
+        {
+            (Services: new ServiceCollection(), Expected: "no keyed or unkeyed"),
+            (Services: new ServiceCollection().AddSingleton<IQueueDataAdapter<string, IBatchContainer>>(new NoOpQueueDataAdapter()), Expected: "AzureQueueDataAdapterV2"),
+            (Services: new ServiceCollection().AddKeyedSingleton<IQueueDataAdapter<string, IBatchContainer>>(
+                "EventStreamProvider", new NoOpQueueDataAdapter()), Expected: "AzureQueueDataAdapterV2")
+        };
+
+        foreach (var configuration in configurations)
+        {
+            using var provider = configuration.Services.BuildServiceProvider();
+            var capture = new OrleansAzureQueueDestinationMeasurementCapture(provider, "EventStreamProvider");
+            var state = capture.Capture(
+                "EventStreamProvider",
+                "AllEvents",
+                serialized.Id,
+                serialized,
+                null,
+                out var failure);
+
+            Assert.Null(state);
+            Assert.NotNull(failure);
+            Assert.Contains(configuration.Expected, failure, StringComparison.Ordinal);
+        }
+    }
+
+    [Fact]
+    public void ProductionCapture_IgnoresNamedNoneAsEncodingProof()
+    {
+        using var services = BuildAzureQueueServices();
+        var adapter = services.GetRequiredKeyedService<IQueueDataAdapter<string, IBatchContainer>>("EventStreamProvider");
+        var serialized = CreateSerializableEvent(256);
+        var capture = new OrleansAzureQueueDestinationMeasurementCapture(services, "EventStreamProvider");
+
+        var state = capture.Capture(
+            "EventStreamProvider",
+            "AllEvents",
+            serialized.Id,
+            serialized,
+            null,
+            out var failure);
+
+        Assert.Null(failure);
+        Assert.NotNull(state);
+        var key = $"EventStreamProvider|AllEvents|{serialized.Id:D}";
+        var planState = new OrleansDestinationPlanState(
+            key,
+            "EventStreamProvider",
+            "AllEvents",
+            serialized.Id,
+            state,
+            null,
+            null);
+        var plan = new ExecutorSizeDestinationPlan("service", [key], new[] { planState })
+        {
+            PreparedEvent = serialized
+        };
+        var result = new OrleansAzureQueueStreamMessageSizeMeasurement("EventStreamProvider").Measure(
+            new ExecutorSizeMeasurementContext(
+                OrleansAzureQueueStreamMessageSizeMeasurement.Scope,
+                ExecutorSizeRepresentation.Destination,
+                CreateEvent(serialized),
+                serialized,
+                "service",
+                key,
+                plan));
+
+        var measured = Encoding.UTF8.GetByteCount(adapter.ToQueueMessage(
+            StreamId.Create("AllEvents", serialized.Id),
+            new[] { serialized },
+            null,
+            null));
+        Assert.Equal(measured, result.MeasuredRepresentationBytes);
+        Assert.Equal(4L * ((measured + 2L) / 3L), result.CertifiedUpperBoundBytes);
     }
 
     [Fact]
@@ -207,8 +508,7 @@ public sealed class AzureQueueSizeGateTests
             adapter,
             serialized,
             StreamId.Create("AllEvents", streamIdGuid),
-            streamIdGuid,
-            QueueMessageEncoding.None);
+            streamIdGuid);
 
         Assert.True(result.IsAvailable);
         Assert.NotNull(result.MeasuredRepresentationBytes);
@@ -227,8 +527,7 @@ public sealed class AzureQueueSizeGateTests
                 services.GetRequiredService<Serializer>()),
             StreamId.Create("AllEvents", serialized.Id),
             serialized,
-            new Dictionary<string, object> { ["trace"] = "value" },
-            QueueMessageEncoding.None);
+            new Dictionary<string, object> { ["trace"] = "value" });
         var destinationState = new OrleansDestinationPlanState(
             "EventStreamProvider|AllEvents|" + serialized.Id.ToString("D"),
             "EventStreamProvider",
@@ -284,15 +583,360 @@ public sealed class AzureQueueSizeGateTests
         Assert.Null(result.ComparableBytes);
     }
 
+    private static ServiceProvider BuildAzureQueueServices()
+    {
+        var services = new ServiceCollection()
+            .AddSerializer();
+        services.Configure<AzureQueueOptions>("EventStreamProvider", options =>
+            options.ClientOptions.MessageEncoding = QueueMessageEncoding.None);
+        services.AddKeyedSingleton<IQueueDataAdapter<string, IBatchContainer>>(
+            "EventStreamProvider",
+            (serviceProvider, _) => new global::Orleans.Providers.Streams.AzureQueue.AzureQueueDataAdapterV2(
+                serviceProvider.GetRequiredService<Serializer>()));
+        return services.BuildServiceProvider();
+    }
+
+    private static SerializableEventCandidate FindCandidateWithAdapterTextBytes(
+        IQueueDataAdapter<string, IBatchContainer> adapter,
+        DcbDomainTypes domain,
+        int targetBytes)
+    {
+        var low = 0;
+        var high = 200_000;
+        while (NormalizedAdapterTextBytes(adapter, domain, CreateSerializableEvent(domain, high)) < targetBytes)
+        {
+            high *= 2;
+        }
+
+        while (low <= high)
+        {
+            var candidateLength = low + ((high - low) / 2);
+            var candidate = CreateSerializableEvent(domain, candidateLength);
+            var actual = NormalizedAdapterTextBytes(adapter, domain, candidate);
+            if (actual == targetBytes)
+            {
+                return new SerializableEventCandidate(
+                    candidate.Payload,
+                    candidate.EventPayloadName,
+                    candidate.Tags);
+            }
+
+            if (actual < targetBytes)
+                low = candidateLength + 1;
+            else
+                high = candidateLength - 1;
+        }
+
+        throw new Xunit.Sdk.XunitException($"Could not create an adapter message of exactly {targetBytes} bytes.");
+    }
+
+    private static int NormalizedAdapterTextBytes(
+        IQueueDataAdapter<string, IBatchContainer> adapter,
+        DcbDomainTypes domain,
+        SerializableEvent serialized)
+    {
+        var eventResult = serialized.ToEvent(domain.EventTypes);
+        Assert.True(eventResult.IsSuccess, eventResult.IsSuccess ? null : eventResult.GetException().ToString());
+        var normalized = eventResult.GetValue().ToSerializableEvent(domain.EventTypes);
+        return AdapterTextBytes(adapter, StreamId.Create("AllEvents", Guid.Empty), normalized);
+    }
+
+    private static SerializableEvent CreateSerializableEvent(DcbDomainTypes domain, int summaryLength)
+    {
+        var id = Guid.Parse("00000000-0000-0000-0000-000000000010");
+        var payload = new WeatherForecastCreated(
+            id,
+            "Tokyo",
+            new DateOnly(2026, 9, 12),
+            21,
+            new string('A', summaryLength));
+        return new SerializableEvent(
+            Encoding.UTF8.GetBytes(domain.EventTypes.SerializeEventPayload(payload)),
+            "000000000000000000100000000001",
+            Guid.Empty,
+            new EventMetadata(Guid.Empty.ToString(), "SerializedCommit", "SerializedSekibanExecutor"),
+            [$"WeatherForecast:{id:D}"],
+            nameof(WeatherForecastCreated));
+    }
+
+    private static GeneralSekibanExecutor CreateDestinationExecutor(
+        DcbDomainTypes domain,
+        IEventStore store,
+        ExecutorSizeStrictness strictness,
+        IEventPublisher publisher,
+        IExecutorSizeMeasurement? measurement = null) =>
+        new(
+            store,
+            new InMemoryObjectAccessor(store, domain),
+            domain,
+            new ExecutorSizeGateOptions().Add(new ExecutorSizePolicy(
+                OrleansAzureQueueStreamMessageSizeMeasurement.Scope,
+                ExecutorSizeRepresentation.Destination,
+                maxBytesPerEvent: 65_536,
+                strictness: strictness,
+                measurement: measurement ?? new DelegateMeasurement(_ => ExecutorSizeMeasurementResult.Exact(10)))),
+            publisher);
+
+    private static async Task<FailureRouteResult> ExecuteFailureRouteAsync(
+        string route,
+        GeneralSekibanExecutor executor,
+        DcbDomainTypes domain)
+    {
+        if (route == "ordinary")
+        {
+            var ordinary = await executor.ExecuteAsync(new CreateWeatherForecast
+            {
+                ForecastId = Guid.NewGuid(),
+                Location = "Tokyo",
+                Date = new DateOnly(2026, 9, 12),
+                TemperatureC = 21
+            });
+            return new FailureRouteResult(
+                ordinary.IsSuccess,
+                ordinary.IsSuccess ? ReadOrdinaryDiagnostics(ordinary.GetValue().Metadata) : [],
+                ordinary.IsSuccess ? null : ordinary.GetException());
+        }
+
+        var id = Guid.NewGuid();
+        if (route == "serialized")
+        {
+            var serialized = await executor.CommitSerializableEventsAsync(
+                new SerializedCommitRequest(
+                    [CreateCandidate(domain, id)],
+                    [new ConsistencyTagEntry($"WeatherForecast:{id}", "")]));
+            return new FailureRouteResult(
+                serialized.IsSuccess,
+                serialized.IsSuccess ? serialized.GetValue().SizeGateDiagnostics : [],
+                serialized.IsSuccess ? null : serialized.GetException());
+        }
+
+        if (route == "conditional")
+        {
+            var conditional = await ((ISerializedConditionalSekibanDcbExecutor)executor)
+                .CommitSerializableEventConditionallyAsync(
+                    new SerializedConditionalCommitRequest(
+                        SerializedConditionalCommitRequest.CurrentVersion,
+                        CreateCandidate(domain, id),
+                        $"g76-failure-{id:N}"));
+            return new FailureRouteResult(
+                conditional.IsSuccess,
+                conditional.IsSuccess ? conditional.GetValue().SizeGateDiagnostics : [],
+                conditional.IsSuccess ? null : conditional.GetException());
+        }
+
+        throw new ArgumentOutOfRangeException(nameof(route), route, "Unknown failure-test route.");
+    }
+
+    private static IReadOnlyList<ExecutorSizeDiagnostic> ReadOrdinaryDiagnostics(
+        IReadOnlyDictionary<string, object>? metadata) =>
+        metadata is not null &&
+        metadata.TryGetValue("SizeGateDiagnostics", out var value) &&
+        value is IReadOnlyList<ExecutorSizeDiagnostic> diagnostics
+            ? diagnostics
+            : [];
+
+    private static SerializableEventCandidate CreateCandidate(DcbDomainTypes domain, Guid id)
+    {
+        var payload = new WeatherForecastCreated(
+            id,
+            "Tokyo",
+            new DateOnly(2026, 9, 12),
+            21,
+            "G76 capture test");
+        return new SerializableEventCandidate(
+            Encoding.UTF8.GetBytes(domain.EventTypes.SerializeEventPayload(payload)),
+            nameof(WeatherForecastCreated),
+            [$"WeatherForecast:{id}"]);
+    }
+
+    private sealed class CapturingDestinationPublisher(
+        DcbDomainTypes domain,
+        OrleansAzureQueueDestinationMeasurementCapture capture)
+        : IEventPublisher, IExecutorSizeDestinationPublisher
+    {
+        public int PlannedPublishCalls { get; private set; }
+        public int LegacyPublishCalls { get; private set; }
+        public long? LastMeasuredBytes { get; private set; }
+        public long? LastCertifiedBytes { get; private set; }
+
+        public ExecutorSizeDestinationPlan? CaptureDestinationPlan(
+            Event @event,
+            IReadOnlyCollection<ITag> tags,
+            string serviceId)
+        {
+            var serialized = @event.ToSerializableEvent(domain.EventTypes);
+            var key = "EventStreamProvider|AllEvents|00000000-0000-0000-0000-000000000000";
+            var state = capture.Capture(
+                "EventStreamProvider",
+                "AllEvents",
+                Guid.Empty,
+                serialized,
+                null,
+                out var failure);
+            var destinationState = new OrleansDestinationPlanState(
+                key,
+                "EventStreamProvider",
+                "AllEvents",
+                Guid.Empty,
+                state,
+                null,
+                failure);
+            var plan = new ExecutorSizeDestinationPlan(serviceId, [key], new[] { destinationState })
+            {
+                PreparedEvent = serialized
+            };
+            var measured = new OrleansAzureQueueStreamMessageSizeMeasurement("EventStreamProvider").Measure(
+                new ExecutorSizeMeasurementContext(
+                    OrleansAzureQueueStreamMessageSizeMeasurement.Scope,
+                    ExecutorSizeRepresentation.Destination,
+                    @event,
+                    serialized,
+                    serviceId,
+                    key,
+                    plan));
+            LastMeasuredBytes = measured.MeasuredRepresentationBytes;
+            LastCertifiedBytes = measured.CertifiedUpperBoundBytes;
+            return plan;
+        }
+
+        public Task PublishAsync(
+            IReadOnlyCollection<(Event Event, IReadOnlyCollection<ITag> Tags)> events,
+            CancellationToken cancellationToken = default)
+        {
+            LegacyPublishCalls++;
+            return Task.CompletedTask;
+        }
+
+        public Task PublishAsync(
+            IReadOnlyCollection<(Event Event, IReadOnlyCollection<ITag> Tags)> events,
+            IReadOnlyDictionary<Guid, ExecutorSizeDestinationPlan> destinationPlans,
+            CancellationToken cancellationToken = default)
+        {
+            PlannedPublishCalls++;
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class FailingDestinationPublisher(int failOnCapture) : IEventPublisher, IExecutorSizeDestinationPublisher
+    {
+        public int CaptureCalls { get; private set; }
+        public int PlannedPublishCalls { get; private set; }
+        public int LegacyPublishCalls { get; private set; }
+        public int LastLegacyEventCount { get; private set; }
+
+        public ExecutorSizeDestinationPlan? CaptureDestinationPlan(
+            Event @event,
+            IReadOnlyCollection<ITag> tags,
+            string serviceId)
+        {
+            CaptureCalls++;
+            return CaptureCalls == failOnCapture
+                ? null
+                : new ExecutorSizeDestinationPlan(serviceId, ["EventStreamProvider|AllEvents|g76"], new object());
+        }
+
+        public Task PublishAsync(
+            IReadOnlyCollection<(Event Event, IReadOnlyCollection<ITag> Tags)> events,
+            CancellationToken cancellationToken = default)
+        {
+            LegacyPublishCalls++;
+            LastLegacyEventCount = events.Count;
+            return Task.CompletedTask;
+        }
+
+        public Task PublishAsync(
+            IReadOnlyCollection<(Event Event, IReadOnlyCollection<ITag> Tags)> events,
+            IReadOnlyDictionary<Guid, ExecutorSizeDestinationPlan> destinationPlans,
+            CancellationToken cancellationToken = default)
+        {
+            PlannedPublishCalls++;
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed record FailureRouteResult(
+        bool IsSuccess,
+        IReadOnlyList<ExecutorSizeDiagnostic> Diagnostics,
+        Exception? Exception);
+
+    private sealed class FailureModeDestinationPublisher(string failureKind)
+        : IEventPublisher, IExecutorSizeDestinationPublisher
+    {
+        public int PlannedPublishCalls { get; private set; }
+        public int LegacyPublishCalls { get; private set; }
+
+        public ExecutorSizeDestinationPlan? CaptureDestinationPlan(
+            Event @event,
+            IReadOnlyCollection<ITag> tags,
+            string serviceId)
+        {
+            if (failureKind == "resolver")
+                throw new InvalidOperationException("deterministic resolver failure");
+
+            return new ExecutorSizeDestinationPlan(
+                serviceId,
+                ["EventStreamProvider|AllEvents|g76-failure"],
+                failureKind == "context" ? new object() : null);
+        }
+
+        public Task PublishAsync(
+            IReadOnlyCollection<(Event Event, IReadOnlyCollection<ITag> Tags)> events,
+            CancellationToken cancellationToken = default)
+        {
+            LegacyPublishCalls++;
+            return Task.CompletedTask;
+        }
+
+        public Task PublishAsync(
+            IReadOnlyCollection<(Event Event, IReadOnlyCollection<ITag> Tags)> events,
+            IReadOnlyDictionary<Guid, ExecutorSizeDestinationPlan> destinationPlans,
+            CancellationToken cancellationToken = default)
+        {
+            PlannedPublishCalls++;
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class FailureModeMeasurement(string failureKind) : IExecutorSizeMeasurement
+    {
+        public ExecutorSizeMeasurementResult Measure(ExecutorSizeMeasurementContext context)
+        {
+            if (failureKind == "context")
+                return ExecutorSizeMeasurementResult.Unavailable("request-context capture failed");
+
+            if (failureKind == "encoder")
+                throw new FormatException("deterministic encoder failure");
+
+            return ExecutorSizeMeasurementResult.Exact(10);
+        }
+    }
+
+    private sealed class DelegateMeasurement(
+        Func<ExecutorSizeMeasurementContext, ExecutorSizeMeasurementResult> measure) : IExecutorSizeMeasurement
+    {
+        public ExecutorSizeMeasurementResult Measure(ExecutorSizeMeasurementContext context) => measure(context);
+    }
+
+    private sealed class NoOpQueueDataAdapter : IQueueDataAdapter<string, IBatchContainer>
+    {
+        public string ToQueueMessage<T>(
+            StreamId streamId,
+            IEnumerable<T> events,
+            StreamSequenceToken? token,
+            Dictionary<string, object>? requestContext) => string.Empty;
+
+        public IBatchContainer FromQueueMessage(string queueMessage, long sequenceId) =>
+            throw new NotSupportedException();
+    }
+
     private static ExecutorSizeMeasurementResult Measure(
         global::Orleans.Streams.IQueueDataAdapter<string, global::Orleans.Streams.IBatchContainer> adapter,
         SerializableEvent serialized,
         StreamId streamId,
-        Guid streamIdGuid,
-        Azure.Storage.Queues.QueueMessageEncoding encoding)
+        Guid streamIdGuid)
     {
         var key = $"EventStreamProvider|AllEvents|{streamIdGuid:D}";
-        var state = new AzureQueueDestinationMeasurementState(adapter, streamId, serialized, null, encoding);
+        var state = new AzureQueueDestinationMeasurementState(adapter, streamId, serialized, null);
         var destinationState = new OrleansDestinationPlanState(
             key,
             "EventStreamProvider",

--- a/dcb/tests/Sekiban.Dcb.Orleans.Tests/Sekiban.Dcb.Orleans.Tests.csproj
+++ b/dcb/tests/Sekiban.Dcb.Orleans.Tests/Sekiban.Dcb.Orleans.Tests.csproj
@@ -31,6 +31,7 @@
 
     <ItemGroup>
         <ProjectReference Include="..\..\src\Sekiban.Dcb.Orleans.WithResult\Sekiban.Dcb.Orleans.WithResult.csproj"/>
+        <ProjectReference Include="..\..\src\Sekiban.Dcb.Orleans.AzureQueue\Sekiban.Dcb.Orleans.AzureQueue.csproj"/>
         <ProjectReference Include="..\..\src\Sekiban.Dcb.Orleans.WithoutResult\Sekiban.Dcb.Orleans.WithoutResult.csproj" Aliases="WithoutResultFacade" />
         <ProjectReference Include="..\..\src\Sekiban.Dcb.WithoutResult\Sekiban.Dcb.WithoutResult.csproj" Aliases="WithoutResultFacade" />
         <ProjectReference Include="..\..\src\Sekiban.Dcb.WithoutResult.Model\Sekiban.Dcb.WithoutResult.Model.csproj" Aliases="WithoutResultFacade" />

--- a/dcb/tests/Sekiban.Dcb.Orleans.Tests/SimpleOrleansCommandQueryTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Orleans.Tests/SimpleOrleansCommandQueryTests.cs
@@ -23,6 +23,7 @@ using Sekiban.Dcb.Tags;
 using Sekiban.Dcb.SizeGates;
 using Sekiban.Dcb.Common;
 using Sekiban.Dcb.Testing;
+using System.Text;
 using System.Text.Json;
 using Xunit;
 namespace Sekiban.Dcb.Orleans.Tests;
@@ -343,17 +344,99 @@ public class SimpleOrleansCommandQueryTests : IAsyncLifetime
             new EventMetadata(Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), "test"),
             []);
 
+        var planned = new TaskCompletionSource<(
+            SerializableEvent Event,
+            string Provider,
+            string Namespace,
+            Guid StreamId,
+            IReadOnlyDictionary<string, object>? Context)>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        publisher.PlannedPublishObserver = (serializable, providerName, streamNamespace, destinationId, context) =>
+            planned.TrySetResult((serializable, providerName, streamNamespace, destinationId, context));
+
         RequestContext.Set("g76-context", "retry-context");
-        await publisher.PublishAsync(new[] { (@event, (IReadOnlyCollection<ITag>)[]) });
+        var plan = publisher.CaptureDestinationPlan(@event, [], "default");
+        Assert.NotNull(plan);
+        var destination = Assert.Single((IReadOnlyList<OrleansDestinationPlanState>)plan.ProviderState!);
+        var capturedEvent = plan.PreparedEvent;
+        Assert.NotNull(capturedEvent);
+        var capturedContext = destination.RequestContext;
+        Assert.NotNull(capturedContext);
+
+        RequestContext.Set("g76-context", "caller-sentinel");
+        await ((IExecutorSizeDestinationPublisher)publisher).PublishAsync(
+            new[] { (@event, (IReadOnlyCollection<ITag>)[]) },
+            new Dictionary<Guid, ExecutorSizeDestinationPlan> { [@event.Id] = plan });
 
         var observed = await received.Task.WaitAsync(TimeSpan.FromSeconds(10));
+        var plannedObservation = await planned.Task.WaitAsync(TimeSpan.FromSeconds(10));
+        Assert.Same(capturedEvent, plannedObservation.Event);
+        Assert.Equal(destination.ProviderName, plannedObservation.Provider);
+        Assert.Equal(destination.StreamNamespace, plannedObservation.Namespace);
+        Assert.Equal(destination.StreamId, plannedObservation.StreamId);
+        Assert.NotSame(capturedContext, plannedObservation.Context);
+        Assert.Equal("retry-context", plannedObservation.Context!["g76-context"]);
         Assert.Equal(@event.Id, observed.Event.Id);
         Assert.Equal(@event.SortableUniqueIdValue, observed.Event.SortableUniqueIdValue);
         Assert.Equal("retry-context", observed.Context);
-        Assert.Equal("retry-context", RequestContext.Get("g76-context"));
+        Assert.Equal("caller-sentinel", RequestContext.Get("g76-context"));
         Assert.True(attempts >= 2, $"Expected a retry after the forced first delivery failure, observed {attempts} attempt(s).");
 
         await subscription.UnsubscribeAsync();
+    }
+
+    [Fact]
+    public async Task OrleansExecutor_UsesPreparedEventForCaptureAndPlannedSend()
+    {
+        await EnsureInitializedAsync();
+
+        var capture = Assert.Single(
+            _cluster.Client.ServiceProvider
+                .GetServices<IOrleansDestinationMeasurementCapture>()
+                .OfType<RecordingDestinationMeasurementCapture>());
+        capture.Reset();
+        var planned = new TaskCompletionSource<SerializableEvent>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var streamId = Guid.NewGuid();
+        var publisher = new OrleansEventPublisher(
+            _cluster.Client,
+            new DefaultOrleansStreamDestinationResolver("EventStreamProvider", "G76Prepared", streamId),
+            _domainTypes,
+            new NullLogger<OrleansEventPublisher>());
+        publisher.PlannedPublishObserver = (serializable, _, _, _, _) => planned.TrySetResult(serializable);
+
+        var executor = new OrleansDcbExecutor(
+            _client,
+            _eventStore,
+            _domainTypes,
+            new ExecutorSizeGateOptions().Add(new ExecutorSizePolicy(
+                OrleansAzureQueueStreamMessageSizeMeasurement.Scope,
+                ExecutorSizeRepresentation.Destination,
+                maxBytesPerEvent: 65_536,
+                strictness: ExecutorSizeStrictness.Strict,
+                measurement: new OrleansAzureQueueStreamMessageSizeMeasurement("EventStreamProvider"))),
+            publisher);
+        var id = Guid.NewGuid();
+        var payload = new TestEntityCreatedEvent { AggregateId = id, Name = "Prepared" };
+        var candidate = new SerializableEventCandidate(
+            Encoding.UTF8.GetBytes(_domainTypes.EventTypes.SerializeEventPayload(payload)),
+            nameof(TestEntityCreatedEvent),
+            []);
+
+        RequestContext.Set("g76-context", "prepared-context");
+        var result = await executor.CommitSerializableEventsAsync(
+            new SerializedCommitRequest([candidate], []));
+
+        Assert.True(result.IsSuccess, result.IsSuccess ? null : result.GetException().ToString());
+        var captured = Assert.Single(capture.CapturedEvents);
+        var sent = await planned.Task.WaitAsync(TimeSpan.FromSeconds(10));
+        Assert.Same(captured, sent);
+        Assert.Equal(candidate.EventPayloadName, sent.EventPayloadName);
+        Assert.Equal(candidate.Payload, sent.Payload);
+        var capturedContext = Assert.Single(capture.CapturedContexts);
+        Assert.NotNull(capturedContext);
+        Assert.Equal("prepared-context", capturedContext["g76-context"]);
+        Assert.Equal("prepared-context", RequestContext.Get("g76-context"));
     }
 
     [Fact]
@@ -672,8 +755,46 @@ public class SimpleOrleansCommandQueryTests : IAsyncLifetime
                         (serviceProvider, _) => new AzureQueueDataAdapterV2(
                             serviceProvider.GetRequiredService<Serializer>()));
                     services.AddSingleton<IOrleansDestinationMeasurementCapture>(serviceProvider =>
-                        new OrleansAzureQueueDestinationMeasurementCapture(serviceProvider, "EventStreamProvider"));
+                        new RecordingDestinationMeasurementCapture(serviceProvider, "EventStreamProvider"));
                 });
+        }
+    }
+
+    private sealed class RecordingDestinationMeasurementCapture(
+        IServiceProvider services,
+        string streamProviderName) : IOrleansDestinationMeasurementCapture
+    {
+        private readonly OrleansAzureQueueDestinationMeasurementCapture _inner =
+            new(services, streamProviderName);
+
+        public List<SerializableEvent> CapturedEvents { get; } = [];
+        public List<IReadOnlyDictionary<string, object>?> CapturedContexts { get; } = [];
+
+        public void Reset()
+        {
+            CapturedEvents.Clear();
+            CapturedContexts.Clear();
+        }
+
+        public bool Matches(string providerName) => _inner.Matches(providerName);
+
+        public object? Capture(
+            string providerName,
+            string streamNamespace,
+            Guid streamId,
+            SerializableEvent serializedEvent,
+            IReadOnlyDictionary<string, object>? requestContext,
+            out string? failureReason)
+        {
+            CapturedEvents.Add(serializedEvent);
+            CapturedContexts.Add(requestContext);
+            return _inner.Capture(
+                providerName,
+                streamNamespace,
+                streamId,
+                serializedEvent,
+                requestContext,
+                out failureReason);
         }
     }
 

--- a/dcb/tests/Sekiban.Dcb.Orleans.Tests/SimpleOrleansCommandQueryTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Orleans.Tests/SimpleOrleansCommandQueryTests.cs
@@ -1,6 +1,9 @@
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
+using Orleans;
+using Orleans.Providers.Streams.AzureQueue;
+using Orleans.Serialization;
 using Orleans.Streams;
 using Orleans.TestingHost;
 using ResultBoxes;
@@ -13,9 +16,11 @@ using Sekiban.Dcb.MultiProjections;
 using Sekiban.Dcb.Orleans;
 using Sekiban.Dcb.Orleans.Grains;
 using Sekiban.Dcb.Orleans.Streams;
+using Sekiban.Dcb.Orleans.AzureQueue;
 using Sekiban.Dcb.Queries;
 using Sekiban.Dcb.Storage;
 using Sekiban.Dcb.Tags;
+using Sekiban.Dcb.SizeGates;
 using Sekiban.Dcb.Common;
 using Sekiban.Dcb.Testing;
 using System.Text.Json;
@@ -248,6 +253,107 @@ public class SimpleOrleansCommandQueryTests : IAsyncLifetime
 
         // Cleanup
         await subscriptionHandle.UnsubscribeAsync();
+    }
+
+    [Fact]
+    public async Task OrleansPublisher_CapturesAzureState_SendsIdentity_AndRestoresRequestContext()
+    {
+        await EnsureInitializedAsync();
+
+        var provider = _cluster.Client.GetStreamProvider("EventStreamProvider");
+        var streamId = Guid.NewGuid();
+        var stream = provider.GetStream<SerializableEvent>(StreamId.Create("G76Publisher", streamId));
+        var received = new TaskCompletionSource<(SerializableEvent Event, object? Context)>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var subscription = await stream.SubscribeAsync((serializable, _) =>
+        {
+            received.TrySetResult((serializable, RequestContext.Get("g76-context")));
+            return Task.CompletedTask;
+        });
+
+        var resolver = new DefaultOrleansStreamDestinationResolver("EventStreamProvider", "G76Publisher", streamId);
+        var publisher = new OrleansEventPublisher(
+            _cluster.Client,
+            resolver,
+            _domainTypes,
+            new NullLogger<OrleansEventPublisher>());
+        var payload = new TestEntityCreatedEvent { AggregateId = Guid.NewGuid(), Name = "Captured" };
+        var @event = new Event(
+            payload,
+            SortableUniqueId.GenerateNew(),
+            nameof(TestEntityCreatedEvent),
+            Guid.NewGuid(),
+            new EventMetadata(Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), "test"),
+            []);
+
+        RequestContext.Set("g76-context", "captured");
+        var plan = publisher.CaptureDestinationPlan(@event, [], "default");
+        Assert.NotNull(plan);
+        Assert.Equal(@event.Id, plan.PreparedEvent!.Id);
+        var destination = Assert.Single((IReadOnlyList<OrleansDestinationPlanState>)plan.ProviderState!);
+        Assert.IsType<AzureQueueDestinationMeasurementState>(destination.MeasurementState);
+        Assert.Null(destination.FailureReason);
+
+        RequestContext.Set("g76-context", "after");
+        await ((IExecutorSizeDestinationPublisher)publisher).PublishAsync(
+            new[] { (@event, (IReadOnlyCollection<ITag>)[]) },
+            new Dictionary<Guid, ExecutorSizeDestinationPlan> { [@event.Id] = plan });
+
+        var observed = await received.Task.WaitAsync(TimeSpan.FromSeconds(10));
+        Assert.Equal(@event.Id, observed.Event.Id);
+        Assert.Equal(@event.SortableUniqueIdValue, observed.Event.SortableUniqueIdValue);
+        Assert.Equal("captured", observed.Context);
+        Assert.Equal("after", RequestContext.Get("g76-context"));
+
+        await subscription.UnsubscribeAsync();
+    }
+
+    [Fact]
+    public async Task OrleansPublisher_RetryRetainsCapturedIdentityAndContext()
+    {
+        await EnsureInitializedAsync();
+
+        var provider = _cluster.Client.GetStreamProvider("EventStreamProvider");
+        var streamId = Guid.NewGuid();
+        var stream = provider.GetStream<SerializableEvent>(StreamId.Create("G76PublisherRetry", streamId));
+        var attempts = 0;
+        var received = new TaskCompletionSource<(SerializableEvent Event, object? Context)>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var subscription = await stream.SubscribeAsync((serializable, _) =>
+        {
+            if (Interlocked.Increment(ref attempts) == 1)
+                throw new InvalidOperationException("deterministic first delivery failure");
+
+            received.TrySetResult((serializable, RequestContext.Get("g76-context")));
+            return Task.CompletedTask;
+        });
+
+        var resolver = new DefaultOrleansStreamDestinationResolver("EventStreamProvider", "G76PublisherRetry", streamId);
+        var publisher = new OrleansEventPublisher(
+            _cluster.Client,
+            resolver,
+            _domainTypes,
+            new NullLogger<OrleansEventPublisher>());
+        var payload = new TestEntityCreatedEvent { AggregateId = Guid.NewGuid(), Name = "Retry" };
+        var @event = new Event(
+            payload,
+            SortableUniqueId.GenerateNew(),
+            nameof(TestEntityCreatedEvent),
+            Guid.NewGuid(),
+            new EventMetadata(Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), "test"),
+            []);
+
+        RequestContext.Set("g76-context", "retry-context");
+        await publisher.PublishAsync(new[] { (@event, (IReadOnlyCollection<ITag>)[]) });
+
+        var observed = await received.Task.WaitAsync(TimeSpan.FromSeconds(10));
+        Assert.Equal(@event.Id, observed.Event.Id);
+        Assert.Equal(@event.SortableUniqueIdValue, observed.Event.SortableUniqueIdValue);
+        Assert.Equal("retry-context", observed.Context);
+        Assert.Equal("retry-context", RequestContext.Get("g76-context"));
+        Assert.True(attempts >= 2, $"Expected a retry after the forced first delivery failure, observed {attempts} attempt(s).");
+
+        await subscription.UnsubscribeAsync();
     }
 
     [Fact]
@@ -556,7 +662,18 @@ public class SimpleOrleansCommandQueryTests : IAsyncLifetime
     {
         public void Configure(IConfiguration configuration, IClientBuilder clientBuilder)
         {
-            clientBuilder.AddMemoryStreams("EventStreamProvider");
+            clientBuilder
+                .AddMemoryStreams("EventStreamProvider")
+                .ConfigureServices(services =>
+                {
+                    services.AddSerializer();
+                    services.AddKeyedSingleton<IQueueDataAdapter<string, IBatchContainer>>(
+                        "EventStreamProvider",
+                        (serviceProvider, _) => new AzureQueueDataAdapterV2(
+                            serviceProvider.GetRequiredService<Serializer>()));
+                    services.AddSingleton<IOrleansDestinationMeasurementCapture>(serviceProvider =>
+                        new OrleansAzureQueueDestinationMeasurementCapture(serviceProvider, "EventStreamProvider"));
+                });
         }
     }
 

--- a/dcb/tests/Sekiban.Dcb.Orleans.Tests/run-packaged-consumer.sh
+++ b/dcb/tests/Sekiban.Dcb.Orleans.Tests/run-packaged-consumer.sh
@@ -94,6 +94,11 @@ if (provider.GetRequiredService<ExecutorSizeGateOptions>().Policies.Count != 1)
 
 Console.WriteLine("G76 Azure Queue package consumer passed.");
 EOF
+  if [[ "${SEKIBAN_G76_FORCE_CONSUMER_THROW:-0}" == "1" ]]; then
+    cat >> "$project/Program.cs" <<'EOF'
+throw new InvalidOperationException("deterministic packaged-consumer failure probe");
+EOF
+  fi
   dotnet restore "$project/consumer.csproj" --configfile "$config" --no-http-cache --nologo -p:NuGetAudit=false
   dotnet build "$project/consumer.csproj" -c Release --no-restore --nologo -p:NuGetAudit=false
   dotnet run --project "$project/consumer.csproj" -c Release --no-build --no-restore --nologo -p:NuGetAudit=false

--- a/dcb/tests/Sekiban.Dcb.Orleans.Tests/run-packaged-consumer.sh
+++ b/dcb/tests/Sekiban.Dcb.Orleans.Tests/run-packaged-consumer.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$script_dir/../../.." && pwd)"
+feed=""
+version=""
+
+while (( $# > 0 )); do
+  case "$1" in
+    --repo-root) repo_root="$(cd "$2" && pwd)"; shift 2 ;;
+    --feed) feed="$(cd "$2" && pwd)"; shift 2 ;;
+    --version) version="$2"; shift 2 ;;
+    *) echo "Usage: $0 --feed <directory> --version <version> [--repo-root <path>]" >&2; exit 2 ;;
+  esac
+done
+
+if [[ -z "$feed" || -z "$version" ]]; then
+  echo "--feed and --version are required" >&2
+  exit 2
+fi
+if [[ "$(git -C "$repo_root" rev-parse --show-toplevel)" != "$repo_root" ]]; then
+  echo "The supplied repo root is not a Git worktree: $repo_root" >&2
+  exit 1
+fi
+
+package="$feed/Sekiban.Dcb.Orleans.AzureQueue.$version.nupkg"
+[[ -f "$package" ]] || { echo "Missing package: $package" >&2; exit 1; }
+
+nuspec="$(unzip -p "$package" '*.nuspec')"
+for required in \
+  '<group targetFramework="net9.0">' \
+  '<group targetFramework="net10.0">' \
+  'id="Sekiban.Dcb.Core" version="'$version'"' \
+  'id="Sekiban.Dcb.Orleans.Core" version="'$version'"' \
+  'id="Azure.Storage.Queues" version="12.25.0"' \
+  'id="Microsoft.Orleans.Streaming.AzureStorage" version="10.3.1"'; do
+  grep -Fq "$required" <<<"$nuspec" || {
+    echo "Azure Queue package nuspec is missing: $required" >&2
+    exit 1
+  }
+done
+
+temp_root="$(mktemp -d "${TMPDIR:-/tmp}/sek-g76-azure-queue-consumer.XXXXXX")"
+trap 'rm -rf "$temp_root"' EXIT
+export DOTNET_CLI_HOME="$temp_root/dotnet-home"
+export NUGET_PACKAGES="$temp_root/nuget-packages"
+export NUGET_HTTP_CACHE_PATH="$temp_root/nuget-http-cache"
+mkdir -p "$DOTNET_CLI_HOME" "$NUGET_PACKAGES" "$NUGET_HTTP_CACHE_PATH"
+
+config="$temp_root/NuGet.Config"
+cat > "$config" <<EOF
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="g76-local" value="$feed" />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+  </packageSources>
+</configuration>
+EOF
+
+for tfm in net9.0 net10.0; do
+  project="$temp_root/consumer-$tfm"
+  mkdir -p "$project"
+  cat > "$project/consumer.csproj" <<EOF
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>$tfm</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Sekiban.Dcb.Orleans.AzureQueue" Version="$version" />
+  </ItemGroup>
+</Project>
+EOF
+  cat > "$project/Program.cs" <<'EOF'
+using Microsoft.Extensions.DependencyInjection;
+using Sekiban.Dcb.Orleans.AzureQueue;
+using Sekiban.Dcb.SizeGates;
+
+var options = new ExecutorSizeGateOptions()
+    .AddOrleansAzureQueueStreamMessagePolicy("EventStreamProvider");
+if (options.Policies.Count != 1)
+    throw new InvalidOperationException("Options API did not install one policy.");
+
+var services = new ServiceCollection();
+services.AddSekibanDcbOrleansAzureQueueStreamMessageSizeGate("EventStreamProvider");
+using var provider = services.BuildServiceProvider();
+if (provider.GetRequiredService<ExecutorSizeGateOptions>().Policies.Count != 1)
+    throw new InvalidOperationException("DI API did not install one policy.");
+
+Console.WriteLine("G76 Azure Queue package consumer passed.");
+EOF
+  dotnet restore "$project/consumer.csproj" --configfile "$config" --no-http-cache --nologo -p:NuGetAudit=false
+  dotnet build "$project/consumer.csproj" -c Release --no-restore --nologo -p:NuGetAudit=false
+  echo "Azure Queue packaged consumer passed for $tfm."
+done

--- a/dcb/tests/Sekiban.Dcb.Orleans.Tests/run-packaged-consumer.sh
+++ b/dcb/tests/Sekiban.Dcb.Orleans.Tests/run-packaged-consumer.sh
@@ -96,5 +96,6 @@ Console.WriteLine("G76 Azure Queue package consumer passed.");
 EOF
   dotnet restore "$project/consumer.csproj" --configfile "$config" --no-http-cache --nologo -p:NuGetAudit=false
   dotnet build "$project/consumer.csproj" -c Release --no-restore --nologo -p:NuGetAudit=false
+  dotnet run --project "$project/consumer.csproj" -c Release --no-build --no-restore --nologo -p:NuGetAudit=false
   echo "Azure Queue packaged consumer passed for $tfm."
 done

--- a/dcb/tests/Sekiban.Dcb.TemplateValidation/Program.cs
+++ b/dcb/tests/Sekiban.Dcb.TemplateValidation/Program.cs
@@ -424,6 +424,27 @@ internal static class Program
                storageJa.Contains("自動", StringComparison.Ordinal),
             "Japanese CAS non-default guidance is incomplete.");
 
+        var azureQueueGuidanceMarkers = new[]
+        {
+            "AddOrleansAzureQueueStreamMessagePolicy",
+            "AddSekibanDcbOrleansAzureQueueStreamMessageSizeGate",
+            "NonStrict",
+            "Strict",
+            "stream-message",
+            "Destination",
+            "49,152",
+            "65,536",
+            "49,156",
+            "65,544"
+        };
+        foreach (var marker in azureQueueGuidanceMarkers)
+        {
+            Assert(storageEn.Contains(marker, StringComparison.Ordinal),
+                $"English Azure Queue V2 guidance is missing '{marker}'.");
+            Assert(storageJa.Contains(marker, StringComparison.Ordinal),
+                $"Japanese Azure Queue V2 guidance is missing '{marker}'.");
+        }
+
         if (requireContributing)
         {
             var contributing = Path.Combine(repoRoot, "CONTRIBUTING.md");
@@ -506,11 +527,18 @@ internal static class Program
             "tests",
             "Sekiban.Dcb.TemplateValidation",
             "run-packaged-consumer.sh");
+        var azureQueueConsumerScript = Path.Combine(
+            repoRoot,
+            "dcb",
+            "tests",
+            "Sekiban.Dcb.Orleans.Tests",
+            "run-packaged-consumer.sh");
         Assert(File.Exists(validationWorkflow), "The DCB template validation workflow is missing.");
         Assert(File.Exists(dcbTestWorkflow), "The DCB test workflow is missing.");
         Assert(File.Exists(dcbPackageWorkflow), "The DCB package workflow is missing.");
         Assert(File.Exists(publishWorkflow), "The DCB template publish workflow is missing.");
         Assert(File.Exists(packagedConsumerScript), "The DCB packaged-consumer script is missing.");
+        Assert(File.Exists(azureQueueConsumerScript), "The Azure Queue packaged-consumer script is missing.");
         var validation = File.ReadAllText(validationWorkflow);
         var dcbTest = File.ReadAllText(dcbTestWorkflow);
         var dcbPackage = File.ReadAllText(dcbPackageWorkflow);
@@ -527,6 +555,34 @@ internal static class Program
                 "dotnet pack dcb/src/Sekiban.Dcb.Orleans.AzureQueue/Sekiban.Dcb.Orleans.AzureQueue.csproj",
                 StringComparison.Ordinal),
             "The DCB package workflow must pack the Azure Queue V2 size-gate package.");
+        Assert(dcbPackage.Contains(
+                "dcb/tests/Sekiban.Dcb.Orleans.Tests/run-packaged-consumer.sh",
+                StringComparison.Ordinal),
+            "The DCB package workflow must run the isolated Azure Queue packaged consumer.");
+
+        var effectivePackableProjects = Directory.EnumerateFiles(
+                Path.Combine(repoRoot, "dcb", "src"),
+                "*.csproj",
+                SearchOption.AllDirectories)
+            .Where(IsEffectivelyPackable)
+            .Select(path => ToRepoPath(repoRoot, path))
+            .OrderBy(path => path, StringComparer.Ordinal)
+            .ToArray();
+        var manifestProjects = Regex.Matches(
+                dcbPackage,
+                @"dotnet\s+pack\s+(?<project>dcb/src/[^\s""']+\.csproj)",
+                RegexOptions.CultureInvariant,
+                RegexTimeout)
+            .Cast<Match>()
+            .Select(match => match.Groups["project"].Value.Replace('\\', '/'))
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(path => path, StringComparer.Ordinal)
+            .ToArray();
+        Assert(
+            effectivePackableProjects.SequenceEqual(manifestProjects, StringComparer.Ordinal),
+            $"The DCB package manifest must exactly match effective packable dcb/src projects. " +
+            $"Missing: {string.Join(", ", effectivePackableProjects.Except(manifestProjects, StringComparer.Ordinal))}; " +
+            $"Unexpected: {string.Join(", ", manifestProjects.Except(effectivePackableProjects, StringComparer.Ordinal))}.");
 
         foreach (var required in new[]
                  {
@@ -575,6 +631,20 @@ internal static class Program
                sourceStage < docsCurrencyStage && docsCurrencyStage < packageBoundary,
             "The packaged-consumer source phase must run the docs-currency stage after source validation and before packing.");
     }
+
+    private static bool IsEffectivelyPackable(string projectPath)
+    {
+        var document = XDocument.Load(projectPath);
+        var values = document
+            .Descendants()
+            .Where(element => element.Name.LocalName == "IsPackable")
+            .Select(element => element.Value.Trim())
+            .ToArray();
+        return values.All(value => !string.Equals(value, "false", StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static string ToRepoPath(string repoRoot, string path) =>
+        Path.GetRelativePath(repoRoot, path).Replace(Path.DirectorySeparatorChar, '/');
 
     private static IReadOnlyList<WorkflowStep> ReadNamedWorkflowSteps(string workflow)
     {

--- a/dcb/tests/Sekiban.Dcb.TemplateValidation/Program.cs
+++ b/dcb/tests/Sekiban.Dcb.TemplateValidation/Program.cs
@@ -498,6 +498,7 @@ internal static class Program
         var workflowRoot = Path.Combine(repoRoot, ".github", "workflows");
         var validationWorkflow = Path.Combine(workflowRoot, "dcb_template_validation.yml");
         var dcbTestWorkflow = Path.Combine(workflowRoot, "run_test_dcb.yml");
+        var dcbPackageWorkflow = Path.Combine(workflowRoot, "packagesDcb.yml");
         var publishWorkflow = Path.Combine(workflowRoot, "packagesDcbTemplate.yml");
         var packagedConsumerScript = Path.Combine(
             repoRoot,
@@ -507,15 +508,25 @@ internal static class Program
             "run-packaged-consumer.sh");
         Assert(File.Exists(validationWorkflow), "The DCB template validation workflow is missing.");
         Assert(File.Exists(dcbTestWorkflow), "The DCB test workflow is missing.");
+        Assert(File.Exists(dcbPackageWorkflow), "The DCB package workflow is missing.");
         Assert(File.Exists(publishWorkflow), "The DCB template publish workflow is missing.");
         Assert(File.Exists(packagedConsumerScript), "The DCB packaged-consumer script is missing.");
         var validation = File.ReadAllText(validationWorkflow);
         var dcbTest = File.ReadAllText(dcbTestWorkflow);
+        var dcbPackage = File.ReadAllText(dcbPackageWorkflow);
         var publish = File.ReadAllText(publishWorkflow);
         Assert(dcbTest.Contains(
                 "dcb/tests/Sekiban.Dcb.TemplateValidation/**",
                 StringComparison.Ordinal),
             "The DCB test workflow must rerun when template-verifier sources or fixtures change.");
+        Assert(dcbTest.Contains(
+                "dcb/src/Sekiban.Dcb.Orleans.AzureQueue/**",
+                StringComparison.Ordinal),
+            "The DCB test workflow must rerun when the Azure Queue V2 size-gate package changes.");
+        Assert(dcbPackage.Contains(
+                "dotnet pack dcb/src/Sekiban.Dcb.Orleans.AzureQueue/Sekiban.Dcb.Orleans.AzureQueue.csproj",
+                StringComparison.Ordinal),
+            "The DCB package workflow must pack the Azure Queue V2 size-gate package.");
 
         foreach (var required in new[]
                  {

--- a/dcb/tests/Sekiban.Dcb.TemplateValidation/Program.cs
+++ b/dcb/tests/Sekiban.Dcb.TemplateValidation/Program.cs
@@ -520,6 +520,9 @@ internal static class Program
         var validationWorkflow = Path.Combine(workflowRoot, "dcb_template_validation.yml");
         var dcbTestWorkflow = Path.Combine(workflowRoot, "run_test_dcb.yml");
         var dcbPackageWorkflow = Path.Combine(workflowRoot, "packagesDcb.yml");
+        var azureQueueConsumerWorkflow = Path.Combine(
+            workflowRoot,
+            "dcb_azure_queue_packaged_consumer.yml");
         var publishWorkflow = Path.Combine(workflowRoot, "packagesDcbTemplate.yml");
         var packagedConsumerScript = Path.Combine(
             repoRoot,
@@ -536,12 +539,14 @@ internal static class Program
         Assert(File.Exists(validationWorkflow), "The DCB template validation workflow is missing.");
         Assert(File.Exists(dcbTestWorkflow), "The DCB test workflow is missing.");
         Assert(File.Exists(dcbPackageWorkflow), "The DCB package workflow is missing.");
+        Assert(File.Exists(azureQueueConsumerWorkflow), "The Azure Queue PR packaged-consumer workflow is missing.");
         Assert(File.Exists(publishWorkflow), "The DCB template publish workflow is missing.");
         Assert(File.Exists(packagedConsumerScript), "The DCB packaged-consumer script is missing.");
         Assert(File.Exists(azureQueueConsumerScript), "The Azure Queue packaged-consumer script is missing.");
         var validation = File.ReadAllText(validationWorkflow);
         var dcbTest = File.ReadAllText(dcbTestWorkflow);
         var dcbPackage = File.ReadAllText(dcbPackageWorkflow);
+        var azureQueueConsumer = File.ReadAllText(azureQueueConsumerWorkflow);
         var publish = File.ReadAllText(publishWorkflow);
         Assert(dcbTest.Contains(
                 "dcb/tests/Sekiban.Dcb.TemplateValidation/**",
@@ -559,6 +564,25 @@ internal static class Program
                 "dcb/tests/Sekiban.Dcb.Orleans.Tests/run-packaged-consumer.sh",
                 StringComparison.Ordinal),
             "The DCB package workflow must run the isolated Azure Queue packaged consumer.");
+        Assert(azureQueueConsumer.Contains("pull_request:", StringComparison.Ordinal),
+            "The Azure Queue packaged-consumer workflow must run for pull requests.");
+        Assert(azureQueueConsumer.Contains("workflow_dispatch:", StringComparison.Ordinal),
+            "The Azure Queue packaged-consumer workflow must support explicit review execution.");
+        Assert(azureQueueConsumer.Contains(
+                "dcb/tests/Sekiban.Dcb.Orleans.Tests/run-packaged-consumer.sh",
+                StringComparison.Ordinal),
+            "The Azure Queue pull-request workflow must execute the isolated consumer script.");
+        Assert(azureQueueConsumer.Contains("-p:GenerateSBOM=false", StringComparison.Ordinal),
+            "The Azure Queue pull-request workflow must use a disposable local-feed pack.");
+        Assert(azureQueueConsumer.Contains("--no-build", StringComparison.Ordinal),
+            "The Azure Queue pull-request workflow must validate the already-built packages.");
+        Assert(azureQueueConsumer.Contains("--feed \"$GITHUB_WORKSPACE/out\"", StringComparison.Ordinal),
+            "The Azure Queue pull-request workflow must pass its local feed to the consumer.");
+        Assert(azureQueueConsumer.Contains("10.0.2-pr.${{ github.run_id }}", StringComparison.Ordinal),
+            "The Azure Queue pull-request workflow must use an isolated review-only package version.");
+        Assert(!azureQueueConsumer.Contains("nuget push", StringComparison.Ordinal) &&
+               !azureQueueConsumer.Contains("action-gh-release", StringComparison.Ordinal),
+            "The Azure Queue pull-request workflow must not publish or release packages.");
 
         var effectivePackableProjects = Directory.EnumerateFiles(
                 Path.Combine(repoRoot, "dcb", "src"),
@@ -583,6 +607,20 @@ internal static class Program
             $"The DCB package manifest must exactly match effective packable dcb/src projects. " +
             $"Missing: {string.Join(", ", effectivePackableProjects.Except(manifestProjects, StringComparer.Ordinal))}; " +
             $"Unexpected: {string.Join(", ", manifestProjects.Except(effectivePackableProjects, StringComparer.Ordinal))}.");
+
+        var pullRequestManifestProjects = Regex.Matches(
+                azureQueueConsumer,
+                @"dotnet\s+pack\s+(?<project>dcb/src/[^\s""']+\.csproj)",
+                RegexOptions.CultureInvariant,
+                RegexTimeout)
+            .Cast<Match>()
+            .Select(match => match.Groups["project"].Value.Replace('\\', '/'))
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(path => path, StringComparer.Ordinal)
+            .ToArray();
+        Assert(
+            effectivePackableProjects.SequenceEqual(pullRequestManifestProjects, StringComparer.Ordinal),
+            "The Azure Queue pull-request workflow must pack the exact effective DCB packable project set.");
 
         foreach (var required in new[]
                  {
@@ -624,6 +662,11 @@ internal static class Program
             "The publish workflow must run the packaged-consumer/docs path before Push Template.");
 
         var script = File.ReadAllText(packagedConsumerScript);
+        var azureQueueScript = File.ReadAllText(azureQueueConsumerScript);
+        Assert(azureQueueScript.Contains(
+                "dotnet run --project \"$project/consumer.csproj\"",
+                StringComparison.Ordinal),
+            "The Azure Queue packaged-consumer path must execute each built consumer, not only compile it.");
         var sourceStage = script.IndexOf("\"$validator\" source", StringComparison.Ordinal);
         var docsCurrencyStage = script.IndexOf("\"$validator\" docs-currency", StringComparison.Ordinal);
         var packageBoundary = script.IndexOf("if [[ -z \"$package_path\" ]]; then", StringComparison.Ordinal);

--- a/dcb/tests/Sekiban.Dcb.TemplateValidation/Program.cs
+++ b/dcb/tests/Sekiban.Dcb.TemplateValidation/Program.cs
@@ -576,6 +576,18 @@ internal static class Program
             "The Azure Queue pull-request workflow must use a disposable local-feed pack.");
         Assert(azureQueueConsumer.Contains("--no-build", StringComparison.Ordinal),
             "The Azure Queue pull-request workflow must validate the already-built packages.");
+        Assert(azureQueueConsumer.Contains(
+                "dotnet restore dcb/tests/Sekiban.Dcb.TemplateValidation/Sekiban.Dcb.TemplateValidation.csproj",
+                StringComparison.Ordinal),
+            "The Azure Queue pull-request workflow must restore TemplateValidation on a clean runner.");
+        Assert(azureQueueConsumer.Contains(
+                "dotnet build dcb/tests/Sekiban.Dcb.TemplateValidation/Sekiban.Dcb.TemplateValidation.csproj -c Release --no-restore",
+                StringComparison.Ordinal),
+            "The Azure Queue pull-request workflow must build TemplateValidation before --no-restore validation.");
+        Assert(azureQueueConsumer.Contains(
+                "dotnet run --project dcb/tests/Sekiban.Dcb.TemplateValidation/Sekiban.Dcb.TemplateValidation.csproj -c Release --no-build --no-restore -- workflow",
+                StringComparison.Ordinal),
+            "The Azure Queue pull-request workflow must execute the built validator without a clean-runner asset gap.");
         Assert(azureQueueConsumer.Contains("--feed \"$GITHUB_WORKSPACE/out\"", StringComparison.Ordinal),
             "The Azure Queue pull-request workflow must pass its local feed to the consumer.");
         Assert(azureQueueConsumer.Contains("10.0.2-pr.${{ github.run_id }}", StringComparison.Ordinal),
@@ -583,6 +595,9 @@ internal static class Program
         Assert(!azureQueueConsumer.Contains("nuget push", StringComparison.Ordinal) &&
                !azureQueueConsumer.Contains("action-gh-release", StringComparison.Ordinal),
             "The Azure Queue pull-request workflow must not publish or release packages.");
+        Assert(azureQueueConsumer.Contains("SEKIBAN_G76_FORCE_CONSUMER_THROW=1", StringComparison.Ordinal) &&
+               azureQueueConsumer.Contains("unconditional consumer-throw probe", StringComparison.Ordinal),
+            "The Azure Queue pull-request workflow must prove that a consumer runtime failure is propagated.");
 
         var effectivePackableProjects = Directory.EnumerateFiles(
                 Path.Combine(repoRoot, "dcb", "src"),
@@ -667,6 +682,9 @@ internal static class Program
                 "dotnet run --project \"$project/consumer.csproj\"",
                 StringComparison.Ordinal),
             "The Azure Queue packaged-consumer path must execute each built consumer, not only compile it.");
+        Assert(azureQueueScript.Contains("SEKIBAN_G76_FORCE_CONSUMER_THROW", StringComparison.Ordinal) &&
+               azureQueueScript.Contains("deterministic packaged-consumer failure probe", StringComparison.Ordinal),
+            "The Azure Queue packaged-consumer must expose an unconditional failure probe.");
         var sourceStage = script.IndexOf("\"$validator\" source", StringComparison.Ordinal);
         var docsCurrencyStage = script.IndexOf("\"$validator\" docs-currency", StringComparison.Ordinal);
         var packageBoundary = script.IndexOf("if [[ -z \"$package_path\" ]]; then", StringComparison.Ordinal);

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/ConditionalAppend/ConditionalAppendSeamArchitectureTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/ConditionalAppend/ConditionalAppendSeamArchitectureTests.cs
@@ -207,9 +207,27 @@ public class ConditionalAppendSeamArchitectureTests
             typeof(IConditionalEventStore).Assembly,
             "Sekiban.Dcb.Postgres", "Sekiban.Dcb.Sqlite", "Sekiban.Dcb.CosmosDb", "Sekiban.Dcb.DynamoDB",
             "Sekiban.Dcb.Orleans.Core", "Sekiban.Dcb.Orleans.WithResult", "Sekiban.Dcb.Orleans.WithoutResult",
+            "Sekiban.Dcb.Orleans.AzureQueue",
             "Sekiban.Dcb.WithResult", "Sekiban.Dcb.WithoutResult",
             "Sekiban.Dcb.SortableUniqueIdWait.Tests",
             "Sekiban.Dcb.SortableUniqueIdWait.WithoutResult.Tests");
+
+        // The Azure Queue package reaches Core only through the internal provider-composable registration marker and
+        // Orleans.Core's opaque capture bridge. Keep both sides non-public so the IVT does not become a public
+        // registration or provider-SDK surface.
+        var marker = typeof(IConditionalEventStore).Assembly.GetType(
+            "Sekiban.Dcb.SizeGates.ExecutorSizeGateRegistrationMarker",
+            throwOnError: true)!;
+        Assert.False(marker.IsPublic);
+        Assert.Empty(marker.GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.DeclaredOnly));
+
+        var bridgeAssembly = Assembly.Load("Sekiban.Dcb.Orleans.Core");
+        var captureBridge = bridgeAssembly.GetType(
+            "Sekiban.Dcb.Orleans.IOrleansDestinationMeasurementCapture",
+            throwOnError: true)!;
+        Assert.False(captureBridge.IsPublic);
+        Assert.All(captureBridge.GetMethods(), method =>
+            Assert.False(method.DeclaringType?.IsPublic ?? true));
     }
 
     [Theory]

--- a/dcb/tests/Sekiban.Dcb.WithResult.Tests/ExecutorSizeGateTests.cs
+++ b/dcb/tests/Sekiban.Dcb.WithResult.Tests/ExecutorSizeGateTests.cs
@@ -555,7 +555,8 @@ public sealed class ExecutorSizeGateTests
         var diagnosticList = Assert.IsAssignableFrom<IReadOnlyList<ExecutorSizeDiagnostic>>(diagnostics!);
         Assert.Contains(diagnosticList, diagnostic => diagnostic.Scope == "destination");
         Assert.Single((await nonStrictStore.ReadAllSerializableEventsAsync()).GetValue());
-        Assert.Equal(1, nonStrictPublisher.PlannedPublishCalls);
+        Assert.Equal(0, nonStrictPublisher.PlannedPublishCalls);
+        Assert.Equal(1, nonStrictPublisher.LegacyPublishCalls);
     }
 
     [Fact]

--- a/docs/dcb_llm/11_storage_providers.md
+++ b/docs/dcb_llm/11_storage_providers.md
@@ -1030,7 +1030,22 @@ are unchanged. This is a per-read-invocation snapshot, not global options valida
 ## SEK-G76 Orleans Azure Queue V2 stream-message size gate
 
 The optional `Sekiban.Dcb.Orleans.AzureQueue` package measures the provider-owned Azure Queue V2 stream message before
-the executor persists or dispatches an event. Register the provider helper against the named stream provider:
+the executor persists or dispatches an event. It offers an options API for hosts that already compose executor gates
+and a DI API for direct registration:
+
+```csharp
+options.AddOrleansAzureQueueStreamMessagePolicy(
+    "EventStreamProvider",
+    maxBytesPerEvent: 65_536);
+
+services.AddSekibanDcbOrleansAzureQueueStreamMessageSizeGate(
+    "EventStreamProvider",
+    maxBytesPerEvent: 65_536);
+```
+
+Both APIs default to `ExecutorSizeStrictness.NonStrict`, which records an explicit unvalidated capability diagnostic
+and preserves the legacy publication path when the provider cannot be measured. Hosts that have verified the named
+provider may promote the same registration to fail-closed `Strict`:
 
 ```csharp
 services.AddSekibanDcbOrleansAzureQueueStreamMessageSizeGate(
@@ -1047,10 +1062,10 @@ The measurement calls the real V2 adapter's `ToQueueMessage` with the prepared e
 create a queue or send a message. The prepared event and captured destination state are reused for publication, so the
 admitted representation is the one that is dispatched.
 
-The default per-event limit is `65_536` bytes. If the adapter text is `n` UTF-8 bytes and the Azure Queue client encoding
-is `None`, the certified bound is `n`; with `Base64`, it is `4 * ceil(n / 3)`. The gate records both the measured
-adapter bytes and the certified upper bound. `MaxBytesPerOperation` sums the captured destination measurements; an
-event limit checks each destination copy independently. The bound covers the V2 adapter/client message representation,
+The default per-event limit is `65_536` bytes. If the adapter text is `n` UTF-8 bytes, the certified bound is always
+`max(n, 4 * ceil(n / 3))`, because the effective client encoding is not observable at the provider-neutral admission
+boundary. The gate records both the measured adapter bytes and the certified upper bound. `MaxBytesPerOperation`
+sums the captured destination measurements; an event limit checks each destination copy independently. The bound covers the V2 adapter/client message representation,
 not Azure Queue service envelopes, batching, retries, or arbitrary external effects in custom application code.
 Existing Orleans publisher constructors and unconfigured publication remain unchanged.
 

--- a/docs/dcb_llm/11_storage_providers.md
+++ b/docs/dcb_llm/11_storage_providers.md
@@ -1027,6 +1027,40 @@ The two public list methods keep their no-tag-rows early return: an empty tag qu
 `UseConsistentReads` is still applied to each request chunk, `QueryPageSize` still controls query pages, and write paths
 are unchanged. This is a per-read-invocation snapshot, not global options validation or retry rechunking.
 
+## SEK-G76 Orleans Azure Queue V2 stream-message size gate
+
+The optional `Sekiban.Dcb.Orleans.AzureQueue` package measures the provider-owned Azure Queue V2 stream message before
+the executor persists or dispatches an event. Register the provider helper against the named stream provider:
+
+```csharp
+services.AddSekibanDcbOrleansAzureQueueStreamMessageSizeGate(
+    "EventStreamProvider",
+    maxBytesPerEvent: 65_536,
+    strictness: ExecutorSizeStrictness.Strict);
+```
+
+The helper accepts only the actual named-keyed, then unkeyed fallback `AzureQueueDataAdapterV2`; a missing provider,
+custom adapter, V1 adapter, or JSON adapter is an unavailable capability. Strict mode fails closed with
+`ExecutorSizeCapabilityException` before durable persistence. Non-strict mode keeps the existing publication path and
+adds one named unvalidated diagnostic; it never treats the logical event UTF-8 size as an Azure Queue measurement.
+The measurement calls the real V2 adapter's `ToQueueMessage` with the prepared event and request context, but does not
+create a queue or send a message. The prepared event and captured destination state are reused for publication, so the
+admitted representation is the one that is dispatched.
+
+The default per-event limit is `65_536` bytes. If the adapter text is `n` UTF-8 bytes and the Azure Queue client encoding
+is `None`, the certified bound is `n`; with `Base64`, it is `4 * ceil(n / 3)`. The gate records both the measured
+adapter bytes and the certified upper bound. `MaxBytesPerOperation` sums the captured destination measurements; an
+event limit checks each destination copy independently. The bound covers the V2 adapter/client message representation,
+not Azure Queue service envelopes, batching, retries, or arbitrary external effects in custom application code.
+Existing Orleans publisher constructors and unconfigured publication remain unchanged.
+
+For a limit `L = 65_536`, the conservative adapter-text payload ceiling is
+`n_max = 3 * floor(L / 4) = 49,152` bytes. At that boundary `n = 49,152` produces a certified bound of `65,536`
+and passes an equal quota; `n = 49,156` produces `65,544` and is rejected before persistence. The payload count is
+not an event-envelope budget: event metadata and other message overhead are included in the actual V2 adapter text,
+so applications must leave room for them. An `Exact` measurement tier is deferred; this package intentionally ships
+the conservative `CertifiedBound` tier.
+
 ## Related
 
 For the current internal-use cold event export, hybrid read, and catch-up worker setup, see [Cold Events and Catch-up](19_cold_events.md).

--- a/docs/dcb_llm_ja/11_storage_providers.md
+++ b/docs/dcb_llm_ja/11_storage_providers.md
@@ -1034,6 +1034,40 @@ batch read を dispatch せずに成功します。callback stream は cancellat
 変更されません。これは read invocation ごとの snapshot であり、global option validation や retry 時の再 chunking
 ではありません。
 
+## SEK-G76 Orleans Azure Queue V2 stream-message サイズゲート
+
+任意の `Sekiban.Dcb.Orleans.AzureQueue` パッケージは、executor が event を永続化または dispatch する前に、provider が所有する
+Azure Queue V2 stream message を測定します。名前付き stream provider に対して provider helper を登録します。
+
+```csharp
+services.AddSekibanDcbOrleansAzureQueueStreamMessageSizeGate(
+    "EventStreamProvider",
+    maxBytesPerEvent: 65_536,
+    strictness: ExecutorSizeStrictness.Strict);
+```
+
+helper が受け付けるのは、名前付き keyed 解決、続く unkeyed fallback で得られる実際の
+`AzureQueueDataAdapterV2` だけです。provider がない場合、custom adapter、V1 adapter、JSON adapter は capability unavailable
+です。strict mode は `ExecutorSizeCapabilityException` で durable persistence より前に fail closed します。
+non-strict mode は既存の publish path を維持し、名前付きの未検証診断を 1 件追加します。logical event の UTF-8 byte を
+Azure Queue の測定値として扱うことはありません。測定では準備済み event と request context を使って実 V2 adapter の
+`ToQueueMessage` を呼びますが、queue の作成や message の送信は行いません。準備済み event と destination state は publish
+にも再利用されるため、admission された representation と dispatch される representation は同じです。
+
+event ごとの既定上限は `65_536` byte です。adapter text が UTF-8 で `n` byte のとき、Azure Queue client encoding が
+`None` なら certified bound は `n`、`Base64` なら `4 * ceil(n / 3)` です。ゲートは測定した adapter byte と certified upper
+bound の両方を記録します。`MaxBytesPerOperation` は捕捉した destination の測定値を合計し、event limit は各 destination
+copy を個別に検査します。この bound が保証するのは V2 adapter/client の message representation であり、Azure Queue の
+service envelope、batch、retry、custom application code の任意の外部効果は保証しません。既存の Orleans publisher constructor
+と、未登録時の publish 挙動は変更されません。
+
+上限 `L = 65,536` のとき、保守的な adapter-text payload の上限は
+`n_max = 3 * floor(L / 4) = 49,152` byte です。この境界では `n = 49,152` の certified bound は `65,536` となり、
+同じ quota を通過します。一方 `n = 49,156` では `65,544` となり、永続化より前に拒否されます。payload の byte 数だけを
+event envelope の予算と解釈してはいけません。event metadata などの message overhead は実際の V2 adapter text に含まれるため、
+アプリケーションはその分の余裕を残す必要があります。`Exact` measurement tier は将来に延期しており、この package が提供するのは
+保守的な `CertifiedBound` tier です。
+
 ## 関連資料
 
 現在のインターナルユースで使っているコールドイベントの書き出し、ハイブリッドリード、キャッチアップワーカー構成については [コールドイベントとキャッチアップ](19_cold_events.md) を参照してください。

--- a/docs/dcb_llm_ja/11_storage_providers.md
+++ b/docs/dcb_llm_ja/11_storage_providers.md
@@ -1037,7 +1037,22 @@ batch read を dispatch せずに成功します。callback stream は cancellat
 ## SEK-G76 Orleans Azure Queue V2 stream-message サイズゲート
 
 任意の `Sekiban.Dcb.Orleans.AzureQueue` パッケージは、executor が event を永続化または dispatch する前に、provider が所有する
-Azure Queue V2 stream message を測定します。名前付き stream provider に対して provider helper を登録します。
+Azure Queue V2 stream message を測定します。executor の gate を既に組み立てている場合の options API と、直接登録する DI API の
+2 通りがあります。
+
+```csharp
+options.AddOrleansAzureQueueStreamMessagePolicy(
+    "EventStreamProvider",
+    maxBytesPerEvent: 65_536);
+
+services.AddSekibanDcbOrleansAzureQueueStreamMessageSizeGate(
+    "EventStreamProvider",
+    maxBytesPerEvent: 65_536);
+```
+
+どちらの API も既定値は `ExecutorSizeStrictness.NonStrict` です。provider を測定できない場合は、明示的な未検証 capability 診断を
+記録し、従来の publish path を維持します。名前付き provider の capability を確認できた host は、同じ登録の strictness を明示的に
+`Strict` に昇格して fail-closed にできます。
 
 ```csharp
 services.AddSekibanDcbOrleansAzureQueueStreamMessageSizeGate(
@@ -1054,9 +1069,9 @@ Azure Queue の測定値として扱うことはありません。測定では�
 `ToQueueMessage` を呼びますが、queue の作成や message の送信は行いません。準備済み event と destination state は publish
 にも再利用されるため、admission された representation と dispatch される representation は同じです。
 
-event ごとの既定上限は `65_536` byte です。adapter text が UTF-8 で `n` byte のとき、Azure Queue client encoding が
-`None` なら certified bound は `n`、`Base64` なら `4 * ceil(n / 3)` です。ゲートは測定した adapter byte と certified upper
-bound の両方を記録します。`MaxBytesPerOperation` は捕捉した destination の測定値を合計し、event limit は各 destination
+event ごとの既定上限は `65_536` byte です。adapter text が UTF-8 で `n` byte のとき、provider-neutral な admission 境界では
+実効 client encoding を観測できないため、certified bound は常に `max(n, 4 * ceil(n / 3))` です。ゲートは測定した adapter byte と
+certified upper bound の両方を記録します。`MaxBytesPerOperation` は捕捉した destination の測定値を合計し、event limit は各 destination
 copy を個別に検査します。この bound が保証するのは V2 adapter/client の message representation であり、Azure Queue の
 service envelope、batch、retry、custom application code の任意の外部効果は保証しません。既存の Orleans publisher constructor
 と、未登録時の publish 挙動は変更されません。


### PR DESCRIPTION
Closes #1227

Implements the standalone SEK-G76 contract: an opt-in Azure Queue V2 destination-message size gate using the actual V2 adapter, conservative certified envelope accounting, atomic pre-write plan capture/reuse, strict/non-strict capability behavior, net9/net10 discriminators, workflow/package reachability, and EN/JA guidance.

Focused evidence: AzureQueueSizeGateTests 10/10 on net9 and net10; ExecutorSizeGateTests 17/17 on net9 and net10; binary compatibility 13/13 on both TFMs; workflow validation and isolated package consumers pass. CI will provide the hosted verification.