### PR TITLE
feat: bound Orleans publisher retries and diagnostics

### DIFF
--- a/.github/workflows/run_test_dcb.yml
+++ b/.github/workflows/run_test_dcb.yml
@@ -30,6 +30,7 @@ on:
       - 'dcb/src/Sekiban.Dcb.Sqlite/**'
       - 'dcb/src/Sekiban.Dcb.ColdStorage/**'
       - 'dcb/tests/Sekiban.Dcb.Orleans.Tests/**'
+      - 'dcb/tests/Sekiban.Dcb.Orleans.LegacyConsumer/**'
       - 'dcb/tests/Sekiban.Dcb.Postgres.Tests/**'
       - 'dcb/tests/Sekiban.Dcb.MaterializedView.BinaryConsumer/**'
       - 'dcb/tests/Sekiban.Dcb.MaterializedView.ApiSurfaceVerifier/**'

--- a/dcb/src/Sekiban.Dcb.Orleans.Core/OrleansEventPublisher.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.Core/OrleansEventPublisher.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Orleans;
 using Orleans.Runtime;
 using Orleans.Serialization;
 using Sekiban.Dcb.Actors;
@@ -9,22 +10,31 @@ using Sekiban.Dcb.ServiceId;
 using Sekiban.Dcb.SizeGates;
 using Sekiban.Dcb.Tags;
 using System.Threading.Channels;
-using System.Collections.Concurrent;
+
 namespace Sekiban.Dcb.Orleans;
 
 /// <summary>
-///     Publishes Sekiban Dcb events to Orleans streams using an Orleans cluster client.
+///     Publishes Sekiban DCB events to Orleans streams using bounded, destination-owned retry queues.
 /// </summary>
-public class OrleansEventPublisher : IEventPublisher, IExecutorSizePreparedDestinationPublisher
+public class OrleansEventPublisher : IEventPublisher, IExecutorSizePreparedDestinationPublisher, IAsyncDisposable,
+    IOrleansPublisherDiagnostics
 {
-    private readonly IClusterClient _clusterClient;
-    private readonly ILogger<OrleansEventPublisher> _logger;
     private readonly IStreamDestinationResolver _resolver;
     private readonly DcbDomainTypes _domainTypes;
     private readonly IServiceIdProvider _serviceIdProvider;
-    private readonly DeepCopier? _deepCopier;
-    private readonly Channel<PublishItem> _channel;
-    private readonly Task _processor;
+    private readonly ILogger<OrleansEventPublisher> _logger;
+    private readonly IOrleansStreamSender _sender;
+    private readonly OrleansEventPublisherOptions _options;
+    private readonly OrleansPublisherDiagnosticsRecorder _diagnostics;
+    private readonly object _queueGate = new();
+    private readonly Dictionary<string, DestinationState> _destinations = new(StringComparer.Ordinal);
+    private readonly HashSet<Task> _activeWorkers = [];
+    private readonly CancellationTokenSource _shutdown = new();
+    private readonly Func<TimeSpan, CancellationToken, Task> _delayAsync;
+    private Task? _disposeTask;
+    private int _totalLiveItems;
+    private bool _disposed;
+    private bool _pumpFaulted;
 
     /// <summary>
     /// Test-only observation of the planned enqueue boundary. This stays internal so production callers cannot
@@ -37,87 +47,129 @@ public class OrleansEventPublisher : IEventPublisher, IExecutorSizePreparedDesti
         Guid,
         IReadOnlyDictionary<string, object>?>? PlannedPublishObserver { get; set; }
 
-    private record PublishItem(
-        string Provider,
-        string Namespace,
-        Guid StreamId,
-        SerializableEvent Event,
-        int Attempt,
-        Dictionary<string, object>? RequestContext = null);
-
     public OrleansEventPublisher(
         IClusterClient clusterClient,
         IStreamDestinationResolver resolver,
         DcbDomainTypes domainTypes,
         ILogger<OrleansEventPublisher> logger)
-        : this(
-            clusterClient,
-            resolver,
-            domainTypes,
-            logger,
-            new DefaultServiceIdProvider())
+        : this(clusterClient, resolver, domainTypes, logger, options: null, serviceIdProvider: null)
     {
     }
 
     /// <summary>Additive constructor retaining the resolver/service identity used by publication.</summary>
+    [ActivatorUtilitiesConstructor]
     public OrleansEventPublisher(
         IClusterClient clusterClient,
         IStreamDestinationResolver resolver,
         DcbDomainTypes domainTypes,
         ILogger<OrleansEventPublisher> logger,
         IServiceIdProvider? serviceIdProvider = null)
+        : this(clusterClient, resolver, domainTypes, logger, options: null, serviceIdProvider)
     {
-        _clusterClient = clusterClient;
+    }
+
+    /// <summary>
+    /// Additive bounded-publisher configuration. A null options value selects the validated defaults, which keeps
+    /// options-free dependency-injection activation compatible with the original registration.
+    /// </summary>
+    public OrleansEventPublisher(
+        IClusterClient clusterClient,
+        IStreamDestinationResolver resolver,
+        DcbDomainTypes domainTypes,
+        ILogger<OrleansEventPublisher> logger,
+        OrleansEventPublisherOptions? options,
+        IServiceIdProvider? serviceIdProvider = null)
+        : this(
+            clusterClient,
+            resolver,
+            domainTypes,
+            logger,
+            options ?? new OrleansEventPublisherOptions(),
+            serviceIdProvider ?? new DefaultServiceIdProvider(),
+            sender: null,
+            delayAsync: null,
+            diagnostics: null)
+    {
+    }
+
+    /// <summary>Internal deterministic seam for Orleans tests; production always uses the real stream sender.</summary>
+    internal OrleansEventPublisher(
+        IClusterClient clusterClient,
+        IStreamDestinationResolver resolver,
+        DcbDomainTypes domainTypes,
+        ILogger<OrleansEventPublisher> logger,
+        OrleansEventPublisherOptions options,
+        IServiceIdProvider serviceIdProvider,
+        IOrleansStreamSender? sender,
+        Func<TimeSpan, CancellationToken, Task>? delayAsync,
+        OrleansPublisherDiagnosticsRecorder? diagnostics = null)
+    {
+        if (sender is null)
+            ArgumentNullException.ThrowIfNull(clusterClient);
+        ArgumentNullException.ThrowIfNull(resolver);
+        ArgumentNullException.ThrowIfNull(domainTypes);
+        ArgumentNullException.ThrowIfNull(logger);
+        ArgumentNullException.ThrowIfNull(serviceIdProvider);
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+        _options.Validate();
         _resolver = resolver;
         _domainTypes = domainTypes;
         _logger = logger;
-        _serviceIdProvider = serviceIdProvider ?? throw new ArgumentNullException(nameof(serviceIdProvider));
-        _deepCopier = _clusterClient.ServiceProvider.GetService<DeepCopier>();
-        // Unbounded channel for simplicity; projection side is idempotent
-        _channel = Channel.CreateUnbounded<PublishItem>(new UnboundedChannelOptions
-        {
-            SingleReader = true,
-            SingleWriter = false
-        });
-        _processor = Task.Run(ProcessQueueAsync);
+        _serviceIdProvider = serviceIdProvider;
+        _diagnostics = diagnostics ?? new OrleansPublisherDiagnosticsRecorder(_options);
+        var deepCopier = sender is null ? clusterClient!.ServiceProvider.GetService<DeepCopier>() : null;
+        _sender = sender ?? new ClusterOrleansStreamSender(clusterClient!, deepCopier);
+        _delayAsync = delayAsync ?? Task.Delay;
     }
 
     public async Task PublishAsync(
         IReadOnlyCollection<(Event Event, IReadOnlyCollection<ITag> Tags)> events,
         CancellationToken cancellationToken = default)
     {
-        // Reduce noise: only trace this queueing operation
-        if (_logger.IsEnabled(LogLevel.Trace))
-        {
-            _logger.LogTrace("Queueing {EventCount} events to Orleans streams (at-least-once)", events.Count);
-        }
-
         foreach (var (evt, tags) in events)
         {
+            if (cancellationToken.IsCancellationRequested)
+                break;
+
+            SerializableEvent serializableEvent;
             try
             {
-                // Convert Event to SerializableEvent for Orleans stream
-                var serializableEvent = evt.ToSerializableEvent(_domainTypes.EventTypes);
-
-                var streams = _resolver.Resolve(evt, tags);
-                foreach (var s in streams)
-                {
-                    if (s is OrleansSekibanStream os)
-                    {
-                        var item = new PublishItem(os.ProviderName, os.StreamNamespace, os.StreamId, serializableEvent, 0);
-                        _channel.Writer.TryWrite(item);
-                    }
-                }
+                serializableEvent = evt.ToSerializableEvent(_domainTypes.EventTypes);
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex,
-                    "Failed to resolve streams for event {EventType} (ID: {EventId})",
-                    evt.EventType, evt.Id);
+                RecordAdmissionFailure(null, evt.Id, "admission-serialize-failed", ex);
+                continue;
+            }
+
+            IReadOnlyList<OrleansPublishDestination> destinations;
+            try
+            {
+                destinations = ResolveDestinations(evt, tags, _serviceIdProvider.GetCurrentServiceId());
+            }
+            catch (Exception ex)
+            {
+                RecordAdmissionFailure(null, evt.Id, "admission-resolve-failed", ex);
+                continue;
+            }
+
+            var context = CaptureRequestContext();
+            var payload = new SharedPublishPayload(serializableEvent, context);
+            try
+            {
+                foreach (var destination in destinations)
+                {
+                    if (cancellationToken.IsCancellationRequested)
+                        break;
+                    TryEnqueue(new OrleansPublishItem(destination, payload));
+                }
+            }
+            finally
+            {
+                payload.Release();
             }
         }
 
-        // Return immediately; background processor ensures at-least-once with retry and logging
         await Task.CompletedTask;
     }
 
@@ -143,48 +195,36 @@ public class OrleansEventPublisher : IEventPublisher, IExecutorSizePreparedDesti
         IReadOnlyCollection<ITag> tags,
         string serviceId)
     {
-        var destinations = (_resolver.Resolve(@event, tags) ?? Enumerable.Empty<ISekibanStream>())
-            .OfType<OrleansSekibanStream>()
-            .Select(stream => new OrleansDestination(
-                stream.ProviderName,
-                stream.StreamNamespace,
-                stream.StreamId))
-            .ToArray();
-
-        if (destinations.Length == 0)
-        {
+        var destinations = ResolveDestinations(@event, tags, serviceId);
+        if (destinations.Count == 0)
             return null;
-        }
 
-        var captures = _clusterClient.ServiceProvider
-            .GetServices<IOrleansDestinationMeasurementCapture>()
-            .ToArray();
-        var destinationStates = new List<OrleansDestinationPlanState>(destinations.Length);
+        var captures = _sender is ClusterOrleansStreamSender clusterSender
+            ? clusterSender.Captures
+            : Array.Empty<IOrleansDestinationMeasurementCapture>();
+        var destinationStates = new List<OrleansDestinationPlanState>(destinations.Count);
         foreach (var destination in destinations)
         {
             string? failureReason = null;
             Dictionary<string, object>? requestContext = null;
-            if (_deepCopier is null)
+            try
             {
-                failureReason = "Orleans request-context deep-copy capability is unavailable";
+                requestContext = CaptureRequestContext()?.ToDictionary(
+                    pair => pair.Key,
+                    pair => pair.Value,
+                    StringComparer.Ordinal);
             }
-            else
+            catch (Exception ex)
             {
-                try
-                {
-                    requestContext = RequestContextExtensions.Export(_deepCopier);
-                }
-                catch (Exception ex)
-                {
-                    failureReason = $"Orleans request-context capture failed with {ex.GetType().Name}";
-                }
+                failureReason = $"Orleans request-context capture failed with {ex.GetType().Name}";
             }
 
             var capture = captures.FirstOrDefault(candidate => candidate.Matches(destination.ProviderName));
             object? providerState = null;
             if (capture is null)
             {
-                failureReason ??= $"no destination measurement capability is registered for provider '{destination.ProviderName}'";
+                failureReason ??=
+                    $"no destination measurement capability is registered for provider '{destination.ProviderName}'";
             }
             else
             {
@@ -199,7 +239,7 @@ public class OrleansEventPublisher : IEventPublisher, IExecutorSizePreparedDesti
             }
 
             destinationStates.Add(new OrleansDestinationPlanState(
-                GetDestinationKey(destination),
+                GetLegacyDestinationKey(destination),
                 destination.ProviderName,
                 destination.StreamNamespace,
                 destination.StreamId,
@@ -208,21 +248,9 @@ public class OrleansEventPublisher : IEventPublisher, IExecutorSizePreparedDesti
                 failureReason));
         }
 
-        var resolverServiceId = _serviceIdProvider.GetCurrentServiceId();
-        if (!string.Equals(resolverServiceId, serviceId, StringComparison.Ordinal))
-        {
-            return new ExecutorSizeDestinationPlan(
-                resolverServiceId,
-                destinations.Select(GetDestinationKey).ToArray(),
-                destinationStates)
-            {
-                PreparedEvent = serializedEvent
-            };
-        }
-
         return new ExecutorSizeDestinationPlan(
             serviceId,
-            destinations.Select(GetDestinationKey).ToArray(),
+            destinations.Select(GetLegacyDestinationKey).ToArray(),
             destinationStates)
         {
             PreparedEvent = serializedEvent
@@ -236,6 +264,8 @@ public class OrleansEventPublisher : IEventPublisher, IExecutorSizePreparedDesti
     {
         foreach (var (evt, _) in events)
         {
+            if (cancellationToken.IsCancellationRequested)
+                break;
             if (!destinationPlans.TryGetValue(evt.Id, out var plan) ||
                 plan.ProviderState is not IReadOnlyList<OrleansDestinationPlanState> destinations)
             {
@@ -244,100 +274,370 @@ public class OrleansEventPublisher : IEventPublisher, IExecutorSizePreparedDesti
             }
 
             var serializableEvent = plan.PreparedEvent ?? evt.ToSerializableEvent(_domainTypes.EventTypes);
-            foreach (var destination in destinations)
+            var context = destinations.FirstOrDefault()?.RequestContext;
+            var payload = new SharedPublishPayload(serializableEvent, context);
+            try
             {
-                var requestContext = destination.RequestContext is null
-                    ? null
-                    : destination.RequestContext.ToDictionary(
-                        pair => pair.Key,
-                        pair => pair.Value,
-                        StringComparer.Ordinal);
-                PlannedPublishObserver?.Invoke(
-                    serializableEvent,
-                    destination.ProviderName,
-                    destination.StreamNamespace,
-                    destination.StreamId,
-                    requestContext);
-                _channel.Writer.TryWrite(new PublishItem(
-                    destination.ProviderName,
-                    destination.StreamNamespace,
-                    destination.StreamId,
-                    serializableEvent,
-                    0,
-                    requestContext));
+                foreach (var destination in destinations)
+                {
+                    if (cancellationToken.IsCancellationRequested)
+                        break;
+                    if (destination.FailureReason is not null)
+                    {
+                        RecordAdmissionFailure(
+                            new OrleansPublishDestination(
+                                plan.ServiceId,
+                                destination.ProviderName,
+                                destination.StreamNamespace,
+                                destination.StreamId),
+                            evt.Id,
+                            "admission-resolve-failed",
+                            new InvalidOperationException(destination.FailureReason));
+                        continue;
+                    }
+
+                    var requestContext = destination.RequestContext is null
+                        ? null
+                        : destination.RequestContext.ToDictionary(
+                            pair => pair.Key,
+                            pair => pair.Value,
+                            StringComparer.Ordinal);
+                    var plannedDestination = new OrleansPublishDestination(
+                        plan.ServiceId,
+                        destination.ProviderName,
+                        destination.StreamNamespace,
+                        destination.StreamId);
+                    PlannedPublishObserver?.Invoke(
+                        serializableEvent,
+                        destination.ProviderName,
+                        destination.StreamNamespace,
+                        destination.StreamId,
+                        requestContext);
+                    var destinationPayload = ReferenceEquals(context, destination.RequestContext)
+                        ? payload
+                        : new SharedPublishPayload(serializableEvent, requestContext);
+                    TryEnqueue(new OrleansPublishItem(plannedDestination, destinationPayload));
+                    if (!ReferenceEquals(destinationPayload, payload))
+                        destinationPayload.Release();
+                }
+            }
+            finally
+            {
+                payload.Release();
             }
         }
 
         await Task.CompletedTask;
     }
 
-    private static string GetDestinationKey(OrleansDestination destination) =>
-        $"{destination.ProviderName}|{destination.StreamNamespace}|{destination.StreamId:D}";
+    public OrleansPublisherDiagnosticsSnapshot GetSnapshot() => _diagnostics.Snapshot();
 
-    private sealed record OrleansDestination(
-        string ProviderName,
-        string StreamNamespace,
-        Guid StreamId);
-
-    private async Task ProcessQueueAsync()
+    public ValueTask DisposeAsync()
     {
-        const int baseDelayMs = 100; // base backoff
-        const int maxDelayMs = 5000; // cap
-
-        await foreach (var item in _channel.Reader.ReadAllAsync())
+        lock (_queueGate)
         {
-            try
-            {
-                var provider = _clusterClient.GetStreamProvider(item.Provider);
-                var stream = provider.GetStream<SerializableEvent>(StreamId.Create(item.Namespace, item.StreamId));
-                var priorContext = _deepCopier is null ? null : RequestContextExtensions.Export(_deepCopier);
-                try
-                {
-                    if (item.RequestContext is not null)
-                    {
-                        RequestContextExtensions.Import(item.RequestContext);
-                    }
+            _disposeTask ??= DisposeCoreAsync();
+            return new ValueTask(_disposeTask);
+        }
+    }
 
-                    await stream.OnNextAsync(item.Event);
-                }
-                finally
-                {
-                    if (priorContext is not null)
-                    {
-                        RequestContextExtensions.Import(priorContext);
-                    }
-                    else
-                    {
-                        RequestContext.Clear();
-                    }
-                }
-                if (_logger.IsEnabled(LogLevel.Trace))
-                {
-                    _logger.LogTrace("Published event {EventId} to {Provider}/{Namespace}/{StreamId}",
-                        item.Event.Id, item.Provider, item.Namespace, item.StreamId);
-                }
+    private async Task DisposeCoreAsync()
+    {
+        Task[] workers;
+        lock (_queueGate)
+        {
+            _disposed = true;
+            _shutdown.Cancel();
+            foreach (var state in _destinations.Values)
+                state.Queue.Writer.TryComplete();
+            workers = _activeWorkers.ToArray();
+        }
+
+        try
+        {
+            await Task.WhenAll(workers).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (_shutdown.IsCancellationRequested)
+        {
+            _logger.LogDebug(ex, "Orleans publisher workers stopped during disposal.");
+        }
+        finally
+        {
+            _shutdown.Dispose();
+        }
+    }
+
+    private IReadOnlyList<OrleansPublishDestination> ResolveDestinations(
+        Event @event,
+        IReadOnlyCollection<ITag> tags,
+        string serviceId)
+    {
+        return (_resolver.Resolve(@event, tags) ?? Enumerable.Empty<ISekibanStream>())
+            .OfType<OrleansSekibanStream>()
+            .Select(stream => new OrleansPublishDestination(
+                serviceId,
+                stream.ProviderName,
+                stream.StreamNamespace,
+                stream.StreamId))
+            .ToArray();
+    }
+
+    private IReadOnlyDictionary<string, object>? CaptureRequestContext()
+    {
+        if (_sender is not ClusterOrleansStreamSender clusterSender || clusterSender.DeepCopier is null)
+            return null;
+        return RequestContextExtensions.Export(clusterSender.DeepCopier);
+    }
+
+    private bool TryEnqueue(OrleansPublishItem item)
+    {
+        lock (_queueGate)
+        {
+            if (_disposed || _pumpFaulted)
+            {
+                _diagnostics.Terminal(item.Destination, item.Payload.Event.Id, "pump-faulted", 0);
+                return false;
             }
-            catch (Exception ex)
-            {
-                var nextAttempt = item.Attempt + 1;
-                var delay = Math.Min(maxDelayMs, baseDelayMs * (int)Math.Pow(2, Math.Min(10, item.Attempt)));
-                _logger.LogWarning(ex,
-                    "Publish failed for event {EventId} (attempt {Attempt}). Retrying in {Delay} ms",
-                    item.Event.Id, nextAttempt, delay);
 
-                _ = Task.Run(async () =>
+            if (!_destinations.TryGetValue(item.Destination.DestinationKey, out var state))
+            {
+                state = new DestinationState(
+                    Channel.CreateBounded<OrleansPublishItem>(new BoundedChannelOptions(
+                        _options.MaxQueuedItemsPerDestination)
+                    {
+                        FullMode = BoundedChannelFullMode.Wait,
+                        SingleReader = true,
+                        SingleWriter = false,
+                        AllowSynchronousContinuations = false
+                    }));
+                _destinations.Add(item.Destination.DestinationKey, state);
+            }
+
+            if (state.LiveCount >= _options.MaxQueuedItemsPerDestination ||
+                _totalLiveItems >= _options.MaxQueuedItemsTotal)
+            {
+                _diagnostics.Terminal(item.Destination, item.Payload.Event.Id, "admission-capacity", 0);
+                return false;
+            }
+
+            item.Payload.Retain();
+            state.LiveCount++;
+            _totalLiveItems++;
+            if (!state.Queue.Writer.TryWrite(item))
+            {
+                state.LiveCount--;
+                _totalLiveItems--;
+                item.Payload.Release();
+                _diagnostics.Terminal(item.Destination, item.Payload.Event.Id, "admission-capacity", 0);
+                return false;
+            }
+
+            if (state.Worker is null || state.Worker.IsCompleted)
+            {
+                state.Worker = Task.Run(() => ProcessDestinationAsync(item.Destination.DestinationKey, state));
+                _activeWorkers.Add(state.Worker);
+                _ = state.Worker.ContinueWith(
+                    completed =>
+                    {
+                        lock (_queueGate)
+                            _activeWorkers.Remove(completed);
+                    },
+                    CancellationToken.None,
+                    TaskContinuationOptions.ExecuteSynchronously,
+                    TaskScheduler.Default);
+            }
+
+            return true;
+        }
+    }
+
+    private async Task ProcessDestinationAsync(string destinationKey, DestinationState state)
+    {
+        try
+        {
+            while (await state.Queue.Reader.WaitToReadAsync(_shutdown.Token).ConfigureAwait(false))
+            {
+                while (state.Queue.Reader.TryRead(out var item))
                 {
                     try
                     {
-                        await Task.Delay(delay);
-                        // re-enqueue with incremented attempt
-                        _channel.Writer.TryWrite(item with { Attempt = nextAttempt });
+                        await ProcessItemAsync(item).ConfigureAwait(false);
                     }
-                    catch (Exception delayEx)
+                    catch
                     {
-                        _logger.LogError(delayEx, "Failed to re-enqueue event {EventId}", item.Event.Id);
+                        ReleaseLive(destinationKey, state);
+                        throw;
                     }
-                });
+                    if (ReleaseLive(destinationKey, state))
+                        return;
+                }
+            }
+        }
+        catch (OperationCanceledException) when (_shutdown.IsCancellationRequested)
+        {
+            // Disposal owns cancellation. The finally block releases any items that never reached the sender.
+        }
+        catch (Exception ex)
+        {
+            lock (_queueGate)
+                _pumpFaulted = true;
+            _logger.LogError(ex, "Orleans publisher destination pump faulted for {DestinationKey}.", destinationKey);
+            DrainState(destinationKey, state, "pump-faulted");
+        }
+        finally
+        {
+            DrainState(destinationKey, state, null);
+        }
+    }
+
+    private async Task ProcessItemAsync(OrleansPublishItem item)
+    {
+        var attempts = 0;
+        try
+        {
+            for (var attempt = 1; attempt <= _options.MaxPublishAttempts; attempt++)
+            {
+                attempts = attempt;
+                _diagnostics.Attempt(item.Destination);
+                try
+                {
+                    await _sender.SendAsync(item.Destination, item.Payload, _shutdown.Token).ConfigureAwait(false);
+                    _diagnostics.Terminal(item.Destination, item.Payload.Event.Id, "writer-completed", attempts);
+                    return;
+                }
+                catch (OperationCanceledException) when (_shutdown.IsCancellationRequested)
+                {
+                    return;
+                }
+                catch (Exception ex)
+                {
+                    if (attempt == _options.MaxPublishAttempts)
+                    {
+                        _logger.LogWarning(
+                            ex,
+                            "Orleans notification attempts exhausted for {EventId} at {DestinationKey}.",
+                            item.Payload.Event.Id,
+                            item.Destination.DestinationKey);
+                        _diagnostics.Terminal(
+                            item.Destination,
+                            item.Payload.Event.Id,
+                            "transport-attempts-exhausted",
+                            attempts);
+                        return;
+                    }
+
+                    var delay = ComputeDelay(attempt);
+                    await _delayAsync(delay, _shutdown.Token).ConfigureAwait(false);
+                }
+            }
+        }
+        catch (OperationCanceledException) when (_shutdown.IsCancellationRequested)
+        {
+            // Disposal owns cancellation; the worker releases the payload in finally.
+        }
+        catch
+        {
+            _diagnostics.Terminal(item.Destination, item.Payload.Event.Id, "pump-faulted", attempts);
+            throw;
+        }
+        finally
+        {
+            item.Payload.Release();
+        }
+    }
+
+    private bool ReleaseLive(string destinationKey, DestinationState state)
+    {
+        lock (_queueGate)
+        {
+            if (state.LiveCount > 0)
+                state.LiveCount--;
+            if (_totalLiveItems > 0)
+                _totalLiveItems--;
+            if (state.LiveCount != 0)
+                return false;
+            if (_destinations.TryGetValue(destinationKey, out var current) && ReferenceEquals(current, state))
+                _destinations.Remove(destinationKey);
+            return true;
+        }
+    }
+
+    private void DrainState(string destinationKey, DestinationState state, string? reason)
+    {
+        while (state.Queue.Reader.TryRead(out var item))
+        {
+            item.Payload.Release();
+            if (reason is not null)
+                _diagnostics.Terminal(item.Destination, item.Payload.Event.Id, reason, 0);
+            ReleaseLive(destinationKey, state);
+        }
+    }
+
+    private TimeSpan ComputeDelay(int completedAttempt)
+    {
+        var multiplier = Math.Pow(2, Math.Min(20, completedAttempt - 1));
+        var milliseconds = Math.Min(
+            _options.MaxRetryDelay.TotalMilliseconds,
+            _options.BaseRetryDelay.TotalMilliseconds * multiplier);
+        return TimeSpan.FromMilliseconds(milliseconds);
+    }
+
+    private void RecordAdmissionFailure(
+        OrleansPublishDestination? destination,
+        Guid eventId,
+        string reason,
+        Exception exception)
+    {
+        _logger.LogWarning(exception, "Orleans notification admission failed with {ReasonCode}.", reason);
+        _diagnostics.Terminal(destination, eventId, reason, 0);
+    }
+
+    private static string GetLegacyDestinationKey(OrleansPublishDestination destination) =>
+        $"{destination.ProviderName}|{destination.StreamNamespace}|{destination.StreamId:D}";
+
+    private sealed class DestinationState(Channel<OrleansPublishItem> queue)
+    {
+        public Channel<OrleansPublishItem> Queue { get; } = queue;
+        public int LiveCount { get; set; }
+        public Task? Worker { get; set; }
+    }
+
+    private sealed class ClusterOrleansStreamSender : IOrleansStreamSender
+    {
+        private readonly IClusterClient _clusterClient;
+        public DeepCopier? DeepCopier { get; }
+        public IReadOnlyList<IOrleansDestinationMeasurementCapture> Captures { get; }
+
+        public ClusterOrleansStreamSender(IClusterClient clusterClient, DeepCopier? deepCopier)
+        {
+            _clusterClient = clusterClient;
+            DeepCopier = deepCopier;
+            Captures = clusterClient.ServiceProvider
+                .GetServices<IOrleansDestinationMeasurementCapture>()
+                .ToArray();
+        }
+
+        public async Task SendAsync(
+            OrleansPublishDestination destination,
+            SharedPublishPayload payload,
+            CancellationToken cancellationToken)
+        {
+            var provider = _clusterClient.GetStreamProvider(destination.ProviderName);
+            var stream = provider.GetStream<SerializableEvent>(
+                StreamId.Create(destination.StreamNamespace, destination.StreamId));
+            var priorContext = DeepCopier is null ? null : RequestContextExtensions.Export(DeepCopier);
+            try
+            {
+                if (payload.RequestContext is not null)
+                    RequestContextExtensions.Import(payload.RequestContext);
+                await stream.OnNextAsync(payload.Event).WaitAsync(cancellationToken).ConfigureAwait(false);
+            }
+            finally
+            {
+                if (priorContext is not null)
+                    RequestContextExtensions.Import(priorContext);
+                else
+                    RequestContext.Clear();
             }
         }
     }

--- a/dcb/src/Sekiban.Dcb.Orleans.Core/OrleansEventPublisher.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.Core/OrleansEventPublisher.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Logging;
 using Orleans;
 using Orleans.Runtime;
 using Orleans.Serialization;
+using Orleans.Streams;
 using Sekiban.Dcb.Actors;
 using Sekiban.Dcb.Events;
 using Sekiban.Dcb.Orleans.Streams;
@@ -26,11 +27,15 @@ public class OrleansEventPublisher : IEventPublisher, IExecutorSizePreparedDesti
     private readonly IOrleansStreamSender _sender;
     private readonly OrleansEventPublisherOptions _options;
     private readonly OrleansPublisherDiagnosticsRecorder _diagnostics;
+    private readonly IReadOnlyList<IOrleansDestinationMeasurementCapture> _measurementCaptures;
     private readonly object _queueGate = new();
     private readonly Dictionary<string, DestinationState> _destinations = new(StringComparer.Ordinal);
     private readonly HashSet<Task> _activeWorkers = [];
     private readonly CancellationTokenSource _shutdown = new();
     private readonly Func<TimeSpan, CancellationToken, Task> _delayAsync;
+    private readonly Func<Func<Task>, CancellationToken, Task> _startWorkerAsync;
+    private readonly Func<Dictionary<string, object>?>? _captureRequestContext;
+    private readonly Action? _payloadReleased;
     private Task? _disposeTask;
     private int _totalLiveItems;
     private bool _disposed;
@@ -102,7 +107,11 @@ public class OrleansEventPublisher : IEventPublisher, IExecutorSizePreparedDesti
         IServiceIdProvider serviceIdProvider,
         IOrleansStreamSender? sender,
         Func<TimeSpan, CancellationToken, Task>? delayAsync,
-        OrleansPublisherDiagnosticsRecorder? diagnostics = null)
+        OrleansPublisherDiagnosticsRecorder? diagnostics = null,
+        Func<Func<Task>, CancellationToken, Task>? startWorkerAsync = null,
+        Func<Dictionary<string, object>?>? captureRequestContext = null,
+        IReadOnlyList<IOrleansDestinationMeasurementCapture>? measurementCaptures = null,
+        Action? payloadReleased = null)
     {
         if (sender is null)
             ArgumentNullException.ThrowIfNull(clusterClient);
@@ -119,7 +128,14 @@ public class OrleansEventPublisher : IEventPublisher, IExecutorSizePreparedDesti
         _diagnostics = diagnostics ?? new OrleansPublisherDiagnosticsRecorder(_options);
         var deepCopier = sender is null ? clusterClient!.ServiceProvider.GetService<DeepCopier>() : null;
         _sender = sender ?? new ClusterOrleansStreamSender(clusterClient!, deepCopier);
+        _measurementCaptures = measurementCaptures ??
+            (_sender is ClusterOrleansStreamSender clusterSender
+                ? clusterSender.Captures
+                : Array.Empty<IOrleansDestinationMeasurementCapture>());
         _delayAsync = delayAsync ?? Task.Delay;
+        _startWorkerAsync = startWorkerAsync ?? ((work, cancellationToken) => Task.Run(work, cancellationToken));
+        _captureRequestContext = captureRequestContext;
+        _payloadReleased = payloadReleased;
     }
 
     public async Task PublishAsync(
@@ -154,14 +170,35 @@ public class OrleansEventPublisher : IEventPublisher, IExecutorSizePreparedDesti
             }
 
             var context = CaptureRequestContext();
-            var payload = new SharedPublishPayload(serializableEvent, context);
+            var payload = new SharedPublishPayload(serializableEvent, context, _payloadReleased);
             try
             {
                 foreach (var destination in destinations)
                 {
                     if (cancellationToken.IsCancellationRequested)
                         break;
-                    TryEnqueue(new OrleansPublishItem(destination, payload));
+                    OrleansDestinationPlanState planState;
+                    try
+                    {
+                        planState = PrepareDestinationPlanState(destination, context);
+                    }
+                    catch (Exception ex)
+                    {
+                        RecordAdmissionFailure(destination, evt.Id, "admission-resolve-failed", ex);
+                        continue;
+                    }
+
+                    if (planState.FailureReason is not null)
+                    {
+                        RecordAdmissionFailure(
+                            destination,
+                            evt.Id,
+                            "admission-resolve-failed",
+                            new InvalidOperationException(planState.FailureReason));
+                        continue;
+                    }
+
+                    TryEnqueue(new OrleansPublishItem(planState, payload));
                 }
             }
             finally
@@ -199,58 +236,71 @@ public class OrleansEventPublisher : IEventPublisher, IExecutorSizePreparedDesti
         if (destinations.Count == 0)
             return null;
 
-        var captures = _sender is ClusterOrleansStreamSender clusterSender
-            ? clusterSender.Captures
-            : Array.Empty<IOrleansDestinationMeasurementCapture>();
+        IReadOnlyDictionary<string, object>? requestContext = null;
+        string? contextFailure = null;
+        try
+        {
+            requestContext = CaptureRequestContext();
+        }
+        catch (Exception ex)
+        {
+            contextFailure = $"Orleans request-context capture failed with {ex.GetType().Name}";
+        }
+
         var destinationStates = new List<OrleansDestinationPlanState>(destinations.Count);
         foreach (var destination in destinations)
         {
-            string? failureReason = null;
-            Dictionary<string, object>? requestContext = null;
+            string? failureReason = contextFailure;
+            IOrleansPreparedStreamTarget? preparedTarget = null;
             try
             {
-                requestContext = CaptureRequestContext()?.ToDictionary(
-                    pair => pair.Key,
-                    pair => pair.Value,
-                    StringComparer.Ordinal);
+                preparedTarget = _sender.PrepareDestination(destination);
             }
             catch (Exception ex)
             {
-                failureReason = $"Orleans request-context capture failed with {ex.GetType().Name}";
+                failureReason ??= $"Orleans destination preparation failed with {ex.GetType().Name}";
             }
 
-            var capture = captures.FirstOrDefault(candidate => candidate.Matches(destination.ProviderName));
             object? providerState = null;
-            if (capture is null)
+            if (failureReason is null)
             {
-                failureReason ??=
-                    $"no destination measurement capability is registered for provider '{destination.ProviderName}'";
-            }
-            else
-            {
-                providerState = capture.Capture(
-                    destination.ProviderName,
-                    destination.StreamNamespace,
-                    destination.StreamId,
-                    serializedEvent,
-                    requestContext,
-                    out var captureFailure);
-                failureReason ??= captureFailure;
+                var capture = _measurementCaptures.FirstOrDefault(
+                    candidate => candidate.Matches(destination.ProviderName));
+                if (capture is null)
+                {
+                    failureReason =
+                        $"no destination measurement capability is registered for provider '{destination.ProviderName}'";
+                }
+                else
+                {
+                    providerState = capture.Capture(
+                        destination.ProviderName,
+                        destination.StreamNamespace,
+                        destination.StreamId,
+                        serializedEvent,
+                        requestContext,
+                        out var captureFailure);
+                    failureReason ??= captureFailure;
+                }
             }
 
             destinationStates.Add(new OrleansDestinationPlanState(
-                GetLegacyDestinationKey(destination),
+                destination.DestinationKey,
                 destination.ProviderName,
                 destination.StreamNamespace,
                 destination.StreamId,
                 providerState,
                 requestContext,
-                failureReason));
+                failureReason)
+            {
+                ServiceId = serviceId,
+                PreparedTarget = preparedTarget
+            });
         }
 
         return new ExecutorSizeDestinationPlan(
             serviceId,
-            destinations.Select(GetLegacyDestinationKey).ToArray(),
+            destinations.Select(destination => destination.DestinationKey).ToArray(),
             destinationStates)
         {
             PreparedEvent = serializedEvent
@@ -273,9 +323,14 @@ public class OrleansEventPublisher : IEventPublisher, IExecutorSizePreparedDesti
                     $"The captured destination plan for event {evt.Id} is unavailable.");
             }
 
-            var serializableEvent = plan.PreparedEvent ?? evt.ToSerializableEvent(_domainTypes.EventTypes);
+            if (plan.PreparedEvent is not { } serializableEvent)
+            {
+                throw new InvalidOperationException(
+                    $"The captured destination plan for event {evt.Id} does not contain its prepared serialized event.");
+            }
+
             var context = destinations.FirstOrDefault()?.RequestContext;
-            var payload = new SharedPublishPayload(serializableEvent, context);
+            var payload = new SharedPublishPayload(serializableEvent, context, _payloadReleased);
             try
             {
                 foreach (var destination in destinations)
@@ -296,29 +351,19 @@ public class OrleansEventPublisher : IEventPublisher, IExecutorSizePreparedDesti
                         continue;
                     }
 
-                    var requestContext = destination.RequestContext is null
-                        ? null
-                        : destination.RequestContext.ToDictionary(
-                            pair => pair.Key,
-                            pair => pair.Value,
-                            StringComparer.Ordinal);
-                    var plannedDestination = new OrleansPublishDestination(
-                        plan.ServiceId,
-                        destination.ProviderName,
-                        destination.StreamNamespace,
-                        destination.StreamId);
+                    if (destination.PreparedTarget is null)
+                    {
+                        throw new InvalidOperationException(
+                            $"The captured destination plan for '{destination.DestinationKey}' does not contain its prepared target.");
+                    }
+
                     PlannedPublishObserver?.Invoke(
                         serializableEvent,
                         destination.ProviderName,
                         destination.StreamNamespace,
                         destination.StreamId,
-                        requestContext);
-                    var destinationPayload = ReferenceEquals(context, destination.RequestContext)
-                        ? payload
-                        : new SharedPublishPayload(serializableEvent, requestContext);
-                    TryEnqueue(new OrleansPublishItem(plannedDestination, destinationPayload));
-                    if (!ReferenceEquals(destinationPayload, payload))
-                        destinationPayload.Release();
+                        destination.RequestContext);
+                    TryEnqueue(new OrleansPublishItem(destination, payload));
                 }
             }
             finally
@@ -382,11 +427,32 @@ public class OrleansEventPublisher : IEventPublisher, IExecutorSizePreparedDesti
             .ToArray();
     }
 
-    private IReadOnlyDictionary<string, object>? CaptureRequestContext()
+    private Dictionary<string, object>? CaptureRequestContext()
     {
+        if (_captureRequestContext is not null)
+            return _captureRequestContext();
         if (_sender is not ClusterOrleansStreamSender clusterSender || clusterSender.DeepCopier is null)
             return null;
         return RequestContextExtensions.Export(clusterSender.DeepCopier);
+    }
+
+    private OrleansDestinationPlanState PrepareDestinationPlanState(
+        OrleansPublishDestination destination,
+        IReadOnlyDictionary<string, object>? requestContext)
+    {
+        var preparedTarget = _sender.PrepareDestination(destination);
+        return new OrleansDestinationPlanState(
+            destination.DestinationKey,
+            destination.ProviderName,
+            destination.StreamNamespace,
+            destination.StreamId,
+            MeasurementState: null,
+            requestContext,
+            FailureReason: null)
+        {
+            ServiceId = destination.ServiceId,
+            PreparedTarget = preparedTarget
+        };
     }
 
     private bool TryEnqueue(OrleansPublishItem item)
@@ -395,7 +461,7 @@ public class OrleansEventPublisher : IEventPublisher, IExecutorSizePreparedDesti
         {
             if (_disposed || _pumpFaulted)
             {
-                _diagnostics.Terminal(item.Destination, item.Payload.Event.Id, "pump-faulted", 0);
+                _diagnostics.Terminal(ToPublishDestination(item.Destination), item.Payload.Event.Id, "pump-faulted", 0);
                 return false;
             }
 
@@ -416,7 +482,11 @@ public class OrleansEventPublisher : IEventPublisher, IExecutorSizePreparedDesti
             if (state.LiveCount >= _options.MaxQueuedItemsPerDestination ||
                 _totalLiveItems >= _options.MaxQueuedItemsTotal)
             {
-                _diagnostics.Terminal(item.Destination, item.Payload.Event.Id, "admission-capacity", 0);
+                _diagnostics.Terminal(
+                    ToPublishDestination(item.Destination),
+                    item.Payload.Event.Id,
+                    "admission-capacity",
+                    0);
                 return false;
             }
 
@@ -428,13 +498,19 @@ public class OrleansEventPublisher : IEventPublisher, IExecutorSizePreparedDesti
                 state.LiveCount--;
                 _totalLiveItems--;
                 item.Payload.Release();
-                _diagnostics.Terminal(item.Destination, item.Payload.Event.Id, "admission-capacity", 0);
+                _diagnostics.Terminal(
+                    ToPublishDestination(item.Destination),
+                    item.Payload.Event.Id,
+                    "admission-capacity",
+                    0);
                 return false;
             }
 
             if (state.Worker is null || state.Worker.IsCompleted)
             {
-                state.Worker = Task.Run(() => ProcessDestinationAsync(item.Destination.DestinationKey, state));
+                state.Worker = _startWorkerAsync(
+                    () => ProcessDestinationAsync(item.Destination.DestinationKey, state),
+                    CancellationToken.None);
                 _activeWorkers.Add(state.Worker);
                 _ = state.Worker.ContinueWith(
                     completed =>
@@ -498,11 +574,23 @@ public class OrleansEventPublisher : IEventPublisher, IExecutorSizePreparedDesti
             for (var attempt = 1; attempt <= _options.MaxPublishAttempts; attempt++)
             {
                 attempts = attempt;
-                _diagnostics.Attempt(item.Destination);
+                _diagnostics.Attempt(ToPublishDestination(item.Destination));
                 try
                 {
-                    await _sender.SendAsync(item.Destination, item.Payload, _shutdown.Token).ConfigureAwait(false);
-                    _diagnostics.Terminal(item.Destination, item.Payload.Event.Id, "writer-completed", attempts);
+                    if (item.Destination.PreparedTarget is null)
+                    {
+                        throw new InvalidOperationException(
+                            $"The destination plan for '{item.Destination.DestinationKey}' has no prepared target.");
+                    }
+
+                    await item.Destination.PreparedTarget
+                        .SendAsync(item.Payload, _shutdown.Token)
+                        .ConfigureAwait(false);
+                    _diagnostics.Terminal(
+                        ToPublishDestination(item.Destination),
+                        item.Payload.Event.Id,
+                        "writer-completed",
+                        attempts);
                     return;
                 }
                 catch (OperationCanceledException) when (_shutdown.IsCancellationRequested)
@@ -519,7 +607,7 @@ public class OrleansEventPublisher : IEventPublisher, IExecutorSizePreparedDesti
                             item.Payload.Event.Id,
                             item.Destination.DestinationKey);
                         _diagnostics.Terminal(
-                            item.Destination,
+                            ToPublishDestination(item.Destination),
                             item.Payload.Event.Id,
                             "transport-attempts-exhausted",
                             attempts);
@@ -537,7 +625,11 @@ public class OrleansEventPublisher : IEventPublisher, IExecutorSizePreparedDesti
         }
         catch
         {
-            _diagnostics.Terminal(item.Destination, item.Payload.Event.Id, "pump-faulted", attempts);
+            _diagnostics.Terminal(
+                ToPublishDestination(item.Destination),
+                item.Payload.Event.Id,
+                "pump-faulted",
+                attempts);
             throw;
         }
         finally
@@ -568,7 +660,7 @@ public class OrleansEventPublisher : IEventPublisher, IExecutorSizePreparedDesti
         {
             item.Payload.Release();
             if (reason is not null)
-                _diagnostics.Terminal(item.Destination, item.Payload.Event.Id, reason, 0);
+                _diagnostics.Terminal(ToPublishDestination(item.Destination), item.Payload.Event.Id, reason, 0);
             ReleaseLive(destinationKey, state);
         }
     }
@@ -592,8 +684,8 @@ public class OrleansEventPublisher : IEventPublisher, IExecutorSizePreparedDesti
         _diagnostics.Terminal(destination, eventId, reason, 0);
     }
 
-    private static string GetLegacyDestinationKey(OrleansPublishDestination destination) =>
-        $"{destination.ProviderName}|{destination.StreamNamespace}|{destination.StreamId:D}";
+    private static OrleansPublishDestination ToPublishDestination(OrleansDestinationPlanState state) =>
+        new(state.ServiceId, state.ProviderName, state.StreamNamespace, state.StreamId);
 
     private sealed class DestinationState(Channel<OrleansPublishItem> queue)
     {
@@ -617,19 +709,28 @@ public class OrleansEventPublisher : IEventPublisher, IExecutorSizePreparedDesti
                 .ToArray();
         }
 
-        public async Task SendAsync(
-            OrleansPublishDestination destination,
-            SharedPublishPayload payload,
-            CancellationToken cancellationToken)
+        public IOrleansPreparedStreamTarget PrepareDestination(OrleansPublishDestination destination)
         {
             var provider = _clusterClient.GetStreamProvider(destination.ProviderName);
             var stream = provider.GetStream<SerializableEvent>(
                 StreamId.Create(destination.StreamNamespace, destination.StreamId));
-            var priorContext = DeepCopier is null ? null : RequestContextExtensions.Export(DeepCopier);
+            return new ClusterOrleansPreparedStreamTarget(stream, DeepCopier);
+        }
+    }
+
+    private sealed class ClusterOrleansPreparedStreamTarget(
+        IAsyncStream<SerializableEvent> stream,
+        DeepCopier? deepCopier) : IOrleansPreparedStreamTarget
+    {
+        public async Task SendAsync(SharedPublishPayload payload, CancellationToken cancellationToken)
+        {
+            var priorContext = deepCopier is null ? null : RequestContextExtensions.Export(deepCopier);
             try
             {
                 if (payload.RequestContext is not null)
                     RequestContextExtensions.Import(payload.RequestContext);
+                else
+                    RequestContext.Clear();
                 await stream.OnNextAsync(payload.Event).WaitAsync(cancellationToken).ConfigureAwait(false);
             }
             finally

--- a/dcb/src/Sekiban.Dcb.Orleans.Core/OrleansEventPublisher.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.Core/OrleansEventPublisher.cs
@@ -20,6 +20,7 @@ namespace Sekiban.Dcb.Orleans;
 public class OrleansEventPublisher : IEventPublisher, IExecutorSizePreparedDestinationPublisher, IAsyncDisposable,
     IOrleansPublisherDiagnostics
 {
+    private const string AdmissionResolveFailedReason = "admission-resolve-failed";
     private readonly IStreamDestinationResolver _resolver;
     private readonly DcbDomainTypes _domainTypes;
     private readonly IServiceIdProvider _serviceIdProvider;
@@ -63,9 +64,7 @@ public class OrleansEventPublisher : IEventPublisher, IExecutorSizePreparedDesti
             domainTypes,
             logger,
             options: new OrleansEventPublisherOptions(),
-            serviceIdProvider: new DefaultServiceIdProvider(),
-            sender: null,
-            delayAsync: null)
+            serviceIdProvider: new DefaultServiceIdProvider())
     {
     }
 
@@ -83,9 +82,7 @@ public class OrleansEventPublisher : IEventPublisher, IExecutorSizePreparedDesti
             domainTypes,
             logger,
             options: new OrleansEventPublisherOptions(),
-            serviceIdProvider: serviceIdProvider ?? new DefaultServiceIdProvider(),
-            sender: null,
-            delayAsync: null)
+            serviceIdProvider: serviceIdProvider ?? new DefaultServiceIdProvider())
     {
     }
 
@@ -106,10 +103,7 @@ public class OrleansEventPublisher : IEventPublisher, IExecutorSizePreparedDesti
             domainTypes,
             logger,
             options,
-            serviceIdProvider ?? new DefaultServiceIdProvider(),
-            sender: null,
-            delayAsync: null,
-            diagnostics: null)
+            serviceIdProvider ?? new DefaultServiceIdProvider())
     {
     }
 
@@ -121,14 +115,9 @@ public class OrleansEventPublisher : IEventPublisher, IExecutorSizePreparedDesti
         ILogger<OrleansEventPublisher> logger,
         OrleansEventPublisherOptions options,
         IServiceIdProvider serviceIdProvider,
-        IOrleansStreamSender? sender,
-        Func<TimeSpan, CancellationToken, Task>? delayAsync,
-        OrleansPublisherDiagnosticsRecorder? diagnostics = null,
-        Func<Func<Task>, CancellationToken, Task>? startWorkerAsync = null,
-        Func<Dictionary<string, object>?>? captureRequestContext = null,
-        IReadOnlyList<IOrleansDestinationMeasurementCapture>? measurementCaptures = null,
-        Action? payloadReleased = null)
+        OrleansEventPublisherTestHooks? testHooks = null)
     {
+        var sender = testHooks?.Sender;
         if (sender is null)
             ArgumentNullException.ThrowIfNull(clusterClient);
         ArgumentNullException.ThrowIfNull(resolver);
@@ -141,17 +130,17 @@ public class OrleansEventPublisher : IEventPublisher, IExecutorSizePreparedDesti
         _domainTypes = domainTypes;
         _logger = logger;
         _serviceIdProvider = serviceIdProvider;
-        _diagnostics = diagnostics ?? new OrleansPublisherDiagnosticsRecorder(_options);
-        var deepCopier = sender is null ? clusterClient!.ServiceProvider.GetService<DeepCopier>() : null;
-        _sender = sender ?? new ClusterOrleansStreamSender(clusterClient!, deepCopier);
-        _measurementCaptures = measurementCaptures ??
+        _diagnostics = testHooks?.Diagnostics ?? new OrleansPublisherDiagnosticsRecorder(_options);
+        var deepCopier = sender is null ? clusterClient.ServiceProvider.GetService<DeepCopier>() : null;
+        _sender = sender ?? new ClusterOrleansStreamSender(clusterClient, deepCopier);
+        _measurementCaptures = testHooks?.MeasurementCaptures ??
             (_sender is ClusterOrleansStreamSender clusterSender
                 ? clusterSender.Captures
                 : Array.Empty<IOrleansDestinationMeasurementCapture>());
-        _delayAsync = delayAsync ?? Task.Delay;
-        _startWorkerAsync = startWorkerAsync ?? ((work, cancellationToken) => Task.Run(work, cancellationToken));
-        _captureRequestContext = captureRequestContext;
-        _payloadReleased = payloadReleased;
+        _delayAsync = testHooks?.DelayAsync ?? Task.Delay;
+        _startWorkerAsync = testHooks?.StartWorkerAsync ?? ((work, cancellationToken) => Task.Run(work, cancellationToken));
+        _captureRequestContext = testHooks?.CaptureRequestContext;
+        _payloadReleased = testHooks?.PayloadReleased;
     }
 
     public async Task PublishAsync(
@@ -181,7 +170,7 @@ public class OrleansEventPublisher : IEventPublisher, IExecutorSizePreparedDesti
             }
             catch (Exception ex)
             {
-                RecordAdmissionFailure(null, evt.Id, "admission-resolve-failed", ex);
+                RecordAdmissionFailure(null, evt.Id, AdmissionResolveFailedReason, ex);
                 continue;
             }
 
@@ -192,7 +181,7 @@ public class OrleansEventPublisher : IEventPublisher, IExecutorSizePreparedDesti
             }
             catch (Exception ex)
             {
-                RecordAdmissionFailure(null, evt.Id, "admission-resolve-failed", ex);
+                RecordAdmissionFailure(null, evt.Id, AdmissionResolveFailedReason, ex);
                 continue;
             }
             var payload = new SharedPublishPayload(serializableEvent, context, _payloadReleased);
@@ -209,7 +198,7 @@ public class OrleansEventPublisher : IEventPublisher, IExecutorSizePreparedDesti
                     }
                     catch (Exception ex)
                     {
-                        RecordAdmissionFailure(destination, evt.Id, "admission-resolve-failed", ex);
+                        RecordAdmissionFailure(destination, evt.Id, AdmissionResolveFailedReason, ex);
                         continue;
                     }
 
@@ -218,7 +207,7 @@ public class OrleansEventPublisher : IEventPublisher, IExecutorSizePreparedDesti
                         RecordAdmissionFailure(
                             destination,
                             evt.Id,
-                            "admission-resolve-failed",
+                            AdmissionResolveFailedReason,
                             new InvalidOperationException(planState.FailureReason));
                         continue;
                     }
@@ -338,7 +327,7 @@ public class OrleansEventPublisher : IEventPublisher, IExecutorSizePreparedDesti
                     serializedEvent,
                     requestContext,
                     out var captureFailure);
-                failureReason ??= captureFailure;
+                failureReason = captureFailure;
             }
         }
 
@@ -395,7 +384,7 @@ public class OrleansEventPublisher : IEventPublisher, IExecutorSizePreparedDesti
                                 destination.StreamNamespace,
                                 destination.StreamId),
                             evt.Id,
-                            "admission-resolve-failed",
+                            AdmissionResolveFailedReason,
                             new InvalidOperationException(destination.FailureReason));
                         continue;
                     }
@@ -542,14 +531,14 @@ public class OrleansEventPublisher : IEventPublisher, IExecutorSizePreparedDesti
         };
     }
 
-    private bool TryEnqueue(OrleansPublishItem item)
+    private void TryEnqueue(OrleansPublishItem item)
     {
         lock (_queueGate)
         {
             if (_disposed || _pumpFaulted)
             {
                 _diagnostics.Terminal(ToPublishDestination(item.Destination), item.Payload.Event.Id, "pump-faulted", 0);
-                return false;
+                return;
             }
 
             if (_totalLiveItems >= _options.MaxQueuedItemsTotal)
@@ -559,7 +548,7 @@ public class OrleansEventPublisher : IEventPublisher, IExecutorSizePreparedDesti
                     item.Payload.Event.Id,
                     "admission-capacity",
                     0);
-                return false;
+                return;
             }
 
             if (!_destinations.TryGetValue(item.Destination.DestinationKey, out var state))
@@ -583,7 +572,7 @@ public class OrleansEventPublisher : IEventPublisher, IExecutorSizePreparedDesti
                     item.Payload.Event.Id,
                     "admission-capacity",
                     0);
-                return false;
+                return;
             }
 
             item.Payload.Retain();
@@ -605,7 +594,7 @@ public class OrleansEventPublisher : IEventPublisher, IExecutorSizePreparedDesti
                     item.Payload.Event.Id,
                     "writer-completed",
                     0);
-                return false;
+                return;
             }
 
             if (state.Worker is null || state.Worker.IsCompleted)
@@ -625,7 +614,6 @@ public class OrleansEventPublisher : IEventPublisher, IExecutorSizePreparedDesti
                     TaskScheduler.Default);
             }
 
-            return true;
         }
     }
 
@@ -845,4 +833,16 @@ public class OrleansEventPublisher : IEventPublisher, IExecutorSizePreparedDesti
             }
         }
     }
+}
+
+/// <summary>Internal deterministic hooks used only by Orleans publisher tests.</summary>
+internal sealed class OrleansEventPublisherTestHooks
+{
+    public IOrleansStreamSender? Sender { get; init; }
+    public Func<TimeSpan, CancellationToken, Task>? DelayAsync { get; init; }
+    public OrleansPublisherDiagnosticsRecorder? Diagnostics { get; init; }
+    public Func<Func<Task>, CancellationToken, Task>? StartWorkerAsync { get; init; }
+    public Func<Dictionary<string, object>?>? CaptureRequestContext { get; init; }
+    public IReadOnlyList<IOrleansDestinationMeasurementCapture>? MeasurementCaptures { get; init; }
+    public Action? PayloadReleased { get; init; }
 }

--- a/dcb/src/Sekiban.Dcb.Orleans.Core/OrleansEventPublisher.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.Core/OrleansEventPublisher.cs
@@ -261,78 +261,15 @@ public class OrleansEventPublisher : IEventPublisher, IExecutorSizePreparedDesti
         if (destinations.Count == 0)
             return null;
 
-        IReadOnlyDictionary<string, object>? requestContext = null;
-        string? contextFailure = null;
-        try
-        {
-            var capture = CaptureRequestContext(requireDeepCopier: true);
-            if (!capture.IsAvailable)
-            {
-                contextFailure = "Orleans request-context capture capability is unavailable";
-            }
-            else
-            {
-                requestContext = capture.Context;
-            }
-        }
-        catch (Exception ex)
-        {
-            contextFailure = $"Orleans request-context capture failed with {ex.GetType().Name}";
-        }
-
-        var destinationStates = new List<OrleansDestinationPlanState>(destinations.Count);
-        foreach (var destination in destinations)
-        {
-            string? failureReason = contextFailure;
-            IOrleansPreparedStreamTarget? preparedTarget = null;
-            if (failureReason is null)
-            {
-                try
-                {
-                    preparedTarget = _sender.PrepareDestination(destination);
-                }
-                catch (Exception ex)
-                {
-                    failureReason = $"Orleans destination preparation failed with {ex.GetType().Name}";
-                }
-            }
-
-            object? providerState = null;
-            if (failureReason is null)
-            {
-                var capture = _measurementCaptures.FirstOrDefault(
-                    candidate => candidate.Matches(destination.ProviderName));
-                if (capture is null)
-                {
-                    failureReason =
-                        $"no destination measurement capability is registered for provider '{destination.ProviderName}'";
-                }
-                else
-                {
-                    providerState = capture.Capture(
-                        destination.ProviderName,
-                        destination.StreamNamespace,
-                        destination.StreamId,
-                        serializedEvent,
-                        requestContext,
-                        out var captureFailure);
-                    failureReason ??= captureFailure;
-                }
-            }
-
-            destinationStates.Add(new OrleansDestinationPlanState(
-                destination.DestinationKey,
-                destination.ProviderName,
-                destination.StreamNamespace,
-                destination.StreamId,
-                providerState,
+        var (requestContext, contextFailure) = CapturePlanRequestContext();
+        var destinationStates = destinations
+            .Select(destination => CapturePlanDestinationState(
+                destination,
+                serializedEvent,
                 requestContext,
-                failureReason)
-            {
-                ServiceId = serviceId,
-                PreparedTarget = preparedTarget
-            });
-        }
+                contextFailure,
+                serviceId))
+            .ToArray();
 
         return new ExecutorSizeDestinationPlan(
             serviceId,
@@ -340,6 +277,82 @@ public class OrleansEventPublisher : IEventPublisher, IExecutorSizePreparedDesti
             destinationStates)
         {
             PreparedEvent = serializedEvent
+        };
+    }
+
+    private (IReadOnlyDictionary<string, object>? RequestContext, string? FailureReason) CapturePlanRequestContext()
+    {
+        try
+        {
+            var capture = CaptureRequestContext(requireDeepCopier: true);
+            if (!capture.IsAvailable)
+            {
+                return (null, "Orleans request-context capture capability is unavailable");
+            }
+
+            return (capture.Context, null);
+        }
+        catch (Exception ex)
+        {
+            return (null, $"Orleans request-context capture failed with {ex.GetType().Name}");
+        }
+    }
+
+    private OrleansDestinationPlanState CapturePlanDestinationState(
+        OrleansPublishDestination destination,
+        SerializableEvent serializedEvent,
+        IReadOnlyDictionary<string, object>? requestContext,
+        string? contextFailure,
+        string serviceId)
+    {
+        string? failureReason = contextFailure;
+        IOrleansPreparedStreamTarget? preparedTarget = null;
+        if (failureReason is null)
+        {
+            try
+            {
+                preparedTarget = _sender.PrepareDestination(destination);
+            }
+            catch (Exception ex)
+            {
+                failureReason = $"Orleans destination preparation failed with {ex.GetType().Name}";
+            }
+        }
+
+        object? providerState = null;
+        if (failureReason is null)
+        {
+            var capture = _measurementCaptures.FirstOrDefault(
+                candidate => candidate.Matches(destination.ProviderName));
+            if (capture is null)
+            {
+                failureReason =
+                    $"no destination measurement capability is registered for provider '{destination.ProviderName}'";
+            }
+            else
+            {
+                providerState = capture.Capture(
+                    destination.ProviderName,
+                    destination.StreamNamespace,
+                    destination.StreamId,
+                    serializedEvent,
+                    requestContext,
+                    out var captureFailure);
+                failureReason ??= captureFailure;
+            }
+        }
+
+        return new OrleansDestinationPlanState(
+            destination.DestinationKey,
+            destination.ProviderName,
+            destination.StreamNamespace,
+            destination.StreamId,
+            providerState,
+            requestContext,
+            failureReason)
+        {
+            ServiceId = serviceId,
+            PreparedTarget = preparedTarget
         };
     }
 

--- a/dcb/src/Sekiban.Dcb.Orleans.Core/OrleansEventPublisher.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.Core/OrleansEventPublisher.cs
@@ -57,7 +57,15 @@ public class OrleansEventPublisher : IEventPublisher, IExecutorSizePreparedDesti
         IStreamDestinationResolver resolver,
         DcbDomainTypes domainTypes,
         ILogger<OrleansEventPublisher> logger)
-        : this(clusterClient, resolver, domainTypes, logger, options: null, serviceIdProvider: null)
+        : this(
+            clusterClient,
+            resolver,
+            domainTypes,
+            logger,
+            options: new OrleansEventPublisherOptions(),
+            serviceIdProvider: new DefaultServiceIdProvider(),
+            sender: null,
+            delayAsync: null)
     {
     }
 
@@ -69,27 +77,35 @@ public class OrleansEventPublisher : IEventPublisher, IExecutorSizePreparedDesti
         DcbDomainTypes domainTypes,
         ILogger<OrleansEventPublisher> logger,
         IServiceIdProvider? serviceIdProvider = null)
-        : this(clusterClient, resolver, domainTypes, logger, options: null, serviceIdProvider)
+        : this(
+            clusterClient,
+            resolver,
+            domainTypes,
+            logger,
+            options: new OrleansEventPublisherOptions(),
+            serviceIdProvider: serviceIdProvider ?? new DefaultServiceIdProvider(),
+            sender: null,
+            delayAsync: null)
     {
     }
 
     /// <summary>
-    /// Additive bounded-publisher configuration. A null options value selects the validated defaults, which keeps
-    /// options-free dependency-injection activation compatible with the original registration.
+    /// Additive bounded-publisher configuration. The required options parameter is placed after the legacy
+    /// service-provider parameter so the original five-argument null-literal call remains source-compatible.
     /// </summary>
     public OrleansEventPublisher(
         IClusterClient clusterClient,
         IStreamDestinationResolver resolver,
         DcbDomainTypes domainTypes,
         ILogger<OrleansEventPublisher> logger,
-        OrleansEventPublisherOptions? options,
-        IServiceIdProvider? serviceIdProvider = null)
+        IServiceIdProvider? serviceIdProvider,
+        OrleansEventPublisherOptions options)
         : this(
             clusterClient,
             resolver,
             domainTypes,
             logger,
-            options ?? new OrleansEventPublisherOptions(),
+            options,
             serviceIdProvider ?? new DefaultServiceIdProvider(),
             sender: null,
             delayAsync: null,
@@ -169,7 +185,16 @@ public class OrleansEventPublisher : IEventPublisher, IExecutorSizePreparedDesti
                 continue;
             }
 
-            var context = CaptureRequestContext();
+            Dictionary<string, object>? context;
+            try
+            {
+                context = CaptureRequestContext(requireDeepCopier: false).Context;
+            }
+            catch (Exception ex)
+            {
+                RecordAdmissionFailure(null, evt.Id, "admission-resolve-failed", ex);
+                continue;
+            }
             var payload = new SharedPublishPayload(serializableEvent, context, _payloadReleased);
             try
             {
@@ -240,7 +265,15 @@ public class OrleansEventPublisher : IEventPublisher, IExecutorSizePreparedDesti
         string? contextFailure = null;
         try
         {
-            requestContext = CaptureRequestContext();
+            var capture = CaptureRequestContext(requireDeepCopier: true);
+            if (!capture.IsAvailable)
+            {
+                contextFailure = "Orleans request-context capture capability is unavailable";
+            }
+            else
+            {
+                requestContext = capture.Context;
+            }
         }
         catch (Exception ex)
         {
@@ -252,13 +285,16 @@ public class OrleansEventPublisher : IEventPublisher, IExecutorSizePreparedDesti
         {
             string? failureReason = contextFailure;
             IOrleansPreparedStreamTarget? preparedTarget = null;
-            try
+            if (failureReason is null)
             {
-                preparedTarget = _sender.PrepareDestination(destination);
-            }
-            catch (Exception ex)
-            {
-                failureReason ??= $"Orleans destination preparation failed with {ex.GetType().Name}";
+                try
+                {
+                    preparedTarget = _sender.PrepareDestination(destination);
+                }
+                catch (Exception ex)
+                {
+                    failureReason = $"Orleans destination preparation failed with {ex.GetType().Name}";
+                }
             }
 
             object? providerState = null;
@@ -377,6 +413,42 @@ public class OrleansEventPublisher : IEventPublisher, IExecutorSizePreparedDesti
 
     public OrleansPublisherDiagnosticsSnapshot GetSnapshot() => _diagnostics.Snapshot();
 
+    internal int DestinationStateCount
+    {
+        get
+        {
+            lock (_queueGate)
+                return _destinations.Count;
+        }
+    }
+
+    internal void CompleteDestinationWriterForTesting(string destinationKey)
+    {
+        lock (_queueGate)
+        {
+            if (!_destinations.TryGetValue(destinationKey, out var state))
+            {
+                state = new DestinationState(
+                    Channel.CreateBounded<OrleansPublishItem>(new BoundedChannelOptions(
+                        _options.MaxQueuedItemsPerDestination)
+                    {
+                        FullMode = BoundedChannelFullMode.Wait,
+                        SingleReader = true,
+                        SingleWriter = false,
+                        AllowSynchronousContinuations = false
+                    }));
+                _destinations.Add(destinationKey, state);
+            }
+
+            state.Queue.Writer.TryComplete();
+        }
+    }
+
+    internal static IOrleansPreparedStreamTarget CreatePreparedStreamTargetForTesting(
+        IAsyncStream<SerializableEvent> stream,
+        DeepCopier? deepCopier = null) =>
+        new ClusterOrleansPreparedStreamTarget(stream, deepCopier);
+
     public ValueTask DisposeAsync()
     {
         lock (_queueGate)
@@ -427,13 +499,15 @@ public class OrleansEventPublisher : IEventPublisher, IExecutorSizePreparedDesti
             .ToArray();
     }
 
-    private Dictionary<string, object>? CaptureRequestContext()
+    private RequestContextCapture CaptureRequestContext(bool requireDeepCopier)
     {
         if (_captureRequestContext is not null)
-            return _captureRequestContext();
-        if (_sender is not ClusterOrleansStreamSender clusterSender || clusterSender.DeepCopier is null)
-            return null;
-        return RequestContextExtensions.Export(clusterSender.DeepCopier);
+            return new RequestContextCapture(true, _captureRequestContext());
+        if (_sender is not ClusterOrleansStreamSender clusterSender)
+            return new RequestContextCapture(true, null);
+        if (clusterSender.DeepCopier is null)
+            return new RequestContextCapture(!requireDeepCopier, null);
+        return new RequestContextCapture(true, RequestContextExtensions.Export(clusterSender.DeepCopier));
     }
 
     private OrleansDestinationPlanState PrepareDestinationPlanState(
@@ -465,6 +539,16 @@ public class OrleansEventPublisher : IEventPublisher, IExecutorSizePreparedDesti
                 return false;
             }
 
+            if (_totalLiveItems >= _options.MaxQueuedItemsTotal)
+            {
+                _diagnostics.Terminal(
+                    ToPublishDestination(item.Destination),
+                    item.Payload.Event.Id,
+                    "admission-capacity",
+                    0);
+                return false;
+            }
+
             if (!_destinations.TryGetValue(item.Destination.DestinationKey, out var state))
             {
                 state = new DestinationState(
@@ -479,8 +563,7 @@ public class OrleansEventPublisher : IEventPublisher, IExecutorSizePreparedDesti
                 _destinations.Add(item.Destination.DestinationKey, state);
             }
 
-            if (state.LiveCount >= _options.MaxQueuedItemsPerDestination ||
-                _totalLiveItems >= _options.MaxQueuedItemsTotal)
+            if (state.LiveCount >= _options.MaxQueuedItemsPerDestination)
             {
                 _diagnostics.Terminal(
                     ToPublishDestination(item.Destination),
@@ -498,10 +581,16 @@ public class OrleansEventPublisher : IEventPublisher, IExecutorSizePreparedDesti
                 state.LiveCount--;
                 _totalLiveItems--;
                 item.Payload.Release();
+                if (state.LiveCount == 0 &&
+                    _destinations.TryGetValue(item.Destination.DestinationKey, out var current) &&
+                    ReferenceEquals(current, state))
+                {
+                    _destinations.Remove(item.Destination.DestinationKey);
+                }
                 _diagnostics.Terminal(
                     ToPublishDestination(item.Destination),
                     item.Payload.Event.Id,
-                    "admission-capacity",
+                    "writer-completed",
                     0);
                 return false;
             }
@@ -586,11 +675,6 @@ public class OrleansEventPublisher : IEventPublisher, IExecutorSizePreparedDesti
                     await item.Destination.PreparedTarget
                         .SendAsync(item.Payload, _shutdown.Token)
                         .ConfigureAwait(false);
-                    _diagnostics.Terminal(
-                        ToPublishDestination(item.Destination),
-                        item.Payload.Event.Id,
-                        "writer-completed",
-                        attempts);
                     return;
                 }
                 catch (OperationCanceledException) when (_shutdown.IsCancellationRequested)
@@ -694,6 +778,10 @@ public class OrleansEventPublisher : IEventPublisher, IExecutorSizePreparedDesti
         public Task? Worker { get; set; }
     }
 
+    private readonly record struct RequestContextCapture(
+        bool IsAvailable,
+        Dictionary<string, object>? Context);
+
     private sealed class ClusterOrleansStreamSender : IOrleansStreamSender
     {
         private readonly IClusterClient _clusterClient;
@@ -731,7 +819,9 @@ public class OrleansEventPublisher : IEventPublisher, IExecutorSizePreparedDesti
                     RequestContextExtensions.Import(payload.RequestContext);
                 else
                     RequestContext.Clear();
-                await stream.OnNextAsync(payload.Event).WaitAsync(cancellationToken).ConfigureAwait(false);
+                cancellationToken.ThrowIfCancellationRequested();
+                var transportTask = stream.OnNextAsync(payload.Event);
+                await transportTask.ConfigureAwait(false);
             }
             finally
             {

--- a/dcb/src/Sekiban.Dcb.Orleans.Core/OrleansPublisherContracts.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.Core/OrleansPublisherContracts.cs
@@ -16,20 +16,23 @@ public sealed class OrleansEventPublisherOptions
     public void Validate()
     {
         if (MaxPublishAttempts is < 1 or > 64)
-            throw new ArgumentOutOfRangeException(nameof(MaxPublishAttempts));
+            ThrowInvalidOption(nameof(MaxPublishAttempts));
         if (BaseRetryDelay <= TimeSpan.Zero)
-            throw new ArgumentOutOfRangeException(nameof(BaseRetryDelay));
+            ThrowInvalidOption(nameof(BaseRetryDelay));
         if (MaxRetryDelay < BaseRetryDelay || MaxRetryDelay > TimeSpan.FromMinutes(5))
-            throw new ArgumentOutOfRangeException(nameof(MaxRetryDelay));
+            ThrowInvalidOption(nameof(MaxRetryDelay));
         if (MaxQueuedItemsPerDestination is < 1 or > 65_536)
-            throw new ArgumentOutOfRangeException(nameof(MaxQueuedItemsPerDestination));
+            ThrowInvalidOption(nameof(MaxQueuedItemsPerDestination));
         if (MaxQueuedItemsTotal < MaxQueuedItemsPerDestination || MaxQueuedItemsTotal > 1_048_576)
-            throw new ArgumentOutOfRangeException(nameof(MaxQueuedItemsTotal));
+            ThrowInvalidOption(nameof(MaxQueuedItemsTotal));
         if (TerminalSampleCount is < 1 or > 1_000)
-            throw new ArgumentOutOfRangeException(nameof(TerminalSampleCount));
+            ThrowInvalidOption(nameof(TerminalSampleCount));
         if (MaxDiagnosticDestinations is < 1 or > 65_536)
-            throw new ArgumentOutOfRangeException(nameof(MaxDiagnosticDestinations));
+            ThrowInvalidOption(nameof(MaxDiagnosticDestinations));
     }
+
+    private static void ThrowInvalidOption(string optionName) =>
+        throw new ArgumentOutOfRangeException(optionName);
 }
 
 /// <summary>Bounded, payload-free diagnostics for notifications that were attempted or rejected.</summary>
@@ -63,26 +66,17 @@ public sealed class OrleansPublisherDiagnosticsSnapshot
 
 public sealed class OrleansPublisherDestinationDiagnostic
 {
-    internal OrleansPublisherDestinationDiagnostic(
-        string destinationKey,
-        string serviceId,
-        string provider,
-        string @namespace,
-        Guid streamId,
-        long terminalCount,
-        long attemptCount,
-        IReadOnlyDictionary<string, long> reasonCounts,
-        IReadOnlyList<OrleansPublisherTerminalSample> samples)
+    internal OrleansPublisherDestinationDiagnostic(OrleansPublisherDestinationDiagnosticData data)
     {
-        DestinationKey = destinationKey;
-        ServiceId = serviceId;
-        Provider = provider;
-        Namespace = @namespace;
-        StreamId = streamId;
-        TerminalCount = terminalCount;
-        AttemptCount = attemptCount;
-        ReasonCounts = reasonCounts;
-        Samples = samples;
+        DestinationKey = data.DestinationKey;
+        ServiceId = data.ServiceId;
+        Provider = data.Provider;
+        Namespace = data.Namespace;
+        StreamId = data.StreamId;
+        TerminalCount = data.TerminalCount;
+        AttemptCount = data.AttemptCount;
+        ReasonCounts = data.ReasonCounts;
+        Samples = data.Samples;
     }
 
     public string DestinationKey { get; }
@@ -94,6 +88,20 @@ public sealed class OrleansPublisherDestinationDiagnostic
     public long AttemptCount { get; }
     public IReadOnlyDictionary<string, long> ReasonCounts { get; }
     public IReadOnlyList<OrleansPublisherTerminalSample> Samples { get; }
+}
+
+internal sealed class OrleansPublisherDestinationDiagnosticData
+{
+    internal string DestinationKey { get; init; } = string.Empty;
+    internal string ServiceId { get; init; } = string.Empty;
+    internal string Provider { get; init; } = string.Empty;
+    internal string Namespace { get; init; } = string.Empty;
+    internal Guid StreamId { get; init; }
+    internal long TerminalCount { get; init; }
+    internal long AttemptCount { get; init; }
+    internal IReadOnlyDictionary<string, long> ReasonCounts { get; init; } =
+        new Dictionary<string, long>(StringComparer.Ordinal);
+    internal IReadOnlyList<OrleansPublisherTerminalSample> Samples { get; init; } = [];
 }
 
 public sealed class OrleansPublisherTerminalSample
@@ -243,15 +251,18 @@ internal sealed class OrleansPublisherDiagnosticsRecorder
             var destinations = _destinations.Values
                 .OrderBy(value => value.DestinationKey, StringComparer.Ordinal)
                 .Select(value => new OrleansPublisherDestinationDiagnostic(
-                    value.DestinationKey,
-                    value.ServiceId,
-                    value.Provider,
-                    value.Namespace,
-                    value.StreamId,
-                    value.TerminalCount,
-                    value.AttemptCount,
-                    new Dictionary<string, long>(value.ReasonCounts, StringComparer.Ordinal),
-                    value.Samples.ToArray()))
+                    new OrleansPublisherDestinationDiagnosticData
+                    {
+                        DestinationKey = value.DestinationKey,
+                        ServiceId = value.ServiceId,
+                        Provider = value.Provider,
+                        Namespace = value.Namespace,
+                        StreamId = value.StreamId,
+                        TerminalCount = value.TerminalCount,
+                        AttemptCount = value.AttemptCount,
+                        ReasonCounts = new Dictionary<string, long>(value.ReasonCounts, StringComparer.Ordinal),
+                        Samples = value.Samples.ToArray()
+                    }))
                 .ToArray();
             return new OrleansPublisherDiagnosticsSnapshot(
                 _totalTerminalCount,

--- a/dcb/src/Sekiban.Dcb.Orleans.Core/OrleansPublisherContracts.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.Core/OrleansPublisherContracts.cs
@@ -1,0 +1,302 @@
+using Sekiban.Dcb.Events;
+
+namespace Sekiban.Dcb.Orleans;
+
+/// <summary>Validated bounds used by the Orleans notification publisher.</summary>
+public sealed class OrleansEventPublisherOptions
+{
+    public int MaxPublishAttempts { get; set; } = 5;
+    public TimeSpan BaseRetryDelay { get; set; } = TimeSpan.FromMilliseconds(100);
+    public TimeSpan MaxRetryDelay { get; set; } = TimeSpan.FromSeconds(5);
+    public int MaxQueuedItemsPerDestination { get; set; } = 1024;
+    public int MaxQueuedItemsTotal { get; set; } = 16_384;
+    public int TerminalSampleCount { get; set; } = 20;
+    public int MaxDiagnosticDestinations { get; set; } = 1024;
+
+    public void Validate()
+    {
+        if (MaxPublishAttempts is < 1 or > 64)
+            throw new ArgumentOutOfRangeException(nameof(MaxPublishAttempts));
+        if (BaseRetryDelay <= TimeSpan.Zero)
+            throw new ArgumentOutOfRangeException(nameof(BaseRetryDelay));
+        if (MaxRetryDelay < BaseRetryDelay || MaxRetryDelay > TimeSpan.FromMinutes(5))
+            throw new ArgumentOutOfRangeException(nameof(MaxRetryDelay));
+        if (MaxQueuedItemsPerDestination is < 1 or > 65_536)
+            throw new ArgumentOutOfRangeException(nameof(MaxQueuedItemsPerDestination));
+        if (MaxQueuedItemsTotal < MaxQueuedItemsPerDestination || MaxQueuedItemsTotal > 1_048_576)
+            throw new ArgumentOutOfRangeException(nameof(MaxQueuedItemsTotal));
+        if (TerminalSampleCount is < 1 or > 1_000)
+            throw new ArgumentOutOfRangeException(nameof(TerminalSampleCount));
+        if (MaxDiagnosticDestinations is < 1 or > 65_536)
+            throw new ArgumentOutOfRangeException(nameof(MaxDiagnosticDestinations));
+    }
+}
+
+/// <summary>Bounded, payload-free diagnostics for notifications that were attempted or rejected.</summary>
+public interface IOrleansPublisherDiagnostics
+{
+    OrleansPublisherDiagnosticsSnapshot GetSnapshot();
+}
+
+public sealed class OrleansPublisherDiagnosticsSnapshot
+{
+    internal OrleansPublisherDiagnosticsSnapshot(
+        long totalTerminalCount,
+        long totalAttemptCount,
+        IReadOnlyDictionary<string, long> reasonCounts,
+        long evictedDestinationCount,
+        IReadOnlyList<OrleansPublisherDestinationDiagnostic> destinations)
+    {
+        TotalTerminalCount = totalTerminalCount;
+        TotalAttemptCount = totalAttemptCount;
+        ReasonCounts = reasonCounts;
+        EvictedDestinationCount = evictedDestinationCount;
+        Destinations = destinations;
+    }
+
+    public long TotalTerminalCount { get; }
+    public long TotalAttemptCount { get; }
+    public IReadOnlyDictionary<string, long> ReasonCounts { get; }
+    public long EvictedDestinationCount { get; }
+    public IReadOnlyList<OrleansPublisherDestinationDiagnostic> Destinations { get; }
+}
+
+public sealed class OrleansPublisherDestinationDiagnostic
+{
+    internal OrleansPublisherDestinationDiagnostic(
+        string destinationKey,
+        string serviceId,
+        string provider,
+        string @namespace,
+        Guid streamId,
+        long terminalCount,
+        long attemptCount,
+        IReadOnlyDictionary<string, long> reasonCounts,
+        IReadOnlyList<OrleansPublisherTerminalSample> samples)
+    {
+        DestinationKey = destinationKey;
+        ServiceId = serviceId;
+        Provider = provider;
+        Namespace = @namespace;
+        StreamId = streamId;
+        TerminalCount = terminalCount;
+        AttemptCount = attemptCount;
+        ReasonCounts = reasonCounts;
+        Samples = samples;
+    }
+
+    public string DestinationKey { get; }
+    public string ServiceId { get; }
+    public string Provider { get; }
+    public string Namespace { get; }
+    public Guid StreamId { get; }
+    public long TerminalCount { get; }
+    public long AttemptCount { get; }
+    public IReadOnlyDictionary<string, long> ReasonCounts { get; }
+    public IReadOnlyList<OrleansPublisherTerminalSample> Samples { get; }
+}
+
+public sealed class OrleansPublisherTerminalSample
+{
+    internal OrleansPublisherTerminalSample(Guid eventId, string reasonCode, int attempts, DateTimeOffset occurredAtUtc)
+    {
+        EventId = eventId;
+        ReasonCode = reasonCode;
+        Attempts = attempts;
+        OccurredAtUtc = occurredAtUtc;
+    }
+
+    public Guid EventId { get; }
+    public string ReasonCode { get; }
+    public int Attempts { get; }
+    public DateTimeOffset OccurredAtUtc { get; }
+}
+
+internal sealed record OrleansPublishDestination(
+    string ServiceId,
+    string ProviderName,
+    string StreamNamespace,
+    Guid StreamId)
+{
+    public string DestinationKey =>
+        $"{ServiceId}|{ProviderName}|{StreamNamespace}|{StreamId:D}";
+}
+
+/// <summary>One immutable prepared event and context shared by all retries and destination work items.</summary>
+internal sealed class SharedPublishPayload
+{
+    private int _references = 1;
+    private readonly Action? _released;
+
+    public SharedPublishPayload(
+        SerializableEvent @event,
+        IReadOnlyDictionary<string, object>? requestContext,
+        Action? released = null)
+    {
+        Event = @event;
+        RequestContext = requestContext is null
+            ? null
+            : new Dictionary<string, object>(requestContext, StringComparer.Ordinal);
+        _released = released;
+    }
+
+    public SerializableEvent Event { get; }
+    public Dictionary<string, object>? RequestContext { get; }
+    internal int ReferenceCount => Volatile.Read(ref _references);
+
+    public void Retain()
+    {
+        while (true)
+        {
+            var current = Volatile.Read(ref _references);
+            if (current == 0)
+                throw new ObjectDisposedException(nameof(SharedPublishPayload));
+            if (Interlocked.CompareExchange(ref _references, current + 1, current) == current)
+                return;
+        }
+    }
+
+    public void Release()
+    {
+        var remaining = Interlocked.Decrement(ref _references);
+        if (remaining < 0)
+            throw new InvalidOperationException("Shared publish payload was released too many times.");
+        if (remaining == 0)
+            _released?.Invoke();
+    }
+}
+
+internal sealed record OrleansPublishItem(
+    OrleansPublishDestination Destination,
+    SharedPublishPayload Payload);
+
+/// <summary>Internal sender seam; the production implementation is the Orleans stream adapter.</summary>
+internal interface IOrleansStreamSender
+{
+    Task SendAsync(OrleansPublishDestination destination, SharedPublishPayload payload, CancellationToken cancellationToken);
+}
+
+internal sealed class OrleansPublisherDiagnosticsRecorder
+{
+    private readonly object _gate = new();
+    private readonly int _sampleCount;
+    private readonly int _maxDestinations;
+    private readonly Dictionary<string, MutableDestination> _destinations = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, long> _reasonCounts = new(StringComparer.Ordinal);
+    private long _totalTerminalCount;
+    private long _totalAttemptCount;
+    private long _evictedDestinationCount;
+
+    public OrleansPublisherDiagnosticsRecorder(OrleansEventPublisherOptions options)
+    {
+        _sampleCount = options.TerminalSampleCount;
+        _maxDestinations = options.MaxDiagnosticDestinations;
+    }
+
+    public void Attempt(OrleansPublishDestination destination)
+    {
+        lock (_gate)
+        {
+            _totalAttemptCount++;
+            if (TryGetDestination(destination, out var state))
+                state.AttemptCount++;
+        }
+    }
+
+    public void Terminal(
+        OrleansPublishDestination? destination,
+        Guid eventId,
+        string reasonCode,
+        int attempts)
+    {
+        lock (_gate)
+        {
+            _totalTerminalCount++;
+            Increment(_reasonCounts, reasonCode);
+            if (destination is null || !TryGetDestination(destination, out var state))
+                return;
+
+            state.TerminalCount++;
+            Increment(state.ReasonCounts, reasonCode);
+            if (state.Samples.Count < _sampleCount)
+            {
+                state.Samples.Add(new OrleansPublisherTerminalSample(
+                    eventId,
+                    reasonCode,
+                    attempts,
+                    DateTimeOffset.UtcNow));
+            }
+        }
+    }
+
+    public OrleansPublisherDiagnosticsSnapshot Snapshot()
+    {
+        lock (_gate)
+        {
+            var destinations = _destinations.Values
+                .OrderBy(value => value.DestinationKey, StringComparer.Ordinal)
+                .Select(value => new OrleansPublisherDestinationDiagnostic(
+                    value.DestinationKey,
+                    value.ServiceId,
+                    value.Provider,
+                    value.Namespace,
+                    value.StreamId,
+                    value.TerminalCount,
+                    value.AttemptCount,
+                    new Dictionary<string, long>(value.ReasonCounts, StringComparer.Ordinal),
+                    value.Samples.ToArray()))
+                .ToArray();
+            return new OrleansPublisherDiagnosticsSnapshot(
+                _totalTerminalCount,
+                _totalAttemptCount,
+                new Dictionary<string, long>(_reasonCounts, StringComparer.Ordinal),
+                _evictedDestinationCount,
+                destinations);
+        }
+    }
+
+    private bool TryGetDestination(OrleansPublishDestination destination, out MutableDestination state)
+    {
+        if (_destinations.TryGetValue(destination.DestinationKey, out state!))
+            return true;
+
+        if (_destinations.Count >= _maxDestinations)
+        {
+            var evicted = _destinations.Keys.OrderBy(key => key, StringComparer.Ordinal).First();
+            _destinations.Remove(evicted);
+            _evictedDestinationCount++;
+        }
+
+        state = new MutableDestination(
+            destination.DestinationKey,
+            destination.ServiceId,
+            destination.ProviderName,
+            destination.StreamNamespace,
+            destination.StreamId);
+        _destinations.Add(destination.DestinationKey, state);
+        return true;
+    }
+
+    private static void Increment(Dictionary<string, long> counts, string reasonCode)
+    {
+        counts[reasonCode] = counts.TryGetValue(reasonCode, out var count) ? count + 1 : 1;
+    }
+
+    private sealed class MutableDestination(
+        string destinationKey,
+        string serviceId,
+        string provider,
+        string @namespace,
+        Guid streamId)
+    {
+        public string DestinationKey { get; } = destinationKey;
+        public string ServiceId { get; } = serviceId;
+        public string Provider { get; } = provider;
+        public string Namespace { get; } = @namespace;
+        public Guid StreamId { get; } = streamId;
+        public long TerminalCount { get; set; }
+        public long AttemptCount { get; set; }
+        public Dictionary<string, long> ReasonCounts { get; } = new(StringComparer.Ordinal);
+        public List<OrleansPublisherTerminalSample> Samples { get; } = [];
+    }
+}

--- a/dcb/src/Sekiban.Dcb.Orleans.Core/OrleansPublisherContracts.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.Core/OrleansPublisherContracts.cs
@@ -136,7 +136,8 @@ internal sealed class SharedPublishPayload
         Event = @event;
         RequestContext = requestContext is null
             ? null
-            : new Dictionary<string, object>(requestContext, StringComparer.Ordinal);
+            : requestContext as Dictionary<string, object> ??
+              new Dictionary<string, object>(requestContext, StringComparer.Ordinal);
         _released = released;
     }
 
@@ -167,13 +168,19 @@ internal sealed class SharedPublishPayload
 }
 
 internal sealed record OrleansPublishItem(
-    OrleansPublishDestination Destination,
+    OrleansDestinationPlanState Destination,
     SharedPublishPayload Payload);
 
-/// <summary>Internal sender seam; the production implementation is the Orleans stream adapter.</summary>
+/// <summary>Prepared provider/stream target retained by one immutable destination plan state.</summary>
+internal interface IOrleansPreparedStreamTarget
+{
+    Task SendAsync(SharedPublishPayload payload, CancellationToken cancellationToken);
+}
+
+/// <summary>Internal sender seam; the production implementation prepares the Orleans stream adapter once.</summary>
 internal interface IOrleansStreamSender
 {
-    Task SendAsync(OrleansPublishDestination destination, SharedPublishPayload payload, CancellationToken cancellationToken);
+    IOrleansPreparedStreamTarget PrepareDestination(OrleansPublishDestination destination);
 }
 
 internal sealed class OrleansPublisherDiagnosticsRecorder

--- a/dcb/src/Sekiban.Dcb.Orleans.Core/OrleansPublisherServiceCollectionExtensions.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.Core/OrleansPublisherServiceCollectionExtensions.cs
@@ -22,8 +22,8 @@ public static class OrleansPublisherServiceCollectionExtensions
                 sp.GetRequiredService<Sekiban.Dcb.Actors.IStreamDestinationResolver>(),
                 sp.GetRequiredService<Sekiban.Dcb.DcbDomainTypes>(),
                 sp.GetRequiredService<Microsoft.Extensions.Logging.ILogger<OrleansEventPublisher>>(),
-                sp.GetRequiredService<OrleansEventPublisherOptions>(),
-                sp.GetService<Sekiban.Dcb.ServiceId.IServiceIdProvider>()));
+                sp.GetService<Sekiban.Dcb.ServiceId.IServiceIdProvider>(),
+                sp.GetRequiredService<OrleansEventPublisherOptions>()));
         services.AddSingleton<IEventPublisher>(sp => sp.GetRequiredService<OrleansEventPublisher>());
         services.TryAddSingleton<IOrleansPublisherDiagnostics>(sp =>
             sp.GetRequiredService<OrleansEventPublisher>());

--- a/dcb/src/Sekiban.Dcb.Orleans.Core/OrleansPublisherServiceCollectionExtensions.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.Core/OrleansPublisherServiceCollectionExtensions.cs
@@ -1,0 +1,32 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Sekiban.Dcb.Actors;
+
+namespace Sekiban.Dcb.Orleans;
+
+/// <summary>Convenience registration for the bounded Orleans publisher and its diagnostics singleton.</summary>
+public static class OrleansPublisherServiceCollectionExtensions
+{
+    public static IServiceCollection AddSekibanDcbOrleansEventPublisher(
+        this IServiceCollection services,
+        Action<OrleansEventPublisherOptions>? configure = null)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        var options = new OrleansEventPublisherOptions();
+        configure?.Invoke(options);
+        options.Validate();
+        services.AddSingleton(options);
+        services.AddSingleton<OrleansEventPublisher>(sp =>
+            new OrleansEventPublisher(
+                sp.GetRequiredService<global::Orleans.IClusterClient>(),
+                sp.GetRequiredService<Sekiban.Dcb.Actors.IStreamDestinationResolver>(),
+                sp.GetRequiredService<Sekiban.Dcb.DcbDomainTypes>(),
+                sp.GetRequiredService<Microsoft.Extensions.Logging.ILogger<OrleansEventPublisher>>(),
+                sp.GetRequiredService<OrleansEventPublisherOptions>(),
+                sp.GetService<Sekiban.Dcb.ServiceId.IServiceIdProvider>()));
+        services.AddSingleton<IEventPublisher>(sp => sp.GetRequiredService<OrleansEventPublisher>());
+        services.TryAddSingleton<IOrleansPublisherDiagnostics>(sp =>
+            sp.GetRequiredService<OrleansEventPublisher>());
+        return services;
+    }
+}

--- a/dcb/src/Sekiban.Dcb.Orleans.Core/SizeGates/OrleansDestinationMeasurementContracts.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.Core/SizeGates/OrleansDestinationMeasurementContracts.cs
@@ -27,4 +27,14 @@ internal sealed record OrleansDestinationPlanState(
     Guid StreamId,
     object? MeasurementState,
     IReadOnlyDictionary<string, object>? RequestContext,
-    string? FailureReason);
+    string? FailureReason)
+{
+    /// <summary>The service identity used in the destination key for the prepared publication.</summary>
+    public string ServiceId { get; init; } = string.Empty;
+
+    /// <summary>
+    /// The provider/stream target prepared before admission. Retries use this opaque target directly and never
+    /// resolve the provider or stream again.
+    /// </summary>
+    public IOrleansPreparedStreamTarget? PreparedTarget { get; init; }
+}

--- a/dcb/tests/Sekiban.Dcb.Orleans.LegacyConsumer/Program.cs
+++ b/dcb/tests/Sekiban.Dcb.Orleans.LegacyConsumer/Program.cs
@@ -1,0 +1,35 @@
+using Microsoft.Extensions.Logging;
+using Orleans;
+using Sekiban.Dcb;
+using Sekiban.Dcb.Actors;
+using Sekiban.Dcb.Orleans;
+using Sekiban.Dcb.ServiceId;
+
+internal static class Program
+{
+    public static void Main()
+    {
+    }
+
+    // This method is intentionally not invoked. Its compilation is the isolated source-consumer proof for both
+    // target frameworks: the four-argument call, typed legacy five-argument call, legacy null-literal call, and
+    // the additive options call must all bind without ambiguity.
+    private static void BindLegacyAndOptionsCalls(
+        IClusterClient clusterClient,
+        IStreamDestinationResolver resolver,
+        DcbDomainTypes domainTypes,
+        ILogger<OrleansEventPublisher> logger,
+        IServiceIdProvider serviceIdProvider)
+    {
+        _ = new OrleansEventPublisher(clusterClient, resolver, domainTypes, logger);
+        _ = new OrleansEventPublisher(clusterClient, resolver, domainTypes, logger, serviceIdProvider);
+        _ = new OrleansEventPublisher(clusterClient, resolver, domainTypes, logger, null);
+        _ = new OrleansEventPublisher(
+            clusterClient,
+            resolver,
+            domainTypes,
+            logger,
+            serviceIdProvider,
+            new OrleansEventPublisherOptions());
+    }
+}

--- a/dcb/tests/Sekiban.Dcb.Orleans.LegacyConsumer/Program.cs
+++ b/dcb/tests/Sekiban.Dcb.Orleans.LegacyConsumer/Program.cs
@@ -9,6 +9,7 @@ internal static class Program
 {
     public static void Main()
     {
+        Console.WriteLine("Sekiban.Dcb.Orleans.LegacyConsumer constructor compatibility probe.");
     }
 
     // This method is intentionally not invoked. Its compilation is the isolated source-consumer proof for both

--- a/dcb/tests/Sekiban.Dcb.Orleans.LegacyConsumer/Program.cs
+++ b/dcb/tests/Sekiban.Dcb.Orleans.LegacyConsumer/Program.cs
@@ -5,6 +5,8 @@ using Sekiban.Dcb.Actors;
 using Sekiban.Dcb.Orleans;
 using Sekiban.Dcb.ServiceId;
 
+namespace Sekiban.Dcb.Orleans.LegacyConsumer;
+
 internal static class Program
 {
     public static void Main()

--- a/dcb/tests/Sekiban.Dcb.Orleans.LegacyConsumer/Sekiban.Dcb.Orleans.LegacyConsumer.csproj
+++ b/dcb/tests/Sekiban.Dcb.Orleans.LegacyConsumer/Sekiban.Dcb.Orleans.LegacyConsumer.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../src/Sekiban.Dcb.Orleans.Core/Sekiban.Dcb.Orleans.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/dcb/tests/Sekiban.Dcb.Orleans.Tests/OrleansEventPublisherBoundedTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Orleans.Tests/OrleansEventPublisherBoundedTests.cs
@@ -1,0 +1,522 @@
+using System.Reflection;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Sekiban.Dcb.Actors;
+using Sekiban.Dcb.Common;
+using Sekiban.Dcb.Domains;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.Orleans.Streams;
+using Sekiban.Dcb.ServiceId;
+using Sekiban.Dcb.Tags;
+using Xunit;
+
+namespace Sekiban.Dcb.Orleans.Tests;
+
+/// <summary>
+/// Deterministic publisher scheduler proofs. The sender seam is internal and only replaces the transport in these
+/// tests; serialization, resolver admission and payload identity still use the production publisher path.
+/// </summary>
+public sealed class OrleansEventPublisherBoundedTests
+{
+    [Fact]
+    public void Options_ValidateEveryBoundaryAndExposeDefaults()
+    {
+        var defaults = new OrleansEventPublisherOptions();
+        Assert.Equal(5, defaults.MaxPublishAttempts);
+        Assert.Equal(TimeSpan.FromMilliseconds(100), defaults.BaseRetryDelay);
+        Assert.Equal(TimeSpan.FromSeconds(5), defaults.MaxRetryDelay);
+        Assert.Equal(1024, defaults.MaxQueuedItemsPerDestination);
+        Assert.Equal(16_384, defaults.MaxQueuedItemsTotal);
+        Assert.Equal(20, defaults.TerminalSampleCount);
+        Assert.Equal(1024, defaults.MaxDiagnosticDestinations);
+        defaults.Validate();
+
+        AssertInvalid(nameof(OrleansEventPublisherOptions.MaxPublishAttempts), () =>
+            new OrleansEventPublisherOptions { MaxPublishAttempts = 0 }.Validate());
+        AssertInvalid(nameof(OrleansEventPublisherOptions.BaseRetryDelay), () =>
+            new OrleansEventPublisherOptions { BaseRetryDelay = TimeSpan.Zero }.Validate());
+        AssertInvalid(nameof(OrleansEventPublisherOptions.MaxRetryDelay), () =>
+            new OrleansEventPublisherOptions
+            {
+                BaseRetryDelay = TimeSpan.FromSeconds(2),
+                MaxRetryDelay = TimeSpan.FromSeconds(1)
+            }.Validate());
+        AssertInvalid(nameof(OrleansEventPublisherOptions.MaxQueuedItemsPerDestination), () =>
+            new OrleansEventPublisherOptions { MaxQueuedItemsPerDestination = 0 }.Validate());
+        AssertInvalid(nameof(OrleansEventPublisherOptions.MaxQueuedItemsTotal), () =>
+            new OrleansEventPublisherOptions
+            {
+                MaxQueuedItemsPerDestination = 2,
+                MaxQueuedItemsTotal = 1
+            }.Validate());
+        AssertInvalid(nameof(OrleansEventPublisherOptions.TerminalSampleCount), () =>
+            new OrleansEventPublisherOptions { TerminalSampleCount = 0 }.Validate());
+        AssertInvalid(nameof(OrleansEventPublisherOptions.MaxDiagnosticDestinations), () =>
+            new OrleansEventPublisherOptions { MaxDiagnosticDestinations = 0 }.Validate());
+    }
+
+    [Fact]
+    public async Task PermanentFailure_StopsAtFiveAttempts_ReleasesPayload_AndBoundsDiagnostics()
+    {
+        var sender = new RecordingSender { FailuresBeforeSuccess = 100 };
+        await using var publisher = CreatePublisher(
+            sender,
+            new OrleansEventPublisherOptions
+            {
+                MaxPublishAttempts = 5,
+                BaseRetryDelay = TimeSpan.FromMilliseconds(1),
+                MaxRetryDelay = TimeSpan.FromMilliseconds(1),
+                TerminalSampleCount = 20
+            });
+
+        await publisher.PublishAsync(new[] { CreatePublication("permanent") });
+        await WaitUntilAsync(() => sender.Attempts == 5);
+        await Task.Delay(20);
+
+        Assert.Equal(5, sender.Attempts);
+        Assert.NotNull(sender.LastPayload);
+        Assert.Equal(0, sender.LastPayload!.ReferenceCount);
+        var snapshot = publisher.GetSnapshot();
+        Assert.Equal(5, snapshot.TotalAttemptCount);
+        Assert.Equal(1, snapshot.TotalTerminalCount);
+        Assert.Equal(1, snapshot.ReasonCounts["transport-attempts-exhausted"]);
+        Assert.Single(snapshot.Destinations);
+        Assert.Equal(5, snapshot.Destinations[0].AttemptCount);
+        Assert.Single(snapshot.Destinations[0].Samples);
+    }
+
+    [Fact]
+    public async Task Retry_ReusesSerializedEventAndResolverResult_AndPreservesFifo()
+    {
+        var resolver = new SequenceResolver(
+            new OrleansSekibanStream("provider", "ordered", Guid.Parse("00000000-0000-0000-0000-000000000001")));
+        var sender = new RecordingSender { FailuresBeforeSuccess = 1 };
+        await using var publisher = CreatePublisher(
+            sender,
+            new OrleansEventPublisherOptions
+            {
+                MaxPublishAttempts = 5,
+                BaseRetryDelay = TimeSpan.FromMilliseconds(1),
+                MaxRetryDelay = TimeSpan.FromMilliseconds(1)
+            },
+            resolver);
+
+        await publisher.PublishAsync(new[] { CreatePublication("identity") });
+        await WaitUntilAsync(() => sender.Successes == 1);
+
+        Assert.Equal(1, resolver.Calls);
+        Assert.Equal(2, sender.Attempts);
+        Assert.Equal(2, sender.ReceivedPayloads.Count);
+        Assert.Same(sender.ReceivedPayloads[0], sender.ReceivedPayloads[1]);
+        Assert.Same(sender.ReceivedPayloadObjects[0], sender.ReceivedPayloadObjects[1]);
+        Assert.Equal("writer-completed", Assert.Single(publisher.GetSnapshot().Destinations).Samples[0].ReasonCode);
+    }
+
+    [Fact]
+    public async Task DestinationCapacity_RejectsOnlyNewItems_AndOtherDestinationProgresses()
+    {
+        var resolver = new SequenceResolver(
+            new OrleansSekibanStream("provider", "capacity", Guid.Parse("00000000-0000-0000-0000-000000000010")));
+        var firstSendEntered = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseFirst = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var sender = new RecordingSender
+        {
+            BeforeSend = (_, attempt, _) =>
+            {
+                if (attempt == 1)
+                {
+                    firstSendEntered.TrySetResult(true);
+                    return releaseFirst.Task;
+                }
+
+                return Task.CompletedTask;
+            }
+        };
+        await using var publisher = CreatePublisher(
+            sender,
+            new OrleansEventPublisherOptions
+            {
+                MaxQueuedItemsPerDestination = 1,
+                MaxQueuedItemsTotal = 1,
+                MaxPublishAttempts = 1
+            },
+            resolver);
+
+        await publisher.PublishAsync(new[] { CreatePublication("accepted") });
+        await firstSendEntered.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        await publisher.PublishAsync(new[] { CreatePublication("rejected-1") });
+        await publisher.PublishAsync(new[] { CreatePublication("rejected-2") });
+        releaseFirst.TrySetResult(true);
+        await WaitUntilAsync(() => sender.Successes == 1);
+
+        var snapshot = publisher.GetSnapshot();
+        Assert.Equal(2, snapshot.ReasonCounts["admission-capacity"]);
+        Assert.Equal(1, snapshot.ReasonCounts["writer-completed"]);
+        Assert.Equal(1, sender.Successes);
+    }
+
+    [Fact]
+    public async Task DestinationCapacity_RejectsExactlyFiveAfter1024Accepted_AndOtherDestinationProgresses()
+    {
+        var resolver = new RouteResolver();
+        var firstSendEntered = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseFirst = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var sender = new RecordingSender
+        {
+            BeforeSend = (destination, attempt, _) =>
+            {
+                if (destination.StreamNamespace == "capacity-a" && attempt == 1)
+                {
+                    firstSendEntered.TrySetResult(true);
+                    return releaseFirst.Task;
+                }
+
+                return Task.CompletedTask;
+            }
+        };
+        await using var publisher = CreatePublisher(
+            sender,
+            new OrleansEventPublisherOptions
+            {
+                MaxQueuedItemsPerDestination = 1_024,
+                MaxQueuedItemsTotal = 16_384,
+                MaxPublishAttempts = 1
+            },
+            resolver);
+
+        var firstA = CreatePublication("A1");
+        await publisher.PublishAsync(new[] { firstA });
+        await firstSendEntered.Task.WaitAsync(TimeSpan.FromSeconds(2));
+
+        var acceptedA = Enumerable.Range(2, 1_023).Select(value => CreatePublication($"A{value}")).ToArray();
+        var rejectedA = Enumerable.Range(1_025, 5).Select(value => CreatePublication($"A{value}")).ToArray();
+        var bEvents = Enumerable.Range(1, 5).Select(value => CreatePublication($"B{value}")).ToArray();
+        await publisher.PublishAsync(acceptedA);
+        await publisher.PublishAsync(rejectedA);
+        await publisher.PublishAsync(bEvents);
+
+        await WaitUntilAsync(() => sender.Successes == 5);
+        Assert.All(bEvents, item => Assert.Contains(item.Event.Id, sender.SuccessfulEventIds));
+        Assert.All(rejectedA, item => Assert.DoesNotContain(item.Event.Id, sender.SuccessfulEventIds));
+        Assert.Equal(5, publisher.GetSnapshot().ReasonCounts["admission-capacity"]);
+
+        releaseFirst.TrySetResult(true);
+        await WaitUntilAsync(() => sender.Successes == 1_029);
+        Assert.All(acceptedA.Append(firstA), item => Assert.Contains(item.Event.Id, sender.SuccessfulEventIds));
+        var acceptedIds = acceptedA.Append(firstA).Select(item => item.Event.Id).ToHashSet();
+        Assert.Equal(
+            new[] { firstA }.Concat(acceptedA).Select(item => item.Event.Id),
+            sender.SuccessfulEventIds.Where(acceptedIds.Contains));
+    }
+
+    [Fact]
+    public async Task FanOut_UsesOneSharedPayloadUntilEveryDestinationSettles()
+    {
+        var sender = new RecordingSender();
+        await using var publisher = CreatePublisher(
+            sender,
+            new OrleansEventPublisherOptions { MaxPublishAttempts = 1 },
+            new SequenceResolver(
+                new OrleansSekibanStream("provider", "fanout-a", Guid.Parse("00000000-0000-0000-0000-00000000000a")),
+                new OrleansSekibanStream("provider", "fanout-b", Guid.Parse("00000000-0000-0000-0000-00000000000b"))));
+
+        var publication = CreatePublication("fanout");
+        await publisher.PublishAsync(new[] { publication });
+        await WaitUntilAsync(() => sender.Successes == 2);
+        Assert.Equal(2, sender.ReceivedPayloadObjects.Count);
+        Assert.Same(sender.ReceivedPayloadObjects[0], sender.ReceivedPayloadObjects[1]);
+        Assert.Equal(0, sender.LastPayload!.ReferenceCount);
+    }
+
+    [Fact]
+    public async Task Diagnostics_RetainTwentySamples_AndEvictBeyond1024Destinations()
+    {
+        var resolver = new ManyDestinationResolver();
+        var sender = new RecordingSender { FailuresBeforeSuccess = 100_000 };
+        await using var publisher = CreatePublisher(
+            sender,
+            new OrleansEventPublisherOptions
+            {
+                MaxPublishAttempts = 1,
+                MaxDiagnosticDestinations = 1_024,
+                TerminalSampleCount = 20,
+                MaxQueuedItemsTotal = 16_384
+            },
+            resolver);
+
+        var publications = Enumerable.Range(0, 20)
+            .Select(value => CreatePublication("sample"))
+            .Concat(Enumerable.Range(0, 9_980).Select(value => CreatePublication($"unique-{value}")))
+            .ToArray();
+        await publisher.PublishAsync(publications);
+        await WaitUntilAsync(() => publisher.GetSnapshot().TotalTerminalCount == 10_000);
+
+        var snapshot = publisher.GetSnapshot();
+        Assert.Equal(10_000, snapshot.TotalAttemptCount);
+        Assert.Equal(10_000, snapshot.TotalTerminalCount);
+        Assert.Equal(10_000, snapshot.ReasonCounts["transport-attempts-exhausted"]);
+        Assert.Equal(1_024, snapshot.Destinations.Count);
+        Assert.True(snapshot.EvictedDestinationCount > 0);
+        var sampleDestination = Assert.Single(snapshot.Destinations, value => value.StreamId == ManyDestinationResolver.SampleStreamId);
+        Assert.Equal(20, sampleDestination.Samples.Count);
+    }
+
+    [Fact]
+    public async Task AdmissionFailures_ExposeSerializeAndResolveReasons()
+    {
+        var throwingEventTypes = DcbDomainTypesExtensions.Simple(builder =>
+            builder.EventTypes.RegisterEventType<PublisherEvent>()) with
+        {
+            EventTypes = new ThrowingEventTypes()
+        };
+        await using (var serializationPublisher = CreatePublisher(
+                         new RecordingSender(),
+                         new OrleansEventPublisherOptions { MaxPublishAttempts = 1 },
+                         domainTypes: throwingEventTypes))
+        {
+            await serializationPublisher.PublishAsync(new[] { CreatePublication("unregistered") });
+            Assert.Equal(1, serializationPublisher.GetSnapshot().ReasonCounts["admission-serialize-failed"]);
+        }
+
+        await using var resolvePublisher = CreatePublisher(
+            new RecordingSender(),
+            new OrleansEventPublisherOptions { MaxPublishAttempts = 1 },
+            new ThrowingResolver());
+        await resolvePublisher.PublishAsync(new[] { CreatePublication("unresolved") });
+        Assert.Equal(1, resolvePublisher.GetSnapshot().ReasonCounts["admission-resolve-failed"]);
+    }
+
+    [Fact]
+    public void PublicSurfaceAndOptionsRegistration_AreAdditiveAndExact()
+    {
+        var optionsProperties = typeof(OrleansEventPublisherOptions)
+            .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Select(property => property.Name)
+            .OrderBy(name => name)
+            .ToArray();
+        Assert.Equal(
+            new[]
+            {
+                "BaseRetryDelay",
+                "MaxDiagnosticDestinations",
+                "MaxPublishAttempts",
+                "MaxQueuedItemsPerDestination",
+                "MaxQueuedItemsTotal",
+                "MaxRetryDelay",
+                "TerminalSampleCount"
+            },
+            optionsProperties);
+
+        var publicConstructors = typeof(OrleansEventPublisher).GetConstructors();
+        Assert.Contains(publicConstructors, constructor => constructor.GetParameters().Length == 4);
+        Assert.Contains(publicConstructors, constructor => constructor.GetParameters().Length == 5);
+        Assert.Contains(publicConstructors, constructor =>
+            constructor.GetParameters().Any(parameter => parameter.ParameterType == typeof(OrleansEventPublisherOptions)));
+
+        Assert.Equal(
+            new[]
+            {
+                "Destinations",
+                "EvictedDestinationCount",
+                "ReasonCounts",
+                "TotalAttemptCount",
+                "TotalTerminalCount"
+            },
+            typeof(OrleansPublisherDiagnosticsSnapshot)
+                .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+                .Select(property => property.Name)
+                .OrderBy(name => name)
+                .ToArray());
+
+        var services = new ServiceCollection();
+        services.AddSekibanDcbOrleansEventPublisher();
+        Assert.Contains(services, descriptor => descriptor.ServiceType == typeof(OrleansEventPublisher));
+        Assert.Contains(services, descriptor => descriptor.ServiceType == typeof(IEventPublisher));
+        Assert.Contains(services, descriptor => descriptor.ServiceType == typeof(IOrleansPublisherDiagnostics));
+        Assert.Equal(
+            5,
+            Assert.IsType<OrleansEventPublisherOptions>(
+                Assert.Single(services.Where(descriptor => descriptor.ServiceType == typeof(OrleansEventPublisherOptions)))
+                    .ImplementationInstance).MaxPublishAttempts);
+    }
+
+    [Fact]
+    public async Task PumpFault_RejectsLaterAdmissionWithoutUnboundedContinuation()
+    {
+        var sender = new RecordingSender { FailuresBeforeSuccess = 1 };
+        await using var publisher = CreatePublisher(
+            sender,
+            new OrleansEventPublisherOptions { MaxPublishAttempts = 2 },
+            delayAsync: (_, _) => throw new InvalidOperationException("test pump fault"));
+
+        await publisher.PublishAsync(new[] { CreatePublication("fault") });
+        await WaitUntilAsync(() => publisher.GetSnapshot().ReasonCounts.ContainsKey("pump-faulted"));
+        var before = sender.Attempts;
+        await publisher.PublishAsync(new[] { CreatePublication("after-fault") });
+        await Task.Delay(20);
+        Assert.Equal(before, sender.Attempts);
+        Assert.True(publisher.GetSnapshot().ReasonCounts["pump-faulted"] >= 1);
+    }
+
+    [Fact]
+    public async Task Disposal_CancelsBlockedSenderAndLeavesNoLivePayload()
+    {
+        var entered = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var sender = new RecordingSender
+        {
+            BeforeSend = (_, _, cancellationToken) =>
+            {
+                entered.TrySetResult(true);
+                return Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+            }
+        };
+        var publisher = CreatePublisher(sender, new OrleansEventPublisherOptions { MaxPublishAttempts = 5 });
+        await publisher.PublishAsync(new[] { CreatePublication("dispose") });
+        await entered.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        await publisher.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(2));
+
+        Assert.NotNull(sender.LastPayload);
+        Assert.Equal(0, sender.LastPayload!.ReferenceCount);
+    }
+
+    private static OrleansEventPublisher CreatePublisher(
+        RecordingSender sender,
+        OrleansEventPublisherOptions options,
+        IStreamDestinationResolver? resolver = null,
+        Func<TimeSpan, CancellationToken, Task>? delayAsync = null,
+        DcbDomainTypes? domainTypes = null)
+    {
+        return new OrleansEventPublisher(
+            clusterClient: null!,
+            resolver ?? new SequenceResolver(
+                new OrleansSekibanStream("provider", "tests", Guid.Parse("00000000-0000-0000-0000-000000000002"))),
+            domainTypes ?? DcbDomainTypesExtensions.Simple(builder => builder.EventTypes.RegisterEventType<PublisherEvent>()),
+            NullLogger<OrleansEventPublisher>.Instance,
+            options,
+            new DefaultServiceIdProvider(),
+            sender,
+            delayAsync);
+    }
+
+    private static (Event Event, IReadOnlyCollection<ITag> Tags) CreatePublication(string value, Guid? eventId = null)
+    {
+        var payload = new PublisherEvent(value);
+        return (
+            new Event(
+                payload,
+                SortableUniqueId.GenerateNew(),
+                nameof(PublisherEvent),
+                eventId ?? Guid.NewGuid(),
+                new EventMetadata("cause", "correlation", "publisher-test"),
+                []),
+            Array.Empty<ITag>());
+    }
+
+    private static async Task WaitUntilAsync(Func<bool> predicate)
+    {
+        for (var i = 0; i < 200; i++)
+        {
+            if (predicate())
+                return;
+            await Task.Delay(10);
+        }
+
+        Assert.True(predicate(), "Timed out waiting for the deterministic publisher observation.");
+    }
+
+    private static void AssertInvalid(string property, Action action)
+    {
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(action);
+        Assert.Equal(property, exception.ParamName);
+    }
+
+    private sealed record PublisherEvent(string Value) : IEventPayload;
+
+    private sealed class SequenceResolver(params OrleansSekibanStream[] streams) : IStreamDestinationResolver
+    {
+        private readonly OrleansSekibanStream[] _streams = streams;
+        public int Calls { get; private set; }
+
+        public IEnumerable<ISekibanStream> Resolve(Event evt, IReadOnlyCollection<ITag> tags)
+        {
+            Calls++;
+            return _streams;
+        }
+    }
+
+    private sealed class RouteResolver : IStreamDestinationResolver
+    {
+        private static readonly OrleansSekibanStream A = new("provider", "capacity-a", Guid.Parse("00000000-0000-0000-0000-00000000000a"));
+        private static readonly OrleansSekibanStream B = new("provider", "capacity-b", Guid.Parse("00000000-0000-0000-0000-00000000000b"));
+
+        public IEnumerable<ISekibanStream> Resolve(Event evt, IReadOnlyCollection<ITag> tags) =>
+            evt.Payload is PublisherEvent { Value: var value } && value.StartsWith("B", StringComparison.Ordinal)
+                ? [B]
+                : [A];
+    }
+
+    private sealed class ManyDestinationResolver : IStreamDestinationResolver
+    {
+        public static readonly Guid SampleStreamId = Guid.Parse("ffffffff-ffff-ffff-ffff-ffffffffffff");
+
+        public IEnumerable<ISekibanStream> Resolve(Event evt, IReadOnlyCollection<ITag> tags)
+        {
+            var streamId = evt.Payload is PublisherEvent { Value: "sample" }
+                ? SampleStreamId
+                : evt.Id;
+            return [new OrleansSekibanStream("provider", "many", streamId)];
+        }
+    }
+
+    private sealed class ThrowingResolver : IStreamDestinationResolver
+    {
+        public IEnumerable<ISekibanStream> Resolve(Event evt, IReadOnlyCollection<ITag> tags) =>
+            throw new InvalidOperationException("deterministic resolver failure");
+    }
+
+    private sealed class ThrowingEventTypes : IEventTypes
+    {
+        public string SerializeEventPayload(IEventPayload payload) =>
+            throw new InvalidOperationException("deterministic serialization failure");
+
+        public IEventPayload? DeserializeEventPayload(string eventTypeName, string json) => null;
+
+        public Type? GetEventType(string eventTypeName) => null;
+    }
+
+    private sealed class RecordingSender : IOrleansStreamSender
+    {
+        private int _attempts;
+        private int _successes;
+        public int FailuresBeforeSuccess { get; set; }
+        public Func<OrleansPublishDestination, int, CancellationToken, Task>? BeforeSend { get; set; }
+        public int Attempts => Volatile.Read(ref _attempts);
+        public int Successes => Volatile.Read(ref _successes);
+        public SharedPublishPayload? LastPayload { get; private set; }
+        public List<SerializableEvent> ReceivedPayloads { get; } = [];
+        public List<SharedPublishPayload> ReceivedPayloadObjects { get; } = [];
+        public List<Guid> SuccessfulEventIds { get; } = [];
+
+        public async Task SendAsync(
+            OrleansPublishDestination destination,
+            SharedPublishPayload payload,
+            CancellationToken cancellationToken)
+        {
+            var attempt = Interlocked.Increment(ref _attempts);
+            LastPayload = payload;
+            lock (ReceivedPayloads)
+            {
+                ReceivedPayloads.Add(payload.Event);
+                ReceivedPayloadObjects.Add(payload);
+            }
+            if (BeforeSend is not null)
+                await BeforeSend(destination, attempt, cancellationToken);
+            cancellationToken.ThrowIfCancellationRequested();
+            if (attempt <= FailuresBeforeSuccess)
+                throw new InvalidOperationException("deterministic sender failure");
+            lock (ReceivedPayloads)
+                SuccessfulEventIds.Add(payload.Event.Id);
+            Interlocked.Increment(ref _successes);
+        }
+    }
+}

--- a/dcb/tests/Sekiban.Dcb.Orleans.Tests/OrleansEventPublisherBoundedTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Orleans.Tests/OrleansEventPublisherBoundedTests.cs
@@ -630,9 +630,7 @@ public sealed class OrleansEventPublisherBoundedTests
             domain,
             NullLogger<OrleansEventPublisher>.Instance,
             new OrleansEventPublisherOptions { MaxPublishAttempts = 1 },
-            new DefaultServiceIdProvider(),
-            sender: null,
-            delayAsync: null);
+            new DefaultServiceIdProvider());
 
         var publication = CreatePublication("missing-deep-copier");
         var plan = publisher.CaptureDestinationPlan(publication.Event, publication.Tags, "default");
@@ -1075,12 +1073,15 @@ public sealed class OrleansEventPublisherBoundedTests
             NullLogger<OrleansEventPublisher>.Instance,
             options,
             new DefaultServiceIdProvider(),
-            sender,
-            delayAsync,
-            startWorkerAsync: startWorkerAsync,
-            captureRequestContext: captureRequestContext,
-            measurementCaptures: measurementCaptures,
-            payloadReleased: payloadReleased);
+            new OrleansEventPublisherTestHooks
+            {
+                Sender = sender,
+                DelayAsync = delayAsync,
+                StartWorkerAsync = startWorkerAsync,
+                CaptureRequestContext = captureRequestContext,
+                MeasurementCaptures = measurementCaptures,
+                PayloadReleased = payloadReleased
+            });
     }
 
     private static (Event Event, IReadOnlyCollection<ITag> Tags) CreatePublication(string value, Guid? eventId = null)

--- a/dcb/tests/Sekiban.Dcb.Orleans.Tests/OrleansEventPublisherBoundedTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Orleans.Tests/OrleansEventPublisherBoundedTests.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Orleans;
 using Orleans.Runtime;
+using Orleans.Streams;
 using Sekiban.Dcb.Actors;
 using Sekiban.Dcb.Common;
 using Sekiban.Dcb.Domains;
@@ -135,7 +136,14 @@ public sealed class OrleansEventPublisherBoundedTests
         Assert.Equal(2, sender.ReceivedPayloads.Count);
         Assert.Same(sender.ReceivedPayloads[0], sender.ReceivedPayloads[1]);
         Assert.Same(sender.ReceivedPayloadObjects[0], sender.ReceivedPayloadObjects[1]);
-        Assert.Equal("writer-completed", Assert.Single(publisher.GetSnapshot().Destinations).Samples[0].ReasonCode);
+        var snapshot = publisher.GetSnapshot();
+        Assert.Equal(2, snapshot.TotalAttemptCount);
+        Assert.Equal(0, snapshot.TotalTerminalCount);
+        Assert.Empty(snapshot.ReasonCounts);
+        var destination = Assert.Single(snapshot.Destinations);
+        Assert.Equal(2, destination.AttemptCount);
+        Assert.Equal(0, destination.TerminalCount);
+        Assert.Empty(destination.ReasonCounts);
     }
 
     [Fact]
@@ -193,7 +201,7 @@ public sealed class OrleansEventPublisherBoundedTests
         await ((IExecutorSizeDestinationPublisher)publisher).PublishAsync(
             new[] { publication },
             new Dictionary<Guid, ExecutorSizeDestinationPlan> { [publication.Event.Id] = plan! });
-        await WaitUntilAsync(() => sender.Successes == 2);
+        await WaitUntilAsync(() => sender.Successes == 2 && sender.LastPayload?.ReferenceCount == 0);
 
         Assert.Equal(1, countingTypes.SerializeCalls);
         Assert.Equal(2, sender.PrepareCalls);
@@ -224,6 +232,7 @@ public sealed class OrleansEventPublisherBoundedTests
         var a1 = CreatePublication("A1");
         var a2 = CreatePublication("A2");
         var b1 = CreatePublication("B1");
+        var b2 = CreatePublication("B2");
         var aFirst = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
         var delayEntered = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
         var releaseDelay = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -255,19 +264,29 @@ public sealed class OrleansEventPublisherBoundedTests
         await publisher.PublishAsync(new[] { a1 });
         await aFirst.Task.WaitAsync(TimeSpan.FromSeconds(2));
         await delayEntered.Task.WaitAsync(TimeSpan.FromSeconds(2));
-        await publisher.PublishAsync(new[] { a2, b1 });
-        await WaitUntilAsync(() => sender.SuccessfulEventIds.Contains(b1.Event.Id));
+        await publisher.PublishAsync(new[] { a2, b1, b2 });
+        await WaitUntilAsync(() =>
+            sender.SuccessfulEventIds.Contains(b1.Event.Id) &&
+            sender.SuccessfulEventIds.Contains(b2.Event.Id));
         Assert.DoesNotContain(a2.Event.Id, sender.AttemptRecords.Select(record => record.EventId));
 
         releaseDelay.TrySetResult(true);
-        await WaitUntilAsync(() => sender.Successes == 3);
+        await WaitUntilAsync(() => sender.Successes == 4);
         var aAttempts = sender.AttemptRecords
             .Where(record => record.Destination == "capacity-a")
             .Select(record => record.EventId)
             .ToArray();
         Assert.Equal(new[] { a1.Event.Id, a1.Event.Id, a2.Event.Id }, aAttempts);
+        Assert.Equal(
+            new[] { b1.Event.Id, b2.Event.Id },
+            sender.AttemptRecords
+                .Where(record => record.Destination == "capacity-b")
+                .Select(record => record.EventId));
         Assert.True(
             sender.AttemptRecords.FindIndex(record => record.EventId == b1.Event.Id) <
+            sender.AttemptRecords.FindIndex(record => record.EventId == a1.Event.Id && record.Attempt > 1));
+        Assert.True(
+            sender.AttemptRecords.FindIndex(record => record.EventId == b2.Event.Id) <
             sender.AttemptRecords.FindIndex(record => record.EventId == a1.Event.Id && record.Attempt > 1));
     }
 
@@ -275,7 +294,9 @@ public sealed class OrleansEventPublisherBoundedTests
     public async Task GlobalAdmissionCapacityRejectsNewWorkWithoutPerDestinationSaturation()
     {
         var firstEntered = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var secondEntered = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
         var releaseFirst = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseSecond = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
         var sender = new RecordingSender
         {
             BeforeSend = (destination, attempt, _) =>
@@ -284,6 +305,12 @@ public sealed class OrleansEventPublisherBoundedTests
                 {
                     firstEntered.TrySetResult(true);
                     return releaseFirst.Task;
+                }
+
+                if (destination.StreamNamespace == "capacity-b" && attempt == 1)
+                {
+                    secondEntered.TrySetResult(true);
+                    return releaseSecond.Task;
                 }
 
                 return Task.CompletedTask;
@@ -304,14 +331,60 @@ public sealed class OrleansEventPublisherBoundedTests
         var a2 = CreatePublication("A-global-2");
         await publisher.PublishAsync(new[] { a1 });
         await firstEntered.Task.WaitAsync(TimeSpan.FromSeconds(2));
-        await publisher.PublishAsync(new[] { b1, a2 });
+        await publisher.PublishAsync(new[] { b1 });
+        await secondEntered.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        await publisher.PublishAsync(new[] { a2 });
         Assert.Equal(1, publisher.GetSnapshot().ReasonCounts["admission-capacity"]);
         Assert.DoesNotContain(a2.Event.Id, sender.SuccessfulEventIds);
 
         releaseFirst.TrySetResult(true);
-        await WaitUntilAsync(() => sender.Successes == 2);
+        releaseSecond.TrySetResult(true);
+        await WaitUntilAsync(() => sender.Successes == 2 && publisher.DestinationStateCount == 0);
         Assert.Contains(a1.Event.Id, sender.SuccessfulEventIds);
         Assert.Contains(b1.Event.Id, sender.SuccessfulEventIds);
+    }
+
+    [Fact]
+    public async Task GlobalCapacityRejectsTenThousandUniqueDestinationsWithoutRetainingEmptyStates()
+    {
+        var firstEntered = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseFirst = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var sender = new RecordingSender
+        {
+            BeforeSend = (_, attempt, _) =>
+            {
+                if (attempt == 1)
+                {
+                    firstEntered.TrySetResult(true);
+                    return releaseFirst.Task;
+                }
+
+                return Task.CompletedTask;
+            }
+        };
+        await using var publisher = CreatePublisher(
+            sender,
+            new OrleansEventPublisherOptions
+            {
+                MaxQueuedItemsPerDestination = 1,
+                MaxQueuedItemsTotal = 1,
+                MaxPublishAttempts = 1
+            },
+            new ManyDestinationResolver());
+
+        await publisher.PublishAsync(new[] { CreatePublication("state-anchor") });
+        await firstEntered.Task.WaitAsync(TimeSpan.FromSeconds(2));
+
+        var rejected = Enumerable.Range(0, 10_000)
+            .Select(value => CreatePublication($"unique-rejection-{value}"))
+            .ToArray();
+        await publisher.PublishAsync(rejected);
+
+        Assert.Equal(10_000, publisher.GetSnapshot().ReasonCounts["admission-capacity"]);
+        Assert.Equal(1, publisher.DestinationStateCount);
+
+        releaseFirst.TrySetResult(true);
+        await WaitUntilAsync(() => sender.Successes == 1 && publisher.DestinationStateCount == 0);
     }
 
     [Fact]
@@ -353,8 +426,39 @@ public sealed class OrleansEventPublisherBoundedTests
 
         var snapshot = publisher.GetSnapshot();
         Assert.Equal(2, snapshot.ReasonCounts["admission-capacity"]);
-        Assert.Equal(1, snapshot.ReasonCounts["writer-completed"]);
+        Assert.DoesNotContain("writer-completed", snapshot.ReasonCounts.Keys);
         Assert.Equal(1, sender.Successes);
+    }
+
+    [Fact]
+    public async Task CompletedWriterRejectsWithoutSendingAndRecordsWriterCompleted()
+    {
+        var streamId = Guid.Parse("00000000-0000-0000-0000-000000000021");
+        var payloadReleased = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var sender = new RecordingSender();
+        await using var publisher = CreatePublisher(
+            sender,
+            new OrleansEventPublisherOptions { MaxPublishAttempts = 1 },
+            new SequenceResolver(new OrleansSekibanStream("provider", "completed-writer", streamId)),
+            payloadReleased: () => payloadReleased.TrySetResult(true));
+
+        var destination = new OrleansPublishDestination(
+            "default",
+            "provider",
+            "completed-writer",
+            streamId);
+        publisher.CompleteDestinationWriterForTesting(destination.DestinationKey);
+
+        await publisher.PublishAsync(new[] { CreatePublication("completed-writer") });
+
+        await WaitUntilAsync(() => publisher.GetSnapshot().ReasonCounts.ContainsKey("writer-completed"));
+        await payloadReleased.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        var snapshot = publisher.GetSnapshot();
+        Assert.Equal(1, snapshot.ReasonCounts["writer-completed"]);
+        Assert.Equal(1, snapshot.TotalTerminalCount);
+        Assert.DoesNotContain(snapshot.ReasonCounts.Keys, reason => reason == "admission-capacity");
+        Assert.Equal(0, sender.Attempts);
+        Assert.Equal(0, publisher.DestinationStateCount);
     }
 
     [Fact]
@@ -449,7 +553,7 @@ public sealed class OrleansEventPublisherBoundedTests
         Assert.Equal(1, sender.Successes);
 
         releaseB.TrySetResult(true);
-        await WaitUntilAsync(() => sender.Successes == 2);
+        await WaitUntilAsync(() => sender.Successes == 2 && sender.LastPayload?.ReferenceCount == 0);
         Assert.Equal(0, sender.LastPayload!.ReferenceCount);
     }
 
@@ -512,6 +616,66 @@ public sealed class OrleansEventPublisherBoundedTests
     }
 
     [Fact]
+    public async Task PlannedCaptureWithoutDeepCopierFailsClosedBeforeAdmission()
+    {
+        var domain = DcbDomainTypesExtensions.Simple(builder =>
+            builder.EventTypes.RegisterEventType<PublisherEvent>());
+        var cluster = DispatchProxy.Create<IClusterClient, ServiceProviderClusterClientProxy>();
+        await using var publisher = new OrleansEventPublisher(
+            cluster,
+            new SequenceResolver(new OrleansSekibanStream(
+                "provider",
+                "missing-deep-copier",
+                Guid.Parse("00000000-0000-0000-0000-000000000031"))),
+            domain,
+            NullLogger<OrleansEventPublisher>.Instance,
+            new OrleansEventPublisherOptions { MaxPublishAttempts = 1 },
+            new DefaultServiceIdProvider(),
+            sender: null,
+            delayAsync: null);
+
+        var publication = CreatePublication("missing-deep-copier");
+        var plan = publisher.CaptureDestinationPlan(publication.Event, publication.Tags, "default");
+        var state = Assert.Single((IReadOnlyList<OrleansDestinationPlanState>)plan!.ProviderState!);
+        Assert.Contains("capability is unavailable", state.FailureReason, StringComparison.Ordinal);
+        Assert.Null(state.PreparedTarget);
+
+        await ((IExecutorSizeDestinationPublisher)publisher).PublishAsync(
+            new[] { publication },
+            new Dictionary<Guid, ExecutorSizeDestinationPlan> { [publication.Event.Id] = plan });
+
+        Assert.Equal(1, publisher.GetSnapshot().ReasonCounts["admission-resolve-failed"]);
+        Assert.Equal(0, publisher.GetSnapshot().TotalAttemptCount);
+    }
+
+    [Fact]
+    public async Task DirectContextCaptureFailureIsAnAdmissionFailureAndLaterEventsContinue()
+    {
+        var first = CreatePublication("context-failure-first");
+        var second = CreatePublication("context-failure-second");
+        var sender = new RecordingSender();
+        var captureAttempts = 0;
+        await using var publisher = CreatePublisher(
+            sender,
+            new OrleansEventPublisherOptions { MaxPublishAttempts = 1 },
+            captureRequestContext: () =>
+            {
+                if (Interlocked.Increment(ref captureAttempts) == 1)
+                    throw new InvalidOperationException("deterministic context export failure");
+                return new Dictionary<string, object>();
+            });
+
+        await publisher.PublishAsync(new[] { first, second });
+        await WaitUntilAsync(() => sender.Successes == 1);
+
+        var snapshot = publisher.GetSnapshot();
+        Assert.Equal(1, snapshot.ReasonCounts["admission-resolve-failed"]);
+        Assert.DoesNotContain(first.Event.Id, sender.SuccessfulEventIds);
+        Assert.Contains(second.Event.Id, sender.SuccessfulEventIds);
+        Assert.Equal(1, snapshot.TotalTerminalCount);
+    }
+
+    [Fact]
     public void PublicSurfaceAndOptionsRegistration_AreAdditiveAndExact()
     {
         var optionsProperties = typeof(OrleansEventPublisherOptions)
@@ -544,12 +708,21 @@ public sealed class OrleansEventPublisherBoundedTests
         Assert.NotNull(typeof(OrleansEventPublisher).GetConstructor(
             constructorPrefix.Append(typeof(IServiceIdProvider)).ToArray()));
         Assert.NotNull(typeof(OrleansEventPublisher).GetConstructor(
-            constructorPrefix.Append(typeof(OrleansEventPublisherOptions)).Append(typeof(IServiceIdProvider)).ToArray()));
+            constructorPrefix.Append(typeof(IServiceIdProvider)).Append(typeof(OrleansEventPublisherOptions)).ToArray()));
         Assert.DoesNotContain(publicConstructors, constructor => constructor.IsStatic);
 
-        Assert.Equal(typeof(int), typeof(OrleansEventPublisherOptions).GetProperty(nameof(OrleansEventPublisherOptions.MaxPublishAttempts))!.PropertyType);
-        Assert.Equal(typeof(TimeSpan), typeof(OrleansEventPublisherOptions).GetProperty(nameof(OrleansEventPublisherOptions.BaseRetryDelay))!.PropertyType);
-        Assert.Equal(typeof(TimeSpan), typeof(OrleansEventPublisherOptions).GetProperty(nameof(OrleansEventPublisherOptions.MaxRetryDelay))!.PropertyType);
+        Assert.Equal(
+            new Dictionary<string, Type>
+            {
+                [nameof(OrleansEventPublisherOptions.MaxPublishAttempts)] = typeof(int),
+                [nameof(OrleansEventPublisherOptions.BaseRetryDelay)] = typeof(TimeSpan),
+                [nameof(OrleansEventPublisherOptions.MaxRetryDelay)] = typeof(TimeSpan),
+                [nameof(OrleansEventPublisherOptions.MaxQueuedItemsPerDestination)] = typeof(int),
+                [nameof(OrleansEventPublisherOptions.MaxQueuedItemsTotal)] = typeof(int),
+                [nameof(OrleansEventPublisherOptions.TerminalSampleCount)] = typeof(int),
+                [nameof(OrleansEventPublisherOptions.MaxDiagnosticDestinations)] = typeof(int)
+            },
+            GetPublicPropertyTypes(typeof(OrleansEventPublisherOptions)));
 
         Assert.Equal(
             new[]
@@ -571,6 +744,17 @@ public sealed class OrleansEventPublisherBoundedTests
         Assert.Equal(typeof(IReadOnlyDictionary<string, long>),
             typeof(OrleansPublisherDiagnosticsSnapshot).GetProperty(nameof(OrleansPublisherDiagnosticsSnapshot.ReasonCounts))!.PropertyType);
         Assert.Equal(
+            new Dictionary<string, Type>
+            {
+                [nameof(OrleansPublisherDiagnosticsSnapshot.Destinations)] =
+                    typeof(IReadOnlyList<OrleansPublisherDestinationDiagnostic>),
+                [nameof(OrleansPublisherDiagnosticsSnapshot.EvictedDestinationCount)] = typeof(long),
+                [nameof(OrleansPublisherDiagnosticsSnapshot.ReasonCounts)] = typeof(IReadOnlyDictionary<string, long>),
+                [nameof(OrleansPublisherDiagnosticsSnapshot.TotalAttemptCount)] = typeof(long),
+                [nameof(OrleansPublisherDiagnosticsSnapshot.TotalTerminalCount)] = typeof(long)
+            },
+            GetPublicPropertyTypes(typeof(OrleansPublisherDiagnosticsSnapshot)));
+        Assert.Equal(
             new[]
             {
                 "AttemptCount", "DestinationKey", "Namespace", "Provider", "ReasonCounts", "Samples", "ServiceId",
@@ -582,6 +766,34 @@ public sealed class OrleansEventPublisherBoundedTests
             new[] { "Attempts", "EventId", "OccurredAtUtc", "ReasonCode" },
             typeof(OrleansPublisherTerminalSample).GetProperties(BindingFlags.Public | BindingFlags.Instance)
                 .Select(property => property.Name).OrderBy(name => name).ToArray());
+
+        Assert.Equal(
+            new Dictionary<string, Type>
+            {
+                [nameof(OrleansPublisherDestinationDiagnostic.AttemptCount)] = typeof(long),
+                [nameof(OrleansPublisherDestinationDiagnostic.DestinationKey)] = typeof(string),
+                [nameof(OrleansPublisherDestinationDiagnostic.Namespace)] = typeof(string),
+                [nameof(OrleansPublisherDestinationDiagnostic.Provider)] = typeof(string),
+                [nameof(OrleansPublisherDestinationDiagnostic.ReasonCounts)] = typeof(IReadOnlyDictionary<string, long>),
+                [nameof(OrleansPublisherDestinationDiagnostic.Samples)] = typeof(IReadOnlyList<OrleansPublisherTerminalSample>),
+                [nameof(OrleansPublisherDestinationDiagnostic.ServiceId)] = typeof(string),
+                [nameof(OrleansPublisherDestinationDiagnostic.StreamId)] = typeof(Guid),
+                [nameof(OrleansPublisherDestinationDiagnostic.TerminalCount)] = typeof(long)
+            },
+            GetPublicPropertyTypes(typeof(OrleansPublisherDestinationDiagnostic)));
+        Assert.Equal(
+            new Dictionary<string, Type>
+            {
+                [nameof(OrleansPublisherTerminalSample.Attempts)] = typeof(int),
+                [nameof(OrleansPublisherTerminalSample.EventId)] = typeof(Guid),
+                [nameof(OrleansPublisherTerminalSample.OccurredAtUtc)] = typeof(DateTimeOffset),
+                [nameof(OrleansPublisherTerminalSample.ReasonCode)] = typeof(string)
+            },
+            GetPublicPropertyTypes(typeof(OrleansPublisherTerminalSample)));
+        var getSnapshot = typeof(IOrleansPublisherDiagnostics).GetMethod(nameof(IOrleansPublisherDiagnostics.GetSnapshot));
+        Assert.NotNull(getSnapshot);
+        Assert.Empty(getSnapshot!.GetParameters());
+        Assert.Equal(typeof(OrleansPublisherDiagnosticsSnapshot), getSnapshot.ReturnType);
 
         var services = new ServiceCollection();
         services.AddSekibanDcbOrleansEventPublisher();
@@ -595,24 +807,57 @@ public sealed class OrleansEventPublisherBoundedTests
                     .ImplementationInstance).MaxPublishAttempts);
     }
 
+    private static Dictionary<string, Type> GetPublicPropertyTypes(Type type) =>
+        type.GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .ToDictionary(property => property.Name, property => property.PropertyType, StringComparer.Ordinal);
+
     [Fact]
     public async Task LegacyOptionsFreeRegistrationResolvesWithDefaultFiveAttemptConfiguration()
     {
         var domain = DcbDomainTypesExtensions.Simple(builder =>
             builder.EventTypes.RegisterEventType<PublisherEvent>());
+        var stream = DispatchProxy.Create<IAsyncStream<SerializableEvent>, FailingStreamProxy>();
+        var streamControl = (FailingStreamProxy)(object)stream;
+        var streamProvider = DispatchProxy.Create<IStreamProvider, FailingStreamProviderProxy>();
+        var streamProviderControl = (FailingStreamProviderProxy)(object)streamProvider;
+        streamProviderControl.Stream = stream;
+        var cluster = DispatchProxy.Create<IClusterClient, FailingClusterClientProxy>();
+        var clusterControl = (FailingClusterClientProxy)(object)cluster;
+        clusterControl.StreamProvider = streamProvider;
+        using var clusterServiceProvider = new ServiceCollection()
+            .AddKeyedSingleton<IStreamProvider>("provider", streamProvider)
+            .BuildServiceProvider();
+        clusterControl.ServiceProviderOverride = clusterServiceProvider;
+        var logger = new RecordingLogger();
         var services = new ServiceCollection();
-        services.AddSingleton<IClusterClient>(DispatchProxy.Create<IClusterClient, ServiceProviderClusterClientProxy>());
+        services.AddSingleton<IClusterClient>(cluster);
         services.AddSingleton<IStreamDestinationResolver>(
             new SequenceResolver(new OrleansSekibanStream("provider", "legacy", Guid.NewGuid())));
         services.AddSingleton(domain);
         services.AddSingleton<Microsoft.Extensions.Logging.ILogger<OrleansEventPublisher>>(
-            NullLogger<OrleansEventPublisher>.Instance);
-        services.AddSingleton<IEventPublisher, OrleansEventPublisher>();
+            logger);
+        services.AddSekibanDcbOrleansEventPublisher();
 
-        await using var provider = services.BuildServiceProvider();
-        var publisher = provider.GetRequiredService<IEventPublisher>();
+        await using var serviceProvider = services.BuildServiceProvider();
+        var publisher = serviceProvider.GetRequiredService<IEventPublisher>();
         Assert.IsType<OrleansEventPublisher>(publisher);
         Assert.Equal(5, new OrleansEventPublisherOptions().MaxPublishAttempts);
+
+        await publisher.PublishAsync(new[] { CreatePublication("legacy-options-free") });
+        var diagnostics = ((IOrleansPublisherDiagnostics)publisher).GetSnapshot();
+        await WaitUntilAsync(
+            () =>
+                streamControl.Attempts == 5 &&
+                ((IOrleansPublisherDiagnostics)publisher).GetSnapshot().TotalTerminalCount == 1,
+            () =>
+                $"stream attempts={streamControl.Attempts}, diagnostics attempts={diagnostics.TotalAttemptCount}, " +
+                $"reasons={string.Join(",", diagnostics.ReasonCounts.Select(pair => $"{pair.Key}:{pair.Value}"))}, " +
+                $"clusterCalls={string.Join("|", clusterControl.Calls)}, " +
+                $"providerCalls={string.Join("|", streamProviderControl.Calls)}, " +
+                $"logs={string.Join("|", logger.Messages)}");
+        diagnostics = ((IOrleansPublisherDiagnostics)publisher).GetSnapshot();
+        Assert.Equal(5, diagnostics.TotalAttemptCount);
+        Assert.Equal(1, diagnostics.ReasonCounts["transport-attempts-exhausted"]);
     }
 
     [Fact]
@@ -691,6 +936,40 @@ public sealed class OrleansEventPublisherBoundedTests
     }
 
     [Fact]
+    public async Task Disposal_AwaitsTheRealNonCancellableTransportTask_AndObservesFaults()
+    {
+        await AssertTransportSettlesBeforeDisposeAsync(completeSuccessfully: true);
+        await AssertTransportSettlesBeforeDisposeAsync(completeSuccessfully: false);
+    }
+
+    private static async Task AssertTransportSettlesBeforeDisposeAsync(bool completeSuccessfully)
+    {
+        var stream = DispatchProxy.Create<IAsyncStream<SerializableEvent>, ControlledStreamProxy>();
+        var streamControl = (ControlledStreamProxy)(object)stream;
+        var target = OrleansEventPublisher.CreatePreparedStreamTargetForTesting(stream);
+        var payloadReleased = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var sender = new FixedTargetSender(target);
+        await using var publisher = CreatePublisher(
+            sender,
+            new OrleansEventPublisherOptions { MaxPublishAttempts = 1 },
+            payloadReleased: () => payloadReleased.TrySetResult(true));
+
+        await publisher.PublishAsync(new[] { CreatePublication(completeSuccessfully ? "transport-complete" : "transport-fault") });
+        await streamControl.SendStarted.Task.WaitAsync(TimeSpan.FromSeconds(2));
+
+        var disposeTask = publisher.DisposeAsync().AsTask();
+        Assert.False(disposeTask.IsCompleted);
+
+        if (completeSuccessfully)
+            streamControl.SendCompletion.TrySetResult(true);
+        else
+            streamControl.SendCompletion.TrySetException(new InvalidOperationException("deterministic transport fault"));
+
+        await disposeTask.WaitAsync(TimeSpan.FromSeconds(2));
+        await payloadReleased.Task.WaitAsync(TimeSpan.FromSeconds(2));
+    }
+
+    [Fact]
     public async Task Disposal_DrainsInFlightQueuedAndRetryDelayWorkWithoutDetachedFaults()
     {
         var delayEntered = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -725,7 +1004,7 @@ public sealed class OrleansEventPublisherBoundedTests
     }
 
     private static OrleansEventPublisher CreatePublisher(
-        RecordingSender sender,
+        IOrleansStreamSender sender,
         OrleansEventPublisherOptions options,
         IStreamDestinationResolver? resolver = null,
         Func<TimeSpan, CancellationToken, Task>? delayAsync = null,
@@ -765,7 +1044,7 @@ public sealed class OrleansEventPublisherBoundedTests
             Array.Empty<ITag>());
     }
 
-    private static async Task WaitUntilAsync(Func<bool> predicate)
+    private static async Task WaitUntilAsync(Func<bool> predicate, Func<string>? diagnostic = null)
     {
         for (var i = 0; i < 200; i++)
         {
@@ -774,7 +1053,9 @@ public sealed class OrleansEventPublisherBoundedTests
             await Task.Delay(10);
         }
 
-        Assert.True(predicate(), "Timed out waiting for the deterministic publisher observation.");
+        Assert.True(
+            predicate(),
+            diagnostic?.Invoke() ?? "Timed out waiting for the deterministic publisher observation.");
     }
 
     private static async Task WaitAndSignalAsync(
@@ -893,6 +1174,100 @@ public sealed class OrleansEventPublisherBoundedTests
             targetMethod?.Name == "get_ServiceProvider"
                 ? _serviceProvider
                 : throw new InvalidOperationException($"Unexpected Orleans client call: {targetMethod?.Name}");
+    }
+
+    private sealed class RecordingLogger : ILogger<OrleansEventPublisher>
+    {
+        public List<string> Messages { get; } = [];
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            Messages.Add(formatter(state, exception) + (exception is null ? string.Empty : $" [{exception.GetType().Name}: {exception.Message}]"));
+        }
+    }
+
+    private class FailingClusterClientProxy : DispatchProxy
+    {
+        private readonly IServiceProvider _serviceProvider = new ServiceCollection().BuildServiceProvider();
+        public IStreamProvider? StreamProvider { get; set; }
+        public IServiceProvider? ServiceProviderOverride { get; set; }
+        public List<string> Calls { get; } = [];
+
+        protected override object? Invoke(MethodInfo? targetMethod, object?[]? args)
+        {
+            Calls.Add(targetMethod?.Name ?? "<null>");
+            return targetMethod?.Name switch
+            {
+                "get_ServiceProvider" => ServiceProviderOverride ?? _serviceProvider,
+                "GetStreamProvider" => StreamProvider,
+                _ => throw new InvalidOperationException($"Unexpected Orleans client call: {targetMethod?.Name}")
+            };
+        }
+    }
+
+    private class FailingStreamProviderProxy : DispatchProxy
+    {
+        public IAsyncStream<SerializableEvent>? Stream { get; set; }
+        public List<string> Calls { get; } = [];
+
+        protected override object? Invoke(MethodInfo? targetMethod, object?[]? args)
+        {
+            Calls.Add(targetMethod?.Name ?? "<null>");
+            return targetMethod?.Name == "GetStream"
+                ? Stream
+                : throw new InvalidOperationException($"Unexpected stream provider call: {targetMethod?.Name}");
+        }
+    }
+
+    private class FailingStreamProxy : DispatchProxy
+    {
+        private int _attempts;
+        public int Attempts => Volatile.Read(ref _attempts);
+
+        protected override object? Invoke(MethodInfo? targetMethod, object?[]? args)
+        {
+            if (targetMethod?.Name == nameof(IAsyncStream<SerializableEvent>.OnNextAsync))
+            {
+                Interlocked.Increment(ref _attempts);
+                return Task.FromException(new InvalidOperationException("deterministic legacy transport failure"));
+            }
+
+            throw new InvalidOperationException($"Unexpected async stream call: {targetMethod?.Name}");
+        }
+    }
+
+    private class ControlledStreamProxy : DispatchProxy
+    {
+        public TaskCompletionSource<bool> SendStarted { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource<bool> SendCompletion { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        protected override object? Invoke(MethodInfo? targetMethod, object?[]? args)
+        {
+            if (targetMethod?.Name == nameof(IAsyncStream<SerializableEvent>.OnNextAsync))
+            {
+                SendStarted.TrySetResult(true);
+                return SendCompletion.Task;
+            }
+
+            throw new InvalidOperationException($"Unexpected async stream call: {targetMethod?.Name}");
+        }
+    }
+
+    private sealed class FixedTargetSender(IOrleansPreparedStreamTarget target) : IOrleansStreamSender
+    {
+        public IOrleansPreparedStreamTarget PrepareDestination(OrleansPublishDestination destination) => target;
     }
 
     private sealed class RecordingSender : IOrleansStreamSender

--- a/dcb/tests/Sekiban.Dcb.Orleans.Tests/OrleansEventPublisherBoundedTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Orleans.Tests/OrleansEventPublisherBoundedTests.cs
@@ -1,12 +1,16 @@
 using System.Reflection;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using Orleans;
+using Orleans.Runtime;
 using Sekiban.Dcb.Actors;
 using Sekiban.Dcb.Common;
 using Sekiban.Dcb.Domains;
 using Sekiban.Dcb.Events;
 using Sekiban.Dcb.Orleans.Streams;
 using Sekiban.Dcb.ServiceId;
+using Sekiban.Dcb.SizeGates;
 using Sekiban.Dcb.Tags;
 using Xunit;
 
@@ -31,8 +35,20 @@ public sealed class OrleansEventPublisherBoundedTests
         Assert.Equal(1024, defaults.MaxDiagnosticDestinations);
         defaults.Validate();
 
+        new OrleansEventPublisherOptions
+        {
+            MaxPublishAttempts = 64,
+            MaxRetryDelay = TimeSpan.FromMinutes(5),
+            MaxQueuedItemsPerDestination = 65_536,
+            MaxQueuedItemsTotal = 1_048_576,
+            TerminalSampleCount = 1_000,
+            MaxDiagnosticDestinations = 65_536
+        }.Validate();
+
         AssertInvalid(nameof(OrleansEventPublisherOptions.MaxPublishAttempts), () =>
             new OrleansEventPublisherOptions { MaxPublishAttempts = 0 }.Validate());
+        AssertInvalid(nameof(OrleansEventPublisherOptions.MaxPublishAttempts), () =>
+            new OrleansEventPublisherOptions { MaxPublishAttempts = 65 }.Validate());
         AssertInvalid(nameof(OrleansEventPublisherOptions.BaseRetryDelay), () =>
             new OrleansEventPublisherOptions { BaseRetryDelay = TimeSpan.Zero }.Validate());
         AssertInvalid(nameof(OrleansEventPublisherOptions.MaxRetryDelay), () =>
@@ -41,18 +57,28 @@ public sealed class OrleansEventPublisherBoundedTests
                 BaseRetryDelay = TimeSpan.FromSeconds(2),
                 MaxRetryDelay = TimeSpan.FromSeconds(1)
             }.Validate());
+        AssertInvalid(nameof(OrleansEventPublisherOptions.MaxRetryDelay), () =>
+            new OrleansEventPublisherOptions { MaxRetryDelay = TimeSpan.FromMinutes(5) + TimeSpan.FromMilliseconds(1) }.Validate());
         AssertInvalid(nameof(OrleansEventPublisherOptions.MaxQueuedItemsPerDestination), () =>
             new OrleansEventPublisherOptions { MaxQueuedItemsPerDestination = 0 }.Validate());
+        AssertInvalid(nameof(OrleansEventPublisherOptions.MaxQueuedItemsPerDestination), () =>
+            new OrleansEventPublisherOptions { MaxQueuedItemsPerDestination = 65_537 }.Validate());
         AssertInvalid(nameof(OrleansEventPublisherOptions.MaxQueuedItemsTotal), () =>
             new OrleansEventPublisherOptions
             {
                 MaxQueuedItemsPerDestination = 2,
                 MaxQueuedItemsTotal = 1
             }.Validate());
+        AssertInvalid(nameof(OrleansEventPublisherOptions.MaxQueuedItemsTotal), () =>
+            new OrleansEventPublisherOptions { MaxQueuedItemsTotal = 1_048_577 }.Validate());
         AssertInvalid(nameof(OrleansEventPublisherOptions.TerminalSampleCount), () =>
             new OrleansEventPublisherOptions { TerminalSampleCount = 0 }.Validate());
+        AssertInvalid(nameof(OrleansEventPublisherOptions.TerminalSampleCount), () =>
+            new OrleansEventPublisherOptions { TerminalSampleCount = 1_001 }.Validate());
         AssertInvalid(nameof(OrleansEventPublisherOptions.MaxDiagnosticDestinations), () =>
             new OrleansEventPublisherOptions { MaxDiagnosticDestinations = 0 }.Validate());
+        AssertInvalid(nameof(OrleansEventPublisherOptions.MaxDiagnosticDestinations), () =>
+            new OrleansEventPublisherOptions { MaxDiagnosticDestinations = 65_537 }.Validate());
     }
 
     [Fact]
@@ -110,6 +136,182 @@ public sealed class OrleansEventPublisherBoundedTests
         Assert.Same(sender.ReceivedPayloads[0], sender.ReceivedPayloads[1]);
         Assert.Same(sender.ReceivedPayloadObjects[0], sender.ReceivedPayloadObjects[1]);
         Assert.Equal("writer-completed", Assert.Single(publisher.GetSnapshot().Destinations).Samples[0].ReasonCode);
+    }
+
+    [Fact]
+    public async Task PlannedPublication_UsesOneCompletePlanPerDestination_AndNeverReSerializes()
+    {
+        var baseDomain = DcbDomainTypesExtensions.Simple(builder =>
+            builder.EventTypes.RegisterEventType<PublisherEvent>());
+        var countingTypes = new CountingEventTypes(baseDomain.EventTypes);
+        var domain = baseDomain with { EventTypes = countingTypes };
+        var capture = new RecordingMeasurementCapture();
+        var sender = new RecordingSender
+        {
+            FailAttempt = (destination, attempt) =>
+                destination.StreamNamespace == "planned-a" && attempt == 1,
+            ObserveRequestContext = true
+        };
+        var capturedContext = new Dictionary<string, object>(StringComparer.Ordinal)
+        {
+            ["g77-context"] = "captured-once"
+        };
+        await using var publisher = CreatePublisher(
+            sender,
+            new OrleansEventPublisherOptions
+            {
+                MaxPublishAttempts = 2,
+                BaseRetryDelay = TimeSpan.FromMilliseconds(1),
+                MaxRetryDelay = TimeSpan.FromMilliseconds(1)
+            },
+            new SequenceResolver(
+                new OrleansSekibanStream("provider", "planned-a", Guid.Parse("00000000-0000-0000-0000-0000000000a1")),
+                new OrleansSekibanStream("provider", "planned-b", Guid.Parse("00000000-0000-0000-0000-0000000000b1"))),
+            domainTypes: domain,
+            captureRequestContext: () => capturedContext,
+            measurementCaptures: [capture]);
+
+        var publication = CreatePublication("planned");
+        RequestContext.Set("g77-context", "caller-sentinel");
+        var plan = publisher.CaptureDestinationPlan(publication.Event, publication.Tags, "service-77");
+
+        Assert.NotNull(plan);
+        Assert.Equal(1, countingTypes.SerializeCalls);
+        var states = Assert.IsAssignableFrom<IReadOnlyList<OrleansDestinationPlanState>>(plan.ProviderState);
+        Assert.Equal(2, states.Count);
+        Assert.All(states, state =>
+        {
+            Assert.Same(capturedContext, state.RequestContext);
+            Assert.NotNull(state.PreparedTarget);
+            Assert.NotNull(state.MeasurementState);
+            Assert.Equal("service-77", state.ServiceId);
+        });
+        Assert.Equal(2, sender.PrepareCalls);
+        Assert.Equal(2, capture.CaptureCalls);
+
+        RequestContext.Set("g77-context", "caller-sentinel");
+        await ((IExecutorSizeDestinationPublisher)publisher).PublishAsync(
+            new[] { publication },
+            new Dictionary<Guid, ExecutorSizeDestinationPlan> { [publication.Event.Id] = plan! });
+        await WaitUntilAsync(() => sender.Successes == 2);
+
+        Assert.Equal(1, countingTypes.SerializeCalls);
+        Assert.Equal(2, sender.PrepareCalls);
+        Assert.Equal(3, sender.Attempts);
+        Assert.Single(sender.ReceivedPayloadObjects.Distinct());
+        Assert.Equal(2, sender.ReceivedTargets.Distinct().Count());
+        Assert.Equal(3, sender.ObservedRequestContexts.Count);
+        Assert.All(sender.ObservedRequestContexts, value => Assert.Equal("captured-once", value));
+        Assert.Equal("caller-sentinel", RequestContext.Get("g77-context"));
+        Assert.Equal(0, sender.LastPayload!.ReferenceCount);
+
+        var incompletePlan = plan! with { PreparedEvent = null };
+        var beforeIncomplete = countingTypes.SerializeCalls;
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            ((IExecutorSizeDestinationPublisher)publisher).PublishAsync(
+                new[] { publication },
+                new Dictionary<Guid, ExecutorSizeDestinationPlan>
+                {
+                    [publication.Event.Id] = incompletePlan
+                }));
+        Assert.Equal(beforeIncomplete, countingTypes.SerializeCalls);
+        Assert.Equal(3, sender.Attempts);
+    }
+
+    [Fact]
+    public async Task RetryScheduler_IsolatesBackoffAndPreservesSameDestinationFifo()
+    {
+        var a1 = CreatePublication("A1");
+        var a2 = CreatePublication("A2");
+        var b1 = CreatePublication("B1");
+        var aFirst = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var delayEntered = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseDelay = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var sender = new RecordingSender
+        {
+            FailFirstEventId = a1.Event.Id,
+            BeforeSend = (destination, attempt, _) =>
+            {
+                if (destination.StreamNamespace == "capacity-a" && attempt == 1)
+                    aFirst.TrySetResult(true);
+                return Task.CompletedTask;
+            }
+        };
+        await using var publisher = CreatePublisher(
+            sender,
+            new OrleansEventPublisherOptions
+            {
+                MaxPublishAttempts = 2,
+                BaseRetryDelay = TimeSpan.FromMilliseconds(1),
+                MaxRetryDelay = TimeSpan.FromMilliseconds(1)
+            },
+            new RouteResolver(),
+            delayAsync: (_, cancellationToken) =>
+            {
+                delayEntered.TrySetResult(true);
+                return releaseDelay.Task.WaitAsync(cancellationToken);
+            });
+
+        await publisher.PublishAsync(new[] { a1 });
+        await aFirst.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        await delayEntered.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        await publisher.PublishAsync(new[] { a2, b1 });
+        await WaitUntilAsync(() => sender.SuccessfulEventIds.Contains(b1.Event.Id));
+        Assert.DoesNotContain(a2.Event.Id, sender.AttemptRecords.Select(record => record.EventId));
+
+        releaseDelay.TrySetResult(true);
+        await WaitUntilAsync(() => sender.Successes == 3);
+        var aAttempts = sender.AttemptRecords
+            .Where(record => record.Destination == "capacity-a")
+            .Select(record => record.EventId)
+            .ToArray();
+        Assert.Equal(new[] { a1.Event.Id, a1.Event.Id, a2.Event.Id }, aAttempts);
+        Assert.True(
+            sender.AttemptRecords.FindIndex(record => record.EventId == b1.Event.Id) <
+            sender.AttemptRecords.FindIndex(record => record.EventId == a1.Event.Id && record.Attempt > 1));
+    }
+
+    [Fact]
+    public async Task GlobalAdmissionCapacityRejectsNewWorkWithoutPerDestinationSaturation()
+    {
+        var firstEntered = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseFirst = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var sender = new RecordingSender
+        {
+            BeforeSend = (destination, attempt, _) =>
+            {
+                if (destination.StreamNamespace == "capacity-a" && attempt == 1)
+                {
+                    firstEntered.TrySetResult(true);
+                    return releaseFirst.Task;
+                }
+
+                return Task.CompletedTask;
+            }
+        };
+        await using var publisher = CreatePublisher(
+            sender,
+            new OrleansEventPublisherOptions
+            {
+                MaxQueuedItemsPerDestination = 2,
+                MaxQueuedItemsTotal = 2,
+                MaxPublishAttempts = 1
+            },
+            new RouteResolver());
+
+        var a1 = CreatePublication("A-global-1");
+        var b1 = CreatePublication("B-global-1");
+        var a2 = CreatePublication("A-global-2");
+        await publisher.PublishAsync(new[] { a1 });
+        await firstEntered.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        await publisher.PublishAsync(new[] { b1, a2 });
+        Assert.Equal(1, publisher.GetSnapshot().ReasonCounts["admission-capacity"]);
+        Assert.DoesNotContain(a2.Event.Id, sender.SuccessfulEventIds);
+
+        releaseFirst.TrySetResult(true);
+        await WaitUntilAsync(() => sender.Successes == 2);
+        Assert.Contains(a1.Event.Id, sender.SuccessfulEventIds);
+        Assert.Contains(b1.Event.Id, sender.SuccessfulEventIds);
     }
 
     [Fact]
@@ -212,7 +414,19 @@ public sealed class OrleansEventPublisherBoundedTests
     [Fact]
     public async Task FanOut_UsesOneSharedPayloadUntilEveryDestinationSettles()
     {
-        var sender = new RecordingSender();
+        var aEntered = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var bEntered = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseA = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseB = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var sender = new RecordingSender
+        {
+            BeforeSend = (destination, _, cancellationToken) => destination.StreamNamespace switch
+            {
+                "fanout-a" => WaitAndSignalAsync(aEntered, releaseA, cancellationToken),
+                "fanout-b" => WaitAndSignalAsync(bEntered, releaseB, cancellationToken),
+                _ => Task.CompletedTask
+            }
+        };
         await using var publisher = CreatePublisher(
             sender,
             new OrleansEventPublisherOptions { MaxPublishAttempts = 1 },
@@ -222,9 +436,20 @@ public sealed class OrleansEventPublisherBoundedTests
 
         var publication = CreatePublication("fanout");
         await publisher.PublishAsync(new[] { publication });
-        await WaitUntilAsync(() => sender.Successes == 2);
+        await Task.WhenAll(
+            aEntered.Task.WaitAsync(TimeSpan.FromSeconds(2)),
+            bEntered.Task.WaitAsync(TimeSpan.FromSeconds(2)));
         Assert.Equal(2, sender.ReceivedPayloadObjects.Count);
         Assert.Same(sender.ReceivedPayloadObjects[0], sender.ReceivedPayloadObjects[1]);
+        Assert.Equal(2, sender.ReceivedPayloadObjects[0].ReferenceCount);
+
+        releaseA.TrySetResult(true);
+        await WaitUntilAsync(() => sender.ReceivedPayloadObjects[0].ReferenceCount == 1);
+        Assert.Equal(1, sender.ReceivedPayloadObjects[0].ReferenceCount);
+        Assert.Equal(1, sender.Successes);
+
+        releaseB.TrySetResult(true);
+        await WaitUntilAsync(() => sender.Successes == 2);
         Assert.Equal(0, sender.LastPayload!.ReferenceCount);
     }
 
@@ -308,10 +533,23 @@ public sealed class OrleansEventPublisherBoundedTests
             optionsProperties);
 
         var publicConstructors = typeof(OrleansEventPublisher).GetConstructors();
-        Assert.Contains(publicConstructors, constructor => constructor.GetParameters().Length == 4);
-        Assert.Contains(publicConstructors, constructor => constructor.GetParameters().Length == 5);
-        Assert.Contains(publicConstructors, constructor =>
-            constructor.GetParameters().Any(parameter => parameter.ParameterType == typeof(OrleansEventPublisherOptions)));
+        var constructorPrefix = new[]
+        {
+            typeof(IClusterClient),
+            typeof(IStreamDestinationResolver),
+            typeof(DcbDomainTypes),
+            typeof(ILogger<OrleansEventPublisher>)
+        };
+        Assert.NotNull(typeof(OrleansEventPublisher).GetConstructor(constructorPrefix));
+        Assert.NotNull(typeof(OrleansEventPublisher).GetConstructor(
+            constructorPrefix.Append(typeof(IServiceIdProvider)).ToArray()));
+        Assert.NotNull(typeof(OrleansEventPublisher).GetConstructor(
+            constructorPrefix.Append(typeof(OrleansEventPublisherOptions)).Append(typeof(IServiceIdProvider)).ToArray()));
+        Assert.DoesNotContain(publicConstructors, constructor => constructor.IsStatic);
+
+        Assert.Equal(typeof(int), typeof(OrleansEventPublisherOptions).GetProperty(nameof(OrleansEventPublisherOptions.MaxPublishAttempts))!.PropertyType);
+        Assert.Equal(typeof(TimeSpan), typeof(OrleansEventPublisherOptions).GetProperty(nameof(OrleansEventPublisherOptions.BaseRetryDelay))!.PropertyType);
+        Assert.Equal(typeof(TimeSpan), typeof(OrleansEventPublisherOptions).GetProperty(nameof(OrleansEventPublisherOptions.MaxRetryDelay))!.PropertyType);
 
         Assert.Equal(
             new[]
@@ -328,6 +566,23 @@ public sealed class OrleansEventPublisherBoundedTests
                 .OrderBy(name => name)
                 .ToArray());
 
+        Assert.Equal(typeof(IReadOnlyList<OrleansPublisherDestinationDiagnostic>),
+            typeof(OrleansPublisherDiagnosticsSnapshot).GetProperty(nameof(OrleansPublisherDiagnosticsSnapshot.Destinations))!.PropertyType);
+        Assert.Equal(typeof(IReadOnlyDictionary<string, long>),
+            typeof(OrleansPublisherDiagnosticsSnapshot).GetProperty(nameof(OrleansPublisherDiagnosticsSnapshot.ReasonCounts))!.PropertyType);
+        Assert.Equal(
+            new[]
+            {
+                "AttemptCount", "DestinationKey", "Namespace", "Provider", "ReasonCounts", "Samples", "ServiceId",
+                "StreamId", "TerminalCount"
+            },
+            typeof(OrleansPublisherDestinationDiagnostic).GetProperties(BindingFlags.Public | BindingFlags.Instance)
+                .Select(property => property.Name).OrderBy(name => name).ToArray());
+        Assert.Equal(
+            new[] { "Attempts", "EventId", "OccurredAtUtc", "ReasonCode" },
+            typeof(OrleansPublisherTerminalSample).GetProperties(BindingFlags.Public | BindingFlags.Instance)
+                .Select(property => property.Name).OrderBy(name => name).ToArray());
+
         var services = new ServiceCollection();
         services.AddSekibanDcbOrleansEventPublisher();
         Assert.Contains(services, descriptor => descriptor.ServiceType == typeof(OrleansEventPublisher));
@@ -338,6 +593,26 @@ public sealed class OrleansEventPublisherBoundedTests
             Assert.IsType<OrleansEventPublisherOptions>(
                 Assert.Single(services.Where(descriptor => descriptor.ServiceType == typeof(OrleansEventPublisherOptions)))
                     .ImplementationInstance).MaxPublishAttempts);
+    }
+
+    [Fact]
+    public async Task LegacyOptionsFreeRegistrationResolvesWithDefaultFiveAttemptConfiguration()
+    {
+        var domain = DcbDomainTypesExtensions.Simple(builder =>
+            builder.EventTypes.RegisterEventType<PublisherEvent>());
+        var services = new ServiceCollection();
+        services.AddSingleton<IClusterClient>(DispatchProxy.Create<IClusterClient, ServiceProviderClusterClientProxy>());
+        services.AddSingleton<IStreamDestinationResolver>(
+            new SequenceResolver(new OrleansSekibanStream("provider", "legacy", Guid.NewGuid())));
+        services.AddSingleton(domain);
+        services.AddSingleton<Microsoft.Extensions.Logging.ILogger<OrleansEventPublisher>>(
+            NullLogger<OrleansEventPublisher>.Instance);
+        services.AddSingleton<IEventPublisher, OrleansEventPublisher>();
+
+        await using var provider = services.BuildServiceProvider();
+        var publisher = provider.GetRequiredService<IEventPublisher>();
+        Assert.IsType<OrleansEventPublisher>(publisher);
+        Assert.Equal(5, new OrleansEventPublisherOptions().MaxPublishAttempts);
     }
 
     [Fact]
@@ -379,12 +654,86 @@ public sealed class OrleansEventPublisherBoundedTests
         Assert.Equal(0, sender.LastPayload!.ReferenceCount);
     }
 
+    [Fact]
+    public async Task Disposal_RaceAfterAdmissionStartsOwnedWorkerWithNoneAndReleasesQueuedPayload()
+    {
+        var workerGate = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var payloadReleased = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var observedStartToken = default(CancellationToken);
+        var sender = new RecordingSender();
+        await using var publisher = CreatePublisher(
+            sender,
+            new OrleansEventPublisherOptions { MaxPublishAttempts = 1 },
+            startWorkerAsync: (work, cancellationToken) =>
+            {
+                observedStartToken = cancellationToken;
+                return Task.Run(
+                    async () =>
+                    {
+                        await workerGate.Task;
+                        if (!cancellationToken.IsCancellationRequested)
+                            await work();
+                    },
+                    CancellationToken.None);
+            },
+            payloadReleased: () => payloadReleased.TrySetResult(true));
+
+        await publisher.PublishAsync(new[] { CreatePublication("start-dispose-race") });
+        var disposeTask = publisher.DisposeAsync().AsTask();
+        await Task.Delay(20);
+        Assert.False(disposeTask.IsCompleted);
+        Assert.False(observedStartToken.IsCancellationRequested);
+
+        workerGate.TrySetResult(true);
+        await disposeTask.WaitAsync(TimeSpan.FromSeconds(2));
+        await payloadReleased.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        Assert.Null(sender.LastPayload);
+    }
+
+    [Fact]
+    public async Task Disposal_DrainsInFlightQueuedAndRetryDelayWorkWithoutDetachedFaults()
+    {
+        var delayEntered = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseCount = 0;
+        var first = CreatePublication("dispose-delay-1");
+        var second = CreatePublication("dispose-delay-2");
+        var sender = new RecordingSender { FailFirstEventId = first.Event.Id };
+        await using var publisher = CreatePublisher(
+            sender,
+            new OrleansEventPublisherOptions
+            {
+                MaxPublishAttempts = 3,
+                MaxQueuedItemsPerDestination = 10,
+                MaxQueuedItemsTotal = 10,
+                BaseRetryDelay = TimeSpan.FromSeconds(1),
+                MaxRetryDelay = TimeSpan.FromSeconds(1)
+            },
+            delayAsync: (_, cancellationToken) =>
+            {
+                delayEntered.TrySetResult(true);
+                return Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+            },
+            payloadReleased: () => Interlocked.Increment(ref releaseCount));
+
+        await publisher.PublishAsync(new[] { first });
+        await delayEntered.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        await publisher.PublishAsync(new[] { second });
+        await publisher.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(2));
+
+        Assert.Equal(2, releaseCount);
+        Assert.Equal(0, publisher.GetSnapshot().ReasonCounts.GetValueOrDefault("pump-faulted"));
+    }
+
     private static OrleansEventPublisher CreatePublisher(
         RecordingSender sender,
         OrleansEventPublisherOptions options,
         IStreamDestinationResolver? resolver = null,
         Func<TimeSpan, CancellationToken, Task>? delayAsync = null,
-        DcbDomainTypes? domainTypes = null)
+        DcbDomainTypes? domainTypes = null,
+        Func<Func<Task>, CancellationToken, Task>? startWorkerAsync = null,
+        Func<Dictionary<string, object>?>? captureRequestContext = null,
+        IReadOnlyList<IOrleansDestinationMeasurementCapture>? measurementCaptures = null,
+        Action? payloadReleased = null)
     {
         return new OrleansEventPublisher(
             clusterClient: null!,
@@ -395,7 +744,11 @@ public sealed class OrleansEventPublisherBoundedTests
             options,
             new DefaultServiceIdProvider(),
             sender,
-            delayAsync);
+            delayAsync,
+            startWorkerAsync: startWorkerAsync,
+            captureRequestContext: captureRequestContext,
+            measurementCaptures: measurementCaptures,
+            payloadReleased: payloadReleased);
     }
 
     private static (Event Event, IReadOnlyCollection<ITag> Tags) CreatePublication(string value, Guid? eventId = null)
@@ -422,6 +775,15 @@ public sealed class OrleansEventPublisherBoundedTests
         }
 
         Assert.True(predicate(), "Timed out waiting for the deterministic publisher observation.");
+    }
+
+    private static async Task WaitAndSignalAsync(
+        TaskCompletionSource<bool> entered,
+        TaskCompletionSource<bool> release,
+        CancellationToken cancellationToken)
+    {
+        entered.TrySetResult(true);
+        await release.Task.WaitAsync(cancellationToken);
     }
 
     private static void AssertInvalid(string property, Action action)
@@ -484,39 +846,173 @@ public sealed class OrleansEventPublisherBoundedTests
         public Type? GetEventType(string eventTypeName) => null;
     }
 
+    private sealed class CountingEventTypes(IEventTypes inner) : IEventTypes
+    {
+        public int SerializeCalls { get; private set; }
+
+        public string SerializeEventPayload(IEventPayload payload)
+        {
+            SerializeCalls++;
+            return inner.SerializeEventPayload(payload);
+        }
+
+        public IEventPayload? DeserializeEventPayload(string eventTypeName, string json) =>
+            inner.DeserializeEventPayload(eventTypeName, json);
+
+        public Type? GetEventType(string eventTypeName) => inner.GetEventType(eventTypeName);
+    }
+
+    private sealed class RecordingMeasurementCapture : IOrleansDestinationMeasurementCapture
+    {
+        public int CaptureCalls { get; private set; }
+        public List<object> States { get; } = [];
+
+        public bool Matches(string providerName) => providerName == "provider";
+
+        public object? Capture(
+            string providerName,
+            string streamNamespace,
+            Guid streamId,
+            SerializableEvent serializedEvent,
+            IReadOnlyDictionary<string, object>? requestContext,
+            out string? failureReason)
+        {
+            failureReason = null;
+            CaptureCalls++;
+            var state = new object();
+            States.Add(state);
+            return state;
+        }
+    }
+
+    private class ServiceProviderClusterClientProxy : DispatchProxy
+    {
+        private readonly IServiceProvider _serviceProvider = new ServiceCollection().BuildServiceProvider();
+
+        protected override object? Invoke(MethodInfo? targetMethod, object?[]? args) =>
+            targetMethod?.Name == "get_ServiceProvider"
+                ? _serviceProvider
+                : throw new InvalidOperationException($"Unexpected Orleans client call: {targetMethod?.Name}");
+    }
+
     private sealed class RecordingSender : IOrleansStreamSender
     {
+        private readonly object _gate = new();
+        private readonly Dictionary<RecordingTarget, int> _attemptsByTarget = [];
         private int _attempts;
         private int _successes;
         public int FailuresBeforeSuccess { get; set; }
+        public Guid? FailFirstEventId { get; set; }
+        public Func<OrleansPublishDestination, int, bool>? FailAttempt { get; set; }
         public Func<OrleansPublishDestination, int, CancellationToken, Task>? BeforeSend { get; set; }
+        public bool ObserveRequestContext { get; set; }
+        public int PrepareCalls { get; private set; }
         public int Attempts => Volatile.Read(ref _attempts);
         public int Successes => Volatile.Read(ref _successes);
         public SharedPublishPayload? LastPayload { get; private set; }
         public List<SerializableEvent> ReceivedPayloads { get; } = [];
         public List<SharedPublishPayload> ReceivedPayloadObjects { get; } = [];
+        public List<IOrleansPreparedStreamTarget> ReceivedTargets { get; } = [];
         public List<Guid> SuccessfulEventIds { get; } = [];
+        public List<AttemptRecord> AttemptRecords { get; } = [];
+        public List<string?> ObservedRequestContexts { get; } = [];
 
-        public async Task SendAsync(
-            OrleansPublishDestination destination,
+        public IOrleansPreparedStreamTarget PrepareDestination(OrleansPublishDestination destination)
+        {
+            var target = new RecordingTarget(this, destination);
+            lock (_gate)
+            {
+                PrepareCalls++;
+                _attemptsByTarget[target] = 0;
+            }
+
+            return target;
+        }
+
+        private async Task SendAsync(
+            RecordingTarget target,
             SharedPublishPayload payload,
             CancellationToken cancellationToken)
         {
-            var attempt = Interlocked.Increment(ref _attempts);
+            int attempt;
+            lock (_gate)
+            {
+                attempt = ++_attemptsByTarget[target];
+                _attempts++;
+            }
+
             LastPayload = payload;
             lock (ReceivedPayloads)
             {
                 ReceivedPayloads.Add(payload.Event);
                 ReceivedPayloadObjects.Add(payload);
+                ReceivedTargets.Add(target);
+                AttemptRecords.Add(new AttemptRecord(
+                    payload.Event.Id,
+                    target.Destination.StreamNamespace,
+                    attempt,
+                    target));
             }
+
+            if (ObserveRequestContext)
+            {
+                var prior = RequestContext.Get("g77-context");
+                var captured = payload.RequestContext is not null &&
+                               payload.RequestContext.TryGetValue("g77-context", out var value)
+                    ? value as string
+                    : null;
+                lock (ReceivedPayloads)
+                    ObservedRequestContexts.Add(captured);
+                RequestContext.Set("g77-context", captured);
+                try
+                {
+                    await SendCoreAsync(target, payload, attempt, cancellationToken);
+                }
+                finally
+                {
+                    if (prior is null)
+                        RequestContext.Clear();
+                    else
+                        RequestContext.Set("g77-context", prior);
+                }
+                return;
+            }
+
+            await SendCoreAsync(target, payload, attempt, cancellationToken);
+        }
+
+        private async Task SendCoreAsync(
+            RecordingTarget target,
+            SharedPublishPayload payload,
+            int attempt,
+            CancellationToken cancellationToken)
+        {
             if (BeforeSend is not null)
-                await BeforeSend(destination, attempt, cancellationToken);
+                await BeforeSend(target.Destination, attempt, cancellationToken);
             cancellationToken.ThrowIfCancellationRequested();
-            if (attempt <= FailuresBeforeSuccess)
+            if ((FailAttempt?.Invoke(target.Destination, attempt) ?? false) ||
+                (FailFirstEventId == payload.Event.Id && attempt == 1) ||
+                attempt <= FailuresBeforeSuccess)
                 throw new InvalidOperationException("deterministic sender failure");
             lock (ReceivedPayloads)
                 SuccessfulEventIds.Add(payload.Event.Id);
             Interlocked.Increment(ref _successes);
         }
+
+        private sealed class RecordingTarget(
+            RecordingSender owner,
+            OrleansPublishDestination destination) : IOrleansPreparedStreamTarget
+        {
+            public OrleansPublishDestination Destination { get; } = destination;
+
+            public Task SendAsync(SharedPublishPayload payload, CancellationToken cancellationToken) =>
+                owner.SendAsync(this, payload, cancellationToken);
+        }
+
+        public sealed record AttemptRecord(
+            Guid EventId,
+            string Destination,
+            int Attempt,
+            IOrleansPreparedStreamTarget Target);
     }
 }

--- a/dcb/tests/Sekiban.Dcb.Orleans.Tests/OrleansEventPublisherBoundedTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Orleans.Tests/OrleansEventPublisherBoundedTests.cs
@@ -697,19 +697,48 @@ public sealed class OrleansEventPublisherBoundedTests
             optionsProperties);
 
         var publicConstructors = typeof(OrleansEventPublisher).GetConstructors();
-        var constructorPrefix = new[]
-        {
-            typeof(IClusterClient),
-            typeof(IStreamDestinationResolver),
-            typeof(DcbDomainTypes),
-            typeof(ILogger<OrleansEventPublisher>)
-        };
-        Assert.NotNull(typeof(OrleansEventPublisher).GetConstructor(constructorPrefix));
-        Assert.NotNull(typeof(OrleansEventPublisher).GetConstructor(
-            constructorPrefix.Append(typeof(IServiceIdProvider)).ToArray()));
-        Assert.NotNull(typeof(OrleansEventPublisher).GetConstructor(
-            constructorPrefix.Append(typeof(IServiceIdProvider)).Append(typeof(OrleansEventPublisherOptions)).ToArray()));
-        Assert.DoesNotContain(publicConstructors, constructor => constructor.IsStatic);
+        var orderedConstructors = publicConstructors
+            .OrderBy(constructor => constructor.GetParameters().Length)
+            .ThenBy(constructor => string.Join(",", constructor.GetParameters().Select(parameter => parameter.ParameterType.FullName)))
+            .ToArray();
+        Assert.Collection(
+            orderedConstructors,
+            constructor => AssertConstructorShape(
+                constructor,
+                new[]
+                {
+                    typeof(IClusterClient),
+                    typeof(IStreamDestinationResolver),
+                    typeof(DcbDomainTypes),
+                    typeof(ILogger<OrleansEventPublisher>)
+                },
+                new[] { "clusterClient", "resolver", "domainTypes", "logger" },
+                new[] { false, false, false, false }),
+            constructor => AssertConstructorShape(
+                constructor,
+                new[]
+                {
+                    typeof(IClusterClient),
+                    typeof(IStreamDestinationResolver),
+                    typeof(DcbDomainTypes),
+                    typeof(ILogger<OrleansEventPublisher>),
+                    typeof(IServiceIdProvider)
+                },
+                new[] { "clusterClient", "resolver", "domainTypes", "logger", "serviceIdProvider" },
+                new[] { false, false, false, false, true }),
+            constructor => AssertConstructorShape(
+                constructor,
+                new[]
+                {
+                    typeof(IClusterClient),
+                    typeof(IStreamDestinationResolver),
+                    typeof(DcbDomainTypes),
+                    typeof(ILogger<OrleansEventPublisher>),
+                    typeof(IServiceIdProvider),
+                    typeof(OrleansEventPublisherOptions)
+                },
+                new[] { "clusterClient", "resolver", "domainTypes", "logger", "serviceIdProvider", "options" },
+                new[] { false, false, false, false, false, false }));
 
         Assert.Equal(
             new Dictionary<string, Type>
@@ -790,10 +819,13 @@ public sealed class OrleansEventPublisherBoundedTests
                 [nameof(OrleansPublisherTerminalSample.ReasonCode)] = typeof(string)
             },
             GetPublicPropertyTypes(typeof(OrleansPublisherTerminalSample)));
-        var getSnapshot = typeof(IOrleansPublisherDiagnostics).GetMethod(nameof(IOrleansPublisherDiagnostics.GetSnapshot));
-        Assert.NotNull(getSnapshot);
-        Assert.Empty(getSnapshot!.GetParameters());
-        Assert.Equal(typeof(OrleansPublisherDiagnosticsSnapshot), getSnapshot.ReturnType);
+        Assert.Equal(
+            new[] { $"GetSnapshot():{typeof(OrleansPublisherDiagnosticsSnapshot).FullName}" },
+            GetDeclaredPublicMethodSignatures(typeof(IOrleansPublisherDiagnostics)));
+        Assert.Empty(typeof(IOrleansPublisherDiagnostics).GetProperties(BindingFlags.Public | BindingFlags.Instance));
+        Assert.Empty(GetDeclaredPublicMethodSignatures(typeof(OrleansPublisherDiagnosticsSnapshot)));
+        Assert.Empty(GetDeclaredPublicMethodSignatures(typeof(OrleansPublisherDestinationDiagnostic)));
+        Assert.Empty(GetDeclaredPublicMethodSignatures(typeof(OrleansPublisherTerminalSample)));
 
         var services = new ServiceCollection();
         services.AddSekibanDcbOrleansEventPublisher();
@@ -810,6 +842,27 @@ public sealed class OrleansEventPublisherBoundedTests
     private static Dictionary<string, Type> GetPublicPropertyTypes(Type type) =>
         type.GetProperties(BindingFlags.Public | BindingFlags.Instance)
             .ToDictionary(property => property.Name, property => property.PropertyType, StringComparer.Ordinal);
+
+    private static void AssertConstructorShape(
+        ConstructorInfo constructor,
+        IReadOnlyList<Type> expectedTypes,
+        IReadOnlyList<string> expectedNames,
+        IReadOnlyList<bool> expectedOptional)
+    {
+        var parameters = constructor.GetParameters();
+        Assert.Equal(expectedTypes, parameters.Select(parameter => parameter.ParameterType).ToArray());
+        Assert.Equal(expectedNames, parameters.Select(parameter => parameter.Name!).ToArray());
+        Assert.Equal(expectedOptional, parameters.Select(parameter => parameter.IsOptional).ToArray());
+        Assert.All(parameters.Where(parameter => parameter.IsOptional), parameter => Assert.Null(parameter.DefaultValue));
+    }
+
+    private static string[] GetDeclaredPublicMethodSignatures(Type type) =>
+        type.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+            .Where(method => !method.IsSpecialName)
+            .Select(method =>
+                $"{method.Name}({string.Join(",", method.GetParameters().Select(parameter => parameter.ParameterType.FullName))}):{method.ReturnType.FullName}")
+            .OrderBy(signature => signature)
+            .ToArray();
 
     [Fact]
     public async Task LegacyOptionsFreeRegistrationResolvesWithDefaultFiveAttemptConfiguration()
@@ -836,7 +889,7 @@ public sealed class OrleansEventPublisherBoundedTests
         services.AddSingleton(domain);
         services.AddSingleton<Microsoft.Extensions.Logging.ILogger<OrleansEventPublisher>>(
             logger);
-        services.AddSekibanDcbOrleansEventPublisher();
+        services.AddSingleton<IEventPublisher, OrleansEventPublisher>();
 
         await using var serviceProvider = services.BuildServiceProvider();
         var publisher = serviceProvider.GetRequiredService<IEventPublisher>();

--- a/dcb/tests/Sekiban.Dcb.Orleans.Tests/Sekiban.Dcb.Orleans.Tests.csproj
+++ b/dcb/tests/Sekiban.Dcb.Orleans.Tests/Sekiban.Dcb.Orleans.Tests.csproj
@@ -45,6 +45,9 @@
              not participate in this test project's compile-time dependency resolution. -->
         <ProjectReference Include="..\Sekiban.Dcb.TagStateCancellation.Legacy1018Fixture\Sekiban.Dcb.TagStateCancellation.Legacy1018Fixture.csproj"
                           ReferenceOutputAssembly="false" />
+        <!-- The mandatory Orleans test builds compile the isolated legacy constructor consumer on both TFMs. -->
+        <ProjectReference Include="..\Sekiban.Dcb.Orleans.LegacyConsumer\Sekiban.Dcb.Orleans.LegacyConsumer.csproj"
+                          ReferenceOutputAssembly="false" />
     </ItemGroup>
 
     <Target Name="CopyTagStateCancellationLegacy1018Fixture"

--- a/dcb/tests/Sekiban.Dcb.Orleans.Tests/SimpleOrleansCommandQueryTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Orleans.Tests/SimpleOrleansCommandQueryTests.cs
@@ -374,7 +374,7 @@ public class SimpleOrleansCommandQueryTests : IAsyncLifetime
         Assert.Equal(destination.ProviderName, plannedObservation.Provider);
         Assert.Equal(destination.StreamNamespace, plannedObservation.Namespace);
         Assert.Equal(destination.StreamId, plannedObservation.StreamId);
-        Assert.NotSame(capturedContext, plannedObservation.Context);
+        Assert.Same(capturedContext, plannedObservation.Context);
         Assert.Equal("retry-context", plannedObservation.Context!["g76-context"]);
         Assert.Equal(@event.Id, observed.Event.Id);
         Assert.Equal(@event.SortableUniqueIdValue, observed.Event.SortableUniqueIdValue);

--- a/docs/dcb_llm/11_storage_providers.md
+++ b/docs/dcb_llm/11_storage_providers.md
@@ -1079,3 +1079,26 @@ the conservative `CertifiedBound` tier.
 ## Related
 
 For the current internal-use cold event export, hybrid read, and catch-up worker setup, see [Cold Events and Catch-up](19_cold_events.md).
+
+## SEK-G77 Orleans event-publisher retries and diagnostics
+
+`OrleansEventPublisher` provides bounded, in-process delivery attempts for Orleans stream notifications. Its defaults are five
+publish attempts, a 100 ms base retry delay capped at 5 seconds, 1,024 queued items per destination, 16,384 queued items in
+total, 20 terminal samples, and 1,024 diagnostic destinations. Options are validated before the hosted publisher starts; the
+queue limits are admission limits, so an item already accepted is never evicted to make room for a new item.
+
+Destination order is FIFO for the full key `(serviceId, provider, namespace, streamId)`. A retry backs off only that destination;
+other destinations can continue. A terminal item is not replayed by this publisher, and `IOrleansPublisherDiagnostics` exposes
+bounded counts, reason codes, destination samples, and attempts without exposing event payloads. The publisher captures the
+serialized event, resolved destination, and request context once per publication plan; retries reuse that captured payload and
+context. Shared payload ownership is released on success, terminal failure, rejected admission, pump failure, and disposal.
+
+This publisher is an in-process notification path, not a durable cursor or outbox. It does not promise recovery of notifications
+lost after a terminal failure or process crash. For durable restart/takeover recovery, use the opt-in PostgreSQL durable Orleans
+subscription described in [Durable Orleans subscriptions](23_durable_orleans_subscriptions.md); its cursor is authoritative,
+and legacy callbacks do not advance that cursor. Registering both mechanisms can independently invoke application handling, so
+application handlers must remain idempotent.
+
+The retry and queue settings are delivery controls, not an arbitrary byte ceiling. This publisher does not certify an Orleans
+provider envelope, queue-service limit, batch limit, or custom application side effect. If a provider-specific size gate is
+configured, its separate capability contract applies; otherwise no provider byte limit is implied by these publisher options.

--- a/docs/dcb_llm_ja/11_storage_providers.md
+++ b/docs/dcb_llm_ja/11_storage_providers.md
@@ -1086,3 +1086,25 @@ event envelope の予算と解釈してはいけません。event metadata な�
 ## 関連資料
 
 現在のインターナルユースで使っているコールドイベントの書き出し、ハイブリッドリード、キャッチアップワーカー構成については [コールドイベントとキャッチアップ](19_cold_events.md) を参照してください。
+
+## SEK-G77 Orleans event publisher の retry と診断
+
+`OrleansEventPublisher` は Orleans stream 通知に対して、プロセス内で上限付きの配信試行を行います。既定値は、publish
+試行 5 回、初回 retry 待機 100 ms、retry 待機の上限 5 秒、destination ごとの待機キュー 1,024 件、全 destination 合計
+16,384 件、terminal sample 20 件、診断対象 destination 1,024 件です。options は hosted publisher の起動前に検証されます。
+キュー上限は admission 上限であり、すでに受け付けた item を追い出して新しい item の場所を作ることはありません。
+
+destination の完全なキー `(serviceId, provider, namespace, streamId)` ごとに FIFO を保ちます。ある destination の retry が
+backoff 中でも、他の destination は進行できます。terminal になった item をこの publisher が再配信することはありません。
+`IOrleansPublisherDiagnostics` から、payload を公開せずに、上限付きの件数、reason code、destination sample、試行回数を確認できます。
+publisher は publication plan ごとに serialized event、解決済み destination、request context を一度捕捉し、retry では同じ payload と
+context を再利用します。共有 payload の所有権は、成功、terminal failure、admission 拒否、pump failure、dispose の各経路で解放されます。
+
+この publisher はプロセス内の通知経路であり、durable cursor や outbox ではありません。terminal failure やプロセス crash 後に
+失われた通知を復旧する保証はありません。再起動や takeover 後の durable recovery が必要な場合は、[永続 Orleans サブスクリプション](23_durable_orleans_subscriptions.md)
+を使用してください。そこでは PostgreSQL の cursor が authoritative であり、legacy callback はその cursor を進めません。両方を登録すると
+application handler が独立して呼び出される可能性があるため、handler は idempotent に保つ必要があります。
+
+retry と queue の options は配信制御であり、任意の byte 上限ではありません。この publisher は Orleans provider の envelope、queue service
+limit、batch limit、または custom application side effect を保証しません。provider 固有の size gate を設定した場合は、その capability
+契約が別途適用されます。未設定の場合、この publisher options から provider byte limit を推測してはいけません。


### PR DESCRIPTION
Closes #1229

## Summary

Adds the bounded, in-process Orleans notification publisher required by SEK-G77. The existing four-argument and legacy five-argument constructor calls remain source-compatible, including a five-argument null literal; the additive options and diagnostics contract does not add a durable cursor, outbox, relay, or provider envelope contract.

## Implementation

- Adds validated OrleansEventPublisherOptions for attempts, backoff, per-destination/global admission, and bounded diagnostic retention.
- Uses destination-keyed FIFO workers; retry backoff is isolated per (serviceId, provider, namespace, streamId) destination, with the complete A1/B1/A2/B2 and FIFO proof matrix.
- Captures one SharedPublishPayload per publication and retains one complete destination plan per target, including service identity, provider/stream target, measurement state, prepared serialized event, and request context.
- Prepares each provider/stream target before admission; retries send only through that captured target and never re-resolve provider or stream. A missing prepared event is rejected without serialization.
- Tracks and awaits the real non-cancellable Orleans OnNextAsync transport task during disposal; payload/context restoration and outcome observation therefore settle before DisposeAsync completes.
- Rejects global-capacity work before allocating a new destination state, and bounds 10,000 unique rejected destinations without retaining empty scheduler state.
- Captures/restores Orleans request context around each send, fails closed when planned DeepCopier capability is absent, records direct capture failures as admission-resolve-failed while later events continue, and starts owned workers with CancellationToken.None.
- Records writer-completed only for a completed writer admission rejection; successful sends do not populate terminal failure diagnostics.
- Adds IOrleansPublisherDiagnostics snapshots with bounded reason-coded samples and a DI registration helper. The exact legacy `services.AddSingleton<IEventPublisher, OrleansEventPublisher>()` path is exercised through an actual five-attempt permanent failure and terminal diagnostic.
- Adds exact ordered reflection inventories for the public publisher constructors and diagnostics interface/DTO surfaces.
- Adds an isolated net9/net10 source consumer for the four-argument, typed legacy five-argument, null-literal legacy five-argument, and additive six-argument options constructor calls. The consumer is a project dependency of the mandatory Orleans test build and its path is included in the DCB PR workflow filter, so both TFM CI jobs compile it.
- Documents the in-process/non-durable boundary and opt-in PostgreSQL durable subscription recovery in EN/JA storage guides.

## Sonar reliability repair

- Put `Sekiban.Dcb.Orleans.LegacyConsumer.Program` in a named namespace while retaining its source-compatibility entrypoint purpose.
- Replaced repeated `admission-resolve-failed` literals with one internal constant.
- Routed option validation through one helper that preserves each `ArgumentOutOfRangeException` parameter name.
- Replaced the nine-parameter internal diagnostics DTO constructor with an internal data carrier, without changing the public DTO properties or their types.
- Consolidated deterministic test-only publisher dependencies into one internal `OrleansEventPublisherTestHooks` object so the public and test constructor contracts remain unchanged.
- Removed the unnecessary null-forgiving/null check flow and made `TryEnqueue` a `void` method because no caller consumed its former Boolean result; admission and diagnostic behavior are unchanged.

## Validation

- `OrleansEventPublisherBoundedTests`: 22/22 net9 and 22/22 net10 on the repair head.
- The bounded suite includes real non-cancellable transport settlement across disposal, 10,000 unique global-capacity rejections, A1/B1/A2/B2 backoff isolation and FIFO, options-free DI five-attempt termination, exact public constructor/property/method reflection, context capability/failure paths, writer-completed rejection, successful-send diagnostic neutrality, and final shared-payload zero ownership.
- Isolated `Sekiban.Dcb.Orleans.LegacyConsumer` source compilation and entrypoint: successful net9 and net10. The mandatory Orleans test project also compiled that consumer for both TFMs through its project reference.
- Orleans test project build: successful net9 and net10, zero errors.
- `git diff --check` and cached diff check: passed before commit.

The repair head is `8bafdee4fea71094d3a2e5d6a45ebc04c6e411ef`. Fresh run `34709197578` attempt 2 is green: `dcbTestsNet9` job `103597173469` and `dcbTestsNet10` job `103597172704` both passed, including the sequential DCB suite and mandatory LegacyConsumer compilation. The same push also has green PostgreSQL packaged consumer job `103594711277`, Azure Queue packaged consumer job `103594711141`, template packaged consumer job `103594710872`, SonarCloud job `103595723723`, and SonarCloud Code Analysis `103595723885` (https://sonarcloud.io/dashboard?id=J-Tech-Japan_Sekiban&pullRequest=1231). Attempt 1 had the only red result, an unrelated runner-sensitive `TaggedStreamMemoryTests.ControlledGeneratedHistory_StaysUnderTheStreamingAllocationCeiling_AndTheListControlRetainsTheHistory` net10 allocation ceiling assertion (`167645976` versus `134217728`); its targeted local control passed 1/1 on both net9 and net10, and the single failed job rerun passed without source changes. The local Orleans TestCluster integration attempt is not claimed green: it failed before cluster startup while Orleans port allocation called `BsdIPGlobalProperties.GetTcpConnections`, producing `System.OverflowException`. The source/build and deterministic bounded publisher evidence above are independent of that host-network limitation.

Fresh exact-head review remains required before merge.
