### PR TITLE
Clear multi-projection catch-up host state after successful refresh

### DIFF
--- a/dcb/src/Sekiban.Dcb.Orleans.Core/Grains/MultiProjectionGrain.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.Core/Grains/MultiProjectionGrain.cs
@@ -1487,7 +1487,7 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
                 _lastError = snapshotWriteResult.GetException().Message;
                 _logger.LogWarning("[{ProjectorName}] {LastError}", projectorName, _lastError);
                 _lastPersistOutcome = PersistOutcomeNoDurableWrite;
-                return ResultBox.FromValue(false);
+                return ResultBox.Error<bool>(snapshotWriteResult.GetException());
             }
 
             if (!snapshotWriteResult.GetValue())
@@ -1692,7 +1692,7 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
                     _lastError = writeResult.GetException().Message;
                     _logger.LogWarning("[{ProjectorName}] Streaming snapshot write failed: {Error}", projectorName, _lastError);
                     _lastPersistOutcome = PersistOutcomeNoDurableWrite;
-                    return ResultBox.FromValue(false);
+                    return ResultBox.Error<bool>(writeResult.GetException());
                 }
 
                 if (!writeResult.GetValue())
@@ -4843,7 +4843,6 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
     private async Task CompleteCatchUp()
     {
         var projectorName = GetProjectorName();
-        var shouldPersist = _catchUpProgress.HadNewEvents;
         var pendingStreamEventsBefore = _pendingStreamEvents.Count;
         long safePromotionElapsedMs = 0;
         long persistElapsedMs = 0;
@@ -4855,17 +4854,27 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
             _catchUpTimer = null;
 
             // Process all buffered events first. Event-bearing work stays in an in-progress host state; the single
-            // empty completion pulse below is the only operation that marks this catch-up complete.
-            await FlushEventBufferAsync(failOnSafePromotion: true);
+            // empty completion pulse below is the only operation that marks this catch-up complete. The completion
+            // path is explicitly allowed to drain while catch-up is active; timer re-entry remains guarded.
+            await FlushEventBufferAsync(
+                failOnSafePromotion: true,
+                allowDuringCatchUp: true);
+
+            // Pending stream receipts are event-bearing work too. Drain them before the final promotion so the
+            // completion decision covers every state mutation accepted during this catch-up window.
+            await ProcessPendingStreamEvents();
+
+            var shouldPersist = _catchUpProgress.HadNewEvents;
+
+            // Every successful completion, including empty and duplicate-only refreshes, must perform the final
+            // promotion stage while catch-up is still active. No later stage may run after promotion fails.
+            var safePromotionStopwatch = System.Diagnostics.Stopwatch.StartNew();
+            await TriggerSafePromotion(failOnFailure: true);
+            safePromotionStopwatch.Stop();
+            safePromotionElapsedMs = safePromotionStopwatch.ElapsedMilliseconds;
 
             if (shouldPersist)
             {
-                // Force promotion of any events that are now safe
-                var safePromotionStopwatch = System.Diagnostics.Stopwatch.StartNew();
-                await TriggerSafePromotion(failOnFailure: true);
-                safePromotionStopwatch.Stop();
-                safePromotionElapsedMs = safePromotionStopwatch.ElapsedMilliseconds;
-
                 // Final persistence
                 var persistStopwatch = System.Diagnostics.Stopwatch.StartNew();
                 var persistResult = await PersistStateAsync();
@@ -4885,9 +4894,6 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
                 persistStopwatch.Stop();
                 persistElapsedMs = persistStopwatch.ElapsedMilliseconds;
             }
-
-            // Process any pending stream events
-            await ProcessPendingStreamEvents();
 
             // Only a successful completion may clear the host's catch-up flag. Keep this pulse empty so it cannot
             // mutate event counts, ordering, positions, or persistence; event-bearing calls above deliberately use
@@ -4969,11 +4975,12 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
 
         var projectorName = GetProjectorName();
         var events = new List<SerializableEvent>();
+        var pendingEventIds = new HashSet<Guid>();
 
         while (_pendingStreamEvents.Count > 0)
         {
             var ev = _pendingStreamEvents.Dequeue();
-            if (_processedEventIds.Contains(ev.Id))
+            if (_processedEventIds.Contains(ev.Id) || !pendingEventIds.Add(ev.Id))
             {
                 continue;
             }
@@ -4996,6 +5003,7 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
         {
             await _host.AddSerializableEventsAsync(allEvents, finishedCatchUp: false);
             _eventsProcessed += allEvents.Count;
+            _catchUpProgress.HadNewEvents |= _catchUpProgress.IsActive;
             foreach (var ev in allEvents)
             {
                 TrackProcessedEventId(ev.Id);
@@ -5278,9 +5286,11 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
     /// <summary>
     ///     Process buffered events - called by timer
     /// </summary>
-    private async Task FlushEventBufferAsync(bool failOnSafePromotion = false)
+    private async Task FlushEventBufferAsync(
+        bool failOnSafePromotion = false,
+        bool allowDuringCatchUp = false)
     {
-        if (_catchUpProgress.IsActive)
+        if (_catchUpProgress.IsActive && !allowDuringCatchUp)
         {
             return;
         }
@@ -5338,6 +5348,8 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
                 events.Count);
             await _host.AddSerializableEventsAsync(events, finishedCatchUp);
             _eventsProcessed += events.Count;
+            _catchUpProgress.HadNewEvents |= _catchUpProgress.IsActive;
+            _lastEventTime = DateTime.UtcNow;
 
             foreach (var ev in events)
             {
@@ -5451,7 +5463,6 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
         if (_catchUpProgress.IsActive)
         {
             EnqueuePendingStreamEvents(list, _catchUpProgress.CurrentPosition);
-            _lastEventTime = DateTime.UtcNow;
             return;
         }
 
@@ -5466,7 +5477,6 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
                 _eventBuffer.Add(ev);
             }
         }
-        _lastEventTime = DateTime.UtcNow;
         // Do not record deliveries here to avoid double-counting.
         // Delivery statistics are recorded after successful processing
         // inside ProcessEventBatch.

--- a/dcb/src/Sekiban.Dcb.Orleans.Core/Grains/MultiProjectionGrain.cs
+++ b/dcb/src/Sekiban.Dcb.Orleans.Core/Grains/MultiProjectionGrain.cs
@@ -1490,6 +1490,14 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
                 return ResultBox.FromValue(false);
             }
 
+            if (!snapshotWriteResult.GetValue())
+            {
+                _lastError = "Snapshot write returned no durable result";
+                _logger.LogWarning("[{ProjectorName}] {LastError}", projectorName, _lastError);
+                _lastPersistOutcome = PersistOutcomeNoDurableWrite;
+                return ResultBox.FromValue(false);
+            }
+
             var envelopeSize = snapshotStream.Length;
 
             // Get metadata via host
@@ -1682,6 +1690,14 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
                 if (!writeResult.IsSuccess)
                 {
                     _lastError = writeResult.GetException().Message;
+                    _logger.LogWarning("[{ProjectorName}] Streaming snapshot write failed: {Error}", projectorName, _lastError);
+                    _lastPersistOutcome = PersistOutcomeNoDurableWrite;
+                    return ResultBox.FromValue(false);
+                }
+
+                if (!writeResult.GetValue())
+                {
+                    _lastError = "Streaming snapshot write returned no durable result";
                     _logger.LogWarning("[{ProjectorName}] Streaming snapshot write failed: {Error}", projectorName, _lastError);
                     _lastPersistOutcome = PersistOutcomeNoDurableWrite;
                     return ResultBox.FromValue(false);
@@ -4838,26 +4854,49 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
             _catchUpTimer?.Dispose();
             _catchUpTimer = null;
 
-            // Process all buffered events first
-            await FlushEventBufferAsync();
+            // Process all buffered events first. Event-bearing work stays in an in-progress host state; the single
+            // empty completion pulse below is the only operation that marks this catch-up complete.
+            await FlushEventBufferAsync(failOnSafePromotion: true);
 
             if (shouldPersist)
             {
                 // Force promotion of any events that are now safe
                 var safePromotionStopwatch = System.Diagnostics.Stopwatch.StartNew();
-                await TriggerSafePromotion();
+                await TriggerSafePromotion(failOnFailure: true);
                 safePromotionStopwatch.Stop();
                 safePromotionElapsedMs = safePromotionStopwatch.ElapsedMilliseconds;
 
                 // Final persistence
                 var persistStopwatch = System.Diagnostics.Stopwatch.StartNew();
-                await PersistStateAsync();
+                var persistResult = await PersistStateAsync();
+                if (!persistResult.IsSuccess)
+                {
+                    throw new InvalidOperationException(
+                        $"Catch-up final persistence failed for projector '{projectorName}'.",
+                        persistResult.GetException());
+                }
+
+                if (!persistResult.GetValue())
+                {
+                    throw new InvalidOperationException(
+                        $"Catch-up final persistence failed for projector '{projectorName}': no durable result.");
+                }
+
                 persistStopwatch.Stop();
                 persistElapsedMs = persistStopwatch.ElapsedMilliseconds;
             }
 
             // Process any pending stream events
             await ProcessPendingStreamEvents();
+
+            // Only a successful completion may clear the host's catch-up flag. Keep this pulse empty so it cannot
+            // mutate event counts, ordering, positions, or persistence; event-bearing calls above deliberately use
+            // finishedCatchUp:false.
+            if (_host is not null)
+            {
+                await _host.AddSerializableEventsAsync([], finishedCatchUp: true);
+            }
+
             CompactRetainedCollections();
 
             _catchUpProgress.IsActive = false;
@@ -4889,7 +4928,7 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
         }
     }
 
-    private async Task TriggerSafePromotion()
+    private async Task TriggerSafePromotion(bool failOnFailure = false)
     {
         try
         {
@@ -4910,9 +4949,15 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
                         projectorName,
                         state.Version);
                 }
+                else if (failOnFailure)
+                {
+                    throw new InvalidOperationException(
+                        $"Catch-up safe promotion failed for projector '{projectorName}'.",
+                        safeState.GetException());
+                }
             }
         }
-        catch (Exception ex)
+        catch (Exception ex) when (!failOnFailure)
         {
             _logger.LogError(ex, "[{ProjectorName}] Error during safe promotion", GetProjectorName());
         }
@@ -4949,7 +4994,7 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
         var allEvents = events.OrderBy(e => e.SortableUniqueIdValue).ToList();
         if (allEvents.Count > 0 && _host != null)
         {
-            await _host.AddSerializableEventsAsync(allEvents, true);
+            await _host.AddSerializableEventsAsync(allEvents, finishedCatchUp: false);
             _eventsProcessed += allEvents.Count;
             foreach (var ev in allEvents)
             {
@@ -5233,7 +5278,7 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
     /// <summary>
     ///     Process buffered events - called by timer
     /// </summary>
-    private async Task FlushEventBufferAsync()
+    private async Task FlushEventBufferAsync(bool failOnSafePromotion = false)
     {
         if (_catchUpProgress.IsActive)
         {
@@ -5260,19 +5305,25 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
 
         if (eventsToProcess.Count > 0)
         {
-            await ProcessBufferedSerializableEvents(eventsToProcess);
+            await ProcessBufferedSerializableEvents(
+                eventsToProcess,
+                finishedCatchUp: !failOnSafePromotion,
+                failOnFailure: failOnSafePromotion);
         }
         else
         {
             // Even if no events to process, trigger safe promotion
-            await TriggerSafePromotion();
+            await TriggerSafePromotion(failOnFailure: failOnSafePromotion);
         }
     }
 
     /// <summary>
     ///     Process buffered serializable events via host
     /// </summary>
-    private async Task ProcessBufferedSerializableEvents(List<SerializableEvent> events)
+    private async Task ProcessBufferedSerializableEvents(
+        List<SerializableEvent> events,
+        bool finishedCatchUp = true,
+        bool failOnFailure = false)
     {
         if (_host == null || events.Count == 0) return;
 
@@ -5285,7 +5336,7 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
                 "[{ProjectorName}] Processing {EventCount} buffered events",
                 projectorName,
                 events.Count);
-            await _host.AddSerializableEventsAsync(events, true);
+            await _host.AddSerializableEventsAsync(events, finishedCatchUp);
             _eventsProcessed += events.Count;
 
             foreach (var ev in events)
@@ -5321,7 +5372,7 @@ public class MultiProjectionGrain : Grain, IMultiProjectionGrain, ILifecyclePart
                 await TriggerSafePromotion();
             }
         }
-        catch (Exception ex)
+        catch (Exception ex) when (!failOnFailure)
         {
             await CaptureAndPersistProjectionFaultIfAnyAsync();
             _lastError = $"Failed to process buffered events: {ex.Message}";

--- a/dcb/tests/Sekiban.Dcb.Orleans.Tests/MultiProjectionGrainCatchUpProductionPathTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Orleans.Tests/MultiProjectionGrainCatchUpProductionPathTests.cs
@@ -581,12 +581,16 @@ public sealed class MultiProjectionGrainCatchUpProductionPathTests
         bool throwFailure)
     {
         var store = new ProductionCatchUpEventStore([1]);
+        var safePromotionSentinel = resultFailure
+            ? new InvalidOperationException("sentinel safe promotion failure")
+            : null;
         var host = new ProductionCatchUpProjectionHost
         {
             AllowApply = true,
             FailInitialStateRead = false,
             FailSafePromotionWithResult = resultFailure,
-            ThrowSafePromotion = throwFailure
+            ThrowSafePromotion = throwFailure,
+            SafePromotionException = safePromotionSentinel
         };
         var grain = CreateGrain(store, host, processedEvents: Array.Empty<SerializableEvent>());
         SetActiveCatchUp(grain, new CatchUpStartPositionLease(
@@ -603,10 +607,17 @@ public sealed class MultiProjectionGrainCatchUpProductionPathTests
         else
         {
             Assert.Contains("Catch-up safe promotion failed", exception.Message);
+            Assert.Same(safePromotionSentinel, exception.InnerException);
+        }
+        if (throwFailure)
+        {
+            Assert.Null(exception.InnerException);
         }
         Assert.Empty(host.AddCalls);
         Assert.DoesNotContain(host.AddCalls, call => call.FinishedCatchUp);
-        Assert.True((await grain.GetProjectionHeadStatusAsync()).IsCatchUpInProgress);
+        var head = await grain.GetProjectionHeadStatusAsync();
+        Assert.True(head.IsCatchUpInProgress);
+        Assert.Equal(0, head.PendingStreamEventCount);
     }
 
     [Theory]
@@ -627,10 +638,14 @@ public sealed class MultiProjectionGrainCatchUpProductionPathTests
         ProductionCatchUpEventStore store = streaming
             ? new ProductionStreamingCatchUpEventStore(batchSizes)
             : new ProductionCatchUpEventStore(batchSizes);
+        var safePromotionSentinel = throwFailure
+            ? null
+            : new InvalidOperationException("sentinel public safe promotion failure");
         var host = new ProductionCatchUpProjectionHost
         {
             FailSafePromotionWithResult = !throwFailure,
-            ThrowSafePromotion = throwFailure
+            ThrowSafePromotion = throwFailure,
+            SafePromotionException = safePromotionSentinel
         };
         var grain = CreateGrain(
             store,
@@ -646,6 +661,11 @@ public sealed class MultiProjectionGrainCatchUpProductionPathTests
         else
         {
             Assert.Contains("Catch-up safe promotion failed", exception.Message);
+            Assert.Same(safePromotionSentinel, exception.InnerException);
+        }
+        if (throwFailure)
+        {
+            Assert.Null(exception.InnerException);
         }
 
         Assert.Empty(host.AddCalls);
@@ -653,6 +673,9 @@ public sealed class MultiProjectionGrainCatchUpProductionPathTests
         Assert.Equal(0, store.PersistentState.WriteCalls);
         Assert.DoesNotContain(host.AddCalls, call => call.FinishedCatchUp);
         Assert.True(host.StateCalls >= 2); // initial cursor probe plus the completion-only promotion attempt
+        var head = await grain.GetProjectionHeadStatusAsync();
+        Assert.True(head.IsCatchUpInProgress);
+        Assert.Equal(0, head.PendingStreamEventCount);
     }
 
     [Theory]
@@ -664,11 +687,15 @@ public sealed class MultiProjectionGrainCatchUpProductionPathTests
         bool returnFalse)
     {
         var store = new ProductionCatchUpEventStore([1]);
+        var snapshotThrownSentinel = throwFailure
+            ? new InvalidOperationException("sentinel snapshot writer failure")
+            : null;
         var host = new ProductionCatchUpProjectionHost
         {
             AllowApply = true,
             FailInitialStateRead = false,
             ThrowSnapshotWrite = throwFailure,
+            SnapshotWriteThrownException = snapshotThrownSentinel,
             FailSnapshotWrite = !throwFailure && !returnFalse,
             ReturnFalseSnapshotWrite = returnFalse,
             SafeVersion = 1,
@@ -683,7 +710,11 @@ public sealed class MultiProjectionGrainCatchUpProductionPathTests
         var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => InvokePrivateTaskAsync(grain, "CompleteCatchUp"));
 
         Assert.Contains("Catch-up final persistence failed", exception.Message);
-        if (returnFalse)
+        if (throwFailure)
+        {
+            Assert.Same(snapshotThrownSentinel, exception.InnerException);
+        }
+        else if (returnFalse)
         {
             Assert.Null(exception.InnerException);
         }
@@ -826,7 +857,13 @@ public sealed class MultiProjectionGrainCatchUpProductionPathTests
                 firstReadStarted,
                 releaseFirstRead);
         var pendingEvent = CreatePendingEvent(20_000);
-        var host = new ProductionCatchUpProjectionHost { AllowApply = true, FailInitialStateRead = false };
+        var unchangedPosition = SortableUniqueId.Generate(DateTime.UtcNow.AddMinutes(-2), Guid.Empty);
+        var host = new ProductionCatchUpProjectionHost
+        {
+            AllowApply = true,
+            FailInitialStateRead = false,
+            SafePosition = unchangedPosition
+        };
         var grain = CreateGrain(store, host, processedEvents: Array.Empty<SerializableEvent>());
         var processedIds = GetPrivateField<HashSet<Guid>>(grain, "_processedEventIds");
         processedIds.Add(pendingEvent.Id);
@@ -843,10 +880,26 @@ public sealed class MultiProjectionGrainCatchUpProductionPathTests
         await refresh;
 
         Assert.Equal(new[] { (EventCount: 0, FinishedCatchUp: true) }, host.AddCalls);
+        Assert.Equal(0, host.SnapshotWriteCalls);
+        Assert.Equal(0, store.PersistentState.WriteCalls);
+        Assert.Empty(host.AppliedEventIds);
         Assert.Equal(123L, GetPrivateField<long>(grain, "_eventsProcessed"));
         Assert.Equal(oldTime, GetPrivateFieldValue(grain, "_lastEventTime"));
         Assert.Equal("before-duplicate", GetPrivateField<string?>(grain, "_liveLastPosition"));
         Assert.Empty(GetPrivateField<Queue<Guid>>(grain, "_processedEventIdOrder"));
+
+        var catchUp = await grain.GetCatchUpStatusAsync();
+        Assert.False(catchUp.IsActive);
+        Assert.Equal(0, catchUp.PendingStreamEvents);
+        Assert.Equal(unchangedPosition, catchUp.CurrentPosition);
+
+        var head = await grain.GetProjectionHeadStatusAsync();
+        Assert.False(head.IsCatchUpInProgress);
+        Assert.Equal(0, head.CurrentEventVersion);
+        Assert.Equal(0, head.ConsistentEventVersion);
+        Assert.Equal(unchangedPosition, head.CurrentLastSortableUniqueId);
+        Assert.Equal(unchangedPosition, head.ConsistentLastSortableUniqueId);
+        Assert.Equal(0, head.PendingStreamEventCount);
     }
 
     [Theory]
@@ -1152,11 +1205,13 @@ public sealed class MultiProjectionGrainCatchUpProductionPathTests
     {
         public bool FailSnapshotWrite { get; init; }
         public bool ThrowSnapshotWrite { get; init; }
+        public Exception? SnapshotWriteThrownException { get; init; }
         public bool ReturnFalseSnapshotWrite { get; init; }
         public Exception? SnapshotWriteException { get; init; }
         public bool AllowApply { get; init; }
         public bool FailSafePromotionWithResult { get; init; }
         public bool ThrowSafePromotion { get; init; }
+        public Exception? SafePromotionException { get; init; }
         public bool ThrowOnApply { get; init; }
         public bool FailInitialStateRead { get; init; } = true;
         public string? ProjectionStartPosition { get; init; }
@@ -1221,7 +1276,8 @@ public sealed class MultiProjectionGrainCatchUpProductionPathTests
 
             if (FailSafePromotionWithResult)
             {
-                return Task.FromResult(ResultBox.Error<MultiProjectionState>(new InvalidOperationException("safe promotion failed by result")));
+                return Task.FromResult(ResultBox.Error<MultiProjectionState>(
+                    SafePromotionException ?? new InvalidOperationException("safe promotion failed by result")));
             }
 
             return Task.FromResult(ResultBox.FromValue<MultiProjectionState>(new MultiProjectionState(
@@ -1268,7 +1324,7 @@ public sealed class MultiProjectionGrainCatchUpProductionPathTests
             SnapshotWriteCalls++;
             if (ThrowSnapshotWrite)
             {
-                throw new InvalidOperationException("snapshot write threw");
+                throw SnapshotWriteThrownException ?? new InvalidOperationException("snapshot write threw");
             }
 
             if (SnapshotWriteException is { } snapshotWriteException)

--- a/dcb/tests/Sekiban.Dcb.Orleans.Tests/MultiProjectionGrainCatchUpProductionPathTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Orleans.Tests/MultiProjectionGrainCatchUpProductionPathTests.cs
@@ -2,6 +2,7 @@ using System.Reflection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using ResultBoxes;
+using Sekiban.Dcb;
 using Sekiban.Dcb.Actors;
 using Sekiban.Dcb.ColdEvents;
 using Sekiban.Dcb.Common;
@@ -468,6 +469,216 @@ public sealed class MultiProjectionGrainCatchUpProductionPathTests
         AssertWindowReset(completedGrain, completedTime);
     }
 
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    [InlineData(true, true)]
+    public async Task Empty_or_duplicate_only_completion_sends_one_empty_finished_pulse_without_mutation(
+        bool streaming,
+        bool duplicateOnly)
+    {
+        var batchSizes = duplicateOnly ? new[] { 3 } : Array.Empty<int>();
+        ProductionCatchUpEventStore store = streaming
+            ? new ProductionStreamingCatchUpEventStore(batchSizes)
+            : new ProductionCatchUpEventStore(batchSizes);
+        var host = new ProductionCatchUpProjectionHost();
+        var grain = CreateGrain(store, host);
+
+        await grain.RefreshAsync();
+
+        Assert.Equal(new[] { (EventCount: 0, FinishedCatchUp: true) }, host.AddCalls);
+        Assert.Empty(host.AppliedEventIds);
+        Assert.Equal(0, store.PersistentState.WriteCalls);
+        Assert.Equal(0, host.SnapshotWriteCalls);
+        Assert.False((await grain.GetCatchUpStatusAsync()).IsActive);
+
+        var head = await grain.GetProjectionHeadStatusAsync();
+        Assert.False(head.IsCatchUpInProgress);
+        Assert.Equal(0, head.CurrentEventVersion);
+        if (duplicateOnly)
+        {
+            Assert.Equal(store.Events[^1].SortableUniqueIdValue, head.CurrentLastSortableUniqueId);
+        }
+        else
+        {
+            Assert.Null(head.CurrentLastSortableUniqueId);
+        }
+        Assert.Equal(0, head.PendingStreamEventCount);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task New_events_are_applied_before_one_separate_empty_completion_pulse(bool streaming)
+    {
+        ProductionCatchUpEventStore store = streaming
+            ? new ProductionStreamingCatchUpEventStore([1])
+            : new ProductionCatchUpEventStore([1]);
+        var host = new ProductionCatchUpProjectionHost { AllowApply = true };
+        var grain = CreateGrain(store, host, processedEvents: Array.Empty<SerializableEvent>());
+
+        await grain.RefreshAsync();
+
+        Assert.Equal(
+            new[] { (EventCount: 1, FinishedCatchUp: false), (EventCount: 0, FinishedCatchUp: true) },
+            host.AddCalls);
+        Assert.Equal(new[] { store.Events[0].Id }, host.AppliedEventIds);
+        Assert.False((await grain.GetProjectionHeadStatusAsync()).IsCatchUpInProgress);
+    }
+
+    [Fact]
+    public async Task Pending_events_are_sorted_and_duplicate_receipts_are_not_reapplied_before_one_completion_pulse()
+    {
+        var store = new ProductionCatchUpEventStore([3]);
+        var host = new ProductionCatchUpProjectionHost { AllowApply = true, FailInitialStateRead = false };
+        var grain = CreateGrain(store, host, processedEvents: Array.Empty<SerializableEvent>());
+        var processedIds = GetPrivateField<HashSet<Guid>>(grain, "_processedEventIds");
+        processedIds.Add(store.Events[1].Id);
+        var pending = GetPrivateField<Queue<SerializableEvent>>(grain, "_pendingStreamEvents");
+        pending.Enqueue(store.Events[2]);
+        pending.Enqueue(store.Events[1]); // already applied: duplicate receipt must be ignored.
+        pending.Enqueue(store.Events[0]);
+        await InvokePrivateTaskAsync(grain, "CompleteCatchUp");
+
+        Assert.Equal(
+            new[] { (EventCount: 2, FinishedCatchUp: false), (EventCount: 0, FinishedCatchUp: true) },
+            host.AddCalls);
+        Assert.Equal(new[] { store.Events[0].Id, store.Events[2].Id }, host.AppliedEventIds);
+        Assert.Equal(store.Events[2].SortableUniqueIdValue, host.LastAppliedPosition);
+        Assert.False((await grain.GetProjectionHeadStatusAsync()).IsCatchUpInProgress);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task Replay_apply_failure_from_each_reader_never_emits_completion_pulse(bool streaming)
+    {
+        ProductionCatchUpEventStore store = streaming
+            ? new ProductionStreamingCatchUpEventStore([1])
+            : new ProductionCatchUpEventStore([1]);
+        var host = new ProductionCatchUpProjectionHost { FailInitialStateRead = false };
+        var grain = CreateGrain(store, host, processedEvents: Array.Empty<SerializableEvent>());
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => grain.RefreshAsync());
+
+        Assert.Equal("pending event application failed", exception.Message);
+        Assert.Equal(new[] { (EventCount: 1, FinishedCatchUp: false) }, host.AddCalls);
+        Assert.DoesNotContain(host.AddCalls, call => call.FinishedCatchUp);
+        Assert.True((await grain.GetProjectionHeadStatusAsync()).IsCatchUpInProgress);
+    }
+
+    [Theory]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    public async Task Safe_promotion_failure_never_emits_completion_pulse(
+        bool resultFailure,
+        bool throwFailure)
+    {
+        var store = new ProductionCatchUpEventStore([1]);
+        var host = new ProductionCatchUpProjectionHost
+        {
+            AllowApply = true,
+            FailInitialStateRead = false,
+            FailSafePromotionWithResult = resultFailure,
+            ThrowSafePromotion = throwFailure
+        };
+        var grain = CreateGrain(store, host, processedEvents: Array.Empty<SerializableEvent>());
+        SetActiveCatchUp(grain, new CatchUpStartPositionLease(
+            new SortableUniqueId(store.Events[0].SortableUniqueIdValue),
+            CatchUpStartPositionSource.RestoredCheckpoint),
+            hadNewEvents: true);
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => InvokePrivateTaskAsync(grain, "CompleteCatchUp"));
+
+        if (throwFailure)
+        {
+            Assert.Equal("safe promotion failed by throw", exception.Message);
+        }
+        else
+        {
+            Assert.Contains("Catch-up safe promotion failed", exception.Message);
+        }
+        Assert.Empty(host.AddCalls);
+        Assert.DoesNotContain(host.AddCalls, call => call.FinishedCatchUp);
+        Assert.True((await grain.GetProjectionHeadStatusAsync()).IsCatchUpInProgress);
+    }
+
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    public async Task Final_persistence_failure_never_emits_completion_pulse(
+        bool throwFailure,
+        bool returnFalse)
+    {
+        var store = new ProductionCatchUpEventStore([1]);
+        var host = new ProductionCatchUpProjectionHost
+        {
+            AllowApply = true,
+            FailInitialStateRead = false,
+            ThrowSnapshotWrite = throwFailure,
+            FailSnapshotWrite = !throwFailure && !returnFalse,
+            ReturnFalseSnapshotWrite = returnFalse,
+            SafeVersion = 1,
+            SafePosition = store.Events[0].SortableUniqueIdValue
+        };
+        var grain = CreateGrain(store, host, processedEvents: Array.Empty<SerializableEvent>());
+        SetActiveCatchUp(grain, new CatchUpStartPositionLease(
+            new SortableUniqueId(store.Events[0].SortableUniqueIdValue),
+            CatchUpStartPositionSource.RestoredCheckpoint),
+            hadNewEvents: true);
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => InvokePrivateTaskAsync(grain, "CompleteCatchUp"));
+
+        Assert.Contains("Catch-up final persistence failed", exception.Message);
+        Assert.Empty(host.AddCalls);
+        Assert.DoesNotContain(host.AddCalls, call => call.FinishedCatchUp);
+        Assert.True((await grain.GetProjectionHeadStatusAsync()).IsCatchUpInProgress);
+    }
+
+    [Fact]
+    public async Task Pending_application_failure_never_emits_completion_pulse()
+    {
+        var store = new ProductionCatchUpEventStore([1]);
+        var host = new ProductionCatchUpProjectionHost
+        {
+            AllowApply = true,
+            ThrowOnApply = true,
+            FailInitialStateRead = false
+        };
+        var grain = CreateGrain(store, host, processedEvents: Array.Empty<SerializableEvent>());
+        GetPrivateField<Queue<SerializableEvent>>(grain, "_pendingStreamEvents").Enqueue(store.Events[0]);
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => InvokePrivateTaskAsync(grain, "CompleteCatchUp"));
+
+        Assert.Equal("pending event application failed", exception.Message);
+        Assert.Equal(new[] { (EventCount: 1, FinishedCatchUp: false) }, host.AddCalls);
+        Assert.DoesNotContain(host.AddCalls, call => call.FinishedCatchUp);
+        Assert.True((await grain.GetProjectionHeadStatusAsync()).IsCatchUpInProgress);
+    }
+
+    [Fact]
+    public async Task Buffered_application_failure_never_emits_completion_pulse()
+    {
+        var store = new ProductionCatchUpEventStore([1]);
+        var host = new ProductionCatchUpProjectionHost
+        {
+            AllowApply = true,
+            ThrowOnApply = true,
+            FailInitialStateRead = false
+        };
+        var grain = CreateGrain(store, host, processedEvents: Array.Empty<SerializableEvent>());
+        GetPrivateField<List<SerializableEvent>>(grain, "_eventBuffer").Add(store.Events[0]);
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => InvokePrivateTaskAsync(grain, "CompleteCatchUp"));
+
+        Assert.Equal("pending event application failed", exception.Message);
+        Assert.Equal(new[] { (EventCount: 1, FinishedCatchUp: false) }, host.AddCalls);
+        Assert.DoesNotContain(host.AddCalls, call => call.FinishedCatchUp);
+        Assert.True((await grain.GetProjectionHeadStatusAsync()).IsCatchUpInProgress);
+    }
+
     private static async Task InvokeProgressUpdateAsync(
         MultiProjectionGrain grain,
         int batchNumber,
@@ -608,7 +819,8 @@ public sealed class MultiProjectionGrainCatchUpProductionPathTests
 
     private static void SetActiveCatchUp(
         MultiProjectionGrain grain,
-        CatchUpStartPositionLease? startLease)
+        CatchUpStartPositionLease? startLease,
+        bool hadNewEvents = false)
     {
         var progressType = grain.GetType().GetNestedType("CatchUpProgress", BindingFlags.NonPublic);
         Assert.NotNull(progressType);
@@ -616,7 +828,7 @@ public sealed class MultiProjectionGrainCatchUpProductionPathTests
         Assert.NotNull(progress);
         SetPrivateProperty(progress!, "StartLease", startLease);
         SetPrivateProperty(progress!, "IsActive", startLease is not null);
-        SetPrivateProperty(progress!, "HadNewEvents", false);
+        SetPrivateProperty(progress!, "HadNewEvents", hadNewEvents);
         SetPrivateProperty(progress!, "StartTime", DateTime.UtcNow);
         SetPrivateProperty(progress!, "LastAttempt", DateTime.UtcNow);
         SetPrivateField(grain, "_catchUpProgress", progress);
@@ -709,16 +921,28 @@ public sealed class MultiProjectionGrainCatchUpProductionPathTests
         }
     }
 
+    private sealed class TestProjectionPayload : IMultiProjectionPayload
+    {
+    }
+
     private sealed class ProductionCatchUpProjectionHost : IProjectionActorHost
     {
         public bool FailSnapshotWrite { get; init; }
+        public bool ThrowSnapshotWrite { get; init; }
+        public bool ReturnFalseSnapshotWrite { get; init; }
         public bool AllowApply { get; init; }
+        public bool FailSafePromotionWithResult { get; init; }
+        public bool ThrowSafePromotion { get; init; }
+        public bool ThrowOnApply { get; init; }
+        public bool FailInitialStateRead { get; init; } = true;
         public string? ProjectionStartPosition { get; init; }
         public int SafeVersion { get; init; }
         public string? SafePosition { get; init; }
         public int StateMetadataCalls { get; private set; }
+        public int StateCalls { get; private set; }
         public int SafeCheckpointCalls { get; private set; }
         public int SnapshotWriteCalls { get; private set; }
+        public List<(int EventCount, bool FinishedCatchUp)> AddCalls { get; } = [];
         public IReadOnlyList<Guid> AppliedEventIds => _appliedEventIds;
         public int AppliedEventCount => _appliedEventIds.Count;
         public string? LastAppliedPosition { get; private set; }
@@ -729,13 +953,18 @@ public sealed class MultiProjectionGrainCatchUpProductionPathTests
 
         public Task AddSerializableEventsAsync(IReadOnlyList<SerializableEvent> events, bool finishedCatchUp = true)
         {
-            if (!AllowApply)
+            AddCalls.Add((events.Count, finishedCatchUp));
+            if (events.Count > 0 && (!AllowApply || ThrowOnApply))
             {
-                throw new Xunit.Sdk.XunitException("The zero-applied production test unexpectedly applied an event.");
+                throw new InvalidOperationException("pending event application failed");
             }
 
-            _appliedEventIds.AddRange(events.Select(ev => ev.Id));
-            LastAppliedPosition = events[^1].SortableUniqueIdValue;
+            if (events.Count > 0)
+            {
+                _appliedEventIds.AddRange(events.Select(ev => ev.Id));
+                LastAppliedPosition = events[^1].SortableUniqueIdValue;
+            }
+
             return Task.CompletedTask;
         }
 
@@ -753,11 +982,51 @@ public sealed class MultiProjectionGrainCatchUpProductionPathTests
                     SafeLastSortableUniqueId: SafePosition)));
         }
 
-        public Task<ResultBox<MultiProjectionState>> GetStateAsync(bool canGetUnsafeState = true) =>
-            Task.FromResult(ResultBox.Error<MultiProjectionState>(new InvalidOperationException("no state payload")));
+        public Task<ResultBox<MultiProjectionState>> GetStateAsync(bool canGetUnsafeState = true)
+        {
+            StateCalls++;
+            if (StateCalls == 1 && FailInitialStateRead)
+            {
+                return Task.FromResult(ResultBox.Error<MultiProjectionState>(new InvalidOperationException("no state payload")));
+            }
 
-        public Task<ProjectionHeadStatus> GetProjectionHeadStatusAsync() =>
-            throw new NotSupportedException();
+            if (ThrowSafePromotion)
+            {
+                throw new InvalidOperationException("safe promotion failed by throw");
+            }
+
+            if (FailSafePromotionWithResult)
+            {
+                return Task.FromResult(ResultBox.Error<MultiProjectionState>(new InvalidOperationException("safe promotion failed by result")));
+            }
+
+            return Task.FromResult(ResultBox.FromValue<MultiProjectionState>(new MultiProjectionState(
+                new TestProjectionPayload(),
+                "production-catch-up",
+                "v1",
+                SafePosition ?? string.Empty,
+                Guid.Empty,
+                SafeVersion)));
+        }
+
+        public Task<ProjectionHeadStatus> GetProjectionHeadStatusAsync()
+        {
+            var completed = AddCalls.Any(call => call is { EventCount: 0, FinishedCatchUp: true });
+            var position = LastAppliedPosition ?? SafePosition;
+            var current = new ProjectionPosition(_appliedEventIds.Count, position);
+            var consistent = new ProjectionPosition(_appliedEventIds.Count, position);
+            var catchUp = new ProjectionCatchUpStatus(
+                IsInProgress: !completed,
+                CurrentSortableUniqueId: position,
+                TargetSortableUniqueId: position,
+                PendingStreamEventCount: 0);
+            return Task.FromResult(new ProjectionHeadStatus(
+                "production-catch-up",
+                "v1",
+                current,
+                consistent,
+                catchUp));
+        }
 
         public Task<ResultBox<bool>> WriteSnapshotToStreamAsync(
             Stream target,
@@ -773,9 +1042,19 @@ public sealed class MultiProjectionGrainCatchUpProductionPathTests
         private async Task<ResultBox<bool>> WriteSnapshotAsync(Stream target)
         {
             SnapshotWriteCalls++;
+            if (ThrowSnapshotWrite)
+            {
+                throw new InvalidOperationException("snapshot write threw");
+            }
+
             if (FailSnapshotWrite)
             {
                 return ResultBox.Error<bool>(new InvalidOperationException("snapshot write failed"));
+            }
+
+            if (ReturnFalseSnapshotWrite)
+            {
+                return ResultBox.FromValue(false);
             }
 
             await target.WriteAsync(new byte[] { 1 });

--- a/dcb/tests/Sekiban.Dcb.Orleans.Tests/MultiProjectionGrainCatchUpProductionPathTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Orleans.Tests/MultiProjectionGrainCatchUpProductionPathTests.cs
@@ -13,6 +13,7 @@ using Sekiban.Dcb.Orleans.Serialization;
 using Sekiban.Dcb.Orleans.Streams;
 using Sekiban.Dcb.Runtime;
 using Sekiban.Dcb.ServiceId;
+using Sekiban.Dcb.Snapshots;
 using Sekiban.Dcb.Storage;
 using Sekiban.Dcb.Tags;
 using Xunit;
@@ -425,7 +426,9 @@ public sealed class MultiProjectionGrainCatchUpProductionPathTests
         var inheritedStore = new ProductionCatchUpEventStore(
             firstReadStarted: inheritedReadStarted,
             releaseFirstRead: releaseInheritedRead);
-        var inheritedGrain = CreateGrain(inheritedStore);
+        var inheritedGrain = CreateGrain(
+            inheritedStore,
+            new ProductionCatchUpProjectionHost { FailInitialStateRead = false });
         var inheritedTime = DateTime.UtcNow - TimeSpan.FromMinutes(2);
         var inheritedPosition = new SortableUniqueId(SortableUniqueId.Generate(DateTime.UtcNow.AddMinutes(-3), Guid.Empty));
         SetActiveCatchUp(
@@ -457,7 +460,9 @@ public sealed class MultiProjectionGrainCatchUpProductionPathTests
 
         AssertWindowPreserved(earlyReturnGrain, earlyReturnTime, usedCold: true);
 
-        var completedGrain = CreateGrain(new ProductionCatchUpEventStore());
+        var completedGrain = CreateGrain(
+            new ProductionCatchUpEventStore(),
+            new ProductionCatchUpProjectionHost { FailInitialStateRead = false });
         var completedTime = DateTime.UtcNow - TimeSpan.FromMinutes(4);
         SetActiveCatchUp(
             completedGrain,
@@ -605,6 +610,52 @@ public sealed class MultiProjectionGrainCatchUpProductionPathTests
     }
 
     [Theory]
+    [InlineData(false, false, false)]
+    [InlineData(true, false, false)]
+    [InlineData(false, true, false)]
+    [InlineData(true, true, false)]
+    [InlineData(false, false, true)]
+    [InlineData(true, false, true)]
+    [InlineData(false, true, true)]
+    [InlineData(true, true, true)]
+    public async Task Empty_and_duplicate_public_refreshes_require_safe_promotion_before_the_completion_pulse(
+        bool streaming,
+        bool throwFailure,
+        bool duplicateOnly)
+    {
+        var batchSizes = duplicateOnly ? new[] { 3 } : Array.Empty<int>();
+        ProductionCatchUpEventStore store = streaming
+            ? new ProductionStreamingCatchUpEventStore(batchSizes)
+            : new ProductionCatchUpEventStore(batchSizes);
+        var host = new ProductionCatchUpProjectionHost
+        {
+            FailSafePromotionWithResult = !throwFailure,
+            ThrowSafePromotion = throwFailure
+        };
+        var grain = CreateGrain(
+            store,
+            host,
+            processedEvents: duplicateOnly ? store.Events : Array.Empty<SerializableEvent>());
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => grain.RefreshAsync());
+
+        if (throwFailure)
+        {
+            Assert.Equal("safe promotion failed by throw", exception.Message);
+        }
+        else
+        {
+            Assert.Contains("Catch-up safe promotion failed", exception.Message);
+        }
+
+        Assert.Empty(host.AddCalls);
+        Assert.Equal(0, host.SnapshotWriteCalls);
+        Assert.Equal(0, store.PersistentState.WriteCalls);
+        Assert.DoesNotContain(host.AddCalls, call => call.FinishedCatchUp);
+        Assert.True(host.StateCalls >= 2); // initial cursor probe plus the completion-only promotion attempt
+    }
+
+    [Theory]
     [InlineData(false, false)]
     [InlineData(true, false)]
     [InlineData(false, true)]
@@ -632,9 +683,59 @@ public sealed class MultiProjectionGrainCatchUpProductionPathTests
         var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => InvokePrivateTaskAsync(grain, "CompleteCatchUp"));
 
         Assert.Contains("Catch-up final persistence failed", exception.Message);
+        if (returnFalse)
+        {
+            Assert.Null(exception.InnerException);
+        }
         Assert.Empty(host.AddCalls);
         Assert.DoesNotContain(host.AddCalls, call => call.FinishedCatchUp);
         Assert.True((await grain.GetProjectionHeadStatusAsync()).IsCatchUpInProgress);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task Final_persistence_resultbox_error_preserves_inner_exception_for_both_snapshot_paths(bool streaming)
+    {
+        var sentinel = new InvalidOperationException("sentinel final persistence failure");
+        var store = new ProductionCatchUpEventStore([1]);
+        var host = new ProductionCatchUpProjectionHost
+        {
+            AllowApply = true,
+            FailInitialStateRead = false,
+            SnapshotWriteException = sentinel,
+            SafeVersion = 1,
+            SafePosition = store.Events[0].SortableUniqueIdValue
+        };
+        var tempDirectory = Path.Combine(Path.GetTempPath(), "sekiban-g78-final-persist-" + Guid.NewGuid().ToString("N"));
+        var tempManager = streaming
+            ? new TempFileSnapshotManager(
+                new SnapshotTempFileOptions { TempDirectory = tempDirectory },
+                NullLogger<TempFileSnapshotManager>.Instance)
+            : null;
+        var grain = CreateGrain(
+            store,
+            host,
+            actorOptions: new GeneralMultiProjectionActorOptions
+            {
+                PersistIntervalSeconds = 0,
+                SkipPersistWhenSafeCheckpointUnchanged = false,
+                UseStreamingSnapshotIO = streaming
+            },
+            tempFileSnapshotManager: tempManager,
+            processedEvents: Array.Empty<SerializableEvent>());
+        SetActiveCatchUp(grain, new CatchUpStartPositionLease(
+            new SortableUniqueId(store.Events[0].SortableUniqueIdValue),
+            CatchUpStartPositionSource.RestoredCheckpoint),
+            hadNewEvents: true);
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => InvokePrivateTaskAsync(grain, "CompleteCatchUp"));
+
+        Assert.Contains("Catch-up final persistence failed", exception.Message);
+        Assert.Same(sentinel, exception.InnerException);
+        Assert.Empty(host.AddCalls);
+        Assert.DoesNotContain(host.AddCalls, call => call.FinishedCatchUp);
     }
 
     [Fact]
@@ -677,6 +778,116 @@ public sealed class MultiProjectionGrainCatchUpProductionPathTests
         Assert.Equal(new[] { (EventCount: 1, FinishedCatchUp: false) }, host.AddCalls);
         Assert.DoesNotContain(host.AddCalls, call => call.FinishedCatchUp);
         Assert.True((await grain.GetProjectionHeadStatusAsync()).IsCatchUpInProgress);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task Active_buffered_application_failure_never_reaches_promotion_or_completion_for_each_reader(bool streaming)
+    {
+        ProductionCatchUpEventStore store = streaming
+            ? new ProductionStreamingCatchUpEventStore([1])
+            : new ProductionCatchUpEventStore([1]);
+        var host = new ProductionCatchUpProjectionHost
+        {
+            AllowApply = true,
+            ThrowOnApply = true,
+            FailInitialStateRead = false
+        };
+        var grain = CreateGrain(store, host, processedEvents: Array.Empty<SerializableEvent>());
+        SetActiveCatchUp(grain, new CatchUpStartPositionLease(
+            new SortableUniqueId(store.Events[0].SortableUniqueIdValue),
+            CatchUpStartPositionSource.RestoredCheckpoint));
+        GetPrivateField<List<SerializableEvent>>(grain, "_eventBuffer").Add(store.Events[0]);
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => InvokePrivateTaskAsync(grain, "CompleteCatchUp"));
+
+        Assert.Equal("pending event application failed", exception.Message);
+        Assert.Equal(new[] { (EventCount: 1, FinishedCatchUp: false) }, host.AddCalls);
+        Assert.Equal(0, host.StateCalls);
+        Assert.DoesNotContain(host.AddCalls, call => call.FinishedCatchUp);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task Public_refresh_drops_already_processed_pending_duplicates_without_mutating_live_state(bool streaming)
+    {
+        var firstReadStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseFirstRead = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        ProductionCatchUpEventStore store = streaming
+            ? new ProductionStreamingCatchUpEventStore(
+                [0],
+                firstReadStarted,
+                releaseFirstRead)
+            : new ProductionCatchUpEventStore(
+                [0],
+                firstReadStarted,
+                releaseFirstRead);
+        var pendingEvent = CreatePendingEvent(20_000);
+        var host = new ProductionCatchUpProjectionHost { AllowApply = true, FailInitialStateRead = false };
+        var grain = CreateGrain(store, host, processedEvents: Array.Empty<SerializableEvent>());
+        var processedIds = GetPrivateField<HashSet<Guid>>(grain, "_processedEventIds");
+        processedIds.Add(pendingEvent.Id);
+        var oldTime = DateTime.UtcNow.AddMinutes(-1);
+        SetPrivateField(grain, "_lastEventTime", oldTime);
+        SetPrivateField(grain, "_liveLastPosition", "before-duplicate");
+
+        var refresh = grain.RefreshAsync();
+        await firstReadStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await grain.ProcessEventBatch([pendingEvent, pendingEvent]);
+
+        Assert.Equal(oldTime, GetPrivateFieldValue(grain, "_lastEventTime"));
+        releaseFirstRead.TrySetResult();
+        await refresh;
+
+        Assert.Equal(new[] { (EventCount: 0, FinishedCatchUp: true) }, host.AddCalls);
+        Assert.Equal(123L, GetPrivateField<long>(grain, "_eventsProcessed"));
+        Assert.Equal(oldTime, GetPrivateFieldValue(grain, "_lastEventTime"));
+        Assert.Equal("before-duplicate", GetPrivateField<string?>(grain, "_liveLastPosition"));
+        Assert.Empty(GetPrivateField<Queue<Guid>>(grain, "_processedEventIdOrder"));
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task Public_refresh_deduplicates_new_pending_receipts_before_one_apply_for_each_reader(bool streaming)
+    {
+        var firstReadStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseFirstRead = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        ProductionCatchUpEventStore store = streaming
+            ? new ProductionStreamingCatchUpEventStore(
+                [0],
+                firstReadStarted,
+                releaseFirstRead)
+            : new ProductionCatchUpEventStore(
+                [0],
+                firstReadStarted,
+                releaseFirstRead);
+        var pendingEvent = CreatePendingEvent(20_000);
+        var host = new ProductionCatchUpProjectionHost { AllowApply = true, FailInitialStateRead = false };
+        var grain = CreateGrain(store, host, processedEvents: Array.Empty<SerializableEvent>());
+        var oldTime = DateTime.UtcNow.AddMinutes(-1);
+        SetPrivateField(grain, "_lastEventTime", oldTime);
+        SetPrivateField(grain, "_liveLastPosition", "before-new");
+
+        var refresh = grain.RefreshAsync();
+        await firstReadStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await grain.ProcessEventBatch([pendingEvent, pendingEvent]);
+
+        Assert.Equal(oldTime, GetPrivateFieldValue(grain, "_lastEventTime"));
+        releaseFirstRead.TrySetResult();
+        await refresh;
+
+        Assert.Equal(
+            new[] { (EventCount: 1, FinishedCatchUp: false), (EventCount: 0, FinishedCatchUp: true) },
+            host.AddCalls);
+        Assert.Equal(new[] { pendingEvent.Id }, host.AppliedEventIds);
+        Assert.Equal(124L, GetPrivateField<long>(grain, "_eventsProcessed"));
+        Assert.True((DateTime)GetPrivateFieldValue(grain, "_lastEventTime")! > oldTime);
+        Assert.Equal(pendingEvent.SortableUniqueIdValue, GetPrivateField<string?>(grain, "_liveLastPosition"));
+        Assert.Equal(new[] { pendingEvent.Id }, GetPrivateField<Queue<Guid>>(grain, "_processedEventIdOrder"));
     }
 
     private static async Task InvokeProgressUpdateAsync(
@@ -731,7 +942,8 @@ public sealed class MultiProjectionGrainCatchUpProductionPathTests
         MultiProjectionGrainState? state = null,
         GeneralMultiProjectionActorOptions? actorOptions = null,
         IEnumerable<SerializableEvent>? processedEvents = null,
-        RecordingPersistentState<MultiProjectionGrainState>? persistentState = null)
+        RecordingPersistentState<MultiProjectionGrainState>? persistentState = null,
+        TempFileSnapshotManager? tempFileSnapshotManager = null)
     {
         host ??= new ProductionCatchUpProjectionHost();
         persistentState ??= new RecordingPersistentState<MultiProjectionGrainState>
@@ -751,7 +963,7 @@ public sealed class MultiProjectionGrainCatchUpProductionPathTests
                 PersistIntervalSeconds = 0,
                 SkipPersistWhenSafeCheckpointUnchanged = true
             },
-            tempFileSnapshotManager: null,
+            tempFileSnapshotManager: tempFileSnapshotManager,
             logger: NullLogger<MultiProjectionGrain>.Instance,
             eventStoreFactory: null,
             serviceIdProvider: new DefaultServiceIdProvider());
@@ -770,6 +982,17 @@ public sealed class MultiProjectionGrainCatchUpProductionPathTests
         }
 
         return grain;
+    }
+
+    private static SerializableEvent CreatePendingEvent(long tick)
+    {
+        return new SerializableEvent(
+            [1],
+            SortableUniqueId.GetTickString(tick) + SortableUniqueId.GetIdString(Guid.Empty),
+            Guid.CreateVersion7(),
+            new EventMetadata("aggregate", "command", "pending"),
+            [],
+            "ProductionCatchUpEvent");
     }
 
     private static string? GetCatchUpCurrentPosition(MultiProjectionGrain grain)
@@ -930,6 +1153,7 @@ public sealed class MultiProjectionGrainCatchUpProductionPathTests
         public bool FailSnapshotWrite { get; init; }
         public bool ThrowSnapshotWrite { get; init; }
         public bool ReturnFalseSnapshotWrite { get; init; }
+        public Exception? SnapshotWriteException { get; init; }
         public bool AllowApply { get; init; }
         public bool FailSafePromotionWithResult { get; init; }
         public bool ThrowSafePromotion { get; init; }
@@ -1045,6 +1269,11 @@ public sealed class MultiProjectionGrainCatchUpProductionPathTests
             if (ThrowSnapshotWrite)
             {
                 throw new InvalidOperationException("snapshot write threw");
+            }
+
+            if (SnapshotWriteException is { } snapshotWriteException)
+            {
+                return ResultBox.Error<bool>(snapshotWriteException);
             }
 
             if (FailSnapshotWrite)
@@ -1187,9 +1416,18 @@ public sealed class MultiProjectionGrainCatchUpProductionPathTests
 
     private sealed class ProductionStreamingCatchUpEventStore : ProductionCatchUpEventStore, IStreamingSerializableEventStore
     {
-        public ProductionStreamingCatchUpEventStore(IReadOnlyList<int>? batchSizes = null)
-            : base(batchSizes)
+        private readonly TaskCompletionSource? _firstReadStarted;
+        private readonly TaskCompletionSource? _releaseFirstRead;
+        private int _firstReadBlocked;
+
+        public ProductionStreamingCatchUpEventStore(
+            IReadOnlyList<int>? batchSizes = null,
+            TaskCompletionSource? firstReadStarted = null,
+            TaskCompletionSource? releaseFirstRead = null)
+            : base(batchSizes, firstReadStarted, releaseFirstRead)
         {
+            _firstReadStarted = firstReadStarted;
+            _releaseFirstRead = releaseFirstRead;
         }
 
         public async Task<ResultBox<SerializableEventStreamReadResult>> StreamAllSerializableEventsAsync(
@@ -1199,6 +1437,14 @@ public sealed class MultiProjectionGrainCatchUpProductionPathTests
             CancellationToken cancellationToken = default)
         {
             ReadSinceValuesInternal(since);
+            if (_firstReadStarted is not null && Interlocked.Exchange(ref _firstReadBlocked, 1) == 0)
+            {
+                _firstReadStarted.TrySetResult();
+                if (_releaseFirstRead is not null)
+                {
+                    await _releaseFirstRead.Task;
+                }
+            }
             var batch = NextBatch();
             foreach (var ev in batch)
             {

--- a/dcb/tests/Sekiban.Dcb.Orleans.Tests/MultiProjectionGrainWatermarkRetirementTests.cs
+++ b/dcb/tests/Sekiban.Dcb.Orleans.Tests/MultiProjectionGrainWatermarkRetirementTests.cs
@@ -561,6 +561,10 @@ public sealed class MultiProjectionGrainWatermarkRetirementTests : IAsyncLifetim
         state.LastGoodOriginalSizeBytes == 0 &&
         state.LastGoodEventsProcessed == 0;
 
+    private sealed class TestProjectionPayload : IMultiProjectionPayload
+    {
+    }
+
     private static IReadOnlyList<SerializableEvent> BuildEvents(int count)
     {
         return Enumerable.Range(0, count)
@@ -973,7 +977,13 @@ public sealed class MultiProjectionGrainWatermarkRetirementTests : IAsyncLifetim
         }
 
         public Task<ResultBox<MultiProjectionState>> GetStateAsync(bool canGetUnsafeState = true) =>
-            Task.FromResult(ResultBox.Error<MultiProjectionState>(new InvalidOperationException("test host state unavailable")));
+            Task.FromResult(ResultBox.FromValue<MultiProjectionState>(new MultiProjectionState(
+                new TestProjectionPayload(),
+                ProjectorName,
+                "v1",
+                _safePosition ?? string.Empty,
+                Guid.Empty,
+                _forcedSafeVersion >= 0 ? _forcedSafeVersion : _appliedEventIds.Count)));
 
         public Task<ProjectionHeadStatus> GetProjectionHeadStatusAsync() => throw new NotSupportedException();
 


### PR DESCRIPTION
Closes #1232

## Summary
- Keep event-bearing replay and pending application calls at `finishedCatchUp: false`.
- Emit exactly one empty `finishedCatchUp: true` host pulse only after safe promotion, required persistence, and pending processing all succeed, including empty and duplicate-only queues.
- Propagate safe-promotion, persistence, buffered-application, and pending-application failures without emitting a completion pulse; preserve normal live-buffer completion behavior.

## Validation
- `dotnet test dcb/tests/Sekiban.Dcb.Orleans.Tests/Sekiban.Dcb.Orleans.Tests.csproj -c Release -f net9.0 --no-restore --filter FullyQualifiedName~MultiProjectionGrainCatchUpProductionPathTests`: 27 passed.
- Same focused test on net10.0: 27 passed.
- `MultiProjectionGrainPersistPolicyTests`: 13 passed on net9.0 and 13 passed on net10.0.
- `git diff --check`: clean.